### PR TITLE
Preserve comments when converting to a VB object literal.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/UseCollectionInitializer/UseCollectionInitializerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseCollectionInitializer/UseCollectionInitializerTests.vb
@@ -289,5 +289,35 @@ Class C
 End Class",
 compareTokens:=False)
         End Function
+
+        <WorkItem(15528, "https://github.com/dotnet/roslyn/pull/15528")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)>
+        Public Async Function TestTrivia2() As Task
+            Await TestAsync(
+"
+Imports System.Collections.Generic
+Class C
+    Sub M()
+        Dim c = [||]New List(Of Integer)()
+        ' Foo
+        c.Add(1)
+        ' Bar
+        c.Add(2)
+    End Sub
+End Class",
+"
+Imports System.Collections.Generic
+Class C
+    Sub M()
+        ' Foo
+        ' Bar
+        Dim c = New List(Of Integer) From {
+            1,
+            2
+        }
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
@@ -321,5 +321,35 @@ Class C
 End Class",
 compareTokens:=False)
         End Function
+
+        <WorkItem(15525, "https://github.com/dotnet/roslyn/issues/15525")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)>
+        Public Async Function TestTrivia3() As Task
+            Await TestAsync(
+"
+Class C
+    Sub M()
+        Dim XmlAppConfigReader As [||]New XmlTextReader(Reader)
+
+        ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
+        XmlAppConfigReader.DtdProcessing = DtdProcessing.Prohibit
+
+        ' Bar
+        XmlAppConfigReader.WhitespaceHandling = WhitespaceHandling.All
+    End Sub
+End Class",
+"
+Class C
+    Sub M()
+        ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
+        ' Bar
+        Dim XmlAppConfigReader As New XmlTextReader(Reader) With {
+            .DtdProcessing = DtdProcessing.Prohibit,
+            .WhitespaceHandling = WhitespaceHandling.All
+        }
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
@@ -294,5 +294,32 @@ Class C
 End Class",
 compareTokens:=False)
         End Function
+
+        <WorkItem(15525, "https://github.com/dotnet/roslyn/issues/15525")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)>
+        Public Async Function TestTrivia2() As Task
+            Await TestAsync(
+"
+Class C
+    Sub M()
+        Dim XmlAppConfigReader As [||]New XmlTextReader(Reader)
+
+        ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
+        XmlAppConfigReader.DtdProcessing = DtdProcessing.Prohibit
+        XmlAppConfigReader.WhitespaceHandling = WhitespaceHandling.All
+    End Sub
+End Class",
+"
+Class C
+    Sub M()
+        ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
+        Dim XmlAppConfigReader As New XmlTextReader(Reader) With {
+            .DtdProcessing = DtdProcessing.Prohibit,
+            .WhitespaceHandling = WhitespaceHandling.All
+        }
+    End Sub
+End Class",
+compareTokens:=False)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider.cs
@@ -23,7 +23,17 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
             ExpressionStatementSyntax,
             VariableDeclaratorSyntax>
     {
-        protected override ObjectCreationExpressionSyntax GetNewObjectCreation(
+        protected override StatementSyntax GetNewStatement(
+            StatementSyntax statement,
+            ObjectCreationExpressionSyntax objectCreation,
+            ImmutableArray<ExpressionStatementSyntax> matches)
+        {
+            return statement.ReplaceNode(
+                objectCreation,
+                GetNewObjectCreation(objectCreation, matches));
+        }
+
+        private ObjectCreationExpressionSyntax GetNewObjectCreation(
             ObjectCreationExpressionSyntax objectCreation,
             ImmutableArray<ExpressionStatementSyntax> matches)
         {

--- a/src/Features/CSharp/Portable/UseObjectInitializer/CSharpUseObjectInitializerCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseObjectInitializer/CSharpUseObjectInitializerCodeFixProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseObjectInitializer
                 GetNewObjectCreation(objectCreation, matches));
         }
 
-        protected override ObjectCreationExpressionSyntax GetNewObjectCreation(
+        private ObjectCreationExpressionSyntax GetNewObjectCreation(
             ObjectCreationExpressionSyntax objectCreation,
             ImmutableArray<Match<ExpressionSyntax, StatementSyntax, MemberAccessExpressionSyntax, ExpressionStatementSyntax>> matches)
         {

--- a/src/Features/CSharp/Portable/UseObjectInitializer/CSharpUseObjectInitializerCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseObjectInitializer/CSharpUseObjectInitializerCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -20,6 +21,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UseObjectInitializer
             ExpressionStatementSyntax,
             VariableDeclaratorSyntax>
     {
+        protected override StatementSyntax GetNewStatement(
+            StatementSyntax statement, ObjectCreationExpressionSyntax objectCreation, 
+            ImmutableArray<Match<ExpressionSyntax, StatementSyntax, MemberAccessExpressionSyntax, ExpressionStatementSyntax>> matches)
+        {
+            return statement.ReplaceNode(
+                objectCreation,
+                GetNewObjectCreation(objectCreation, matches));
+        }
+
         protected override ObjectCreationExpressionSyntax GetNewObjectCreation(
             ObjectCreationExpressionSyntax objectCreation,
             ImmutableArray<Match<ExpressionSyntax, StatementSyntax, MemberAccessExpressionSyntax, ExpressionStatementSyntax>> matches)

--- a/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
@@ -92,9 +92,8 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 }
 
                 var statement = objectCreation.FirstAncestorOrSelf<TStatementSyntax>();
-                var newStatement = statement.ReplaceNode(
-                    objectCreation,
-                    GetNewObjectCreation(objectCreation, matches.Value)).WithAdditionalAnnotations(Formatter.Annotation);
+                var newStatement = GetNewStatement(statement, objectCreation, matches.Value)
+                    .WithAdditionalAnnotations(Formatter.Annotation);
 
                 var subEditor = new SyntaxEditor(currentRoot, workspace);
 
@@ -111,8 +110,8 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             return SpecializedTasks.EmptyTask;
         }
 
-        protected abstract TObjectCreationExpressionSyntax GetNewObjectCreation(
-            TObjectCreationExpressionSyntax objectCreation,
+        protected abstract TStatementSyntax GetNewStatement(
+            TStatementSyntax statement, TObjectCreationExpressionSyntax objectCreation, 
             ImmutableArray<TExpressionStatementSyntax> matches);
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
@@ -113,10 +113,6 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
             TStatementSyntax statement, TObjectCreationExpressionSyntax objectCreation, 
             ImmutableArray<Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>> matches);
 
-        protected abstract TObjectCreationExpressionSyntax GetNewObjectCreation(
-            TObjectCreationExpressionSyntax objectCreation,
-            ImmutableArray<Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>> matches);
-
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
             public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
@@ -91,9 +91,8 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 }
 
                 var statement = objectCreation.FirstAncestorOrSelf<TStatementSyntax>();
-                var newStatement = statement.ReplaceNode(
-                    objectCreation,
-                    GetNewObjectCreation(objectCreation, matches.Value)).WithAdditionalAnnotations(Formatter.Annotation);
+                var newStatement = GetNewStatement(statement, objectCreation, matches.Value)
+                    .WithAdditionalAnnotations(Formatter.Annotation);
 
                 var subEditor = new SyntaxEditor(currentRoot, workspace);
 
@@ -109,6 +108,10 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
             editor.ReplaceNode(editor.OriginalRoot, currentRoot);
             return SpecializedTasks.EmptyTask;
         }
+
+        protected abstract TStatementSyntax GetNewStatement(
+            TStatementSyntax statement, TObjectCreationExpressionSyntax objectCreation, 
+            ImmutableArray<Match<TExpressionSyntax, TStatementSyntax, TMemberAccessExpressionSyntax, TAssignmentStatementSyntax>> matches);
 
         protected abstract TObjectCreationExpressionSyntax GetNewObjectCreation(
             TObjectCreationExpressionSyntax objectCreation,

--- a/src/Features/VisualBasic/Portable/UseCollectionInitializer/VisualBasicUseCollectionInitializerCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseCollectionInitializer/VisualBasicUseCollectionInitializerCodeFixProvider.vb
@@ -19,7 +19,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseCollectionInitializer
             ExpressionStatementSyntax,
             VariableDeclaratorSyntax)
 
-        Protected Overrides Function GetNewObjectCreation(
+        Protected Overrides Function GetNewStatement(
+                statement As StatementSyntax, objectCreation As ObjectCreationExpressionSyntax,
+                matches As ImmutableArray(Of ExpressionStatementSyntax)) As StatementSyntax
+            Dim newStatement = statement.ReplaceNode(
+                objectCreation,
+                GetNewObjectCreation(objectCreation, matches))
+
+            Dim totalTrivia = ArrayBuilder(Of SyntaxTrivia).GetInstance()
+            totalTrivia.AddRange(statement.GetLeadingTrivia())
+            totalTrivia.Add(SyntaxFactory.ElasticMarker)
+
+            For Each match In matches
+                For Each trivia In match.GetLeadingTrivia()
+                    If trivia.Kind = SyntaxKind.CommentTrivia Then
+                        totalTrivia.Add(trivia)
+                        totalTrivia.Add(SyntaxFactory.ElasticMarker)
+                    End If
+                Next
+            Next
+
+            Return newStatement.WithLeadingTrivia(totalTrivia)
+        End Function
+
+        Private Function GetNewObjectCreation(
                 objectCreation As ObjectCreationExpressionSyntax,
                 matches As ImmutableArray(Of ExpressionStatementSyntax)) As ObjectCreationExpressionSyntax
 

--- a/src/Features/VisualBasic/Portable/UseObjectInitializer/VisualBasicUseObjectInitializerCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseObjectInitializer/VisualBasicUseObjectInitializerCodeFixProvider.vb
@@ -25,10 +25,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseObjectInitializer
                 objectCreation,
                 GetNewObjectCreation(objectCreation, matches))
 
-            Dim leadingComments = matches.SelectMany(Function(m) m.Statement.GetLeadingTrivia()).
-                                          Where(Function(t) t.Kind = SyntaxKind.CommentTrivia)
+            Dim totalTrivia = ArrayBuilder(Of SyntaxTrivia).GetInstance()
+            totalTrivia.AddRange(statement.GetLeadingTrivia())
+            totalTrivia.Add(SyntaxFactory.ElasticMarker)
 
-            Dim totalTrivia = statement.GetLeadingTrivia().Concat(leadingComments).Concat(SyntaxFactory.ElasticMarker)
+            For Each match In matches
+                For Each trivia In match.Statement.GetLeadingTrivia()
+                    If trivia.Kind = SyntaxKind.CommentTrivia Then
+                        totalTrivia.Add(trivia)
+                        totalTrivia.Add(SyntaxFactory.ElasticMarker)
+                    End If
+                Next
+            Next
+
             Return newStatement.WithLeadingTrivia(totalTrivia)
         End Function
 

--- a/src/Features/VisualBasic/Portable/UseObjectInitializer/VisualBasicUseObjectInitializerCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseObjectInitializer/VisualBasicUseObjectInitializerCodeFixProvider.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseObjectInitializer
             Return newStatement.WithLeadingTrivia(totalTrivia)
         End Function
 
-        Protected Overrides Function GetNewObjectCreation(
+        Private Function GetNewObjectCreation(
                 objectCreation As ObjectCreationExpressionSyntax,
                 matches As ImmutableArray(Of Match(Of ExpressionSyntax, StatementSyntax, MemberAccessExpressionSyntax, AssignmentStatementSyntax))) As ObjectCreationExpressionSyntax
 

--- a/src/Features/VisualBasic/Portable/UseObjectInitializer/VisualBasicUseObjectInitializerCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseObjectInitializer/VisualBasicUseObjectInitializerCodeFixProvider.vb
@@ -18,6 +18,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseObjectInitializer
             AssignmentStatementSyntax,
             VariableDeclaratorSyntax)
 
+        Protected Overrides Function GetNewStatement(
+                statement As StatementSyntax, objectCreation As ObjectCreationExpressionSyntax,
+                matches As ImmutableArray(Of Match(Of ExpressionSyntax, StatementSyntax, MemberAccessExpressionSyntax, AssignmentStatementSyntax))) As StatementSyntax
+            Dim newStatement = statement.ReplaceNode(
+                objectCreation,
+                GetNewObjectCreation(objectCreation, matches))
+
+            Dim leadingComments = matches.SelectMany(Function(m) m.Statement.GetLeadingTrivia()).
+                                          Where(Function(t) t.Kind = SyntaxKind.CommentTrivia)
+
+            Dim totalTrivia = statement.GetLeadingTrivia().Concat(leadingComments).Concat(SyntaxFactory.ElasticMarker)
+            Return newStatement.WithLeadingTrivia(totalTrivia)
+        End Function
+
         Protected Overrides Function GetNewObjectCreation(
                 objectCreation As ObjectCreationExpressionSyntax,
                 matches As ImmutableArray(Of Match(Of ExpressionSyntax, StatementSyntax, MemberAccessExpressionSyntax, AssignmentStatementSyntax))) As ObjectCreationExpressionSyntax


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15525