### PR TITLE
Better diagnostics for our test infrastructure

### DIFF
--- a/src/Tools/Source/RunTests/Cache/WebDataStorage.Json.cs
+++ b/src/Tools/Source/RunTests/Cache/WebDataStorage.Json.cs
@@ -40,7 +40,13 @@ namespace RunTests.Cache
             public string AssemblyName { get; set; }
             public string Source { get; set; }
             public bool IsJenkins { get; set; }
-        }
+            public string CommitSha { get; set; }
+            public string MergeCommitSha { get; set; }
+            public string Repository { get; set; }
+            public bool IsPullRequest { get; set; }
+            public int PullRequestId { get; set; }
+            public string PullRequestUserName { get; set; }
+       } 
 
         internal sealed class TestCacheData
         {

--- a/src/Tools/Source/RunTests/Cache/WebDataStorage.cs
+++ b/src/Tools/Source/RunTests/Cache/WebDataStorage.cs
@@ -25,6 +25,8 @@ namespace RunTests.Cache
             try
             {
                 var testCacheData = CreateTestCacheData(assemblyInfo, assemblyInfo.ResultsFileName, testResult);
+                Logger.Log($"Source data for ${assemblyInfo.DisplayName}: {JsonConvert.SerializeObject(testCacheData.TestSourceData, Formatting.Indented)}");
+
                 var request = new RestRequest($"api/testData/cache/{contentFile.Checksum}");
                 request.Method = Method.PUT;
                 request.RequestFormat = DataFormat.Json;
@@ -107,13 +109,34 @@ namespace RunTests.Cache
 
         private static TestSourceData CreateTestSourceData(AssemblyInfo assemblyInfo)
         {
-            return new TestSourceData()
+            var data = new TestSourceData()
             {
                 MachineName = Environment.MachineName,
                 EnlistmentRoot = Constants.EnlistmentRoot,
                 AssemblyName = assemblyInfo.DisplayName,
                 IsJenkins = Constants.IsJenkinsRun
             };
+
+            if (data.IsJenkins)
+            {
+                // Add the core git information
+                data.CommitSha = Environment.GetEnvironmentVariable("ghprbActualCommit");
+                data.MergeCommitSha = Environment.GetEnvironmentVariable("GIT_COMMIT");
+                data.Repository = Environment.GetEnvironmentVariable("ghprbGhRepository");
+
+                // For PR runs include extra data about the PR.  This enables us to track down bugs server 
+                // side when PRs are believed to hit test / cache issues.
+                var idStr = Environment.GetEnvironmentVariable("ghprbPullId");
+                int id;
+                if (idStr != null && int.TryParse(idStr, out id))
+                {
+                    data.IsPullRequest = true;
+                    data.PullRequestId = id;
+                    data.PullRequestUserName = Environment.GetEnvironmentVariable("ghprbPullAuthorLogin");
+                } 
+            }
+
+            return data;
         }
 
         private static Tuple<int, int, int> GetTestNumbers(string resultsFileName, CachedTestResult testResult)

--- a/src/Tools/Source/RunTests/Logger.cs
+++ b/src/Tools/Source/RunTests/Logger.cs
@@ -34,13 +34,22 @@ namespace RunTests
             }
         }
 
-        internal static void Finish(string logDir)
+        internal static void Clear()
         {
-            var logFilePath = Path.Combine(logDir, "runtests.log");
             lock (s_lines)
             {
-                File.WriteAllLines(logFilePath, s_lines.ToArray());
                 s_lines.Clear();
+            }
+        }
+
+        internal static void WriteTo(TextWriter textWriter)
+        {
+            lock (s_lines)
+            {
+                foreach (var line in s_lines)
+                {
+                    textWriter.WriteLine(line);
+                }
             }
         }
     }

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -60,8 +60,7 @@ namespace RunTests
 
             Console.WriteLine($"Test execution time: {elapsed}");
 
-            Logger.Finish(Path.GetDirectoryName(options.Assemblies.FirstOrDefault() ?? ""));
-
+            WriteLogFile(options);
             DisplayResults(options.Display, result.TestResults);
 
             if (CanUseWebStorage())
@@ -77,6 +76,25 @@ namespace RunTests
 
             Console.WriteLine($"All tests passed");
             return ExitSuccess;
+        }
+
+        private static void WriteLogFile(Options options)
+        {
+            var fileName = Path.Combine(Path.GetDirectoryName(options.Assemblies.First()), "runtests.log");
+            using (var writer = new StreamWriter(fileName, append: false))
+            {
+                Logger.WriteTo(writer);
+            }
+
+            // This is deliberately being checked in on a temporary basis.  Need to see how this data behaves in the commit
+            // queue and the easiest way is to dump to the console.  Once the commit queue behavior is verified this will
+            // be deleted.
+            if (Constants.IsJenkinsRun)
+            {
+                Logger.WriteTo(Console.Out);
+            }
+
+            Logger.Clear();
         }
 
         /// <summary>


### PR DESCRIPTION
Added a few more fields to the data we track for test diagnostics.  This will help us in seeing the effectiveness of tests / caching against the lifetime of a given PR.  This is a frequent request from some users.