### PR TITLE
always save changes to unopened documents

### DIFF
--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -134,9 +134,9 @@ namespace Microsoft.VisualStudio.LanguageServices
 
         internal override IInvisibleEditor OpenInvisibleEditor(IVisualStudioHostDocument hostDocument)
         {
-            // We need to ensure the file is saved, only if a global undo transaction is open
+            // We need to ensure the file is saved if a global undo transaction is open or the document is not open in the editor
             var globalUndoService = this.Services.GetService<IGlobalUndoService>();
-            var needsSave = globalUndoService.IsGlobalTransactionOpen(this);
+            var needsSave = globalUndoService.IsGlobalTransactionOpen(this) || !hostDocument.IsOpen;
 
             var needsUndoDisabled = false;
             if (needsSave)


### PR DESCRIPTION
This fixes a bug found when investigating #12531 

This change makes it so InvisibleEditor's created via the vs workspace will always be set to save the document if the document is not open in the editor. 

The problem this is fixing is one where an edit is made to just a single closed document.  In this case we were failing to call SaveDocuments on the running document table.  We generally only called SaveDocuments if there is a global undo transaction in effect, and there is only a global undo transaction if there is more than one document involved. Except closed documents cannot be saved manually by the user as they don't correspond to an open text buffer in the editor.

@dotnet/roslyn-ide please review