### PR TITLE
	Extract method should introduce variables with 'var' if that is the user preference.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -19,12 +19,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Extrac
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace)
             => new ExtractMethodCodeRefactoringProvider();
 
-        private IDictionary<OptionKey, object> DoNotUseVarOption => OptionsSet(
-            SingleOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals, false),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, CodeStyleOptions.FalseWithNoneEnforcement),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, CodeStyleOptions.FalseWithNoneEnforcement),
-            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, CodeStyleOptions.FalseWithNoneEnforcement));
-
         [WorkItem(540799, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540799")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
         public async Task TestPartialSelection()
@@ -51,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Extrac
         return b != true;
     }
 }",
-index: 0, options: DoNotUseVarOption); 
+index: 0); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -117,7 +111,7 @@ options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CodeStyleO
         return t;
     }
 }",
-index: 0, options: DoNotUseVarOption); 
+index: 0); 
         }
 
         [WorkItem(540819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540819")]
@@ -138,7 +132,7 @@ class C
     label2:
         return;
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [WorkItem(540819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540819")]
@@ -179,7 +173,7 @@ class C
         return x * x;
     }
 }",
-index: 0, options: DoNotUseVarOption); 
+index: 0); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -204,7 +198,7 @@ index: 0, options: DoNotUseVarOption);
     {
         System.Console.WriteLine(4);
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -229,7 +223,7 @@ index: 0, options: DoNotUseVarOption);
     {
         System.Console.WriteLine(4);
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -254,7 +248,7 @@ index: 0, options: DoNotUseVarOption);
     {
         base.ToString();
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [WorkItem(545623, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545623")]
@@ -294,7 +288,7 @@ class Program
     {
         return C.X;
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [WorkItem(529841, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529841"), WorkItem(714632, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/714632")]
@@ -335,7 +329,7 @@ class Program
     static void Foo(Func<byte, byte> p, Func<byte, byte> q, int r, int s) { Console.WriteLine(2); }
 }",
 
-compareTokens: false, options: DoNotUseVarOption); 
+compareTokens: false); 
         }
 
         [WorkItem(529841, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529841"), WorkItem(714632, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/714632")]
@@ -376,7 +370,7 @@ class Program
     static void Foo(Func<byte, byte> p, Func<byte, byte> q, int r, int s) { Console.WriteLine(2); }
 }",
 
-compareTokens: false, options: DoNotUseVarOption); 
+compareTokens: false); 
         }
 
         [WorkItem(530709, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530709")]
@@ -619,7 +613,7 @@ parseOptions: Options.Regular);
     }
 }",
 
-compareTokens: false, options: DoNotUseVarOption); 
+compareTokens: false); 
         }
 
         [WorkItem(984831, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/984831")]
@@ -671,7 +665,7 @@ compareTokens: false, options: DoNotUseVarOption);
     }
 }",
 
-compareTokens: false, options: DoNotUseVarOption); 
+compareTokens: false); 
         }
 
         [WorkItem(984831, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/984831")]
@@ -720,7 +714,7 @@ compareTokens: false, options: DoNotUseVarOption);
     }
 }",
 
-compareTokens: false, options: DoNotUseVarOption); 
+compareTokens: false); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -748,7 +742,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -776,7 +770,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -804,7 +798,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -832,7 +826,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return (a: 1, b: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -860,7 +854,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return (c: 1, d: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -888,7 +882,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return (c: 1, d: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -916,7 +910,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return (c: 1, d: 2);
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -945,7 +939,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return new System.ValueTuple<int, int, int, int, int, int, int, (string a, string b)>(1, 2, 3, 4, 5, 6, 7, (a: ""hello"", b: ""world""));
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -972,7 +966,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -1001,7 +995,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         return 3;
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1032,7 +1026,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         r = M1(out y, i);
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1063,7 +1057,7 @@ compareTokens: false, options: DoNotUseVarOption);
     {
         r = M1(3 is int {|Conflict:y|}, i);
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1095,7 +1089,7 @@ compareTokens: false, options: DoNotUseVarOption);
         r = M1(out /*out*/  /*int*/ y /*y*/) + M2(3 is int {|Conflict:z|});
     }
 } ",
-compareTokens: false, options: DoNotUseVarOption); 
+compareTokens: false); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1135,7 +1129,7 @@ compareTokens: false, options: DoNotUseVarOption);
             System.Console.Write(y);
         }
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1175,7 +1169,7 @@ compareTokens: false, options: DoNotUseVarOption);
             System.Console.Write(y);
         }
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [WorkItem(15218, "https://github.com/dotnet/roslyn/issues/15218")]
@@ -1218,7 +1212,7 @@ class C
             Console.WriteLine(v);
         }
     }
-}", options: DoNotUseVarOption); 
+}"); 
         }
 
         [WorkItem(15219, "https://github.com/dotnet/roslyn/issues/15219")]

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Extrac
         return b != true;
     }
 }",
-index: 0); 
+index: 0);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -111,7 +111,7 @@ options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CodeStyleO
         return t;
     }
 }",
-index: 0); 
+index: 0);
         }
 
         [WorkItem(540819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540819")]
@@ -132,7 +132,7 @@ class C
     label2:
         return;
     }
-}"); 
+}");
         }
 
         [WorkItem(540819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540819")]
@@ -173,7 +173,7 @@ class C
         return x * x;
     }
 }",
-index: 0); 
+index: 0);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -198,7 +198,7 @@ index: 0);
     {
         System.Console.WriteLine(4);
     }
-}"); 
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -223,7 +223,7 @@ index: 0);
     {
         System.Console.WriteLine(4);
     }
-}"); 
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -248,7 +248,7 @@ index: 0);
     {
         base.ToString();
     }
-}"); 
+}");
         }
 
         [WorkItem(545623, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545623")]
@@ -288,7 +288,7 @@ class Program
     {
         return C.X;
     }
-}"); 
+}");
         }
 
         [WorkItem(529841, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529841"), WorkItem(714632, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/714632")]
@@ -329,7 +329,7 @@ class Program
     static void Foo(Func<byte, byte> p, Func<byte, byte> q, int r, int s) { Console.WriteLine(2); }
 }",
 
-compareTokens: false); 
+compareTokens: false);
         }
 
         [WorkItem(529841, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529841"), WorkItem(714632, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/714632")]
@@ -370,7 +370,7 @@ class Program
     static void Foo(Func<byte, byte> p, Func<byte, byte> q, int r, int s) { Console.WriteLine(2); }
 }",
 
-compareTokens: false); 
+compareTokens: false);
         }
 
         [WorkItem(530709, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530709")]
@@ -613,7 +613,7 @@ parseOptions: Options.Regular);
     }
 }",
 
-compareTokens: false); 
+compareTokens: false);
         }
 
         [WorkItem(984831, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/984831")]
@@ -665,7 +665,7 @@ compareTokens: false);
     }
 }",
 
-compareTokens: false); 
+compareTokens: false);
         }
 
         [WorkItem(984831, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/984831")]
@@ -714,7 +714,7 @@ compareTokens: false);
     }
 }",
 
-compareTokens: false); 
+compareTokens: false);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -742,7 +742,7 @@ compareTokens: false);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -770,7 +770,7 @@ compareTokens: false);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -798,7 +798,7 @@ compareTokens: false);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -826,7 +826,7 @@ compareTokens: false);
     {
         return (a: 1, b: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -854,7 +854,7 @@ compareTokens: false);
     {
         return (c: 1, d: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -882,7 +882,7 @@ compareTokens: false);
     {
         return (c: 1, d: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -910,7 +910,7 @@ compareTokens: false);
     {
         return (c: 1, d: 2);
     }
-}"); 
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -939,7 +939,7 @@ compareTokens: false);
     {
         return new System.ValueTuple<int, int, int, int, int, int, int, (string a, string b)>(1, 2, 3, 4, 5, 6, 7, (a: ""hello"", b: ""world""));
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -966,7 +966,7 @@ compareTokens: false);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -995,7 +995,7 @@ compareTokens: false);
     {
         return 3;
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs); 
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1026,7 +1026,7 @@ compareTokens: false);
     {
         r = M1(out y, i);
     }
-}"); 
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1057,7 +1057,7 @@ compareTokens: false);
     {
         r = M1(3 is int {|Conflict:y|}, i);
     }
-}"); 
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1089,7 +1089,7 @@ compareTokens: false);
         r = M1(out /*out*/  /*int*/ y /*y*/) + M2(3 is int {|Conflict:z|});
     }
 } ",
-compareTokens: false); 
+compareTokens: false);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1129,7 +1129,7 @@ compareTokens: false);
             System.Console.Write(y);
         }
     }
-}"); 
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1169,7 +1169,7 @@ compareTokens: false);
             System.Console.Write(y);
         }
     }
-}"); 
+}");
         }
 
         [WorkItem(15218, "https://github.com/dotnet/roslyn/issues/15218")]
@@ -1212,7 +1212,7 @@ class C
             Console.WriteLine(v);
         }
     }
-}"); 
+}");
         }
 
         [WorkItem(15219, "https://github.com/dotnet/roslyn/issues/15219")]

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CodeRefactorings.ExtractMethod;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Options;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -14,9 +17,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Extrac
     public class ExtractMethodTests : AbstractCSharpCodeActionTest
     {
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace)
-        {
-            return new ExtractMethodCodeRefactoringProvider();
-        }
+            => new ExtractMethodCodeRefactoringProvider();
+
+        private IDictionary<OptionKey, object> DoNotUseVarOption => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals, false));
+
+        private IDictionary<OptionKey, object> UseVarOption => OptionsSet(
+            SingleOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals, true),
+            SingleOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, CodeStyleOptions.TrueWithSuggestionEnforcement));
 
         [WorkItem(540799, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540799")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -44,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Extrac
         return b != true;
     }
 }",
-index: 0);
+index: 0, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -110,7 +118,7 @@ options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CodeStyleO
         return t;
     }
 }",
-index: 0);
+index: 0, options: DoNotUseVarOption); 
         }
 
         [WorkItem(540819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540819")]
@@ -131,7 +139,7 @@ class C
     label2:
         return;
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [WorkItem(540819, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540819")]
@@ -172,7 +180,7 @@ class C
         return x * x;
     }
 }",
-index: 0);
+index: 0, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -197,7 +205,7 @@ index: 0);
     {
         System.Console.WriteLine(4);
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -222,7 +230,7 @@ index: 0);
     {
         System.Console.WriteLine(4);
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -247,7 +255,7 @@ index: 0);
     {
         base.ToString();
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [WorkItem(545623, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545623")]
@@ -287,7 +295,7 @@ class Program
     {
         return C.X;
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [WorkItem(529841, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529841"), WorkItem(714632, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/714632")]
@@ -328,7 +336,7 @@ class Program
     static void Foo(Func<byte, byte> p, Func<byte, byte> q, int r, int s) { Console.WriteLine(2); }
 }",
 
-compareTokens: false);
+compareTokens: false, options: DoNotUseVarOption); 
         }
 
         [WorkItem(529841, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529841"), WorkItem(714632, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/714632")]
@@ -369,7 +377,7 @@ class Program
     static void Foo(Func<byte, byte> p, Func<byte, byte> q, int r, int s) { Console.WriteLine(2); }
 }",
 
-compareTokens: false);
+compareTokens: false, options: DoNotUseVarOption); 
         }
 
         [WorkItem(530709, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530709")]
@@ -612,7 +620,7 @@ parseOptions: Options.Regular);
     }
 }",
 
-compareTokens: false);
+compareTokens: false, options: DoNotUseVarOption); 
         }
 
         [WorkItem(984831, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/984831")]
@@ -664,7 +672,7 @@ compareTokens: false);
     }
 }",
 
-compareTokens: false);
+compareTokens: false, options: DoNotUseVarOption); 
         }
 
         [WorkItem(984831, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/984831")]
@@ -713,7 +721,7 @@ compareTokens: false);
     }
 }",
 
-compareTokens: false);
+compareTokens: false, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -741,7 +749,7 @@ compareTokens: false);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -769,7 +777,7 @@ compareTokens: false);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -797,7 +805,7 @@ compareTokens: false);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -825,7 +833,7 @@ compareTokens: false);
     {
         return (a: 1, b: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -853,7 +861,7 @@ compareTokens: false);
     {
         return (c: 1, d: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -881,7 +889,7 @@ compareTokens: false);
     {
         return (c: 1, d: 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -909,7 +917,7 @@ compareTokens: false);
     {
         return (c: 1, d: 2);
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -938,7 +946,7 @@ compareTokens: false);
     {
         return new System.ValueTuple<int, int, int, int, int, int, int, (string a, string b)>(1, 2, 3, 4, 5, 6, 7, (a: ""hello"", b: ""world""));
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -965,7 +973,7 @@ compareTokens: false);
     {
         return (1, 2);
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -994,7 +1002,7 @@ compareTokens: false);
     {
         return 3;
     }
-}" + TestResources.NetFX.ValueTuple.tuplelib_cs);
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1025,7 +1033,7 @@ compareTokens: false);
     {
         r = M1(out y, i);
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1056,7 +1064,7 @@ compareTokens: false);
     {
         r = M1(3 is int {|Conflict:y|}, i);
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1088,7 +1096,7 @@ compareTokens: false);
         r = M1(out /*out*/  /*int*/ y /*y*/) + M2(3 is int {|Conflict:z|});
     }
 } ",
-compareTokens: false);
+compareTokens: false, options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1128,7 +1136,7 @@ compareTokens: false);
             System.Console.Write(y);
         }
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
@@ -1168,7 +1176,7 @@ compareTokens: false);
             System.Console.Write(y);
         }
     }
-}");
+}", options: DoNotUseVarOption); 
         }
 
         [WorkItem(15218, "https://github.com/dotnet/roslyn/issues/15218")]
@@ -1211,7 +1219,55 @@ class C
             Console.WriteLine(v);
         }
     }
-}");
+}", options: DoNotUseVarOption); 
+        }
+
+        [WorkItem(15219, "https://github.com/dotnet/roslyn/issues/15219")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod)]
+        public async Task TestUseVar1()
+        {
+            await TestAsync(
+@"using System;
+
+class C
+{
+    void Foo(int i)
+    {
+        [|var v = (string)null;
+
+        switch (i)
+        {
+            case 0: v = ""0""; break;
+            case 1: v = ""1""; break;
+        }|]
+
+        Console.WriteLine(v);
+    }
+}",
+@"using System;
+
+class C
+{
+    void Foo(int i)
+    {
+        var v = {|Rename:NewMethod|}(i);
+
+        Console.WriteLine(v);
+    }
+
+    private static string NewMethod(int i)
+    {
+        var v = (string)null;
+
+        switch (i)
+        {
+            case 0: v = ""0""; break;
+            case 1: v = ""1""; break;
+        }
+
+        return v;
+    }
+}", options: UseVarOption); 
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -1266,7 +1266,7 @@ class C
 
         return v;
     }
-}", options: Option(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, CodeStyleOptions.TrueWithSuggestionEnforcement));
+}", options: Option(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, CodeStyleOptions.TrueWithSuggestionEnforcement));
         }
 
         [WorkItem(15219, "https://github.com/dotnet/roslyn/issues/15219")]

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -118,9 +118,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             var options = originalOptions.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, allowMovingDeclaration)
                                          .WithChangedOption(ExtractMethodOptions.DontPutOutOrRefOnStruct, document.Project.Language, dontPutOutOrRefOnStruct);
 
-            workspace.Options = workspace.Options
-                                         .WithChangedOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals, false);
-
             var semanticDocument = await SemanticDocument.CreateAsync(document, CancellationToken.None);
             var validator = new CSharpSelectionValidator(semanticDocument, testDocument.SelectedSpans.Single(), options);
 

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.ExtractMethod;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -82,7 +83,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
                 var testDocument = workspace.Documents.Single();
                 var subjectBuffer = testDocument.TextBuffer;
 
-                var tree = await ExtractMethodAsync(workspace, testDocument, allowMovingDeclaration: allowMovingDeclaration, dontPutOutOrRefOnStruct: dontPutOutOrRefOnStruct);
+                var tree = await ExtractMethodAsync(
+                    workspace, testDocument, allowMovingDeclaration: allowMovingDeclaration,
+                    dontPutOutOrRefOnStruct: dontPutOutOrRefOnStruct);
 
                 using (var edit = subjectBuffer.CreateEdit())
                 {
@@ -114,6 +117,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             var originalOptions = await document.GetOptionsAsync();
             var options = originalOptions.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, allowMovingDeclaration)
                                          .WithChangedOption(ExtractMethodOptions.DontPutOutOrRefOnStruct, document.Project.Language, dontPutOutOrRefOnStruct);
+
+            workspace.Options = workspace.Options
+                                         .WithChangedOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals, false);
 
             var semanticDocument = await SemanticDocument.CreateAsync(document, CancellationToken.None);
             var validator = new CSharpSelectionValidator(semanticDocument, testDocument.SelectedSpans.Single(), options);

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -530,9 +530,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         protected static IList<CodeAction> FlattenActions(IEnumerable<CodeAction> codeActions)
         {
             return codeActions?.SelectMany(a => a.NestedCodeActions.Length > 0
-                ? a.NestedCodeActions.ToArray() 
+                ? a.NestedCodeActions.ToArray()
                 : new[] { a }).ToList();
         }
+
+        protected (OptionKey, object) SingleOption(Option<bool> option, bool enabled)
+            => (new OptionKey(option), enabled);
 
         protected (OptionKey, object) SingleOption(Option<CodeStyleOption<bool>> option, bool enabled, NotificationOption notification)
             => SingleOption(option, new CodeStyleOption<bool>(enabled, notification));

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
@@ -97,12 +97,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
             private bool IsInferredPredefinedType(SyntaxNode declarationStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
             {
-                TypeSyntax typeSyntax = GetTypeSyntaxFromDeclaration(declarationStatement);
+                var typeSyntax = GetTypeSyntaxFromDeclaration(declarationStatement);
 
-                return typeSyntax != null
-                     ? typeSyntax.IsTypeInferred(semanticModel) &&
-                        semanticModel.GetTypeInfo(typeSyntax).Type?.IsSpecialType() == true
-                     : false;
+                return typeSyntax != null &&
+                    typeSyntax.IsTypeInferred(semanticModel) &&
+                    semanticModel.GetTypeInfo(typeSyntax).Type?.IsSpecialType() == true;
             }
 
             private TypeSyntax GetTypeSyntaxFromDeclaration(SyntaxNode declarationStatement)

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -128,7 +128,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             // Then the type is not-apperant, and we shoudl not use var if the user only wants
             // it for apperant types
 
-            // Switching to 'var' changed semantics.  Just use the original type of the local.
             var local = (ILocalSymbol)semanticModel.GetDeclaredSymbol(declarator);
             var newType = local.Type.GenerateTypeSyntaxOrVar(options, typeIsApperant: false);
 

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -62,15 +62,12 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             protected abstract Task<TNodeUnderContainer> GetStatementOrInitializerContainingInvocationToExtractedMethodAsync(SyntaxAnnotation callsiteAnnotation, CancellationToken cancellationToken);
 
             protected abstract TExpression CreateCallSignature();
-            protected abstract TStatement CreateDeclarationStatement(
-                VariableInfo variable, TExpression initialValue, OptionSet options, CancellationToken cancellationToken);
+            protected abstract TStatement CreateDeclarationStatement(VariableInfo variable, TExpression initialValue, CancellationToken cancellationToken);
             protected abstract TStatement CreateAssignmentExpressionStatement(SyntaxToken identifier, TExpression rvalue);
             protected abstract TStatement CreateReturnStatement(string identifierName = null);
 
             protected abstract IEnumerable<TStatement> GetInitialStatementsForMethodDefinitions();
             #endregion
-
-            private OptionSet Options => this.SemanticDocument.Document.Project.Solution.Options;
 
             public async Task<GeneratedCode> GenerateAsync(CancellationToken cancellationToken)
             {
@@ -193,8 +190,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                     Contract.ThrowIfFalse(this.AnalyzerResult.GetVariablesToSplitOrMoveOutToCallSite(cancellationToken).Single(v => v.ReturnBehavior == ReturnBehavior.Initialization) != null);
 
                     var declarationStatement = CreateDeclarationStatement(
-                        variable, CreateCallSignature(),
-                        this.Options, cancellationToken).WithAdditionalAnnotations(this.CallSiteAnnotation);
+                        variable, CreateCallSignature(), cancellationToken).WithAdditionalAnnotations(this.CallSiteAnnotation);
 
                     return statements.Concat(declarationStatement);
                 }
@@ -208,13 +204,11 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 IEnumerable<VariableInfo> variables, CancellationToken cancellationToken)
             {
                 var list = new List<TStatement>();
-                var options = this.Options;
 
                 foreach (var variable in variables)
                 {
                     list.Add(CreateDeclarationStatement(
-                        variable, initialValue: null, options: options, 
-                        cancellationToken: cancellationToken));
+                        variable, initialValue: null, cancellationToken: cancellationToken));
                 }
 
                 return list;
@@ -224,7 +218,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 IEnumerable<TStatement> statements, CancellationToken cancellationToken)
             {
                 var list = new List<TStatement>();
-                var options = this.Options;
 
                 foreach (var variable in this.AnalyzerResult.GetVariablesToSplitOrMoveOutToCallSite(cancellationToken))
                 {
@@ -234,8 +227,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                     }
 
                     list.Add(CreateDeclarationStatement(
-                        variable, initialValue: null, options: options,
-                        cancellationToken: cancellationToken));
+                        variable, initialValue: null, cancellationToken: cancellationToken));
                 }
 
                 return list;

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -353,7 +353,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
             Protected Overrides Function CreateDeclarationStatement(
                     variable As VariableInfo,
                     givenInitializer As ExpressionSyntax,
-                    options As OptionSet,
                     cancellationToken As CancellationToken) As StatementSyntax
 
                 Dim shouldInitializeWithNothing = (variable.GetDeclarationBehavior(cancellationToken) = DeclarationBehavior.MoveOut OrElse variable.GetDeclarationBehavior(cancellationToken) = DeclarationBehavior.SplitOut) AndAlso

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.VisualBasicCodeGenerator.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Simplification
+Imports Microsoft.CodeAnalysis.Options
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
     Partial Friend Class VisualBasicMethodExtractor
@@ -349,9 +350,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
                 Return identifier.CreateAssignmentExpressionStatementWithValue(rvalue)
             End Function
 
-            Protected Overrides Function CreateDeclarationStatement(variable As VariableInfo,
-                                                                    cancellationToken As CancellationToken,
-                                                                    Optional givenInitializer As ExpressionSyntax = Nothing) As StatementSyntax
+            Protected Overrides Function CreateDeclarationStatement(
+                    variable As VariableInfo,
+                    givenInitializer As ExpressionSyntax,
+                    options As OptionSet,
+                    cancellationToken As CancellationToken) As StatementSyntax
 
                 Dim shouldInitializeWithNothing = (variable.GetDeclarationBehavior(cancellationToken) = DeclarationBehavior.MoveOut OrElse variable.GetDeclarationBehavior(cancellationToken) = DeclarationBehavior.SplitOut) AndAlso
                                                   (variable.ParameterModifier = ParameterBehavior.Out)

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -14,13 +14,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
             nameof(CodeStyleOptions), nameof(UseVarWhenDeclaringLocals), defaultValue: true,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseVarWhenDeclaringLocals"));
 
-        public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeForIntrinsicTypes = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(UseImplicitTypeForIntrinsicTypes), defaultValue: CodeStyleOption<bool>.Default,
+        public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeForIntrinsicTypes = new Option<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions), nameof(UseImplicitTypeForIntrinsicTypes), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeForIntrinsicTypes"));
 
-        public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWhereApparent = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(UseImplicitTypeWhereApparent), defaultValue: CodeStyleOption<bool>.Default,
+        public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWhereApparent = new Option<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions), nameof(UseImplicitTypeWhereApparent), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWhereApparent"));
 
-        public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWherePossible = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(UseImplicitTypeWherePossible), defaultValue: CodeStyleOption<bool>.Default,
+        public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWherePossible = new Option<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions), nameof(UseImplicitTypeWherePossible), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWherePossible"));
 
         public static readonly Option<CodeStyleOption<bool>> PreferConditionalDelegateCall = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferConditionalDelegateCall), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -10,7 +10,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
     internal static class CSharpCodeStyleOptions
     {
         // TODO: get sign off on public api changes.
-        public static readonly Option<bool> UseVarWhenDeclaringLocals = new Option<bool>(nameof(CodeStyleOptions), nameof(UseVarWhenDeclaringLocals), defaultValue: true,
+        public static readonly Option<bool> UseVarWhenDeclaringLocals = new Option<bool>(
+            nameof(CodeStyleOptions), nameof(UseVarWhenDeclaringLocals), defaultValue: true,
             storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseVarWhenDeclaringLocals"));
 
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeForIntrinsicTypes = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(UseImplicitTypeForIntrinsicTypes), defaultValue: CodeStyleOption<bool>.Default,

--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         private static bool IsVarDesired(ITypeSymbol type, OptionSet options, bool typeIsApperant)
         {
             // If they want it for intrinsics, and this is an intrinsic, then use var.
-            if (type?.IsSpecialType() == true)
+            if (type.IsSpecialType() == true)
             {
                 return options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes).Value;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
@@ -173,58 +173,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             return false;
         }
-
-
-#if false
-        public static TypeSyntax ConvertToVarIfDesired(
-            this TypeSyntax type, Compilation compilation, OptionSet options, bool typeIsApperant)
-        {
-            var useVar = IsVarDesired(type, compilation, options, typeIsApperant);
-
-            return useVar
-                ? SyntaxFactory.IdentifierName("var").WithTriviaFrom(type)
-                : type;
-        }
-
-        private static bool IsVarDesired(TypeSyntax type, Compilation compilation, OptionSet options, bool typeIsApperant)
-        {
-            // If they want "var" whenever possible, then use "var".
-            var useImplicitTypeWherePossible = options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible).Value;
-            if (useImplicitTypeWherePossible)
-            {
-                return true;
-            }
-
-            // If they want it for intrinsics, and this is an intrinsic, then use var.
-            var useImplicitTypeForIntrinsicTypes = options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes).Value;
-            if (useImplicitTypeForIntrinsicTypes)
-            {
-                if (TypeStyleHelper.IsPredefinedType(type))
-                {
-                    return true;
-                }
-
-                var annotation = type.GetAnnotations(SymbolAnnotation.Kind).FirstOrDefault();
-                if (annotation != null)
-                {
-                    var symbol = SymbolAnnotation.GetSymbol(annotation, compilation) as ITypeSymbol;
-                    if (symbol?.IsSpecialType() == true)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            // If they want it only for apperant types, then only use "var" if the caller
-            // says the type was apperant.
-            var useImplicitTypeWhereApperant = options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent).Value;
-            if (useImplicitTypeWhereApperant && typeIsApperant)
-            {
-                return true;
-            }
-
-            return false;
-        }
-#endif
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
@@ -148,30 +148,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         private static bool IsVarDesired(ITypeSymbol type, OptionSet options, bool typeIsApperant)
         {
-            // If they want "var" whenever possible, then use "var".
-            var useImplicitTypeWherePossible = options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible).Value;
-            if (useImplicitTypeWherePossible)
-            {
-                return true;
-            }
-
             // If they want it for intrinsics, and this is an intrinsic, then use var.
-            var useImplicitTypeForIntrinsicTypes = options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes).Value;
-            if (useImplicitTypeForIntrinsicTypes &&
-                type?.IsSpecialType() == true)
+            if (type?.IsSpecialType() == true)
             {
-                return true;
+                return options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes).Value;
             }
 
             // If they want it only for apperant types, then only use "var" if the caller
             // says the type was apperant.
-            var useImplicitTypeWhereApperant = options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent).Value;
-            if (useImplicitTypeWhereApperant && typeIsApperant)
+            if (typeIsApperant)
             {
-                return true;
+                return options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent).Value;
             }
 
-            return false;
+            // If they want "var" whenever possible, then use "var".
+            return  options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible).Value;
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
@@ -3,8 +3,11 @@
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
@@ -91,6 +94,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             return true;
+        }
+
+        public static TypeSyntax ConvertToVarIfDesired(
+            this TypeSyntax type, OptionSet options)
+        {
+            var useVarWhenDeclaringLocals = options.GetOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals);
+
+            if (useVarWhenDeclaringLocals)
+            {
+                var useImplicitTypeForIntrinsicTypes = options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes).Value;
+                if (useImplicitTypeForIntrinsicTypes ||
+                    !TypeStyleHelper.IsPredefinedType(type))
+                {
+                    return SyntaxFactory.IdentifierName("var").WithTriviaFrom(type);
+                }
+            }
+
+            return type;
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
@@ -1,17 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Simplification;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions
 {

--- a/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/TypeSyntaxExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
@@ -9,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions
@@ -94,24 +96,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             }
 
             return true;
-        }
-
-        public static TypeSyntax ConvertToVarIfDesired(
-            this TypeSyntax type, OptionSet options)
-        {
-            var useVarWhenDeclaringLocals = options.GetOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals);
-
-            if (useVarWhenDeclaringLocals)
-            {
-                var useImplicitTypeForIntrinsicTypes = options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes).Value;
-                if (useImplicitTypeForIntrinsicTypes ||
-                    !TypeStyleHelper.IsPredefinedType(type))
-                {
-                    return SyntaxFactory.IdentifierName("var").WithTriviaFrom(type);
-                }
-            }
-
-            return type;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15219