### PR TITLE
Disabling the integration jobs from running automatically during PRs.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -197,7 +197,7 @@ set TMP=%TEMP%
         }
       }
 
-      def triggerPhraseOnly = false
+      def triggerPhraseOnly = true
       def triggerPhraseExtra = ""
       Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-dev15-rc')
       Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')


### PR DESCRIPTION
Jobs are currently failing somewhere between 5-10% of the time with the following failure:

```
error VSSDK1081: Problem occurred while extracting the vsix to the experimental extensions path. [D:\j\workspace\windows_relea---8a39a417\src\VisualStudio\VisualStudioDiagnosticsToolWindow\VisualStudioDiagnosticsWindow.csproj]
```

This is one of the VSIX deployment issues I am told should be fixed in RC2.