### PR TITLE
make document and syntax changed as high priority changes.

### DIFF
--- a/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
@@ -56,7 +56,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             new InvocationReasons(
                 ImmutableHashSet.Create<string>(
                                     PredefinedInvocationReasons.SyntaxChanged,
-                                    PredefinedInvocationReasons.SemanticChanged));
+                                    PredefinedInvocationReasons.SemanticChanged,
+                                    PredefinedInvocationReasons.HighPriority));
 
         public static readonly InvocationReasons AdditionalDocumentChanged =
             new InvocationReasons(
@@ -67,7 +68,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         public static readonly InvocationReasons SyntaxChanged =
             new InvocationReasons(
                 ImmutableHashSet.Create<string>(
-                                    PredefinedInvocationReasons.SyntaxChanged));
+                                    PredefinedInvocationReasons.SyntaxChanged,
+                                    PredefinedInvocationReasons.HighPriority));
 
         public static readonly InvocationReasons SemanticChanged =
             new InvocationReasons(


### PR DESCRIPTION
this address one we discussed here - https://github.com/dotnet/roslyn/issues/14993

basically, if a document is changed (due to text changes), we mark it as high priority changes. syntax changed is a special version of document changes where we verify that only syntax changed due to text changes but no semantic changes.