### PR TITLE
include portable pdb in nupkg

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -51,7 +51,7 @@
   <!-- Windows specific settings -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <BaseNuGetRuntimeIdentifier>win7</BaseNuGetRuntimeIdentifier>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <UseSharedCompilation>true</UseSharedCompilation>
 
     <!-- This is a really hacky way to detect whether we are on a legacy or a willow based VS install.

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
@@ -21,6 +21,7 @@
   </metadata>
   <files>
     <file src="Dlls\CSharpCodeAnalysis\Microsoft.CodeAnalysis.CSharp.dll" target="lib\netstandard1.3" />
+    <file src="Dlls\CSharpCodeAnalysis\Microsoft.CodeAnalysis.CSharp.pdb" target="lib\netstandard1.3" />
     <file src="Dlls\CSharpCodeAnalysis\Microsoft.CodeAnalysis.CSharp.xml" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />
   </files>


### PR DESCRIPTION
Revisiting @davkean's [plan from February](https://github.com/dotnet/roslyn/issues/3#issuecomment-180123687), this is the start of Step 1. Step 1 is to add the portable pdb files to all of the nupkg files. Step 2 will be to source link (index) those pdb files, but that will be a separate pull request at a later date.

There are several more nupkg's and this is so far just an example for one by adding the portable pdb to the Microsoft.CodeAnalysis.CSharp nupkg. I [posted the analysis](https://github.com/NuGet/Home/issues/1696#issuecomment-260168364) of the file size increase here, so the NuGet team could review the proposal again. It sounds like we may have gotten the green light or will get it very soon. @yishaigalatzer, can you confirm that it is okay now/soon for Microsoft open source to include the portable pdb files in the nupkg files? 


