### PR TITLE
Update locate-vs.ps1 to write out failure information

### DIFF
--- a/build/scripts/locate-vs.ps1
+++ b/build/scripts/locate-vs.ps1
@@ -51,6 +51,7 @@ try
 }
 catch
 {
+  Write-Error $_.Exception.Message
   # Return an empty string and let the caller fallback or handle this as appropriate
   return ""
 }


### PR DESCRIPTION
When the locate-vs.ps1 script fails it does so silently, swallowing all exceptions. This commit updates it to print out the exception messages so we can start to diagnose the failures we're seeing in our integration test runs.