### PR TITLE
Provide a user facing option to control the 'add-braces' code style feature

### DIFF
--- a/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -46,15 +47,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
 
         public void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
+            var syntaxTree = context.Node.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
             var node = context.Node;
 
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
+            var option = optionSet.GetOption(CSharpCodeStyleOptions.PreferBraces);
+            if (!option.Value)
+            {
+                return;
+            }
+
+            var descriptor = GetDescriptorWithSeverity(option.Notification.Value);
             if (node.IsKind(SyntaxKind.IfStatement))
             {
                 var ifStatement = (IfStatementSyntax)node;
                 if (AnalyzeIfStatement(ifStatement))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(HiddenDescriptor,
-                        ifStatement.IfKeyword.GetLocation(), SyntaxFacts.GetText(SyntaxKind.IfKeyword)));
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor,
+                        ifStatement.IfKeyword.GetLocation(),
+                        SyntaxFacts.GetText(SyntaxKind.IfKeyword)));
                 }
             }
 
@@ -63,8 +80,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 var elseClause = (ElseClauseSyntax)node;
                 if (AnalyzeElseClause(elseClause))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(HiddenDescriptor,
-                        elseClause.ElseKeyword.GetLocation(), SyntaxFacts.GetText(SyntaxKind.ElseKeyword)));
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor,
+                        elseClause.ElseKeyword.GetLocation(),
+                        SyntaxFacts.GetText(SyntaxKind.ElseKeyword)));
                 }
             }
 
@@ -73,8 +91,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 var forStatement = (ForStatementSyntax)node;
                 if (AnalyzeForStatement(forStatement))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(HiddenDescriptor,
-                        forStatement.ForKeyword.GetLocation(), SyntaxFacts.GetText(SyntaxKind.ForKeyword)));
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor,
+                        forStatement.ForKeyword.GetLocation(),
+                        SyntaxFacts.GetText(SyntaxKind.ForKeyword)));
                 }
             }
 
@@ -83,8 +102,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 var forEachStatement = (CommonForEachStatementSyntax)node;
                 if (AnalyzeForEachStatement(forEachStatement))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(HiddenDescriptor,
-                        forEachStatement.ForEachKeyword.GetLocation(), SyntaxFacts.GetText(SyntaxKind.ForEachKeyword)));
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor,
+                        forEachStatement.ForEachKeyword.GetLocation(),
+                        SyntaxFacts.GetText(SyntaxKind.ForEachKeyword)));
                 }
             }
 
@@ -93,8 +113,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 var whileStatement = (WhileStatementSyntax)node;
                 if (AnalyzeWhileStatement(whileStatement))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(HiddenDescriptor,
-                        whileStatement.WhileKeyword.GetLocation(), SyntaxFacts.GetText(SyntaxKind.WhileKeyword)));
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor,
+                        whileStatement.WhileKeyword.GetLocation(),
+                        SyntaxFacts.GetText(SyntaxKind.WhileKeyword)));
                 }
             }
 
@@ -103,8 +124,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 var doStatement = (DoStatementSyntax)node;
                 if (AnalyzeDoStatement(doStatement))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(HiddenDescriptor,
-                        doStatement.DoKeyword.GetLocation(), SyntaxFacts.GetText(SyntaxKind.DoKeyword)));
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor,
+                        doStatement.DoKeyword.GetLocation(),
+                        SyntaxFacts.GetText(SyntaxKind.DoKeyword)));
                 }
             }
 
@@ -113,8 +135,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 var usingStatement = (UsingStatementSyntax)context.Node;
                 if (AnalyzeUsingStatement(usingStatement))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(HiddenDescriptor,
-                        usingStatement.UsingKeyword.GetLocation(), SyntaxFacts.GetText(SyntaxKind.UsingKeyword)));
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor,
+                        usingStatement.UsingKeyword.GetLocation(),
+                        SyntaxFacts.GetText(SyntaxKind.UsingKeyword)));
                 }
             }
 
@@ -123,8 +146,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 var lockStatement = (LockStatementSyntax)context.Node;
                 if (AnalyzeLockStatement(lockStatement))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(HiddenDescriptor,
-                        lockStatement.LockKeyword.GetLocation(), SyntaxFacts.GetText(SyntaxKind.LockKeyword)));
+                    context.ReportDiagnostic(Diagnostic.Create(descriptor,
+                        lockStatement.LockKeyword.GetLocation(),
+                        SyntaxFacts.GetText(SyntaxKind.LockKeyword)));
                 }
             }
         }

--- a/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
@@ -12,17 +12,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
     internal sealed class CSharpAddBracesDiagnosticAnalyzer : 
         AbstractCodeStyleDiagnosticAnalyzer, IBuiltInAnalyzer
     {
-        private static readonly LocalizableString s_localizableTitle =
-            new LocalizableResourceString(nameof(FeaturesResources.Add_braces), FeaturesResources.ResourceManager,
-                typeof(FeaturesResources));
-
-        private static readonly LocalizableString s_localizableMessage =
-            new LocalizableResourceString(nameof(WorkspacesResources.Add_braces_to_0_statement), WorkspacesResources.ResourceManager,
-                typeof(WorkspacesResources));
-
         public CSharpAddBracesDiagnosticAnalyzer()
             : base(IDEDiagnosticIds.AddBracesDiagnosticId,
-                   s_localizableTitle, s_localizableMessage)
+                   new LocalizableResourceString(nameof(FeaturesResources.Add_braces), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                   new LocalizableResourceString(nameof(WorkspacesResources.Add_braces_to_0_statement), WorkspacesResources.ResourceManager, typeof(WorkspacesResources)))
         {
         }
 

--- a/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
@@ -22,7 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
         public bool OpenFileOnly(Workspace workspace) => false;
 
         private static readonly ImmutableArray<SyntaxKind> s_syntaxKindsOfInterest =
-            ImmutableArray.Create(SyntaxKind.IfStatement,
+            ImmutableArray.Create(
+                SyntaxKind.IfStatement,
                 SyntaxKind.ElseClause,
                 SyntaxKind.ForStatement,
                 SyntaxKind.ForEachStatement,
@@ -31,7 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                 SyntaxKind.DoStatement,
                 SyntaxKind.UsingStatement,
                 SyntaxKind.LockStatement);
-
 
         protected override void InitializeWorker(AnalysisContext context)
             => context.RegisterSyntaxNodeAction(AnalyzeNode, s_syntaxKindsOfInterest);

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 if (TryAnalyzeVariableDeclaration(declaredType, semanticModel, optionSet, cancellationToken, out var diagnosticSpan))
                 {
                     // The severity preference is not Hidden, as indicated by shouldAnalyze.
-                    var descriptor = CreateDescriptorWithSeverity(state.GetDiagnosticSeverityPreference());
+                    var descriptor = GetDescriptorWithSeverity(state.GetDiagnosticSeverityPreference());
                     context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, diagnosticSpan));
                 }
             }

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                 : localDeclarator;
 
             context.ReportDiagnostic(Diagnostic.Create(
-                CreateDescriptorWithSeverity(option.Notification.Value),
+                GetDescriptorWithSeverity(option.Notification.Value),
                 reportNode.GetLocation(),
                 additionalLocations: allLocations));
         }

--- a/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
 
             // Put a diagnostic with the appropriate severity on the expression-statement itself.
             syntaxContext.ReportDiagnostic(Diagnostic.Create(
-                CreateDescriptorWithSeverity(severity),
+                GetDescriptorWithSeverity(severity),
                 expressionStatement.GetLocation(),
                 additionalLocations, properties));
 

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
             // Put a diagnostic with the appropriate severity on the declaration-statement itself.
             syntaxContext.ReportDiagnostic(Diagnostic.Create(
-                CreateDescriptorWithSeverity(severity),
+                GetDescriptorWithSeverity(severity),
                 localDeclarationStatement.GetLocation(),
                 additionalLocations));
         }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckDiagnosticAnalyzer.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
             // Put a diagnostic with the appropriate severity on the declaration-statement itself.
             syntaxContext.ReportDiagnostic(Diagnostic.Create(
-                CreateDescriptorWithSeverity(severity),
+                GetDescriptorWithSeverity(severity),
                 localDeclarationStatement.GetLocation(),
                 additionalLocations));
         }

--- a/src/Features/Core/Portable/CodeStyle/AbstractCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/CodeStyle/AbstractCodeStyleDiagnosticAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -10,9 +11,12 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         protected readonly string DescriptorId;
 
         /// <summary>
-        /// Diagnostic descriptor that for analysis results that we don't want any treatment for.
+        /// Diagnostic descriptors corresponding to each of the DiagnosticSeverities.
         /// </summary>
         protected readonly DiagnosticDescriptor HiddenDescriptor;
+        protected readonly DiagnosticDescriptor InfoDescriptor;
+        protected readonly DiagnosticDescriptor WarningDescriptor;
+        protected readonly DiagnosticDescriptor ErrorDescriptor;
 
         /// <summary>
         /// Diagnostic descriptor for code you want to fade out *and* want to have a smart-tag
@@ -45,6 +49,9 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             _localizableMessage = message ?? title;
 
             HiddenDescriptor = CreateDescriptorWithSeverity(DiagnosticSeverity.Hidden);
+            InfoDescriptor = CreateDescriptorWithSeverity(DiagnosticSeverity.Info);
+            WarningDescriptor = CreateDescriptorWithSeverity(DiagnosticSeverity.Warning);
+            ErrorDescriptor = CreateDescriptorWithSeverity(DiagnosticSeverity.Error);
 
             UnnecessaryWithSuggestionDescriptor = CreateDescriptorWithId(
                 descriptorId, _localizableTitle, _localizableMessage, 
@@ -60,6 +67,18 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         }
 
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+        protected DiagnosticDescriptor GetDescriptorWithSeverity(DiagnosticSeverity severity)
+        {
+            switch (severity)
+            {
+                case DiagnosticSeverity.Hidden: return HiddenDescriptor;
+                case DiagnosticSeverity.Info: return InfoDescriptor;
+                case DiagnosticSeverity.Warning: return WarningDescriptor;
+                case DiagnosticSeverity.Error: return ErrorDescriptor;
+                default: throw new InvalidOperationException();
+            }
+        }
 
         protected DiagnosticDescriptor CreateDescriptorWithSeverity(DiagnosticSeverity severity, params string[] customTags)
             => CreateDescriptorWithId(DescriptorId, _localizableTitle, _localizableMessage, severity, customTags);

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 if (severity != DiagnosticSeverity.Hidden)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
-                        CreateDescriptorWithSeverity(severity), 
+                        GetDescriptorWithSeverity(severity), 
                         context.Operation.Syntax.GetLocation()));
                 }
             }

--- a/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionDiagnosticAnalyzer.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
                 whenPartToCheck.GetLocation());
 
             context.ReportDiagnostic(Diagnostic.Create(
-                this.CreateDescriptorWithSeverity(option.Notification.Value),
+                this.GetDescriptorWithSeverity(option.Notification.Value),
                 conditionalExpression.GetLocation(),
                 locations));
         }

--- a/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
                 whenPartToKeep.GetLocation());
 
             context.ReportDiagnostic(Diagnostic.Create(
-                this.CreateDescriptorWithSeverity(option.Notification.Value),
+                this.GetDescriptorWithSeverity(option.Notification.Value),
                 conditionalExpression.GetLocation(),
                 locations));
         }

--- a/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseExplicitTupleName/UseExplicitTupleNameDiagnosticAnalyzer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.UseExplicitTupleName
                             var properties = ImmutableDictionary<string, string>.Empty.Add(
                                 nameof(ElementName), namedField.Name);
                             context.ReportDiagnostic(Diagnostic.Create(
-                                CreateDescriptorWithSeverity(severity),
+                                GetDescriptorWithSeverity(severity),
                                 nameNode.GetLocation(),
                                 properties));
                         }

--- a/src/Features/Core/Portable/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
                 whenPartToCheck.GetLocation());
 
             context.ReportDiagnostic(Diagnostic.Create(
-                this.CreateDescriptorWithSeverity(option.Notification.Value),
+                this.GetDescriptorWithSeverity(option.Notification.Value),
                 conditionalExpression.GetLocation(),
                 locations));
         }

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                 throwOperation.ThrownObject.Syntax.GetLocation(),
                 assignmentExpression.Value.Syntax.GetLocation());
 
-            var descriptor = CreateDescriptorWithSeverity(option.Notification.Value);
+            var descriptor = GetDescriptorWithSeverity(option.Notification.Value);
 
             context.ReportDiagnostic(
                 Diagnostic.Create(descriptor, throwStatement.GetLocation(), additionalLocations: allLocations));

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -451,6 +451,30 @@ class Customer
 }
 ";
 
+        private static readonly string s_preferBraces = @"
+using System;
+
+class Customer
+{
+    private int Age;
+
+    public int GetAge()
+    {
+//[
+        // Prefer: 
+        if (test)
+        {
+            this.Display();
+        }
+        
+        // Over:
+        if (test)
+            this.Display();
+//]
+    }
+}
+";
+
         private static readonly string s_preferExpressionBodyForMethods = @"
 using System;
 
@@ -668,6 +692,7 @@ class List<T>
             CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, CSharpVSResources.Elsewhere, s_varWherePossiblePreviewTrue, s_varWherePossiblePreviewFalse, this, optionSet, varGroupTitle, typeStylePreferences));
 
             // Code block
+            CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferBraces, ServicesVSResources.Prefer_braces, s_preferBraces, s_preferBraces, this, optionSet, codeBlockPreferencesGroupTitle));
             CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, ServicesVSResources.For_methods, s_preferExpressionBodyForMethods, s_preferBlockBodyForMethods, this, optionSet, codeBlockPreferencesGroupTitle, codeBlockPreferences));
             CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, ServicesVSResources.For_constructors, s_preferExpressionBodyForConstructors, s_preferBlockBodyForConstructors, this, optionSet, codeBlockPreferencesGroupTitle, codeBlockPreferences));
             CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, ServicesVSResources.For_operators, s_preferExpressionBodyForOperators, s_preferBlockBodyForOperators, this, optionSet, codeBlockPreferencesGroupTitle, codeBlockPreferences));

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1413,6 +1413,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Prefer braces.
+        /// </summary>
+        internal static string Prefer_braces {
+            get {
+                return ResourceManager.GetString("Prefer_braces", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Prefer coalesce expression.
         /// </summary>
         internal static string Prefer_coalesce_expression {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -840,4 +840,7 @@ Additional information: {1}</value>
   <data name="with_other_members_of_the_same_kind" xml:space="preserve">
     <value>with other members of the same kind</value>
   </data>
+  <data name="Prefer_braces" xml:space="preserve">
+    <value>Prefer braces</value>
+  </data>
 </root>

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -88,6 +88,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
                 new EditorConfigStorageLocation("csharp_style_expression_bodied_accessors", ParseEditorConfigCodeStyleOption),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedAccessors)}")});
 
+        public static readonly Option<CodeStyleOption<bool>> PreferBraces = new Option<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions), nameof(PreferBraces), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_prefer_braces", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferBraces)}")});
+
         public static IEnumerable<Option<CodeStyleOption<bool>>> GetCodeStyleOptions()
         {
             yield return UseImplicitTypeForIntrinsicTypes;
@@ -102,6 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
             yield return PreferExpressionBodiedProperties;
             yield return PreferExpressionBodiedIndexers;
             yield return PreferExpressionBodiedAccessors;
+            yield return PreferBraces;
         }
     }
 }


### PR DESCRIPTION
Users can now control if this feature runs and what severity error they should get when braces are missing.