### PR TITLE
IDE type inference should not crash on deconstructions (new syntax model for discards)

### DIFF
--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -2020,5 +2020,13 @@ class C
 
             await TestAsync(text, "global::C", testNode: false);
         }
+
+        [WorkItem(15468, "https://github.com/dotnet/roslyn/issues/15468")]
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        public async Task TestDeconstruction()
+        {
+            await TestInMethodAsync(
+@"[|(int i, _)|] =", "global::System.Object");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -2020,7 +2020,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
 
-                    if (elementTypesBuilder.Contains(null))
+                    if (elementTypesBuilder.Contains(null) || elementTypesBuilder.Count != arguments.Count)
                     {
                         return false;
                     }


### PR DESCRIPTION
Type a deconstruction declaration with a discard, VS crashes. The only workaround is to avoid using deconstructions.
Mitigates https://github.com/dotnet/roslyn/issues/15468 (avoids crash, but IDE refactoring still incorrect)
Low risk of perf impact.
I should have done some IDE tests on discard change before merging to RC2. I only thought about it afterwards.
I will immediately follow up with a more thorough solution for refactoring with discards in RC2.

@CyrusNajmabadi for review.
FYI @gafter 