### PR TITLE
Always locate csc/vbc/csi from 32-bit MSBuild

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -154,7 +154,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         internal static string GenerateFullPathToMSBuildRoslynTool(string toolName)
         {
-            var pathToBuildTools = ToolLocationHelper.GetPathToBuildTools(ToolLocationHelper.CurrentToolsVersion);
+            // The Roslyn folder is a subfolder of the MSBuildToolsPath, but isn't duplicated
+            // in the amd64 MSBuild folder, so specify the parent (32-bit) folder.
+            var pathToBuildTools = ToolLocationHelper.GetPathToBuildTools(ToolLocationHelper.CurrentToolsVersion,
+                DotNetFrameworkArchitecture.Bitness32);
 
             if (null != pathToBuildTools)
             {


### PR DESCRIPTION
@OmarTawfik I think this'll fix the problem I'm currently seeing with 64-bit MSBuild.