### PR TITLE
Fix fallback encoding case; canBeEmbedded was not propogated

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/EmbeddedTextTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/EmbeddedTextTests.cs
@@ -244,6 +244,17 @@ class Program
             }
         }
 
+        [Fact]
+        public void FromBytes_EncodingFallbackCase()
+        {
+            var source = EncodedStringText.Create(new MemoryStream(new byte[] { 0xA9, 0x0D, 0x0A }), canBeEmbedded: true);
+            var text = EmbeddedText.FromSource("pathToLarge", source);
+
+            Assert.Equal("pathToLarge", text.FilePath);
+            Assert.Equal(SourceHashAlgorithm.Sha1, text.ChecksumAlgorithm);
+            AssertEx.Equal(source.GetChecksum(), text.Checksum);
+        }
+
         private byte[] Decompress(IEnumerable<byte> bytes)
         {
             var destination = new MemoryStream();

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Text
 
             try
             {
-                return Decode(stream, defaultEncoding ?? getEncoding.Value, checksumAlgorithm, throwIfBinaryDetected: detectEncoding);
+                return Decode(stream, defaultEncoding ?? getEncoding.Value, checksumAlgorithm, throwIfBinaryDetected: detectEncoding, canBeEmbedded: canBeEmbedded);
             }
             catch (DecoderFallbackException e)
             {


### PR DESCRIPTION
Fixes #15254

When the DecoderFallbackException is encountered for a source that is initially assumed to be UTF8, the second Decode (for the default ANSI code page) doesn't propagate the ``canBeEmbedded`` parameter.