### PR TITLE
Adds support for namespace XML doc comments

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.DocumentationComments;
 using Roslyn.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Threading;
@@ -41,6 +43,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         /// All type members in a flat array
         /// </summary>
         private ImmutableArray<PENamedTypeSymbol> _lazyFlattenedTypes;
+
+        private Tuple<CultureInfo, string> _lazyDocComment;
 
         internal sealed override NamespaceExtent Extent
         {
@@ -307,6 +311,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
 
             return result;
+        }
+
+        public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return PEDocumentationCommentUtils.GetDocumentationComment(this, ContainingPEModule, preferredCulture, cancellationToken, ref _lazyDocComment);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -26,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private Dictionary<string, ImmutableArray<NamedTypeSymbol>> _nameToTypeMembersMap;
         private ImmutableArray<Symbol> _lazyAllMembers;
         private ImmutableArray<NamedTypeSymbol> _lazyTypeMembersUnordered;
+        private string _lazyDocComment;
 
         private const int LazyAllMembersIsSorted = 0x1;   // Set if "lazyAllMembers" is sorted.
         private int _flags;
@@ -546,6 +548,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 return result;
             }
+        }
+
+        public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return SourceDocumentationCommentUtils.GetAndCacheDocumentationComment(this, expandIncludes, ref _lazyDocComment);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
@@ -3800,6 +3800,34 @@ class C { }
         }
 
         [Fact]
+        public void ForSingleNamespace()
+        {
+            var source = @"
+/// <summary>
+///  A
+///   B
+///  C
+/// </summary>
+namespace N { class C { } }
+";
+
+            var compilation = CreateCompilationWithMscorlibAndDocumentationComments(source);
+
+            var type = compilation.GlobalNamespace.GetMember<NamespaceSymbol>("N");
+            var actualText = DocumentationCommentCompiler.GetDocumentationCommentXml(type, processIncludes: true, cancellationToken: default(CancellationToken));
+            var expectedText =
+@"<member name=""N:N"">
+    <summary>
+     A
+      B
+     C
+    </summary>
+</member>
+";
+            Assert.Equal(expectedText, actualText);
+        }
+
+        [Fact]
         public void ForSingleTypeWithInclude()
         {
             var xmlFile = Temp.CreateFile(extension: ".xml").WriteAllText("<stuff />");

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Common.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Common.vb
@@ -726,6 +726,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Case SymbolKind.Event
                         Return "event"
+                        
+                    Case SymbolKind.Namespace
+                        Return "namespace"
 
                     Case SymbolKind.NamedType
                         Select Case DirectCast(symbol, NamedTypeSymbol).TypeKind

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Namespace.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.Namespace.vb
@@ -24,40 +24,112 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If Not ShouldSkipSymbol(symbol) Then
 
-                    If symbol.IsGlobalNamespace Then
-                        Debug.Assert(Me._assemblyName IsNot Nothing)
+                    If Not Me._isForSingleSymbol Then
+                        If symbol.IsGlobalNamespace Then
+                            Debug.Assert(Me._assemblyName IsNot Nothing)
 
-                        WriteLine("<?xml version=""1.0""?>")
-                        WriteLine("<doc>")
-                        Indent()
-
-                        If Not Me._compilation.Options.OutputKind.IsNetModule() Then
-                            WriteLine("<assembly>")
+                            WriteLine("<?xml version=""1.0""?>")
+                            WriteLine("<doc>")
                             Indent()
-                            WriteLine("<name>")
-                            WriteLine(Me._assemblyName)
-                            WriteLine("</name>")
-                            Unindent()
-                            WriteLine("</assembly>")
-                        End If
 
-                        WriteLine("<members>")
-                        Indent()
+                            If Not Me._compilation.Options.OutputKind.IsNetModule() Then
+                                WriteLine("<assembly>")
+                                Indent()
+                                WriteLine("<name>")
+                                WriteLine(Me._assemblyName)
+                                WriteLine("</name>")
+                                Unindent()
+                                WriteLine("</assembly>")
+                            End If
+
+                            WriteLine("<members>")
+                            Indent()
+                        End If
                     End If
 
-                    Debug.Assert(Not Me._isForSingleSymbol, "Do not expect a doc comment query for a single namespace")
-                    For Each member In symbol.GetMembers()
-                        Me.Visit(member)
-                    Next
+                    WriteDocumentationCommentForNamedType(symbol)
+                    
+                    If Not Me._isForSingleSymbol Then
+                        For Each member In symbol.GetMembers()
+                            Me.Visit(member)
+                        Next
 
-                    If symbol.IsGlobalNamespace Then
-                        Unindent()
-                        WriteLine("</members>")
-                        Unindent()
-                        WriteLine("</doc>")
+                        If symbol.IsGlobalNamespace Then
+                            Unindent()
+                            WriteLine("</members>")
+                            Unindent()
+                            WriteLine("</doc>")
+                        End If
                     End If
 
                 End If
+            End Sub
+            
+            Private Sub WriteDocumentationCommentForNamedType(symbol As Symbols.NamespaceSymbol)
+
+                Dim multipleDocComments = ArrayBuilder(Of DocumentationCommentTriviaSyntax).GetInstance
+                Dim maxDocumentationMode As DocumentationMode = DocumentationMode.None
+
+                Dim symbolName As String = GetSymbolName(symbol)
+
+                If multipleDocComments.Count > 1 Then
+                    ' In case we have multiple documentation comments we should discard 
+                    ' all of them with (optionally) reporting all diagnostics 
+                    If maxDocumentationMode = DocumentationMode.Diagnose Then
+                        For Each trivia In multipleDocComments
+                            Me._diagnostics.Add(ERRID.WRN_XMLDocOnAPartialType, trivia.GetLocation(), symbolName)
+                        Next
+                    End If
+                    multipleDocComments.Free()
+
+                    ' No further processing of any of the found documentation comments
+                    Return
+
+                ElseIf multipleDocComments.Count = 0 Then
+                    multipleDocComments.Free()
+                    Return
+                End If
+
+                Dim wellKnownElementNodes As New Dictionary(Of WellKnownTag, ArrayBuilder(Of XmlNodeSyntax))
+                Dim theOnlyDocumentationCommentTrivia As DocumentationCommentTriviaSyntax = multipleDocComments(0)
+                multipleDocComments.Free()
+
+                Dim docCommentXml As String = GetDocumentationCommentForSymbol(symbol, theOnlyDocumentationCommentTrivia, wellKnownElementNodes)
+
+                ' No further processing
+                If docCommentXml Is Nothing Then
+                    FreeWellKnownElementNodes(wellKnownElementNodes)
+                    Return
+                End If
+
+                If theOnlyDocumentationCommentTrivia.SyntaxTree.ReportDocumentationCommentDiagnostics OrElse _writer.IsSpecified Then
+
+                    ' Duplicate top-level well known tags
+                    ReportWarningsForDuplicatedTags(wellKnownElementNodes)
+
+                    ' <exception>
+                    ReportIllegalWellKnownTagIfAny(WellKnownTag.Exception, wellKnownElementNodes, symbolName)
+
+                    ' <returns>
+                    ReportIllegalWellKnownTagIfAny(WellKnownTag.Returns, wellKnownElementNodes, symbolName)
+
+                    ' <param> & <paramref>
+                    ReportIllegalWellKnownTagIfAny(WellKnownTag.Param, wellKnownElementNodes, symbolName)
+                    ReportIllegalWellKnownTagIfAny(WellKnownTag.ParamRef, wellKnownElementNodes, symbolName)
+
+                    ' <value>
+                    ReportIllegalWellKnownTagIfAny(WellKnownTag.Value, wellKnownElementNodes, symbolName)
+
+                    ' <typeparam>
+                    ReportIllegalWellKnownTagIfAny(WellKnownTag.TypeParam, wellKnownElementNodes, symbolName)
+
+                    ' <typeparamref>
+                    ReportWarningsForTypeParamRefTags(wellKnownElementNodes, symbolName, symbol, theOnlyDocumentationCommentTrivia.SyntaxTree)
+                End If
+
+                FreeWellKnownElementNodes(wellKnownElementNodes)
+
+                WriteDocumentationCommentForSymbol(docCommentXml)
             End Sub
 
         End Class

--- a/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/DocumentationComments/DocumentationCommentCompiler.vb
@@ -109,7 +109,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                              symbol.Kind = SymbolKind.Field OrElse
                              symbol.Kind = SymbolKind.Method OrElse
                              symbol.Kind = SymbolKind.NamedType OrElse
-                             symbol.Kind = SymbolKind.Property)
+                             symbol.Kind = SymbolKind.Property OrElse
+                             symbol.Kind = SymbolKind.Namespace)
 
                 Dim compilation As VisualBasicCompilation = symbol.DeclaringCompilation
                 Debug.Assert(compilation IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamespaceSymbol.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Globalization
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.ImmutableArrayExtensions
 Imports Microsoft.CodeAnalysis.Text
@@ -17,6 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private _nameToMembersMap As Dictionary(Of String, ImmutableArray(Of NamespaceOrTypeSymbol))
         Private _nameToTypeMembersMap As Dictionary(Of String, ImmutableArray(Of NamedTypeSymbol))
         Private _lazyEmbeddedKind As Integer = EmbeddedSymbolKind.Unset
+        Private _lazyDocComment As String
 
         ' lazily evaluated state of the symbol (StateFlags)
         Private _lazyState As Integer
@@ -666,5 +668,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return _declaration
             End Get
         End Property
+
+        Public Overrides Function GetDocumentationCommentXml(Optional preferredCulture As CultureInfo = Nothing, Optional expandIncludes As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As String
+            If _lazyDocComment Is Nothing Then
+                ' NOTE: replace Nothing with empty comment
+                Interlocked.CompareExchange(
+                    _lazyDocComment, GetDocumentationCommentForSymbol(Me, preferredCulture, expandIncludes, cancellationToken), Nothing)
+            End If
+
+            Return _lazyDocComment
+        End Function
+
     End Class
 End Namespace


### PR DESCRIPTION
This PR addresses the lack of support for namespace XML comments as described in #15474. Since it was a fairly simple change, I decided to go ahead and implement so that the PR could be used for discussion (and hopefully merged eventually).

**Customer scenario**

.NET documentation generators have been forced to come up with their own ways of representing namespace documentation, and nearly all of them have tried to approach namespace-level documentation in one way or another. This shows that the lack of official compiler support for namespace documentation comments is an ongoing deficit. This PR adds support for reporting XML documentation comments at the namespace level in both Roslyn symbol representations and the generated XML documentation output file.

**Bugs this fixes:** 

#15474

**Workarounds, if any**

Reflection can be used to get the formatted XML documentation for a namespace (see #15474).

**Risk**

There is a chance that changes to the generated XML documentation output file to include namespace XML documentation comments might break consumers of the file. This is mitigated by the fact that unless a namespace has XML documentation comments in the first place, they won't be output to the file. The presence of such comments on a namespace prior to this change is unlikely as they wouldn't have been picked up by the compiler and so would have been of little use.

**Performance impact**

I suspect (though do not know for sure) that this has a low performance impact since it uses the same mechanisms of compiling documentation comments as do other symbols, which have already been optimized.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This is new functionality, and a test has been added to verify correct operation.

**How was the bug found?**

While developing a Roslyn-based .NET documentation generator and requiring information about namespaces to be available.
