### PR TITLE
Update `GitMergeBot` to support VSO repositories.

### DIFF
--- a/src/Tools/Github/GitMergeBot/GitHubRepository.cs
+++ b/src/Tools/Github/GitMergeBot/GitHubRepository.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Octokit;
+
+namespace GitMergeBot
+{
+    internal sealed class GitHubRepository : RepositoryBase
+    {
+        private GitHubClient _client;
+
+        public GitHubRepository(string path, string repoName, string userName, string authToken)
+            : base(path, repoName, userName, authToken)
+        {
+            _client = new GitHubClient(new ProductHeaderValue(userName))
+            {
+                Credentials = new Credentials(authToken)
+            };
+        }
+
+        public override async Task<bool> ShouldMakePullRequestAsync(string title)
+        {
+            return (await GetExistingMergePrsAsync(title)).Count == 0;
+        }
+
+        public override async Task CreatePullRequestAsync(string title, string destinationOwner, string pullRequestBranch, string sourceBranch, string destinationBranch)
+        {
+            var remoteName = $"{UserName}-{RepositoryName}";
+            var prMessage = $@"
+This is an automatically generated pull request from {sourceBranch} into {destinationBranch}.
+
+@dotnet/roslyn-infrastructure:
+
+``` bash
+git remote add {remoteName} ""https://github.com/{UserName}/{RepositoryName}.git""
+git fetch {remoteName}
+git fetch upstream
+git checkout {pullRequestBranch}
+git reset --hard upstream/{destinationBranch}
+git merge upstream/{sourceBranch}
+# Fix merge conflicts
+git commit
+git push {remoteName} {pullRequestBranch} --force
+```
+
+Once all conflicts are resolved and all the tests pass, you are free to merge the pull request.
+".Trim();
+
+            var pullRequest = await _client.PullRequest.Create(
+                owner: destinationOwner,
+                name: RepositoryName,
+                newPullRequest: new NewPullRequest(
+                    title: title,
+                    head: $"{UserName}:{pullRequestBranch}",
+                    baseRef: destinationBranch)
+                    {
+                        Body = prMessage
+                    }
+                );
+
+            // The reason for this delay is twofold:
+            //
+            // * Github has a bug in which it can "create" a pull request without that pull request
+            //   being able to be commented on for a short period of time.
+            // * The Jenkins "comment watcher" has a bug whereby any comment posted shortly after
+            //   pull-request creation is ignored.
+            //
+            // Thus, this delay sidesteps both of those bugs by asking for a VSI test 30 seconds after 
+            // the creation of the PR.  Ugly, yes; but the only *real* way to sidestep this would be to 
+            // 1) Fix github, 2) Fix jenkins, and while those might be lofty goals, they are not in the 
+            // scope of this PR.
+            await Task.Delay(TimeSpan.FromSeconds(30.0));
+
+            await _client.Issue.Comment.Create(destinationOwner, RepositoryName, pullRequest.Number, "@dotnet-bot test vsi please");
+        }
+
+        /// <returns>The existing open merge PRs.</returns>
+        private async Task<IList<PullRequest>> GetExistingMergePrsAsync(string newBranchPrefix)
+        {
+            var allPullRequests = await _client.PullRequest.GetAllForRepository(UserName, RepositoryName);
+            var openPrs = allPullRequests.Where(pr => pr.Head.Ref.StartsWith(newBranchPrefix) && pr.User.Login == UserName).ToList();
+
+            Console.WriteLine($"Found {openPrs.Count} existing open merge pull requests.");
+            foreach (var pr in openPrs)
+            {
+                Console.WriteLine($"  Open PR: {pr.HtmlUrl}");
+            }
+
+            return openPrs;
+        }
+    }
+}

--- a/src/Tools/Github/GitMergeBot/GitHubRepository.cs
+++ b/src/Tools/Github/GitMergeBot/GitHubRepository.cs
@@ -26,7 +26,7 @@ namespace GitMergeBot
             return (await GetExistingMergePrsAsync(title)).Count == 0;
         }
 
-        public override async Task CreatePullRequestAsync(string title, string destinationOwner, string pullRequestBranch, string sourceBranch, string destinationBranch)
+        public override async Task CreatePullRequestAsync(string title, string destinationOwner, string pullRequestBranch, string prBranchSourceRemote, string sourceBranch, string destinationBranch)
         {
             var remoteName = $"{UserName}-{RepositoryName}";
             var prMessage = $@"
@@ -37,10 +37,10 @@ This is an automatically generated pull request from {sourceBranch} into {destin
 ``` bash
 git remote add {remoteName} ""https://github.com/{UserName}/{RepositoryName}.git""
 git fetch {remoteName}
-git fetch upstream
+git fetch {prBranchSourceRemote}
 git checkout {pullRequestBranch}
-git reset --hard upstream/{destinationBranch}
-git merge upstream/{sourceBranch}
+git reset --hard {prBranchSourceRemote}/{destinationBranch}
+git merge {prBranchSourceRemote}/{sourceBranch}
 # Fix merge conflicts
 git commit
 git push {remoteName} {pullRequestBranch} --force

--- a/src/Tools/Github/GitMergeBot/GitMergeBot.csproj
+++ b/src/Tools/Github/GitMergeBot/GitMergeBot.csproj
@@ -39,6 +39,10 @@
       <HintPath>..\..\..\..\..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Octokit, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Octokit.0.17.0\lib\net45\Octokit.dll</HintPath>
       <Private>True</Private>

--- a/src/Tools/Github/GitMergeBot/GitMergeBot.csproj
+++ b/src/Tools/Github/GitMergeBot/GitMergeBot.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\..\..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>GitMergeBot</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,12 +35,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="LibGit2Sharp, Version=0.22.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Octokit, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\Octokit.0.17.0\lib\net45\Octokit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\System.ValueTuple.4.3.0-preview1-24530-04\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -46,16 +57,26 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GitHubRepository.cs" />
+    <Compile Include="RepositoryBase.cs" />
     <Compile Include="Mono.Options\Options.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RepositoryType.cs" />
+    <Compile Include="VisualStudioOnlineRepository.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Tools/Github/GitMergeBot/Options.cs
+++ b/src/Tools/Github/GitMergeBot/Options.cs
@@ -6,16 +6,83 @@ namespace GitMergeBot
 {
     internal sealed class Options
     {
-        public string AuthToken { get; set; }
-        public string RepoName { get; set; }
-        public string SourceBranch { get; set; }
-        public string DestinationBranch { get; set; }
-        public string SourceUser { get; set; }
-        public string DestinationUser { get; set; }
         public bool Force { get; set; }
         public bool Debug { get; set; }
-        public bool ShowHelp { get; set; }
+        public string RepositoryPath { get; set; }
+        public RepositoryType SourceRepoType { get; set; }
+        public string SourceRepoName { get; set; }
+        public string SourceUserName { get; set; }
+        public string SourcePassword { get; set; }
+        public string SourceRemoteName { get; set; }
+        public string SourceBranchName { get; set; }
 
-        public bool AreValid => new[] { AuthToken, RepoName, SourceBranch, DestinationBranch, SourceUser, DestinationUser }.All(s => s != null);
+        public bool PushBranchToDestination { get; set; }
+
+        private string _prBranchSourceRemote;
+        private RepositoryType? _destinationRepoType;
+        private string _destinationRepoOwner;
+        private string _destinationRepoName;
+        private string _destinationUserName;
+        private string _destinationPassword;
+        private string _destinationRemoteName;
+        private string _destinationBranchName;
+
+        public string PullRequestBranchSourceRemote
+        {
+            get { return _prBranchSourceRemote ?? SourceRemoteName; }
+            set { _prBranchSourceRemote = value; }
+        }
+
+        public RepositoryType DestinationRepoType
+        {
+            get { return _destinationRepoType ?? SourceRepoType; }
+            set { _destinationRepoType = value; }
+        }
+
+        public string DestinationRepoOwner
+        {
+            get { return _destinationRepoOwner ?? DestinationUserName; }
+            set { _destinationRepoOwner = value; }
+        }
+
+        public string DestinationRepoName
+        {
+            get { return _destinationRepoName ?? SourceRepoName; }
+            set { _destinationRepoName = value; }
+        }
+
+        public string DestinationUserName
+        {
+            get { return _destinationUserName ?? SourceUserName; }
+            set { _destinationUserName = value; }
+        }
+
+        public string DestinationPassword
+        {
+            get { return _destinationPassword ?? SourcePassword; }
+            set { _destinationPassword = value; }
+        }
+
+        public string DestinationRemoteName
+        {
+            get { return _destinationRemoteName ?? SourceRemoteName; }
+            set { _destinationRemoteName = value; }
+        }
+
+        public string DestinationBranchName
+        {
+            get { return _destinationBranchName ?? SourceBranchName; }
+            set { _destinationBranchName = value; }
+        }
+
+        public bool IsValid => new[]
+        {
+            RepositoryPath,
+            SourceRepoName,
+            SourceUserName,
+            SourcePassword,
+            SourceRemoteName,
+            SourceBranchName
+        }.All(s => s != null);
     }
 }

--- a/src/Tools/Github/GitMergeBot/Options.cs
+++ b/src/Tools/Github/GitMergeBot/Options.cs
@@ -11,6 +11,8 @@ namespace GitMergeBot
         public string RepositoryPath { get; set; }
         public RepositoryType SourceRepoType { get; set; }
         public string SourceRepoName { get; set; }
+        public string SourceProject { get; set; }
+        public string SourceUserId { get; set; }
         public string SourceUserName { get; set; }
         public string SourcePassword { get; set; }
         public string SourceRemoteName { get; set; }
@@ -26,6 +28,9 @@ namespace GitMergeBot
         private string _destinationPassword;
         private string _destinationRemoteName;
         private string _destinationBranchName;
+
+        public string DestinationProject { get; set; }
+        public string DestinationUserId { get; set; }
 
         public string PullRequestBranchSourceRemote
         {

--- a/src/Tools/Github/GitMergeBot/Program.cs
+++ b/src/Tools/Github/GitMergeBot/Program.cs
@@ -1,215 +1,146 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Mono.Options;
-using Octokit;
+
+using static System.Console;
 
 namespace GitMergeBot
 {
-    class Program
+    internal sealed class Program
     {
         static int Main(string[] args)
         {
             var exeName = Assembly.GetExecutingAssembly().GetName().Name;
+            var showHelp = false;
             var options = new Options();
-
-            // default to using an environment variable, but allow an explicitly provided value to override
-            options.AuthToken = Environment.GetEnvironmentVariable("AUTH_CODE");
             var parameters = new OptionSet()
             {
                 $"Usage: {exeName} [options]",
                 "Create a pull request from the specified user and branch to another specified user and branch.",
                 "",
                 "Options:",
-                { "a|auth=", "The GitHub authentication token.", value => options.AuthToken = value },
-                { "r|repo=", "The name of the remote repository.", value => options.RepoName = value },
-                { "s|source=", "The source branch of the merge operation.", value => options.SourceBranch = value },
-                { "d|dest=", "The destination branch of the merge operation.", value => options.DestinationBranch = value },
-                { "su|sourceuser=", "The user hosting the source branch of the merge operation.", value => options.SourceUser = value },
-                { "du|destuser=", "The user hosting the destination branch of the merge operation.", value => options.DestinationUser = value },
+                { "repopath=", "The local path to the repository.", value => options.RepositoryPath = value },
+                { "sourcetype=", "The source repository type.  Valid values are 'GitHub' and 'VisualStudioOnline'.", value => options.SourceRepoType = (RepositoryType)Enum.Parse(typeof(RepositoryType), value) },
+                { "sourcereponame=", "The name of the source repository.", value => options.SourceRepoName = value },
+                { "sourceuser=", "The source user name.", value => options.SourceUserName = value },
+                { "sourcepassword=", "The source password.", value => options.SourcePassword = value },
+                { "sourceremote=", "The source remote name.", value => options.SourceRemoteName = value },
+                { "sourcebranch=", "The source branch name.", value => options.SourceBranchName = value },
+                { "pushtodestination=", "If true the PR branch will be pushed to the destination repository; if false the PR branch will be pushed to the source.", value => options.PushBranchToDestination = value != null },
+                { "prbranchsourceremote=", "The name of the remote the PR should initiate from.  Defaults to `sourceremote` parameter.", value => options.PullRequestBranchSourceRemote = value },
+                { "destinationtype=", "The destination repository type.  Valid values are 'GitHub' and 'VisualStudioOnline'.  Defaults to `sourcetype` parameter.", value => options.SourceRepoType = (RepositoryType)Enum.Parse(typeof(RepositoryType), value) },
+                { "destinationrepoowner=", "", value => options.DestinationRepoOwner = value },
+                { "destinationreponame=", "The name of the destination repository.  Defaults to `sourcereponame` parameter.", value => options.DestinationRepoName = value },
+                { "destinationuser=", "The destination user name.  Defaults to `sourceuser` parameter.", value => options.DestinationUserName = value },
+                { "destinationpassword=", "The destination password.  Defaults to `sourcepassword` parameter.", value => options.DestinationPassword = value },
+                { "destinationremote=", "The destination remote name.  Defaults to `sourceremote` parameter.", value => options.DestinationRemoteName = value },
+                { "destinationbranch=", "The destination branch name.  Defaults to `sourcebranch` parameter.", value => options.DestinationBranchName = value },
                 { "f|force", "Force the creation of the PR even if an open PR already exists.", value => options.Force = value != null },
                 { "debug", "Print debugging information about the merge but don't actually create the pull request.", value => options.Debug = value != null },
-                { "h|help", "Show this message and exit.", value => options.ShowHelp = value != null }
+                { "h|?|help", "Show this message and exit.", value => showHelp = value != null }
             };
 
             try
             {
                 parameters.Parse(args);
+                if (showHelp || !options.IsValid)
+                {
+                    parameters.WriteOptionDescriptions(Out);
+                    return options.IsValid ? 0 : 1;
+                }
+
+                var sourceRepository = RepositoryBase.Create(options.SourceRepoType, options.RepositoryPath, options.SourceRepoName, options.SourceUserName, options.SourcePassword);
+                var destRepository = RepositoryBase.Create(options.DestinationRepoType, options.RepositoryPath, options.DestinationRepoName, options.DestinationUserName, options.DestinationPassword);
+                new Program(sourceRepository, destRepository, options).RunAsync().GetAwaiter().GetResult();
+                return 0;
             }
             catch (OptionException e)
             {
-                Console.WriteLine($"{exeName}: {e.Message}");
-                Console.WriteLine($"Try `{exeName} --help` for more information.");
+                WriteLine($"{exeName}: {e.Message}");
+                WriteLine($"Try `{exeName} --help` for more information.");
                 return 1;
-            }
-
-            if (options.ShowHelp || !options.AreValid)
-            {
-                parameters.WriteOptionDescriptions(Console.Out);
-                return options.AreValid ? 0 : 1;
-            }
-            else
-            {
-                var github = new GitHubClient(new ProductHeaderValue(options.SourceUser));
-                github.Credentials = new Credentials(options.AuthToken);
-                new Program(options).MakePullRequest().GetAwaiter().GetResult();
-                return 0;
             }
         }
 
+        private RepositoryBase _sourceRepo;
+        private RepositoryBase _destRepo;
         private Options _options;
-        private GitHubClient _client;
 
-        private Program(Options options)
+        private Program(RepositoryBase sourceRepository, RepositoryBase destinationRepository, Options options)
         {
+            _sourceRepo = sourceRepository;
+            _destRepo = destinationRepository;
             _options = options;
         }
 
-        public async Task MakePullRequest()
+        public async Task RunAsync()
         {
-            _client = new GitHubClient(new ProductHeaderValue(_options.SourceUser));
-            _client.Credentials = new Credentials(_options.AuthToken);
-            var remoteIntoBranch = await GetShaFromBranch(_options.DestinationUser, _options.RepoName, _options.SourceBranch);
-            var newBranchPrefix = $"merge-{_options.SourceBranch}-into-{_options.DestinationBranch}";
-            if (!_options.Force && await DoesOpenPrAlreadyExist(newBranchPrefix))
+            // fetch latest sources
+            WriteLine("Fetching.");
+            _sourceRepo.FetchAll();
+            _destRepo.FetchAll();
+
+            var (prRepo, prRemoteName, prUserName, prPassword) = _options.PushBranchToDestination
+                ? (_destRepo, _options.DestinationRemoteName, _options.DestinationUserName, _options.DestinationPassword)
+                : (_sourceRepo, _options.SourceRemoteName, _options.SourceUserName, _options.SourcePassword);
+
+            // branch from the source
+            var title = $"Merge {_options.SourceBranchName} into {_options.DestinationBranchName}";
+            if (_options.Force || await prRepo.ShouldMakePullRequestAsync(title))
             {
-                Console.WriteLine("Existing merge PRs exist; aboring creation.  Use `--force` option to override.");
+            }
+            else
+            {
+                WriteLine("Existing merge PRs exist; aboring creation.");
                 return;
             }
 
-            var newBranchName = await MakePrBranch(_options.SourceUser, _options.RepoName, remoteIntoBranch, newBranchPrefix);
-            var pullRequest = await SubmitPullRequest(newBranchName);
-
-            // The reason for this delay is twofold:
-            //
-            // * Github has a bug in which it can "create" a pull request without that pull request
-            //   being able to be commented on for a short period of time.
-            // * The Jenkins "comment watcher" has a bug whereby any comment posted shortly after
-            //   pull-request creation is ignored.
-            //
-            // Thus, this delay sidesteps both of those bugs by asking for a VSI test 30 seconds after 
-            // the creation of the PR.  Ugly, yes; but the only *real* way to sidestep this would be to 
-            // 1) Fix github, 2) Fix jenkins, and while those might be lofty goals, they are not in the 
-            // scope of this PR.
-            await Task.Delay(TimeSpan.FromSeconds(30.0));
-
-            await _client.Issue.Comment.Create(_options.DestinationUser, _options.RepoName, pullRequest.Number, "@dotnet-bot test vsi please");
-        }
-
-        /// <returns> The SHA at the tip of `branchName` in the repository `user/repo` </returns>
-        private async Task<string> GetShaFromBranch(string user, string repo, string branchName) 
-        {
-            var refs = await _client.GitDatabase.Reference.Get(user, repo, $"heads/{branchName}");
-            return refs.Object.Sha;
-        }
-
-        /// <returns>True if an existing auto merge PR is still open.</returns>
-        private async Task<bool> DoesOpenPrAlreadyExist(string newBranchPrefix)
-        {
-            return (await GetExistingMergePrs(newBranchPrefix)).Count > 0;
-        }
-
-        /// <returns>The existing open merge PRs.</returns>
-        private async Task<IList<PullRequest>> GetExistingMergePrs(string newBranchPrefix)
-        {
-            var allPullRequests = await _client.PullRequest.GetAllForRepository(_options.DestinationUser, _options.RepoName);
-            var openPrs = allPullRequests.Where(pr => pr.Head.Ref.StartsWith(newBranchPrefix) && pr.User.Login == _options.SourceUser).ToList();
-
-            Console.WriteLine($"Found {openPrs.Count} existing open merge pull requests.");
-            foreach (var pr in openPrs)
-            {
-                Console.WriteLine($"  Open PR: {pr.HtmlUrl}");
-            }
-
-            return openPrs;
-        }
-
-        /// <summary>
-        /// Creates a PR branch on the bot account with the branch head at `sha`.
-        /// </summary>
-        /// <returns> The name of the branch that was created </returns>
-        private async Task<string> MakePrBranch(string user, string repo, string sha, string branchNamePrefix)
-        {
-            var branchName = branchNamePrefix + DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
-
+            var prBranchName = $"merge-{_options.SourceBranchName}-into-{_options.DestinationBranchName}-{DateTime.UtcNow.ToString("yyyyMMdd-HHmmss")}";
+            var prSourceBranch = $"{_options.PullRequestBranchSourceRemote}/{_options.SourceBranchName}";
+            WriteLine($"Creating branch '{prBranchName}' from '{prSourceBranch}'.");
             if (_options.Debug)
             {
-                WriteDebugLine($"Create remote branch '{user}/{repo}/{branchName}' at {sha}");
+                WriteLine("Debug: Skiping branch creation.");
             }
             else
             {
-                var resp = await _client.Connection.Post<string>(
-                    uri: new Uri($"https://api.github.com/repos/{user}/{repo}/git/refs"),
-                    body: $"{{\"ref\": \"refs/heads/{branchName}\", \"sha\": \"{sha}\"}}",
-                    accepts: "*/*",
-                    contentType: "application/json");
-                var statusCode = resp.HttpResponse.StatusCode;
-                if (statusCode != HttpStatusCode.Created)
+                var prBranch = prRepo.Repository.CreateBranch(prBranchName, prSourceBranch);
+            }
+
+            // push the branch
+            var remote = prRepo.Repository.Network.Remotes[prRemoteName];
+            WriteLine($"Pushing branch '{prBranchName}'.");
+            if (_options.Debug)
+            {
+                WriteLine("Debug: Skipping branch push.");
+            }
+            else
+            {
+                var pushOptions = new PushOptions()
                 {
-                    throw new Exception($"Failed creating a new branch {branchName} on {user}/{repo} with code {statusCode}");
-                }
+                    CredentialsProvider = (url, usernameFromUrl, types) => new UsernamePasswordCredentials()
+                    {
+                        Username = prUserName,
+                        Password = prPassword
+                    }
+                };
+                prRepo.Repository.Network.Push(remote, $"+refs/heads/{prBranchName}:refs/heads/{prBranchName}", pushOptions);
             }
 
-            return branchName;
-        }
-
-        /// <summary>
-        /// Creates a pull request 
-        /// </summary>
-        private async Task<PullRequest> SubmitPullRequest(string newBranchName)
-        {
-            var remoteName = $"{_options.SourceUser}-{_options.RepoName}";
-            var prTitle = $"Merge {_options.SourceBranch} into {_options.DestinationBranch}";
-            var prMessage = $@"
-This is an automatically generated pull request from {_options.SourceBranch} into {_options.DestinationBranch}.
-
-@dotnet/roslyn-infrastructure:
-
-``` bash
-git remote add {remoteName} ""https://github.com/{_options.SourceUser}/{_options.RepoName}.git""
-git fetch {remoteName}
-git fetch upstream
-git checkout {newBranchName}
-git reset --hard upstream/{_options.DestinationBranch}
-git merge upstream/{_options.SourceBranch}
-# Fix merge conflicts
-git commit
-git push {remoteName} {newBranchName} --force
-```
-
-Once the merge can be made and all the tests pass, you are free to merge the pull request.
-".Trim();
-
+            // create PR
+            WriteLine("Creating PR.");
             if (_options.Debug)
             {
-                WriteDebugLine($"Create PR with title: {prTitle}.");
-                WriteDebugLine($"Create PR with body:\r\n{prMessage}");
-                return null;
+                WriteLine("Debug: Skipping PR creation.");
             }
             else
             {
-                return await _client.PullRequest.Create(
-                    owner: _options.DestinationUser,
-                    name: _options.RepoName,
-                    newPullRequest: new NewPullRequest(
-                        title: prTitle,
-                        head: $"{_options.SourceUser}:{newBranchName}",
-                        baseRef: _options.DestinationBranch)
-                        {
-                            Body = prMessage
-                        }
-                    );
+                await _destRepo.CreatePullRequestAsync(title, _options.DestinationRepoOwner, prBranchName, _options.SourceBranchName, _options.DestinationBranchName);
             }
-        }
-
-        private void WriteDebugLine(string line)
-        {
-            Console.WriteLine("Debug: " + line);
         }
     }
 }

--- a/src/Tools/Github/GitMergeBot/README.md
+++ b/src/Tools/Github/GitMergeBot/README.md
@@ -1,0 +1,11 @@
+# Example
+
+Example merge from `dotnet:dev15-rc2` to `dotnet:master` where the credentials used belong to a fictional user `merge-bot`.
+
+``` cmd
+set username=merge-bot
+set password=[password-or-auth-token]
+set sourcebranch=dev15-rc2
+set destbranch=master
+GitMergeBot.exe --repopath=C:\path\to\repo --sourcetype=GitHub --sourcereponame=roslyn --sourceuser=%username% --sourcepassword=%password% --sourceremote=origin --sourcebranch=%sourcebranch% --pushtodestination- --prbranchsourceremote=upstream --destinationrepoowner=dotnet --destinationremote=upstream --destinationbranch=%destbranch%
+```

--- a/src/Tools/Github/GitMergeBot/README.md
+++ b/src/Tools/Github/GitMergeBot/README.md
@@ -1,11 +1,13 @@
-# Example
+# Examples
 
-Example merge from `dotnet:dev15-rc2` to `dotnet:master` where the credentials used belong to a fictional user `merge-bot`.
+## Merge from `https://github.com/dotnet/roslyn`:`dev15-rc2` to `master` where the credentials used belong to a fictional user `merge-bot`.
 
 ``` cmd
-set username=merge-bot
-set password=[password-or-auth-token]
-set sourcebranch=dev15-rc2
-set destbranch=master
-GitMergeBot.exe --repopath=C:\path\to\repo --sourcetype=GitHub --sourcereponame=roslyn --sourceuser=%username% --sourcepassword=%password% --sourceremote=origin --sourcebranch=%sourcebranch% --pushtodestination- --prbranchsourceremote=upstream --destinationrepoowner=dotnet --destinationremote=upstream --destinationbranch=%destbranch%
+GitMergeBot.exe --repopath=C:\path\to\roslyn\repo --sourcetype=GitHub --sourcereponame=roslyn --sourceuser=merge-bot --sourcepassword=super-secret-key --sourceremote=origin --sourcebranch=dev15-rc2 --pushtodestination- --prbranchsourceremote=upstream --destinationrepoowner=dotnet --destinationremote=upstream --destinationbranch=master
+```
+
+## Merge from `https://github.com/Microsoft/visualfsharp`:`master` to `https://<internal-f#-repository>`:`microbuild` on a VSO instance where the credentials belong to a fictional user `merge-bot`.
+
+``` cmd
+GitMergeBot.exe --repopath=C:\path\to\fsharp\repo --sourcetype=GitHub --sourcereponame=visualfsharp --sourceuser=merge-bot --sourcepassword=super-secret-key --sourceremote=origin --sourcebranch=master --pushtodestination+ --prbranchsourceremote=upstream --destinationtype=VisualStudioOnline --destinationreponame=FSharp --destinationproject=DevDiv --destinationuserid=[GUID] --destinationuser= --destinationpassword=super-secret-key --destinationremote=vso --destinationbranch=microbuild
 ```

--- a/src/Tools/Github/GitMergeBot/RepositoryBase.cs
+++ b/src/Tools/Github/GitMergeBot/RepositoryBase.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using LibGit2Sharp;
+
+namespace GitMergeBot
+{
+    internal abstract class RepositoryBase
+    {
+        public Repository Repository { get; }
+        public string RepositoryName { get; }
+        public string UserName { get; }
+        public string Password { get; }
+
+        protected RepositoryBase(string path, string repoName, string userName, string password)
+        {
+            Repository = new Repository(path);
+            RepositoryName = repoName;
+            UserName = userName;
+            Password = password;
+        }
+
+        public abstract Task<bool> ShouldMakePullRequestAsync(string title);
+        public abstract Task CreatePullRequestAsync(string title, string destinationOwner, string pullRequestBranch, string sourceBranch, string destinationBranch);
+
+        protected void WriteDebugLine(string line)
+        {
+            Console.WriteLine("Debug: " + line);
+        }
+
+        public void FetchAll()
+        {
+            foreach (var remote in Repository.Network.Remotes)
+            {
+                Repository.Fetch(remote.Name);
+            }
+        }
+
+        public static RepositoryBase Create(RepositoryType type, string path, string repoName, string userName, string password)
+        {
+            switch (type)
+            {
+                case RepositoryType.GitHub:
+                    return new GitHubRepository(path, repoName, userName, password);
+                case RepositoryType.VisualStudioOnline:
+                    return new VisualStudioOnlineRepository(path, repoName, userName, password);
+                default:
+                    throw new InvalidOperationException("Unknown repository type.");
+            }
+        }
+    }
+}

--- a/src/Tools/Github/GitMergeBot/RepositoryType.cs
+++ b/src/Tools/Github/GitMergeBot/RepositoryType.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace GitMergeBot
+{
+    internal enum RepositoryType
+    {
+        GitHub,
+        VisualStudioOnline
+    }
+}

--- a/src/Tools/Github/GitMergeBot/VisualStudioOnlineRepository.cs
+++ b/src/Tools/Github/GitMergeBot/VisualStudioOnlineRepository.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace GitMergeBot
+{
+    internal sealed class VisualStudioOnlineRepository : RepositoryBase
+    {
+        public VisualStudioOnlineRepository(string path, string repoName, string userName, string password)
+            : base(path, repoName, userName, password)
+        {
+        }
+
+        public override Task<bool> ShouldMakePullRequestAsync(string title)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task CreatePullRequestAsync(string title, string destinationOwner, string pullRequestBranch, string sourceBranch, string destinationBranch)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Tools/Github/GitMergeBot/VisualStudioOnlineRepository.cs
+++ b/src/Tools/Github/GitMergeBot/VisualStudioOnlineRepository.cs
@@ -1,25 +1,142 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 
 namespace GitMergeBot
 {
     internal sealed class VisualStudioOnlineRepository : RepositoryBase
     {
-        public VisualStudioOnlineRepository(string path, string repoName, string userName, string password)
+        private const string ApiVersion = "3.0";
+
+        private HttpClient _client;
+        private string _project;
+        private string _remoteName;
+        private string _repositoryId;
+        private string _userId;
+
+        public VisualStudioOnlineRepository(string path, string repoName, string project, string userId, string userName, string password, string remoteName)
             : base(path, repoName, userName, password)
         {
+            _project = project;
+            _remoteName = remoteName;
+            _userId = userId;
+
+            var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{userName}:{password}"));
+            var remote = Repository.Network.Remotes[remoteName];
+            var remoteUri = new Uri(remote.Url);
+            _client = new HttpClient();
+            _client.BaseAddress = new Uri($"{remoteUri.Scheme}://{remoteUri.Host}");
+            _client.DefaultRequestHeaders.Accept.Clear();
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
         }
 
-        public override Task<bool> ShouldMakePullRequestAsync(string title)
+        public override async Task Initialize()
         {
-            throw new NotImplementedException();
+            // find the repository ID
+            // https://www.visualstudio.com/en-us/docs/integrate/api/git/repositories#get-a-list-of-repositories
+            var repositories = await GetJsonAsync($"DefaultCollection/{_project}/_apis/git/repositories?api-version={ApiVersion}");
+            _repositoryId = (string)repositories["value"].Single(r => r?["name"].Type == JTokenType.String && (string)r["name"] == RepositoryName)["id"];
         }
 
-        public override Task CreatePullRequestAsync(string title, string destinationOwner, string pullRequestBranch, string sourceBranch, string destinationBranch)
+        public override async Task<bool> ShouldMakePullRequestAsync(string title)
         {
-            throw new NotImplementedException();
+            // https://www.visualstudio.com/en-us/docs/integrate/api/git/pull-requests/pull-requests#get-a-list-of-pull-requests-in-the-repository
+            var foundMatch = false;
+            var result = await GetJsonAsync($"DefaultCollection/_apis/git/repositories/{_repositoryId}/pullRequests?api-version={ApiVersion}&creatorId={_userId}");
+            var pullRequests = (JArray)result["value"];
+            foreach (JObject pr in pullRequests)
+            {
+                if (pr?["repository"]?["name"].Type == JTokenType.String && (string)pr["repository"]["name"] == RepositoryName)
+                {
+                    var prTitle = (string)pr["title"];
+                    Console.WriteLine($"  Open PR: {prTitle}");
+                    foundMatch |= prTitle == title;
+                }
+            }
+
+            return !foundMatch;
+        }
+
+        public override async Task CreatePullRequestAsync(string title, string destinationOwner, string pullRequestBranch, string prBranchSourceRemote, string sourceBranch, string destinationBranch)
+        {
+            // https://www.visualstudio.com/en-us/docs/integrate/api/git/pull-requests/pull-requests#create-a-pull-request
+            var prMessage = $@"
+This is an automatically generated pull request from {sourceBranch} into {destinationBranch}.
+
+``` bash
+git remote add {_remoteName} {Repository.Network.Remotes[_remoteName].Url}
+git fetch --all
+git checkout {pullRequestBranch}
+git reset --hard {_remoteName}/{destinationBranch}
+git merge {prBranchSourceRemote}/{sourceBranch}
+# Fix merge conflicts
+git commit
+git push {pullRequestBranch} --force
+```
+
+Once all conflicts are resolved and all the tests pass, you are free to merge the pull request.
+".Trim();
+            var request = new JObject()
+            {
+                ["sourceRefName"] = $"refs/heads/{pullRequestBranch}",
+                ["targetRefName"] = $"refs/heads/{destinationBranch}",
+                ["title"] = title,
+                ["description"] = prMessage,
+                ["reviewers"] = new JArray() // no required reviewers, but necessary for the request
+            };
+            var result = await GetJsonAsync(
+                $"DefaultCollection/_apis/git/repositories/{_repositoryId}/pullRequests?api-version={ApiVersion}",
+                body: request,
+                method: "POST");
+
+            var pullRequestId = (string)result["pullRequestId"];
+
+            // mark the PR to auto complete
+            // https://www.visualstudio.com/en-us/docs/integrate/api/git/pull-requests/pull-requests#auto-complete
+            var autoCompleteRequest = new JObject()
+            {
+                ["autoCompleteSetBy"] = new JObject()
+                {
+                    ["id"] = _userId
+                },
+                ["completionOptions"] = new JObject()
+                {
+                    ["deleteSourceBranch"] = true,
+                    ["mergeCommitMessage"] = $"Pull request #{pullRequestId} auto-completed after passing checks.",
+                    ["squashMerge"] = false
+                }
+            };
+
+            result = await GetJsonAsync(
+                $"DefaultCollection/_apis/git/repositories/{_repositoryId}/pullRequests/{pullRequestId}?api-version={ApiVersion}",
+                body: autoCompleteRequest,
+                method: "PATCH");
+        }
+
+        private async Task<JObject> GetJsonAsync(string requestUri, JObject body = null, string method = "GET")
+        {
+            HttpResponseMessage response;
+            if (body == null)
+            {
+                response = await _client.GetAsync(requestUri);
+            }
+            else
+            {
+                var requestMessage = new HttpRequestMessage(new HttpMethod(method), requestUri);
+                requestMessage.Content = new ByteArrayContent(Encoding.ASCII.GetBytes(body.ToString()));
+                requestMessage.Content.Headers.Add("Content-Type", "application/json");
+                response = await _client.SendAsync(requestMessage);
+            }
+
+            var result = await response.Content.ReadAsStringAsync();
+            return JObject.Parse(result);
         }
     }
 }

--- a/src/Tools/Github/GitMergeBot/packages.config
+++ b/src/Tools/Github/GitMergeBot/packages.config
@@ -3,6 +3,7 @@
   <package id="LibGit2Sharp" version="0.22.0" targetFramework="net46" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net46" />
   <package id="Mono.Options" version="1.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Octokit" version="0.17.0" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.3.0-preview1-24530-04" targetFramework="net46" />
 </packages>

--- a/src/Tools/Github/GitMergeBot/packages.config
+++ b/src/Tools/Github/GitMergeBot/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="LibGit2Sharp" version="0.22.0" targetFramework="net46" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net46" />
   <package id="Mono.Options" version="1.1" targetFramework="net452" />
   <package id="Octokit" version="0.17.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.3.0-preview1-24530-04" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
There are two major changes to the merge bot:

1.  Make local git operations repo-type-agnostic by performing operations on a local clone, instead of using GitHub APIs.
2.  Move repo-specific code into `GitHubRepository.cs` and `VisualStudioOnlineRepository.cs`.

Example GitHub PR created by this code: #15267 (n.b., I manually closed this PR, but the rest of it was done by the tool.  There should be no difference between this PR and our existing ones, with the exception that this one was created using my own GitHub access token.)

Example GitHub -> Visual Studio Online PR created by this code (internal): [here](https://devdiv.visualstudio.com/DevDiv/_git/FSharp/pullrequest/46881?_a=overview).  Note that these PRs are set to auto-merge once everything is green.  Currently 'green' means there are no merge conflicts; I'm currently working on enabling PR builds here for additional validation.

@dotnet/roslyn-infrastructure @KevinRansom @TyOverby