### PR TITLE
Extension method reducer needs to parenthesize argument to prevent precedence change.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -13,9 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
     public class InlineTemporaryTests : AbstractCSharpCodeActionTest
     {
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace)
-        {
-            return new InlineTemporaryCodeRefactoringProvider();
-        }
+            => new InlineTemporaryCodeRefactoringProvider();
 
         private async Task TestFixOneAsync(string initial, string expected, bool compareTokens = true)
         {
@@ -3847,6 +3845,34 @@ class C
     public void M(int x)
     {
         var s2 = string.Replace($""hello {x}"", ""world"");
+    }
+}");
+        }
+
+        [WorkItem(15530, "https://github.com/dotnet/roslyn/issues/15530")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task PArenthesizeAwaitInlinedIntoReducedExtensionMethod()
+        {
+            await TestAsync(
+@"using System.Linq;
+using System.Threading.Tasks;
+
+internal class C
+{
+    async Task M()
+    {
+        var [|t|] = await Task.FromResult("""");
+        t.Any();
+    }
+}",
+@"using System.Linq;
+using System.Threading.Tasks;
+
+internal class C
+{
+    async Task M()
+    {
+        (await Task.FromResult("""")).Any();
     }
 }");
         }

--- a/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/CSharpMetadataAsSourceService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -68,12 +69,11 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
 
-        protected override IEnumerable<AbstractReducer> GetReducers()
-        {
-            yield return new CSharpNameReducer();
-            yield return new CSharpEscapingReducer();
-            yield return new CSharpParenthesesReducer();
-        }
+        protected override ImmutableArray<AbstractReducer> GetReducers()
+            => ImmutableArray.Create<AbstractReducer>(
+                new CSharpNameReducer(),
+                new CSharpEscapingReducer(),
+                new CSharpParenthesesReducer());
 
         private class FormattingRule : AbstractFormattingRule
         {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeGeneration;
@@ -71,7 +72,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
         protected abstract Task<Document> ConvertDocCommentsToRegularComments(Document document, IDocumentationCommentFormattingService docCommentFormattingService, CancellationToken cancellationToken);
 
-        protected abstract IEnumerable<AbstractReducer> GetReducers();
+        protected abstract ImmutableArray<AbstractReducer> GetReducers();
 
         private static INamespaceOrTypeSymbol CreateCodeGenerationSymbol(Document document, ISymbol symbol)
         {

--- a/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
+++ b/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.DocumentationComments
@@ -63,10 +64,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MetadataAsSource
             Return _memberSeparationRule.Concat(Formatter.GetDefaultFormattingRules(document))
         End Function
 
-        Protected Overrides Iterator Function GetReducers() As IEnumerable(Of AbstractReducer)
-            Yield New VisualBasicNameReducer
-            Yield New VisualBasicEscapingReducer
-            Yield New VisualBasicParenthesesReducer
+        Protected Overrides Function GetReducers() As ImmutableArray(Of AbstractReducer)
+            Return ImmutableArray.Create(Of AbstractReducer)(
+                New VisualBasicNameReducer(),
+                New VisualBasicEscapingReducer(),
+                New VisualBasicParenthesesReducer())
         End Function
 
         Private Class FormattingRule

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpExtensionMethodReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpExtensionMethodReducer.cs
@@ -3,6 +3,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -53,19 +54,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     {
                         MemberAccessExpressionSyntax newMemberAccess = null;
                         var invocationExpressionNodeExpression = node.Expression;
-                        var expression = argumentList.Arguments[0].Expression;
+
+                        // Ensure the first expression is parenthesized so that we don't cause any
+                        // precedence issues when we take the extension method and tack it on the 
+                        // end of it.
+                        var expression = argumentList.Arguments[0].Expression.Parenthesize();
 
                         if (node.Expression.Kind() == SyntaxKind.SimpleMemberAccessExpression)
                         {
-                            newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, ((MemberAccessExpressionSyntax)invocationExpressionNodeExpression).OperatorToken, ((MemberAccessExpressionSyntax)invocationExpressionNodeExpression).Name);
+                            newMemberAccess = SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression, expression,
+                                ((MemberAccessExpressionSyntax)invocationExpressionNodeExpression).OperatorToken, 
+                                ((MemberAccessExpressionSyntax)invocationExpressionNodeExpression).Name);
                         }
                         else if (node.Expression.Kind() == SyntaxKind.IdentifierName)
                         {
-                            newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, (IdentifierNameSyntax)invocationExpressionNodeExpression.WithoutLeadingTrivia());
+                            newMemberAccess = SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression, expression, 
+                                (IdentifierNameSyntax)invocationExpressionNodeExpression.WithoutLeadingTrivia());
                         }
                         else if (node.Expression.Kind() == SyntaxKind.GenericName)
                         {
-                            newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, (GenericNameSyntax)invocationExpressionNodeExpression.WithoutLeadingTrivia());
+                            newMemberAccess = SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression, expression, 
+                                (GenericNameSyntax)invocationExpressionNodeExpression.WithoutLeadingTrivia());
                         }
                         else
                         {

--- a/src/Workspaces/Core/Portable/Simplification/ISimplificationService.cs
+++ b/src/Workspaces/Core/Portable/Simplification/ISimplificationService.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -30,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Simplification
             Document document,
             IEnumerable<TextSpan> spans,
             OptionSet optionSet = null,
-            IEnumerable<AbstractReducer> reducers = null,
+            ImmutableArray<AbstractReducer> reducers = default(ImmutableArray<AbstractReducer>),
             CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Workspaces/Core/Portable/Simplification/Simplifier.cs
+++ b/src/Workspaces/Core/Portable/Simplification/Simplifier.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -184,14 +186,17 @@ namespace Microsoft.CodeAnalysis.Simplification
                 throw new ArgumentNullException(nameof(spans));
             }
 
-            return document.Project.LanguageServices.GetService<ISimplificationService>().ReduceAsync(document, spans, optionSet, cancellationToken: cancellationToken);
+            return document.GetLanguageService<ISimplificationService>().ReduceAsync(
+                document, spans, optionSet, cancellationToken: cancellationToken);
         }
 
-        internal static async Task<Document> ReduceAsync(Document document, IEnumerable<AbstractReducer> reducers, OptionSet optionSet = null, CancellationToken cancellationToken = default(CancellationToken))
+        internal static async Task<Document> ReduceAsync(
+            Document document, ImmutableArray<AbstractReducer> reducers, OptionSet optionSet = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             return await document.Project.LanguageServices.GetService<ISimplificationService>()
-                .ReduceAsync(document, SpecializedCollections.SingletonEnumerable(root.FullSpan), optionSet, reducers, cancellationToken).ConfigureAwait(false);
+                .ReduceAsync(document, SpecializedCollections.SingletonEnumerable(root.FullSpan), optionSet, 
+                             reducers, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/VisualBasicSimplificationService.vb
@@ -4,7 +4,6 @@ Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Internal.Log
 Imports Microsoft.CodeAnalysis.Simplification
@@ -16,8 +15,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
     Partial Friend Class VisualBasicSimplificationService
         Inherits AbstractSimplificationService(Of ExpressionSyntax, ExecutableStatementSyntax, CrefReferenceSyntax)
 
-        Protected Overrides Function GetReducers() As IEnumerable(Of AbstractReducer)
-            Return {
+        Private Shared ReadOnly s_reducers As ImmutableArray(Of AbstractReducer) =
+            ImmutableArray.Create(Of AbstractReducer)(
                 New VisualBasicExtensionMethodReducer(),
                 New VisualBasicCastReducer(),
                 New VisualBasicNameReducer(),
@@ -26,9 +25,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 New VisualBasicEscapingReducer(), ' order before VisualBasicMiscellaneousReducer, see RenameNewOverload test
                 New VisualBasicMiscellaneousReducer(),
                 New VisualBasicCastReducer(),
-                New VisualBasicVariableDeclaratorReducer()
-            }
-        End Function
+                New VisualBasicVariableDeclaratorReducer())
+
+        Public Sub New()
+            MyBase.New(s_reducers)
+        End Sub
 
         Public Overrides Function Expand(node As SyntaxNode, semanticModel As SemanticModel, aliasReplacementAnnotation As SyntaxAnnotation, expandInsideNode As Func(Of SyntaxNode, Boolean), expandParameter As Boolean, cancellationToken As CancellationToken) As SyntaxNode
             Using Logger.LogBlock(FunctionId.Simplifier_ExpandNode, cancellationToken)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15530