### PR TITLE
Add a small amount of support for Expression-Bodied properties in CodeModel.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
@@ -37,6 +37,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             {
                 switch (node.Kind())
                 {
+                    case SyntaxKind.ArrowExpressionClause:
+                        return GetStartPoint(text, (ArrowExpressionClauseSyntax)node, part);
                     case SyntaxKind.Attribute:
                         return GetStartPoint(text, (AttributeSyntax)node, part);
                     case SyntaxKind.AttributeArgument:
@@ -83,6 +85,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             {
                 switch (node.Kind())
                 {
+                    case SyntaxKind.ArrowExpressionClause:
+                        return GetEndPoint(text, (ArrowExpressionClauseSyntax)node, part);
                     case SyntaxKind.Attribute:
                         return GetEndPoint(text, (AttributeSyntax)node, part);
                     case SyntaxKind.AttributeArgument:
@@ -209,6 +213,27 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 return string.IsNullOrWhiteSpace(textBeforeBrace)
                     ? new VirtualTreePoint(closeBrace.SyntaxTree, text, closeBraceLine.Start)
                     : new VirtualTreePoint(closeBrace.SyntaxTree, text, closeBrace.SpanStart);
+            }
+
+            private VirtualTreePoint GetStartPoint(SourceText text, ArrowExpressionClauseSyntax node, EnvDTE.vsCMPart part)
+            {
+                int startPosition;
+
+                switch (part)
+                {
+                    case EnvDTE.vsCMPart.vsCMPartWhole:
+                        startPosition = node.SpanStart;
+                        break;
+
+                    case EnvDTE.vsCMPart.vsCMPartBody:
+                        startPosition = node.Expression.SpanStart;
+                        break;
+
+                    default:
+                        throw Exceptions.ThrowENotImpl();
+                }
+
+                return new VirtualTreePoint(node.SyntaxTree, text, startPosition);
             }
 
             private VirtualTreePoint GetStartPoint(SourceText text, AttributeSyntax node, EnvDTE.vsCMPart part)
@@ -757,6 +782,24 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 }
 
                 return new VirtualTreePoint(node.SyntaxTree, text, startPosition);
+            }
+
+            private VirtualTreePoint GetEndPoint(SourceText text, ArrowExpressionClauseSyntax node, EnvDTE.vsCMPart part)
+            {
+                int endPosition;
+
+                switch (part)
+                {
+                    case EnvDTE.vsCMPart.vsCMPartWhole:
+                    case EnvDTE.vsCMPart.vsCMPartBody:
+                        endPosition = node.Span.End;
+                        break;
+
+                    default:
+                        throw Exceptions.ThrowENotImpl();
+                }
+
+                return new VirtualTreePoint(node.SyntaxTree, text, endPosition);
             }
 
             private VirtualTreePoint GetEndPoint(SourceText text, AttributeSyntax node, EnvDTE.vsCMPart part)

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -1478,7 +1478,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             return SpecializedCollections.EmptyEnumerable<ParameterSyntax>();
         }
 
-        public override bool IsAutoProperty(SyntaxNode node)
+        public override bool IsExpressionBodiedProperty(SyntaxNode node)
             => (node as PropertyDeclarationSyntax)?.ExpressionBody != null;
 
         public override bool TryGetAutoPropertyExpressionBody(SyntaxNode parentNode, out SyntaxNode accessorNode)

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -1478,6 +1478,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             return SpecializedCollections.EmptyEnumerable<ParameterSyntax>();
         }
 
+        public override bool IsAutoProperty(SyntaxNode node)
+            => (node as PropertyDeclarationSyntax)?.ExpressionBody != null;
+
+        public override bool TryGetAutoPropertyExpressionBody(SyntaxNode parentNode, out SyntaxNode accessorNode)
+        {
+            accessorNode = (parentNode as PropertyDeclarationSyntax)?.ExpressionBody;
+            return accessorNode != null;
+        }
+
         public override bool IsAccessorNode(SyntaxNode node)
         {
             switch (node.Kind())

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -686,10 +686,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             return false;
         }
 
+        public abstract bool IsAutoProperty(SyntaxNode node);
         public abstract bool IsAccessorNode(SyntaxNode node);
         public abstract MethodKind GetAccessorKind(SyntaxNode node);
 
         public abstract bool TryGetAccessorNode(SyntaxNode parentNode, MethodKind kind, out SyntaxNode accessorNode);
+        public abstract bool TryGetAutoPropertyExpressionBody(SyntaxNode parentNode, out SyntaxNode accessorNode);
         public abstract bool TryGetParameterNode(SyntaxNode parentNode, string name, out SyntaxNode parameterNode);
         public abstract bool TryGetImportNode(SyntaxNode parentNode, string dottedName, out SyntaxNode importNode);
         public abstract bool TryGetOptionNode(SyntaxNode parentNode, string name, int ordinal, out SyntaxNode optionNode);

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -686,7 +686,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             return false;
         }
 
-        public abstract bool IsAutoProperty(SyntaxNode node);
+        public abstract bool IsExpressionBodiedProperty(SyntaxNode node);
         public abstract bool IsAccessorNode(SyntaxNode node);
         public abstract MethodKind GetAccessorKind(SyntaxNode node);
 

--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         SyntaxNode SetAccess(SyntaxNode node, EnvDTE.vsCMAccess access);
         EnvDTE.vsCMElement GetElementKind(SyntaxNode node);
 
-        bool IsAutoProperty(SyntaxNode node);
+        bool IsExpressionBodiedProperty(SyntaxNode node);
         bool IsAccessorNode(SyntaxNode node);
         MethodKind GetAccessorKind(SyntaxNode node);
 

--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -146,10 +146,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         SyntaxNode SetAccess(SyntaxNode node, EnvDTE.vsCMAccess access);
         EnvDTE.vsCMElement GetElementKind(SyntaxNode node);
 
+        bool IsAutoProperty(SyntaxNode node);
         bool IsAccessorNode(SyntaxNode node);
         MethodKind GetAccessorKind(SyntaxNode node);
 
         bool TryGetAccessorNode(SyntaxNode parentNode, MethodKind kind, out SyntaxNode accessorNode);
+        bool TryGetAutoPropertyExpressionBody(SyntaxNode parentNode, out SyntaxNode expressionBody);
         bool TryGetParameterNode(SyntaxNode parentNode, string name, out SyntaxNode parameterNode);
         bool TryGetImportNode(SyntaxNode parentNode, string dottedName, out SyntaxNode importNode);
         bool TryGetOptionNode(SyntaxNode parentNode, string name, int ordinal, out SyntaxNode optionNode);

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAccessorFunction.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAccessorFunction.cs
@@ -35,15 +35,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             _kind = kind;
         }
 
-        private AbstractCodeMember ParentMember
-        {
-            get { return _parentHandle.Value; }
-        }
+        private AbstractCodeMember ParentMember => _parentHandle.Value;
 
         private bool IsPropertyAccessor()
-        {
-            return _kind == MethodKind.PropertyGet || _kind == MethodKind.PropertySet;
-        }
+            => _kind == MethodKind.PropertyGet || _kind == MethodKind.PropertySet;
 
         internal override bool TryLookupNode(out SyntaxNode node)
         {
@@ -55,53 +50,29 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
                 return false;
             }
 
-            SyntaxNode accessorNode;
-            if (!CodeModelService.TryGetAccessorNode(parentNode, _kind, out accessorNode))
-            {
-                return false;
-            }
-
-            node = accessorNode;
-            return node != null;
+            return CodeModelService.TryGetAutoPropertyExpressionBody(parentNode, out node) ||
+                   CodeModelService.TryGetAccessorNode(parentNode, _kind, out node);
         }
 
         public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementFunction; }
-        }
+            => EnvDTE.vsCMElement.vsCMElementFunction;
 
-        public override object Parent
-        {
-            get { return _parentHandle.Value; }
-        }
+        public override object Parent => _parentHandle.Value;
 
         public override EnvDTE.CodeElements Children
-        {
-            get { return EmptyCollection.Create(this.State, this); }
-        }
+            => EmptyCollection.Create(this.State, this);
 
         protected override string GetName()
-        {
-            return this.ParentMember.Name;
-        }
+            => this.ParentMember.Name;
 
         protected override void SetName(string value)
-        {
-            this.ParentMember.Name = value;
-        }
+            => this.ParentMember.Name = value;
 
         protected override string GetFullName()
-        {
-            return this.ParentMember.FullName;
-        }
+            => this.ParentMember.FullName;
 
         public EnvDTE.CodeElements Attributes
-        {
-            get
-            {
-                return AttributeCollection.Create(this.State, this);
-            }
-        }
+            => AttributeCollection.Create(this.State, this);
 
         public EnvDTE.vsCMAccess Access
         {
@@ -212,10 +183,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             }
         }
 
-        public bool IsOverloaded
-        {
-            get { return false; }
-        }
+        public bool IsOverloaded => false;
 
         public bool IsShared
         {
@@ -272,12 +240,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         }
 
         public EnvDTE.CodeElements Overloads
-        {
-            get
-            {
-                throw Exceptions.ThrowEFail();
-            }
-        }
+            => throw Exceptions.ThrowEFail();
 
         public EnvDTE.CodeElements Parameters
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
@@ -144,16 +144,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         }
 
         private bool HasAccessorNode(MethodKind methodKind)
-        {
-            SyntaxNode accessorNode;
-            return CodeModelService.TryGetAccessorNode(LookupNode(), methodKind, out accessorNode);
-        }
+            => CodeModelService.TryGetAccessorNode(LookupNode(), methodKind, out var accessorNode);
+
+        private bool IsAutoProperty()
+            => CodeModelService.IsAutoProperty(LookupNode());
 
         public EnvDTE.CodeFunction Getter
         {
             get
             {
-                if (!HasAccessorNode(MethodKind.PropertyGet))
+                if (!HasAccessorNode(MethodKind.PropertyGet) &&
+                    !IsAutoProperty())
                 {
                     return null;
                 }

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
@@ -146,15 +146,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         private bool HasAccessorNode(MethodKind methodKind)
             => CodeModelService.TryGetAccessorNode(LookupNode(), methodKind, out var accessorNode);
 
-        private bool IsAutoProperty()
-            => CodeModelService.IsAutoProperty(LookupNode());
+        private bool IsExpressionBodiedProperty()
+            => CodeModelService.IsExpressionBodiedProperty(LookupNode());
 
         public EnvDTE.CodeFunction Getter
         {
             get
             {
                 if (!HasAccessorNode(MethodKind.PropertyGet) &&
-                    !IsAutoProperty())
+                    !IsExpressionBodiedProperty())
                 {
                     return null;
                 }

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
@@ -55,6 +55,68 @@ class C
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestAutoPropGetStartPoint1() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P => 0;
+}
+</Code>
+
+            Await TestElement(
+                code,
+                Sub(prop)
+                    Dim getter = prop.Getter
+                    Dim textPointGetter = Function(part As EnvDTE.vsCMPart)
+                                              Return getter.GetStartPoint(part)
+                                          End Function
+
+                    Part(EnvDTE.vsCMPart.vsCMPartAttributes, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartAttributesWithDelimiter, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartBody, TextPoint(line:=3, lineOffset:=21, absoluteOffset:=31, lineLength:=22))(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartBodyWithDelimiter, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartHeader, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartHeaderWithAttributes, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartName, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartNavigate, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartWhole, TextPoint(line:=3, lineOffset:=18, absoluteOffset:=28, lineLength:=22))(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes, ThrowsNotImplementedException)(textPointGetter)
+                End Sub)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestAutoPropGetEndPoint1() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P => 0;
+}
+</Code>
+
+            Await TestElement(
+                code,
+                Sub(prop)
+                    Dim getter = prop.Getter
+                    Dim textPointGetter = Function(part As EnvDTE.vsCMPart)
+                                              Return getter.GetEndPoint(part)
+                                          End Function
+
+                    Part(EnvDTE.vsCMPart.vsCMPartAttributes, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartAttributesWithDelimiter, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartBody, TextPoint(line:=3, lineOffset:=22, absoluteOffset:=32, lineLength:=22))(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartBodyWithDelimiter, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartHeader, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartHeaderWithAttributes, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartName, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartNavigate, ThrowsNotImplementedException)(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartWhole, TextPoint(line:=3, lineOffset:=22, absoluteOffset:=32, lineLength:=22))(textPointGetter)
+                    Part(EnvDTE.vsCMPart.vsCMPartWholeWithAttributes, ThrowsNotImplementedException)(textPointGetter)
+                End Sub)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestGetStartPoint_Attribute() As Task
             Dim code =
 <Code>

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -1048,6 +1048,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
             Return GetExternalSymbolFullName(symbol)
         End Function
 
+        Public Overrides Function IsAutoProperty(node As SyntaxNode) As Boolean
+            Return False
+        End Function
+
+        Public Overrides Function TryGetAutoPropertyExpressionBody(parentNode As SyntaxNode, ByRef accessorNode As SyntaxNode) As Boolean
+            Return False
+        End Function
+
         Public Overrides Function IsAccessorNode(node As SyntaxNode) As Boolean
             Select Case node.Kind
                 Case SyntaxKind.GetAccessorBlock,

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -1048,7 +1048,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
             Return GetExternalSymbolFullName(symbol)
         End Function
 
-        Public Overrides Function IsAutoProperty(node As SyntaxNode) As Boolean
+        Public Overrides Function IsExpressionBodiedProperty(node As SyntaxNode) As Boolean
             Return False
         End Function
 


### PR DESCRIPTION
**Customer scenario**

Customer uses the existing Unit-Test-Generation framework.  Customer is using modern C# expression-bodied properties (i.e. => properties).  UnitTestGeneration fails because their code does not understand expressed-bodied properties.  Customer cannot create unit-tests.

This is exacerbated by us changing our defaults to prefer => properties over old-style properties.



**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/290127


**Workarounds, if any**

Customer has to change how they write code (rolling back use of modern C# features), and disable our code gen options.


**Risk**

Tiny.


**Performance impact**

None.  


**Is this a regression from a previous update?**

No.  But it's more prevalent now as we push people to modern C# features.


**Root cause analysis:**

UnitTestGeneratoin framework uses CodeModel to introspect and mutate the user's code. Our CodeModel layer is basically in pure maintenance mode (after all, we recommend using Roslyn APIs directly now) and was never updated to handle modern features like C# auto-properties.  Because of this, the UnitTestGEneration feature didn't know how to handle these styles of properties and ends up failing.


**How was the bug found?**

From the UnitTestGeneration team.  Looks like ownership of this has floated around.  So this was found very late.  Also, in default projects/tests you don't see this.  