### PR TITLE
Use async overload of OnFunctionResolved

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/MetadataResolver.cs
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/MetadataResolver.cs
@@ -11,6 +11,8 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 {
+    internal delegate void OnFunctionResolvedDelegate<TModule, TRequest>(TModule module, TRequest request, int token, int version, int ilOffset);
+
     internal sealed class MetadataResolver<TProcess, TModule, TRequest>
         where TProcess : class
         where TModule : class
@@ -18,21 +20,21 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
     {
         private static readonly StringComparer s_stringComparer = StringComparer.Ordinal;
 
-        private readonly FunctionResolverBase<TProcess, TModule, TRequest> _resolver;
         private readonly TProcess _process;
         private readonly TModule _module;
         private readonly MetadataReader _reader;
+        private readonly OnFunctionResolvedDelegate<TModule, TRequest> _onFunctionResolved;
 
         internal MetadataResolver(
-            FunctionResolverBase<TProcess, TModule, TRequest> resolver,
             TProcess process,
             TModule module,
-            MetadataReader reader)
+            MetadataReader reader,
+            OnFunctionResolvedDelegate<TModule, TRequest> onFunctionResolved)
         {
-            _resolver = resolver;
             _process = process;
             _module = module;
             _reader = reader;
+            _onFunctionResolved = onFunctionResolved;
         }
 
         internal void Resolve(TRequest request, RequestSignature signature)
@@ -293,7 +295,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             MethodDefinitionHandle handle)
         {
             Debug.Assert(!handle.IsNil);
-            _resolver.OnFunctionResolved(_module, request, token: MetadataTokens.GetToken(handle), version: 1, ilOffset: 0);
+            _onFunctionResolved(_module, request, token: MetadataTokens.GetToken(handle), version: 1, ilOffset: 0);
         }
 
         private void OnAccessorResolved(

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/CSharpFunctionResolverTests.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/CSharpFunctionResolverTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
                 VerifySignatures(requestG);
             }
 
-            // Two modules after after two requests for same module,
+            // Two modules after two requests for same module,
             // ... resolver enabled.
             moduleA = new Module(bytesA, name: "A.dll");
             moduleB = new Module(bytesB, name: "B.dll");

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/Request.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/Request.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -23,7 +24,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
     internal sealed class Request
     {
-        internal readonly List<Address> _resolvedAddresses;
+        private readonly List<Address> _resolvedAddresses;
 
         internal Request(string moduleName, RequestSignature signature)
         {

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/Resolver.cs
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/Resolver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             _requests = new Dictionary<Process, List<Request>>();
         }
 
-        internal new void EnableResolution(Process process, Request request)
+        internal void EnableResolution(Process process, Request request)
         {
             List<Request> requests;
             if (!_requests.TryGetValue(process, out requests))
@@ -23,7 +24,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
                 _requests.Add(process, requests);
             }
             requests.Add(request);
-            base.EnableResolution(process, request);
+            base.EnableResolution(process, request, OnFunctionResolved);
+        }
+
+        internal void OnModuleLoad(Process process, Module module)
+        {
+            base.OnModuleLoad(process, module, OnFunctionResolved);
         }
 
         internal override bool ShouldEnableFunctionResolver(Process process)
@@ -66,14 +72,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
             return request.Signature;
         }
 
-        internal override void OnFunctionResolved(Module module, Request request, int token, int version, int ilOffset)
+        private static void OnFunctionResolved(Module module, Request request, int token, int version, int ilOffset)
         {
             request.OnFunctionResolved(module, token, version, ilOffset);
-        }
-
-        private void OnModuleLoaded(object sender, Module e)
-        {
-            OnModuleLoad((Process)sender, e);
         }
     }
 }


### PR DESCRIPTION
Use async overload of `DkmRuntimeFunctionResolutionRequest.OnFunctionResolved` to avoid deadlock.