### PR TITLE
Add fixed version of Newtonsoft.Json

### DIFF
--- a/build/ToolsetPackages/closed.project.json
+++ b/build/ToolsetPackages/closed.project.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
         "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.35",
+        "Newtonsoft.Json": "9.0.1",
         "System.IdentityModel.Tokens.Jwt": "5.0.0",
         "System.IO.Compression.ZipFile": "4.0.1"
     },

--- a/build/config/RepoUtilData.json
+++ b/build/config/RepoUtilData.json
@@ -2,6 +2,7 @@
     "fixedPackages": {
         "Microsoft.VisualStudio.Language.Intellisense": "14.3.25407",
         "Microsoft.VSSDK.BuildTools": [ "14.3.25420", "15.0.25907-RC2" ],
+        "Newtonsoft.Json": [ "9.0.1" ],
         "System.Reflection.Metadata": "1.0.21",
         "System.Collections.Immutable": "1.1.36",
         "Microsoft.VisualStudio.Editor": [ "14.3.25407", "15.0.25726-Preview5" ],


### PR DESCRIPTION
One of our internal tools can't use the standard version of Newtonsoft.Json.  Need an exception for this package.