### PR TITLE
Do not qualify static methods in delegate creations.

### DIFF
--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -983,5 +983,57 @@ CodeStyleOptions.QualifyPropertyAccess, NotificationOption.Warning);
 }",
 CodeStyleOptions.QualifyPropertyAccess, NotificationOption.Error);
         }
+
+        [WorkItem(15325, "https://github.com/dotnet/roslyn/issues/15325")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task QualifyInstanceMethodInDelegateCreation()
+        {
+            await TestAsyncWithOption(
+@"using System;
+
+class A
+{
+    int Function(int x) => x + x;
+
+    void Error()
+    { 
+        var func = new Func<int, int>([|Function|]);
+        func(1);
+    }
+}",
+@"using System;
+
+class A
+{
+    int Function(int x) => x + x;
+
+    void Error()
+    { 
+        var func = new Func<int, int>(this.Function);
+        func(1);
+    }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
+
+        [WorkItem(15325, "https://github.com/dotnet/roslyn/issues/15325")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotQualifyStaticMethodInDelegateCreation()
+        {
+            await TestMissingAsyncWithOption(
+@"using System;
+
+class A
+{
+    static int Function(int x) => x + x;
+
+    void Error()
+    { 
+        var func = new Func<int, int>([|Function|]);
+        func(1);
+    }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
     }
 }

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -66,8 +66,10 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 return;
             }
 
-            // if we can't find a member then we can't do anything
-            if (memberReference.Member == null)
+            // if we can't find a member then we can't do anything.  Also, we shouldn't qualify
+            // accesses to static members.  
+            if (memberReference.Member == null ||
+                memberReference.Member.IsStatic)
             {
                 return;
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15325