### PR TITLE
Reduce completion annoyances when typing deconstruction declarations

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -145,8 +145,10 @@
     <AssemblyName>Roslyn.Services.Editor.CSharp.UnitTests</AssemblyName>
     <RoslynProjectType>UnitTest</RoslynProjectType>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "></PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationCore" />
@@ -222,6 +224,8 @@
     <Compile Include="Diagnostics\NamingStyles\NamingStylesTests_OptionSets.cs" />
     <Compile Include="Diagnostics\PreferFrameworkType\PreferFrameworkTypeTests.cs" />
     <Compile Include="Diagnostics\PreferFrameworkType\PreferFrameworkTypeTests_FixAllTests.cs" />
+    <Compile Include="Extensions\ContextQuery\IsPossibleDeconstructionDesignationTests.cs" />
+    <Compile Include="Extensions\ContextQuery\PossibleTupleContextTests.cs" />
     <Compile Include="QualifyMemberAccess\QualifyMemberAccessTests.cs" />
     <Compile Include="QualifyMemberAccess\QualifyMemberAccessTests_FixAllTests.cs" />
     <Compile Include="Diagnostics\SpellCheck\SpellCheckTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
@@ -24,13 +24,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task AfterFirstExplicitArgument()
         {
-            await VerifyNotBuilderAsync(AddInsideMethod(@"Func<int, int, int> f = (int x, i $$"));
+            // The right-hand-side parses like a possible deconstruction or tuple type
+            await VerifyBuilderAsync(AddInsideMethod(@"Func<int, int, int> f = (int x, i $$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task AfterFirstImplicitArgument()
         {
-            await VerifyNotBuilderAsync(AddInsideMethod(@"Func<int, int, int> f = (x, i $$"));
+            // The right-hand-side parses like a possible deconstruction or tuple type
+            await VerifyBuilderAsync(AddInsideMethod(@"Func<int, int, int> f = (x, i $$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -46,7 +48,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     }
 }
 ";
-            await VerifyNotBuilderAsync(markup);
+            // The right-hand-side parses like a possible deconstruction or tuple type
+            await VerifyBuilderAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -62,7 +65,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     }
 }
 ";
-            await VerifyNotBuilderAsync(markup);
+            // Could be a deconstruction expression
+            await VerifyBuilderAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Extensions/ContextQuery/AbstractContextTests.cs
+++ b/src/EditorFeatures/CSharpTest/Extensions/ContextQuery/AbstractContextTests.cs
@@ -137,5 +137,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntelliSense.Completion
 @"  }
 }";
         }
+
+        protected string AddInsideClass(string text)
+        {
+            return
+@"class C
+{
+    " + text +
+@"}";
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Extensions/ContextQuery/IsPossibleDeconstructionDesignationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Extensions/ContextQuery/IsPossibleDeconstructionDesignationTests.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntelliSense.CompletionSetSources
+{
+    public class IsPossibleDeconstructionDesignationTests : AbstractContextTests
+    {
+        protected override void CheckResult(bool expected, int position, SyntaxTree syntaxTree)
+        {
+            var actual = syntaxTree.IsPossibleDeconstructionDesignation(position, CancellationToken.None);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test1()
+        {
+            VerifyTrue(AddInsideMethod(@"(var $$, var y)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void WellFormed1()
+        {
+            VerifyTrue(AddInsideMethod(@"(var $$, var y) = e;"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test2()
+        {
+            VerifyTrue(AddInsideMethod(@"(var x, var $$)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test3()
+        {
+            VerifyTrue(AddInsideMethod(@"var ($$, y)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test4()
+        {
+            VerifyTrue(AddInsideMethod(@"var ($$, y)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test5()
+        {
+            VerifyTrue(AddInsideMethod(@"var ($$)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test6()
+        {
+            VerifyTrue(AddInsideMethod(@"(var $$)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test7()
+        {
+            VerifyTrue(AddInsideMethod(@"(var a, var $$)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test8()
+        {
+            VerifyFalse(AddInsideMethod(@"var str = (($$)items) as string;"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test9()
+        {
+            VerifyTrue(AddInsideMethod(@"Func<int, int, int> f = (x, i $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestNestedVar()
+        {
+            VerifyTrue(AddInsideMethod(@"var (($$), y)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestNestedVar2()
+        {
+            VerifyTrue(AddInsideMethod(@"var ((x, $$), y)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestNestedVar3()
+        {
+            VerifyTrue(AddInsideMethod(@"var ((x, $$), y) = e;"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar1()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var ($$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar2()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var ($$)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar3()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var ($$))"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar4()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var (x, $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar5()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var ($$) in "));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar6()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var (($$), y)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar7()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var (($$), y) in "));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar8()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var ((x, $$), y)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void TestForeachVar9()
+        {
+            VerifyTrue(AddInsideMethod(@"foreach(var ((x, $$), y) in "));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void False1()
+        {
+            VerifyFalse(AddInsideMethod(@"var $$"));
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Extensions/ContextQuery/PossibleTupleContextTests.cs
+++ b/src/EditorFeatures/CSharpTest/Extensions/ContextQuery/PossibleTupleContextTests.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntelliSense.CompletionSetSources
+{
+    public class PossibleTupleContextTests : AbstractContextTests
+    {
+        protected override void CheckResult(bool validLocation, int position, SyntaxTree syntaxTree)
+        {
+            var leftToken = syntaxTree.FindTokenOnLeftOfPosition(position, CancellationToken.None);
+            var isPossibleTupleContext = syntaxTree.IsPossibleTupleContext(leftToken, position);
+
+            Assert.Equal(validLocation, isPossibleTupleContext);
+        }
+
+        private void VerifyMultipleContexts(string x)
+        {
+            VerifyTrue(x);
+            VerifyTrue(AddInsideClass(x));
+            VerifyTrue(AddInsideMethod(x));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test1()
+        {
+            VerifyMultipleContexts(@"((a, b) $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test2()
+        {
+            VerifyMultipleContexts(@"(xyz, (a, b) $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test3()
+        {
+            VerifyMultipleContexts(@"(a $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test4()
+        {
+            VerifyMultipleContexts(@"(a, b $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test5()
+        {
+            VerifyMultipleContexts(@"($$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test6()
+        {
+            VerifyMultipleContexts(@"(a, $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test7()
+        {
+            VerifyMultipleContexts(@"(a.b $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test8()
+        {
+            VerifyMultipleContexts(@"(a, a.b $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test9()
+        {
+            VerifyTrue(@"class C : I<($$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test10()
+        {
+            VerifyTrue(@"class C : I<(a, $$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test11()
+        {
+            VerifyTrue(AddInsideMethod(@"(var $$)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test12()
+        {
+            VerifyTrue(AddInsideMethod(@"(var a, var $$)"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void Test13()
+        {
+            VerifyTrue(AddInsideMethod(@"var str = (($$)items) as string;"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void False1()
+        {
+            VerifyFalse(@"$$");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void False2()
+        {
+            VerifyFalse(AddInsideMethod(@"(int) $$"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void False3()
+        {
+            VerifyFalse(AddInsideMethod(@"(Foo()) $$"));
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
@@ -80,16 +80,16 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotInCastType()
+        public async Task TestInCastType()
         {
-            await VerifyAbsenceAsync(AddInsideMethod(
+            await VerifyKeywordAsync(AddInsideMethod(
 @"var str = (($$"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotInCastType2()
+        public async Task TestInCastType2()
         {
-            await VerifyAbsenceAsync(AddInsideMethod(
+            await VerifyKeywordAsync(AddInsideMethod(
 @"var str = (($$)items) as string;"));
         }
 

--- a/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
@@ -90,7 +90,7 @@ $$");
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestInCastType2()
         {
-            // Locally could be a deconstruction
+            // Could be a deconstruction
             await VerifyKeywordAsync(AddInsideMethod(
 @"var str = (($$)items) as string;"));
         }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
@@ -82,6 +82,7 @@ $$");
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestInCastType()
         {
+            // Could be a deconstruction
             await VerifyKeywordAsync(AddInsideMethod(
 @"var str = (($$"));
         }
@@ -89,6 +90,7 @@ $$");
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestInCastType2()
         {
+            // Locally could be a deconstruction
             await VerifyKeywordAsync(AddInsideMethod(
 @"var str = (($$)items) as string;"));
         }

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -284,27 +284,29 @@ class Variable
 {
     public void Foo()
     {
-       ($$) = (1, 2);
+       (var a$$) = (1, 2);
     }
 }]]></Document>)
 
-                state.SendTypeChars("va")
-                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
-                state.SendTypeChars(" ")
-                Assert.Contains("(var ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
-                Await state.AssertNoCompletionSession()
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+            End Using
+        End Function
 
-                state.SendTypeChars("a")
-                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedDeconstructionDeclarationWithVarAfterComma() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+       (var a, var a$$) = (1, 2);
+    }
+}]]></Document>)
 
-                state.SendTypeChars(", va")
-                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
-
-                state.SendTypeChars(" ")
-                Assert.Contains("(var a, var ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
-
-                state.SendTypeChars("a")
-                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+                state.SendInvokeCompletionList()
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -470,7 +470,6 @@ class Variable
                 Await state.AssertSelectedCompletionItem(displayText:="bool", isSoftSelected:=True)
                 state.SendReturn()
                 Assert.Contains("(var a, va a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
-                ' TODO REVIEW Not sure why the close paren disappears
             End Using
         End Function
 
@@ -526,7 +525,7 @@ class Variable
 
                 state.SendTypeChars(", var as")
                 state.SendBackspace()
-                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True) ' TODO REVIEW this uses an insert, dunno why
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
 
                 state.SendReturn()
                 Await state.AssertNoCompletionSession()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -434,7 +434,7 @@ class Variable
                 Await state.AssertNoCompletionSession()
 
                 state.SendTypeChars("a")
-                Await state.AssertNoCompletionSession()
+                Await state.AssertSelectedCompletionItem(displayText:="bool", isSoftSelected:=True)
                 state.SendTypeChars(")")
                 Assert.Contains("(var a, va a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
                 Await state.AssertNoCompletionSession()
@@ -467,8 +467,10 @@ class Variable
                 Await state.AssertNoCompletionSession()
 
                 state.SendTypeChars("a")
-                Await state.AssertNoCompletionSession()
-                Assert.Contains("(var a, va a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertSelectedCompletionItem(displayText:="bool", isSoftSelected:=True)
+                state.SendReturn()
+                Assert.Contains("(var a, va a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                ' TODO REVIEW Not sure why the close paren disappears
             End Using
         End Function
 
@@ -488,17 +490,17 @@ class Variable
                     CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
 
                 state.SendBackspace()
-                ' Those completions are hard-selected because the suggestion mode never triggers on backspace
+                ' This completion is hard-selected because the suggestion mode never triggers on backspace
                 ' See issue https://github.com/dotnet/roslyn/issues/15302
                 Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
 
                 state.SendTypeChars(", var as")
                 state.SendBackspace()
-                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
 
                 state.SendTypeChars(")")
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("(var as, var as)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("(var as, var a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 
@@ -518,17 +520,17 @@ class Variable
                     CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
 
                 state.SendBackspace()
-                ' Those completions are hard-selected because the suggestion mode never triggers on backspace
+                ' This completion is hard-selected because the suggestion mode never triggers on backspace
                 ' See issue https://github.com/dotnet/roslyn/issues/15302
                 Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
 
                 state.SendTypeChars(", var as")
                 state.SendBackspace()
-                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True) ' TODO REVIEW this uses an insert, dunno why
 
                 state.SendReturn()
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("(var as, var as)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("(var as, var a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -277,6 +277,200 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedDeconstructionDeclarationWithVar() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+       ($$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendTypeChars("va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(var ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+
+                state.SendTypeChars(", va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+
+                state.SendTypeChars(" ")
+                Assert.Contains("(var a, var ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedVarDeconstructionDeclarationWithVar() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+       (var a, var ($$)) = (1, 2);
+    }
+}]]></Document>)
+
+
+                state.SendTypeChars("a")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars(", a")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("(var a, var (a, a)) = ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestVarDeconstructionDeclarationWithVar() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+        $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+
+                state.SendTypeChars(" (a")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars(", a")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("var (a, a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedDeconstructionDeclarationWithSymbol() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+       ($$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendTypeChars("vari")
+                Await state.AssertSelectedCompletionItem(displayText:="Variable", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(Variable ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("x, vari")
+                Await state.AssertSelectedCompletionItem(displayText:="Variable", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(Variable x, Variable ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestParenthesizedDeconstructionDeclarationWithInt() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Integer
+{
+    public void Foo()
+    {
+       ($$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendTypeChars("int")
+                Await state.AssertSelectedCompletionItem(displayText:="int", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(int ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("x, int")
+                Await state.AssertSelectedCompletionItem(displayText:="int", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Assert.Contains("(int x, int ", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestIncompleteParenthesizedDeconstructionDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+       ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+
+                state.SendTypeChars(", va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isSoftSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertNoCompletionSession()
+                state.SendTypeChars(")")
+                Assert.Contains("(var a, va a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestIncompleteParenthesizedDeconstructionDeclaration2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+       ($$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isHardSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="as", isSoftSelected:=True)
+
+                state.SendTypeChars(", va")
+                Await state.AssertSelectedCompletionItem(displayText:="var", isSoftSelected:=True)
+                state.SendTypeChars(" ")
+                Await state.AssertNoCompletionSession()
+
+                state.SendTypeChars("a")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("(var a, va a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -473,6 +473,66 @@ class Variable
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBackspaceInIncompleteParenthesizedDeconstructionDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+       (var as$$
+    }
+}]]></Document>)
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                state.SendBackspace()
+                ' Those completions are hard-selected because the suggestion mode never triggers on backspace
+                ' See issue https://github.com/dotnet/roslyn/issues/15302
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+
+                state.SendTypeChars(", var as")
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+
+                state.SendTypeChars(")")
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("(var as, var as)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestBackspaceInParenthesizedDeconstructionDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class Variable
+{
+    public void Foo()
+    {
+       (var as$$)
+    }
+}]]></Document>)
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(
+                    CompletionOptions.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                state.SendBackspace()
+                ' Those completions are hard-selected because the suggestion mode never triggers on backspace
+                ' See issue https://github.com/dotnet/roslyn/issues/15302
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+
+                state.SendTypeChars(", var as")
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+                Assert.Contains("(var as, var as)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -107,6 +107,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Autoselect disabled due to possible deconstruction declaration..
+        /// </summary>
+        internal static string Autoselect_disabled_due_to_possible_deconstruction_declaration {
+            get {
+                return ResourceManager.GetString("Autoselect_disabled_due_to_possible_deconstruction_declaration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Autoselect disabled due to possible explicitly named anonymous type member creation..
         /// </summary>
         internal static string Autoselect_disabled_due_to_possible_explicitly_named_anonymous_type_member_creation {
@@ -293,6 +302,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string deprecated {
             get {
                 return ResourceManager.GetString("deprecated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;designation name&gt;.
+        /// </summary>
+        internal static string designation_name {
+            get {
+                return ResourceManager.GetString("designation_name", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -479,11 +479,17 @@
   <data name="Autoselect_disabled_due_to_type_declaration" xml:space="preserve">
     <value>Autoselect disabled due to type declaration.</value>
   </data>
+  <data name="Autoselect_disabled_due_to_possible_deconstruction_declaration" xml:space="preserve">
+    <value>Autoselect disabled due to possible deconstruction declaration.</value>
+  </data>
   <data name="class_name" xml:space="preserve">
     <value>&lt;class name&gt;</value>
   </data>
   <data name="interface_name" xml:space="preserve">
     <value>&lt;interface name&gt;</value>
+  </data>
+  <data name="designation_name" xml:space="preserve">
+    <value>&lt;designation name&gt;</value>
   </data>
   <data name="struct_name" xml:space="preserve">
     <value>&lt;struct name&gt;</value>

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/VarKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/VarKeywordRecommender.cs
@@ -18,7 +18,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         private bool IsValidContext(CSharpSyntaxContext context)
         {
             if (context.IsStatementContext ||
-                context.IsGlobalStatementContext)
+                context.IsGlobalStatementContext ||
+                context.IsPossibleTupleContext)
             {
                 return true;
             }

--- a/src/Features/CSharp/Portable/Completion/SuggestionMode/CSharpSuggestionModeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/SuggestionMode/CSharpSuggestionModeCompletionProvider.cs
@@ -78,6 +78,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.SuggestionMode
                             return CreateSuggestionModeItem(CSharpFeaturesResources.interface_name, CSharpFeaturesResources.Autoselect_disabled_due_to_type_declaration);
                     }
                 }
+                else if (tree.IsPossibleDeconstructionDesignation(position, cancellationToken))
+                {
+                    return CreateSuggestionModeItem(CSharpFeaturesResources.designation_name,
+                        CSharpFeaturesResources.Autoselect_disabled_due_to_possible_deconstruction_declaration);
+                }
             }
 
             return null;

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -1132,52 +1133,209 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return false;
         }
 
-        // Tuple literals aren't recognized by the parser until there is a comma
-        // So a parenthesized expression is a possible tuple context too
-        public static bool IsPossibleTupleContext(this SyntaxTree syntaxTree,
-            SyntaxToken tokenOnLeftOfPosition, int position)
+        /// <summary>
+        /// Are you possibly typing a tuple type or expression?
+        /// This is used to suppress colon as a completion trigger (so that you can type element names).
+        /// This is also used to recommend some keywords (like var).
+        /// </summary>
+        public static bool IsPossibleTupleContext(this SyntaxTree syntaxTree, SyntaxToken leftToken, int position)
         {
-            tokenOnLeftOfPosition = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
+            leftToken = leftToken.GetPreviousTokenIfTouchingWord(position);
 
-            if (tokenOnLeftOfPosition.Parent.IsKind(SyntaxKind.ParenthesizedExpression,
-                    SyntaxKind.TupleExpression, SyntaxKind.TupleType) ||
-                tokenOnLeftOfPosition.Parent.IsParentKind(SyntaxKind.ParenthesizedExpression,
-                    SyntaxKind.TupleExpression, SyntaxKind.TupleType))
+            // ($$
+            // (a, $$
+            if (IsPossibleTupleOpenParenOrComma(leftToken))
             {
                 return true;
             }
 
-            // (int a, i$$
-            // ($$int a, int b
-            if (tokenOnLeftOfPosition.Parent.IsKind(SyntaxKind.ParameterList) &&
-                tokenOnLeftOfPosition.Parent.IsParentKind(SyntaxKind.ParenthesizedLambdaExpression))
+            // ((a, b) $$
+            // (..., (a, b) $$
+            if (leftToken.IsKind(SyntaxKind.CloseParenToken))
             {
-                return true;
+                if (leftToken.Parent.IsKind(
+                    SyntaxKind.ParenthesizedExpression,
+                    SyntaxKind.TupleExpression,
+                    SyntaxKind.TupleType))
+                {
+                    var possibleCommaOrParen = FindTokenOnLeftOfNode(leftToken.Parent);
+                    if (IsPossibleTupleOpenParenOrComma(possibleCommaOrParen))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            // (a $$
+            // (..., b $$
+            if (leftToken.IsKind(SyntaxKind.IdentifierToken))
+            {
+                var possibleCommaOrParen = FindTokenOnLeftOfNode(leftToken.Parent);
+                if (IsPossibleTupleOpenParenOrComma(possibleCommaOrParen))
+                {
+                    return true;
+                }
+            }
+
+            // (a.b $$
+            // (..., a.b $$
+            if (leftToken.IsKind(SyntaxKind.IdentifierToken) &&
+                leftToken.Parent.IsKind(SyntaxKind.IdentifierName) &&
+                leftToken.Parent.IsParentKind(SyntaxKind.QualifiedName, SyntaxKind.SimpleMemberAccessExpression))
+            {
+                var possibleCommaOrParen = FindTokenOnLeftOfNode(leftToken.Parent.Parent);
+                if (IsPossibleTupleOpenParenOrComma(possibleCommaOrParen))
+                {
+                    return true;
+                }
             }
 
             return false;
         }
 
-        public static bool IsPossibleDeconstructionDesignation(this SyntaxTree syntaxTree,
-            int position, CancellationToken cancellationToken)
+        private static SyntaxToken FindTokenOnLeftOfNode(SyntaxNode node)
         {
-            var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
+            return node.FindTokenOnLeftOfPosition(node.SpanStart);
+        }
 
-            if (token.Parent.IsKind(SyntaxKind.SingleVariableDesignation))
+        private static bool IsPossibleTupleOpenParenOrComma(SyntaxToken possibleCommaOrParen)
+        {
+            if (!possibleCommaOrParen.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
             {
-                var designation = (SingleVariableDesignationSyntax)token.Parent;
-                if (designation.IsParentKind(SyntaxKind.DeclarationExpression))
-                {
-                    var declaration = (DeclarationExpressionSyntax)designation.Parent;
-                    return !declaration.Type.IsMissing && designation.Identifier == token;
-                }
                 return false;
             }
 
-            var prev = token.GetPreviousTokenIfTouchingWord(position);
+            if (possibleCommaOrParen.Parent.IsKind(
+                SyntaxKind.ParenthesizedExpression,
+                SyntaxKind.TupleExpression,
+                SyntaxKind.TupleType,
+                SyntaxKind.CastExpression))
+            {
+                return true;
+            }
 
-            return IsPossibleTupleContext(syntaxTree, token, position) &&
-                !prev.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken);
+            // in script
+            if (possibleCommaOrParen.Parent.IsKind(SyntaxKind.ParameterList) &&
+                possibleCommaOrParen.Parent.IsParentKind(SyntaxKind.ParenthesizedLambdaExpression))
+            {
+                var parenthesizedLambda = (ParenthesizedLambdaExpressionSyntax)possibleCommaOrParen.Parent.Parent;
+                if (parenthesizedLambda.ArrowToken.IsMissing)
+                {
+                    return true;
+                }
+
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Are you possibly in the designation part of a deconstruction?
+        /// This is used to enter suggestion mode (suggestions become soft-selected).
+        /// </summary>
+        public static bool IsPossibleDeconstructionDesignation(this SyntaxTree syntaxTree,
+            int position, CancellationToken cancellationToken)
+        {
+            var leftToken = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
+            leftToken = leftToken.GetPreviousTokenIfTouchingWord(position);
+
+            // The well-formed cases:
+            // var ($$, y) = e;
+            // (var $$, var y) = e;
+            if (leftToken.Parent.IsKind(SyntaxKind.SingleVariableDesignation, SyntaxKind.ParenthesizedVariableDesignation))
+            {
+                return true;
+            }
+
+            // (var $$, var y)
+            // (var x, var y)
+            if (syntaxTree.IsPossibleTupleContext(leftToken, position) && !IsPossibleTupleOpenParenOrComma(leftToken))
+            {
+                return true;
+            }
+
+            // var ($$)
+            // var (x, $$)
+            if (IsPossibleVarDeconstructionOpenParenOrComma(leftToken))
+            {
+                return true;
+            }
+
+            // var (($$), y)
+            if (leftToken.IsKind(SyntaxKind.OpenParenToken) && leftToken.Parent.IsKind(SyntaxKind.ParenthesizedExpression))
+            {
+                if (IsPossibleVarDeconstructionOpenParenOrComma(FindTokenOnLeftOfNode(leftToken.Parent)))
+                {
+                    return true;
+                }
+            }
+
+            // var ((x, $$), y)
+            // var (($$, x), y)
+            if (leftToken.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken) && leftToken.Parent.IsKind(SyntaxKind.TupleExpression))
+            {
+                if (IsPossibleVarDeconstructionOpenParenOrComma(FindTokenOnLeftOfNode(leftToken.Parent)))
+                {
+                    return true;
+                }
+            }
+
+            // foreach (var ($$
+            // foreach (var ((x, $$), y)
+            if (leftToken.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
+            {
+                var outter = UnwrapPossibleTuple(leftToken.Parent);
+                if (outter.Parent.IsKind(SyntaxKind.ForEachStatement))
+                {
+                    var @foreach = (ForEachStatementSyntax)outter.Parent;
+
+                    if (@foreach.Expression == outter &&
+                        @foreach.Type.IsKind(SyntaxKind.IdentifierName) &&
+                        ((IdentifierNameSyntax)@foreach.Type).Identifier.ValueText == "var")
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// If inside a parenthesized or tuple expression, unwrap the nestings and return the container.
+        /// </summary>
+        private static SyntaxNode UnwrapPossibleTuple(SyntaxNode node)
+        {
+            while (true)
+            {
+                if (node.Parent.IsKind(SyntaxKind.ParenthesizedExpression))
+                {
+                    node = node.Parent;
+                    continue;
+                }
+                if (node.Parent.IsKind(SyntaxKind.Argument) && node.Parent.IsParentKind(SyntaxKind.TupleExpression))
+                {
+                    node = node.Parent.Parent;
+                    continue;
+                }
+
+                return node;
+            }
+        }
+
+        private static bool IsPossibleVarDeconstructionOpenParenOrComma(SyntaxToken leftToken)
+        {
+            if (leftToken.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken) &&
+                leftToken.Parent.IsKind(SyntaxKind.ArgumentList) &&
+                leftToken.Parent.IsParentKind(SyntaxKind.InvocationExpression))
+            {
+                var invocation = (InvocationExpressionSyntax)leftToken.Parent.Parent;
+                if (invocation.Expression.IsKind(SyntaxKind.IdentifierName) &&
+                    ((IdentifierNameSyntax)invocation.Expression).Identifier.ValueText == "var")
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public static bool HasNames(this TupleExpressionSyntax tuple)

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1154,9 +1154,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             if (leftToken.IsKind(SyntaxKind.CloseParenToken))
             {
                 if (leftToken.Parent.IsKind(
-                    SyntaxKind.ParenthesizedExpression,
-                    SyntaxKind.TupleExpression,
-                    SyntaxKind.TupleType))
+                        SyntaxKind.ParenthesizedExpression,
+                        SyntaxKind.TupleExpression,
+                        SyntaxKind.TupleType))
                 {
                     var possibleCommaOrParen = FindTokenOnLeftOfNode(leftToken.Parent);
                     if (IsPossibleTupleOpenParenOrComma(possibleCommaOrParen))
@@ -1283,12 +1283,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // foreach (var ((x, $$), y)
             if (leftToken.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
             {
-                var outter = UnwrapPossibleTuple(leftToken.Parent);
-                if (outter.Parent.IsKind(SyntaxKind.ForEachStatement))
+                var outer = UnwrapPossibleTuple(leftToken.Parent);
+                if (outer.Parent.IsKind(SyntaxKind.ForEachStatement))
                 {
-                    var @foreach = (ForEachStatementSyntax)outter.Parent;
+                    var @foreach = (ForEachStatementSyntax)outer.Parent;
 
-                    if (@foreach.Expression == outter &&
+                    if (@foreach.Expression == outer &&
                         @foreach.Type.IsKind(SyntaxKind.IdentifierName) &&
                         ((IdentifierNameSyntax)@foreach.Type).Identifier.ValueText == "var")
                     {

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1139,9 +1139,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             tokenOnLeftOfPosition = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
-            if (tokenOnLeftOfPosition.Parent?.IsKind(SyntaxKind.ParenthesizedExpression,
+            if (tokenOnLeftOfPosition.Parent.IsKind(SyntaxKind.ParenthesizedExpression,
                     SyntaxKind.TupleExpression, SyntaxKind.TupleType) == true ||
-                tokenOnLeftOfPosition.Parent?.Parent?.IsKind(SyntaxKind.ParenthesizedExpression,
+                tokenOnLeftOfPosition.Parent.IsParentKind(SyntaxKind.ParenthesizedExpression,
                     SyntaxKind.TupleExpression, SyntaxKind.TupleType) == true)
             {
                 return true;
@@ -1149,8 +1149,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // (int a, i$$
             // ($$int a, int b
-            if (tokenOnLeftOfPosition.Parent?.IsKind(SyntaxKind.ParameterList) == true &&
-                tokenOnLeftOfPosition.Parent?.Parent?.IsKind(SyntaxKind.ParenthesizedLambdaExpression) == true)
+            if (tokenOnLeftOfPosition.Parent.IsKind(SyntaxKind.ParameterList) == true &&
+                tokenOnLeftOfPosition.Parent.IsParentKind(SyntaxKind.ParenthesizedLambdaExpression) == true)
             {
                 return true;
             }
@@ -1163,10 +1163,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
 
-            if (token.Parent?.IsKind(SyntaxKind.SingleVariableDesignation) == true)
+            if (token.Parent.IsKind(SyntaxKind.SingleVariableDesignation) == true)
             {
                 var designation = (SingleVariableDesignationSyntax)token.Parent;
-                if (designation.Parent?.IsKind(SyntaxKind.DeclarationExpression) == true)
+                if (designation.IsParentKind(SyntaxKind.DeclarationExpression) == true)
                 {
                     var declaration = (DeclarationExpressionSyntax)designation.Parent;
                     return !declaration.Type.IsMissing && designation.Identifier == token;

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1140,17 +1140,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             tokenOnLeftOfPosition = tokenOnLeftOfPosition.GetPreviousTokenIfTouchingWord(position);
 
             if (tokenOnLeftOfPosition.Parent.IsKind(SyntaxKind.ParenthesizedExpression,
-                    SyntaxKind.TupleExpression, SyntaxKind.TupleType) == true ||
+                    SyntaxKind.TupleExpression, SyntaxKind.TupleType) ||
                 tokenOnLeftOfPosition.Parent.IsParentKind(SyntaxKind.ParenthesizedExpression,
-                    SyntaxKind.TupleExpression, SyntaxKind.TupleType) == true)
+                    SyntaxKind.TupleExpression, SyntaxKind.TupleType))
             {
                 return true;
             }
 
             // (int a, i$$
             // ($$int a, int b
-            if (tokenOnLeftOfPosition.Parent.IsKind(SyntaxKind.ParameterList) == true &&
-                tokenOnLeftOfPosition.Parent.IsParentKind(SyntaxKind.ParenthesizedLambdaExpression) == true)
+            if (tokenOnLeftOfPosition.Parent.IsKind(SyntaxKind.ParameterList) &&
+                tokenOnLeftOfPosition.Parent.IsParentKind(SyntaxKind.ParenthesizedLambdaExpression))
             {
                 return true;
             }
@@ -1163,10 +1163,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         {
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
 
-            if (token.Parent.IsKind(SyntaxKind.SingleVariableDesignation) == true)
+            if (token.Parent.IsKind(SyntaxKind.SingleVariableDesignation))
             {
                 var designation = (SingleVariableDesignationSyntax)token.Parent;
-                if (designation.IsParentKind(SyntaxKind.DeclarationExpression) == true)
+                if (designation.IsParentKind(SyntaxKind.DeclarationExpression))
                 {
                     var declaration = (DeclarationExpressionSyntax)designation.Parent;
                     return !declaration.Type.IsMissing && designation.Identifier == token;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14901

Two completions were still getting in the way:

1. Symbol completion if you have any symbol that looks like "var" (would get in the way of typing "var")
2. As and Is keyword completion would get in the way of typing designation identifiers (such as "a" in "(int a, int b) = ...")

Now, the "var" keyword is also suggested in deconstruction contexts and a suggestion/builder mode is added when typing a likely designation.

@CyrusNajmabadi and @dotnet/roslyn-ide for RC2 review. Thanks
FYI @dotnet/roslyn-compiler 