### PR TITLE
Account for bad commit missing

### DIFF
--- a/build/scripts/test-build-correctness.ps1
+++ b/build/scripts/test-build-correctness.ps1
@@ -27,13 +27,6 @@ function Get-PackagesPath {
 pushd $sourcePath
 try
 {
-    write-host "Checking for bad branch data"
-    [string]$output = & git branch --contains 29a0db828359046e61542c4b62fa72743a905a40
-    if ($output.Length -ne 0) {
-        write-host "Error!!! Branch still contains something we got rid of in a force push."
-        exit 1
-    }
-
     # Need to parse out the current NuGet package version of Structured Logger
     [xml]$deps = get-content (join-path $sourcePath "build\Targets\Dependencies.props")
     $structuredLoggerVersion = $deps.Project.PropertyGroup.MicrosoftBuildLoggingStructuredLoggerVersion


### PR DESCRIPTION
It seems it's possible for our bad branch commit to be missing.  Suspect
this is due to it being GC'd out of our history since it's no longer
used.  Change our check for the bad commit to account for this
possibility.