### PR TITLE
Expose if an INamedTypeSymbol is a 'ComImport'

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1473,6 +1473,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         INamedTypeSymbol INamedTypeSymbol.TupleUnderlyingType => this.TupleUnderlyingType;
 
+        bool INamedTypeSymbol.IsComImport => IsComImport;
+
         #endregion
 
         #region ISymbol Members

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5233,6 +5233,9 @@ class C
             {
                 throw new NotImplementedException();
             }
+
+            public bool IsComImport => throw new NotImplementedException();
+
             #endregion
         }
 

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -89,6 +89,7 @@ Microsoft.CodeAnalysis.IArrayTypeSymbol.Sizes.get -> System.Collections.Immutabl
 Microsoft.CodeAnalysis.IFieldSymbol.CorrespondingTupleField.get -> Microsoft.CodeAnalysis.IFieldSymbol
 Microsoft.CodeAnalysis.IMethodSymbol.ReturnsByRef.get -> bool
 Microsoft.CodeAnalysis.INamedTypeSymbol.GetTypeArgumentCustomModifiers(int ordinal) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CustomModifier>
+Microsoft.CodeAnalysis.INamedTypeSymbol.IsComImport.get -> bool
 Microsoft.CodeAnalysis.INamedTypeSymbol.TupleElements.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IFieldSymbol>
 Microsoft.CodeAnalysis.INamedTypeSymbol.TupleUnderlyingType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.IOperation

--- a/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -2,6 +2,8 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -45,6 +47,12 @@ namespace Microsoft.CodeAnalysis
         /// statements in a non script file).
         /// </summary>
         bool IsImplicitClass { get; }
+
+        /// <summary>
+        /// Specifies that the class or interface is imported from another module.  See
+        /// <see cref="TypeAttributes.Import"/> and <see cref="ComImportAttribute"/>
+        /// </summary>
+        bool IsComImport { get; }
 
         /// <summary>
         /// Returns collection of names of members declared within this type.

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1189,6 +1189,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property INamedTypeSymbol_IsComImport As Boolean Implements INamedTypeSymbol.IsComImport
+            Get
+                Return IsComImport
+            End Get
+        End Property
+
 #End Region
 
 #Region "ISymbol"

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -60,97 +60,41 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 throw ExceptionUtilities.Unreachable;
             }
 
-            public int Arity
-            {
-                get
-                {
-                    return _symbol.Arity;
-                }
-            }
+            public bool IsAnonymousType => _symbol.IsAnonymousType;
+            public bool IsComImport => _symbol.IsComImport;
+            public bool IsGenericType => _symbol.IsGenericType;
+            public bool IsImplicitClass => _symbol.IsImplicitClass;
+            public bool IsReferenceType => _symbol.IsReferenceType;
+            public bool IsScriptClass => _symbol.IsScriptClass;
+            public bool IsTupleType => _symbol.IsTupleType;
+            public bool IsUnboundGenericType => _symbol.IsUnboundGenericType;
+            public bool IsValueType => _symbol.IsValueType;
+            public bool MightContainExtensionMethods => _symbol.MightContainExtensionMethods;
 
-            public bool IsGenericType
-            {
-                get
-                {
-                    return _symbol.IsGenericType;
-                }
-            }
+            public int Arity => _symbol.Arity;
 
-            public bool IsUnboundGenericType
-            {
-                get
-                {
-                    return _symbol.IsUnboundGenericType;
-                }
-            }
+            public TypeKind TypeKind => _symbol.TypeKind;
+            public SpecialType SpecialType => _symbol.SpecialType;
+            public ISymbol AssociatedSymbol => _symbol.AssociatedSymbol;
+            public IMethodSymbol DelegateInvokeMethod => _symbol.DelegateInvokeMethod;
 
-            public bool IsScriptClass
-            {
-                get
-                {
-                    return _symbol.IsScriptClass;
-                }
-            }
+            public INamedTypeSymbol EnumUnderlyingType => _symbol.EnumUnderlyingType;
+            public INamedTypeSymbol ConstructedFrom => _symbol.ConstructedFrom;
+            public INamedTypeSymbol BaseType => _symbol.BaseType;
+            public INamedTypeSymbol TupleUnderlyingType => _symbol.TupleUnderlyingType;
 
-            public bool IsImplicitClass
-            {
-                get
-                {
-                    return _symbol.IsImplicitClass;
-                }
-            }
-
-            public IEnumerable<string> MemberNames
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            public ImmutableArray<ITypeParameterSymbol> TypeParameters
-            {
-                get
-                {
-                    return _symbol.TypeParameters;
-                }
-            }
-
-            public ImmutableArray<ITypeSymbol> TypeArguments
-            {
-                get
-                {
-                    return _symbol.TypeArguments;
-                }
-            }
+            public ImmutableArray<ITypeParameterSymbol> TypeParameters => _symbol.TypeParameters;
+            public ImmutableArray<ITypeSymbol> TypeArguments => _symbol.TypeArguments;
+            public ImmutableArray<IMethodSymbol> InstanceConstructors => _symbol.InstanceConstructors;
+            public ImmutableArray<IMethodSymbol> StaticConstructors => _symbol.StaticConstructors;
+            public ImmutableArray<IMethodSymbol> Constructors => _symbol.Constructors;
+            public ImmutableArray<INamedTypeSymbol> Interfaces => _symbol.Interfaces;
+            public ImmutableArray<INamedTypeSymbol> AllInterfaces => _symbol.AllInterfaces;
+            public ImmutableArray<IFieldSymbol> TupleElements => _symbol.TupleElements;
 
             public ImmutableArray<CustomModifier> GetTypeArgumentCustomModifiers(int ordinal)
             {
                 return _symbol.GetTypeArgumentCustomModifiers(ordinal);
-            }
-
-            public IMethodSymbol DelegateInvokeMethod
-            {
-                get
-                {
-                    return _symbol.DelegateInvokeMethod;
-                }
-            }
-
-            public INamedTypeSymbol EnumUnderlyingType
-            {
-                get
-                {
-                    return _symbol.EnumUnderlyingType;
-                }
-            }
-
-            public INamedTypeSymbol ConstructedFrom
-            {
-                get
-                {
-                    return _symbol.ConstructedFrom;
-                }
             }
 
             public INamedTypeSymbol Construct(params ITypeSymbol[] typeArguments)
@@ -163,113 +107,6 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 return _symbol.ConstructUnboundGenericType();
             }
 
-            public ImmutableArray<IMethodSymbol> InstanceConstructors
-            {
-                get
-                {
-                    return _symbol.InstanceConstructors;
-                }
-            }
-
-            public ImmutableArray<IMethodSymbol> StaticConstructors
-            {
-                get
-                {
-                    return _symbol.StaticConstructors;
-                }
-            }
-
-            public ImmutableArray<IMethodSymbol> Constructors
-            {
-                get
-                {
-                    return _symbol.Constructors;
-                }
-            }
-
-            public ISymbol AssociatedSymbol
-            {
-                get
-                {
-                    return _symbol.AssociatedSymbol;
-                }
-            }
-
-            public TypeKind TypeKind
-            {
-                get
-                {
-                    return _symbol.TypeKind;
-                }
-            }
-
-            public INamedTypeSymbol BaseType
-            {
-                get
-                {
-                    return _symbol.BaseType;
-                }
-            }
-
-            public ImmutableArray<INamedTypeSymbol> Interfaces
-            {
-                get
-                {
-                    return _symbol.Interfaces;
-                }
-            }
-
-            public ImmutableArray<INamedTypeSymbol> AllInterfaces
-            {
-                get { return _symbol.AllInterfaces; }
-            }
-
-            public bool IsReferenceType
-            {
-                get
-                {
-                    return _symbol.IsReferenceType;
-                }
-            }
-
-            public bool IsValueType
-            {
-                get
-                {
-                    return _symbol.IsValueType;
-                }
-            }
-
-            public bool IsAnonymousType
-            {
-                get
-                {
-                    return _symbol.IsAnonymousType;
-                }
-            }
-
-            public bool IsTupleType => _symbol.IsTupleType;
-
-            public ImmutableArray<IFieldSymbol> TupleElements => _symbol.TupleElements;
-
-            public INamedTypeSymbol TupleUnderlyingType => _symbol.TupleUnderlyingType;
-
-            ITypeSymbol ITypeSymbol.OriginalDefinition
-            {
-                get
-                {
-                    return _symbol.OriginalDefinition;
-                }
-            }
-
-            public SpecialType SpecialType
-            {
-                get
-                {
-                    return _symbol.SpecialType;
-                }
-            }
-
             public ISymbol FindImplementationForInterfaceMember(ISymbol interfaceMember)
             {
                 return _symbol.FindImplementationForInterfaceMember(interfaceMember);
@@ -278,6 +115,14 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             public override ImmutableArray<ISymbol> GetMembers()
             {
                 return _members;
+            }
+
+            public IEnumerable<string> MemberNames
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
             }
 
             public override ImmutableArray<ISymbol> GetMembers(string name)
@@ -300,18 +145,8 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 throw new NotImplementedException();
             }
 
-            public new INamedTypeSymbol OriginalDefinition
-            {
-                get
-                {
-                    return this;
-                }
-            }
-
-            public bool MightContainExtensionMethods
-            {
-                get { return _symbol.MightContainExtensionMethods; }
-            }
+            ITypeSymbol ITypeSymbol.OriginalDefinition => _symbol.OriginalDefinition;
+            public new INamedTypeSymbol OriginalDefinition => this;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
@@ -32,13 +32,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.NamedType;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.NamedType;
 
         public override void Accept(SymbolVisitor visitor)
         {
@@ -99,9 +93,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public ISymbol AssociatedSymbol { get; internal set; }
 
-        public bool MightContainExtensionMethods
-        {
-            get { return false; }
-        }
+        public bool MightContainExtensionMethods => false;
+
+        public bool IsComImport => false;
     }
 }


### PR DESCRIPTION
IDE would like this as we want certain special behaviors of a type is a 'ComImport' type.  For example, in Metadata-as-source, we would not do any sort of grouping/reordering of members.  Similarly, when implementing hte interface, we would also preserve the order of members in metadata.

This introduces a public API.  However, a very simple one that only exposes information the compiler already has and already tests extensively.  