### PR TITLE
Add explanatory text to Naming Styles

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -751,6 +751,17 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to For a given symbol, only the topmost rule with a matching &apos;Specification&apos; will be applied. Violation of that rule&apos;s &apos;Required Style&apos; will be reported at the chosen &apos;Severity&apos; level..
+        /// </summary>
+        internal static string For_a_given_symbol_only_the_topmost_rule_with_a_matching_Specification_will_be_applied_Violation_of_that_rules_Required_Style_will_be_reported_at_the_chosen_Severity_level {
+            get {
+                return ResourceManager.GetString("For_a_given_symbol_only_the_topmost_rule_with_a_matching_Specification_will_be_ap" +
+                        "plied_Violation_of_that_rules_Required_Style_will_be_reported_at_the_chosen_Seve" +
+                        "rity_level", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to For accessors.
         /// </summary>
         internal static string For_accessors {
@@ -1633,6 +1644,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Required Style.
+        /// </summary>
+        internal static string Required_Style {
+            get {
+                return ResourceManager.GetString("Required_Style", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Required Suffix:.
         /// </summary>
         internal static string Required_Suffix_colon {
@@ -1791,15 +1811,6 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Specification {
             get {
                 return ResourceManager.GetString("Specification", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Style.
-        /// </summary>
-        internal static string Style {
-            get {
-                return ResourceManager.GetString("Style", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -798,8 +798,8 @@ Additional information: {1}</value>
   <data name="Specification" xml:space="preserve">
     <value>Specification</value>
   </data>
-  <data name="Style" xml:space="preserve">
-    <value>Style</value>
+  <data name="Required_Style" xml:space="preserve">
+    <value>Required Style</value>
   </data>
   <data name="This_item_cannot_be_deleted_because_it_is_used_by_an_existing_Naming_Rule" xml:space="preserve">
     <value>This item cannot be deleted because it is used by an existing Naming Rule.</value>
@@ -821,5 +821,8 @@ Additional information: {1}</value>
   </data>
   <data name="Preference" xml:space="preserve">
     <value>Preference</value>
+  </data>
+  <data name="For_a_given_symbol_only_the_topmost_rule_with_a_matching_Specification_will_be_applied_Violation_of_that_rules_Required_Style_will_be_reported_at_the_chosen_Severity_level" xml:space="preserve">
+    <value>For a given symbol, only the topmost rule with a matching 'Specification' will be applied. Violation of that rule's 'Required Style' will be reported at the chosen 'Severity' level.</value>
   </data>
 </root>

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
@@ -42,11 +42,13 @@
             <KeyBinding Key="Down" Modifiers="Alt" Command="{StaticResource MoveDown}" />
         </Grid.InputBindings>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" Margin="5 0 5 0 " TextWrapping="Wrap" Text="{x:Static style:NamingStyleOptionPageControl.ExplanatoryText}" />
         <DataGrid
-            Grid.Row="0"
+            Grid.Row="1"
             x:Uid="CodeStyleContent"
             x:Name="CodeStyleMembers"
             Margin="0,5,0,0"
@@ -162,7 +164,7 @@
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn 
                     x:Name="style"
-                    Header="{x:Static style:NamingStyleOptionPageControl.StyleHeader}"
+                    Header="{x:Static style:NamingStyleOptionPageControl.RequiredStyleHeader}"
                     Width="3*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
@@ -233,7 +235,7 @@
             </DataGrid.Columns>
         </DataGrid>
 
-        <Border Grid.Row="1">
+        <Border Grid.Row="2">
             <StackPanel Orientation="Horizontal"
                         Margin="7">
                 <Button Name="AddButton" 

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
@@ -22,7 +22,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
     {
         public static string ReorderHeader => ServicesVSResources.Reorder;
         public static string SpecificationHeader => ServicesVSResources.Specification;
-        public static string StyleHeader => ServicesVSResources.Style;
+        public static string RequiredStyleHeader => ServicesVSResources.Required_Style;
+        public static string ExplanatoryText => ServicesVSResources.For_a_given_symbol_only_the_topmost_rule_with_a_matching_Specification_will_be_applied_Violation_of_that_rules_Required_Style_will_be_reported_at_the_chosen_Severity_level;
 
         private NamingStyleOptionPageViewModel _viewModel;
         private readonly string _languageName;


### PR DESCRIPTION
Fixes #15217

Also, change the column header from "Style" to "Required Style"

![image](https://cloud.githubusercontent.com/assets/235241/20329000/a6d273e4-ab4a-11e6-99ce-e2631c6f9c66.png)

## Ask Mode Info

**Customer scenario**: Using Naming Styles without any sort of explanation is confusing (bordering on impossible), as discovered by usability studies. It's impossible to tell that exactly one rule will be applied, that it will be the topmost matching one, and that the chosen style is what is *expected* of matching symbols, not what should cause the error/warning/etc..
**Bugs this fixes**: #15217 
**Workarounds**: None
**Risk**: None
**Performance impact**: None
**Is this a regression from a previous update?**: No
**Root cause analysis**: We never included instructions.
**How was the bug found?**: Usability studies (thanks @kuhlenh)

