### PR TITLE
Discard in deconstruction and out var 

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 var pending = (BoundDiscardedExpression)variable.Single;
                                 if ((object)pending.Type == null)
                                 {
-                                    variables[i] = new DeconstructionVariable(pending.Update(foundTypes[i]), pending.Syntax);
+                                    variables[i] = new DeconstructionVariable(pending.SetInferredType(foundTypes[i]), pending.Syntax);
                                 }
                             }
                             break;
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if ((object)pending.Type == null)
                             {
                                 Error(diagnostics, ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, pending.Syntax, "_");
-                                variables[i] = new DeconstructionVariable(pending.Update(CreateErrorType("var")), pending.Syntax);
+                                variables[i] = new DeconstructionVariable(pending.FailInference(this, diagnostics), pending.Syntax);
                             }
                             break;
                     }
@@ -761,6 +761,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)declType != null)
             {
                 TypeSymbol fieldType = field.GetFieldType(this.FieldsBeingBound);
+                Debug.Assert(declType == fieldType);
                 return new BoundFieldAccess(designation,
                                             receiver,
                                             field,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var right = node.Right;
 
             bool isDeclaration = node.IsDeconstructionDeclaration();
-            Debug.Assert(isDeclaration || DeconstructionIsAssignment(left));
+            Debug.Assert(isDeclaration || !ContainsDeclarations(left));
             return BindDeconstruction(node, left, right, diagnostics, isDeclaration);
         }
 
@@ -45,20 +45,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        /// <summary>
-        /// Checks that the expression doesn't contain any declaration expressions.
-        /// </summary>
-        private bool DeconstructionIsAssignment(ExpressionSyntax expression)
+        private static bool ContainsDeclarations(ExpressionSyntax expression)
         {
             switch (expression.Kind())
             {
                 case SyntaxKind.DeclarationExpression:
-                    return false;
+                    return true;
                 case SyntaxKind.TupleExpression:
                     var tuple = (TupleExpressionSyntax)expression;
-                    return tuple.Arguments.All(a => DeconstructionIsAssignment(a.Expression));
+                    return tuple.Arguments.Any(a => ContainsDeclarations(a.Expression));
                 default:
-                    return true;
+                    return false;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
-using System;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -25,37 +25,40 @@ namespace Microsoft.CodeAnalysis.CSharp
             var left = node.Left;
             var right = node.Right;
 
-            if (node.IsDeconstructionDeclaration())
-            {
-                return BindDeconstructionDeclaration(node, left, right, diagnostics);
-            }
+            bool isDeclaration = node.IsDeconstructionDeclaration();
+            Debug.Assert(isDeclaration || DeconstructionIsAssignment(left));
+            return BindDeconstruction(node, left, right, diagnostics, isDeclaration);
+        }
 
-            AssertDeconstructionIsAssignment(left);
-
-            var tuple = (TupleExpressionSyntax)left;
-            ArrayBuilder<DeconstructionVariable> checkedVariables = BindDeconstructionAssignmentVariables(tuple.Arguments, tuple, diagnostics);
-            var result = BindDeconstructionAssignment(node, node.Right, checkedVariables, diagnostics, isDeclaration: false);
-            FreeDeconstructionVariables(checkedVariables);
+        internal BoundDeconstructionAssignmentOperator BindDeconstruction(
+                                                            CSharpSyntaxNode node,
+                                                            ExpressionSyntax left,
+                                                            ExpressionSyntax right,
+                                                            DiagnosticBag diagnostics,
+                                                            bool isDeclaration,
+                                                            BoundDeconstructValuePlaceholder rightPlaceholder = null)
+        {
+            DeconstructionVariable locals = BindDeconstructionVariables(left, isDeclaration, diagnostics);
+            Debug.Assert(locals.HasNestedVariables);
+            var result = BindDeconstructionAssignment(node, right, locals.NestedVariables, diagnostics, rhsPlaceholder: rightPlaceholder);
+            FreeDeconstructionVariables(locals.NestedVariables);
             return result;
         }
 
-        [Conditional("DEBUG")]
-        private void AssertDeconstructionIsAssignment(ExpressionSyntax expression)
+        /// <summary>
+        /// Checks that the expression doesn't contain any declaration expressions.
+        /// </summary>
+        private bool DeconstructionIsAssignment(ExpressionSyntax expression)
         {
             switch (expression.Kind())
             {
                 case SyntaxKind.DeclarationExpression:
-                    Debug.Assert(false);
-                    break;
+                    return false;
                 case SyntaxKind.TupleExpression:
                     var tuple = (TupleExpressionSyntax)expression;
-                    foreach (var arg in tuple.Arguments)
-                    {
-                        AssertDeconstructionIsAssignment(arg.Expression);
-                    }
-                    break;
+                    return tuple.Arguments.All(a => DeconstructionIsAssignment(a.Expression));
                 default:
-                    return;
+                    return true;
             }
         }
 
@@ -84,7 +87,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                         ExpressionSyntax right,
                                                         ArrayBuilder<DeconstructionVariable> checkedVariables,
                                                         DiagnosticBag diagnostics,
-                                                        bool isDeclaration,
                                                         BoundDeconstructValuePlaceholder rhsPlaceholder = null)
         {
             // receiver for first Deconstruct step
@@ -98,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 FailRemainingInferences(checkedVariables, diagnostics);
 
                 return new BoundDeconstructionAssignmentOperator(
-                            node, isDeclaration, FlattenDeconstructVariables(checkedVariables), boundRHS,
+                            node, FlattenDeconstructVariables(checkedVariables), boundRHS,
                             ImmutableArray<BoundDeconstructionDeconstructStep>.Empty,
                             ImmutableArray<BoundDeconstructionAssignmentStep>.Empty,
                             ImmutableArray<BoundDeconstructionAssignmentStep>.Empty,
@@ -110,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var deconstructionSteps = ArrayBuilder<BoundDeconstructionDeconstructStep>.GetInstance(1);
             var conversionSteps = ArrayBuilder<BoundDeconstructionAssignmentStep>.GetInstance(1);
             var assignmentSteps = ArrayBuilder<BoundDeconstructionAssignmentStep>.GetInstance(1);
-            var constructionStepsOpt = isDeclaration ? null : ArrayBuilder<BoundDeconstructionConstructionStep>.GetInstance(1);
+            var constructionStepsOpt = ArrayBuilder<BoundDeconstructionConstructionStep>.GetInstance(1);
 
             bool hasErrors = !DeconstructIntoSteps(
                                     new BoundDeconstructValuePlaceholder(boundRHS.Syntax, boundRHS.Type),
@@ -122,21 +124,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     assignmentSteps,
                                     constructionStepsOpt);
 
-            TypeSymbol returnType = isDeclaration ?
-                                            GetSpecialType(SpecialType.System_Void, diagnostics, node) :
-                                            hasErrors ?
-                                                CreateErrorType() :
-                                                constructionStepsOpt.Last().OutputPlaceholder.Type;
+            TypeSymbol returnType = hasErrors ?
+                                        CreateErrorType() :
+                                        constructionStepsOpt.Last().OutputPlaceholder.Type;
 
             var deconstructions = deconstructionSteps.ToImmutableAndFree();
             var conversions = conversionSteps.ToImmutableAndFree();
             var assignments = assignmentSteps.ToImmutableAndFree();
-            var constructions = isDeclaration ? default(ImmutableArray<BoundDeconstructionConstructionStep>) : constructionStepsOpt.ToImmutableAndFree();
+            var constructions = constructionStepsOpt.ToImmutableAndFree();
 
             FailRemainingInferences(checkedVariables, diagnostics);
 
             return new BoundDeconstructionAssignmentOperator(
-                            node, isDeclaration, FlattenDeconstructVariables(checkedVariables), boundRHS,
+                            node, FlattenDeconstructVariables(checkedVariables), boundRHS,
                             deconstructions, conversions, assignments, constructions, returnType, hasErrors: hasErrors);
         }
 
@@ -496,38 +496,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Returns a list of variables, where some may be nested variables (BoundDeconstructionVariables).
-        /// Checks that all the variables are assignable to.
-        /// The caller is responsible for releasing the nested ArrayBuilders.
-        /// </summary>
-        private ArrayBuilder<DeconstructionVariable> BindDeconstructionAssignmentVariables(SeparatedSyntaxList<ArgumentSyntax> arguments, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
-        {
-            int numElements = arguments.Count;
-            Debug.Assert(numElements >= 2); // this should not have parsed as a tuple.
-
-            // bind the variables and check they can be assigned to
-            var checkedVariablesBuilder = ArrayBuilder<DeconstructionVariable>.GetInstance(numElements);
-
-            foreach (var argument in arguments)
-            {
-                if (argument.Expression.Kind() == SyntaxKind.TupleExpression) // nested tuple case
-                {
-                    var nested = (TupleExpressionSyntax)argument.Expression;
-                    checkedVariablesBuilder.Add(new DeconstructionVariable(BindDeconstructionAssignmentVariables(nested.Arguments, nested, diagnostics), syntax));
-                }
-                else
-                {
-                    var boundVariable = BindExpression(argument.Expression, diagnostics, invoked: false, indexed: false);
-                    var checkedVariable = CheckValue(boundVariable, BindValueKind.Assignment, diagnostics);
-
-                    checkedVariablesBuilder.Add(new DeconstructionVariable(checkedVariable, argument));
-                }
-            }
-
-            return checkedVariablesBuilder;
-        }
-
-        /// <summary>
         /// Figures out how to assign from inputPlaceholder into receivingVariable and bundles the information (leaving holes for the actual source and receiver) into an AssignmentInfo.
         /// </summary>
         private BoundDeconstructionAssignmentStep MakeDeconstructionAssignmentStep(
@@ -668,31 +636,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return BadExpression(syntax, childNode);
         }
 
-        internal BoundDeconstructionAssignmentOperator BindDeconstructionDeclaration(CSharpSyntaxNode node, ExpressionSyntax declaration, ExpressionSyntax right,
-                                                        DiagnosticBag diagnostics, BoundDeconstructValuePlaceholder rightPlaceholder = null)
-        {
-            DeconstructionVariable locals = BindDeconstructionDeclarationVariables(declaration, diagnostics);
-            Debug.Assert(locals.HasNestedVariables);
-            var result = BindDeconstructionAssignment(node, right, locals.NestedVariables, diagnostics, isDeclaration: true, rhsPlaceholder: rightPlaceholder);
-            FreeDeconstructionVariables(locals.NestedVariables);
-            return result;
-        }
-
         /// <summary>
-        /// Prepares locals (or fields in global statement) corresponding to the variables of the declaration.
-        /// The locals/fields are kept in a tree which captures the nesting of variables.
-        /// Each local or field is either a simple local or field access (when its type is known) or a deconstruction variable pending inference.
+        /// Returns bound variables in a tree.
+        /// For variables that are being declared, it makes locals (or fields in global statement).
+        /// If the type is unknown, a deconstruction variable pending inference is used instead (which will be replaced with a local or field later).
+        /// For expressions that don't declare variables, simply binds them and verify they are assignable to.
+        ///
         /// The caller is responsible for releasing the nested ArrayBuilders.
         /// </summary>
-        private DeconstructionVariable BindDeconstructionDeclarationVariables(
-            ExpressionSyntax node,
-            DiagnosticBag diagnostics)
+        private DeconstructionVariable BindDeconstructionVariables(ExpressionSyntax node, bool isDeclaration, DiagnosticBag diagnostics)
         {
             switch (node.Kind())
             {
                 case SyntaxKind.DeclarationExpression:
                     {
                         var component = (DeclarationExpressionSyntax)node;
+
                         bool isVar;
                         bool isConst = false;
                         AliasSymbol alias;
@@ -704,7 +663,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             Error(diagnostics, ErrorCode.ERR_DeconstructionVarFormDisallowsSpecificType, component.Designation);
                         }
 
-                        return BindDeconstructionDeclarationVariables(declType, component.Designation, diagnostics);
+                        return BindDeconstructionVariables(declType, component.Designation, diagnostics);
                     }
                 case SyntaxKind.TupleExpression:
                     {
@@ -712,17 +671,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var builder = ArrayBuilder<DeconstructionVariable>.GetInstance(component.Arguments.Count);
                         foreach (var arg in component.Arguments)
                         {
-                            builder.Add(BindDeconstructionDeclarationVariables(arg.Expression, diagnostics));
+                            builder.Add(BindDeconstructionVariables(arg.Expression, isDeclaration, diagnostics));
                         }
 
                         return new DeconstructionVariable(builder, node);
                     }
                 default:
-                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
+                    {
+                        var boundVariable = BindExpression(node, diagnostics, invoked: false, indexed: false);
+                        if (isDeclaration && boundVariable.Kind != BoundKind.DiscardedExpression )
+                        {
+                            Error(diagnostics, ErrorCode.ERR_MixedDeconstructionDisallowed, node, node);
+                        }
+                        var checkedVariable = CheckValue(boundVariable, BindValueKind.Assignment, diagnostics);
+                        return new DeconstructionVariable(checkedVariable, node);
+                    }
             }
         }
 
-        private DeconstructionVariable BindDeconstructionDeclarationVariables(
+        private DeconstructionVariable BindDeconstructionVariables(
             TypeSymbol declType,
             VariableDesignationSyntax node,
             DiagnosticBag diagnostics)
@@ -732,12 +699,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.SingleVariableDesignation:
                     {
                         var single = (SingleVariableDesignationSyntax)node;
-                        return new DeconstructionVariable(BindDeconstructionDeclarationVariable(declType, single, diagnostics), node);
+                        return new DeconstructionVariable(BindDeconstructionVariable(declType, single, diagnostics), node);
                     }
                 case SyntaxKind.DiscardedDesignation:
                     {
                         var discarded = (DiscardedDesignationSyntax)node;
-                        return new DeconstructionVariable(BindDiscardedExpression(discarded, declType), node);
+                        return new DeconstructionVariable(new BoundDiscardedExpression(discarded, declType), node);
                     }
                 case SyntaxKind.ParenthesizedVariableDesignation:
                     {
@@ -745,7 +712,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var builder = ArrayBuilder<DeconstructionVariable>.GetInstance();
                         foreach (var n in tuple.Variables)
                         {
-                            builder.Add(BindDeconstructionDeclarationVariables(declType, n, diagnostics));
+                            builder.Add(BindDeconstructionVariables(declType, n, diagnostics));
                         }
                         return new DeconstructionVariable(builder, node);
                     }
@@ -754,19 +721,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundDiscardedExpression BindDiscardedExpression(
-            DiscardedDesignationSyntax designation,
-            TypeSymbol declType)
-        {
-            return new BoundDiscardedExpression(designation, declType);
-        }
-
         /// <summary>
         /// In embedded statements, returns a BoundLocal when the type was explicit.
         /// In global statements, returns a BoundFieldAccess when the type was explicit.
         /// Otherwise returns a DeconstructionVariablePendingInference when the type is implicit.
         /// </summary>
-        private BoundExpression BindDeconstructionDeclarationVariable(
+        private BoundExpression BindDeconstructionVariable(
             TypeSymbol declType,
             SingleVariableDesignationSyntax designation,
             DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1142,7 +1142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                if (FallBackOnDiscard(node, diagnostics))
+                if (node.IsKind(SyntaxKind.IdentifierName) && FallBackOnDiscard((IdentifierNameSyntax)node, diagnostics))
                 {
                     return new BoundDiscardedExpression(node, type: null);
                 }
@@ -1174,9 +1174,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Is this is an _ identifier in a context where discards are allowed?
         /// </summary>
-        private static bool FallBackOnDiscard(SimpleNameSyntax node, DiagnosticBag diagnostics)
+        private static bool FallBackOnDiscard(IdentifierNameSyntax node, DiagnosticBag diagnostics)
         {
-            if (!node.IsKind(SyntaxKind.IdentifierName) || node.Identifier.ContextualKind() != SyntaxKind.UnderscoreToken)
+            if (node.Identifier.ContextualKind() != SyntaxKind.UnderscoreToken)
             {
                 return false;
             }
@@ -1190,13 +1190,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node.Identifier.ContextualKind() == SyntaxKind.UnderscoreToken);
 
             CSharpSyntaxNode parent = node.Parent;
-            return parent?.Kind() == SyntaxKind.Argument &&
-                ((ArgumentSyntax)parent).RefOrOutKeyword.Kind() == SyntaxKind.OutKeyword &&
-                (parent = parent.Parent)?.Kind() == SyntaxKind.ArgumentList &&
-                ((parent = parent.Parent)?.Kind() == SyntaxKind.InvocationExpression ||
-                    parent?.Kind() == SyntaxKind.ObjectCreationExpression ||
-                    parent?.Kind() == SyntaxKind.BaseConstructorInitializer ||
-                    parent?.Kind() == SyntaxKind.ThisConstructorInitializer);
+            if (parent?.Kind() != SyntaxKind.Argument ||
+                ((ArgumentSyntax)parent).RefOrOutKeyword.Kind() != SyntaxKind.OutKeyword)
+            {
+                return false;
+            }
+
+            parent = parent.Parent;
+            if (parent?.Kind() == SyntaxKind.BracketedArgumentList)
+            {
+                return true;
+            }
+
+            if (parent?.Kind() == SyntaxKind.ArgumentList)
+            {
+                parent = parent.Parent;
+                return parent?.Kind() == SyntaxKind.InvocationExpression ||
+                        parent?.Kind() == SyntaxKind.ObjectCreationExpression ||
+                        parent?.Kind() == SyntaxKind.BaseConstructorInitializer ||
+                        parent?.Kind() == SyntaxKind.ThisConstructorInitializer;
+            }
+
+            return false;
         }
 
         private BoundExpression SynthesizeMethodGroupReceiver(CSharpSyntaxNode syntax, ArrayBuilder<Symbol> members)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2397,11 +2397,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     TypeSymbol parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
                     arguments[arg] = ((OutDeconstructVarPendingInference)argument).SetInferredType(parameterType, success: true);
                 }
-                else if (argument.Kind == BoundKind.DiscardedExpression && (object)argument.Type == null)
+                else if (argument.Kind == BoundKind.DiscardedExpression && !argument.HasExpressionType())
                 {
                     TypeSymbol parameterType = GetCorrespondingParameterType(ref result, parameters, arg);
                     Debug.Assert((object)parameterType != null);
-                    arguments[arg] = ((BoundDiscardedExpression)argument).Update(parameterType);
+                    arguments[arg] = ((BoundDiscardedExpression)argument).SetInferredType(parameterType);
                 }
             }
         }
@@ -6228,6 +6228,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (index.Kind == BoundKind.OutVariablePendingInference)
             {
                 return ((OutVariablePendingInference)index).FailInference(this, diagnostics);
+            }
+            else if (index.Kind == BoundKind.DiscardedExpression && !index.HasExpressionType())
+            {
+                return ((BoundDiscardedExpression)index).FailInference(this, diagnostics);
             }
 
             var result =

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1190,28 +1190,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node.Identifier.ContextualKind() == SyntaxKind.UnderscoreToken);
 
             CSharpSyntaxNode parent = node.Parent;
-            if (parent?.Kind() != SyntaxKind.Argument ||
-                ((ArgumentSyntax)parent).RefOrOutKeyword.Kind() != SyntaxKind.OutKeyword)
-            {
-                return false;
-            }
-
-            parent = parent.Parent;
-            if (parent?.Kind() == SyntaxKind.BracketedArgumentList)
-            {
-                return true;
-            }
-
-            if (parent?.Kind() == SyntaxKind.ArgumentList)
-            {
-                parent = parent.Parent;
-                return parent?.Kind() == SyntaxKind.InvocationExpression ||
-                        parent?.Kind() == SyntaxKind.ObjectCreationExpression ||
-                        parent?.Kind() == SyntaxKind.BaseConstructorInitializer ||
-                        parent?.Kind() == SyntaxKind.ThisConstructorInitializer;
-            }
-
-            return false;
+            return (parent?.Kind() == SyntaxKind.Argument &&
+                ((ArgumentSyntax)parent).RefOrOutKeyword.Kind() == SyntaxKind.OutKeyword);
         }
 
         private BoundExpression SynthesizeMethodGroupReceiver(CSharpSyntaxNode syntax, ArrayBuilder<Symbol> members)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1192,8 +1192,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                             break;
                         }
                     case BoundKind.OutVariablePendingInference:
-                    case BoundKind.DiscardedExpression when !argument.HasExpressionType():
+                    case BoundKind.DiscardedExpression:
                         {
+                            if (argument.HasExpressionType())
+                            {
+                                break;
+                            }
+
                             // See if all applicable applicable parameters have the same type
                             TypeSymbol candidateType = null;
                             foreach (var parameterList in parameterListList)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -114,7 +114,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             boundExpression.WasCompilerGenerated = true;
 
             var analyzedArguments = AnalyzedArguments.GetInstance();
-            Debug.Assert(!args.Any(e => e.Kind == BoundKind.OutVariablePendingInference || e.Kind == BoundKind.OutDeconstructVarPendingInference));
+            Debug.Assert(!args.Any(e => e.Kind == BoundKind.OutVariablePendingInference ||
+                                        e.Kind == BoundKind.OutDeconstructVarPendingInference ||
+                                        e.Kind == BoundKind.DiscardedExpression && !e.HasExpressionType()));
             analyzedArguments.Arguments.AddRange(args);
             BoundExpression result = BindInvocationExpression(
                 node, node, methodName, boundExpression, analyzedArguments, diagnostics, queryClause,
@@ -336,7 +338,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(arguments.Arguments[i].Kind != BoundKind.OutDeconstructVarPendingInference);
 
-                if (arguments.Arguments[i].Kind == BoundKind.OutVariablePendingInference)
+                if (arguments.Arguments[i].Kind == BoundKind.OutVariablePendingInference ||
+                    arguments.Arguments[i].Kind == BoundKind.DiscardedExpression && !arguments.Arguments[i].HasExpressionType())
                 {
                     var builder = ArrayBuilder<BoundExpression>.GetInstance(arguments.Arguments.Count);
                     builder.AddRange(arguments.Arguments);
@@ -348,6 +351,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (argument.Kind == BoundKind.OutVariablePendingInference)
                         {
                             builder[i] = ((OutVariablePendingInference)argument).FailInference(this, diagnostics);
+                        }
+                        else if (argument.Kind == BoundKind.DiscardedExpression && !argument.HasExpressionType())
+                        {
+                            builder[i] = ((BoundDiscardedExpression)argument).FailInference(this, diagnostics);
                         }
 
                         i++;
@@ -1185,6 +1192,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             break;
                         }
                     case BoundKind.OutVariablePendingInference:
+                    case BoundKind.DiscardedExpression when !argument.HasExpressionType():
                         {
                             // See if all applicable applicable parameters have the same type
                             TypeSymbol candidateType = null;
@@ -1206,13 +1214,27 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 }
                             }
 
-                            if ((object)candidateType == null)
+                            if (argument.Kind == BoundKind.OutVariablePendingInference)
                             {
-                                newArguments[i] = ((OutVariablePendingInference)argument).FailInference(this, null);
+                                if ((object)candidateType == null)
+                                {
+                                    newArguments[i] = ((OutVariablePendingInference)argument).FailInference(this, null);
+                                }
+                                else
+                                {
+                                    newArguments[i] = ((OutVariablePendingInference)argument).SetInferredType(candidateType, null);
+                                }
                             }
-                            else
+                            else if (argument.Kind == BoundKind.DiscardedExpression)
                             {
-                                newArguments[i] = ((OutVariablePendingInference)argument).SetInferredType(candidateType, null);
+                                if ((object)candidateType == null)
+                                {
+                                    newArguments[i] = ((BoundDiscardedExpression)argument).FailInference(this, null);
+                                }
+                                else
+                                {
+                                    newArguments[i] = ((BoundDiscardedExpression)argument).SetInferredType(candidateType);
+                                }
                             }
 
                             break;
@@ -1220,11 +1242,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BoundKind.OutDeconstructVarPendingInference:
                         {
                             newArguments[i] = ((OutDeconstructVarPendingInference)argument).FailInference(this);
-                            break;
-                        }
-                    case BoundKind.DiscardedExpression:
-                        {
-                            newArguments[i] = ((BoundDiscardedExpression)argument).Update(CreateErrorType("var"));
                             break;
                         }
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -590,7 +590,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(
                 declarationNode is VariableDesignationSyntax ||
                 declarationNode.Kind() == SyntaxKind.VariableDeclaration ||
-                declarationNode.Kind() == SyntaxKind.DeclarationExpression);
+                declarationNode.Kind() == SyntaxKind.DeclarationExpression ||
+                declarationNode.Kind() == SyntaxKind.DiscardedDesignation);
 
             // If the type is "var" then suppress errors when binding it. "var" might be a legal type
             // or it might not; if it is not then we do not want to report an error. If it is, then
@@ -1715,7 +1716,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             var op1 = BindValue(node.Left, diagnostics, BindValueKind.Assignment); // , BIND_MEMBERSET);
             var op2 = BindValue(node.Right, diagnostics, BindValueKind.RValue); // , BIND_RVALUEREQUIRED);
 
+            if (op1.Kind == BoundKind.DiscardedExpression)
+            {
+                op1 = InferTypeForDiscard((BoundDiscardedExpression)op1, op2, diagnostics);
+            }
+
             return BindAssignment(node, op1, op2, diagnostics);
+        }
+
+        private static BoundExpression InferTypeForDiscard(BoundDiscardedExpression op1, BoundExpression op2, DiagnosticBag diagnostics)
+        {
+            if (op2.Type == null)
+            {
+                Error(diagnostics, ErrorCode.ERR_DiscardVariableAssignedBadValue, op1.Syntax, op2.Syntax);
+                return new BoundDiscardedExpression(op2.Syntax, type: null, hasErrors: true);
+            }
+            else
+            {
+                return op1.Update(op2.Type);
+            }
         }
 
         private BoundAssignmentOperator BindAssignment(SyntaxNode node, BoundExpression op1, BoundExpression op2, DiagnosticBag diagnostics)
@@ -1848,6 +1867,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.OutVariablePendingInference:
                 case BoundKind.OutDeconstructVarPendingInference:
                     Debug.Assert(valueKind == BindValueKind.RefOrOut);
+                    return expr;
+                case BoundKind.DiscardedExpression:
+                    Debug.Assert(valueKind == BindValueKind.Assignment);
                     return expr;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1724,12 +1724,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return BindAssignment(node, op1, op2, diagnostics);
         }
 
-        private static BoundExpression InferTypeForDiscard(BoundDiscardedExpression op1, BoundExpression op2, DiagnosticBag diagnostics)
+        private BoundExpression InferTypeForDiscard(BoundDiscardedExpression op1, BoundExpression op2, DiagnosticBag diagnostics)
         {
             if (op2.Type == null)
             {
-                Error(diagnostics, ErrorCode.ERR_DiscardVariableAssignedBadValue, op1.Syntax, op2.Syntax);
-                return new BoundDiscardedExpression(op2.Syntax, type: null, hasErrors: true);
+                Error(diagnostics, ErrorCode.ERR_DiscardVariableAssignedBadValue, op1.Syntax, op2.Display);
+                return op1.Update(this.CreateErrorType("var"));
             }
             else
             {
@@ -1869,7 +1869,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(valueKind == BindValueKind.RefOrOut);
                     return expr;
                 case BoundKind.DiscardedExpression:
-                    Debug.Assert(valueKind == BindValueKind.Assignment);
+                    Debug.Assert(valueKind == BindValueKind.Assignment || valueKind == BindValueKind.RefOrOut);
                     return expr;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1728,12 +1728,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (op2.Type == null)
             {
-                Error(diagnostics, ErrorCode.ERR_DiscardVariableAssignedBadValue, op1.Syntax, op2.Display);
-                return op1.Update(this.CreateErrorType("var"));
+                return op1.FailInference(this, diagnostics);
             }
             else
             {
-                return op1.Update(op2.Type);
+                return op1.SetInferredType(op2.Type);
             }
         }
 
@@ -1868,6 +1867,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.OutDeconstructVarPendingInference:
                     Debug.Assert(valueKind == BindValueKind.RefOrOut);
                     return expr;
+
                 case BoundKind.DiscardedExpression:
                     Debug.Assert(valueKind == BindValueKind.Assignment || valueKind == BindValueKind.RefOrOut);
                     return expr;

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitAssignmentExpression(AssignmentExpressionSyntax node)
         {
-            if (node.IsDeconstructionDeclaration())
+            if (node.Left.IsKind(SyntaxKind.TupleExpression) || node.Left.IsKind(SyntaxKind.DeclarationExpression))
             {
                 CollectVariablesFromDeconstruction(node.Left, node);
             }
@@ -304,7 +304,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
                     }
                 default:
-                    throw ExceptionUtilities.UnexpectedValue(declaration.Kind());
+                    Visit(declaration);
+                    break;
             }
         }
 
@@ -334,6 +335,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         break;
                     }
+                case SyntaxKind.DiscardedDesignation:
+                    break;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(designation.Kind());
             }

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -96,6 +96,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         break;
                     }
+                case SyntaxKind.IdentifierName:
+                    break;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(declaration.Kind());
             }
@@ -134,6 +136,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         break;
                     }
+                case SyntaxKind.DiscardedDesignation:
+                    break;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(designation.Kind());
             }
@@ -162,12 +166,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ExpressionSyntax variables = ((ForEachVariableStatementSyntax)_syntax).Variable;
             var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, inferredType ?? CreateErrorType("var"));
-            BoundDeconstructionAssignmentOperator deconstruction = BindDeconstructionDeclaration(
+            BoundDeconstructionAssignmentOperator deconstruction = BindDeconstruction(
                                                                     variables,
                                                                     variables,
                                                                     right: null,
                                                                     diagnostics: diagnostics,
+                                                                    isDeclaration: true,
                                                                     rightPlaceholder: valuePlaceholder);
+
             return new BoundExpressionStatement(_syntax, deconstruction);
         }
 
@@ -228,11 +234,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         var variables = node.Variable;
                         var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, iterationVariableType);
-                        BoundDeconstructionAssignmentOperator deconstruction = BindDeconstructionDeclaration(
+                        BoundDeconstructionAssignmentOperator deconstruction = BindDeconstruction(
                                                                                 variables,
                                                                                 variables,
                                                                                 right: null,
                                                                                 diagnostics: diagnostics,
+                                                                                isDeclaration: true,
                                                                                 rightPlaceholder: valuePlaceholder);
 
                         deconstructStep = new BoundForEachDeconstructStep(variables, deconstruction, valuePlaceholder);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1793,7 +1793,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             var lambdaOpt = node as UnboundLambda;
 
             var nodeKind = node.Kind;
-            if (nodeKind == BoundKind.OutVariablePendingInference || nodeKind == BoundKind.OutDeconstructVarPendingInference)
+            if (nodeKind == BoundKind.OutVariablePendingInference ||
+                nodeKind == BoundKind.OutDeconstructVarPendingInference ||
+                nodeKind == BoundKind.DiscardedExpression)
             {
                 // Neither conversion from expression is better when the argument is an implicitly-typed out variable declaration.
                 okToDowngradeToNeither = false;
@@ -2970,7 +2972,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return Conversion.ImplicitDynamic;
             }
 
-            if (argument.Kind == BoundKind.OutVariablePendingInference || argument.Kind == BoundKind.OutDeconstructVarPendingInference)
+            if (argument.Kind == BoundKind.OutVariablePendingInference ||
+                argument.Kind == BoundKind.OutDeconstructVarPendingInference ||
+                argument.Kind == BoundKind.DiscardedExpression)
             {
                 Debug.Assert(argRefKind != RefKind.None);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1795,7 +1795,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var nodeKind = node.Kind;
             if (nodeKind == BoundKind.OutVariablePendingInference ||
                 nodeKind == BoundKind.OutDeconstructVarPendingInference ||
-                nodeKind == BoundKind.DiscardedExpression)
+                (nodeKind == BoundKind.DiscardedExpression && (object)node.Type == null))
             {
                 // Neither conversion from expression is better when the argument is an implicitly-typed out variable declaration.
                 okToDowngradeToNeither = false;
@@ -2972,9 +2972,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return Conversion.ImplicitDynamic;
             }
 
+            var argType = argument.Type;
             if (argument.Kind == BoundKind.OutVariablePendingInference ||
                 argument.Kind == BoundKind.OutDeconstructVarPendingInference ||
-                argument.Kind == BoundKind.DiscardedExpression)
+                (argument.Kind == BoundKind.DiscardedExpression && (object)argType == null))
             {
                 Debug.Assert(argRefKind != RefKind.None);
 
@@ -2989,7 +2990,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return conversion;
             }
 
-            var argType = argument.Type;
             if ((object)argType != null && Conversions.HasIdentityConversion(argType, parameterType))
             {
                 return Conversion.Identity;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1795,7 +1795,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var nodeKind = node.Kind;
             if (nodeKind == BoundKind.OutVariablePendingInference ||
                 nodeKind == BoundKind.OutDeconstructVarPendingInference ||
-                (nodeKind == BoundKind.DiscardedExpression && (object)node.Type == null))
+                (nodeKind == BoundKind.DiscardedExpression && !node.HasExpressionType()))
             {
                 // Neither conversion from expression is better when the argument is an implicitly-typed out variable declaration.
                 okToDowngradeToNeither = false;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -921,7 +921,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // If the expression is untyped because it is a lambda, anonymous method, method group or null
             // then we never want to report the error "you need a ref on that thing". Rather, we want to
             // say that you can't convert "null" to "ref int".
-            if (!argument.HasExpressionType() && argument.Kind != BoundKind.OutDeconstructVarPendingInference && argument.Kind != BoundKind.OutVariablePendingInference)
+            if (!argument.HasExpressionType() &&
+                argument.Kind != BoundKind.OutDeconstructVarPendingInference &&
+                argument.Kind != BoundKind.OutVariablePendingInference &&
+                argument.Kind != BoundKind.DiscardedExpression)
             {
                 // If the problem is that a lambda isn't convertible to the given type, also report why.
                 // The argument and parameter type might match, but may not have same in/out modifiers
@@ -970,6 +973,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(argument.Kind != BoundKind.OutDeconstructVarPendingInference);
                 Debug.Assert(argument.Kind != BoundKind.OutVariablePendingInference);
+                Debug.Assert(argument.Kind != BoundKind.DiscardedExpression);
                 Debug.Assert(argument.Display != null);
 
                 if (arguments.IsExtensionMethodThisArgument(arg))

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -973,7 +973,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(argument.Kind != BoundKind.OutDeconstructVarPendingInference);
                 Debug.Assert(argument.Kind != BoundKind.OutVariablePendingInference);
-                Debug.Assert(argument.Kind != BoundKind.DiscardedExpression);
+                Debug.Assert(argument.Kind != BoundKind.DiscardedExpression || argument.HasExpressionType());
                 Debug.Assert(argument.Display != null);
 
                 if (arguments.IsExtensionMethodThisArgument(arg))

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardedExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardedExpression.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class BoundDiscardedExpression
+    {
+        public BoundExpression SetInferredType(TypeSymbol type)
+        {
+            Debug.Assert((object)Type == null && (object)type != null);
+            return this.Update(type);
+        }
+
+        public BoundDiscardedExpression FailInference(Binder binder, DiagnosticBag diagnosticsOpt)
+        {
+            if (diagnosticsOpt != null)
+            {
+                Binder.Error(diagnosticsOpt, ErrorCode.ERR_DiscardTypeInferenceFailed, this.Syntax);
+            }
+            return this.Update(binder.CreateErrorType("var"));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -388,15 +388,9 @@
     <Field Name="RefKind" Type="RefKind" Null="NotApplicable"/>
   </Node>
 
-  <Node Name="BoundLocalDeconstructionDeclaration" Base="BoundStatement">
-    <Field Name="Assignment" Type="BoundDeconstructionAssignmentOperator" Null="disallow"/>
-  </Node>
-
   <Node Name="BoundDeconstructionAssignmentOperator" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-
-    <Field Name="IsDeclaration" Type="bool"/>
 
     <!-- Various assignable expressions, in a flat structure (no nesting) -->
     <Field Name="LeftVariables" Type="ImmutableArray&lt;BoundExpression&gt;" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -1037,21 +1037,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundLocalDeconstructionDeclaration : BoundStatement
-    {
-        protected override OperationKind StatementKind => OperationKind.None;
-
-        public override void Accept(OperationVisitor visitor)
-        {
-            visitor.VisitNoneOperation(this);
-        }
-
-        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-        {
-            return visitor.VisitNoneOperation(this, argument);
-        }
-    }
-
     internal sealed partial class BoundVoid : BoundExpression
     {
         protected override OperationKind ExpressionKind => OperationKind.None;

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -120,6 +120,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal partial class BoundDiscardedExpression
+    {
+        public override object Display
+        {
+            get { return string.Empty; }
+        }
+    }
+
     internal partial class DeconstructionVariablePendingInference
     {
         public override object Display

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override object Display
         {
-            get { return string.Empty; }
+            get { return (object)this.Type ?? "_"; }
         }
     }
 

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -173,6 +173,7 @@
     <Compile Include="BoundTree\DecisionTreeBuilder.cs" />
     <Compile Include="BoundTree\Expression.cs" />
     <Compile Include="BoundTree\DeconstructionVariablePendingInference.cs" />
+    <Compile Include="BoundTree\BoundDiscardedExpression.cs" />
     <Compile Include="BoundTree\OutVariablePendingInference.cs" />
     <Compile Include="BoundTree\OutDeconstructVarPendingInference.cs" />
     <Compile Include="BoundTree\PseudoVariableExpressions.cs" />

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3311,6 +3311,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot assign {0} to a discard variable.
+        /// </summary>
+        internal static string ERR_DiscardVariableAssignedBadValue {
+            get {
+                return ResourceManager.GetString("ERR_DiscardVariableAssignedBadValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The DllImport attribute cannot be applied to a method that is generic or contained in a generic type..
         /// </summary>
         internal static string ERR_DllImportOnGenericMethod {
@@ -6124,6 +6133,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_MissingTypeInSource {
             get {
                 return ResourceManager.GetString("ERR_MissingTypeInSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot reference {0} in a deconstruction declaration.
+        /// </summary>
+        internal static string ERR_MixedDeconstructionDisallowed {
+            get {
+                return ResourceManager.GetString("ERR_MixedDeconstructionDisallowed", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3320,15 +3320,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot assign {0} to a discard.
-        /// </summary>
-        internal static string ERR_DiscardVariableAssignedBadValue {
-            get {
-                return ResourceManager.GetString("ERR_DiscardVariableAssignedBadValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The DllImport attribute cannot be applied to a method that is generic or contained in a generic type..
         /// </summary>
         internal static string ERR_DllImportOnGenericMethod {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3311,7 +3311,16 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot assign {0} to a discard variable.
+        ///   Looks up a localized string similar to Cannot infer the type of implicitly-typed discard..
+        /// </summary>
+        internal static string ERR_DiscardTypeInferenceFailed {
+            get {
+                return ResourceManager.GetString("ERR_DiscardTypeInferenceFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot assign {0} to a discard.
         /// </summary>
         internal static string ERR_DiscardVariableAssignedBadValue {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2105,6 +2105,12 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_ImplicitlyTypedVariableAssignedBadValue" xml:space="preserve">
     <value>Cannot assign {0} to an implicitly-typed variable</value>
   </data>
+  <data name="ERR_DiscardVariableAssignedBadValue" xml:space="preserve">
+    <value>Cannot assign {0} to a discard variable</value>
+  </data>
+  <data name="ERR_MixedDeconstructionDisallowed" xml:space="preserve">
+    <value>Cannot reference {0} in a deconstruction declaration</value>
+  </data>
   <data name="ERR_ImplicitlyTypedVariableWithNoInitializer" xml:space="preserve">
     <value>Implicitly-typed variables must be initialized</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2106,7 +2106,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>Cannot assign {0} to an implicitly-typed variable</value>
   </data>
   <data name="ERR_DiscardVariableAssignedBadValue" xml:space="preserve">
-    <value>Cannot assign {0} to a discard variable</value>
+    <value>Cannot assign {0} to a discard</value>
   </data>
   <data name="ERR_MixedDeconstructionDisallowed" xml:space="preserve">
     <value>Cannot reference {0} in a deconstruction declaration</value>
@@ -4914,6 +4914,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable" xml:space="preserve">
     <value>Cannot infer the type of implicitly-typed deconstruction variable '{0}'.</value>
+  </data>
+  <data name="ERR_DiscardTypeInferenceFailed" xml:space="preserve">
+    <value>Cannot infer the type of implicitly-typed discard.</value>
   </data>
   <data name="ERR_DeconstructWrongCardinality" xml:space="preserve">
     <value>Cannot deconstruct a tuple of '{0}' elements into '{1}' variables.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2105,9 +2105,6 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_ImplicitlyTypedVariableAssignedBadValue" xml:space="preserve">
     <value>Cannot assign {0} to an implicitly-typed variable</value>
   </data>
-  <data name="ERR_DiscardVariableAssignedBadValue" xml:space="preserve">
-    <value>Cannot assign {0} to a discard</value>
-  </data>
   <data name="ERR_MixedDeconstructionDisallowed" xml:space="preserve">
     <value>Cannot reference {0} in a deconstruction declaration</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -257,12 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
             {
-                // For deconstruction declarations, the BoundLocals in the LeftVariables should not be added to the map
-                if (!node.IsDeclaration)
-                {
-                    VisitList(node.LeftVariables);
-                }
-
+                VisitList(node.LeftVariables);
                 Visit(node.Right);
                 // don't map the deconstruction, conversion or assignment steps
                 return null;

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1624,7 +1624,7 @@ done:
 
                     case SyntaxKind.DeclarationExpression:
                     case SyntaxKind.TupleExpression:
-                        var assignment = GetContainingDeconstruction((ExpressionSyntax)node);
+                        var assignment = ((ExpressionSyntax)node).GetContainingDeconstruction() as AssignmentExpressionSyntax;
                         if (assignment != null)
                         {
                             return assignment;
@@ -1668,40 +1668,6 @@ done:
             }
 
             return node;
-        }
-
-        /// <summary>
-        /// If this declaration is part of a deconstruction, find the deconstruction.
-        /// Returns null otherwise.
-        /// </summary>
-        private static AssignmentExpressionSyntax GetContainingDeconstruction(ExpressionSyntax expr)
-        {
-            while (true)
-            {
-                Debug.Assert(expr.Kind() == SyntaxKind.TupleExpression || expr.Kind() == SyntaxKind.DeclarationExpression);
-                var parent = expr.Parent;
-                if (parent == null) { return null; }
-
-                if (parent.Kind() == SyntaxKind.Argument)
-                {
-                    if (parent.Parent?.Kind() == SyntaxKind.TupleExpression)
-                    {
-                        expr = (TupleExpressionSyntax)parent.Parent;
-                        continue;
-                    }
-                    else
-                    {
-                        return null;
-                    }
-                }
-                else if (parent.Kind() == SyntaxKind.SimpleAssignmentExpression &&
-                        (object)((AssignmentExpressionSyntax)parent).Left == expr)
-                {
-                    return (AssignmentExpressionSyntax)parent;
-                }
-
-                return null;
-            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1430,8 +1430,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_SemiOrLBraceOrArrowExpected = 8180,
         ERR_NewWithTupleTypeSyntax = 8181,
         ERR_PredefinedValueTupleTypeMustBeStruct = 8182,
+        ERR_DiscardVariableAssignedBadValue = 8183,
+        ERR_MixedDeconstructionDisallowed = 8184,
 
-        // Available  = 8183-8195
+        // Available  = 8185-8195
 
         #region diagnostics for out var
         ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList = 8196,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1430,7 +1430,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_SemiOrLBraceOrArrowExpected = 8180,
         ERR_NewWithTupleTypeSyntax = 8181,
         ERR_PredefinedValueTupleTypeMustBeStruct = 8182,
-        ERR_DiscardVariableAssignedBadValue = 8183,
+        ERR_DiscardTypeInferenceFailed = 8183,
         ERR_MixedDeconstructionDisallowed = 8184,
 
         // Available  = 8185-8195

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1674,12 +1674,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public override BoundNode VisitLocalDeconstructionDeclaration(BoundLocalDeconstructionDeclaration node)
-        {
-            VisitDeconstructionAssignmentOperator(node.Assignment);
-            return null;
-        }
-
         public override sealed BoundNode VisitOutDeconstructVarPendingInference(OutDeconstructVarPendingInference node)
         {
             // OutDeconstructVarPendingInference nodes are only used within initial binding, but don't survive past that stage
@@ -2698,6 +2692,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public override BoundNode VisitVoid(BoundVoid node)
+        {
+            return null;
+        }
+
+        public override BoundNode VisitDiscardedExpression(BoundDiscardedExpression node)
         {
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
@@ -217,10 +217,5 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return Previous.InstrumentForEachStatementDeconstructionVariablesDeclaration(original, iterationVarDecl);
         }
-
-        public override BoundStatement InstrumentLocalDeconstructionDeclaration(BoundLocalDeconstructionDeclaration original, BoundStatement rewritten)
-        {
-            return Previous.InstrumentLocalDeconstructionDeclaration(original, rewritten);
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -206,11 +206,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundSequencePointWithSpan(forEachSyntax, base.InstrumentForEachStatementDeconstructionVariablesDeclaration(original, iterationVarDecl), forEachSyntax.Variable.Span);
         }
 
-        public override BoundStatement InstrumentLocalDeconstructionDeclaration(BoundLocalDeconstructionDeclaration original, BoundStatement rewritten)
-        {
-            return AddSequencePoint(base.InstrumentLocalDeconstructionDeclaration(original, rewritten));
-        }
-
         /// <summary>
         /// Add sequence point |here|:
         /// 

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -248,11 +248,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return AddDynamicAnalysis(original, base.InstrumentUsingTargetCapture(original, usingTargetCapture));
         }
 
-        public override BoundStatement InstrumentLocalDeconstructionDeclaration(BoundLocalDeconstructionDeclaration original, BoundStatement rewritten)
-        {
-            return AddDynamicAnalysis(original, base.InstrumentLocalDeconstructionDeclaration(original, rewritten));
-        }
-
         private BoundStatement AddDynamicAnalysis(BoundStatement original, BoundStatement rewritten)
         {
             if (!original.WasCompilerGenerated)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -87,11 +87,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return InstrumentStatement(original, rewritten);
         }
 
-        public virtual BoundStatement InstrumentLocalDeconstructionDeclaration(BoundLocalDeconstructionDeclaration original, BoundStatement rewritten)
-        {
-            return InstrumentStatement(original, rewritten);
-        }
-
         public virtual BoundStatement InstrumentFieldOrPropertyInitializer(BoundExpressionStatement original, BoundStatement rewritten)
         {
             Debug.Assert(LocalRewriter.IsFieldOrPropertyInitializer(original));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -195,6 +195,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                             refKind: refKind);
                     }
 
+                case BoundKind.DiscardedExpression:
+                    {
+                        var temps = ArrayBuilder<LocalSymbol>.GetInstance(1);
+                        BoundLocal discard = MakeTempForDiscardedExpression((BoundDiscardedExpression)rewrittenLeft, temps);
+
+                        return _factory.Sequence(temps.ToImmutableAndFree(),
+                                            sideEffects: ImmutableArray<BoundExpression>.Empty,
+                                            result: new BoundAssignmentOperator(
+                                                         syntax,
+                                                         discard,
+                                                         rewrittenRight,
+                                                         type,
+                                                         refKind: refKind));
+                    }
+
                 default:
                     {
                         Debug.Assert(refKind == RefKind.None);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -197,17 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.DiscardedExpression:
                     {
-                        var temps = ArrayBuilder<LocalSymbol>.GetInstance(1);
-                        BoundLocal discard = MakeTempForDiscardedExpression((BoundDiscardedExpression)rewrittenLeft, temps);
-
-                        return _factory.Sequence(temps.ToImmutableAndFree(),
-                                            sideEffects: ImmutableArray<BoundExpression>.Empty,
-                                            result: new BoundAssignmentOperator(
-                                                         syntax,
-                                                         discard,
-                                                         rewrittenRight,
-                                                         type,
-                                                         refKind: refKind));
+                        return rewrittenRight;
                     }
 
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var placeholders = ArrayBuilder<BoundValuePlaceholderBase>.GetInstance();
 
             // evaluate left-hand-side side-effects
-            ImmutableArray<BoundExpression> lhsTargets = LeftHandSideSideEffects(node.LeftVariables, temps, stores);
+            ImmutableArray<BoundExpression> lhsTargets = GetAssignmentTargetsAndSideEffects(node.LeftVariables, temps, stores);
 
             // get or make right-hand-side values
             BoundExpression loweredRight = VisitExpression(node.Right);
@@ -152,23 +152,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Adds the side effects to stores and returns temporaries (as a flat list) to access them.
         /// </summary>
-        private ImmutableArray<BoundExpression> LeftHandSideSideEffects(ImmutableArray<BoundExpression> variables, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
+        private ImmutableArray<BoundExpression> GetAssignmentTargetsAndSideEffects(ImmutableArray<BoundExpression> variables, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
         {
-            var lhsReceivers = ArrayBuilder<BoundExpression>.GetInstance(variables.Length);
+            var assignmentTargets = ArrayBuilder<BoundExpression>.GetInstance(variables.Length);
 
             foreach (var variable in variables)
             {
                 if (variable.Kind == BoundKind.DiscardedExpression)
                 {
-                    lhsReceivers.Add(variable);
+                    assignmentTargets.Add(variable);
                 }
                 else
                 {
-                    lhsReceivers.Add(TransformCompoundAssignmentLHS(variable, stores, temps, isDynamicAssignment: variable.Type.IsDynamic()));
+                    assignmentTargets.Add(TransformCompoundAssignmentLHS(variable, stores, temps, isDynamicAssignment: variable.Type.IsDynamic()));
                 }
             }
 
-            return lhsReceivers.ToImmutableAndFree();
+            return assignmentTargets.ToImmutableAndFree();
         }
 
         private void AccessTupleFields(BoundDeconstructionAssignmentOperator node, BoundDeconstructionDeconstructStep deconstruction, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores, ArrayBuilder<BoundValuePlaceholderBase> placeholders)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ExpressionStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ExpressionStatement.cs
@@ -36,30 +36,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public override BoundNode VisitLocalDeconstructionDeclaration(BoundLocalDeconstructionDeclaration node)
-        {
-            var syntax = node.Syntax;
-            var loweredExpression = VisitUnusedExpression(node.Assignment);
-
-            if (loweredExpression == null)
-            {
-                // NOTE: not using a BoundNoOpStatement, since we don't want a nop to be emitted.
-                // CONSIDER: could use a BoundNoOpStatement (DevDiv #12943).
-                return BoundStatementList.Synthesized(syntax);
-            }
-            else
-            {
-                BoundStatement result = new BoundExpressionStatement(loweredExpression.Syntax, loweredExpression, node.HasErrors);
-                result.WasCompilerGenerated = node.WasCompilerGenerated;
-                if (this.Instrument && !node.WasCompilerGenerated)
-                {
-                    result = _instrumenter.InstrumentLocalDeconstructionDeclaration(node, result);
-                }
-
-                return result;
-            }
-        }
-
         private BoundExpression VisitUnusedExpression(BoundExpression expression)
         {
             if (expression.HasErrors)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -520,10 +519,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 iterationVarDecl = new BoundExpressionStatement(assignment.Syntax, loweredAssignment);
                 RemovePlaceholderReplacement(deconstruction.TargetPlaceholder);
 
-                iterationVariables = assignment.LeftVariables.SelectAsArray(v => ((BoundLocal)v).LocalSymbol);
+                iterationVariables = GetLocalSymbols(assignment.LeftVariables);
             }
 
             return iterationVarDecl;
+        }
+
+        private static ImmutableArray<LocalSymbol> GetLocalSymbols(ImmutableArray<BoundExpression> leftVariables)
+        {
+            var builder = ArrayBuilder<LocalSymbol>.GetInstance();
+            foreach (var variable in leftVariables.OfType<BoundLocal>())
+            {
+                builder.Add(variable.LocalSymbol);
+            }
+            return builder.ToImmutableAndFree();
         }
 
         private static BoundBlock CreateBlockDeclaringIterationVariables(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -528,9 +528,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static ImmutableArray<LocalSymbol> GetLocalSymbols(ImmutableArray<BoundExpression> leftVariables)
         {
             var builder = ArrayBuilder<LocalSymbol>.GetInstance();
-            foreach (var variable in leftVariables.OfType<BoundLocal>())
+            foreach (var variable in leftVariables)
             {
-                builder.Add(variable.LocalSymbol);
+                if (variable.Kind == BoundKind.Local)
+                {
+                    builder.Add(((BoundLocal)variable).LocalSymbol);
+                }
             }
             return builder.ToImmutableAndFree();
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -88,10 +88,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardedExpression)
             {
-                var temps = ArrayBuilder<LocalSymbol>.GetInstance(1);
-                BoundLocal discard = MakeTempForDiscardedExpression((BoundDiscardedExpression)loweredPattern.VariableAccess, temps);
+                LocalSymbol temp;
+                BoundLocal discard = MakeTempForDiscardedExpression((BoundDiscardedExpression)loweredPattern.VariableAccess, out temp);
 
-                return _factory.Sequence(temps.ToImmutableAndFree(),
+                return _factory.Sequence(ImmutableArray.Create(temp),
                          sideEffects: ImmutableArray<BoundExpression>.Empty,
                          result: MakeIsDeclarationPattern(loweredPattern.Syntax, loweredInput, discard, requiresNullTest: true));
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -3,6 +3,7 @@
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -67,14 +68,32 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression MakeIsDeclarationPattern(BoundDeclarationPattern loweredPattern, BoundExpression loweredInput)
         {
-            Debug.Assert(loweredPattern.Variable.GetTypeOrReturnType() == loweredPattern.DeclaredType.Type);
+            Debug.Assert(((object)loweredPattern.Variable == null && loweredPattern.VariableAccess.Kind == BoundKind.DiscardedExpression) ||
+                         loweredPattern.Variable.GetTypeOrReturnType() == loweredPattern.DeclaredType.Type);
 
             if (loweredPattern.IsVar)
             {
-                Debug.Assert(loweredInput.Type == loweredPattern.Variable.GetTypeOrReturnType());
-                var assignment = _factory.AssignmentExpression(loweredPattern.VariableAccess, loweredInput);
                 var result = _factory.Literal(true);
+
+                if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardedExpression)
+                {
+                    return result;
+                }
+
+                Debug.Assert((object)loweredPattern.Variable != null && loweredInput.Type == loweredPattern.Variable.GetTypeOrReturnType());
+
+                var assignment = _factory.AssignmentExpression(loweredPattern.VariableAccess, loweredInput);
                 return _factory.MakeSequence(assignment, result);
+            }
+
+            if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardedExpression)
+            {
+                var temps = ArrayBuilder<LocalSymbol>.GetInstance(1);
+                BoundLocal discard = MakeTempForDiscardedExpression((BoundDiscardedExpression)loweredPattern.VariableAccess, temps);
+
+                return _factory.Sequence(temps.ToImmutableAndFree(),
+                         sideEffects: ImmutableArray<BoundExpression>.Empty,
+                         result: MakeIsDeclarationPattern(loweredPattern.Syntax, loweredInput, discard, requiresNullTest: true));
             }
 
             return MakeIsDeclarationPattern(loweredPattern.Syntax, loweredInput, loweredPattern.VariableAccess, requiresNullTest: true);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (loweredPattern.VariableAccess.Kind == BoundKind.DiscardedExpression)
             {
                 LocalSymbol temp;
-                BoundLocal discard = MakeTempForDiscardedExpression((BoundDiscardedExpression)loweredPattern.VariableAccess, out temp);
+                BoundLocal discard = _factory.MakeTempForDiscard((BoundDiscardedExpression)loweredPattern.VariableAccess, out temp);
 
                 return _factory.Sequence(ImmutableArray.Create(temp),
                          sideEffects: ImmutableArray<BoundExpression>.Empty,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperation.cs
@@ -19,13 +19,15 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly SyntheticBoundNodeFactory _factory;
         private readonly TypeSymbol _resultType;
+        private readonly ImmutableArray<LocalSymbol> _temps;
         public readonly BoundExpression SiteInitialization;
         public readonly BoundExpression SiteInvocation;
 
-        public LoweredDynamicOperation(SyntheticBoundNodeFactory factory, BoundExpression siteInitialization, BoundExpression siteInvocation, TypeSymbol resultType)
+        public LoweredDynamicOperation(SyntheticBoundNodeFactory factory, BoundExpression siteInitialization, BoundExpression siteInvocation, TypeSymbol resultType, ImmutableArray<LocalSymbol> temps)
         {
             _factory = factory;
             _resultType = resultType;
+            _temps = temps;
             this.SiteInitialization = siteInitialization;
             this.SiteInvocation = siteInvocation;
         }
@@ -48,19 +50,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(children.Length > 0);
             var bad = new BoundBadExpression(children[0].Syntax, LookupResultKind.Empty, ImmutableArray<Symbol>.Empty, children, resultType);
-            return new LoweredDynamicOperation(null, null, bad, resultType);
+            return new LoweredDynamicOperation(null, null, bad, resultType, default(ImmutableArray<LocalSymbol>));
         }
 
         public BoundExpression ToExpression()
         {
             if (_factory == null)
             {
-                Debug.Assert(SiteInitialization == null && SiteInvocation is BoundBadExpression);
+                Debug.Assert(SiteInitialization == null && SiteInvocation is BoundBadExpression && _temps.IsDefault);
                 return SiteInvocation;
             }
 
-            // TODO (tomat): we might be able to using SiteInvocation.Type instead of resultType once we stop using GetLoweredType
-            return _factory.Sequence(new[] { SiteInitialization }, SiteInvocation, _resultType);
+            // TODO (tomat): we might be able to use SiteInvocation.Type instead of resultType once we stop using GetLoweredType
+            if (_temps.IsDefault)
+            {
+                return _factory.Sequence(new[] { SiteInitialization }, SiteInvocation, _resultType);
+            }
+            else
+            {
+                return new BoundSequence(_factory.Syntax, _temps, ImmutableArray.Create(SiteInitialization), SiteInvocation, _resultType) { WasCompilerGenerated = true };
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperation.cs
@@ -57,12 +57,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (_factory == null)
             {
-                Debug.Assert(SiteInitialization == null && SiteInvocation is BoundBadExpression && _temps.IsDefault);
+                Debug.Assert(SiteInitialization == null && SiteInvocation is BoundBadExpression && _temps.IsDefaultOrEmpty);
                 return SiteInvocation;
             }
 
             // TODO (tomat): we might be able to use SiteInvocation.Type instead of resultType once we stop using GetLoweredType
-            if (_temps.IsDefault)
+            if (_temps.IsDefaultOrEmpty)
             {
                 return _factory.Sequence(new[] { SiteInitialization }, SiteInvocation, _resultType);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
@@ -640,6 +640,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var containerDef = (SynthesizedContainer)_currentDynamicCallSiteContainer.OriginalDefinition;
             var methodToContainerTypeParametersMap = containerDef.TypeMap;
 
+            ImmutableArray<LocalSymbol> temps = MakeTempsForDiscardArguments(ref loweredArguments);
+             
             var callSiteType = callSiteTypeGeneric.Construct(new[] { delegateTypeOverMethodTypeParameters });
             var callSiteFactoryMethod = callSiteFactoryGeneric.AsMember(callSiteType);
             var callSiteTargetField = callSiteTargetFieldGeneric.AsMember(callSiteType);
@@ -660,7 +662,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                 delegateInvoke,
                 callSiteArguments);
 
-            return new LoweredDynamicOperation(_factory, siteInitialization, siteInvocation, resultType);
+            return new LoweredDynamicOperation(_factory, siteInitialization, siteInvocation, resultType, temps);
+        }
+
+        /// <summary>
+        /// If there are any discards in the arguments, create locals for each, updates the arguments and
+        /// returns the symbols that were created.
+        /// Returns default if no discards found.
+        /// </summary>
+        private ImmutableArray<LocalSymbol> MakeTempsForDiscardArguments(ref ImmutableArray<BoundExpression> loweredArguments)
+        {
+            int discardCount = loweredArguments.Count(a => a.Kind == BoundKind.DiscardedExpression);
+
+            if (discardCount == 0)
+            {
+                return default(ImmutableArray<LocalSymbol>);
+            }
+
+            ArrayBuilder<LocalSymbol> temporariesBuilder = ArrayBuilder<LocalSymbol>.GetInstance(discardCount);
+            loweredArguments = _factory.MakeTempsForDiscardArguments(loweredArguments, temporariesBuilder);
+            return temporariesBuilder.ToImmutableAndFree();
         }
 
         private static NamedTypeSymbol CreateCallSiteContainer(SyntheticBoundNodeFactory factory, int methodOrdinal)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
@@ -676,7 +676,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (discardCount == 0)
             {
-                return default(ImmutableArray<LocalSymbol>);
+                return ImmutableArray<LocalSymbol>.Empty;
             }
 
             ArrayBuilder<LocalSymbol> temporariesBuilder = ArrayBuilder<LocalSymbol>.GetInstance(discardCount);

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1274,5 +1274,35 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new BoundNoOpStatement(Syntax, noOpStatementFlavor);
         }
+
+        internal BoundLocal MakeTempForDiscard(BoundDiscardedExpression node, ArrayBuilder<LocalSymbol> temps)
+        {
+            LocalSymbol temp;
+            BoundLocal result = MakeTempForDiscard(node, out temp);
+            temps.Add(temp);
+            return result;
+        }
+
+        internal BoundLocal MakeTempForDiscard(BoundDiscardedExpression node, out LocalSymbol temp)
+        {
+            temp = new SynthesizedLocal(this.CurrentMethod, node.Type, SynthesizedLocalKind.LoweringTemp);
+
+            return new BoundLocal(node.Syntax, temp, constantValueOpt: null, type: node.Type) { WasCompilerGenerated = true };
+        }
+
+        internal ImmutableArray<BoundExpression> MakeTempsForDiscardArguments(ImmutableArray<BoundExpression> arguments, ArrayBuilder<LocalSymbol> builder)
+        {
+            var discardsCount = arguments.Count(a => a.Kind == BoundKind.DiscardedExpression);
+
+            if (discardsCount != 0)
+            {
+                arguments = arguments.SelectAsArray(
+                                            arg => arg.Kind == BoundKind.DiscardedExpression ?
+                                                this.MakeTempForDiscard((BoundDiscardedExpression)arg, builder) :
+                                                arg);
+            }
+
+            return arguments;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1297,8 +1297,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (discardsCount != 0)
             {
                 arguments = arguments.SelectAsArray(
-                    (arg, b) => arg.Kind == BoundKind.DiscardedExpression ?  this.MakeTempForDiscard((BoundDiscardedExpression)arg, b) : arg,
-                    builder);
+                    (arg, t) => arg.Kind == BoundKind.DiscardedExpression ?  t.Item1.MakeTempForDiscard((BoundDiscardedExpression)arg, t.Item2) : arg,
+                    ValueTuple.Create(this, builder));
             }
 
             return arguments;

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1297,9 +1297,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (discardsCount != 0)
             {
                 arguments = arguments.SelectAsArray(
-                                            arg => arg.Kind == BoundKind.DiscardedExpression ?
-                                                this.MakeTempForDiscard((BoundDiscardedExpression)arg, builder) :
-                                                arg);
+                    (arg, b) => arg.Kind == BoundKind.DiscardedExpression ?  this.MakeTempForDiscard((BoundDiscardedExpression)arg, b) : arg,
+                    builder);
             }
 
             return arguments;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8605,6 +8605,12 @@ tryAgain:
             }
             else
             {
+                if (this.CurrentToken.ContextualKind == SyntaxKind.UnderscoreToken &&
+                    (this.PeekToken(1).Kind == SyntaxKind.CommaToken || this.PeekToken(1).Kind == SyntaxKind.CloseParenToken))
+                {
+                    return this.ParseIdentifierName();
+                }
+
                 TypeSyntax type;
                 bool reportMissingType = false;
                 if (this.CurrentToken.Kind == SyntaxKind.IdentifierToken &&
@@ -8662,6 +8668,8 @@ tryAgain:
 
                         return true;
                     }
+                case SyntaxKind.IdentifierName:
+                    return false;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.Kind);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -658,8 +658,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     case SyntaxKind.SimpleAssignmentExpression:
                         var assignment = (AssignmentExpressionSyntax)_deconstruction;
-                        Debug.Assert(assignment.IsDeconstructionDeclaration());
-                        _nodeBinder.BindDeconstructionDeclaration(assignment, assignment.Left, assignment.Right, diagnostics);
+                        _nodeBinder.BindDeconstruction(assignment, assignment.Left, assignment.Right, diagnostics, isDeclaration: true);
                         break;
 
                     case SyntaxKind.ForEachVariableStatement:

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Is this expression composed only of declaration expressions nested in tuple expressions?
+        /// Is this expression composed only of declaration expressions and discards nested in tuple expressions?
         /// </summary>
         private static bool IsDeconstructionDeclarationLeft(this ExpressionSyntax self)
         {
@@ -218,13 +218,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.TupleExpression:
                     var tuple = (TupleExpressionSyntax)self;
                     return tuple.Arguments.All(a => IsDeconstructionDeclarationLeft(a.Expression));
+                case SyntaxKind.IdentifierName:
+                    // Underscore is the only expression that is not clearly a declaration that we tolerate for now
+                    var identifier = (IdentifierNameSyntax)self;
+                    return identifier.Identifier.ContextualKind() == SyntaxKind.UnderscoreToken;
                 default:
                     return false;
             }
         }
 
         /// <summary>
-        /// Returns true if the expression is composed only of nested tuple and declaration expressions.
+        /// Returns true if the expression is composed only of nested tuple, declaration expressions and discards.
         /// </summary>
         internal static bool IsDeconstructionDeclarationLeft(this Syntax.InternalSyntax.ExpressionSyntax node)
         {
@@ -240,6 +244,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 case SyntaxKind.DeclarationExpression:
                     return true;
+                case SyntaxKind.IdentifierName:
+                    // Underscore is the only expression that is not clearly a declaration that we tolerate for now
+                    return node.RawContextualKind == (int)SyntaxKind.UnderscoreToken;
                 default:
                     return false;
             }
@@ -352,6 +359,52 @@ namespace Microsoft.CodeAnalysis.CSharp
                 block,
                 default(ArrowExpressionClauseSyntax),
                 semicolonToken);
+        }
+
+        /// <summary>
+        /// If this declaration or identifier is part of a deconstruction, find the deconstruction.
+        /// If found, returns either an assignment expression or a foreach variable statement.
+        /// Returns null otherwise.
+        /// </summary>
+        internal static CSharpSyntaxNode GetContainingDeconstruction(this ExpressionSyntax expr)
+        {
+            var kind = expr.Kind();
+            if (kind != SyntaxKind.TupleExpression && kind != SyntaxKind.DeclarationExpression && kind != SyntaxKind.IdentifierName)
+            {
+                return null;
+            }
+
+            while (true)
+            {
+                Debug.Assert(expr.Kind() == SyntaxKind.TupleExpression || expr.Kind() == SyntaxKind.DeclarationExpression || expr.Kind() == SyntaxKind.IdentifierName);
+                var parent = expr.Parent;
+                if (parent == null) { return null; }
+
+                if (parent.Kind() == SyntaxKind.Argument)
+                {
+                    if (parent.Parent?.Kind() == SyntaxKind.TupleExpression)
+                    {
+                        expr = (TupleExpressionSyntax)parent.Parent;
+                        continue;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+                else if (parent.Kind() == SyntaxKind.SimpleAssignmentExpression &&
+                        (object)((AssignmentExpressionSyntax)parent).Left == expr)
+                {
+                    return parent;
+                }
+                else if (parent.Kind() == SyntaxKind.ForEachVariableStatement &&
+                    (object)((ForEachVariableStatementSyntax)parent).Variable == expr)
+                {
+                    return parent;
+                }
+
+                return null;
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -380,30 +380,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var parent = expr.Parent;
                 if (parent == null) { return null; }
 
-                if (parent.Kind() == SyntaxKind.Argument)
+                switch (parent.Kind())
                 {
-                    if (parent.Parent?.Kind() == SyntaxKind.TupleExpression)
-                    {
-                        expr = (TupleExpressionSyntax)parent.Parent;
-                        continue;
-                    }
-                    else
-                    {
+                    case SyntaxKind.Argument:
+                        if (parent.Parent?.Kind() == SyntaxKind.TupleExpression)
+                        {
+                            expr = (TupleExpressionSyntax)parent.Parent;
+                            continue;
+                        }
                         return null;
-                    }
+                    case SyntaxKind.SimpleAssignmentExpression:
+                        if ((object)((AssignmentExpressionSyntax)parent).Left == expr)
+                        {
+                            return parent;
+                        }
+                        return null;
+                    case SyntaxKind.ForEachVariableStatement:
+                        if ((object)((ForEachVariableStatementSyntax)parent).Variable == expr)
+                        {
+                            return parent;
+                        }
+                        return null;
+                    default:
+                        return null;
                 }
-                else if (parent.Kind() == SyntaxKind.SimpleAssignmentExpression &&
-                        (object)((AssignmentExpressionSyntax)parent).Left == expr)
-                {
-                    return parent;
-                }
-                else if (parent.Kind() == SyntaxKind.ForEachVariableStatement &&
-                    (object)((ForEachVariableStatementSyntax)parent).Variable == expr)
-                {
-                    return parent;
-                }
-
-                return null;
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -2066,11 +2066,12 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size       49 (0x31)
+  // Code size       51 (0x33)
   .maxstack  3
   .locals init (int V_0, //x1
                 string V_1, //x2
-                int V_2)
+                int V_2,
+                string V_3)
   IL_0000:  ldc.i4.1
   IL_0001:  ldstr      ""hello""
   IL_0006:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
@@ -2078,16 +2079,18 @@ class C
   IL_000c:  ldfld      ""int System.ValueTuple<int, string>.Item1""
   IL_0011:  stloc.2
   IL_0012:  ldfld      ""string System.ValueTuple<int, string>.Item2""
-  IL_0017:  ldloc.2
-  IL_0018:  stloc.0
-  IL_0019:  stloc.1
-  IL_001a:  ldloc.0
-  IL_001b:  box        ""int""
-  IL_0020:  ldstr      "" ""
-  IL_0025:  ldloc.1
-  IL_0026:  call       ""string string.Concat(object, object, object)""
-  IL_002b:  call       ""void System.Console.WriteLine(string)""
-  IL_0030:  ret
+  IL_0017:  stloc.3
+  IL_0018:  ldloc.2
+  IL_0019:  stloc.0
+  IL_001a:  ldloc.3
+  IL_001b:  stloc.1
+  IL_001c:  ldloc.0
+  IL_001d:  box        ""int""
+  IL_0022:  ldstr      "" ""
+  IL_0027:  ldloc.1
+  IL_0028:  call       ""string string.Concat(object, object, object)""
+  IL_002d:  call       ""void System.Console.WriteLine(string)""
+  IL_0032:  ret
 }
 ");
         }
@@ -2232,7 +2235,7 @@ class C
 
                 var lhs = tree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>().First();
                 Assert.Equal(@"(string x1, byte x2, var x3)", lhs.ToString());
-                Assert.Equal("System.Void", model.GetTypeInfo(lhs).Type.ToTestDisplayString());
+                Assert.Equal("(System.String, System.Byte, System.Int32)", model.GetTypeInfo(lhs).Type.ToTestDisplayString());
 
                 var literal = tree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>().Skip(1).First();
                 Assert.Equal(@"(null, 2, 3)", literal.ToString());
@@ -2268,7 +2271,7 @@ class C
 
                 var lhs = tree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>().First();
                 Assert.Equal(@"(string x1, var x2)", lhs.ToString());
-                Assert.Equal("System.Void", model.GetTypeInfo(lhs).Type.ToTestDisplayString());
+                Assert.Equal("(System.String, (System.Int32, System.Int32))", model.GetTypeInfo(lhs).Type.ToTestDisplayString());
 
                 var literal = tree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>().Skip(1).First();
                 Assert.Equal(@"(null, (1, 2))", literal.ToString());
@@ -2343,7 +2346,8 @@ Deconstructing (1, hello)
                 VerifyModelForDeconstructionLocal(model, x3, x3Ref);
             };
 
-            var comp = CompileAndVerify(source, expectedOutput: expected, parseOptions: TestOptions.Regular, sourceSymbolValidator: validator);
+            var comp = CompileAndVerify(source, expectedOutput: expected, parseOptions: TestOptions.Regular,
+                            sourceSymbolValidator: validator, additionalRefs: s_valueTupleRefs);
             comp.VerifyDiagnostics();
         }
 
@@ -2416,6 +2420,16 @@ Deconstructing (1, hello)
         private static SingleVariableDesignationSyntax GetDeconstructionVariable(SyntaxTree tree, string name)
         {
             return tree.GetRoot().DescendantNodes().OfType<SingleVariableDesignationSyntax>().Where(d => d.Identifier.ValueText == name).Single();
+        }
+
+        private static IEnumerable<DiscardedDesignationSyntax> GetDiscardDesignations(SyntaxTree tree)
+        {
+            return tree.GetRoot().DescendantNodes().OfType<DiscardedDesignationSyntax>();
+        }
+
+        private static IEnumerable<IdentifierNameSyntax> GetDiscardIdentifiers(SyntaxTree tree)
+        {
+            return tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(i => i.Identifier.ContextualKind() == SyntaxKind.UnderscoreToken);
         }
 
         private static IdentifierNameSyntax GetReference(SyntaxTree tree, string name)
@@ -2809,46 +2823,49 @@ class C
 
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       72 (0x48)
+  // Code size       76 (0x4c)
   .maxstack  2
   .locals init (System.Collections.Generic.IEnumerator<(int, int)> V_0,
                 int V_1, //x1
                 int V_2, //x2
-                int V_3)
+                int V_3,
+                int V_4)
   IL_0000:  call       ""System.Collections.Generic.IEnumerable<(int, int)> C.M()""
   IL_0005:  callvirt   ""System.Collections.Generic.IEnumerator<(int, int)> System.Collections.Generic.IEnumerable<(int, int)>.GetEnumerator()""
   IL_000a:  stloc.0
   .try
   {
-    IL_000b:  br.s       IL_0033
+    IL_000b:  br.s       IL_0037
     IL_000d:  ldloc.0
     IL_000e:  callvirt   ""(int, int) System.Collections.Generic.IEnumerator<(int, int)>.Current.get""
     IL_0013:  dup
     IL_0014:  ldfld      ""int System.ValueTuple<int, int>.Item1""
     IL_0019:  stloc.3
     IL_001a:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-    IL_001f:  ldloc.3
-    IL_0020:  stloc.1
-    IL_0021:  stloc.2
-    IL_0022:  ldloc.1
-    IL_0023:  box        ""int""
-    IL_0028:  ldloc.2
-    IL_0029:  box        ""int""
-    IL_002e:  call       ""void C.Print(object, object)""
-    IL_0033:  ldloc.0
-    IL_0034:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
-    IL_0039:  brtrue.s   IL_000d
-    IL_003b:  leave.s    IL_0047
+    IL_001f:  stloc.s    V_4
+    IL_0021:  ldloc.3
+    IL_0022:  stloc.1
+    IL_0023:  ldloc.s    V_4
+    IL_0025:  stloc.2
+    IL_0026:  ldloc.1
+    IL_0027:  box        ""int""
+    IL_002c:  ldloc.2
+    IL_002d:  box        ""int""
+    IL_0032:  call       ""void C.Print(object, object)""
+    IL_0037:  ldloc.0
+    IL_0038:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
+    IL_003d:  brtrue.s   IL_000d
+    IL_003f:  leave.s    IL_004b
   }
   finally
   {
-    IL_003d:  ldloc.0
-    IL_003e:  brfalse.s  IL_0046
-    IL_0040:  ldloc.0
-    IL_0041:  callvirt   ""void System.IDisposable.Dispose()""
-    IL_0046:  endfinally
+    IL_0041:  ldloc.0
+    IL_0042:  brfalse.s  IL_004a
+    IL_0044:  ldloc.0
+    IL_0045:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_004a:  endfinally
   }
-  IL_0047:  ret
+  IL_004b:  ret
 }
 ");
         }
@@ -2897,18 +2914,19 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       95 (0x5f)
+  // Code size       99 (0x63)
   .maxstack  4
   .locals init ((int, int)[] V_0,
                 int V_1,
                 int V_2, //x1
                 int V_3, //x2
-                int V_4)
+                int V_4,
+                int V_5)
   IL_0000:  call       ""(int, int)[] C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldc.i4.0
   IL_0007:  stloc.1
-  IL_0008:  br.s       IL_0058
+  IL_0008:  br.s       IL_005c
   IL_000a:  ldloc.0
   IL_000b:  ldloc.1
   IL_000c:  ldelem     ""System.ValueTuple<int, int>""
@@ -2916,41 +2934,43 @@ class C
   IL_0012:  ldfld      ""int System.ValueTuple<int, int>.Item1""
   IL_0017:  stloc.s    V_4
   IL_0019:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-  IL_001e:  ldloc.s    V_4
-  IL_0020:  stloc.2
-  IL_0021:  stloc.3
-  IL_0022:  ldc.i4.4
-  IL_0023:  newarr     ""object""
-  IL_0028:  dup
-  IL_0029:  ldc.i4.0
-  IL_002a:  ldloc.2
-  IL_002b:  box        ""int""
-  IL_0030:  stelem.ref
-  IL_0031:  dup
-  IL_0032:  ldc.i4.1
-  IL_0033:  ldstr      "" ""
-  IL_0038:  stelem.ref
-  IL_0039:  dup
-  IL_003a:  ldc.i4.2
-  IL_003b:  ldloc.3
-  IL_003c:  box        ""int""
-  IL_0041:  stelem.ref
-  IL_0042:  dup
-  IL_0043:  ldc.i4.3
-  IL_0044:  ldstr      "" - ""
-  IL_0049:  stelem.ref
-  IL_004a:  call       ""string string.Concat(params object[])""
-  IL_004f:  call       ""void System.Console.Write(string)""
-  IL_0054:  ldloc.1
-  IL_0055:  ldc.i4.1
-  IL_0056:  add
-  IL_0057:  stloc.1
+  IL_001e:  stloc.s    V_5
+  IL_0020:  ldloc.s    V_4
+  IL_0022:  stloc.2
+  IL_0023:  ldloc.s    V_5
+  IL_0025:  stloc.3
+  IL_0026:  ldc.i4.4
+  IL_0027:  newarr     ""object""
+  IL_002c:  dup
+  IL_002d:  ldc.i4.0
+  IL_002e:  ldloc.2
+  IL_002f:  box        ""int""
+  IL_0034:  stelem.ref
+  IL_0035:  dup
+  IL_0036:  ldc.i4.1
+  IL_0037:  ldstr      "" ""
+  IL_003c:  stelem.ref
+  IL_003d:  dup
+  IL_003e:  ldc.i4.2
+  IL_003f:  ldloc.3
+  IL_0040:  box        ""int""
+  IL_0045:  stelem.ref
+  IL_0046:  dup
+  IL_0047:  ldc.i4.3
+  IL_0048:  ldstr      "" - ""
+  IL_004d:  stelem.ref
+  IL_004e:  call       ""string string.Concat(params object[])""
+  IL_0053:  call       ""void System.Console.Write(string)""
   IL_0058:  ldloc.1
-  IL_0059:  ldloc.0
-  IL_005a:  ldlen
-  IL_005b:  conv.i4
-  IL_005c:  blt.s      IL_000a
-  IL_005e:  ret
+  IL_0059:  ldc.i4.1
+  IL_005a:  add
+  IL_005b:  stloc.1
+  IL_005c:  ldloc.1
+  IL_005d:  ldloc.0
+  IL_005e:  ldlen
+  IL_005f:  conv.i4
+  IL_0060:  blt.s      IL_000a
+  IL_0062:  ret
 }");
         }
 
@@ -2997,7 +3017,7 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size      110 (0x6e)
+  // Code size      114 (0x72)
   .maxstack  3
   .locals init ((int, int)[,] V_0,
                 int V_1,
@@ -3006,7 +3026,8 @@ class C
                 int V_4,
                 int V_5, //x1
                 int V_6, //x2
-                int V_7)
+                int V_7,
+                int V_8)
   IL_0000:  call       ""(int, int)[,] C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -3021,12 +3042,12 @@ class C
   IL_0017:  ldc.i4.0
   IL_0018:  callvirt   ""int System.Array.GetLowerBound(int)""
   IL_001d:  stloc.3
-  IL_001e:  br.s       IL_0069
+  IL_001e:  br.s       IL_006d
   IL_0020:  ldloc.0
   IL_0021:  ldc.i4.1
   IL_0022:  callvirt   ""int System.Array.GetLowerBound(int)""
   IL_0027:  stloc.s    V_4
-  IL_0029:  br.s       IL_0060
+  IL_0029:  br.s       IL_0064
   IL_002b:  ldloc.0
   IL_002c:  ldloc.3
   IL_002d:  ldloc.s    V_4
@@ -3035,29 +3056,31 @@ class C
   IL_0035:  ldfld      ""int System.ValueTuple<int, int>.Item1""
   IL_003a:  stloc.s    V_7
   IL_003c:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-  IL_0041:  ldloc.s    V_7
-  IL_0043:  stloc.s    V_5
-  IL_0045:  stloc.s    V_6
-  IL_0047:  ldloc.s    V_5
-  IL_0049:  box        ""int""
-  IL_004e:  ldloc.s    V_6
-  IL_0050:  box        ""int""
-  IL_0055:  call       ""void C.Print(object, object)""
-  IL_005a:  ldloc.s    V_4
-  IL_005c:  ldc.i4.1
-  IL_005d:  add
-  IL_005e:  stloc.s    V_4
-  IL_0060:  ldloc.s    V_4
-  IL_0062:  ldloc.2
-  IL_0063:  ble.s      IL_002b
-  IL_0065:  ldloc.3
-  IL_0066:  ldc.i4.1
-  IL_0067:  add
-  IL_0068:  stloc.3
+  IL_0041:  stloc.s    V_8
+  IL_0043:  ldloc.s    V_7
+  IL_0045:  stloc.s    V_5
+  IL_0047:  ldloc.s    V_8
+  IL_0049:  stloc.s    V_6
+  IL_004b:  ldloc.s    V_5
+  IL_004d:  box        ""int""
+  IL_0052:  ldloc.s    V_6
+  IL_0054:  box        ""int""
+  IL_0059:  call       ""void C.Print(object, object)""
+  IL_005e:  ldloc.s    V_4
+  IL_0060:  ldc.i4.1
+  IL_0061:  add
+  IL_0062:  stloc.s    V_4
+  IL_0064:  ldloc.s    V_4
+  IL_0066:  ldloc.2
+  IL_0067:  ble.s      IL_002b
   IL_0069:  ldloc.3
-  IL_006a:  ldloc.1
-  IL_006b:  ble.s      IL_0020
-  IL_006d:  ret
+  IL_006a:  ldc.i4.1
+  IL_006b:  add
+  IL_006c:  stloc.3
+  IL_006d:  ldloc.3
+  IL_006e:  ldloc.1
+  IL_006f:  ble.s      IL_0020
+  IL_0071:  ret
 }");
         }
 
@@ -3111,43 +3134,48 @@ static class Extension
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       64 (0x40)
+  // Code size       69 (0x45)
   .maxstack  3
   .locals init (string V_0,
                 int V_1,
-                int V_2, //x2
-                int V_3,
+                int V_2, //x1
+                int V_3, //x2
                 int V_4,
-                int V_5)
+                int V_5,
+                int V_6)
   IL_0000:  call       ""string C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldc.i4.0
   IL_0007:  stloc.1
-  IL_0008:  br.s       IL_0036
+  IL_0008:  br.s       IL_003b
   IL_000a:  ldloc.0
   IL_000b:  ldloc.1
   IL_000c:  callvirt   ""char string.this[int].get""
-  IL_0011:  ldloca.s   V_3
-  IL_0013:  ldloca.s   V_4
+  IL_0011:  ldloca.s   V_4
+  IL_0013:  ldloca.s   V_5
   IL_0015:  call       ""void Extension.Deconstruct(char, out int, out int)""
-  IL_001a:  ldloc.3
-  IL_001b:  ldloc.s    V_4
-  IL_001d:  stloc.s    V_5
-  IL_001f:  ldloc.s    V_5
+  IL_001a:  ldloc.s    V_4
+  IL_001c:  ldloc.s    V_5
+  IL_001e:  stloc.s    V_6
+  IL_0020:  dup
   IL_0021:  stloc.2
-  IL_0022:  box        ""int""
-  IL_0027:  ldloc.2
-  IL_0028:  box        ""int""
-  IL_002d:  call       ""void C.Print(object, object)""
-  IL_0032:  ldloc.1
-  IL_0033:  ldc.i4.1
-  IL_0034:  add
-  IL_0035:  stloc.1
-  IL_0036:  ldloc.1
-  IL_0037:  ldloc.0
-  IL_0038:  callvirt   ""int string.Length.get""
-  IL_003d:  blt.s      IL_000a
-  IL_003f:  ret
+  IL_0022:  ldloc.s    V_6
+  IL_0024:  stloc.3
+  IL_0025:  pop
+  IL_0026:  ldloc.2
+  IL_0027:  box        ""int""
+  IL_002c:  ldloc.3
+  IL_002d:  box        ""int""
+  IL_0032:  call       ""void C.Print(object, object)""
+  IL_0037:  ldloc.1
+  IL_0038:  ldc.i4.1
+  IL_0039:  add
+  IL_003a:  stloc.1
+  IL_003b:  ldloc.1
+  IL_003c:  ldloc.0
+  IL_003d:  callvirt   ""int string.Length.get""
+  IL_0042:  blt.s      IL_000a
+  IL_0044:  ret
 }");
         }
 
@@ -3334,62 +3362,67 @@ Deconstructing (5, 6)
 
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       98 (0x62)
+  // Code size      103 (0x67)
   .maxstack  3
   .locals init (System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>> V_0,
-                int V_1, //x2
-                int V_2, //x3
-                int V_3,
-                Pair<int, int> V_4,
-                int V_5,
+                long V_1, //x1
+                int V_2, //x2
+                int V_3, //x3
+                int V_4,
+                Pair<int, int> V_5,
                 int V_6,
                 int V_7,
-                int V_8)
+                int V_8,
+                int V_9)
   IL_0000:  call       ""System.Collections.Generic.IEnumerable<Pair<int, Pair<int, int>>> C.M()""
   IL_0005:  callvirt   ""System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>> System.Collections.Generic.IEnumerable<Pair<int, Pair<int, int>>>.GetEnumerator()""
   IL_000a:  stloc.0
   .try
   {
-    IL_000b:  br.s       IL_004d
+    IL_000b:  br.s       IL_0052
     IL_000d:  ldloc.0
     IL_000e:  callvirt   ""Pair<int, Pair<int, int>> System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>>.Current.get""
-    IL_0013:  ldloca.s   V_3
-    IL_0015:  ldloca.s   V_4
+    IL_0013:  ldloca.s   V_4
+    IL_0015:  ldloca.s   V_5
     IL_0017:  callvirt   ""void Pair<int, Pair<int, int>>.Deconstruct(out int, out Pair<int, int>)""
-    IL_001c:  ldloc.s    V_4
-    IL_001e:  ldloca.s   V_5
-    IL_0020:  ldloca.s   V_6
+    IL_001c:  ldloc.s    V_5
+    IL_001e:  ldloca.s   V_6
+    IL_0020:  ldloca.s   V_7
     IL_0022:  callvirt   ""void Pair<int, int>.Deconstruct(out int, out int)""
-    IL_0027:  ldloc.3
-    IL_0028:  conv.i8
-    IL_0029:  ldloc.s    V_5
-    IL_002b:  stloc.s    V_7
-    IL_002d:  ldloc.s    V_6
-    IL_002f:  stloc.s    V_8
-    IL_0031:  ldloc.s    V_7
+    IL_0027:  ldloc.s    V_4
+    IL_0029:  conv.i8
+    IL_002a:  ldloc.s    V_6
+    IL_002c:  stloc.s    V_8
+    IL_002e:  ldloc.s    V_7
+    IL_0030:  stloc.s    V_9
+    IL_0032:  dup
     IL_0033:  stloc.1
     IL_0034:  ldloc.s    V_8
     IL_0036:  stloc.2
-    IL_0037:  box        ""long""
-    IL_003c:  ldloc.1
-    IL_003d:  box        ""int""
-    IL_0042:  ldloc.2
-    IL_0043:  box        ""int""
-    IL_0048:  call       ""void C.Print(object, object, object)""
-    IL_004d:  ldloc.0
-    IL_004e:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
-    IL_0053:  brtrue.s   IL_000d
-    IL_0055:  leave.s    IL_0061
+    IL_0037:  ldloc.s    V_9
+    IL_0039:  stloc.3
+    IL_003a:  pop
+    IL_003b:  ldloc.1
+    IL_003c:  box        ""long""
+    IL_0041:  ldloc.2
+    IL_0042:  box        ""int""
+    IL_0047:  ldloc.3
+    IL_0048:  box        ""int""
+    IL_004d:  call       ""void C.Print(object, object, object)""
+    IL_0052:  ldloc.0
+    IL_0053:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
+    IL_0058:  brtrue.s   IL_000d
+    IL_005a:  leave.s    IL_0066
   }
   finally
   {
-    IL_0057:  ldloc.0
-    IL_0058:  brfalse.s  IL_0060
-    IL_005a:  ldloc.0
-    IL_005b:  callvirt   ""void System.IDisposable.Dispose()""
-    IL_0060:  endfinally
+    IL_005c:  ldloc.0
+    IL_005d:  brfalse.s  IL_0065
+    IL_005f:  ldloc.0
+    IL_0060:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0065:  endfinally
   }
-  IL_0061:  ret
+  IL_0066:  ret
 }
 ");
         }
@@ -4612,6 +4645,804 @@ System.Console.Write($""{x1} {x2} {x3}"");
             Assert.Equal(SymbolKind.NamedType, model.GetSymbolInfo(x3Type).Symbol.Kind);
             Assert.Equal("var", model.GetSymbolInfo(x3Type).Symbol.ToDisplayString());
             Assert.Null(model.GetAliasInfo(x3Type));
+        }
+
+        [Fact]
+        public void SimpleDiscardWithConversion()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (int _, var x) = (new C(1), 1);
+        (var _, var y) = (new C(2), 2);
+        var (_, z) = (new C(3), 3);
+        System.Console.Write($""Output {x} {y} {z}."");
+    }
+    int _i;
+    public C(int i) { _i = i; }
+    public static implicit operator int(C c) { System.Console.Write($""Converted {c._i}. ""); return 0; }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Converted 1. Output 1 2 3.");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var discard1 = GetDiscardDesignations(tree).First();
+            Assert.Null(model.GetDeclaredSymbol(discard1));
+            var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
+            Assert.Equal("int _", declaration1.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration1).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            var discard2 = GetDiscardDesignations(tree).Skip(1).First();
+            Assert.Null(model.GetDeclaredSymbol(discard2));
+            var declaration2 = (DeclarationExpressionSyntax)discard2.Parent;
+            Assert.Equal("var _", declaration2.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration2).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            var discard3 = GetDiscardDesignations(tree).Skip(2).First();
+            var declaration3 = (DeclarationExpressionSyntax)discard3.Parent.Parent;
+            Assert.Equal("var (_, z)", declaration3.ToString());
+            //Assert.Equal("", model.GetTypeInfo(var_2).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+        }
+
+        [Fact]
+        public void CannotDeconstructIntoDiscardOfWrongType()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (int _, string _) = (""hello"", 42);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,30): error CS0029: Cannot implicitly convert type 'string' to 'int'
+                //         (int _, string _) = ("hello", 42);
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""hello""").WithArguments("string", "int").WithLocation(6, 30),
+                // (6,39): error CS0029: Cannot implicitly convert type 'int' to 'string'
+                //         (int _, string _) = ("hello", 42);
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "42").WithArguments("int", "string").WithLocation(6, 39)
+                );
+        }
+
+        [Fact]
+        public void DiscardFromDeconstructMethod()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (var _, string y) = new C();
+        System.Console.Write(y);
+    }
+    void Deconstruct(out int x, out string y) { x = 42; y = ""hello""; }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "hello");
+        }
+
+        [Fact]
+        public void ShortDiscardInDeclaration()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (_, var x) = (1, 2);
+        System.Console.Write(x);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "2");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var discard = GetDiscardIdentifiers(tree).First();
+            var symbol = (IDiscardedSymbol)model.GetSymbolInfo(discard).Symbol; // PROTOTYPE(wildcards): returns null
+            //Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void UnderscoreLocalInDeconstructDeclaration()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        int _;
+        (_, var x) = (1, 2);
+        System.Console.Write(_);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (7,10): error CS8184: Cannot reference _ in a deconstruction declaration
+                //         (_, var x) = (1, 2);
+                Diagnostic(ErrorCode.ERR_MixedDeconstructionDisallowed, "_").WithArguments("_").WithLocation(7, 10)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var discard = GetDiscardIdentifiers(tree).First();
+            Assert.Equal("(_, var x)", discard.Parent.Parent.ToString());
+            var symbol = (LocalSymbol)model.GetSymbolInfo(discard).Symbol;
+            Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void ShortDiscardInDeconstructAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        int x;
+        (_, _, x) = (1, 2, 3);
+        System.Console.Write(x);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "3");
+        }
+
+        [Fact]
+        public void MixedDeconstructionIsBlocked()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        int i;
+        (i, var x) = (1, 2);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            // PROTOTYPE(wildcards) parsing error for now, until we do mixing
+            comp.VerifyDiagnostics(
+                // (7,10): error CS1031: Type expected
+                //         (i, var x) = (1, 2);
+                Diagnostic(ErrorCode.ERR_TypeExpected, "i").WithLocation(7, 10),
+                // (7,10): error CS0128: A local variable or function named 'i' is already defined in this scope
+                //         (i, var x) = (1, 2);
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "i").WithArguments("i").WithLocation(7, 10),
+                // (6,13): warning CS0168: The variable 'i' is declared but never used
+                //         int i;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "i").WithArguments("i").WithLocation(6, 13)
+                );
+        }
+
+        [Fact]
+        public void DiscardInDeconstructAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        int x;
+        (_, x) = (1, 2);
+        System.Console.Write(x);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "2");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var discard1 = GetDiscardIdentifiers(tree).First();
+            Assert.Null(model.GetDeclaredSymbol(discard1));
+            var tuple1 = (TupleExpressionSyntax)discard1.Parent.Parent;
+            Assert.Equal("(_, x)", tuple1.ToString());
+            Assert.Equal("(System.Int32, System.Int32)", model.GetTypeInfo(tuple1).Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void DiscardInDeconstructDeclaration()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        var (_, x) = (1, 2);
+        System.Console.Write(x);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "2");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var discard1 = GetDiscardDesignations(tree).First();
+            Assert.Null(model.GetDeclaredSymbol(discard1));
+            var tuple1 = (DeclarationExpressionSyntax)discard1.Parent.Parent;
+            Assert.Equal("var (_, x)", tuple1.ToString());
+            //Assert.Equal("(System.Int32, System.Int32)", model.GetTypeInfo(tuple1).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix null type
+        }
+
+        [Fact]
+        public void UnderscoreLocalInDeconstructAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        int x, _;
+        (_, x) = (1, 2);
+        System.Console.Write($""{_} {x}"");
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "1 2");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var discard = GetDiscardIdentifiers(tree).First();
+            Assert.Equal("(_, x)", discard.Parent.Parent.ToString());
+            var symbol = (LocalSymbol)model.GetSymbolInfo(discard).Symbol;
+            Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void DiscardInForeach()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        foreach (var (_, x) in new[] { (1, ""hello"") }) { System.Console.Write(""1 ""); }
+        foreach ((_, var x) in new[] { (1, ""hello"") }) { System.Console.Write(""2""); }
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "1 2");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var discard1 = GetDiscardDesignations(tree).First();
+            Assert.Null(model.GetDeclaredSymbol(discard1));
+            var declaration1 = (DeclarationExpressionSyntax)discard1.Parent.Parent;
+            Assert.Equal("var (_, x)", declaration1.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration1).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            var discard3 = GetDiscardIdentifiers(tree).First();
+            var symbol3 = (IDiscardedSymbol)model.GetSymbolInfo(discard3).Symbol; // PROTOTYPE(wildcards): returns null
+            //Assert.Equal("System.Int32", symbol3.Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TwoDiscardsInForeach()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        foreach ((_, _) in new[] { (1, ""hello"") }) { System.Console.Write(""2""); }
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,25): error CS1001: Identifier expected
+                //         foreach ((_, _) in new[] { (1, "hello") }) { System.Console.Write("2"); }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "in").WithLocation(6, 25),
+                // (6,25): error CS0230: Type and identifier are both required in a foreach statement
+                //         foreach ((_, _) in new[] { (1, "hello") }) { System.Console.Write("2"); }
+                Diagnostic(ErrorCode.ERR_BadForeachDecl, "in").WithLocation(6, 25),
+                // (6,19): error CS0246: The type or namespace name '_' could not be found (are you missing a using directive or an assembly reference?)
+                //         foreach ((_, _) in new[] { (1, "hello") }) { System.Console.Write("2"); }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "_").WithArguments("_").WithLocation(6, 19),
+                // (6,22): error CS0246: The type or namespace name '_' could not be found (are you missing a using directive or an assembly reference?)
+                //         foreach ((_, _) in new[] { (1, "hello") }) { System.Console.Write("2"); }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "_").WithArguments("_").WithLocation(6, 22),
+                // (6,9): error CS0030: Cannot convert type '(int, string)' to '(_, _)'
+                //         foreach ((_, _) in new[] { (1, "hello") }) { System.Console.Write("2"); }
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "foreach").WithArguments("(int, string)", "(_, _)").WithLocation(6, 9)
+                );
+                // PROTOTYPE(wildcards) Parsing only underscores in foreach doesn't work presently
+                // We need at least one declaration expression to confirm it is a d-declaration
+                // TODO: This should parse, but report an error if a local called underscore exists.
+        }
+
+        [Fact]
+        public void UnderscoreLocalDisallowedInForEach()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        {
+            foreach ((var x, _) in new[] { (1, ""hello"") }) { System.Console.Write(""2 ""); }
+        }
+        {
+            int _;
+            foreach ((var y, _) in new[] { (1, ""hello"") }) { System.Console.Write(""4""); } // error
+        }
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (11,30): error CS8184: Cannot reference _ in a deconstruction declaration
+                //             foreach ((var y, _) in new[] { (1, "hello") }) { System.Console.Write("4"); } // error
+                Diagnostic(ErrorCode.ERR_MixedDeconstructionDisallowed, "_").WithArguments("_").WithLocation(11, 30),
+                // (11,30): error CS0029: Cannot implicitly convert type 'string' to 'int'
+                //             foreach ((var y, _) in new[] { (1, "hello") }) { System.Console.Write("4"); } // error
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "_").WithArguments("string", "int").WithLocation(11, 30),
+                // (10,17): warning CS0168: The variable '_' is declared but never used
+                //             int _;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "_").WithArguments("_").WithLocation(10, 17)
+                );
+        }
+
+        [Fact]
+        public void TwoDiscardsInDeconstructAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (_, _) = (new C(), new C());
+    }
+    public C() { System.Console.Write(""C""); }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "CC");
+        }
+
+        [Fact]
+        public void SingleDiscardInAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        _ = M();
+    }
+    public static int M() { System.Console.Write(""M""); return 1; }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "M");
+        }
+
+        [Fact]
+        public void SingleDiscardInUntypedAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        _ = null;
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,9): error CS8183: Cannot assign null to a discard variable
+                //         _ = null;
+                Diagnostic(ErrorCode.ERR_DiscardVariableAssignedBadValue, "_").WithArguments("null").WithLocation(6, 9)
+                );
+        }
+
+        [Fact]
+        public void UnderscoreLocalInAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        int _;
+        _ = M();
+        System.Console.Write(_);
+    }
+    public static int M() { return 1; }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "1");
+        }
+
+        [Fact]
+        public void DeclareAndUseLocalInDeconstruction()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (var x, x) = (1, 2);
+        (y, var y) = (1, 2);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            // mixing declaration and expressions isn't supported yet
+            comp.VerifyDiagnostics(
+                // (6,17): error CS1031: Type expected
+                //         (var x, x) = (1, 2);
+                Diagnostic(ErrorCode.ERR_TypeExpected, "x").WithLocation(6, 17),
+                // (7,10): error CS1031: Type expected
+                //         (y, var y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_TypeExpected, "y").WithLocation(7, 10),
+                // (6,17): error CS0128: A local variable or function named 'x' is already defined in this scope
+                //         (var x, x) = (1, 2);
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x").WithArguments("x").WithLocation(6, 17),
+                // (7,17): error CS0128: A local variable or function named 'y' is already defined in this scope
+                //         (y, var y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "y").WithArguments("y").WithLocation(7, 17)
+                );
+        }
+
+        [Fact]
+        public void OutVarAndUsageInDeconstructAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (M(out var x).P, x) = (1, x);
+        System.Console.Write(x);
+    }
+    static C M(out int i) { i = 42; return new C(); }
+    int P { set { System.Console.Write($""Written {value}. ""); } }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Written 1. 42");
+        }
+
+        [Fact]
+        public void OutDiscardInDeconstructAssignment()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        int _;
+        (M(out var _).P, _) = (1, 2);
+        System.Console.Write(_);
+    }
+    static C M(out int i) { i = 42; return new C(); }
+    int P { set { System.Console.Write($""Written {value}. ""); } }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "Written 1. 2");
+        }
+
+        [Fact]
+        public void OutDiscardInDeconstructTarget()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        (x, _) = (M(out var x), 2);
+        System.Console.Write(x);
+    }
+    static int M(out int i) { i = 42; return 3; }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,10): error CS0841: Cannot use local variable 'x' before it is declared
+                //         (x, _) = (M(out var x), 2);
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x").WithArguments("x").WithLocation(6, 10)
+                );
+        }
+
+
+        [Fact]
+        public void SimpleDiscardDeconstructInScript()
+        {
+            var source =
+@"
+using alias = System.Int32;
+(string _, alias _) = (""hello"", 42);
+";
+
+            Action<ModuleSymbol> validator = (ModuleSymbol module) =>
+            {
+                var sourceModule = (SourceModuleSymbol)module;
+                var compilation = sourceModule.DeclaringCompilation;
+                var tree = compilation.SyntaxTrees.First();
+                var model = compilation.GetSemanticModel(tree);
+
+                var discard1 = GetDiscardDesignations(tree).First();
+                var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
+                Assert.Equal("string _", declaration1.ToString());
+                Assert.Null(model.GetDeclaredSymbol(declaration1));
+                Assert.Null(model.GetDeclaredSymbol(discard1));
+
+                var discard2 = GetDiscardDesignations(tree).Skip(1).First();
+                var declaration2 = (DeclarationExpressionSyntax)discard2.Parent;
+                Assert.Equal("alias _", declaration2.ToString());
+                Assert.Null(model.GetDeclaredSymbol(declaration2));
+                Assert.Null(model.GetDeclaredSymbol(discard2));
+
+                var tuple = (TupleExpressionSyntax)declaration1.Parent.Parent;
+                Assert.Equal("(string _, alias _)", tuple.ToString());
+                Assert.Equal("(System.String, System.Int32)", model.GetTypeInfo(tuple).Type.ToTestDisplayString());
+            };
+
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, sourceSymbolValidator: validator);
+        }
+
+        [Fact]
+        public void SingleDiscardInAssignmentInScript()
+        {
+            var source =
+@"
+int M() { System.Console.Write(""M""); return 1; }
+_ = M();
+";
+
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "M");
+        }
+
+        [Fact]
+        public void NestedVarDiscardDeconstructionInScript()
+        {
+            var source =
+@"
+(var _, var (_, x3)) = (""hello"", (42, 43));
+System.Console.Write($""{x3}"");
+";
+
+            Action<ModuleSymbol> validator = (ModuleSymbol module) =>
+            {
+                var sourceModule = (SourceModuleSymbol)module;
+                var compilation = sourceModule.DeclaringCompilation;
+                var tree = compilation.SyntaxTrees.First();
+                var model = compilation.GetSemanticModel(tree);
+
+                var discard2 = GetDiscardDesignations(tree).Skip(1).First();
+                var nestedDeclaration = (DeclarationExpressionSyntax)discard2.Parent.Parent;
+                Assert.Equal("var (_, x3)", nestedDeclaration.ToString());
+                Assert.Null(model.GetDeclaredSymbol(nestedDeclaration));
+                Assert.Null(model.GetDeclaredSymbol(discard2));
+                //Assert.Equal("", model.GetTypeInfo(nestedDeclaration).Type.ToString()); // PROTOTYPE(wildcards) null
+
+                var tuple = (TupleExpressionSyntax)discard2.Parent.Parent.Parent.Parent;
+                Assert.Equal("(var _, var (_, x3))", tuple.ToString());
+                Assert.Equal("(System.String, (System.Int32, System.Int32))", model.GetTypeInfo(tuple).Type.ToTestDisplayString());
+            };
+
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "43", sourceSymbolValidator: validator);
+        }
+
+        [Fact]
+        public void VariousDiscardsInForeach()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        foreach ((var _, int _, _, var (_, _), int x) in new[] { (1, 2, 3, (4, 5), 6) })
+        {
+            System.Console.Write(x);
+        }
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "6");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            var discard1 = GetDiscardDesignations(tree).First();
+            Assert.Null(model.GetDeclaredSymbol(discard1));
+            var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
+            Assert.Equal("var _", declaration1.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration1).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            var discard2 = GetDiscardDesignations(tree).Skip(1).First();
+            Assert.Null(model.GetDeclaredSymbol(discard2));
+            var declaration2 = (DeclarationExpressionSyntax)discard2.Parent;
+            Assert.Equal("int _", declaration2.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration2).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            var discard3 = GetDiscardIdentifiers(tree).First();
+            Assert.Null(model.GetDeclaredSymbol(discard3));
+        }
+
+        [Fact]
+        public void DiscardInLegacyForeach()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        foreach (var _ in M())
+        {
+        }
+    }
+    static System.Collections.Generic.IEnumerable<int> M()
+    {
+        System.Console.Write(""M"");
+        yield return 1;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "M");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+
+            //var discard1 = GetDiscardDesignations(tree).First();
+            //Assert.Null(model.GetDeclaredSymbol(discard1));
+            //var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
+            //Assert.Equal("var _", declaration1.ToString());
+            ////Assert.Equal("", model.GetTypeInfo(declaration1).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            //var discard3 = GetDiscardIdentifiers(tree).First();
+            //Assert.Null(model.GetDeclaredSymbol(discard3));
+        }
+
+        [Fact]
+        public void ShortDiscardDisallowedInForeach()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        foreach (_ in M())
+        {
+        }
+    }
+    static System.Collections.Generic.IEnumerable<int> M()
+    {
+        yield return 1;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,20): error CS1001: Identifier expected
+                //         foreach (_ in M())
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "in").WithLocation(6, 20),
+                // (6,20): error CS0230: Type and identifier are both required in a foreach statement
+                //         foreach (_ in M())
+                Diagnostic(ErrorCode.ERR_BadForeachDecl, "in").WithLocation(6, 20),
+                // (6,18): error CS0246: The type or namespace name '_' could not be found (are you missing a using directive or an assembly reference?)
+                //         foreach (_ in M())
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "_").WithArguments("_").WithLocation(6, 18)
+                );
+        }
+
+        [Fact]
+        public void ExistingUnderscoreLocalInLegacyForeach()
+        {
+            var source =
+@"
+class C
+{
+    static void Main()
+    {
+        int _;
+        foreach (var _ in new[] { 1 })
+        {
+        }
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (7,22): error CS0136: A local or parameter named '_' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //         foreach (var _ in new[] { 1 })
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "_").WithArguments("_").WithLocation(7, 22),
+                // (6,13): warning CS0168: The variable '_' is declared but never used
+                //         int _;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "_").WithArguments("_").WithLocation(6, 13)
+                );
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5125,9 +5125,9 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (6,9): error CS8183: Cannot assign <null> to a discard variable
+                // (6,9): error CS8183: Cannot infer the type of implicitly-typed discard.
                 //         _ = null;
-                Diagnostic(ErrorCode.ERR_DiscardVariableAssignedBadValue, "_").WithArguments("<null>").WithLocation(6, 9)
+                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "_").WithLocation(6, 9)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
@@ -456,7 +456,7 @@ public class C
     }
 }
 ";
-            var c = CreateCompilationWithMscorlib(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilationWithMscorlib(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -527,7 +527,7 @@ public class C
     }
 }
 ";
-            var c = CreateCompilationWithMscorlib(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilationWithMscorlib(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { ValueTupleRef, SystemRuntimeFacadeRef});
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -2119,6 +2119,6 @@ public class Program
             return base.CompileAndVerify(source, expectedOutput: expectedOutput, additionalRefs: s_refs, options: (options ?? TestOptions.ReleaseExe).WithDeterministic(true), emitOptions: EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
         }
 
-        private static readonly MetadataReference[] s_refs = new[] { MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929 };
+        private static readonly MetadataReference[] s_refs = new[] { MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, ValueTupleRef, SystemRuntimeFacadeRef };
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTupleTests.cs
@@ -238,6 +238,7 @@ string.Format(@"<symbols>
           <slot kind=""0"" offset=""59"" />
           <slot kind=""0"" offset=""62"" />
           <slot kind=""temp"" />
+          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -246,16 +247,16 @@ string.Format(@"<symbols>
         <entry offset=""0x2"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""15"" />
         <entry offset=""0x9"" hidden=""true"" />
         <entry offset=""0xb"" startLine=""6"" startColumn=""13"" endLine=""6"" endColumn=""23"" />
-        <entry offset=""0x20"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x22"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""15"" />
-        <entry offset=""0x2c"" hidden=""true"" />
-        <entry offset=""0x37"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x24"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
+        <entry offset=""0x25"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
+        <entry offset=""0x26"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""15"" />
+        <entry offset=""0x30"" hidden=""true"" />
+        <entry offset=""0x3b"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x38"">
-        <scope startOffset=""0xb"" endOffset=""0x22"">
-          <local name=""a"" il_index=""1"" il_start=""0xb"" il_end=""0x22"" attributes=""0"" />
-          <local name=""b"" il_index=""2"" il_start=""0xb"" il_end=""0x22"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x3c"">
+        <scope startOffset=""0xb"" endOffset=""0x26"">
+          <local name=""a"" il_index=""1"" il_start=""0xb"" il_end=""0x26"" attributes=""0"" />
+          <local name=""b"" il_index=""2"" il_start=""0xb"" il_end=""0x26"" attributes=""0"" />
         </scope>
       </scope>
     </method>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -17555,9 +17555,9 @@ public class Cls
 }";
             var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe);
             compilation.VerifyDiagnostics(
-                // (7,23): error CS0103: The name '_' does not exist in the current context
+                // (7,23): error CS8183: Cannot infer the type of implicitly-typed discard.
                 //         var x = d[out _];
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(7, 23)
+                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "_").WithLocation(7, 23)
                 );
         }
 
@@ -17878,13 +17878,13 @@ class B
     {{
         A a = new A();
         IA ia = a;
-        Console.WriteLine(ia.P[out int _]);
+        Console.WriteLine(ia.P[out {0} _]);
         ia.P[out {0} _] = 4;
-        Console.WriteLine(ia[out int _]);
+        Console.WriteLine(ia[out {0} _]);
         ia[out {0} _] = 4;
     }}
 }}";
-            string[] fillIns = new[] { "int", "var" };
+            string[] fillIns = new[] { "int", "var", "" };
             foreach (var fillIn in fillIns)
             {
                 var source2 = string.Format(source2Template, fillIn);
@@ -17976,9 +17976,9 @@ public class Cls
                 // (10,22): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //             [out var _] = 4,
                 Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(10, 22),
-                // (11,18): error CS0103: The name '_' does not exist in the current context
+                // (11,18): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //             [out _] = 5
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(11, 18),
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(11, 18),
                 // (14,30): error CS0103: The name '_' does not exist in the current context
                 //         System.Console.Write(_);
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(14, 30),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -27832,17 +27832,18 @@ public class C
     @"
 public class C
 {
-    static void M(out object x) { x = 1; }
-    static void M(out int x) { x = 2; System.Console.Write(""int returning M""); }
+    static void M(out object x) { x = 1; System.Console.Write(""object returing M. ""); }
+    static void M(out int x) { x = 2; System.Console.Write(""int returning M.""); }
     static void Main()
     {
+        M(out object _);
         M(out int _);
     }
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "int returning M");
+            CompileAndVerify(comp, expectedOutput: "object returing M. int returning M.");
         }
 
         [Fact]
@@ -27853,11 +27854,12 @@ public class C
 public class C
 {
     static void M(out object x) { x = 1; }
-    static void M(out int x) { x = 2; System.Console.Write(""int returning M""); }
+    static void M(out int x) { x = 2; }
     static void Main()
     {
         M(out var _);
         M(out _);
+        M(out byte _);
     }
 }
 ";
@@ -27868,7 +27870,10 @@ public class C
                 Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(out object)", "C.M(out int)").WithLocation(8, 9),
                 // (9,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.M(out object)' and 'C.M(out int)'
                 //         M(out _);
-                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(out object)", "C.M(out int)").WithLocation(9, 9)
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(out object)", "C.M(out int)").WithLocation(9, 9),
+                // (10,20): error CS1503: Argument 1: cannot convert from 'out byte' to 'out object'
+                //         M(out byte _);
+                Diagnostic(ErrorCode.ERR_BadArgType, "_").WithArguments("1", "out byte", "out object").WithLocation(10, 20)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTestBase.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTestBase.cs
@@ -31,6 +31,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return tree.GetRoot().DescendantNodes().OfType<SingleVariableDesignationSyntax>().Where(p => p.Parent.Kind() == SyntaxKind.DeclarationPattern);
         }
 
+        protected static IEnumerable<DiscardedDesignationSyntax> GetDiscardDesignations(SyntaxTree tree)
+        {
+            return tree.GetRoot().DescendantNodes().OfType<DiscardedDesignationSyntax>();
+        }
+
         protected static IdentifierNameSyntax GetReference(SyntaxTree tree, string name)
         {
             return GetReferences(tree, name).Single();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -3491,5 +3491,109 @@ public class C
             VerifyModelForDeclarationPattern(model, x2Decl, x2Ref);
             Assert.Equal("System.Collections.Generic.IEnumerable<System.String>", model.GetTypeInfo(x2Ref).Type.ToTestDisplayString());
         }
+
+        [Fact]
+        public void DiscardInPattern()
+        {
+            var source =
+@"
+using static System.Console;
+public class C
+{
+    public static void Main()
+    {
+        int i = 3;
+        Write($""is int _: {i is int _}, "");
+        Write($""is var _: {i is var _}, "");
+        switch (3)
+        {
+            case int _:
+                Write(""case int _, "");
+                break;
+        }
+        switch (3)
+        {
+            case var _:
+                Write(""case var _"");
+                break;
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "is int _: True, is var _: True, case int _, case var _");
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var discard1 = GetDiscardDesignations(tree).First();
+            Assert.Null(model.GetDeclaredSymbol(discard1));
+            var declaration1 = (DeclarationPatternSyntax)discard1.Parent;
+            Assert.Equal("int _", declaration1.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration1).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            var discard2 = GetDiscardDesignations(tree).Skip(1).First();
+            Assert.Null(model.GetDeclaredSymbol(discard2));
+            var declaration2 = (DeclarationPatternSyntax)discard2.Parent;
+            Assert.Equal("var _", declaration2.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration2).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            var discard3 = GetDiscardDesignations(tree).Skip(2).First();
+            Assert.Null(model.GetDeclaredSymbol(discard3));
+            var declaration3 = (DeclarationPatternSyntax)discard3.Parent;
+            Assert.Equal("int _", declaration3.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration3).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+
+            var discard4 = GetDiscardDesignations(tree).Skip(3).First();
+            Assert.Null(model.GetDeclaredSymbol(discard4));
+            var declaration4 = (DeclarationPatternSyntax)discard4.Parent;
+            Assert.Equal("var _", declaration4.ToString());
+            //Assert.Equal("", model.GetTypeInfo(declaration4).Type.ToTestDisplayString()); // PROTOTYPE(wildcards) fix
+        }
+
+        [Fact]
+        public void UnderscoreInPattern()
+        {
+            var source =
+@"
+using static System.Console;
+public class C
+{
+    public static void Main()
+    {
+        int i = 3;
+        if (i is int _) { Write(_); }
+        if (i is var _) { Write(_); }
+        switch (3)
+        {
+            case int _:
+                Write(_);
+                break;
+        }
+        switch (3)
+        {
+            case var _:
+                Write(_);
+                break;
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics(
+                // (8,33): error CS0103: The name '_' does not exist in the current context
+                //         if (i is int _) { Write(_); }
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(8, 33),
+                // (9,33): error CS0103: The name '_' does not exist in the current context
+                //         if (i is var _) { Write(_); }
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(9, 33),
+                // (13,23): error CS0103: The name '_' does not exist in the current context
+                //                 Write(_);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(13, 23),
+                // (19,23): error CS0103: The name '_' does not exist in the current context
+                //                 Write(_);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(19, 23)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -32,8 +32,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 {
                     continue;
                 }
-                var message = ErrorFacts.GetMessage(code, CultureInfo.InvariantCulture);
-                Assert.False(string.IsNullOrEmpty(message));
+
+                try
+                {
+                    var message = ErrorFacts.GetMessage(code, CultureInfo.InvariantCulture);
+                    Assert.False(string.IsNullOrEmpty(message));
+                }
+                catch (Exception)
+                {
+                    System.Console.WriteLine($"Failed on {code}");
+                    throw;
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTests.cs
@@ -1411,7 +1411,7 @@ class C
             {
                 foreach ((int x, var y) in foo) { }
             }
-        }", options: TestOptions.Regular.WithTuplesFeature());
+        }");
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.ClassDeclaration);
@@ -1743,6 +1743,128 @@ class C
                     {
                         N(SyntaxKind.SemicolonToken);
                     }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void DeconstructionDeclarationWithDiscard()
+        {
+            var tree = UsingTree(@"
+class C
+{
+    void Foo()
+    {
+        (int _, var _, var (_, _), _) = e;
+    }
+}");
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "Foo");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.SimpleAssignmentExpression);
+                                {
+                                    N(SyntaxKind.TupleExpression);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.DeclarationExpression);
+                                            {
+                                                N(SyntaxKind.PredefinedType);
+                                                {
+                                                    N(SyntaxKind.IntKeyword);
+                                                }
+                                                N(SyntaxKind.DiscardedDesignation);
+                                                {
+                                                    N(SyntaxKind.UnderscoreToken);
+                                                }
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.DeclarationExpression);
+                                            {
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "var");
+                                                }
+                                                N(SyntaxKind.DiscardedDesignation);
+                                                {
+                                                    N(SyntaxKind.UnderscoreToken);
+                                                }
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.DeclarationExpression);
+                                            {
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "var");
+                                                }
+                                                N(SyntaxKind.ParenthesizedVariableDesignation);
+                                                {
+                                                    N(SyntaxKind.OpenParenToken);
+                                                    N(SyntaxKind.DiscardedDesignation);
+                                                    {
+                                                        N(SyntaxKind.UnderscoreToken);
+                                                    }
+                                                    N(SyntaxKind.CommaToken);
+                                                    N(SyntaxKind.DiscardedDesignation);
+                                                    {
+                                                        N(SyntaxKind.UnderscoreToken);
+                                                    }
+                                                    N(SyntaxKind.CloseParenToken);
+                                                }
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "_");
+                                            }
+                                        }
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "e");
+                                    }
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }

--- a/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.cs
@@ -282,6 +282,19 @@ namespace Microsoft.CodeAnalysis
             return _list.Any();
         }
 
+        internal bool All(Func<TNode, bool> predicate)
+        {
+            for (int i = 0; i < this.Count; i++)
+            {
+                if (!predicate(this[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public SyntaxNodeOrTokenList GetWithSeparators()
         {
             return _list;

--- a/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/SeparatedSyntaxList.cs
@@ -282,17 +282,17 @@ namespace Microsoft.CodeAnalysis
             return _list.Any();
         }
 
-        internal bool All(Func<TNode, bool> predicate)
+        internal bool Any(Func<TNode, bool> predicate)
         {
             for (int i = 0; i < this.Count; i++)
             {
-                if (!predicate(this[i]))
+                if (predicate(this[i]))
                 {
-                    return false;
+                    return true;
                 }
             }
 
-            return true;
+            return false;
         }
 
         public SyntaxNodeOrTokenList GetWithSeparators()

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -640,7 +640,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 case BoundKind.ExpressionStatement:
                 case BoundKind.LocalDeclaration:
                 case BoundKind.MultipleLocalDeclarations:
-                case BoundKind.LocalDeconstructionDeclaration:
                     return compilation.GetSpecialType(SpecialType.System_Void);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(bodyOpt.Kind);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -119,10 +119,11 @@ class C
 
                    testData.GetMethodData("<>x.<>m0(C)").VerifyIL(@"
 {
-  // Code size      103 (0x67)
+  // Code size      105 (0x69)
   .maxstack  4
   .locals init (System.Guid V_0,
-                int V_1)
+                int V_1,
+                string V_2)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""z1""
@@ -146,14 +147,16 @@ class C
   IL_0044:  ldfld      ""int System.ValueTuple<int, string>.Item1""
   IL_0049:  stloc.1
   IL_004a:  ldfld      ""string System.ValueTuple<int, string>.Item2""
-  IL_004f:  ldstr      ""z1""
-  IL_0054:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_0059:  ldloc.1
-  IL_005a:  stind.i4
-  IL_005b:  ldstr      ""z2""
-  IL_0060:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
-  IL_0065:  stind.ref
-  IL_0066:  ret
+  IL_004f:  stloc.2
+  IL_0050:  ldstr      ""z1""
+  IL_0055:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_005a:  ldloc.1
+  IL_005b:  stind.i4
+  IL_005c:  ldstr      ""z2""
+  IL_0061:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
+  IL_0066:  ldloc.2
+  IL_0067:  stind.ref
+  IL_0068:  ret
 }");
                });
         }


### PR DESCRIPTION
Adds binding and lowering logic to support discards in deconstruction, out var and assignment.

```C#
(var x, var _, _) = e;
foreach ((var y, var _, _) in e) { }
M(out var _, out _);
_ = e;
```

Some test code is commented out (with PROTOTYPE marker) until semantic model is updated (`GetTypeInfo` and `GetSymbolInfo`).

From discussion with Neal, we won't do `case _:` for now (he'll ping LDM).

@dotnet/roslyn-compiler for review.