### PR TITLE
Localize code style option previews

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -160,319 +160,319 @@ class Program
 //]
 }";
 
-        private static readonly string s_varForIntrinsicsPreviewFalse = @"
+        private static readonly string s_varForIntrinsicsPreviewFalse = $@"
 using System;
-class C{
+class C{{
     void Method()
-    {
+    {{
 //[
-        int x = 5; // built-in types
+        int x = 5; // {ServicesVSResources.built_in_types}
 //]
-    }
-}";
+    }}
+}}";
 
-        private static readonly string s_varForIntrinsicsPreviewTrue = @"
+        private static readonly string s_varForIntrinsicsPreviewTrue = $@"
 using System;
-class C{
+class C{{
     void Method()
-    {
+    {{
 //[
-        var x = 5; // built-in types
+        var x = 5; // {ServicesVSResources.built_in_types}
 //]
-    }
-}";
+    }}
+}}";
 
-        private static readonly string s_varWhereApparentPreviewFalse = @"
+        private static readonly string s_varWhereApparentPreviewFalse = $@"
 using System;
-class C{
+class C{{
     void Method()
-    {
+    {{
 //[
-        C cobj = new C(); // type is apparent from assignment expression
+        C cobj = new C(); // {ServicesVSResources.type_is_apparent_from_assignment_expression}
 //]
-    }
-}";
+    }}
+}}";
 
-        private static readonly string s_varWhereApparentPreviewTrue = @"
+        private static readonly string s_varWhereApparentPreviewTrue = $@"
 using System;
-class C{
+class C{{
     void Method()
-    {
+    {{
 //[
-        var cobj = new C(); // type is apparent from assignment expression
+        var cobj = new C(); // {ServicesVSResources.type_is_apparent_from_assignment_expression}
 //]
-    }
-}";
+    }}
+}}";
 
-        private static readonly string s_varWherePossiblePreviewFalse = @"
+        private static readonly string s_varWherePossiblePreviewFalse = $@"
 using System;
-class C{
+class C{{
     void Init()
-    {
+    {{
 //[
-        Action f = this.Init(); // everywhere else.
+        Action f = this.Init(); // {ServicesVSResources.everywhere_else}
 //]
-    }
-}";
+    }}
+}}";
 
-        private static readonly string s_varWherePossiblePreviewTrue = @"
+        private static readonly string s_varWherePossiblePreviewTrue = $@"
 using System;
-class C{
+class C{{
     void Init()
-    {
+    {{
 //[
-        var f = this.Init(); // everywhere else.
+        var f = this.Init(); // {ServicesVSResources.everywhere_else}
 //]
-    }
-}";
+    }}
+}}";
 
-        private static readonly string s_preferThrowExpression = @"
+        private static readonly string s_preferThrowExpression = $@"
 using System;
 
 class C
-{
+{{
     private string s;
 
     public C(string s)
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         this.s = s ?? throw new ArgumentNullException(nameof(s));
 
-        // Over:
+        // {ServicesVSResources.Over_colon}
         if (s == null)
-        {
+        {{
             throw new ArgumentNullException(nameof(s));
-        }
+        }}
 
         this.s = s;
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferCoalesceExpression = @"
+        private static readonly string s_preferCoalesceExpression = $@"
 using System;
 
 class C
-{
+{{
     private string s;
 
     public C(string s)
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         var v = x ?? y;
 
-        // Over:
-        var v = x != null ? x : y; // or
+        // {ServicesVSResources.Over_colon}
+        var v = x != null ? x : y; // {ServicesVSResources.or}
         var v = x == null ? y : x;
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferConditionalDelegateCall = @"
+        private static readonly string s_preferConditionalDelegateCall = $@"
 using System;
 
 class C
-{
+{{
     private string s;
 
     public C(string s)
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         func?.Invoke(args);
 
-        // Over:
+        // {ServicesVSResources.Over_colon}
         if (func != null)
-        {
+        {{
             func(args);
-        }
+        }}
 //]
-    }
-}
+    }}
+}}
 ";
 
-    private static readonly string s_preferNullPropagation = @"
+    private static readonly string s_preferNullPropagation = $@"
 using System;
 
 class C
-{
+{{
     public C(object o)
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         var v = o?.ToString();
 
-        // Over:
-        var v = o == null ? null : o.ToString(); // or
+        // {ServicesVSResources.Over_colon}
+        var v = o == null ? null : o.ToString(); // {ServicesVSResources.or}
         var v = o != null ? o.ToString() : null;
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferPatternMatchingOverAsWithNullCheck = @"
+        private static readonly string s_preferPatternMatchingOverAsWithNullCheck = $@"
 class C
-{
+{{
     void M()
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         if (o is string s)
-        {
-        }
+        {{
+        }}
 
-        // Over:
+        // {ServicesVSResources.Over_colon}
         var s = o as string;
         if (s != null)
-        {
-        }
+        {{
+        }}
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferPatternMatchingOverIsWithCastCheck = @"
+        private static readonly string s_preferPatternMatchingOverIsWithCastCheck = $@"
 class C
-{
+{{
     void M()
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         if (o is int i)
-        {
-        }
+        {{
+        }}
 
-        // Over:
+        // {ServicesVSResources.Over_colon}
         if (o is int)
-        {
+        {{
             var i = (int)o;
-        }
+        }}
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferObjectInitializer = @"
+        private static readonly string s_preferObjectInitializer = $@"
 using System;
 
 class Customer
-{
+{{
     private int Age;
 
     public Customer()
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         var c = new Customer()
-        {
+        {{
             Age = 21
-        };
+        }};
 
-        // Over:
+        // {ServicesVSResources.Over_colon}
         var c = new Customer();
         c.Age = 21;
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferCollectionInitializer = @"
+        private static readonly string s_preferCollectionInitializer = $@"
 using System.Collections.Generic;
 
 class Customer
-{
+{{
     private int Age;
 
     public Customer()
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         var list = new List<int>
-        {
+        {{
             1,
             2,
             3
-        };
+        }};
 
-        // Over:
+        // {ServicesVSResources.Prefer_colon}
         var list = new List<int>();
         list.Add(1);
         list.Add(2);
         list.Add(3);
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferExplicitTupleName = @"
+        private static readonly string s_preferExplicitTupleName = $@"
 class Customer
-{
+{{
     public Customer()
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         (string name, int age) customer = GetCustomer();
         var name = customer.name;
         var age = customer.age;
 
-        // Over:
+        // {ServicesVSResources.Over_colon}
         (string name, int age) customer = GetCustomer();
         var name = customer.Item1;
         var age = customer.Item2;
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferInlinedVariableDeclaration = @"
+        private static readonly string s_preferInlinedVariableDeclaration = $@"
 using System;
 
 class Customer
-{
+{{
     public Customer(string value)
-    {
+    {{
 //[
-        // Prefer:
+        // {ServicesVSResources.Prefer_colon}
         if (int.TryParse(value, out int i))
-        {
-        }
+        {{
+        }}
 
-        // Over:
+        // {ServicesVSResources.Over_colon}
         int i;
         if (int.TryParse(value, out i))
-        {
-        }
+        {{
+        }}
 //]
-    }
-}
+    }}
+}}
 ";
 
-        private static readonly string s_preferBraces = @"
+        private static readonly string s_preferBraces = $@"
 using System;
 
 class Customer
-{
+{{
     private int Age;
 
     public int GetAge()
-    {
+    {{
 //[
-        // Prefer: 
+        // {ServicesVSResources.Prefer_colon}
         if (test)
-        {
+        {{
             this.Display();
-        }
+        }}
         
-        // Over:
+        // {ServicesVSResources.Over_colon}
         if (test)
             this.Display();
 //]
-    }
-}
+    }}
+}}
 ";
 
         private static readonly string s_preferExpressionBodyForMethods = @"

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -290,6 +290,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to built-in types.
+        /// </summary>
+        internal static string built_in_types {
+            get {
+                return ResourceManager.GetString("built_in_types", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to camel Case Name.
         /// </summary>
         internal static string camel_Case_Name {
@@ -666,6 +675,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Event_type_is_invalid {
             get {
                 return ResourceManager.GetString("Event_type_is_invalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to everywhere else.
+        /// </summary>
+        internal static string everywhere_else {
+            get {
+                return ResourceManager.GetString("everywhere_else", resourceCulture);
             }
         }
         
@@ -1314,11 +1332,29 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to or.
+        /// </summary>
+        internal static string or {
+            get {
+                return ResourceManager.GetString("or", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Outlining.
         /// </summary>
         internal static string Outlining {
             get {
                 return ResourceManager.GetString("Outlining", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Over:.
+        /// </summary>
+        internal static string Over_colon {
+            get {
+                return ResourceManager.GetString("Over_colon", resourceCulture);
             }
         }
         
@@ -1436,6 +1472,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Prefer_collection_initializer {
             get {
                 return ResourceManager.GetString("Prefer_collection_initializer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer:.
+        /// </summary>
+        internal static string Prefer_colon {
+            get {
+                return ResourceManager.GetString("Prefer_colon", resourceCulture);
             }
         }
         
@@ -2038,6 +2083,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Type_Details_colon {
             get {
                 return ResourceManager.GetString("Type_Details_colon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to type is apparent from assignment expression.
+        /// </summary>
+        internal static string type_is_apparent_from_assignment_expression {
+            get {
+                return ResourceManager.GetString("type_is_apparent_from_assignment_expression", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -843,4 +843,22 @@ Additional information: {1}</value>
   <data name="Prefer_braces" xml:space="preserve">
     <value>Prefer braces</value>
   </data>
+  <data name="Over_colon" xml:space="preserve">
+    <value>Over:</value>
+  </data>
+  <data name="Prefer_colon" xml:space="preserve">
+    <value>Prefer:</value>
+  </data>
+  <data name="or" xml:space="preserve">
+    <value>or</value>
+  </data>
+  <data name="built_in_types" xml:space="preserve">
+    <value>built-in types</value>
+  </data>
+  <data name="everywhere_else" xml:space="preserve">
+    <value>everywhere else</value>
+  </data>
+  <data name="type_is_apparent_from_assignment_expression" xml:space="preserve">
+    <value>type is apparent from assignment expression</value>
+  </data>
 </root>

--- a/src/VisualStudio/VisualBasic/Impl/Options/StyleViewModel.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/StyleViewModel.vb
@@ -145,7 +145,7 @@ Class Program
 End Class
 ]]></a>.Value
 
-        Private Shared ReadOnly s_preferObjectInitializer As String = "
+        Private Shared ReadOnly s_preferObjectInitializer As String = $"
 Imports System
 
 Class Customer
@@ -153,33 +153,33 @@ Class Customer
 
     Sub New()
 //[
-        ' Prefer:
-        Dim c = New Customer() With {
+        ' {ServicesVSResources.Prefer_colon}
+        Dim c = New Customer() With {{
             .Age = 21
-        }
+        }}
 
-        ' Over:
+        ' {ServicesVSResources.Over_colon}
         Dim c = New Customer()
         c.Age = 21
 //]
     End Sub
 End Class"
 
-        Private Shared ReadOnly s_preferCollectionInitializer As String = "
+        Private Shared ReadOnly s_preferCollectionInitializer As String = $"
 
 Class Customer
     Private Age As Integer
 
     Sub New()
 //[
-        ' Prefer:
-        Dim list = New List(Of Integer) From {
+        ' {ServicesVSResources.Prefer_colon}
+        Dim list = New List(Of Integer) From {{
             1,
             2,
             3
-        }
+        }}
 
-        ' Over:
+        ' {ServicesVSResources.Over_colon}
         Dim list = New List(Of Integer)()
         list.Add(1)
         list.Add(2)
@@ -188,16 +188,16 @@ Class Customer
     End Sub
 End Class"
 
-        Private Shared ReadOnly s_preferExplicitTupleName As String = "
+        Private Shared ReadOnly s_preferExplicitTupleName As String = $"
 Class Customer
     Public Sub New()
 //[
-        ' Prefer:
+        ' {ServicesVSResources.Prefer_colon}
         Dim customer As (name As String, age As Integer)
         Dim name = customer.name
         Dim age = customer.age
 
-        ' Over
+        ' {ServicesVSResources.Over_colon}
         Dim customer As (name As String, age As Integer)
         Dim name = customer.Item1
         Dim age = customer.Item2
@@ -206,7 +206,7 @@ Class Customer
 end class
 "
 
-        Private Shared ReadOnly s_preferCoalesceExpression As String = "
+        Private Shared ReadOnly s_preferCoalesceExpression As String = $"
 Imports System
 
 Class Customer
@@ -214,17 +214,17 @@ Class Customer
 
     Sub New()
 //[
-        ' Prefer:
+        ' {ServicesVSResources.Prefer_colon}
         Dim v = If(x, y)
 
-        ' Over:
-        Dim v = If(x Is Nothing, y, x)    ' or
+        ' {ServicesVSResources.Over_colon}
+        Dim v = If(x Is Nothing, y, x)    ' {ServicesVSResources.or}
         Dim v = If(x IsNot Nothing, x, y)
 //]
     End Sub
 End Class"
 
-        Private Shared ReadOnly s_preferNullPropagation As String = "
+        Private Shared ReadOnly s_preferNullPropagation As String = $"
 Imports System
 
 Class Customer
@@ -232,11 +232,11 @@ Class Customer
 
     Sub New()
 //[
-        ' Prefer:
+        ' {ServicesVSResources.Prefer_colon}
         Dim v = o?.ToString()
 
-        ' Over:
-        Dim v = If(o Is Nothing, Nothing, o.ToString())    ' or
+        ' {ServicesVSResources.Over_colon}
+        Dim v = If(o Is Nothing, Nothing, o.ToString())    ' {ServicesVSResources.or}
         Dim v = If(o IsNot Nothing, o.ToString(), Nothing)
 //]
     End Sub


### PR DESCRIPTION
Fixes part 3 of #9674

## Ask Mode Info

**Customer scenario**: The previews for Code Styles were not localized, making it hard for non-English users to understand which choice resulted in which code.
**Bugs this fixes**: Part 3 of #9674
**Workarounds**: None
**Risk**: Very low
**Performance impact**: None.
**Is this a regression from a previous update?**: No, this has been broken since the UI was introduced
**Root cause analysis**: It was skipped as part of the original feature work.
**How was the bug found?**: Ad hoc testing (see screenshot from #9674)