### PR TITLE
Correctly deal with bad upstream data being fetched from the settings store

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
@@ -132,8 +132,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 }
                 else
                 {
-                    value = optionKey.Option.DefaultValue;
+                    value = null;
+                    return false;
                 }
+            }
+            else if (optionKey.Option.Type == typeof(bool) && value is int intValue)
+            {
+                // TypeScript used to store some booleans as integers. We now handle them properly for legacy sync scenarios.
+                value = intValue != 0;
+                return true;
+            }
+            else if (optionKey.Option.Type == typeof(bool) && value is long longValue)
+            {
+                // TypeScript used to store some booleans as integers. We now handle them properly for legacy sync scenarios.
+                value = longValue != 0;
+                return true;
+            }
+            else if (value != null && optionKey.Option.Type != value.GetType())
+            {
+                // We got something back different than we expected, so fail to deserialize
+                value = null;
+                return false;
             }
 
             return true;


### PR DESCRIPTION
Previously, we would return the incorrectly typed data and then we'd
crash downstream of that. Now we'll be more robust.

**Customer scenario**

In the particular report, the user crashed when pasting code. More generally, this is a general stability improvement in a core service that would impact any user that had their cloud profile get corrupted somehow.

**Bugs this fixes:** Fixes dotnet/roslyn#15214.

**Workarounds, if any:** No good ones. The data is being roamed to the cloud and there's no gesture to clear that.

**Risk** Low.

**Performance impact:** None. Adding a simple type check.

**Is this a regression from a previous update?** No, this has been unsafe for a long time.

**Root cause analysis:** The code was simply never safe against bad data being put into the cloud. This is probably happening because the TypeScript editor before being switched to Roslyn stored this as an int, when now it's a Boolean.

**How was the bug found?** Internal report.