### PR TITLE
always save changes to unopened documents

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.25914.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysisTest", "src\Compilers\Core\CodeAnalysisTest\CodeAnalysisTest.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -300,6 +300,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudioTestSetup", "src\VisualStudio\TestSetup\VisualStudioTestSetup.csproj", "{A88AB44F-7F9D-43F6-A127-83BB65E5A7E2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudioIntegrationTests", "src\VisualStudio\IntegrationTests\VisualStudioIntegrationTests.csproj", "{E5A55C16-A5B9-4874-9043-A5266DC02F58}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A88AB44F-7F9D-43F6-A127-83BB65E5A7E2} = {A88AB44F-7F9D-43F6-A127-83BB65E5A7E2}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudioTestUtilities", "src\VisualStudio\TestUtilities\VisualStudioTestUtilities.csproj", "{3BED15FD-D608-4573-B432-1569C1026F6D}"
 EndProject

--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.25914.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysisTest", "src\Compilers\Core\CodeAnalysisTest\CodeAnalysisTest.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -300,9 +300,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudioTestSetup", "src\VisualStudio\TestSetup\VisualStudioTestSetup.csproj", "{A88AB44F-7F9D-43F6-A127-83BB65E5A7E2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudioIntegrationTests", "src\VisualStudio\IntegrationTests\VisualStudioIntegrationTests.csproj", "{E5A55C16-A5B9-4874-9043-A5266DC02F58}"
-	ProjectSection(ProjectDependencies) = postProject
-		{A88AB44F-7F9D-43F6-A127-83BB65E5A7E2} = {A88AB44F-7F9D-43F6-A127-83BB65E5A7E2}
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudioTestUtilities", "src\VisualStudio\TestUtilities\VisualStudioTestUtilities.csproj", "{3BED15FD-D608-4573-B432-1569C1026F6D}"
 EndProject

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.LanguageServices
         {
             // We need to ensure the file is saved, only if a global undo transaction is open
             var globalUndoService = this.Services.GetService<IGlobalUndoService>();
-            var needsSave = globalUndoService.IsGlobalTransactionOpen(this);
+            var needsSave = globalUndoService.IsGlobalTransactionOpen(this); // || !hostDocument.IsOpen;
 
             var needsUndoDisabled = false;
             if (needsSave)

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -134,11 +134,11 @@ namespace Microsoft.VisualStudio.LanguageServices
 
         internal override IInvisibleEditor OpenInvisibleEditor(IVisualStudioHostDocument hostDocument)
         {
-            // We need to ensure the file is saved, only if a global undo transaction is open
             var globalUndoService = this.Services.GetService<IGlobalUndoService>();
-            var needsSave = globalUndoService.IsGlobalTransactionOpen(this); // || !hostDocument.IsOpen;
-
             var needsUndoDisabled = false;
+
+            // Do not save the file if is open and there is not a global undo transaction.
+            var needsSave = globalUndoService.IsGlobalTransactionOpen(this) || !hostDocument.IsOpen;
             if (needsSave)
             {
                 if (this.CurrentSolution.ContainsDocument(hostDocument.Id))

--- a/src/VisualStudio/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -27,8 +27,7 @@ public class Foo
 {
 }
 ");
-            Editor.MessageBox("Attach Now");
-
+ 
             SetUpEditor(@"
 using System;
 

--- a/src/VisualStudio/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.Test.Utilities;
+using Roslyn.VisualStudio.Test.Utilities.Common;
+using Roslyn.VisualStudio.Test.Utilities.Input;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpCodeActions : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+
+        public CSharpCodeActions(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory, nameof(CSharpIntelliSense))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public void GenerateMethodInClosedFile()
+        {
+            AddFile("Foo.cs", @"
+public class Foo
+{
+}
+");
+            Editor.MessageBox("Attach Now");
+
+            SetUpEditor(@"
+using System;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Foo f = new Foo();
+        f.Bar()$$
+    }
+}
+");
+
+            InvokeCodeActionList();
+            VerifyCodeAction("Generate method 'Foo.Bar'", applyFix: true);
+
+            VerifyFileContents("Foo.cs", @"
+using System;
+
+public class Foo
+{
+    internal void Bar()
+    {
+        throw new NotImplementedException();
+    }
+}
+");
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTests/VisualStudioIntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTests/VisualStudioIntegrationTests.csproj
@@ -13,8 +13,10 @@
     <Nonshipping>true</Nonshipping>
     <RoslynProjectType>UnitTest</RoslynProjectType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'"></PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'"></PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+  </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
@@ -24,6 +26,7 @@
     <Compile Include="CSharp\CSharpAsyncOutput.cs" />
     <Compile Include="CSharp\CSharpAutomaticBraceCompletion.cs" />
     <Compile Include="CSharp\CSharpBuild.cs" />
+    <Compile Include="CSharp\CSharpCodeActions.cs" />
     <Compile Include="CSharp\CSharpIntelliSense.cs" />
     <Compile Include="CSharp\CSharpInteractiveDemo.cs" />
     <Compile Include="AbstractEditorTest.cs" />

--- a/src/VisualStudio/TestUtilities/Helper.cs
+++ b/src/VisualStudio/TestUtilities/Helper.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Roslyn.VisualStudio.Test.Utilities
+{
+    public static class Helper
+    {
+        /// <summary>
+        /// This method will retry the action represented by the 'action' argument, up to 'timeout'
+        /// milliseconds, waiting 'delay' milliseconds after each retry. If a given retry returns a value 
+        /// other than default(T), this value is returned.
+        /// </summary>
+        /// <param name="action">the action to retry</param>
+        /// <param name="delay">the amount of time to wait between retries in milliseconds</param>
+        /// <param name="timeout">the max amount of time to spend retrying in milliseconds</param>
+        /// <typeparam name="T">type of return value</typeparam>
+        /// <returns>the return value of 'action'</returns>
+        public static T Retry<T>(Func<T> action, int delay, int timeout)
+        {
+            return Retry(action, TimeSpan.FromMilliseconds(delay), TimeSpan.FromMilliseconds(timeout));
+        }
+
+        /// <summary>
+        /// This method will retry the action represented by the 'action' argument, up to 'timeout'
+        /// milliseconds, waiting 'delay' milliseconds after each retry and will swallow all exceptions. 
+        /// If a given retry returns a value other than default(T), this value is returned.
+        /// </summary>
+        /// <param name="action">the action to retry</param>
+        /// <param name="delay">the amount of time to wait between retries in milliseconds</param>
+        /// <param name="timeout">the max amount of time to spend retrying in milliseconds</param>
+        /// <typeparam name="T">type of return value</typeparam>
+        /// <returns>the return value of 'action'</returns>
+        public static T RetryIgnoringExceptions<T>(Func<T> action, int delay, int timeout)
+        {
+            return RetryIgnoringExceptions(action, TimeSpan.FromMilliseconds(delay), TimeSpan.FromMilliseconds(timeout));
+        }
+
+        /// <summary>
+        /// This method will retry the action represented by the 'action' argument, up to 'timeout',
+        /// waiting for 'delay' time after each retry. If a given retry returns a value 
+        /// other than default(T), this value is returned.
+        /// </summary>
+        /// <param name="action">the action to retry</param>
+        /// <param name="delay">the amount of time to wait between retries</param>
+        /// <param name="timeout">the max amount of time to spend retrying</param>
+        /// <typeparam name="T">type of return value</typeparam>
+        /// <returns>the return value of 'action'</returns>
+        public static T Retry<T>(Func<T> action, TimeSpan delay, TimeSpan timeout)
+        {
+            DateTime beginTime = DateTime.UtcNow;
+            T retval = default(T);
+
+            do
+            {
+                try
+                {
+                    retval = action();
+                }
+                catch (COMException)
+                {
+                    // Devenv can throw COMExceptions if it's busy when we make DTE calls.
+                }
+
+                if (!Equals(default(T), retval))
+                {
+                    return retval;
+                }
+                else
+                {
+                    System.Threading.Thread.Sleep(delay);
+                }
+            }
+            while (beginTime.Add(timeout) > DateTime.UtcNow);
+
+            return retval;
+        }
+
+        /// <summary>
+        /// This method will retry the action represented by the 'action' argument, up to 'timeout'
+        /// milliseconds, waiting 'delay' milliseconds after each retry and will swallow all exceptions. 
+        /// If a given retry returns a value other than default(T), this value is returned.
+        /// </summary>
+        /// <param name="action">the action to retry</param>
+        /// <param name="delay">the amount of time to wait between retries in milliseconds</param>
+        /// <param name="timeout">the max amount of time to spend retrying in milliseconds</param>
+        /// <typeparam name="T">type of return value</typeparam>
+        /// <returns>the return value of 'action'</returns>
+        public static T RetryIgnoringExceptions<T>(Func<T> action, TimeSpan delay, TimeSpan timeout)
+        {
+            DateTime beginTime = DateTime.UtcNow;
+            T retval = default(T);
+            Exception e = null;
+
+            do
+            {
+                try
+                {
+                    retval = action();
+                }
+                catch (Exception ex)
+                {
+                    e = ex;
+                }
+
+                if (!Equals(default(T), retval))
+                {
+                    return retval;
+                }
+                else
+                {
+                    System.Threading.Thread.Sleep(delay);
+                }
+            }
+            while (beginTime.Add(timeout) > DateTime.UtcNow);
+
+            if (Equals(default(T), retval))
+            {
+                if (e == null)
+                {
+                    throw new Exception($"Function never assigned a value after {timeout.Minutes} minutes and {timeout.Seconds} seconds and no exceptions were thrown");
+                }
+                else
+                {
+                    throw new Exception($"Function never assigned a value after {timeout.Minutes} minutes and {timeout.Seconds} seconds.  Last observed excepton was:{e.Message}{e.StackTrace}");
+                }
+            }
+
+            return retval;
+        }
+    }
+}

--- a/src/VisualStudio/TestUtilities/HostWaitHelper.cs
+++ b/src/VisualStudio/TestUtilities/HostWaitHelper.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Roslyn.VisualStudio.Test.Utilities
+{
+    public static class HostWaitHelper
+    {
+        public static void WaitForDispatchedOperationsToComplete(DispatcherPriority priority)
+        {
+            Action action = delegate { };
+            new FrameworkElement().Dispatcher.Invoke(action, priority);
+        }
+
+        public static void PumpingWait(Task task)
+        {
+            PumpingWaitAll(new[] { task });
+        }
+
+        public static T PumpingWaitResult<T>(Task<T> task)
+        {
+            PumpingWait(task);
+            return task.Result;
+        }
+
+        public static void PumpingWaitAll(IEnumerable<Task> tasks)
+        {
+            var smallTimeout = TimeSpan.FromMilliseconds(10);
+            var taskArray = tasks.ToArray();
+            var done = false;
+            while (!done)
+            {
+                done = Task.WaitAll(taskArray, smallTimeout);
+                if (!done)
+                {
+                    WaitForDispatchedOperationsToComplete(DispatcherPriority.ApplicationIdle);
+                }
+            }
+
+            foreach (var task in tasks)
+            {
+                if (task.Exception != null)
+                {
+                    throw task.Exception;
+                }
+            }
+        }
+    }
+}

--- a/src/VisualStudio/TestUtilities/LightBulbHelper.cs
+++ b/src/VisualStudio/TestUtilities/LightBulbHelper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Roslyn.Test.Utilities;
+
+namespace Roslyn.VisualStudio.Test.Utilities
+{
+    public static class LightBulbHelper
+    {
+        public static bool WaitForLightBulbSession(ILightBulbBroker broker, Microsoft.VisualStudio.Text.Editor.IWpfTextView view)
+        {
+            return Helper.Retry<bool>(() =>
+            {
+                if (broker.IsLightBulbSessionActive(view))
+                {
+                    return true;
+                }
+
+                // checking whether there is any suggested action is async up to editor layer and our waiter doesnt track up to that point.
+                // so here, we have no other way than sleep (with timeout) to see LB is available.
+                HostWaitHelper.PumpingWait(Task.Delay(TimeSpan.FromSeconds(1)));
+
+                return broker.IsLightBulbSessionActive(view);
+            }, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(20));
+        }
+    }
+}

--- a/src/VisualStudio/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CodeFixes;
 using Roslyn.VisualStudio.Test.Utilities.Common;
 using Roslyn.VisualStudio.Test.Utilities.InProcess;
+using System.Collections.Generic;
 
 namespace Roslyn.VisualStudio.Test.Utilities.OutOfProcess
 {
@@ -60,6 +62,36 @@ namespace Roslyn.VisualStudio.Test.Utilities.OutOfProcess
             return _inProc.GetCurrentSignature();
         }
 
+        public void ShowLightBulb()
+        {
+            _inProc.ShowLightBulb();
+        }
+
+        public void WaitForLightBulbSession()
+        {
+            _inProc.WaitForLightBulbSession();
+        }
+
+        public void DismissLightBulbSession()
+        {
+            _inProc.DismissLightBulbSession();
+        }
+
+        public bool IsLightBulbSessionExpanded()
+        {
+            return _inProc.IsLightBulbSessionExpanded();
+        }
+
+        public string[] GetLightBulbActions()
+        {
+            return _inProc.GetLightBulbActions();
+        }
+
+        public void ApplyLightBulbAction(string action, FixAllScope? fixAllScope)
+        {
+            _inProc.ApplyLightBulbAction(action, fixAllScope);
+        }
+
         public bool IsCaretOnScreen() => _inProc.IsCaretOnScreen();
 
         /// <summary>
@@ -72,6 +104,11 @@ namespace Roslyn.VisualStudio.Test.Utilities.OutOfProcess
             Activate();
             VisualStudioInstance.SendKeys.Send(keys);
             VisualStudioInstance.WaitForApplicationIdle();
+        }
+
+        public void MessageBox(string message)
+        {
+            _inProc.MessageBox(message);
         }
     }
 }

--- a/src/VisualStudio/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -41,5 +41,31 @@ namespace Roslyn.VisualStudio.Test.Utilities.OutOfProcess
         {
             _inProc.CleanUpOpenSolution();
         }
+
+        public int ErrorListErrorCount => _inProc.GetErrorListErrorCount();
+
+        public void AddFile(string projectName, string fileName, string contents = null, bool open = false) => _inProc.AddFile(projectName, fileName, contents, open);
+
+        public void SetFileContents(string projectName, string fileName, string contents) => _inProc.SetFileContents(projectName, fileName, contents);
+
+        public string GetFileContents(string projectName, string fileName) => _inProc.GetFileContents(projectName, fileName);
+
+        public void BuildSolution(bool waitForBuildToFinish = false) => _inProc.BuildSolution(waitForBuildToFinish);
+
+        public void OpenFile(string projectName, string fileName) => _inProc.OpenFile(projectName, fileName);
+
+        public void ReloadProject(string projectName) => _inProc.ReloadProject(projectName);
+
+        public void RestoreNuGetPackages() => _inProc.RestoreNuGetPackages();
+
+        public void SaveAll() => _inProc.SaveAll();
+
+        public void ShowErrorList() => _inProc.ShowErrorList();
+
+        public void ShowOutputWindow() => _inProc.ShowOutputWindow();
+
+        public void UnloadProject(string projectName) => _inProc.UnloadProject(projectName);
+
+        public void WaitForNoErrorsInErrorList() => _inProc.WaitForNoErrorsInErrorList();
     }
 }

--- a/src/VisualStudio/TestUtilities/TestUtilities.cs
+++ b/src/VisualStudio/TestUtilities/TestUtilities.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Roslyn.VisualStudio.Test.Utilities
+{
+    public class TestUtilities
+    {
+        public static void CompareAndThrowIfNotEqual<TItem>(TItem expected, TItem actual) where TItem : IEquatable<TItem>
+        {
+            if (!expected.Equals(actual))
+            {
+                throw new Exception("Actual and expected items don't match:" + Environment.NewLine +
+                    "Expected: " + expected.ToString() + Environment.NewLine +
+                    "Actual: " + actual.ToString() + Environment.NewLine);
+            }
+        }
+
+        public static void ThrowIfExpectedItemNotFound<TCollection>(IEnumerable<TCollection> actual, IEnumerable<TCollection> expected)
+            where TCollection : IEquatable<TCollection>
+        {
+            bool shouldThrow = false;
+            StringBuilder sb = new StringBuilder();
+            sb.Append("The following expected item(s) not found:\r\n");
+
+            foreach (var item in expected)
+            {
+                if (!actual.Contains(item))
+                {
+                    shouldThrow = true;
+                    sb.AppendLine(item.ToString());
+                }
+            }
+
+            if (shouldThrow)
+            {
+                throw new Exception(sb.ToString());
+            }
+        }
+
+        public static void ThrowIfExpectedItemNotFound<TCollection>(IEnumerable<TCollection> actual,
+            IEnumerable<TCollection> expected,
+            IEqualityComparer<TCollection> comparer)
+            where TCollection : IEquatable<TCollection>
+        {
+            bool shouldThrow = false;
+            StringBuilder sb = new StringBuilder();
+            sb.Append("The following expected item(s) not found:\r\n");
+
+            foreach (var item in expected)
+            {
+                if (!actual.Contains(item, comparer))
+                {
+                    shouldThrow = true;
+                    sb.AppendLine(item.ToString());
+                }
+            }
+
+            if (shouldThrow)
+            {
+                throw new Exception(sb.ToString());
+            }
+        }
+
+        public static void ThrowIfExpectedItemNotFoundInOrder<TCollection>(IEnumerable<TCollection> actual, IEnumerable<TCollection> expected)
+            where TCollection : IEquatable<TCollection>
+        {
+            bool shouldThrow = false;
+            StringBuilder sb = new StringBuilder();
+            sb.Append("The following expected item(s) not found in sequence:\r\n");
+
+            var remainingActualList = actual;
+
+            foreach (var item in expected)
+            {
+                remainingActualList = remainingActualList.SkipWhile(a => !a.Equals(item));
+
+                if (!remainingActualList.Any())
+                {
+                    shouldThrow = true;
+                    sb.AppendLine(item.ToString());
+                }
+
+                remainingActualList = remainingActualList.Skip(1);
+            }
+
+            if (shouldThrow)
+            {
+                throw new Exception(sb.ToString());
+            }
+        }
+
+        public static void ThrowIfUnExpectedItemFound<TCollection>(IEnumerable<TCollection> actual, IEnumerable<TCollection> unexpected)
+        {
+            bool shouldThrow = false;
+            StringBuilder sb = new StringBuilder();
+            sb.Append("The following UN-expected item(s) were encountered:\r\n");
+
+            foreach (var item in unexpected)
+            {
+                if (actual.Contains(item))
+                {
+                    shouldThrow = true;
+                    sb.AppendLine(item.ToString());
+                }
+            }
+
+            if (shouldThrow)
+            {
+                throw new Exception(sb.ToString());
+            }
+        }
+
+        public static void CompareAsSequenceAndThrowIfNotEqual<TListItem>(IEnumerable<TListItem> expectedList,
+            IEnumerable<TListItem> actualList,
+            IEqualityComparer<TListItem> comparer = null)
+            where TListItem : IEquatable<TListItem>
+        {
+            if (!expectedList.SequenceEqual(actualList, comparer))
+            {
+                throw new Exception(string.Format("Expected list:\n{0}\nActual list:\n{1}", BuildString(expectedList), BuildString(actualList)));
+            }
+        }
+
+        private static string BuildString<TElement>(IEnumerable<TElement> list)
+        {
+            return string.Join(Environment.NewLine, list.Select(item => item.ToString()).ToArray());
+        }
+    }
+}

--- a/src/VisualStudio/TestUtilities/VisualStudioTestUtilities.csproj
+++ b/src/VisualStudio/TestUtilities/VisualStudioTestUtilities.csproj
@@ -11,12 +11,16 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <Nonshipping>true</Nonshipping>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'"></PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'"></PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Common\Comparison.cs" />
     <Compile Include="Common\Parameter.cs" />
     <Compile Include="Common\Signature.cs" />
+    <Compile Include="Helper.cs" />
+    <Compile Include="HostWaitHelper.cs" />
     <Compile Include="InProcess\CSharpInteractiveWindow_InProc.cs" />
     <Compile Include="InProcess\InProcComponent.cs" />
     <Compile Include="InProcess\SolutionExplorer_InProc.cs" />
@@ -28,9 +32,11 @@
     <Compile Include="IntegrationHelper.cs" />
     <Compile Include="InProcess\Editor_InProc.cs" />
     <Compile Include="Interop\NativeMethods.cs" />
+    <Compile Include="LightBulbHelper.cs" />
     <Compile Include="OutOfProcess\OutOfProcComponent.cs" />
     <Compile Include="OutOfProcess\SolutionExplorer_OutOfProc.cs" />
     <Compile Include="InProcess\VisualStudioWorkspace_InProc.cs" />
+    <Compile Include="TestUtilities.cs" />
     <Compile Include="WellKnownCommandNames.cs" />
     <Compile Include="VisualStudioInstance.cs" />
     <Compile Include="IntegrationService.cs" />
@@ -63,6 +69,7 @@
   <ItemGroup>
     <Reference Include="EnvDTE" />
     <Reference Include="EnvDTE80" />
+    <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />


### PR DESCRIPTION
This fixes a bug found when investigating #12531

This is an update to a prior PR #15183, with added integration tests that proves that a change in a single closed document is saved to disk.

This change makes it so InvisibleEditor's created via the vs workspace will always be set to save the document if the document is not open in the editor.

The problem this is fixing is one where an edit is made to just a single closed document. In this case we were failing to call SaveDocuments on the running document table. We generally only called SaveDocuments if there is a global undo transaction in effect, and there is only a global undo transaction if there is more than one document involved. Except closed documents cannot be saved manually by the user as they don't correspond to an open text buffer in the editor.

@dotnet/roslyn-ide please review