### PR TITLE
Check that the project being enabled for pushing events to workspace …

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
@@ -52,13 +53,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             private void AddToPushListIfNeeded(AbstractProject project, List<AbstractProject> inOrderToPush, HashSet<AbstractProject> visited)
             {
-                AssertIsForeground();
+                AssertIsForeground();                
+                Contract.ThrowIfFalse(_tracker.ContainsProject(project));
 
                 // Bail out if any of the following is true:
                 //  1. We have already started pushing changes for this project OR
-                //  2. We have removed the project from the tracker on the UI thread
-                //  3. We have already visited this project in a prior recursive call                
-                if (_pushedProjects.Contains(project) || !_tracker.ContainsProject(project) || !visited.Add(project))
+                //  2. We have already visited this project in a prior recursive call                
+                if (_pushedProjects.Contains(project) || !visited.Add(project))
                 {
                     return;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
@@ -54,12 +54,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 AssertIsForeground();
 
-                if (_pushedProjects.Contains(project))
-                {
-                    return;
-                }
-
-                if (!visited.Add(project))
+                // Bail out if any of the following is true:
+                //  1. We have already started pushing changes for this project OR
+                //  2. We have removed the project from the tracker on the UI thread
+                //  3. We have already visited this project in a prior recursive call                
+                if (_pushedProjects.Contains(project) || !_tracker.ContainsProject(project) || !visited.Add(project))
                 {
                     return;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -354,6 +354,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             AssertIsForeground();
 
+            // Filter out the projects that have been removed from the tracker.
+            projects = projects.Where(p => this.ContainsProject(p));
+
             using (Dispatcher.CurrentDispatcher.DisableProcessing())
             {
                 foreach (var hostState in _workspaceHosts)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -354,7 +354,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             AssertIsForeground();
 
-            // Filter out the projects that have been removed from the tracker.
+            // StartPushingToWorkspaceAndNotifyOfOpenDocuments might be invoked from a background thread,
+            // and hence StartPushingToWorkspaceAndNotifyOfOpenDocuments_Foreground scheduled to be executed later on the foreground task scheduler.
+            // By the time it gets scheduled, we might have removed some project(s) from the tracker on the UI thread.
+            // So, we filter out the projects that have been removed from the tracker.
             projects = projects.Where(p => this.ContainsProject(p));
 
             using (Dispatcher.CurrentDispatcher.DisableProcessing())

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -298,6 +298,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
+        internal bool ContainsProject(AbstractProject project)
+        {
+            lock (_gate)
+            {
+                return _projectMap.ContainsKey(project.Id);
+            }
+        }
+
         /// <summary>
         /// Add a project to the workspace.
         /// If invoked on the foreground thread, the add is executed right away.


### PR DESCRIPTION
…hostw is still being tracked by the project tracker

[StartPushingToWorkspaceAndNotifyOfOpenDocuments](http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/Implementation/ProjectSystem/VisualStudioProjectTracker.cs,187e105ec91d077b,references) might be invoked from a background thread, and hence scheduled to be executed later on the foreground task scheduler. By the time it gets scheduled, we might have removed the project from the tracker on the UI thread. We now guard against this condition by filtering out the removed projects from the push list.
Fixes VSO #[271781](https://devdiv.visualstudio.com/DevDiv/_workitems?id=271781)