### PR TITLE
Don't crash if completion filters cause there to be no selected item

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                             model, localId, caretPosition, recheckCaretPosition, dismissIfEmptyAllowed, filterReason);
 
                         return filteredModel != null
-                            ? filteredModel.WithFilteredItems(filteredModel.TotalItems).WithSelectedItem(filteredModel.SelectedItem)
+                            ? filteredModel.WithFilteredItems(filteredModel.TotalItems).WithSelectedItem(filteredModel.SelectedItemOpt)
                             : null;
                     });
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_SetModelBuilderState.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_SetModelBuilderState.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 // already in soft select mode.
                 var softSelect = includeBuilder || model.IsSoftSelection;
 
-                if (model.SelectedItem == model.SuggestionModeItem &&
+                if (model.SelectedItemOpt == model.SuggestionModeItem &&
                     !includeBuilder)
                 {
                     // Use had the builder selected, but turned off the builder.  Switch to the

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
             else
             {
-                var selectedItem = modelOpt.SelectedItem;
+                var selectedItem = modelOpt.SelectedItemOpt;
                 var viewSpan = selectedItem == null ? (ViewTextSpan?)null : modelOpt.GetViewBufferSpan(selectedItem.Span);
                 var triggerSpan = viewSpan == null ? null : modelOpt.GetCurrentSpanInSnapshot(viewSpan.Value, this.TextView.TextSnapshot)
                                           .CreateTrackingSpan(SpanTrackingMode.EdgeInclusive);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CaretPositionChanged.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CaretPositionChanged.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 return;
             }
 
-            if (model.SelectedItem != null && model.IsHardSelection)
+            if (model.SelectedItemOpt != null && model.IsHardSelection)
             {
                 // Switch to soft selection, if user moved caret to the start of a non-empty filter span.
                 // This prevents commiting if user types a commit character at this position later, but still has the list if user types filter character
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 // We want the filter span non-empty because we still want completion in the following case:
                 // A a = new | -> A a = new (|
 
-                var currentSpan = model.GetViewBufferSpan(model.SelectedItem.Span).TextSpan;
+                var currentSpan = model.GetViewBufferSpan(model.SelectedItemOpt.Span).TextSpan;
                 if (caretPoint == currentSpan.Start && currentSpan.Length > 0)
                 {
                     sessionOpt.SetModelIsHardSelection(false);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CommitUniqueCompletionListItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CommitUniqueCompletionListItem.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // we do want it through, it would be easy to get again simply by asking the model
             // computation to remove all filtering.
 
-            if (model.IsUnique)
+            if (model.IsUnique && model.SelectedItem != null)
             {
                 // We had a unique item in the list.  Commit it and dismiss this session.
                 this.CommitOnNonTypeChar(model.SelectedItem, model);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CommitUniqueCompletionListItem.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_CommitUniqueCompletionListItem.cs
@@ -49,10 +49,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // we do want it through, it would be easy to get again simply by asking the model
             // computation to remove all filtering.
 
-            if (model.IsUnique && model.SelectedItem != null)
+            if (model.IsUnique && model.SelectedItemOpt != null)
             {
                 // We had a unique item in the list.  Commit it and dismiss this session.
-                this.CommitOnNonTypeChar(model.SelectedItem, model);
+                this.CommitOnNonTypeChar(model.SelectedItemOpt, model);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
@@ -67,6 +67,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // more than one line of text.
             sendThrough = !_isDebugger || _isImmediateWindow;
 
+            // If the user used completion filters to empty the list, just dismiss
+            if (model.SelectedItem == null)
+            {
+                committed = false;
+                return;
+            }
+
             if (model.IsSoftSelection)
             {
                 // If the completion list is soft selected, then don't commit on enter.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ReturnKey.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             sendThrough = !_isDebugger || _isImmediateWindow;
 
             // If the user used completion filters to empty the list, just dismiss
-            if (model.SelectedItem == null)
+            if (model.SelectedItemOpt == null)
             {
                 committed = false;
                 return;
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
 
             // If the selected item is the builder, dismiss
-            if (model.SelectedItem == model.SuggestionModeItem)
+            if (model.SelectedItemOpt == model.SuggestionModeItem)
             {
                 sendThrough = false;
                 committed = false;
@@ -93,16 +93,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             if (sendThrough)
             {
                 // Get the text that the user has currently entered into the buffer
-                var viewSpan = model.GetViewBufferSpan(model.SelectedItem.Span);
+                var viewSpan = model.GetViewBufferSpan(model.SelectedItemOpt.Span);
                 var textTypedSoFar = model.GetCurrentTextInSnapshot(
                     viewSpan, this.TextView.TextSnapshot, this.GetCaretPointInViewBuffer());
 
                 var service = GetCompletionService();
                 sendThrough = SendEnterThroughToEditor(
-                     service.GetRules(), model.SelectedItem, textTypedSoFar);
+                     service.GetRules(), model.SelectedItemOpt, textTypedSoFar);
             }
 
-            this.CommitOnNonTypeChar(model.SelectedItem, model);
+            this.CommitOnNonTypeChar(model.SelectedItemOpt, model);
             committed = true;
         }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
@@ -169,6 +169,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 return;
             }
 
+            // If there's no selected item, there's nothing to commit
+            if (model.SelectedItem == null)
+            {
+                committed = false;
+                return;
+            }
+
             // If the selected item is the builder, there's not actually any work to do to commit
             if (model.SelectedItem == model.SuggestionModeItem)
             {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
@@ -170,21 +170,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
 
             // If there's no selected item, there's nothing to commit
-            if (model.SelectedItem == null)
+            if (model.SelectedItemOpt == null)
             {
                 committed = false;
                 return;
             }
 
             // If the selected item is the builder, there's not actually any work to do to commit
-            if (model.SelectedItem == model.SuggestionModeItem)
+            if (model.SelectedItemOpt == model.SuggestionModeItem)
             {
                 committed = true;
                 this.StopModelComputation();
                 return;
             }
 
-            CommitOnNonTypeChar(model.SelectedItem, model);
+            CommitOnNonTypeChar(model.SelectedItemOpt, model);
             committed = true;
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -304,12 +304,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             // TODO(cyrusn): Find a way to allow the user to cancel out of this.
             var model = sessionOpt.WaitForModel();
-            if (model == null || model.IsSoftSelection || model.SelectedItem == null)
+            if (model == null || model.IsSoftSelection || model.SelectedItemOpt == null)
             {
                 return false;
             }
 
-            if (model.SelectedItem == model.SuggestionModeItem)
+            if (model.SelectedItemOpt == model.SuggestionModeItem)
             {
                 return char.IsLetterOrDigit(ch);
             }
@@ -320,9 +320,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 return false;
             }
 
-            var textTypedSoFar = GetTextTypedSoFar(model, model.SelectedItem);
+            var textTypedSoFar = GetTextTypedSoFar(model, model.SelectedItemOpt);
             return IsCommitCharacter(
-                completionService.GetRules(), model.SelectedItem, ch, textTypedSoFar);
+                completionService.GetRules(), model.SelectedItemOpt, ch, textTypedSoFar);
         }
 
         /// <summary>
@@ -376,13 +376,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 return false;
             }
 
-            if (model.SelectedItem == model.SuggestionModeItem)
+            if (model.SelectedItemOpt == model.SuggestionModeItem)
             {
                 return char.IsLetterOrDigit(ch);
             }
 
-            var textTypedSoFar = GetTextTypedSoFar(model, model.SelectedItem);
-            return IsFilterCharacter(model.SelectedItem, ch, textTypedSoFar);
+            var textTypedSoFar = GetTextTypedSoFar(model, model.SelectedItemOpt);
+            return IsFilterCharacter(model.SelectedItemOpt, ch, textTypedSoFar);
         }
 
         private static bool TextTypedSoFarMatchesItem(CompletionItem item, char ch, string textTypedSoFar)
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             Contract.ThrowIfNull(model);
 
             this.Commit(
-                model.SelectedItem, model, ch,
+                model.SelectedItemOpt, model, ch,
                 initialTextSnapshot, nextHandler);
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             // TODO(cyrusn): Find a way to allow the user to cancel out of this.
             var model = sessionOpt.WaitForModel();
-            if (model == null || model.IsSoftSelection)
+            if (model == null || model.IsSoftSelection || model.SelectedItem == null)
             {
                 return false;
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
@@ -22,6 +22,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         public CompletionList OriginalList { get; }
         public ImmutableArray<CompletionItem> FilteredItems { get; }
 
+        /// <summary>
+        /// The currently selected item. Note that this can be null
+        /// in VS 15+ if the user uses completion list filters
+        /// hide all the items in the list.
+        /// </summary>
         public CompletionItem SelectedItem { get; }
 
         public ImmutableArray<CompletionItemFilter> CompletionItemFilters { get; }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
@@ -65,7 +65,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             bool dismissIfEmpty)
         {
             Contract.ThrowIfFalse(originalList.Items.Length != 0, "Must have at least one item.");
-            Contract.ThrowIfNull(selectedItem);
 
             this.TriggerDocument = triggerDocument;
             _disconnectedBufferGraph = disconnectedBufferGraph;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
@@ -24,10 +24,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
         /// <summary>
         /// The currently selected item. Note that this can be null
-        /// in VS 15+ if the user uses completion list filters
+        /// in VS 15+ if the user uses completion list filters to
         /// hide all the items in the list.
         /// </summary>
-        public CompletionItem SelectedItem { get; }
+        public CompletionItem SelectedItemOpt { get; }
 
         public ImmutableArray<CompletionItemFilter> CompletionItemFilters { get; }
         public ImmutableDictionary<CompletionItemFilter, bool> FilterState { get; }
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             this.OriginalList = originalList;
             this.FilteredItems = filteredItems;
             this.FilterState = filterState;
-            this.SelectedItem = selectedItem;
+            this.SelectedItemOpt = selectedItem;
             this.CompletionItemFilters = completionItemFilters;
             this.FilterText = filterText;
             this.IsHardSelection = isHardSelection;
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             Optional<ITrackingPoint> commitTrackingSpanEndPoint = default(Optional<ITrackingPoint>))
         {
             var newFilteredItems = filteredItems.HasValue ? filteredItems.Value : FilteredItems;
-            var newSelectedItem = selectedItem.HasValue ? selectedItem.Value : SelectedItem;
+            var newSelectedItem = selectedItem.HasValue ? selectedItem.Value : SelectedItemOpt;
             var newFilterState = filterState.HasValue ? filterState.Value : FilterState;
             var newFilterText = filterText.HasValue ? filterText.Value : FilterText;
             var newIsHardSelection = isHardSelection.HasValue ? isHardSelection.Value : IsHardSelection;
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             var newCommitTrackingSpanEndPoint = commitTrackingSpanEndPoint.HasValue ? commitTrackingSpanEndPoint.Value : CommitTrackingSpanEndPoint;
 
             if (newFilteredItems == FilteredItems &&
-                newSelectedItem == SelectedItem &&
+                newSelectedItem == SelectedItemOpt &&
                 newFilterState == FilterState &&
                 newFilterText == FilterText &&
                 newIsHardSelection == IsHardSelection &&

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/Roslyn14CompletionSet.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/Roslyn14CompletionSet.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
             CreateCompletionListBuilder(selectedItem, suggestionModeItem, suggestionMode);
             CreateNormalCompletionListItems(completionItems);
 
-            var selectedCompletionItem = GetVSCompletion(selectedItem);
+            var selectedCompletionItem = selectedItem != null ? GetVSCompletion(selectedItem) : null;
             VsCompletionSet.SelectionStatus = new CompletionSelectionStatus(
                 selectedCompletionItem, 
                 isSelected: !isSoftSelected, isUnique: selectedCompletionItem != null);

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.Commands
@@ -2568,6 +2569,141 @@ class C
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem("ConfigureAwait")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function Filters_EmptyList1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        var x = asd$$
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.InterfaceFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SelectedItem)
+
+            End Using
+        End Function
+
+        Public Async Function Filters_EmptyList2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        var x = asd$$
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.InterfaceFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SelectedItem)
+                state.SendTab()
+                Await state.AssertNoCompletionSession()
+
+            End Using
+        End Function
+
+        Public Async Function Filters_EmptyList3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        var x = asd$$
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.InterfaceFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SelectedItem)
+                state.SendReturn()
+                Await state.AssertNoCompletionSession()
+
+            End Using
+        End Function
+
+        Public Async Function Filters_EmptyList4() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+using System.IO;
+using System.Threading.Tasks;
+class C
+{
+    async Task Moo()
+    {
+        var x = asd$$
+    }
+}
+            ]]></Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Dim filters = state.CurrentCompletionPresenterSession.CompletionItemFilters
+                Dim dict = New Dictionary(Of CompletionItemFilter, Boolean)
+                For Each f In filters
+                    dict(f) = False
+                Next
+
+                dict(CompletionItemFilter.InterfaceFilter) = True
+
+                Dim args = New CompletionItemFilterStateChangedEventArgs(dict.ToImmutableDictionary())
+                state.CurrentCompletionPresenterSession.RaiseFiltersChanged(args)
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SelectedItem)
+                state.SendTypeChars(".")
+                Await state.AssertNoCompletionSession()
+
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenterSession.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenterSession.vb
@@ -40,6 +40,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Me.SelectedItem = selectedItem
             Me.IsSoftSelected = isSoftSelected
             Me.SuggestionModeItem = suggestionModeItem
+            Me._completionFilters = completionItemFilters
         End Sub
 
         Public Sub Dismiss() Implements ICompletionPresenterSession.Dismiss
@@ -73,6 +74,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         End Sub
 
         Private Const s_itemsPerPage = 9
+        Private _completionFilters As ImmutableArray(Of CompletionItemFilter)
+
+        Public ReadOnly Property CompletionItemFilters As ImmutableArray(Of CompletionItemFilter)
+            Get
+                Return _completionFilters
+            End Get
+        End Property
 
         Public Sub SelectPreviousPageItem() Implements ICompletionPresenterSession.SelectPreviousPageItem
             SetSelectedItem(GetFilteredItemAt(CompletionItems.IndexOf(SelectedItem) - s_itemsPerPage))
@@ -80,6 +88,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         Public Sub SelectNextPageItem() Implements ICompletionPresenterSession.SelectNextPageItem
             SetSelectedItem(GetFilteredItemAt(CompletionItems.IndexOf(SelectedItem) + s_itemsPerPage))
+        End Sub
+
+        Public Sub RaiseFiltersChanged(args As CompletionItemFilterStateChangedEventArgs)
+            RaiseEvent CompletionFiltersChanged(Me, args)
         End Sub
     End Class
 End Namespace


### PR DESCRIPTION
**Customer scenario**

If the customer uses completion list filters in a way that hides all the items in the list, Visual Studio crashes.

**Bugs this fixes:** 
https://github.com/dotnet/roslyn/issues/15006

**Workarounds, if any**
None


**Risk**
Low--this only affects handling of the case where completion filters remove all items from the editor list.

**Performance impact**
None--no additional allocations or CPU time.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
When we implemented completion filters, we did not test what happened if you filtered all items out of the list.

**How was the bug found?**
Dogfooding.
