### PR TITLE
Don't allow an empty assembly name to be stored in the workspace.

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
@@ -501,17 +501,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         }
 
         private static string GetAssemblyNameFromProjectPath(string projectFilePath)
-        {
-            var assemblyName = Path.GetFileNameWithoutExtension(projectFilePath);
-
-            // if this is still unreasonable, use a fixed name.
-            if (string.IsNullOrWhiteSpace(assemblyName))
-            {
-                assemblyName = "assembly";
-            }
-
-            return assemblyName;
-        }
+            => Path.GetFileNameWithoutExtension(projectFilePath);
 
         private static readonly char[] s_directorySplitChars = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -319,6 +320,8 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal class ProjectAttributes : IChecksummedObject, IObjectWritable
         {
+            private static int s_nextInvalidAssemblySuffix = 0;
+
             /// <summary>
             /// The unique Id of the project.
             /// </summary>
@@ -380,7 +383,15 @@ namespace Microsoft.CodeAnalysis
                 Id = id ?? throw new ArgumentNullException(nameof(id));
                 Name = name ?? throw new ArgumentNullException(nameof(name));
                 Language = language ?? throw new ArgumentNullException(nameof(language));
-                AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
+
+                // Empty assembly names are not allowed.  For now just default to an unused assembly
+                // name.
+                if (string.IsNullOrWhiteSpace(assemblyName))
+                {
+                    assemblyName = "__InvalidAssembly_" + Interlocked.Increment(ref s_nextInvalidAssemblySuffix);
+                }
+
+                AssemblyName = assemblyName;
 
                 Version = version;
                 FilePath = filePath;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -386,12 +386,9 @@ namespace Microsoft.CodeAnalysis
 
                 // Empty assembly names are not allowed.  For now just default to an unused assembly
                 // name.
-                if (string.IsNullOrWhiteSpace(assemblyName))
-                {
-                    assemblyName = "__InvalidAssembly_" + Interlocked.Increment(ref s_nextInvalidAssemblySuffix);
-                }
-
-                AssemblyName = assemblyName;
+                AssemblyName = string.IsNullOrWhiteSpace(assemblyName)
+                    ? "__InvalidAssembly_" + Interlocked.Increment(ref s_nextInvalidAssemblySuffix)
+                    : assemblyName;
 
                 Version = version;
                 FilePath = filePath;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public sealed class ProjectInfo
     {
+        internal const string InvalidAssemblyNamePrefix = "__InvalidAssembly_";
+
         internal ProjectAttributes Attributes { get; }
 
         /// <summary>
@@ -387,7 +389,7 @@ namespace Microsoft.CodeAnalysis
                 // Empty assembly names are not allowed.  For now just default to an unused assembly
                 // name.
                 AssemblyName = string.IsNullOrWhiteSpace(assemblyName)
-                    ? "__InvalidAssembly_" + Interlocked.Increment(ref s_nextInvalidAssemblySuffix)
+                    ? InvalidAssemblyNamePrefix + Interlocked.Increment(ref s_nextInvalidAssemblySuffix)
                     : assemblyName;
 
                 Version = version;

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
@@ -13,8 +13,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var pid = ProjectId.CreateNewId();
             Assert.Throws<ArgumentNullException>(() => ProjectInfo.Create(id: null, version: VersionStamp.Default, name: "Foo", assemblyName: "Bar", language: "C#"));
             Assert.Throws<ArgumentNullException>(() => ProjectInfo.Create(pid, VersionStamp.Default, name: null, assemblyName: "Bar", language: "C#"));
-            Assert.Throws<ArgumentNullException>(() => ProjectInfo.Create(pid, VersionStamp.Default, name: "Foo", assemblyName: null, language: "C#"));
             Assert.Throws<ArgumentNullException>(() => ProjectInfo.Create(pid, VersionStamp.Default, name: "Foo", assemblyName: "Bar", language: null));
+
+            var info = ProjectInfo.Create(pid, VersionStamp.Default, name: "Foo", assemblyName: null, language: "C#");
+            Assert.True(info.AssemblyName.StartsWith(ProjectInfo.InvalidAssemblyNamePrefix));
         }
 
         [Fact]

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
@@ -14,8 +14,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<ArgumentNullException>(() => ProjectInfo.Create(id: null, version: VersionStamp.Default, name: "Foo", assemblyName: "Bar", language: "C#"));
             Assert.Throws<ArgumentNullException>(() => ProjectInfo.Create(pid, VersionStamp.Default, name: null, assemblyName: "Bar", language: "C#"));
             Assert.Throws<ArgumentNullException>(() => ProjectInfo.Create(pid, VersionStamp.Default, name: "Foo", assemblyName: "Bar", language: null));
+        }
 
+        [Fact]
+        public void TestNullOrWhitespaceAssemblyNameAllowed(ProjectId pid)
+        {
             var info = ProjectInfo.Create(pid, VersionStamp.Default, name: "Foo", assemblyName: null, language: "C#");
+            Assert.True(info.AssemblyName.StartsWith(ProjectInfo.InvalidAssemblyNamePrefix));
+
+            info = ProjectInfo.Create(pid, VersionStamp.Default, name: "Foo", assemblyName: "", language: "C#");
+            Assert.True(info.AssemblyName.StartsWith(ProjectInfo.InvalidAssemblyNamePrefix));
+
+            info = ProjectInfo.Create(pid, VersionStamp.Default, name: "Foo", assemblyName: " ", language: "C#");
             Assert.True(info.AssemblyName.StartsWith(ProjectInfo.InvalidAssemblyNamePrefix));
         }
 

--- a/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/ProjectInfoTests.cs
@@ -17,8 +17,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void TestNullOrWhitespaceAssemblyNameAllowed(ProjectId pid)
+        public void TestNullOrWhitespaceAssemblyNameAllowed()
         {
+            var pid = ProjectId.CreateNewId();
             var info = ProjectInfo.Create(pid, VersionStamp.Default, name: "Foo", assemblyName: null, language: "C#");
             Assert.True(info.AssemblyName.StartsWith(ProjectInfo.InvalidAssemblyNamePrefix));
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=233669&_a=edit