### PR TITLE
Use immutable arrays with SymbolInfo to avoid Enumerator allocations.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/IDeclarationInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/IDeclarationInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
@@ -8,6 +9,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     /// </summary>
     internal interface IDeclarationInfo
     {
-        IReadOnlyList<DeclaredSymbolInfo> DeclaredSymbolInfos { get; }
+        ImmutableArray<DeclaredSymbolInfo> DeclaredSymbolInfos { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/IDeclarationInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/IDeclarationInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.FindSymbols

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeInfo.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 var predefinedTypes = (int)PredefinedType.None;
                 var predefinedOperators = (int)PredefinedOperator.None;
 
-                var declaredSymbolInfos = new List<DeclaredSymbolInfo>();
+                var declaredSymbolInfos = ArrayBuilder<DeclaredSymbolInfo>.GetInstance();
 
                 if (syntaxFacts != null)
                 {
@@ -249,7 +249,7 @@ $@"Invalid span in {nameof(declaredSymbolInfo)}.
                         containsIndexerMemberCref),
                     new SyntaxTreeDeclarationInfo(
                         version,
-                        declaredSymbolInfos));
+                        declaredSymbolInfos.ToImmutableAndFree()));
             }
             finally
             {


### PR DESCRIPTION
This is a port of https://github.com/dotnet/roslyn/pull/15305 to RC2.