### PR TITLE
Check for restricted types in deconstruction in async method

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -745,6 +745,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!isVar)
                 {
+                    CheckSpecialByRefLocal(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
                     return new BoundLocal(designation, localSymbol, constantValueOpt: null, type: declType, hasErrors: hasErrors);
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -745,7 +745,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!isVar)
                 {
-                    CheckSpecialByRefLocal(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
+                    CheckRestrictedTypeInAsync(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
                     return new BoundLocal(designation, localSymbol, constantValueOpt: null, type: declType, hasErrors: hasErrors);
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2120,7 +2120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return new OutVariablePendingInference(declarationExpression, localSymbol, null);
                 }
 
-                CheckSpecialByRefLocal(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
+                CheckRestrictedTypeInAsync(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
 
                 return new BoundLocal(declarationExpression, localSymbol, constantValueOpt: null, type: declType);
             }
@@ -2157,7 +2157,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Returns true if a bad special by ref local was found.
         /// </summary>
-        internal static bool CheckSpecialByRefLocal(Symbol containingSymbol, TypeSymbol type, DiagnosticBag diagnostics, SyntaxNode syntax)
+        internal static bool CheckRestrictedTypeInAsync(Symbol containingSymbol, TypeSymbol type, DiagnosticBag diagnostics, SyntaxNode syntax)
         {
             if (containingSymbol.Kind == SymbolKind.Method
                 && ((MethodSymbol)containingSymbol).IsAsync

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2120,12 +2120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return new OutVariablePendingInference(declarationExpression, localSymbol, null);
                 }
 
-                if (this.ContainingMemberOrLambda.Kind == SymbolKind.Method
-                    && ((MethodSymbol)this.ContainingMemberOrLambda).IsAsync
-                    && declType.IsRestrictedType())
-                {
-                    Error(diagnostics, ErrorCode.ERR_BadSpecialByRefLocal, typeSyntax, declType);
-                }
+                CheckSpecialByRefLocal(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
 
                 return new BoundLocal(declarationExpression, localSymbol, constantValueOpt: null, type: declType);
             }
@@ -2157,6 +2152,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundFieldAccess(declarationExpression,
                                         receiver,
                                         expressionVariableField, null, LookupResultKind.Viable, fieldType);
+        }
+
+        /// <summary>
+        /// Returns true if a bad special by ref local was found.
+        /// </summary>
+        internal static bool CheckSpecialByRefLocal(Symbol containingSymbol, TypeSymbol type, DiagnosticBag diagnostics, SyntaxNode syntax)
+        {
+            if (containingSymbol.Kind == SymbolKind.Method
+                && ((MethodSymbol)containingSymbol).IsAsync
+                && type.IsRestrictedType())
+            {
+                Error(diagnostics, ErrorCode.ERR_BadSpecialByRefLocal, syntax, type);
+                return true;
+            }
+            return false;
         }
 
         internal GlobalExpressionVariable LookupDeclaredField(SingleVariableDesignationSyntax variableDesignator)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!hasErrors)
                 {
-                    hasErrors = CheckSpecialByRefLocal(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
+                    hasErrors = CheckRestrictedTypeInAsync(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
                 }
 
                 return new BoundDeclarationPattern(node, localSymbol, boundDeclType, isVar, hasErrors);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -291,13 +291,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Check for variable declaration errors.
                 hasErrors |= localSymbol.ScopeBinder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
-                if (this.ContainingMemberOrLambda.Kind == SymbolKind.Method
-                    && ((MethodSymbol)this.ContainingMemberOrLambda).IsAsync
-                    && declType.IsRestrictedType()
-                    && !hasErrors)
+                if (!hasErrors)
                 {
-                    Error(diagnostics, ErrorCode.ERR_BadSpecialByRefLocal, typeSyntax, declType);
-                    hasErrors = true;
+                    hasErrors = CheckSpecialByRefLocal(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
                 }
 
                 return new BoundDeclarationPattern(node, localSymbol, boundDeclType, isVar, hasErrors);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -882,7 +882,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (CheckSpecialByRefLocal(this.ContainingMemberOrLambda, declTypeOpt, localDiagnostics, typeSyntax))
+            if (CheckRestrictedTypeInAsync(this.ContainingMemberOrLambda, declTypeOpt, localDiagnostics, typeSyntax))
             {
                 hasErrors = true;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -882,11 +882,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (this.ContainingMemberOrLambda.Kind == SymbolKind.Method
-                && ((MethodSymbol)this.ContainingMemberOrLambda).IsAsync
-                && declTypeOpt.IsRestrictedType())
+            if (CheckSpecialByRefLocal(this.ContainingMemberOrLambda, declTypeOpt, localDiagnostics, typeSyntax))
             {
-                Error(localDiagnostics, ErrorCode.ERR_BadSpecialByRefLocal, typeSyntax, declTypeOpt);
                 hasErrors = true;
             }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        Binder.CheckSpecialByRefLocal(local.ContainingSymbol, type, diagnostics, this.Syntax);
+                        Binder.CheckRestrictedTypeInAsync(local.ContainingSymbol, type, diagnostics, this.Syntax);
                     }
 
                     local.SetType(type);

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
@@ -29,6 +29,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         ReportInferenceFailure(diagnostics);
                     }
+                    else
+                    {
+                        Binder.CheckSpecialByRefLocal(local.ContainingSymbol, type, diagnostics, this.Syntax);
+                    }
+
                     local.SetType(type);
                     return new BoundLocal(this.Syntax, local, constantValueOpt: null, type: type, hasErrors: this.HasErrors || inferenceFailed);
 

--- a/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
@@ -39,12 +39,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             ReportInferenceFailure(diagnosticsOpt);
                         }
-                        else if (localSymbol.ContainingSymbol.Kind == SymbolKind.Method &&
-                                 ((MethodSymbol)localSymbol.ContainingSymbol).IsAsync &&
-                                 type.IsRestrictedType())
+                        else
                         {
-                            var declaration = (DeclarationExpressionSyntax)this.Syntax;
-                            Binder.Error(diagnosticsOpt, ErrorCode.ERR_BadSpecialByRefLocal, declaration.Type, type);
+                            TypeSyntax typeSyntax = ((DeclarationExpressionSyntax)Syntax).Type;
+                            Binder.CheckSpecialByRefLocal(localSymbol.ContainingSymbol, type, diagnosticsOpt, typeSyntax);
                         }
                     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         else
                         {
                             TypeSyntax typeSyntax = ((DeclarationExpressionSyntax)Syntax).Type;
-                            Binder.CheckSpecialByRefLocal(localSymbol.ContainingSymbol, type, diagnosticsOpt, typeSyntax);
+                            Binder.CheckRestrictedTypeInAsync(localSymbol.ContainingSymbol, type, diagnosticsOpt, typeSyntax);
                         }
                     }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1174,6 +1174,9 @@ class C
     {
         (int x, var (err1, y)) = (0, new C());
         (ArgIterator err2, var err3) = M2();
+        foreach ((ArgIterator err4, var err5) in new[] { M2() })
+        {
+        }
     }
 
     public static (ArgIterator, ArgIterator) M2()
@@ -1190,15 +1193,15 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (11,20): error CS0610: Field or property cannot be of type 'ArgIterator'
+                // (14,20): error CS0610: Field or property cannot be of type 'ArgIterator'
                 //     public static (ArgIterator, ArgIterator) M2()
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator").WithLocation(11, 20),
-                // (11,33): error CS0610: Field or property cannot be of type 'ArgIterator'
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator").WithLocation(14, 20),
+                // (14,33): error CS0610: Field or property cannot be of type 'ArgIterator'
                 //     public static (ArgIterator, ArgIterator) M2()
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator").WithLocation(11, 33),
-                // (15,29): error CS1601: Cannot make reference to variable of type 'ArgIterator'
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "ArgIterator").WithArguments("System.ArgIterator").WithLocation(14, 33),
+                // (18,29): error CS1601: Cannot make reference to variable of type 'ArgIterator'
                 //     public void Deconstruct(out ArgIterator a, out int b)
-                Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "out ArgIterator a").WithArguments("System.ArgIterator").WithLocation(15, 29),
+                Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "out ArgIterator a").WithArguments("System.ArgIterator").WithLocation(18, 29),
                 // (7,22): error CS4012: Parameters or locals of type 'ArgIterator' cannot be declared in async methods or lambda expressions.
                 //         (int x, var (err1, y)) = (0, new C());
                 Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "err1").WithArguments("System.ArgIterator").WithLocation(7, 22),
@@ -1208,15 +1211,21 @@ class C
                 // (8,32): error CS4012: Parameters or locals of type 'ArgIterator' cannot be declared in async methods or lambda expressions.
                 //         (ArgIterator err2, var err3) = M2();
                 Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "err3").WithArguments("System.ArgIterator").WithLocation(8, 32),
+                // (9,19): error CS4012: Parameters or locals of type 'ArgIterator' cannot be declared in async methods or lambda expressions.
+                //         foreach ((ArgIterator err4, var err5) in new[] { M2() })
+                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "ArgIterator").WithArguments("System.ArgIterator").WithLocation(9, 19),
+                // (9,41): error CS4012: Parameters or locals of type 'ArgIterator' cannot be declared in async methods or lambda expressions.
+                //         foreach ((ArgIterator err4, var err5) in new[] { M2() })
+                Diagnostic(ErrorCode.ERR_BadSpecialByRefLocal, "err5").WithArguments("System.ArgIterator").WithLocation(9, 41),
                 // (5,23): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     public async void M()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "M").WithLocation(5, 23),
-                // (13,17): error CS0610: Field or property cannot be of type 'ArgIterator'
+                // (16,17): error CS0610: Field or property cannot be of type 'ArgIterator'
                 //         return (default(ArgIterator), default(ArgIterator));
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "default(ArgIterator)").WithArguments("System.ArgIterator").WithLocation(13, 17),
-                // (13,39): error CS0610: Field or property cannot be of type 'ArgIterator'
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "default(ArgIterator)").WithArguments("System.ArgIterator").WithLocation(16, 17),
+                // (16,39): error CS0610: Field or property cannot be of type 'ArgIterator'
                 //         return (default(ArgIterator), default(ArgIterator));
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "default(ArgIterator)").WithArguments("System.ArgIterator").WithLocation(13, 39)
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "default(ArgIterator)").WithArguments("System.ArgIterator").WithLocation(16, 39)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1188,6 +1188,15 @@ class C
         a = default(ArgIterator);
         b = 2;
     }
+
+    public void M3()
+    {
+        (int x, var (err1, y)) = (0, new C());
+        (ArgIterator err2, var err3) = M2();
+        foreach ((ArgIterator err4, var err5) in new[] { M2() })
+        {
+        }
+    }
 }
 ";
 


### PR DESCRIPTION
Customer scenario: In an async method, if the explicit or inferred type of a deconstruction local is `ArgIterator`, there should be an error on the declaration of that local. That error is currently missing.

Fixes https://github.com/dotnet/roslyn/issues/15180

Performance impact: low because we only add a check and report an error in deconstruction scenarios.

Root cause analysis and how found: this error was missing from the feature. It is not a regression. We didn't think about it until a peer remembered about this special case (some restricted types are disallowed in asynd methods) while doing some other feature work and noticing this error message in the code.


```C#
   public async void M()
    {
        (int x, var (err1, y)) = (0, new C()); // where C deconstruction produces (ArgIterator, int)
        (ArgIterator err2, var err3) = M2(); // where M2 returns (ArgIterator, ArgIterator)
    }
    // There should be an error on err1, err2 and err3
```

@dotnet/roslyn-compiler for review.
