### PR TITLE
Adapting discard branch to latest RC2 changes

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -660,7 +660,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             Error(diagnostics, ErrorCode.ERR_DeconstructionVarFormDisallowsSpecificType, component.Designation);
                         }
 
-                        return BindDeconstructionVariables(declType, component.Designation, diagnostics);
+                        return BindDeconstructionVariables(declType, component.Type, component.Designation, diagnostics);
                     }
                 case SyntaxKind.TupleExpression:
                     {
@@ -688,6 +688,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private DeconstructionVariable BindDeconstructionVariables(
             TypeSymbol declType,
+            TypeSyntax typeSyntax,
             VariableDesignationSyntax node,
             DiagnosticBag diagnostics)
         {
@@ -696,7 +697,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.SingleVariableDesignation:
                     {
                         var single = (SingleVariableDesignationSyntax)node;
-                        return new DeconstructionVariable(BindDeconstructionVariable(declType, single, diagnostics), node);
+                        return new DeconstructionVariable(BindDeconstructionVariable(declType, typeSyntax, single, diagnostics), node);
                     }
                 case SyntaxKind.DiscardedDesignation:
                     {
@@ -709,7 +710,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var builder = ArrayBuilder<DeconstructionVariable>.GetInstance();
                         foreach (var n in tuple.Variables)
                         {
-                            builder.Add(BindDeconstructionVariables(declType, n, diagnostics));
+                            builder.Add(BindDeconstructionVariables(declType, typeSyntax, n, diagnostics));
                         }
                         return new DeconstructionVariable(builder, node);
                     }
@@ -725,6 +726,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression BindDeconstructionVariable(
             TypeSymbol declType,
+            TypeSyntax typeSyntax,
             SingleVariableDesignationSyntax designation,
             DiagnosticBag diagnostics)
         {


### PR DESCRIPTION
In order to clean up the features/wildcard branch and allow for a PR to dev15-rc2, I reset the branch to latest RC2 (Jason's change below), cherry-picked four discard changes, and I'm doing a PR for the last change (to run everything through CI).


```
commit 19c9c3f93b1ca04ec3493170441adb5dd5f153d5
Author: Julien Couvreur <julien.couvreur@gmail.com>
Date:   Mon Nov 21 21:18:53 2016 -0800

    Adapting discard branch to latest RC2 changes


commit 993daf631e36f33dd264abc141fb04617e3287e7
Author: Julien Couvreur <jcouv@users.noreply.github.com>
Date:   Mon Nov 21 20:23:17 2016 -0800

    Removing PROTOTYPE markers (#15452)

commit 3a8774eefaeb22f10fcb4b8433a68a9e666616f6
Author: Julien Couvreur <jcouv@users.noreply.github.com>
Date:   Mon Nov 21 19:33:18 2016 -0800

    Discard in deconstruction, out var and patterns  (#15192)

commit 278f9a14d4d3781848592aaadd57ab6729b6cc13
Author: Neal Gafter <neal@gafter.com>
Date:   Wed Nov 16 10:12:54 2016 -0800

    Add IDiscardedSymbol and initial discard binding (#15139)

    Fixes #7895

commit 59a2a0c7679db6d763254fe99acd05ecda9c23d3
Author: Neal Gafter <neal@gafter.com>
Date:   Thu Nov 10 08:49:35 2016 -0800

    Use a DesignatorSyntax for declaration patterns, and add DiscardedToken for wildcards (#15107)

    Also add wildcards.work.md to track outstanding work.

commit 29e1cfd0fa546fc691c2ffc2a1f0f09c57e1ca2b
Merge: abf9a6b 390f4d5
Author: Jason Malinowski <jason@jason-m.com>
Date:   Mon Nov 21 17:15:04 2016 -0800

    Merge pull request #15382 from jasonmalinowski/fix-temppe-crash

    Don't crash if we can't resolve a file during a TempPE build
```

If this needs to be undone for some reason, the last commits on the features/wildcard branch were:
```
commit a81226771b7bbbe0c8a17ceaf658a1058e5eb647
Author: Julien Couvreur <jcouv@users.noreply.github.com>
Date:   Mon Nov 21 20:23:17 2016 -0800

    Removing PROTOTYPE markers (#15452)

commit 3ec7cb47af26d3ad7e696ee5b81e097c80a271b5
Author: Julien Couvreur <jcouv@users.noreply.github.com>
Date:   Mon Nov 21 19:33:18 2016 -0800

    Discard in deconstruction, out var and patterns  (#15192)
```