### PR TITLE
Create a code fix that offers to add a reference to System.ValueTuple if it is missing and you use a tuple.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_NuGet.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests_NuGet.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
                 var installerServiceMock = new Mock<IPackageInstallerService>(MockBehavior.Loose);
                 installerServiceMock.SetupGet(i => i.IsEnabled).Returns(true);
                 installerServiceMock.SetupGet(i => i.PackageSources).Returns(NugetPackageSources);
-                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                                     .Returns(true);
 
                 var packageServiceMock = new Mock<ISymbolSearchService>();
@@ -89,7 +89,7 @@ class C
                 var installerServiceMock = new Mock<IPackageInstallerService>(MockBehavior.Loose);
                 installerServiceMock.SetupGet(i => i.IsEnabled).Returns(true);
                 installerServiceMock.SetupGet(i => i.PackageSources).Returns(NugetPackageSources);
-                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                                     .Returns(true);
 
                 var packageServiceMock = new Mock<ISymbolSearchService>();
@@ -184,7 +184,7 @@ fixProviderData: data);
                 var installerServiceMock = new Mock<IPackageInstallerService>(MockBehavior.Loose);
                 installerServiceMock.SetupGet(i => i.IsEnabled).Returns(true);
                 installerServiceMock.SetupGet(i => i.PackageSources).Returns(NugetPackageSources);
-                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", /*versionOpt*/ null, It.IsAny<CancellationToken>()))
+                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", /*versionOpt*/ null, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                                     .Returns(true);
 
                 var packageServiceMock = new Mock<ISymbolSearchService>();
@@ -214,7 +214,7 @@ class C
                 installerServiceMock.SetupGet(i => i.PackageSources).Returns(NugetPackageSources);
                 installerServiceMock.Setup(s => s.GetInstalledVersions("NuGetPackage"))
                     .Returns(ImmutableArray.Create("1.0"));
-                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", "1.0", It.IsAny<CancellationToken>()))
+                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", "1.0", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                                     .Returns(true);
 
                 var packageServiceMock = new Mock<ISymbolSearchService>();
@@ -244,7 +244,7 @@ class C
                 installerServiceMock.SetupGet(i => i.PackageSources).Returns(NugetPackageSources);
                 installerServiceMock.Setup(s => s.GetInstalledVersions("NuGetPackage"))
                     .Returns(ImmutableArray.Create("1.0"));
-                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", "1.0", It.IsAny<CancellationToken>()))
+                installerServiceMock.Setup(s => s.TryInstallPackage(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<string>(), "NuGetPackage", "1.0", It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                                     .Returns(false);
 
                 var packageServiceMock = new Mock<ISymbolSearchService>();

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests_NuGet.vb
@@ -49,7 +49,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
                 Dim installerServiceMock = New Mock(Of IPackageInstallerService)(MockBehavior.Loose)
                 installerServiceMock.SetupGet(Function(i) i.IsEnabled).Returns(True)
                 installerServiceMock.SetupGet(Function(i) i.PackageSources).Returns(NugetPackageSources)
-                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", It.IsAny(Of String), It.IsAny(Of CancellationToken))).
+                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", It.IsAny(Of String), It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
                                      Returns(True)
 
                 Dim packageServiceMock = New Mock(Of ISymbolSearchService)()
@@ -76,7 +76,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 Dim installerServiceMock = New Mock(Of IPackageInstallerService)(MockBehavior.Loose)
                 installerServiceMock.SetupGet(Function(i) i.IsEnabled).Returns(True)
                 installerServiceMock.SetupGet(Function(i) i.PackageSources).Returns(NugetPackageSources)
-                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", It.IsAny(Of String), It.IsAny(Of CancellationToken))).
+                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", It.IsAny(Of String), It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
                                      Returns(True)
 
                 Dim packageServiceMock = New Mock(Of ISymbolSearchService)()
@@ -103,7 +103,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 Dim installerServiceMock = New Mock(Of IPackageInstallerService)(MockBehavior.Loose)
                 installerServiceMock.SetupGet(Function(i) i.IsEnabled).Returns(True)
                 installerServiceMock.SetupGet(Function(i) i.PackageSources).Returns(NugetPackageSources)
-                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", It.IsAny(Of String), It.IsAny(Of CancellationToken))).
+                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", It.IsAny(Of String), It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
                                      Returns(False)
 
                 Dim packageServiceMock = New Mock(Of ISymbolSearchService)()
@@ -191,7 +191,7 @@ fixProviderData:=data)
                 Dim installerServiceMock = New Mock(Of IPackageInstallerService)(MockBehavior.Loose)
                 installerServiceMock.SetupGet(Function(i) i.IsEnabled).Returns(True)
                 installerServiceMock.SetupGet(Function(i) i.PackageSources).Returns(NugetPackageSources)
-                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", Nothing, It.IsAny(Of CancellationToken))).
+                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", Nothing, It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
                                      Returns(True)
 
                 Dim packageServiceMock = New Mock(Of ISymbolSearchService)()
@@ -219,7 +219,7 @@ End Class", fixProviderData:=New ProviderData(installerServiceMock.Object, packa
                 installerServiceMock.SetupGet(Function(i) i.PackageSources).Returns(NugetPackageSources)
                 installerServiceMock.Setup(Function(s) s.GetInstalledVersions("NuGetPackage")).
                     Returns(ImmutableArray.Create("1.0"))
-                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", "1.0", It.IsAny(Of CancellationToken))).
+                installerServiceMock.Setup(Function(s) s.TryInstallPackage(It.IsAny(Of Workspace), It.IsAny(Of DocumentId), It.IsAny(Of String), "NuGetPackage", "1.0", It.IsAny(Of Boolean), It.IsAny(Of CancellationToken))).
                                      Returns(True)
 
                 Dim packageServiceMock = New Mock(Of ISymbolSearchService)()

--- a/src/Features/CSharp/Portable/AddPackage/CSharpAddSpecificPackageCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddPackage/CSharpAddSpecificPackageCodeFixProvider.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.AddPackage;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Microsoft.CodeAnalysis.CSharp.AddPackage
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal class CSharpAddSpecificPackageCodeFixProvider : AbstractAddSpecificPackageCodeFixProvider
+    {
+        private const string CS8179 = nameof(CS8179); // Predefined type 'System.ValueTuple`2' is not defined or imported
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(CS8179);
+
+        protected override string GetAssemblyName(string id)
+        {
+            switch (id)
+            {
+                case CS8179: return "System.ValueTuple";
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\..\..\Compilers\CSharp\Portable\Syntax\LambdaUtilities.cs">
       <Link>InternalUtilities\LambdaUtilities.cs</Link>
     </Compile>
+    <Compile Include="AddPackage\CSharpAddSpecificPackageCodeFixProvider.cs" />
     <Compile Include="Structure\Providers\ArrowExpressionClauseStructureProvider.cs" />
     <Compile Include="ConvertToInterpolatedString\CSharpConvertConcatenationToInterpolatedStringRefactoringProvider.cs" />
     <Compile Include="RemoveUnnecessaryImports\CSharpRemoveUnnecessaryImportsService.cs" />

--- a/src/Features/Core/Portable/AddImport/CodeActions/PackageReference.ParentCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/PackageReference.ParentCodeAction.cs
@@ -120,7 +120,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 
                     var installOperation = new InstallPackageDirectlyCodeActionOperation(
                         reference._installerService, document, reference._source, 
-                        reference._packageName, versionOpt, isLocal);
+                        reference._packageName, versionOpt, 
+                        includePrerelease: false, isLocal: isLocal);
 
                     return new InstallPackageAndAddImportData(
                         oldDocument, newDocument, installOperation);

--- a/src/Features/Core/Portable/AddPackage/AbstractAddPackageCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddPackage/AbstractAddPackageCodeFixProvider.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Packaging;
+using Microsoft.CodeAnalysis.SymbolSearch;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.AddPackage
+{
+    internal abstract partial class AbstractAddPackageCodeFixProvider : CodeFixProvider
+    {
+        private readonly IPackageInstallerService _packageInstallerService;
+        private readonly ISymbolSearchService _symbolSearchService;
+
+        /// <summary>
+        /// Values for these parameters can be provided (during testing) for mocking purposes.
+        /// </summary> 
+        protected AbstractAddPackageCodeFixProvider(
+            IPackageInstallerService packageInstallerService,
+            ISymbolSearchService symbolSearchService)
+        {
+            _packageInstallerService = packageInstallerService;
+            _symbolSearchService = symbolSearchService;
+        }
+
+        protected abstract bool IncludePrerelease { get; }
+
+        protected async Task<ImmutableArray<CodeAction>> GetAddPackagesCodeActionsAsync(
+            CodeFixContext context, ISet<string> assemblyNames)
+        {
+            var document = context.Document;
+            var cancellationToken = context.CancellationToken;
+
+            var workspaceServices = document.Project.Solution.Workspace.Services;
+
+            var symbolSearchService = _symbolSearchService ?? workspaceServices.GetService<ISymbolSearchService>();
+            var installerService = _packageInstallerService ?? workspaceServices.GetService<IPackageInstallerService>();
+
+            var language = document.Project.Language;
+
+            var options = workspaceServices.Workspace.Options;
+            var searchNugetPackages = options.GetOption(
+                SymbolSearchOptions.SuggestForTypesInNuGetPackages, language);
+
+            var codeActions = ArrayBuilder<CodeAction>.GetInstance();
+            if (symbolSearchService != null &&
+                installerService != null &&
+                searchNugetPackages &&
+                installerService.IsEnabled)
+            {
+                foreach (var packageSource in installerService.PackageSources)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var sortedPackages = await FindMatchingPackagesAsync(
+                        packageSource, symbolSearchService,
+                        installerService, assemblyNames, cancellationToken).ConfigureAwait(false);
+
+                    foreach (var package in sortedPackages)
+                    {
+                        codeActions.Add(new InstallPackageParentCodeAction(
+                            installerService, packageSource.Source,
+                            package.PackageName, this.IncludePrerelease, document));
+                    }
+                }
+            }
+
+            return codeActions.ToImmutableAndFree();
+        }
+
+        private async Task<ImmutableArray<PackageWithAssemblyResult>> FindMatchingPackagesAsync(
+            PackageSource source,
+            ISymbolSearchService searchService,
+            IPackageInstallerService installerService,
+            ISet<string> assemblyNames,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var result = new HashSet<PackageWithAssemblyResult>();
+
+            foreach (var assemblyName in assemblyNames)
+            {
+                var packagesWithAssembly = await searchService.FindPackagesWithAssemblyAsync(
+                    source.Name, assemblyName, cancellationToken).ConfigureAwait(false);
+
+                result.AddRange(packagesWithAssembly);
+            }
+
+            // Ensure the packages are sorted by rank.
+            var sortedPackages = result.ToImmutableArray().Sort();
+
+            return sortedPackages;
+        }
+    }
+}

--- a/src/Features/Core/Portable/AddPackage/AbstractAddSpecificPackageCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddPackage/AbstractAddSpecificPackageCodeFixProvider.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Packaging;
+using Microsoft.CodeAnalysis.SymbolSearch;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+
+namespace Microsoft.CodeAnalysis.AddPackage
+{
+    internal abstract partial class AbstractAddSpecificPackageCodeFixProvider : AbstractAddPackageCodeFixProvider
+    {
+        /// <summary>
+        /// Values for these parameters can be provided (during testing) for mocking purposes.
+        /// </summary> 
+        protected AbstractAddSpecificPackageCodeFixProvider(
+            IPackageInstallerService packageInstallerService = null,
+            ISymbolSearchService symbolSearchService = null)
+            : base(packageInstallerService, symbolSearchService)
+        {
+        }
+
+        protected override bool IncludePrerelease => true;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var cancellationToken = context.CancellationToken;
+            var assemblyName = GetAssemblyName(context.Diagnostics[0].Id);
+
+            if (assemblyName != null)
+            {
+                var assemblyNames = new HashSet<string> { assemblyName };
+                var addPackageCodeActions = await GetAddPackagesCodeActionsAsync(context, assemblyNames).ConfigureAwait(false);
+                context.RegisterFixes(addPackageCodeActions, context.Diagnostics);
+            }
+        }
+
+        protected abstract string GetAssemblyName(string id);
+    }
+}

--- a/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeAction.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeAction.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.AddPackage
             string source,
             string packageName,
             string versionOpt,
+            bool includePrerelease,
             bool isLocal)
         {
             Title = versionOpt == null
@@ -30,7 +31,8 @@ namespace Microsoft.CodeAnalysis.AddPackage
                     : string.Format(FeaturesResources.Install_version_0, versionOpt);
 
             _installPackageOperation = new InstallPackageDirectlyCodeActionOperation(
-                installerService, document, source, packageName, versionOpt, isLocal);
+                installerService, document, source, packageName,
+                versionOpt, includePrerelease, isLocal);
         }
 
         protected override Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeActionOperation.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeActionOperation.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.AddPackage
         private readonly string _source;
         private readonly string _packageName;
         private readonly string _versionOpt;
+        private readonly bool _includePrerelease;
         private readonly bool _isLocal;
         private readonly List<string> _projectsWithMatchingVersion;
 
@@ -30,6 +31,7 @@ namespace Microsoft.CodeAnalysis.AddPackage
             string source,
             string packageName,
             string versionOpt,
+            bool includePrerelease,
             bool isLocal)
         {
             _installerService = installerService;
@@ -37,7 +39,9 @@ namespace Microsoft.CodeAnalysis.AddPackage
             _source = source;
             _packageName = packageName;
             _versionOpt = versionOpt;
+            _includePrerelease = includePrerelease;
             _isLocal = isLocal;
+
             if (versionOpt != null)
             {
                 const int projectsToShow = 5;
@@ -59,10 +63,12 @@ namespace Microsoft.CodeAnalysis.AddPackage
 
         internal override bool ApplyDuringTests => true;
 
-        internal override bool TryApply(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+        internal override bool TryApply(
+            Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             return _installerService.TryInstallPackage(
-                workspace, _document.Id, _source, _packageName, _versionOpt, cancellationToken);
+                workspace, _document.Id, _source, _packageName, 
+                _versionOpt, _includePrerelease, cancellationToken);
         }
     }
 }

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -94,9 +94,11 @@
     <Compile Include="..\..\..\Compilers\Shared\DesktopShim.cs">
       <Link>Shared\Utilities\DesktopShim.cs</Link>
     </Compile>
+    <Compile Include="AddPackage\AbstractAddPackageCodeFixProvider.cs" />
+    <Compile Include="AddPackage\AbstractAddSpecificPackageCodeFixProvider.cs" />
     <Compile Include="AddPackage\InstallPackageDirectlyCodeActionOperation.cs" />
     <Compile Include="AddPackage\InstallWithPackageManagerCodeAction.cs" />
-    <Compile Include="AddMissingReference\InstallPackageParentCodeAction.cs" />
+    <Compile Include="AddPackage\InstallPackageParentCodeAction.cs" />
     <Compile Include="CodeStyle\AbstractCodeStyleDiagnosticAnalyzer.cs" />
     <Compile Include="AddImport\CodeActions\PackageReference.InstallPackageAndAddImportCodeAction.cs" />
     <Compile Include="AddImport\CodeActions\PackageReference.InstallWithPackageManagerCodeAction.cs" />

--- a/src/Features/VisualBasic/Portable/AddPackage/VisualBasicAddSpecificPackageCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/AddPackage/VisualBasicAddSpecificPackageCodeFixProvider.vb
@@ -1,0 +1,26 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.AddPackage
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.AddPackage
+    Friend Class VisualBasicAddSpecificPackageCodeFixProvider
+        Inherits AbstractAddSpecificPackageCodeFixProvider
+
+        Private Const BC37267 As String = NameOf(BC37267) ' Predefined type 'ValueTuple(Of ,)' is not defined or imported.
+
+        Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
+            Get
+                Return ImmutableArray.Create(BC37267)
+            End Get
+        End Property
+
+        Protected Overrides Function GetAssemblyName(id As String) As String
+            Select Case id
+                Case BC37267 : Return "System.ValueTuple"
+            End Select
+
+            Return Nothing
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -78,6 +78,7 @@
     <Compile Include="..\..\..\Compilers\VisualBasic\Portable\Syntax\LambdaUtilities.vb">
       <Link>InternalUtilities\LambdaUtilities.vb</Link>
     </Compile>
+    <Compile Include="AddPackage\VisualBasicAddSpecificPackageCodeFixProvider.vb" />
     <Compile Include="ChangeSignature\ChangeSignatureFormattingRule.vb" />
     <Compile Include="ChangeSignature\UnifiedArgumentSyntax.vb" />
     <Compile Include="ChangeSignature\VisualBasicChangeSignatureService.vb" />

--- a/src/VisualStudio/Core/Def/Packaging/IPackageServicesProxy.cs
+++ b/src/VisualStudio/Core/Def/Packaging/IPackageServicesProxy.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using EnvDTE;
 using NuGet.VisualStudio;
 
@@ -23,6 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
         bool IsPackageInstalled(Project project, string id);
 
         void InstallPackage(string source, Project project, string packageId, string version, bool ignoreDependencies);
+        void InstallLatestPackage(string source, Project project, string packageId, bool includePrerelease, bool ignoreDependencies);
 
         void UninstallPackage(Project project, string packageId, bool removeDependencies);
     }
@@ -38,5 +38,4 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             VersionString = versionString;
         }
     }
-
 }

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -140,6 +141,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             string source,
             string packageName,
             string versionOpt,
+            bool includePrerelease,
             CancellationToken cancellationToken)
         {
             this.AssertIsForeground();
@@ -159,7 +161,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                     var undoManager = _editorAdaptersFactoryService.TryGetUndoManager(
                         workspace, documentId, cancellationToken);
 
-                    return TryInstallAndAddUndoAction(source, packageName, versionOpt, dte, dteProject, undoManager);
+                    return TryInstallAndAddUndoAction(
+                        source, packageName, versionOpt, includePrerelease, dte, dteProject, undoManager);
                 }
             }
 
@@ -170,6 +173,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             string source,
             string packageName,
             string versionOpt,
+            bool includePrerelease,
             EnvDTE.DTE dte,
             EnvDTE.Project dteProject)
         {
@@ -178,7 +182,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 if (!_packageServices.IsPackageInstalled(dteProject, packageName))
                 {
                     dte.StatusBar.Text = string.Format(ServicesVSResources.Installing_0, packageName);
-                    _packageServices.InstallPackage(source, dteProject, packageName, versionOpt, ignoreDependencies: false);
+
+                    if (versionOpt == null)
+                    {
+                        _packageServices.InstallLatestPackage(
+                            source, dteProject, packageName, includePrerelease, ignoreDependencies: false);
+                    }
+                    else
+                    {
+                        _packageServices.InstallPackage(
+                            source, dteProject, packageName, versionOpt, ignoreDependencies: false);
+                    }
 
                     var installedVersion = GetInstalledVersion(packageName, dteProject);
                     dte.StatusBar.Text = string.Format(ServicesVSResources.Installing_0_completed,
@@ -586,6 +600,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             public void InstallPackage(string source, EnvDTE.Project project, string packageId, string version, bool ignoreDependencies)
             {
                 _packageInstaller.InstallPackage(source, project, packageId, version, ignoreDependencies);
+            }
+
+            public void InstallLatestPackage(string source, EnvDTE.Project project, string packageId, bool includePrerelease, bool ignoreDependencies)
+            {
+                // Use reflection until the 3.5.0 version of NuGet.VisualStudio is released
+                // publicly.  Then we call into this method directly.
+                var installLatestPackageInfo = _packageInstaller.GetType().GetMethod(
+                    nameof(InstallLatestPackage), BindingFlags.Public | BindingFlags.Instance);
+
+                if (installLatestPackageInfo != null)
+                {
+                    installLatestPackageInfo.Invoke(_packageInstaller,
+                        new object[] { source, project, packageId, includePrerelease, ignoreDependencies });
+                }
             }
 
             public event EventHandler SourcesChanged

--- a/src/Workspaces/Core/Desktop/SymbolSearch/SymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Desktop/SymbolSearch/SymbolSearchUpdateEngine.cs
@@ -108,7 +108,25 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             return Task.FromResult(result.ToImmutableAndFree());
         }
 
-        public Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+        public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
+            string source, string assemblyName)
+        {
+            var result = await FindPackagesWithAssemblyWorkerAsync(source, assemblyName).ConfigureAwait(false);
+
+#if DEBUG
+            // For testing purposes, we hardcode this in if we're in DEBUG mode.
+            if (result.Length == 0 &&
+                source == NugetOrgSource &&
+                assemblyName == "System.ValueTuple")
+            {
+                return ImmutableArray.Create(new PackageWithAssemblyResult("System.ValueTuple", "", rank: 0));
+            }
+#endif
+
+            return result;
+        }
+
+        public Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyWorkerAsync(
             string source, string assemblyName)
         {
             if (!_sourceToDatabase.TryGetValue(source, out var databaseWrapper))

--- a/src/Workspaces/Core/Portable/Packaging/IPackageInstallerService.cs
+++ b/src/Workspaces/Core/Portable/Packaging/IPackageInstallerService.cs
@@ -15,7 +15,10 @@ namespace Microsoft.CodeAnalysis.Packaging
 
         bool IsInstalled(Workspace workspace, ProjectId projectId, string packageName);
 
-        bool TryInstallPackage(Workspace workspace, DocumentId documentId, string source, string packageName, string versionOpt, CancellationToken cancellationToken);
+        bool TryInstallPackage(Workspace workspace, DocumentId documentId,
+            string source, string packageName, 
+            string versionOpt, bool includePrerelease,
+            CancellationToken cancellationToken);
 
         ImmutableArray<string> GetInstalledVersions(string packageName);
 


### PR DESCRIPTION
This is a port of https://github.com/dotnet/roslyn/pull/15014 to RC2.