### PR TITLE
Extend RepoUtil so it can support our internal repo

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -12,6 +12,7 @@
     <MicrosoftCodeAnalysisAnalyzersVersion>1.1.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCompositionVersion>1.0.27</MicrosoftCompositionVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.1.0-beta1-60625-03</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.5.0-beta1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0-beta1-60831-01</MicrosoftDiaSymReaderPortablePdbVersion>
@@ -32,8 +33,10 @@
     <SystemDiagnosticsToolsVersion>4.0.1</SystemDiagnosticsToolsVersion>
     <SystemDynamicRuntimeVersion>4.0.11</SystemDynamicRuntimeVersion>
     <SystemGlobalizationVersion>4.0.11</SystemGlobalizationVersion>
+    <SystemIdentityModelTokensJwtVersion>5.0.0</SystemIdentityModelTokensJwtVersion>
     <SystemIOVersion>4.1.0</SystemIOVersion>
     <SystemIOCompressionVersion>4.1.0</SystemIOCompressionVersion>
+    <SystemIOCompressionZipFileVersion>4.0.1</SystemIOCompressionZipFileVersion>
     <SystemIOFileSystemVersion>4.0.1</SystemIOFileSystemVersion>
     <SystemIOFileSystemDriveInfoVersion>4.0.0</SystemIOFileSystemDriveInfoVersion>
     <SystemIOFileSystemPrimitivesVersion>4.0.1</SystemIOFileSystemPrimitivesVersion>

--- a/build/ToolsetPackages/closed.project.json
+++ b/build/ToolsetPackages/closed.project.json
@@ -1,0 +1,10 @@
+{
+    "dependencies": {
+        "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.35",
+        "System.IdentityModel.Tokens.Jwt": "5.0.0",
+        "System.IO.Compression.ZipFile": "4.0.1"
+    },
+    "frameworks": {
+        "net46": {}
+    }
+}

--- a/src/Tools/RepoUtil/ChangeCommand.cs
+++ b/src/Tools/RepoUtil/ChangeCommand.cs
@@ -17,10 +17,12 @@ namespace RepoUtil
     internal sealed class ChangeCommand : ICommand
     {
         private readonly RepoData _repoData;
+        private readonly string _generateDirectory;
 
-        internal ChangeCommand(RepoData repoData)
+        internal ChangeCommand(RepoData repoData, string generateDir)
         {
             _repoData = repoData;
+            _generateDirectory = generateDir;
         }
 
         public bool Run(TextWriter writer, string[] args)
@@ -183,7 +185,7 @@ namespace RepoUtil
         private void ChangeProjectJsonFiles(ImmutableDictionary<NuGetPackage, NuGetPackage> changeMap)
         {
             Console.WriteLine("Changing project.json files");
-            foreach (var filePath in ProjectJsonUtil.GetProjectJsonFiles(_repoData.SourcesPath))
+            foreach (var filePath in ProjectJsonUtil.GetProjectJsonFiles(_repoData.SourcesDirectory))
             {
                 if (ProjectJsonUtil.ChangeDependencies(filePath, changeMap))
                 {
@@ -197,7 +199,7 @@ namespace RepoUtil
             var msbuildData = _repoData.RepoConfig.MSBuildGenerateData;
             if (msbuildData.HasValue)
             {
-                var fileName = new FileName(_repoData.SourcesPath, msbuildData.Value.RelativeFileName);
+                var fileName = new FileName(_generateDirectory, msbuildData.Value.RelativeFilePath);
                 var packages = GenerateUtil.GetFilteredPackages(msbuildData.Value, _repoData);
                 GenerateUtil.WriteMSBuildContent(fileName, packages);
             }

--- a/src/Tools/RepoUtil/GenerateData.cs
+++ b/src/Tools/RepoUtil/GenerateData.cs
@@ -14,12 +14,12 @@ namespace RepoUtil
     /// </summary>
     internal struct GenerateData
     {
-        internal string RelativeFileName { get; }
+        internal string RelativeFilePath { get; }
         internal ImmutableArray<Regex> Packages { get; }
 
         internal GenerateData(string relativeFileName, ImmutableArray<Regex> packages)
         {
-            RelativeFileName = relativeFileName;
+            RelativeFilePath = relativeFileName;
             Packages = packages;
         }
     }

--- a/src/Tools/RepoUtil/RepoData.cs
+++ b/src/Tools/RepoUtil/RepoData.cs
@@ -12,7 +12,7 @@ namespace RepoUtil
 {
     internal sealed class RepoData
     {
-        internal string SourcesPath { get; }
+        internal string SourcesDirectory { get; }
         internal RepoConfig RepoConfig { get; }
         internal ImmutableArray<NuGetFeed> NuGetFeeds { get; }
         internal ImmutableArray<NuGetPackage> FloatingBuildPackages { get; }
@@ -21,9 +21,9 @@ namespace RepoUtil
         internal ImmutableArray<NuGetPackage> FixedPackages => RepoConfig.FixedPackages;
         internal ImmutableArray<NuGetPackage> AllPackages { get; }
 
-        private RepoData(RepoConfig config, string sourcesPath, IEnumerable<NuGetFeed> nugetFeeds, IEnumerable<NuGetPackage> floatingPackages)
+        private RepoData(RepoConfig config, string sourcesDir, IEnumerable<NuGetFeed> nugetFeeds, IEnumerable<NuGetPackage> floatingPackages)
         {
-            SourcesPath = sourcesPath;
+            SourcesDirectory = sourcesDir;
             RepoConfig = config;
             NuGetFeeds = nugetFeeds.ToImmutableArray();
             FloatingToolsetPackages = floatingPackages
@@ -56,10 +56,10 @@ namespace RepoUtil
         /// state of the repo and add in the current data.  If any conflicting package definitions are detected this method 
         /// will throw.
         /// </summary>
-        internal static RepoData Create(RepoConfig config, string sourcesPath)
+        internal static RepoData Create(RepoConfig config, string sourcesDir)
         {
             List<NuGetPackageConflict> conflicts;
-            var repoData = Create(config, sourcesPath, out conflicts);
+            var repoData = Create(config, sourcesDir, out conflicts);
             if (conflicts?.Count > 0)
             {
                 throw new ConflictingPackagesException(conflicts);
@@ -68,10 +68,10 @@ namespace RepoUtil
             return repoData;
         }
 
-        internal static RepoData Create(RepoConfig config, string sourcesPath, out List<NuGetPackageConflict> conflicts)
+        internal static RepoData Create(RepoConfig config, string sourcesDir, out List<NuGetPackageConflict> conflicts)
         {
             var nugetFeeds = new List<NuGetFeed>();
-            foreach (var nugetConfig in NuGetConfigUtil.GetNuGetConfigFiles(sourcesPath))
+            foreach (var nugetConfig in NuGetConfigUtil.GetNuGetConfigFiles(sourcesDir))
             {
                 var nugetFeed = NuGetConfigUtil.GetNuGetFeeds(nugetConfig);
                 nugetFeeds.AddRange(nugetFeed);
@@ -81,14 +81,14 @@ namespace RepoUtil
 
             var fixedPackageSet = new HashSet<NuGetPackage>(config.FixedPackages, default(Constants.IgnoreGenerateNameComparer));
             var floatingPackageMap = new Dictionary<string, NuGetPackageSource>(Constants.NugetPackageNameComparer);
-            foreach (var filePath in ProjectJsonUtil.GetProjectJsonFiles(sourcesPath))
+            foreach (var filePath in ProjectJsonUtil.GetProjectJsonFiles(sourcesDir))
             {
                 if (config.ProjectJsonExcludes.Any(x => x.IsMatch(filePath)))
                 {
                     continue;
                 }
 
-                var fileName = FileName.FromFullPath(sourcesPath, filePath);
+                var fileName = FileName.FromFullPath(sourcesDir, filePath);
                 foreach (var package in ProjectJsonUtil.GetDependencies(filePath))
                 {
                     if (fixedPackageSet.Contains(package))
@@ -116,7 +116,7 @@ namespace RepoUtil
                 }
             }
 
-            return new RepoData(config, sourcesPath, nugetFeeds, floatingPackageMap.Values.Select(x => x.NuGetPackage));
+            return new RepoData(config, sourcesDir, nugetFeeds, floatingPackageMap.Values.Select(x => x.NuGetPackage));
         }
     }
 }

--- a/src/Tools/RepoUtil/ViewCommand.cs
+++ b/src/Tools/RepoUtil/ViewCommand.cs
@@ -131,7 +131,7 @@ namespace RepoUtil
                 var packages = GenerateUtil.GetFilteredPackages(data, repoData);
 
                 // Need to verify the contents of the generated file are correct.
-                var fileName = new FileName(_sourcesPath, data.RelativeFileName);
+                var fileName = new FileName(_sourcesPath, data.RelativeFilePath);
                 var actualContent = File.ReadAllText(fileName.FullPath, GenerateUtil.Encoding);
                 var expectedContent = GenerateUtil.GenerateMSBuildContent(packages);
                 if (actualContent != expectedContent)


### PR DESCRIPTION
Our internal repo uses dotnet/roslyn as a submodule.  It has additional project.json entries that need to go through the same verification as dotnet/roslyn.  This updates RepoUtil so it can handle this structure.  In particular having the configuration file and generation files be in non-standard locations.