### PR TITLE
Place Roslyn under a separate directory in MSBuild.

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -180,21 +180,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         /// <summary>
-        /// Return the path to the tool to execute.
-        /// </summary>
-        protected override string GenerateFullPathToTool()
-        {
-            var pathToTool = Utilities.GenerateFullPathToMSBuildRoslynTool(ToolName);
-
-            if (null == pathToTool)
-            {
-                Log.LogErrorWithCodeFromResources("General_ToolFileNotFound", ToolName);
-            }
-
-            return pathToTool;
-        }
-
-        /// <summary>
         /// Fills the provided CommandLineBuilderExtension with those switches and other information that can go into a response file.
         /// </summary>
         protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine)

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -184,16 +184,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         protected override string GenerateFullPathToTool()
         {
-            string pathToTool = ToolLocationHelper.GetPathToBuildToolsFile(ToolName, ToolLocationHelper.CurrentToolsVersion);
+            var pathToTool = Utilities.GenerateFullPathToMSBuildRoslynTool(ToolName);
 
             if (null == pathToTool)
             {
-                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolName, TargetDotNetFrameworkVersion.VersionLatest);
-
-                if (null == pathToTool)
-                {
-                    Log.LogErrorWithCodeFromResources("General_FrameworksFileNotFound", ToolName, ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
-                }
+                Log.LogErrorWithCodeFromResources("General_ToolFileNotFound", ToolName);
             }
 
             return pathToTool;

--- a/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
@@ -143,11 +143,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MSB3082: Task failed because &quot;{0}&quot; was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}..
+        ///   Looks up a localized string similar to MSB3082: Task failed because &quot;{0}&quot; was not found..
         /// </summary>
-        internal static string General_FrameworksFileNotFound {
+        internal static string General_ToolFileNotFound {
             get {
-                return ResourceManager.GetString("General_FrameworksFileNotFound", resourceCulture);
+                return ResourceManager.GetString("General_ToolFileNotFound", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/MSBuildTask/ErrorString.resx
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.resx
@@ -151,8 +151,8 @@
   <data name="General_ExpectedFileMissing" xml:space="preserve">
     <value>Expected file "{0}" does not exist.</value>
   </data>
-  <data name="General_FrameworksFileNotFound" xml:space="preserve">
-    <value>MSB3082: Task failed because "{0}" was not found, or the .NET Framework {1} is not installed.  Please install the .NET Framework {1}.</value>
+  <data name="General_ToolFileNotFound" xml:space="preserve">
+    <value>MSB3082: Task failed because "{0}" was not found.</value>
     <comment>{StrBegin="MSB3082: "}</comment>
   </data>
   <data name="General_IncorrectHostObject" xml:space="preserve">

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         protected override string GenerateFullPathToTool()
         {
-            var pathToTool = Utilities.GenerateFullPathToMSBuildRoslynTool(ToolName);
+            var pathToTool = Utilities.GenerateFullPathToTool(ToolName);
 
             if (null == pathToTool)
             {

--- a/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/InteractiveCompiler.cs
@@ -204,16 +204,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         protected override string GenerateFullPathToTool()
         {
-            string pathToTool = ToolLocationHelper.GetPathToBuildToolsFile(ToolName, ToolLocationHelper.CurrentToolsVersion);
+            var pathToTool = Utilities.GenerateFullPathToMSBuildRoslynTool(ToolName);
 
-            if (pathToTool == null)
+            if (null == pathToTool)
             {
-                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolName, TargetDotNetFrameworkVersion.VersionLatest);
-
-                if (pathToTool == null)
-                {
-                    Log.LogErrorWithCodeFromResources("General_FrameworksFileNotFound", ToolName, ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
-                }
+                Log.LogErrorWithCodeFromResources("General_ToolFileNotFound", ToolName);
             }
 
             return pathToTool;

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -154,7 +154,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         internal static string GenerateFullPathToMSBuildRoslynTool(string toolName)
         {
-            var pathToBuildTools = ToolLocationHelper.GetPathToBuildTools(ToolLocationHelper.CurrentToolsVersion);
+            // Roslyn always deploys to the 32Bit folder of MSBuild, so request this path on all architectures.
+            var pathToBuildTools = ToolLocationHelper.GetPathToBuildTools(ToolLocationHelper.CurrentToolsVersion, DotNetFrameworkArchitecture.Bitness32);
 
             if (null != pathToBuildTools)
             {

--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using System;
 using System.Globalization;
 using System.IO;
-using System.Security;
-using Microsoft.Build.Framework;
-using System.Runtime.InteropServices;
 using System.Reflection;
+using System.Security;
 
 namespace Microsoft.CodeAnalysis.BuildTasks
 {
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
     /// </summary>
     internal static class Utilities
     {
+        private const string MSBuildRoslynFolderName = "Roslyn";
+
         /// <summary>
         /// Convert a task item metadata to bool. Throw an exception if the string is badly formed and can't
         /// be converted.
@@ -148,6 +150,23 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
 
             return (string)method.Invoke(assembly, parameters: null);
+        }
+
+        internal static string GenerateFullPathToMSBuildRoslynTool(string toolName)
+        {
+            var pathToBuildTools = ToolLocationHelper.GetPathToBuildTools(ToolLocationHelper.CurrentToolsVersion);
+
+            if (null != pathToBuildTools)
+            {
+                var pathToTool = Path.Combine(pathToBuildTools, MSBuildRoslynFolderName, toolName);
+
+                if (File.Exists(pathToTool))
+                {
+                    return pathToTool;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -333,21 +333,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         }
 
         /// <summary>
-        /// Generate the path to the tool
-        /// </summary>
-        protected override string GenerateFullPathToTool()
-        {
-            var pathToTool = Utilities.GenerateFullPathToMSBuildRoslynTool(ToolName);
-
-            if (null == pathToTool)
-            {
-                Log.LogErrorWithCodeFromResources("General_ToolFileNotFound", ToolName);
-            }
-
-            return pathToTool;
-        }
-
-        /// <summary>
         /// vbc.exe only takes the BaseAddress in hexadecimal format.  But we allow the caller
         /// of the task to pass in the BaseAddress in either decimal or hexadecimal format.
         /// Examples of supported hex formats include "0x10000000" or "&amp;H10000000".

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -337,16 +337,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         protected override string GenerateFullPathToTool()
         {
-            string pathToTool = ToolLocationHelper.GetPathToBuildToolsFile(ToolName, ToolLocationHelper.CurrentToolsVersion);
+            var pathToTool = Utilities.GenerateFullPathToMSBuildRoslynTool(ToolName);
 
             if (null == pathToTool)
             {
-                pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolName, TargetDotNetFrameworkVersion.VersionLatest);
-
-                if (null == pathToTool)
-                {
-                    Log.LogErrorWithCodeFromResources("General_FrameworksFileNotFound", ToolName, ToolLocationHelper.GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion.VersionLatest));
-                }
+                Log.LogErrorWithCodeFromResources("General_ToolFileNotFound", ToolName);
             }
 
             return pathToTool;

--- a/src/Compilers/Core/MSBuildTaskTests/MSBuildTaskTests.csproj
+++ b/src/Compilers/Core/MSBuildTaskTests/MSBuildTaskTests.csproj
@@ -22,6 +22,10 @@
       <Project>{76C6F005-C89D-4348-BB4A-391898DBEB52}</Project>
       <Name>TestUtilities.Desktop</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\CSharp\csc\csc.csproj">
+      <Project>{4b45ca0c-03a0-400f-b454-3d4bcb16af38}</Project>
+      <Name>csc</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\CSharp\Portable\CSharpCodeAnalysis.csproj">
       <Project>{b501a547-c911-4a05-ac6e-274a50dff30e}</Project>
       <Name>CSharpCodeAnalysis</Name>
@@ -33,6 +37,10 @@
     <ProjectReference Include="..\..\..\Test\Utilities\Portable.FX45\TestUtilities.FX45.csproj">
       <Project>{F7712928-1175-47B3-8819-EE086753DEE2}</Project>
       <Name>TestUtilities.FX45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\VisualBasic\vbc\vbc.csproj">
+      <Project>{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}</Project>
+      <Name>vbc</Name>
     </ProjectReference>
     <ProjectReference Include="..\MSBuildTask\MSBuildTask.csproj">
       <Project>{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}</Project>

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -6,61 +6,7 @@ package name=Microsoft.CodeAnalysis.Compilers
 vs.dependencies
   vs.dependency id=Microsoft.Net.PackageGroup.4.6.1.Redist
 
-folder InstallDir:\MSBuild\15.0\Bin
-    file source=$(OutputPath)\Exes\VBCSCompiler\VBCSCompiler.exe vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Exes\csc\csc.exe vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Exes\csi\csi.exe vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Exes\vbc\vbc.exe vs.file.ngenArchitecture=all
-
-    file source=$(OutputPath)\Exes\csc\csc.exe.config
-    file source=$(OutputPath)\Exes\vbc\vbc.exe.config
-    file source=$(OutputPath)\Exes\VBCSCompiler\VBCSCompiler.exe.config
-
-    file source=$(OutputPath)\Exes\csc\csc.rsp
-    file source=$(OutputPath)\Exes\csi\csi.rsp
-    file source=$(OutputPath)\Exes\vbc\vbc.rsp
-
-    file source=$(OutputPath)\Dlls\MSBuildTask\Microsoft.VisualBasic.Core.targets
-    file source=$(OutputPath)\Dlls\MSBuildTask\Microsoft.CSharp.Core.targets
-
-    file source=$(OutputPath)\Dlls\Scripting\Microsoft.CodeAnalysis.Scripting.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Dlls\CSharpScripting\Microsoft.CodeAnalysis.CSharp.Scripting.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Dlls\CSharpCodeAnalysis\Microsoft.CodeAnalysis.CSharp.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Dlls\MSBuildTask\Microsoft.Build.Tasks.CodeAnalysis.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Dlls\BasicCodeAnalysis\Microsoft.CodeAnalysis.VisualBasic.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Dlls\CodeAnalysis\Microsoft.CodeAnalysis.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Collections.Immutable.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Reflection.Metadata.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Exes\csi\System.ValueTuple.dll vs.file.ngenArchitecture=all
-
-    file source=$(OutputPath)\Vsix\CompilerExtension\Microsoft.DiaSymReader.Native.amd64.dll
-    file source=$(OutputPath)\Vsix\CompilerExtension\Microsoft.DiaSymReader.Native.x86.dll
-
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.AppContext.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Console.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.Process.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.StackTrace.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.FileVersionInfo.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.Compression.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.DriveInfo.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.Primitives.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.Pipes.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.AccessControl.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Claims.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Cryptography.Algorithms.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Cryptography.Encoding.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Cryptography.Primitives.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Cryptography.X509Certificates.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Principal.Windows.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Text.Encoding.CodePages.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Threading.Thread.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XmlDocument.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XPath.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XPath.XDocument.dll vs.file.ngenArchitecture=all
-
-folder InstallDir:\MSBuild\15.0\Bin\amd64
+folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Exes\VBCSCompiler\VBCSCompiler.exe vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Exes\csc\csc.exe vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Exes\csi\csi.exe vs.file.ngenArchitecture=all


### PR DESCRIPTION
@dotnet/roslyn-compiler @dotnet/roslyn-infrastructure @rainersigwald 
Fixes #14660