### PR TITLE
Typing <enter> after an interpolated string should not cause 'split string' to invoke.

### DIFF
--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.InterpolatedStringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.InterpolatedStringSplitter.cs
@@ -25,16 +25,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 
             protected override SyntaxNode GetNodeToReplace() => _interpolatedStringExpression;
 
+            // Don't offer on $@"" strings.  They support newlines directly in their content.
             protected override bool CheckToken()
-            {
-                if (_interpolatedStringExpression.StringStartToken.Kind() == SyntaxKind.InterpolatedVerbatimStringStartToken)
-                {
-                    // Don't offer on $@"" strings.  They support newlines directly in their content.
-                    return false;
-                }
-
-                return true;
-            }
+                => _interpolatedStringExpression.StringStartToken.Kind() != SyntaxKind.InterpolatedVerbatimStringStartToken;
 
             protected override BinaryExpressionSyntax CreateSplitString()
             {

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.SimpleStringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.SimpleStringSplitter.cs
@@ -18,21 +18,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 _token = token;
             }
 
+            // Don't split @"" strings.  They already support directly embedding newlines.
             protected override bool CheckToken()
-            {
-                if (CursorPosition <= _token.SpanStart || CursorPosition >= _token.Span.End)
-                {
-                    return false;
-                }
-
-                if (_token.IsVerbatimStringLiteral())
-                {
-                    // Don't split @"" strings.  They already support directly embedding newlines.
-                    return false;
-                }
-
-                return true;
-            }
+                => !_token.IsVerbatimStringLiteral();
 
             protected override SyntaxNode GetNodeToReplace() => _token.Parent;
 

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
@@ -91,6 +91,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 
             public int? TrySplit()
             {
+                var nodeToReplace = GetNodeToReplace();
+
+                if (CursorPosition <= nodeToReplace.SpanStart || CursorPosition >= nodeToReplace.Span.End)
+                {
+                    return null;
+                }
+
                 if (!CheckToken())
                 {
                     return null;

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
-        public async Task TestMissingAfterString()
+        public async Task TestMissingAfterString_1()
         {
             await TestNotHandledAsync(
 @"class C
@@ -104,7 +104,46 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
-        public async Task TestMissingAfterInterpolatedString()
+        public async Task TestMissingAfterString_2()
+        {
+            await TestNotHandledAsync(
+@"class C
+{
+    void M()
+    {
+        var v = """" [||];
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public async Task TestMissingAfterString_3()
+        {
+            await TestNotHandledAsync(
+@"class C
+{
+    void M()
+    {
+        var v = """"[||]
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public async Task TestMissingAfterString_4()
+        {
+            await TestNotHandledAsync(
+@"class C
+{
+    void M()
+    {
+        var v = """" [||]
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public async Task TestMissingAfterInterpolatedString_1()
         {
             await TestNotHandledAsync(
 @"class C
@@ -112,6 +151,45 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = $""""[||];
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public async Task TestMissingAfterInterpolatedString_2()
+        {
+            await TestNotHandledAsync(
+@"class C
+{
+    void M()
+    {
+        var v = $"""" [||];
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public async Task TestMissingAfterInterpolatedString_3()
+        {
+            await TestNotHandledAsync(
+@"class C
+{
+    void M()
+    {
+        var v = $""""[||]
+    }
+}");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public async Task TestMissingAfterInterpolatedString_4()
+        {
+            await TestNotHandledAsync(
+@"class C
+{
+    void M()
+    {
+        var v = $"""" [||]
     }
 }");
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15043