### PR TITLE
Conditionally turn echo on

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if not defined EchoOn @echo off
 @setlocal enabledelayedexpansion
 
 set RoslynRoot=%~dp0

--- a/SetDevCommandPrompt.cmd
+++ b/SetDevCommandPrompt.cmd
@@ -1,4 +1,4 @@
-@echo off
+@if not defined EchoOn @echo off
 
 :: Prefer building with Dev15 and try the simple route first (we may be running from a DevCmdPrompt already)
 set CommonToolsDir=%VS150COMNTOOLS%


### PR DESCRIPTION
Most of the time when running our build scripts we want echo to be off to limit useless output. This commit allows us to keep it off by default, and turn it on when we need it by defining the "EchoOn" variable.