### PR TITLE
Always show use of unassigned var errors

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -92,9 +92,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (slot > 0 && !this.State.IsAssigned(slot))
                     {
                         // Local functions can "call forward" to after a variable has
-                        // been defined but before it has been assigned, so we can never
-                        // consider the definition location when reporting errors.
-                        ReportUnassigned(symbol, node, slot, considerDefineLocation: false);
+                        // been declared but before it has been assigned, so we can never
+                        // consider the declaration location when reporting errors.
+                        ReportUnassigned(symbol, node, slot, skipIfUseBeforeDeclaration: false);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -61,7 +61,41 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (reads[slot])
                 {
                     var symbol = variableBySlot[slot].Symbol;
-                    CheckAssigned(symbol, syntax, slot);
+                    CheckIfAssignedDuringLocalFunctionReplay(symbol, syntax, slot);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check that the given variable is definitely assigned when replaying local function
+        /// reads. If not, produce an error.
+        /// </summary>
+        /// <remarks>
+        /// Specifying the slot manually may be necessary if the symbol is a field,
+        /// in which case <see cref="VariableSlot(Symbol, int)"/> will not know
+        /// which containing slot to look for.
+        /// </remarks>
+        private void CheckIfAssignedDuringLocalFunctionReplay(Symbol symbol, SyntaxNode node, int slot)
+        {
+            Debug.Assert(!IsConditionalState);
+            if ((object)symbol != null)
+            {
+                NoteRead(symbol);
+
+                if (this.State.Reachable)
+                {
+                    if (slot >= this.State.Assigned.Capacity)
+                    {
+                        Normalize(ref this.State);
+                    }
+
+                    if (slot > 0 && !this.State.IsAssigned(slot))
+                    {
+                        // Local functions can "call forward" to after a variable has
+                        // been defined but before it has been assigned, so we can never
+                        // consider the definition location when reporting errors.
+                        ReportUnassigned(symbol, node, slot, considerDefineLocation: false);
+                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -899,12 +899,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="symbol">Symbol to variable that is unassigned.</param>
         /// <param name="node">Syntax where read occurs.</param>
         /// <param name="slotOpt">Optional slot where variable is located.</param>
-        /// <param name="considerDefineLocation">
+        /// <param name="skipIfUseBeforeDeclaration">
         /// True if error reporting should consider the location where the
-        /// variable is defined (for instance, eliding errors about reading
-        /// variables that have not yet been defined).
+        /// variable is declared (for instance, eliding errors about reading
+        /// variables that have not yet been declared).
         /// </param>
-        private void ReportUnassigned(Symbol symbol, SyntaxNode node, int? slotOpt, bool considerDefineLocation = true)
+        private void ReportUnassigned(Symbol symbol, SyntaxNode node, int? slotOpt, bool skipIfUseBeforeDeclaration = true)
         {
             int slot = slotOpt ?? VariableSlot(symbol);
             if (slot <= 0) return;
@@ -927,7 +927,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             if (slot >= _alreadyReported.Capacity) _alreadyReported.EnsureCapacity(nextVariableSlot);
-            if (considerDefineLocation &&
+            if (skipIfUseBeforeDeclaration &&
                 symbol.Kind == SymbolKind.Local &&
                 (symbol.Locations.Length == 0 || node.Span.End < symbol.Locations[0].SourceSpan.Start))
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -949,12 +949,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             if (slot >= _alreadyReported.Capacity) _alreadyReported.EnsureCapacity(nextVariableSlot);
-            if (symbol.Kind == SymbolKind.Local && (symbol.Locations.Length == 0 || node.Span.End < symbol.Locations[0].SourceSpan.Start))
-            {
-                // We've already reported the use of a local before its declaration.  No need to emit
-                // another diagnostic for the same issue.
-            }
-            else if (!_alreadyReported[slot] && VariableType(symbol)?.IsErrorType() != true)
+            if (!_alreadyReported[slot] && VariableType(symbol)?.IsErrorType() != true)
             {
                 // CONSIDER: could suppress this diagnostic in cases where the local was declared in a using
                 // or fixed statement because there's a special error code for not initializing those.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3072,6 +3072,20 @@ class Program
             VerifyOutput(source, "2", TestOptions.ReleaseExe.WithAllowUnsafe(true));
         }
 
+        [Fact]
+        [WorkItem(15322, "https://github.com/dotnet/roslyn/issues/15322")]
+        public void UseBeforeDeclaration()
+        {
+            var src = @"
+Assign();
+Local();
+int x;
+void Local() => System.Console.WriteLine(x);
+void Assign() { x = 5; }";
+
+            VerifyOutputInMain(src, "5");
+        }
+
         internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options)
         {
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: options);

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -1091,5 +1091,51 @@ class C
 }");
             comp.VerifyDiagnostics();
         }
+
+        [Fact]
+        [WorkItem(15298, "https://github.com/dotnet/roslyn/issues/15298")]
+        public void UnassignedUndefinedVariable()
+        {
+            var comp = CreateCompilationWithMscorlib(@"
+class C
+{
+    void M()
+    {
+        Foo();
+        int x;
+        void Foo() => x++;
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (6,9): error CS0165: Use of unassigned local variable 'x'
+                //         Foo();
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "Foo()").WithArguments("x").WithLocation(6, 9));
+        }
+
+        [Fact]
+        [WorkItem(15322, "https://github.com/dotnet/roslyn/issues/15322")]
+        public void UseBeforeDeclarationInSwitch()
+        {
+            var comp = CreateCompilationWithMscorlib(@"
+class Program
+{
+    static void Main(object[] args)
+    {
+        switch(args[0])
+        {
+            case string x:
+                Foo(); 
+                break;
+            case int x:
+                void Foo() => System.Console.WriteLine(x);
+                break;
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (9,17): error CS0165: Use of unassigned local variable 'x'
+                //                 Foo();
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "Foo()").WithArguments("x").WithLocation(9, 17));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -1101,15 +1101,25 @@ class C
 {
     void M()
     {
-        Foo();
-        int x;
-        void Foo() => x++;
+        {
+            Foo();
+            int x = 0;
+            void Foo() => x++;
+        }
+        {
+            System.Action a = Foo;
+            int x = 0;
+            void Foo() => x++;
+        }
     }
 }");
             comp.VerifyDiagnostics(
-                // (6,9): error CS0165: Use of unassigned local variable 'x'
-                //         Foo();
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "Foo()").WithArguments("x").WithLocation(6, 9));
+                // (7,13): error CS0165: Use of unassigned local variable 'x'
+                //             Foo();
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "Foo()").WithArguments("x").WithLocation(7, 13),
+                // (12,31): error CS0165: Use of unassigned local variable 'x'
+                //             System.Action a = Foo;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "Foo").WithArguments("x").WithLocation(12, 31));
         }
 
         [Fact]


### PR DESCRIPTION
Prior to C# 7 we tried to avoid giving duplicate errors
when the user used a variable before it was defined (which
is both a use-before-defined and a use-before-assigned error),
but the line here is blurred with local functions, which can
use variables before they are declared in subtle ways that can't
be detected based on declaration order in syntax.

It may be possible to provide the earlier behavior, but the
current optimization is definitely insufficient and hides
legitimate errors in user programs.

Fixes #15322
Fixes #15298