### PR TITLE
Only resolve breakpoints for modules with symbols

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.vsdconfigxml
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.vsdconfigxml
@@ -28,6 +28,7 @@
           <Interface Name="IDkmModuleInstanceLoadNotification"/>
           <Interface Name="IDkmModuleInstanceUnloadNotification"/>
           <Interface Name="IDkmModuleModifiedNotification"/>
+          <Interface Name="IDkmModuleSymbolsLoadedNotification"/>
         </InterfaceGroup>
       </Implements>
     </Class>

--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/project.json
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/project.json
@@ -1,5 +1,6 @@
 ﻿{
     "dependencies": {
+        "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
         "System.Collections.Immutable": "1.2.0",
         "System.Reflection.Metadata": "1.4.1-beta-24430-01",
         "Microsoft.VisualStudio.Debugger.Engine": "14.3.25422",


### PR DESCRIPTION
Customer scenario: Breakpoints are not resolved if the breakpoints are created before module symbols are loaded.

Bug: This is a regression from the behavior of the native EE, found by regression tests.

Workaround: Load symbols and re-create breakpoints.

Risk and performance impact: Low since breakpoints are still only resolved once per module, but now only after symbols are loaded.