### PR TITLE
Don't crash if we can't resolve a file during a TempPE build

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.CodeAnalysis.Host;
 
 // NOTE(DustinCa): The EditorFactory registration is in VisualStudioComponents\CSharpPackageRegistration.pkgdef.
 // The reason for this is because the ProvideEditorLogicalView does not allow a name value to specified in addition to
@@ -74,7 +75,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             {
                 base.Initialize();
 
-                this.RegisterService<ICSharpTempPECompilerService>(() => new TempPECompilerService(this.Workspace));
+                this.RegisterService<ICSharpTempPECompilerService>(() => new TempPECompilerService(this.Workspace.Services.GetService<IMetadataService>()));
 
                 RegisterObjectBrowserLibraryManager();
             }

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/Interop/ICSharpTempPECompilerService.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/Interop/ICSharpTempPECompilerService.cs
@@ -10,7 +10,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Inter
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     internal interface ICSharpTempPECompilerService
     {
-        void CompileTempPE(
+        [PreserveSig]
+        int CompileTempPE(
             [MarshalAs(UnmanagedType.LPWStr)] string pszOutputFileName,
             int sourceCount,
             [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] string[] fileNames,

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/TempPECompilerService.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/TempPECompilerService.cs
@@ -4,13 +4,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Interop;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
@@ -22,14 +21,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
     /// </summary>
     internal class TempPECompilerService : ICSharpTempPECompilerService
     {
-        private readonly VisualStudioWorkspace _workspace;
+        private readonly IMetadataService _metadataService;
 
-        public TempPECompilerService(VisualStudioWorkspace workspace)
+        public TempPECompilerService(IMetadataService metadataService)
         {
-            _workspace = workspace;
+            _metadataService = metadataService;
         }
 
-        public void CompileTempPE(string pszOutputFileName, int sourceCount, string[] fileNames, string[] fileContents, int optionCount, string[] optionNames, object[] optionValues)
+        public int CompileTempPE(string pszOutputFileName, int sourceCount, string[] fileNames, string[] fileContents, int optionCount, string[] optionNames, object[] optionValues)
         {
             var baseDirectory = Path.GetDirectoryName(pszOutputFileName);
             var parsedArguments = ParseCommandLineArguments(baseDirectory, optionNames, optionValues);
@@ -48,13 +47,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             // TODO (tomat): move resolver initialization (With* methods below) to CommandLineParser.Parse
 
             var metadataResolver = new WorkspaceMetadataFileReferenceResolver(
-                _workspace.Services.GetService<IMetadataService>(),
+                _metadataService,
                 new RelativePathResolver(ImmutableArray<string>.Empty, baseDirectory: null));
 
             var compilation = CSharpCompilation.Create(
                 Path.GetFileName(pszOutputFileName),
                 trees,
-                parsedArguments.ResolveMetadataReferences(metadataResolver),
+                parsedArguments.ResolveMetadataReferences(metadataResolver).Where(m => !(m is UnresolvedMetadataReference)),
                 parsedArguments.CompilationOptions
                     .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
                     .WithSourceReferenceResolver(SourceFileResolver.Default)
@@ -63,7 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 
             var result = compilation.Emit(pszOutputFileName);
 
-            Contract.ThrowIfFalse(result.Success);
+            return result.Success ? VSConstants.S_OK : VSConstants.S_FALSE;
         }
 
         private CSharpCommandLineArguments ParseCommandLineArguments(string baseDirectory, string[] optionNames, object[] optionValues)

--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -226,6 +226,7 @@
     <Compile Include="ProjectSystemShim\LegacyProject\CSharpReferencesTests.cs" />
     <Compile Include="ProjectSystemShim\CPS\SourceFileHandlingTests.cs" />
     <Compile Include="ProjectSystemShim\LegacyProject\SourceFileHandlingTests.cs" />
+    <Compile Include="ProjectSystemShim\TempPECompilerServiceTests.cs" />
     <Content Include="Debugging\ProximityExpressionsGetterTestFile.cs" />
     <Compile Include="Debugging\ProximityExpressionsGetterTests.cs" />
     <Compile Include="Debugging\ProximityExpressionsGetterTests.Lines.cs" />

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/TempPECompilerServiceTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/TempPECompilerServiceTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim;
+using Xunit;
+
+namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
+{
+    public class TempPECompilerServiceTests
+    {
+        [Fact]
+        public void TempPECompilationWithInvalidReferenceDoesNotCrash()
+        {
+            var tempPEService = new TempPECompilerService(new TrivialMetadataService());
+
+            using (var tempRoot = new TempRoot())
+            {
+                var directory = tempRoot.CreateDirectory();
+
+                // This should not crash. Visual inspection of the Dev12 codebase implied we might return
+                // S_FALSE in this case, but it wasn't very clear. In any case, it's not expected to throw,m
+                // so S_FALSE seems fine.
+                var hr = tempPEService.CompileTempPE(
+                    pszOutputFileName: Path.Combine(directory.Path, "Output.dll"),
+                    sourceCount: 0,
+                    fileNames: Array.Empty<string>(),
+                    fileContents: Array.Empty<string>(),
+                    optionCount: 1,
+                    optionNames: new[] { "r" },
+                    optionValues: new[] { Path.Combine(directory.Path, "MissingReference.dll") });
+
+                Assert.Equal(VSConstants.S_FALSE, hr);
+            }
+        }
+
+        private class TrivialMetadataService : IMetadataService
+        {
+            public PortableExecutableReference GetReference(string resolvedPath, MetadataReferenceProperties properties)
+            {
+                return MetadataReference.CreateFromFile(resolvedPath, properties);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since this involves the filesystem, there's always the possibility
the file might disappear out from underneath you. Let's accept that
might happen.

Fixes dotnet/roslyn#15101.

**Customer scenario**

This is a sporatic crash due to a race for files existing in the file system. @CyrusNajmabadi encountered this during dogfooding.

**Bugs this fixes:** #15101

**Workarounds, if any**

It's a random crash that would be encountered during a rebuild, or maybe git clean. Only workaround would be to not do those.

**Risk**

Low. This is a constrained API used for certain legacy scenarios.

**Performance impact**

Low. Only additional perf is some type checks.

**Is this a regression from a previous update?**

This was rewritten as a part of the Big Switch, so it's been present in Visual Studio 2015 RTM and onwards.

**Root cause analysis**

When this was rewritten, error handling cases in the old code wasn't carefully understood. The old code is sufficiently opaque that it's really hard to figure out without a lot of debug time. A unit test has been added.

**How was the bug found?**

@CyrusNajmabadi hit this.