### PR TITLE
Create a custom Rename-File code operation so that we don't show a very unhelpful 'full file added' preview.

### DIFF
--- a/src/EditorFeatures/TestUtilities/Workspaces/TestHostDocument.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestHostDocument.cs
@@ -140,7 +140,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _loader = new TestDocumentLoader(this);
         }
 
-        public TestHostDocument(string text = "", string displayName = "", SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, DocumentId id = null, string filePath = null)
+        public TestHostDocument(
+            string text = "", string displayName = "", 
+            SourceCodeKind sourceCodeKind = SourceCodeKind.Regular, 
+            DocumentId id = null, string filePath = null,
+            IReadOnlyList<string> folders = null)
         {
             _exportProvider = TestExportProvider.ExportProviderWithCSharpAndVisualBasic;
             _id = id;
@@ -149,6 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _sourceCodeKind = sourceCodeKind;
             _loader = new TestDocumentLoader(this);
             _filePath = filePath;
+            _folders = folders;
         }
 
         internal void SetProject(TestHostProject project)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -224,6 +224,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public new void OnDocumentRemoved(DocumentId documentId)
         {
+            if (this.IsDocumentOpen(documentId))
+            {
+                this.CloseDocument(documentId);
+            }
+
             base.OnDocumentRemoved(documentId);
         }
 
@@ -299,7 +304,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         protected override void ApplyDocumentAdded(DocumentInfo info, SourceText text)
         {
             var hostProject = this.GetTestProject(info.Id.ProjectId);
-            var hostDocument = new TestHostDocument(text.ToString(), info.Name, info.SourceCodeKind, info.Id);
+            var hostDocument = new TestHostDocument(
+                text.ToString(), info.Name, info.SourceCodeKind, 
+                info.Id, folders: info.Folders);
             hostProject.AddDocument(hostDocument);
             this.OnDocumentAdded(hostDocument.ToDocumentInfo());
         }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -222,9 +222,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             base.OnParseOptionsChanged(projectId, parseOptions);
         }
 
-        public new void OnDocumentRemoved(DocumentId documentId)
+        public void OnDocumentRemoved(DocumentId documentId, bool closeDocument = false)
         {
-            if (this.IsDocumentOpen(documentId))
+            if (closeDocument && this.IsDocumentOpen(documentId))
             {
                 this.CloseDocument(documentId);
             }
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var hostProject = this.GetTestProject(documentId.ProjectId);
             var hostDocument = this.GetTestDocument(documentId);
             hostProject.RemoveDocument(hostDocument);
-            this.OnDocumentRemoved(documentId);
+            this.OnDocumentRemoved(documentId, closeDocument: true);
         }
 
         protected override void ApplyAdditionalDocumentTextChanged(DocumentId document, SourceText newText)

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,9 +17,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             }
 
             internal override Task<ImmutableArray<CodeActionOperation>> GetOperationsAsync()
-            {
-                return Task.FromResult(RenameFileToMatchTypeName());
-            }
+                => Task.FromResult(RenameFileToMatchTypeName());
 
             /// <summary>
             /// Renames the file to match the type contained in it.
@@ -28,19 +25,12 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             private ImmutableArray<CodeActionOperation> RenameFileToMatchTypeName()
             {
                 var oldDocument = SemanticDocument.Document;
-                var solution = oldDocument.Project.Solution;
-                var text = SemanticDocument.Text;
-                var oldDocumentId = oldDocument.Id;
                 var newDocumentId = DocumentId.CreateNewId(oldDocument.Project.Id, FileName);
 
-                // currently, document rename is accomplished by a remove followed by an add.
-                // the workspace takes care of resolving conflicts if the document name is not unique in the project
-                // by adding numeric suffixes to the new document being added.
-                var newSolution = solution.RemoveDocument(oldDocumentId);
-                newSolution = newSolution.AddDocument(newDocumentId, FileName, text, oldDocument.Folders);
-
                 return ImmutableArray.Create<CodeActionOperation>(
-                    new ApplyChangesOperation(newSolution),
+                    new RenameDocumentOperation(
+                        oldDocument.Id, newDocumentId, 
+                        FileName, SemanticDocument.Text),
                     new OpenDocumentOperation(newDocumentId, activateIfAlreadyOpen: true));
             }
         }

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/RenameDocumentOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/RenameDocumentOperation.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CodeActions
+{
+    internal class RenameDocumentOperation : CodeActionOperation
+    {
+        private readonly DocumentId _oldDocumentId;
+        private readonly DocumentId _newDocumentId;
+        private readonly string _newFileName;
+        private readonly SourceText _text;
+
+        public override string Title { get; }
+
+        internal override bool ApplyDuringTests => true;
+
+        public RenameDocumentOperation(
+            DocumentId oldDocumentId, 
+            DocumentId newDocumentId, 
+            string newFileName,
+            SourceText text)
+        {
+            _oldDocumentId = oldDocumentId;
+            _newDocumentId = newDocumentId;
+            _newFileName = newFileName;
+            _text = text;
+        }
+
+        internal override bool TryApply(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+        {
+            var solution = workspace.CurrentSolution;
+
+            // currently, document rename is accomplished by a remove followed by an add.
+            // the workspace takes care of resolving conflicts if the document name is not unique in the project
+            // by adding numeric suffixes to the new document being added.
+            var oldDocument = solution.GetDocument(_oldDocumentId);
+            var newSolution = solution.RemoveDocument(_oldDocumentId);
+
+            newSolution = newSolution.AddDocument(_newDocumentId, _newFileName, _text, oldDocument.Folders);
+            return workspace.TryApplyChanges(newSolution, progressTracker);
+        }
+
+        public override void Apply(Workspace workspace, CancellationToken cancellationToken)
+        {
+            TryApply(workspace, new ProgressTracker(), cancellationToken);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -304,6 +304,7 @@
     <Compile Include="CodeActions\Annotations\SuppressDiagnosticsAnnotation.cs" />
     <Compile Include="CodeActions\CodeActionPriority.cs" />
     <Compile Include="CodeActions\Operations\PreviewOperation.cs" />
+    <Compile Include="CodeActions\Operations\RenameDocumentOperation.cs" />
     <Compile Include="CodeCleanup\AbstractCodeCleanerService.cs" />
     <Compile Include="CodeCleanup\CodeCleaner.cs" />
     <Compile Include="CodeCleanup\ICodeCleanerService.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15368