### PR TITLE
Use -final suffix for prerelease packages

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -40,6 +40,7 @@
 
     <!-- NuGet version -->
     <NuGetReleaseVersion>$(RoslynFileVersionBase)</NuGetReleaseVersion>
+    <NuGetFinalPreReleaseVersion>$(NuGetPreReleaseVersion)-final</NuGetFinalPreReleaseVersion>
     <NuGetPerBuildPreReleaseVersion>$(NuGetPreReleaseVersion)-$(BuildNumberFiveDigitDateStamp)-$(BuildNumberBuildOfTheDayPadded)</NuGetPerBuildPreReleaseVersion>
   </PropertyGroup>
   

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -6,8 +6,8 @@
     <!-- NuGetPerBuildPreReleaseVersion -->
     <Exec Command="$(OutDir)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutDir) $(NuGetPerBuildPreReleaseVersion) $(OutDir)NuGet\PerBuildPreRelease" Condition="'$(NuGetPerBuildPreReleaseVersion)' != ''" />
 
-    <!-- NuGetPreReleaseVersion -->
-    <Exec Command="$(OutDir)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutDir) $(NuGetPreReleaseVersion) $(OutDir)NuGet\PreRelease" Condition="'$(NuGetPreReleaseVersion)' != ''"/>
+    <!-- NuGetFinalPreReleaseVersion -->
+    <Exec Command="$(OutDir)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutDir) $(NuGetFinalPreReleaseVersion) $(OutDir)NuGet\PreRelease" Condition="'$(NuGetFinalPreReleaseVersion)' != ''"/>
 
     <!-- NuGetReleaseVersion -->
     <Exec Command="$(OutDir)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutDir) $(NuGetReleaseVersion) $(OutDir)NuGet\Release" Condition="'$(NuGetReleaseVersion)' != ''" />


### PR DESCRIPTION
Currently when we release per-build prerelease packages (e.g.,
-beta1-20160505...) and then release the final prerelease package (e.g.,
-beta1) the per-build prerelease package is considered to be "newer"
than the final prerelease package because of the lexical ordering for
prerelease packages. By using the -final tag and ordinal build numbers
for per-build prereleases the final package should always be considered
the "newest" available package.

/cc @jaredpar @jasonmalinowski @jinujoseph @dotnet/roslyn-infrastructure 