### PR TITLE
Scripting on .NET Core: implement FX assembly resolution and enable tests

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -15,6 +15,7 @@
     <MicrosoftCodeAnalysisAnalyzersVersion>1.1.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisElfieVersion>0.10.6-rc2</MicrosoftCodeAnalysisElfieVersion>
     <MicrosoftCompositionVersion>1.0.27</MicrosoftCompositionVersion>
+    <MicrosoftCSharpVersion>4.0.1</MicrosoftCSharpVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.1.0-beta1-60625-03</MicrosoftDiaSymReaderVersion>

--- a/build/config/RepoUtilData.json
+++ b/build/config/RepoUtilData.json
@@ -35,6 +35,7 @@
                 "Microsoft.CodeAnalysis.Analyzers",
                 "Microsoft.VisualBasic",
                 "Microsoft.Composition",
+                "Microsoft.CSharp",
                 "MicroBuild.*",
                 "ManagedEsent",
                 "Microsoft.CodeAnalysis.Elfie",

--- a/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AnalyzerFileReferenceTests.cs
@@ -228,7 +228,7 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 new SyntaxTree[] { CSharp.SyntaxFactory.ParseSyntaxTree(analyzerSource) },
                 new MetadataReference[]
                 {
-                    SystemRuntimeNetstandard13FacadeRef.Value,
+                    TestReferences.NetStandard13.SystemRuntime,
                     MetadataReference.CreateFromFile(immutable.Path),
                     MetadataReference.CreateFromFile(analyzer.Path)
                 },

--- a/src/Compilers/Core/Portable/CorLightup.cs
+++ b/src/Compilers/Core/Portable/CorLightup.cs
@@ -49,18 +49,6 @@ namespace Roslyn.Utilities
                 }
             }
 
-            private static class _RuntimeEnvironment
-            {
-                internal static readonly Type TypeOpt = ReflectionUtilities.TryGetType("System.Runtime.InteropServices.RuntimeEnvironment, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
-
-                internal static readonly Func<string> GetRuntimeDirectoryOpt = TypeOpt?
-                    .GetTypeInfo()
-                    .GetDeclaredMethod("GetRuntimeDirectory", Array.Empty<Type>())?
-                    .CreateDelegate<Func<string>>();
-            }
-
-            internal static string TryGetRuntimeDirectory() => _RuntimeEnvironment.GetRuntimeDirectoryOpt?.Invoke();
-
             private static class _Assembly
             {
                 internal static readonly Type Type = typeof(Assembly);

--- a/src/Interactive/CsiCore/Csi.cs
+++ b/src/Interactive/CsiCore/Csi.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 {
@@ -21,8 +18,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
                 var buildPaths = new BuildPaths(
                     clientDir: AppContext.BaseDirectory,
                     workingDir: Directory.GetCurrentDirectory(),
-                    sdkDir: CorLightup.Desktop.TryGetRuntimeDirectory(),
+                    sdkDir: RuntimeMetadataReferenceResolver.GetCorLibDirectory(),
                     tempDir: Path.GetTempPath());
+
                 var compiler = new CSharpInteractiveCompiler(
                     responseFile: responseFile,
                     buildPaths: buildPaths,

--- a/src/Interactive/CsiCore/csi.rsp
+++ b/src/Interactive/CsiCore/csi.rsp
@@ -1,29 +1,33 @@
-# references
+# basic references
 /r:System.Collections.dll
+/r:System.Collections.Concurrent.dll
 /r:System.Console.dll
+/r:System.Diagnostics.Debug.dll
 /r:System.Diagnostics.Process.dll
-/r:System.Dynamic.Runtime.dll
+/r:System.Diagnostics.StackTrace.dll
 /r:System.Globalization.dll
 /r:System.IO.dll
 /r:System.IO.FileSystem.dll
 /r:System.IO.FileSystem.Primitives.dll
-/r:System.Linq.dll
-/r:System.Linq.Expressions.dll
 /r:System.Reflection.dll
 /r:System.Reflection.Primitives.dll
 /r:System.Runtime.dll
-/r:System.Runtime.Numerics.dll
-/r:System.Runtime.Serialization.Json.dll
-/r:System.Runtime.Serialization.Primitives.dll
-/r:System.Text.Encoding.CodePages.dll
+/r:System.Runtime.InteropServices.dll
 /r:System.Text.Encoding.dll
+/r:System.Text.Encoding.CodePages.dll
 /r:System.Text.Encoding.Extensions.dll
 /r:System.Text.RegularExpressions.dll
 /r:System.Threading.dll
 /r:System.Threading.Tasks.dll
 /r:System.Threading.Tasks.Parallel.dll
 /r:System.Threading.Thread.dll
+# extra references
+/r:System.Linq.dll
+/r:System.Linq.Expressions.dll
+/r:System.Runtime.Numerics.dll
+/r:System.Dynamic.Runtime.dll
 /r:System.ValueTuple.dll
+/r:Microsoft.CSharp.dll
 # imports
 /u:System
 /u:System.IO

--- a/src/Interactive/CsiCore/project.json
+++ b/src/Interactive/CsiCore/project.json
@@ -1,6 +1,8 @@
 ﻿{
   "dependencies": {
-    "System.ValueTuple": "4.0.1-beta-24425-02"
+    "System.ValueTuple": "4.0.1-beta-24425-02",
+    "System.Dynamic.Runtime": "4.0.11",
+    "Microsoft.CSharp": "4.0.1"
   },
   "frameworks": {
     // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -264,9 +264,10 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
         {
             return new RuntimeMetadataReferenceResolver(
                 new RelativePathResolver(searchPaths, baseDirectory),
-                null,
-                GacFileResolver.IsAvailable ? new GacFileResolver(preferredCulture: CultureInfo.CurrentCulture) : null,
-                (path, properties) => metadataService.GetReference(path, properties));
+                packageResolver: null,
+                gacFileResolver: GacFileResolver.IsAvailable ? new GacFileResolver(preferredCulture: CultureInfo.CurrentCulture) : null,
+                corLibDirectoryOpt: null, // TODO: specify when .NET Core is supported
+                fileReferenceProvider: (path, properties) => metadataService.GetReference(path, properties));
         }
 
         private static SourceReferenceResolver CreateSourceReferenceResolver(ImmutableArray<string> searchPaths, string baseDirectory)

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.Service.cs
@@ -172,9 +172,10 @@ namespace Microsoft.CodeAnalysis.Interactive
             {
                 return new RuntimeMetadataReferenceResolver(
                     new RelativePathResolver(searchPaths, baseDirectory),
-                    null,
-                    GacFileResolver.IsAvailable ? new GacFileResolver(preferredCulture: CultureInfo.CurrentCulture) : null,
-                    (path, properties) => new ShadowCopyReference(_metadataFileProvider, path, properties));
+                    packageResolver: null,
+                    gacFileResolver: GacFileResolver.IsAvailable ? new GacFileResolver(preferredCulture: CultureInfo.CurrentCulture) : null,
+                    corLibDirectoryOpt: null, // TODO: specify when .NET Core is supported
+                    fileReferenceProvider: (path, properties) => new ShadowCopyReference(_metadataFileProvider, path, properties));
             }
 
             private SourceReferenceResolver CreateSourceReferenceResolver(ImmutableArray<string> searchPaths, string baseDirectory)

--- a/src/Interactive/VbiCore/Vbi.vb
+++ b/src/Interactive/VbiCore/Vbi.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
                 Dim responseFile = Path.Combine(AppContext.BaseDirectory, InteractiveResponseFileName)
                 Dim buildPaths = New BuildPaths(
                     clientDir:=AppContext.BaseDirectory,
-                    workingDir:=CorLightup.Desktop.TryGetRuntimeDirectory(),
+                    workingDir:=RuntimeMetadataReferenceResolver.GetCorLibDirectory(),
                     sdkDir:=AppContext.BaseDirectory,
                     tempDir:=Path.GetTempPath())
 

--- a/src/Interactive/VbiCore/project.json
+++ b/src/Interactive/VbiCore/project.json
@@ -1,6 +1,8 @@
 ﻿{
   "dependencies": {
-    "System.ValueTuple": "4.0.1-beta-24425-02"
+    "System.ValueTuple": "4.0.1-beta-24425-02",
+    "System.Dynamic.Runtime": "4.0.11",
+    "Microsoft.VisualBasic": "10.0.1"
   },
   "frameworks": {
     // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458

--- a/src/Interactive/csi/project.json
+++ b/src/Interactive/csi/project.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
-    "System.ValueTuple": "4.0.1-beta-24425-02"
+    "System.ValueTuple": "4.0.1-beta-24425-02",
+    "System.Dynamic.Runtime": "4.0.11",
+    "Microsoft.CSharp": "4.0.1"
   },
   "frameworks": {
     "net46": {}

--- a/src/Interactive/vbi/project.json
+++ b/src/Interactive/vbi/project.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
-    "System.ValueTuple": "4.0.1-beta-24425-02"
+    "System.ValueTuple": "4.0.1-beta-24425-02",
+    "System.Dynamic.Runtime": "4.0.11",
+    "Microsoft.VisualBasic": "10.0.1"
   },
   "frameworks": {
     "net46": {}

--- a/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
@@ -20,6 +20,9 @@
         <dependency id="Microsoft.CodeAnalysis.Compilers" version="$version$" />
         <dependency id="Microsoft.CodeAnalysis.Scripting" version="$version$" />
         <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="Microsoft.CSharp" target="$MicrosoftCSharpVersion$" />
+        <dependency id="System.Dynamic.Runtime" target="$SystemDynamicRuntimeVersion$" />
+        <dependency id="System.ValueTuple" target="$SystemValueTupleVersion$" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
@@ -3,30 +3,37 @@ extern alias PortableTestUtils;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting.Test;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using TestBase = PortableTestUtils::Roslyn.Test.Utilities.TestBase;
 using AssertEx = PortableTestUtils::Roslyn.Test.Utilities.AssertEx;
+using TestBase = PortableTestUtils::Roslyn.Test.Utilities.TestBase;
+using WorkItemAttribute = PortableTestUtils::Roslyn.Test.Utilities.WorkItemAttribute;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.Test
 {
     using static TestCompilationFactory;
     using DiagnosticExtensions = PortableTestUtils::Microsoft.CodeAnalysis.DiagnosticExtensions;
+    using TestReferences = PortableTestUtils::TestReferences;
 
     public class InteractiveSessionTests : TestBase
     {
+        private static readonly CSharpCompilationOptions s_signedDll =
+           new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, cryptoPublicKey: TestResources.TestKeys.PublicKey_ce65828c82a341f2);
+
+        private static readonly CSharpCompilationOptions s_signedDll2 =
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, cryptoPublicKey: TestResources.TestKeys.PublicKey_ce65828c82a341f2);
+
         [Fact]
         public async Task CompilationChain_GlobalImportsRebinding()
         {
@@ -362,8 +369,11 @@ new C()
         [Fact]
         public void References_Versioning_WeakNames1()
         {
-            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
-            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(
+                CreateCSharpCompilation(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, assemblyName: "C").EmitToArray());
+
+            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(
+                CreateCSharpCompilation(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, assemblyName: "C").EmitToArray());
 
             var result = CSharpScript.EvaluateAsync($@"
 #r ""{c1.Path}""
@@ -378,8 +388,11 @@ new C()
         [Fact]
         public void References_Versioning_WeakNames2()
         {
-            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
-            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(
+                CreateCSharpCompilation(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, assemblyName: "C").EmitToArray());
+
+            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(
+                CreateCSharpCompilation(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, assemblyName: "C").EmitToArray());
 
             var result = CSharpScript.Create($@"
 #r ""{c1.Path}""
@@ -395,8 +408,11 @@ new C()
         [Fact]
         public void References_Versioning_WeakNames3()
         {
-            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
-            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", assemblyName: "C").EmitToArray());
+            var c1 = Temp.CreateFile(extension: ".dll").WriteAllBytes(
+                CreateCSharpCompilation(@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")] public class C {}", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, assemblyName: "C").EmitToArray());
+
+            var c2 = Temp.CreateFile(extension: ".dll").WriteAllBytes(
+                CreateCSharpCompilation(@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")] public class C {}", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, assemblyName: "C").EmitToArray());
 
             var script0 = CSharpScript.Create($@"
 #r ""{c1.Path}""
@@ -545,7 +561,7 @@ x
         [Fact]
         public void HostObjectInInMemoryAssembly()
         {
-            var lib = CreateCSharpCompilationWithMscorlib("public class C { public int X = 1, Y = 2; }", "HostLib");
+            var lib = CreateCSharpCompilation("public class C { public int X = 1, Y = 2; }", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, "HostLib");
             var libImage = lib.EmitToArray();
             var libRef = MetadataImageReference.CreateFromImage(libImage);
 
@@ -566,6 +582,542 @@ x
                 int result = script.RunAsync(globals).Result.ReturnValue;
                 Assert.Equal(3, result);
             }
+        }
+
+
+        [Fact]
+        public async Task SharedLibCopy_Identical_Weak()
+        {
+            string libBaseName = "LibBase_" + Guid.NewGuid();
+            string lib1Name = "Lib1_" + Guid.NewGuid();
+            string lib2Name = "Lib2_" + Guid.NewGuid();
+
+            var libBase = CreateCSharpCompilation(@"
+public class LibBase
+{
+    public readonly int X = 1;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
+
+            var lib1 = CreateCSharpCompilation(@"
+public class Lib1
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib1Name);
+
+            var lib2 = CreateCSharpCompilation(@"
+public class Lib2
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib2Name);
+
+            var libBaseImage = libBase.EmitToArray();
+            var lib1Image = lib1.EmitToArray();
+            var lib2Image = lib2.EmitToArray();
+
+            var root = Temp.CreateDirectory();
+            var dir1 = root.CreateDirectory("1");
+            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
+            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBaseImage);
+
+            var dir2 = root.CreateDirectory("2");
+            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
+            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBaseImage);
+
+            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
+            var s1 = await s0.ContinueWithAsync($@"var l1 = new Lib1();");
+            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
+            var s3 = await s2.ContinueWithAsync($@"var l2 = new Lib2();");
+            var s4 = await s3.ContinueWithAsync($@"l2.libBase.X");
+
+            var c4 = s4.Script.GetCompilation();
+            c4.VerifyAssemblyAliases(
+                lib2Name,
+                lib1Name,
+                "mscorlib",
+                libBaseName + ": <implicit>,global");
+
+            var libBaseRefAndSymbol = c4.GetBoundReferenceManager().GetReferencedAssemblies().ToArray()[3];
+            Assert.Equal(fileBase1.Path, ((PortableExecutableReference)libBaseRefAndSymbol.Key).FilePath);
+        }
+
+        [Fact]
+        public async Task SharedLibCopy_Identical_Strong()
+        {
+            string libBaseName = "LibBase_" + Guid.NewGuid();
+            string lib1Name = "Lib1_" + Guid.NewGuid();
+            string lib2Name = "Lib2_" + Guid.NewGuid();
+
+            var libBase = CreateCSharpCompilation(@"
+public class LibBase
+{
+    public readonly int X = 1;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
+
+            var lib1 = CreateCSharpCompilation(@"
+public class Lib1
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib1Name);
+
+            var lib2 = CreateCSharpCompilation(@"
+public class Lib2
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib2Name);
+
+            var libBaseImage = libBase.EmitToArray();
+            var lib1Image = lib1.EmitToArray();
+            var lib2Image = lib2.EmitToArray();
+
+            var root = Temp.CreateDirectory();
+            var dir1 = root.CreateDirectory("1");
+            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
+            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBaseImage);
+
+            var dir2 = root.CreateDirectory("2");
+            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
+            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBaseImage);
+
+            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
+            var s1 = await s0.ContinueWithAsync($@"var l1 = new Lib1();");
+            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
+            var s3 = await s2.ContinueWithAsync($@"var l2 = new Lib2();");
+            var s4 = await s3.ContinueWithAsync($@"l2.libBase.X");
+
+            var c4 = s4.Script.GetCompilation();
+            c4.VerifyAssemblyAliases(
+                lib2Name,
+                lib1Name,
+                "mscorlib",
+                libBaseName + ": <implicit>,global");
+
+            var libBaseRefAndSymbol = c4.GetBoundReferenceManager().GetReferencedAssemblies().ToArray()[3];
+            Assert.Equal(fileBase1.Path, ((PortableExecutableReference)libBaseRefAndSymbol.Key).FilePath);
+        }
+
+        [Fact]
+        public async Task SharedLibCopy_SameVersion_Weak_DifferentContent()
+        {
+            string libBaseName = "LibBase_" + Guid.NewGuid();
+            string lib1Name = "Lib1_" + Guid.NewGuid();
+            string lib2Name = "Lib2_" + Guid.NewGuid();
+
+            var libBase1 = CreateCSharpCompilation(@"
+public class LibBase
+{
+    public readonly int X = 1;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
+
+            var libBase2 = CreateCSharpCompilation(@"
+public class LibBase
+{
+    public readonly int X = 2;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
+
+            var lib1 = CreateCSharpCompilation(@"
+public class Lib1
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
+
+            var lib2 = CreateCSharpCompilation(@"
+public class Lib2
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib2Name);
+
+            var libBase1Image = libBase1.EmitToArray();
+            var libBase2Image = libBase2.EmitToArray();
+            var lib1Image = lib1.EmitToArray();
+            var lib2Image = lib2.EmitToArray();
+
+            var root = Temp.CreateDirectory();
+            var dir1 = root.CreateDirectory("1");
+            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
+            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
+
+            var dir2 = root.CreateDirectory("2");
+            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
+            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
+
+            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
+            var s1 = await s0.ContinueWithAsync($@"var l1 = new Lib1();");
+            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
+
+            bool exceptionSeen = false;
+            try
+            {
+                await s2.ContinueWithAsync($@"var l2 = new Lib2();");
+            }
+            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
+            {
+                exceptionSeen = true;
+            }
+
+            Assert.True(exceptionSeen);
+        }
+
+        [Fact]
+        public async Task SharedLibCopy_SameVersion_Strong_DifferentContent()
+        {
+            string libBaseName = "LibBase_" + Guid.NewGuid();
+            string lib1Name = "Lib1_" + Guid.NewGuid();
+            string lib2Name = "Lib2_" + Guid.NewGuid();
+
+            var libBase1 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 1;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
+
+            var libBase2 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 2;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
+
+            var lib1 = CreateCSharpCompilation(@"
+public class Lib1
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
+
+            var lib2 = CreateCSharpCompilation(@"
+public class Lib2
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib2Name);
+
+            var libBase1Image = libBase1.EmitToArray();
+            var libBase2Image = libBase2.EmitToArray();
+            var lib1Image = lib1.EmitToArray();
+            var lib2Image = lib2.EmitToArray();
+
+            var root = Temp.CreateDirectory();
+            var dir1 = root.CreateDirectory("1");
+            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
+            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
+
+            var dir2 = root.CreateDirectory("2");
+            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
+            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
+
+            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
+            var s1 = await s0.ContinueWithAsync($@"new Lib1().libBase.X");
+            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
+
+            bool exceptionSeen = false;
+            try
+            {
+                await s2.ContinueWithAsync($@"new Lib2().libBase.X");
+            }
+            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
+            {
+                exceptionSeen = true;
+            }
+
+            Assert.True(exceptionSeen);
+        }
+
+        [Fact]
+        public async Task SharedLibCopy_SameVersion_StrongWeak_DifferentContent()
+        {
+            string libBaseName = "LibBase_" + Guid.NewGuid();
+            string lib1Name = "Lib1_" + Guid.NewGuid();
+            string lib2Name = "Lib2_" + Guid.NewGuid();
+
+            var libBase1 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 1;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
+
+            var libBase2 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 2;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
+
+            var lib1 = CreateCSharpCompilation(@"
+public class Lib1
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
+
+            var lib2 = CreateCSharpCompilation(@"
+public class Lib2
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib2Name);
+
+            var libBase1Image = libBase1.EmitToArray();
+            var libBase2Image = libBase2.EmitToArray();
+            var lib1Image = lib1.EmitToArray();
+            var lib2Image = lib2.EmitToArray();
+
+            var root = Temp.CreateDirectory();
+            var dir1 = root.CreateDirectory("1");
+            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
+            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
+
+            var dir2 = root.CreateDirectory("2");
+            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
+            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
+
+            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
+            var s1 = await s0.ContinueWithAsync($@"new Lib1().libBase.X");
+            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
+
+            bool exceptionSeen = false;
+            try
+            {
+                await s2.ContinueWithAsync($@"new Lib2().libBase.X");
+            }
+            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
+            {
+                exceptionSeen = true;
+            }
+
+            Assert.True(exceptionSeen);
+        }
+
+        [Fact]
+        public async Task SharedLibCopy_SameVersion_StrongDifferentPKT_DifferentContent()
+        {
+            string libBaseName = "LibBase_" + Guid.NewGuid();
+            string lib1Name = "Lib1_" + Guid.NewGuid();
+            string lib2Name = "Lib2_" + Guid.NewGuid();
+
+            var libBase1 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 1;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
+
+            var libBase2 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 2;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll2);
+
+            var lib1 = CreateCSharpCompilation(@"
+public class Lib1
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
+
+            var lib2 = CreateCSharpCompilation(@"
+public class Lib2
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib2Name);
+
+            var libBase1Image = libBase1.EmitToArray();
+            var libBase2Image = libBase2.EmitToArray();
+            var lib1Image = lib1.EmitToArray();
+            var lib2Image = lib2.EmitToArray();
+
+            var root = Temp.CreateDirectory();
+            var dir1 = root.CreateDirectory("1");
+            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
+            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
+
+            var dir2 = root.CreateDirectory("2");
+            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
+            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
+
+            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
+            var s1 = await s0.ContinueWithAsync($@"new Lib1().libBase.X");
+            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
+
+            bool exceptionSeen = false;
+            try
+            {
+                await s2.ContinueWithAsync($@"new Lib2().libBase.X");
+            }
+            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
+            {
+                exceptionSeen = true;
+            }
+
+            Assert.True(exceptionSeen);
+        }
+
+        [Fact]
+        public async Task SharedLibCopy_DifferentVersion_Weak()
+        {
+            string libBaseName = "LibBase_" + Guid.NewGuid();
+            string lib1Name = "Lib1_" + Guid.NewGuid();
+            string lib2Name = "Lib2_" + Guid.NewGuid();
+
+            var libBase1 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 1;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
+
+            var libBase2 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 2;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
+
+            var lib1 = CreateCSharpCompilation(@"
+public class Lib1
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
+
+            var lib2 = CreateCSharpCompilation(@"
+public class Lib2
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase2.ToMetadataReference() }, lib2Name);
+
+            var libBase1Image = libBase1.EmitToArray();
+            var libBase2Image = libBase2.EmitToArray();
+            var lib1Image = lib1.EmitToArray();
+            var lib2Image = lib2.EmitToArray();
+
+            var root = Temp.CreateDirectory();
+            var dir1 = root.CreateDirectory("1");
+            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
+            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
+
+            var dir2 = root.CreateDirectory("2");
+            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
+            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
+
+            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
+            var s1 = await s0.ContinueWithAsync($@"var l1 = new Lib1().libBase.X;");
+            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
+
+            bool exceptionSeen = false;
+            try
+            {
+                await s2.ContinueWithAsync($@"var l2 = new Lib2().libBase.X;");
+            }
+            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
+            {
+                exceptionSeen = true;
+            }
+
+            Assert.True(exceptionSeen);
+        }
+
+        [Fact]
+        public async Task SharedLibCopy_DifferentVersion_Strong()
+        {
+            string libBaseName = "LibBase_" + Guid.NewGuid();
+            string lib1Name = "Lib1_" + Guid.NewGuid();
+            string lib2Name = "Lib2_" + Guid.NewGuid();
+
+            var libBase1 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 1;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
+
+            var libBase2 = CreateCSharpCompilation(@"
+[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")]
+public class LibBase
+{
+    public readonly int X = 2;
+}
+", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
+
+            var lib1 = CreateCSharpCompilation(@"
+public class Lib1
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
+
+            var lib2 = CreateCSharpCompilation(@"
+public class Lib2
+{
+    public LibBase libBase = new LibBase();
+}
+", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase2.ToMetadataReference() }, lib2Name);
+
+            var libBase1Image = libBase1.EmitToArray();
+            var libBase2Image = libBase2.EmitToArray();
+            var lib1Image = lib1.EmitToArray();
+            var lib2Image = lib2.EmitToArray();
+
+            var root = Temp.CreateDirectory();
+            var dir1 = root.CreateDirectory("1");
+            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
+            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
+
+            var dir2 = root.CreateDirectory("2");
+            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
+            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
+
+            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
+            var s1 = await s0.ContinueWithAsync($@"new Lib1().libBase.X");
+            Assert.Equal(1, s1.ReturnValue);
+            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
+            var s3 = await s2.ContinueWithAsync($@"new Lib2().libBase.X");
+            Assert.Equal(2, s3.ReturnValue);
+        }
+
+        [Fact, WorkItem(6457, "https://github.com/dotnet/roslyn/issues/6457")]
+        public async Task MissingReferencesReuse()
+        {
+            var source = @"
+public class C
+{
+    public System.Diagnostics.Process P;
+}
+";
+
+            var lib = CSharpCompilation.Create(
+                "Lib",
+                new[] { SyntaxFactory.ParseSyntaxTree(source) },
+                new[] { TestReferences.NetFx.v4_0_30319.mscorlib, TestReferences.NetFx.v4_0_30319.System },
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var libFile = Temp.CreateFile("lib").WriteAllBytes(lib.EmitToArray());
+
+            var s0 = await CSharpScript.RunAsync("C c;", ScriptOptions.Default.WithReferences(libFile.Path));
+            var s1 = await s0.ContinueWithAsync("c = new C()");
         }
     }
 }

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -577,16 +577,16 @@ Print(new C4());
 ");
 
             var dir1 = Temp.CreateDirectory();
-            dir1.CreateFile("1.dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib("public class C1 {}", "1").EmitToArray());
+            dir1.CreateFile("1.dll").WriteAllBytes(CreateCSharpCompilationWithCorlib("public class C1 {}", "1").EmitToArray());
 
             var dir2 = Temp.CreateDirectory();
-            dir2.CreateFile("2.dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib("public class C2 {}", "2").EmitToArray());
+            dir2.CreateFile("2.dll").WriteAllBytes(CreateCSharpCompilationWithCorlib("public class C2 {}", "2").EmitToArray());
 
             var dir3 = Temp.CreateDirectory();
-            dir3.CreateFile("3.dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib("public class C3 {}", "3").EmitToArray());
+            dir3.CreateFile("3.dll").WriteAllBytes(CreateCSharpCompilationWithCorlib("public class C3 {}", "3").EmitToArray());
 
             var dir4 = Temp.CreateDirectory();
-            dir4.CreateFile("4.dll").WriteAllBytes(CreateCSharpCompilationWithMscorlib("public class C4 {}", "4").EmitToArray());
+            dir4.CreateFile("4.dll").WriteAllBytes(CreateCSharpCompilationWithCorlib("public class C4 {}", "4").EmitToArray());
 
             var runner = CreateRunner(new[] { "/r:4.dll", $"/lib:{dir1.Path}", $"/libpath:{dir2.Path}", $"/libpaths:{dir3.Path};{dir4.Path}", main.Path });
 

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -11,8 +12,8 @@ using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.Scripting.Test;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using Xunit;
 using Roslyn.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 {
@@ -26,9 +27,53 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
         // default csi.rsp
         private static readonly string[] s_defaultArgs = new[]
         {
-            "/r:System;System.Core;Microsoft.CSharp;System.ValueTuple.dll",
+            "/r:" + string.Join(";", GetReferences()),
             "/u:System;System.IO;System.Collections.Generic;System.Diagnostics;System.Dynamic;System.Linq;System.Linq.Expressions;System.Text;System.Threading.Tasks",
         };
+
+        private static IEnumerable<string> GetReferences()
+        {
+            if (RuntimeMetadataReferenceResolver.DefaultCorLibDirectoryOpt != null)
+            {
+                // keep in sync with list in core csi.rsp
+                yield return "System.Collections";
+                yield return "System.Collections.Concurrent";
+                yield return "System.Console";
+                yield return "System.Diagnostics.Debug";
+                yield return "System.Diagnostics.Process";
+                yield return "System.Diagnostics.StackTrace";
+                yield return "System.Globalization";
+                yield return "System.IO";
+                yield return "System.IO.FileSystem";
+                yield return "System.IO.FileSystem.Primitives";
+                yield return "System.Reflection";
+                yield return "System.Reflection.Primitives";
+                yield return "System.Runtime";
+                yield return "System.Runtime.InteropServices";
+                yield return "System.Text.Encoding";
+                yield return "System.Text.Encoding.CodePages";
+                yield return "System.Text.Encoding.Extensions";
+                yield return "System.Text.RegularExpressions";
+                yield return "System.Threading";
+                yield return "System.Threading.Tasks";
+                yield return "System.Threading.Tasks.Parallel";
+                yield return "System.Threading.Thread";
+                yield return "System.Linq";
+                yield return "System.Linq.Expressions";
+                yield return "System.Runtime.Numerics";
+                yield return "System.Dynamic.Runtime";
+                yield return "System.ValueTuple";
+                yield return "Microsoft.CSharp";
+            }
+            else
+            {
+                // keep in sync with list in csi.rsp
+                yield return "System";
+                yield return "System.Core";
+                yield return "Microsoft.CSharp";
+                yield return "System.ValueTuple.dll";
+            }
+        }
 
         private static CommandLineRunner CreateRunner(
             string[] args = null,
@@ -40,13 +85,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
             var buildPaths = new BuildPaths(
                 clientDir: AppContext.BaseDirectory,
                 workingDir: workingDirectory ?? AppContext.BaseDirectory,
-                sdkDir: null,
+                sdkDir: RuntimeMetadataReferenceResolver.GetCorLibDirectory(),
                 tempDir: Path.GetTempPath());
 
             var compiler = new CSharpInteractiveCompiler(
                 responseFile,
                 buildPaths,
-                args ?? s_defaultArgs,
+                args?.Where(a => a != null).ToArray() ?? s_defaultArgs,
                 new NotImplementedAnalyzerLoader());
 
             return new CommandLineRunner(io, compiler, CSharpScriptCompiler.Instance, CSharpObjectFormatter.Instance);
@@ -94,10 +139,10 @@ Enumerable.WhereSelectArrayIterator<int, int> {{ 9, 16, 25 }}
         public void TestDisplayResultsWithCurrentUICulture()
         {
             var runner = CreateRunner(input:
-@"using static System.Globalization.CultureInfo;
-DefaultThreadCurrentUICulture = GetCultureInfo(""en-GB"")
+@"using System.Globalization;
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"")
 Math.PI
-DefaultThreadCurrentUICulture = GetCultureInfo(""de-DE"")
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""de-DE"")
 Math.PI
 ");
             runner.RunInteractive();
@@ -107,12 +152,12 @@ $@"Microsoft (R) Visual C# Interactive Compiler version {s_compilerVersion}
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 Type ""#help"" for more information.
-> using static System.Globalization.CultureInfo;
-> DefaultThreadCurrentUICulture = GetCultureInfo(""en-GB"")
+> using System.Globalization;
+> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"")
 [en-GB]
 > Math.PI
 3.1415926535897931
-> DefaultThreadCurrentUICulture = GetCultureInfo(""de-DE"")
+> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""de-DE"")
 [de-DE]
 > Math.PI
 3,1415926535897931
@@ -120,11 +165,11 @@ Type ""#help"" for more information.
 
             // Tests that DefaultThreadCurrentUICulture is respected and not DefaultThreadCurrentCulture.
             runner = CreateRunner(input:
-@"using static System.Globalization.CultureInfo;
-DefaultThreadCurrentUICulture = GetCultureInfo(""en-GB"")
-DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
+@"using System.Globalization;
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"")
+CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""en-GB"")
 Math.PI
-DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
+CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""de-DE"")
 Math.PI
 ");
             runner.RunInteractive();
@@ -134,14 +179,14 @@ $@"Microsoft (R) Visual C# Interactive Compiler version {s_compilerVersion}
 Copyright (C) Microsoft Corporation. All rights reserved.
 
 Type ""#help"" for more information.
-> using static System.Globalization.CultureInfo;
-> DefaultThreadCurrentUICulture = GetCultureInfo(""en-GB"")
+> using System.Globalization;
+> CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo(""en-GB"")
 [en-GB]
-> DefaultThreadCurrentCulture = GetCultureInfo(""en-GB"")
+> CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""en-GB"")
 [en-GB]
 > Math.PI
 3.1415926535897931
-> DefaultThreadCurrentCulture = GetCultureInfo(""de-DE"")
+> CultureInfo.DefaultThreadCurrentCulture = new CultureInfo(""de-DE"")
 [de-DE]
 > Math.PI
 3.1415926535897931
@@ -482,11 +527,16 @@ Options:
         {
             var script = Temp.CreateFile(extension: ".csx").WriteAllText("WriteLine(42);");
 
-            var runner = CreateRunner(new[] { "/u:System.Console;Foo.Bar", script.Path });
+            var runner = CreateRunner(new[]
+            {
+                (RuntimeMetadataReferenceResolver.DefaultCorLibDirectoryOpt != null) ? "/r:System.Console" : null,
+                "/u:System.Console;Alpha.Beta",
+                script.Path
+            });
 
             Assert.Equal(1, runner.RunInteractive());
 
-            const string error = @"error CS0246: The type or namespace name 'Foo' could not be found (are you missing a using directive or an assembly reference?)";
+            const string error = @"error CS0246: The type or namespace name 'Alpha' could not be found (are you missing a using directive or an assembly reference?)";
             AssertEx.AssertEqualToleratingWhitespaceDifferences(error, runner.Console.Out.ToString());
             AssertEx.AssertEqualToleratingWhitespaceDifferences(error, runner.Console.Error.ToString());
         }

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1203,21 +1203,21 @@ public class C
             string lib1Name = "Lib1_" + Guid.NewGuid();
             string lib2Name = "Lib2_" + Guid.NewGuid();
 
-            var libBase = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase = CreateCSharpCompilation(@"
 public class LibBase
 {
     public readonly int X = 1;
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
 
-            var lib1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib1 = CreateCSharpCompilation(@"
 public class Lib1
 {
     public LibBase libBase = new LibBase();
 }
 ", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib1Name);
 
-            var lib2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib2 = CreateCSharpCompilation(@"
 public class Lib2
 {
     public LibBase libBase = new LibBase();
@@ -1261,21 +1261,21 @@ public class Lib2
             string lib1Name = "Lib1_" + Guid.NewGuid();
             string lib2Name = "Lib2_" + Guid.NewGuid();
 
-            var libBase = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase = CreateCSharpCompilation(@"
 public class LibBase
 {
     public readonly int X = 1;
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
 
-            var lib1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib1 = CreateCSharpCompilation(@"
 public class Lib1
 {
     public LibBase libBase = new LibBase();
 }
 ", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib1Name);
 
-            var lib2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib2 = CreateCSharpCompilation(@"
 public class Lib2
 {
     public LibBase libBase = new LibBase();
@@ -1319,28 +1319,28 @@ public class Lib2
             string lib1Name = "Lib1_" + Guid.NewGuid();
             string lib2Name = "Lib2_" + Guid.NewGuid();
 
-            var libBase1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase1 = CreateCSharpCompilation(@"
 public class LibBase
 {
     public readonly int X = 1;
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
 
-            var libBase2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase2 = CreateCSharpCompilation(@"
 public class LibBase
 {
     public readonly int X = 2;
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
 
-            var lib1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib1 = CreateCSharpCompilation(@"
 public class Lib1
 {
     public LibBase libBase = new LibBase();
 }
 ", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
 
-            var lib2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib2 = CreateCSharpCompilation(@"
 public class Lib2
 {
     public LibBase libBase = new LibBase();
@@ -1385,7 +1385,7 @@ public class Lib2
             string lib1Name = "Lib1_" + Guid.NewGuid();
             string lib2Name = "Lib2_" + Guid.NewGuid();
 
-            var libBase1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase1 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 public class LibBase
 {
@@ -1393,7 +1393,7 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
 
-            var libBase2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase2 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 public class LibBase
 {
@@ -1401,14 +1401,14 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
 
-            var lib1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib1 = CreateCSharpCompilation(@"
 public class Lib1
 {
     public LibBase libBase = new LibBase();
 }
 ", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
 
-            var lib2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib2 = CreateCSharpCompilation(@"
 public class Lib2
 {
     public LibBase libBase = new LibBase();
@@ -1453,7 +1453,7 @@ public class Lib2
             string lib1Name = "Lib1_" + Guid.NewGuid();
             string lib2Name = "Lib2_" + Guid.NewGuid();
 
-            var libBase1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase1 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 public class LibBase
 {
@@ -1461,7 +1461,7 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
 
-            var libBase2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase2 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 public class LibBase
 {
@@ -1469,14 +1469,14 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
 
-            var lib1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib1 = CreateCSharpCompilation(@"
 public class Lib1
 {
     public LibBase libBase = new LibBase();
 }
 ", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
 
-            var lib2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib2 = CreateCSharpCompilation(@"
 public class Lib2
 {
     public LibBase libBase = new LibBase();
@@ -1521,7 +1521,7 @@ public class Lib2
             string lib1Name = "Lib1_" + Guid.NewGuid();
             string lib2Name = "Lib2_" + Guid.NewGuid();
 
-            var libBase1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase1 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 public class LibBase
 {
@@ -1529,7 +1529,7 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
 
-            var libBase2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase2 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 public class LibBase
 {
@@ -1537,14 +1537,14 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll2);
 
-            var lib1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib1 = CreateCSharpCompilation(@"
 public class Lib1
 {
     public LibBase libBase = new LibBase();
 }
 ", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
 
-            var lib2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib2 = CreateCSharpCompilation(@"
 public class Lib2
 {
     public LibBase libBase = new LibBase();
@@ -1589,7 +1589,7 @@ public class Lib2
             string lib1Name = "Lib1_" + Guid.NewGuid();
             string lib2Name = "Lib2_" + Guid.NewGuid();
 
-            var libBase1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase1 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 public class LibBase
 {
@@ -1597,7 +1597,7 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
 
-            var libBase2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase2 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")]
 public class LibBase
 {
@@ -1605,14 +1605,14 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
 
-            var lib1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib1 = CreateCSharpCompilation(@"
 public class Lib1
 {
     public LibBase libBase = new LibBase();
 }
 ", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
 
-            var lib2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib2 = CreateCSharpCompilation(@"
 public class Lib2
 {
     public LibBase libBase = new LibBase();
@@ -1657,7 +1657,7 @@ public class Lib2
             string lib1Name = "Lib1_" + Guid.NewGuid();
             string lib2Name = "Lib2_" + Guid.NewGuid();
 
-            var libBase1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase1 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
 public class LibBase
 {
@@ -1665,7 +1665,7 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
 
-            var libBase2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var libBase2 = CreateCSharpCompilation(@"
 [assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")]
 public class LibBase
 {
@@ -1673,14 +1673,14 @@ public class LibBase
 }
 ", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
 
-            var lib1 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib1 = CreateCSharpCompilation(@"
 public class Lib1
 {
     public LibBase libBase = new LibBase();
 }
 ", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
 
-            var lib2 = TestCompilationFactory.CreateCSharpCompilation(@"
+            var lib2 = CreateCSharpCompilation(@"
 public class Lib2
 {
     public LibBase libBase = new LibBase();
@@ -1719,7 +1719,7 @@ public class Lib2
             var libDll = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""dll""; }", libName);
             var libWinmd = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""winmd""; }", libName);
 
-            var main = TestCompilationFactory.CreateCSharpCompilation(
+            var main = CreateCSharpCompilation(
                 @"public static class M { public static readonly C X = new C(); }",
                 new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libExe.ToMetadataReference() },
                 mainName);
@@ -1749,7 +1749,7 @@ public class Lib2
             var libDll = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""dll""; }", libName);
             var libWinmd = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""winmd""; }", libName);
 
-            var main = TestCompilationFactory.CreateCSharpCompilation(
+            var main = CreateCSharpCompilation(
                 @"public static class M { public static readonly C X = new C(); }",
                 new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libExe.ToMetadataReference() },
                 mainName);

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -30,12 +30,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
 
     public class InteractiveSessionTests : TestBase
     {
-        private static readonly CSharpCompilationOptions s_signedDll =
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, cryptoPublicKey: TestResources.TestKeys.PublicKey_ce65828c82a341f2);
-
-        private static readonly CSharpCompilationOptions s_signedDll2 =
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, cryptoPublicKey: TestResources.TestKeys.PublicKey_ce65828c82a341f2);
-
         internal static readonly Assembly HostAssembly = typeof(InteractiveSessionTests).GetTypeInfo().Assembly;
 
         #region Namespaces, Types
@@ -1134,14 +1128,29 @@ static T G<T>(T t, Func<T, Task<T>> f)
         [Fact]
         public void ReferenceDirective_FileWithDependencies()
         {
-            string file1 = Temp.CreateFile().WriteAllBytes(TestResources.MetadataTests.InterfaceAndClass.CSClasses01).Path;
-            string file2 = Temp.CreateFile().WriteAllBytes(TestResources.MetadataTests.InterfaceAndClass.CSInterfaces01).Path;
+            var file1 = Temp.CreateFile();
+            var file2 = Temp.CreateFile();
 
-            // ICSPropImpl in CSClasses01.dll implements ICSProp in CSInterfces01.dll.
-            object result = CSharpScript.EvaluateAsync(@"
-#r """ + file1 + @"""
-#r """ + file2 + @"""
-new Metadata.ICSPropImpl()
+            var lib1 = CreateCSharpCompilationWithCorlib(@"
+public interface I
+{
+    int F();
+}");
+
+            lib1.Emit(file1.Path);
+
+            var lib2 = CreateCSharpCompilation(@" 
+public class C : I
+{
+    public int F() => 1;
+}", new MetadataReference[] { TestReferences.NetStandard13.SystemRuntime, lib1.ToMetadataReference() });
+
+            lib2.Emit(file2.Path);
+
+            object result = CSharpScript.EvaluateAsync($@"
+#r ""{file1.Path}""
+#r ""{file2.Path}""
+new C()
 ").Result;
             Assert.NotNull(result);
         }
@@ -1149,12 +1158,17 @@ new Metadata.ICSPropImpl()
         [Fact]
         public void ReferenceDirective_RelativeToBaseParent()
         {
-            string path = Temp.CreateFile().WriteAllBytes(TestResources.MetadataTests.InterfaceAndClass.CSClasses01).Path;
-            string fileName = Path.GetFileName(path);
-            string dir = Path.Combine(Path.GetDirectoryName(path), "subdir");
+            var file = Temp.CreateFile();
+            var lib = CreateCSharpCompilationWithCorlib("public class C {}");
+            lib.Emit(file.Path);
 
-            var script = CSharpScript.Create($@"#r ""..\{fileName}""",
-                ScriptOptions.Default.WithFilePath(Path.Combine(dir, "a.csx")));
+            string dir = Path.Combine(Path.GetDirectoryName(file.Path), "subdir");
+            string libFileName = Path.GetFileName(file.Path);
+            string scriptPath = Path.Combine(dir, "a.csx");
+
+            var script = CSharpScript.Create(
+                $@"#r ""..\{libFileName}""",
+                ScriptOptions.Default.WithFilePath(scriptPath));
 
             script.GetCompilation().VerifyDiagnostics();
         }
@@ -1162,551 +1176,21 @@ new Metadata.ICSPropImpl()
         [Fact]
         public void ReferenceDirective_RelativeToBaseRoot()
         {
-            string path = Temp.CreateFile().WriteAllBytes(TestResources.MetadataTests.InterfaceAndClass.CSClasses01).Path;
-            string root = Path.GetPathRoot(path);
-            string unrooted = path.Substring(root.Length);
+            var file = Temp.CreateFile();
+            var lib = CreateCSharpCompilationWithCorlib("public class C {}");
+            lib.Emit(file.Path);
+
+            string root = Path.GetPathRoot(file.Path);
+            string unrooted = file.Path.Substring(root.Length);
 
             string dir = Path.Combine(root, "foo", "bar", "baz");
+            string scriptPath = Path.Combine(dir, "a.csx");
 
-            var script = CSharpScript.Create($@"#r ""\{unrooted}""",
-                ScriptOptions.Default.WithFilePath(Path.Combine(dir, "a.csx")));
+            var script = CSharpScript.Create(
+                $@"#r ""\{unrooted}""",
+                ScriptOptions.Default.WithFilePath(scriptPath));
 
             script.GetCompilation().VerifyDiagnostics();
-        }
-
-        [Fact, WorkItem(6457, "https://github.com/dotnet/roslyn/issues/6457")]
-        public async Task MissingReferencesReuse()
-        {
-            var source = @"
-public class C
-{
-    public System.Diagnostics.Process P;
-}
-";
-
-            var lib = CSharpCompilation.Create(
-                "Lib",
-                new[] { SyntaxFactory.ParseSyntaxTree(source) },
-                new[] { TestReferences.NetFx.v4_0_30319.mscorlib, TestReferences.NetFx.v4_0_30319.System },
-                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-
-            var libFile = Temp.CreateFile("lib").WriteAllBytes(lib.EmitToArray());
-
-            var s0 = await CSharpScript.RunAsync("C c;", ScriptOptions.Default.WithReferences(libFile.Path));
-            var s1 = await s0.ContinueWithAsync("c = new C()");
-        }
-
-        [Fact]
-        public async Task SharedLibCopy_Identical_Weak()
-        {
-            string libBaseName = "LibBase_" + Guid.NewGuid();
-            string lib1Name = "Lib1_" + Guid.NewGuid();
-            string lib2Name = "Lib2_" + Guid.NewGuid();
-
-            var libBase = CreateCSharpCompilation(@"
-public class LibBase
-{
-    public readonly int X = 1;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
-
-            var lib1 = CreateCSharpCompilation(@"
-public class Lib1
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib1Name);
-
-            var lib2 = CreateCSharpCompilation(@"
-public class Lib2
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib2Name);
-
-            var libBaseImage = libBase.EmitToArray();
-            var lib1Image = lib1.EmitToArray();
-            var lib2Image = lib2.EmitToArray();
-
-            var root = Temp.CreateDirectory();
-            var dir1 = root.CreateDirectory("1");
-            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
-            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBaseImage);
-
-            var dir2 = root.CreateDirectory("2");
-            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
-            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBaseImage);
-
-            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
-            var s1 = await s0.ContinueWithAsync($@"var l1 = new Lib1();");
-            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
-            var s3 = await s2.ContinueWithAsync($@"var l2 = new Lib2();");
-            var s4 = await s3.ContinueWithAsync($@"l2.libBase.X");
-
-            var c4 = s4.Script.GetCompilation();
-            c4.VerifyAssemblyAliases(
-                lib2Name,
-                lib1Name,
-                "mscorlib",
-                libBaseName + ": <implicit>,global");
-
-            var libBaseRefAndSymbol = c4.GetBoundReferenceManager().GetReferencedAssemblies().ToArray()[3];
-            Assert.Equal(fileBase1.Path, ((PortableExecutableReference)libBaseRefAndSymbol.Key).FilePath);
-        }
-
-        [Fact]
-        public async Task SharedLibCopy_Identical_Strong()
-        {
-            string libBaseName = "LibBase_" + Guid.NewGuid();
-            string lib1Name = "Lib1_" + Guid.NewGuid();
-            string lib2Name = "Lib2_" + Guid.NewGuid();
-
-            var libBase = CreateCSharpCompilation(@"
-public class LibBase
-{
-    public readonly int X = 1;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
-
-            var lib1 = CreateCSharpCompilation(@"
-public class Lib1
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib1Name);
-
-            var lib2 = CreateCSharpCompilation(@"
-public class Lib2
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase.ToMetadataReference() }, lib2Name);
-
-            var libBaseImage = libBase.EmitToArray();
-            var lib1Image = lib1.EmitToArray();
-            var lib2Image = lib2.EmitToArray();
-
-            var root = Temp.CreateDirectory();
-            var dir1 = root.CreateDirectory("1");
-            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
-            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBaseImage);
-
-            var dir2 = root.CreateDirectory("2");
-            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
-            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBaseImage);
-
-            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
-            var s1 = await s0.ContinueWithAsync($@"var l1 = new Lib1();");
-            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
-            var s3 = await s2.ContinueWithAsync($@"var l2 = new Lib2();");
-            var s4 = await s3.ContinueWithAsync($@"l2.libBase.X");
-
-            var c4 = s4.Script.GetCompilation();
-            c4.VerifyAssemblyAliases(
-                lib2Name,
-                lib1Name,
-                "mscorlib",
-                libBaseName + ": <implicit>,global");
-
-            var libBaseRefAndSymbol = c4.GetBoundReferenceManager().GetReferencedAssemblies().ToArray()[3];
-            Assert.Equal(fileBase1.Path, ((PortableExecutableReference)libBaseRefAndSymbol.Key).FilePath);
-        }
-
-        [Fact]
-        public async Task SharedLibCopy_SameVersion_Weak_DifferentContent()
-        {
-            string libBaseName = "LibBase_" + Guid.NewGuid();
-            string lib1Name = "Lib1_" + Guid.NewGuid();
-            string lib2Name = "Lib2_" + Guid.NewGuid();
-
-            var libBase1 = CreateCSharpCompilation(@"
-public class LibBase
-{
-    public readonly int X = 1;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
-
-            var libBase2 = CreateCSharpCompilation(@"
-public class LibBase
-{
-    public readonly int X = 2;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
-
-            var lib1 = CreateCSharpCompilation(@"
-public class Lib1
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
-
-            var lib2 = CreateCSharpCompilation(@"
-public class Lib2
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib2Name);
-
-            var libBase1Image = libBase1.EmitToArray();
-            var libBase2Image = libBase2.EmitToArray();
-            var lib1Image = lib1.EmitToArray();
-            var lib2Image = lib2.EmitToArray();
-
-            var root = Temp.CreateDirectory();
-            var dir1 = root.CreateDirectory("1");
-            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
-            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
-
-            var dir2 = root.CreateDirectory("2");
-            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
-            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
-
-            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
-            var s1 = await s0.ContinueWithAsync($@"var l1 = new Lib1();");
-            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
-
-            bool exceptionSeen = false;
-            try
-            {
-                await s2.ContinueWithAsync($@"var l2 = new Lib2();");
-            }
-            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
-            {
-                exceptionSeen = true;
-            }
-
-            Assert.True(exceptionSeen);
-        }
-
-        [Fact]
-        public async Task SharedLibCopy_SameVersion_Strong_DifferentContent()
-        {
-            string libBaseName = "LibBase_" + Guid.NewGuid();
-            string lib1Name = "Lib1_" + Guid.NewGuid();
-            string lib2Name = "Lib2_" + Guid.NewGuid();
-
-            var libBase1 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 1;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
-
-            var libBase2 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 2;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
-
-            var lib1 = CreateCSharpCompilation(@"
-public class Lib1
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
-
-            var lib2 = CreateCSharpCompilation(@"
-public class Lib2
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib2Name);
-
-            var libBase1Image = libBase1.EmitToArray();
-            var libBase2Image = libBase2.EmitToArray();
-            var lib1Image = lib1.EmitToArray();
-            var lib2Image = lib2.EmitToArray();
-
-            var root = Temp.CreateDirectory();
-            var dir1 = root.CreateDirectory("1");
-            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
-            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
-
-            var dir2 = root.CreateDirectory("2");
-            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
-            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
-
-            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
-            var s1 = await s0.ContinueWithAsync($@"new Lib1().libBase.X");
-            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
-
-            bool exceptionSeen = false;
-            try
-            {
-                await s2.ContinueWithAsync($@"new Lib2().libBase.X");
-            }
-            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
-            {
-                exceptionSeen = true;
-            }
-
-            Assert.True(exceptionSeen);
-        }
-
-        [Fact]
-        public async Task SharedLibCopy_SameVersion_StrongWeak_DifferentContent()
-        {
-            string libBaseName = "LibBase_" + Guid.NewGuid();
-            string lib1Name = "Lib1_" + Guid.NewGuid();
-            string lib2Name = "Lib2_" + Guid.NewGuid();
-
-            var libBase1 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 1;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
-
-            var libBase2 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 2;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
-
-            var lib1 = CreateCSharpCompilation(@"
-public class Lib1
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
-
-            var lib2 = CreateCSharpCompilation(@"
-public class Lib2
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib2Name);
-
-            var libBase1Image = libBase1.EmitToArray();
-            var libBase2Image = libBase2.EmitToArray();
-            var lib1Image = lib1.EmitToArray();
-            var lib2Image = lib2.EmitToArray();
-
-            var root = Temp.CreateDirectory();
-            var dir1 = root.CreateDirectory("1");
-            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
-            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
-
-            var dir2 = root.CreateDirectory("2");
-            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
-            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
-
-            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
-            var s1 = await s0.ContinueWithAsync($@"new Lib1().libBase.X");
-            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
-
-            bool exceptionSeen = false;
-            try
-            {
-                await s2.ContinueWithAsync($@"new Lib2().libBase.X");
-            }
-            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
-            {
-                exceptionSeen = true;
-            }
-
-            Assert.True(exceptionSeen);
-        }
-
-        [Fact]
-        public async Task SharedLibCopy_SameVersion_StrongDifferentPKT_DifferentContent()
-        {
-            string libBaseName = "LibBase_" + Guid.NewGuid();
-            string lib1Name = "Lib1_" + Guid.NewGuid();
-            string lib2Name = "Lib2_" + Guid.NewGuid();
-
-            var libBase1 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 1;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
-
-            var libBase2 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 2;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll2);
-
-            var lib1 = CreateCSharpCompilation(@"
-public class Lib1
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
-
-            var lib2 = CreateCSharpCompilation(@"
-public class Lib2
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib2Name);
-
-            var libBase1Image = libBase1.EmitToArray();
-            var libBase2Image = libBase2.EmitToArray();
-            var lib1Image = lib1.EmitToArray();
-            var lib2Image = lib2.EmitToArray();
-
-            var root = Temp.CreateDirectory();
-            var dir1 = root.CreateDirectory("1");
-            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
-            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
-
-            var dir2 = root.CreateDirectory("2");
-            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
-            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
-
-            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
-            var s1 = await s0.ContinueWithAsync($@"new Lib1().libBase.X");
-            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
-
-            bool exceptionSeen = false;
-            try
-            {
-                await s2.ContinueWithAsync($@"new Lib2().libBase.X");
-            }
-            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
-            {
-                exceptionSeen = true;
-            }
-
-            Assert.True(exceptionSeen);
-        }
-
-        [Fact]
-        public async Task SharedLibCopy_DifferentVersion_Weak()
-        {
-            string libBaseName = "LibBase_" + Guid.NewGuid();
-            string lib1Name = "Lib1_" + Guid.NewGuid();
-            string lib2Name = "Lib2_" + Guid.NewGuid();
-
-            var libBase1 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 1;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
-
-            var libBase2 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 2;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName);
-
-            var lib1 = CreateCSharpCompilation(@"
-public class Lib1
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
-
-            var lib2 = CreateCSharpCompilation(@"
-public class Lib2
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase2.ToMetadataReference() }, lib2Name);
-
-            var libBase1Image = libBase1.EmitToArray();
-            var libBase2Image = libBase2.EmitToArray();
-            var lib1Image = lib1.EmitToArray();
-            var lib2Image = lib2.EmitToArray();
-
-            var root = Temp.CreateDirectory();
-            var dir1 = root.CreateDirectory("1");
-            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
-            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
-
-            var dir2 = root.CreateDirectory("2");
-            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
-            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
-
-            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
-            var s1 = await s0.ContinueWithAsync($@"var l1 = new Lib1().libBase.X;");
-            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
-
-            bool exceptionSeen = false;
-            try
-            {
-                await s2.ContinueWithAsync($@"var l2 = new Lib2().libBase.X;");
-            }
-            catch (FileLoadException fileLoadEx) when (fileLoadEx.InnerException is InteractiveAssemblyLoaderException)
-            {
-                exceptionSeen = true;
-            }
-
-            Assert.True(exceptionSeen);
-        }
-
-        [Fact]
-        public async Task SharedLibCopy_DifferentVersion_Strong()
-        {
-            string libBaseName = "LibBase_" + Guid.NewGuid();
-            string lib1Name = "Lib1_" + Guid.NewGuid();
-            string lib2Name = "Lib2_" + Guid.NewGuid();
-
-            var libBase1 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 1;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
-
-            var libBase2 = CreateCSharpCompilation(@"
-[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")]
-public class LibBase
-{
-    public readonly int X = 2;
-}
-", new[] { TestReferences.NetFx.v4_0_30319.mscorlib }, libBaseName, s_signedDll);
-
-            var lib1 = CreateCSharpCompilation(@"
-public class Lib1
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase1.ToMetadataReference() }, lib1Name);
-
-            var lib2 = CreateCSharpCompilation(@"
-public class Lib2
-{
-    public LibBase libBase = new LibBase();
-}
-", new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libBase2.ToMetadataReference() }, lib2Name);
-
-            var libBase1Image = libBase1.EmitToArray();
-            var libBase2Image = libBase2.EmitToArray();
-            var lib1Image = lib1.EmitToArray();
-            var lib2Image = lib2.EmitToArray();
-
-            var root = Temp.CreateDirectory();
-            var dir1 = root.CreateDirectory("1");
-            var file1 = dir1.CreateFile(lib1Name + ".dll").WriteAllBytes(lib1Image);
-            var fileBase1 = dir1.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase1Image);
-
-            var dir2 = root.CreateDirectory("2");
-            var file2 = dir2.CreateFile(lib2Name + ".dll").WriteAllBytes(lib2Image);
-            var fileBase2 = dir2.CreateFile(libBaseName + ".dll").WriteAllBytes(libBase2Image);
-
-            var s0 = await CSharpScript.RunAsync($@"#r ""{file1.Path}""");
-            var s1 = await s0.ContinueWithAsync($@"new Lib1().libBase.X");
-            Assert.Equal(1, s1.ReturnValue);
-            var s2 = await s1.ContinueWithAsync($@"#r ""{file2.Path}""");
-            var s3 = await s2.ContinueWithAsync($@"new Lib2().libBase.X");
-            Assert.Equal(2, s3.ReturnValue);
         }
 
         [Fact]
@@ -1715,13 +1199,13 @@ public class Lib2
             string mainName = "Main_" + Guid.NewGuid();
             string libName = "Lib_" + Guid.NewGuid();
 
-            var libExe = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""exe""; }", libName);
-            var libDll = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""dll""; }", libName);
-            var libWinmd = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""winmd""; }", libName);
+            var libExe = CreateCSharpCompilationWithCorlib(@"public class C { public string F = ""exe""; }", libName);
+            var libDll = CreateCSharpCompilationWithCorlib(@"public class C { public string F = ""dll""; }", libName);
+            var libWinmd = CreateCSharpCompilationWithCorlib(@"public class C { public string F = ""winmd""; }", libName);
 
             var main = CreateCSharpCompilation(
                 @"public static class M { public static readonly C X = new C(); }",
-                new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libExe.ToMetadataReference() },
+                new MetadataReference[] { TestReferences.NetStandard13.SystemRuntime, libExe.ToMetadataReference() },
                 mainName);
 
             var exeImage = libExe.EmitToArray();
@@ -1745,13 +1229,13 @@ public class Lib2
             string mainName = "Main_" + Guid.NewGuid();
             string libName = "Lib_" + Guid.NewGuid();
 
-            var libExe = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""exe""; }", libName);
-            var libDll = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""dll""; }", libName);
-            var libWinmd = TestCompilationFactory.CreateCSharpCompilationWithMscorlib(@"public class C { public string F = ""winmd""; }", libName);
+            var libExe = CreateCSharpCompilationWithCorlib(@"public class C { public string F = ""exe""; }", libName);
+            var libDll = CreateCSharpCompilationWithCorlib(@"public class C { public string F = ""dll""; }", libName);
+            var libWinmd = CreateCSharpCompilationWithCorlib(@"public class C { public string F = ""winmd""; }", libName);
 
             var main = CreateCSharpCompilation(
                 @"public static class M { public static readonly C X = new C(); }",
-                new MetadataReference[] { TestReferences.NetFx.v4_0_30319.mscorlib, libExe.ToMetadataReference() },
+                new MetadataReference[] { TestReferences.NetStandard13.SystemRuntime, libExe.ToMetadataReference() },
                 mainName);
 
             var exeImage = libExe.EmitToArray();
@@ -1779,7 +1263,7 @@ public class D { }
 public class E { }
 ";
 
-            var libRef = CreateCSharpCompilationWithMscorlib(source, "lib").EmitToImageReference();
+            var libRef = CreateCSharpCompilationWithCorlib(source, "lib").EmitToImageReference();
 
             var script = CSharpScript.Create(@"new C()",
                 ScriptOptions.Default.WithReferences(libRef.WithAliases(new[] { "Hidden" })).WithImports("Hidden::N"));

--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -1562,32 +1562,57 @@ new List<ArgumentException>()
             Assert.Equal(1, r1.Result);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/8332")]
+        [Fact]
         public void HostObjectAssemblyReference1()
         {
             var scriptCompilation = CSharpScript.Create(
                 "nameof(Microsoft.CodeAnalysis.Scripting)",
+                ScriptOptions.Default.WithMetadataResolver(TestRuntimeMetadataReferenceResolver.Instance),
                 globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
 
             scriptCompilation.VerifyDiagnostics(
                 // (1,8): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
                 Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "Microsoft.CodeAnalysis").WithArguments("CodeAnalysis", "Microsoft"));
 
-            foreach (var assemblyAndAliases in scriptCompilation.GetBoundReferenceManager().GetReferencedAssemblyAliases())
-            {
-                switch (assemblyAndAliases.Item1.Identity.Name)
-                {
-                    case "mscorlib":
-                        AssertEx.SetEqual(new[] { "global", "<host>" }, assemblyAndAliases.Item2);
-                        break;
+            string corAssemblyName = typeof(object).GetTypeInfo().Assembly.GetName().Name;
+            string hostObjectAssemblyName = scriptCompilation.ScriptCompilationInfo.GlobalsType.GetTypeInfo().Assembly.GetName().Name;
 
-                    case "Microsoft.CodeAnalysis.Scripting":
-                        AssertEx.SetEqual(new[] { "<host>" }, assemblyAndAliases.Item2);
+            // The host adds 
+            // 1) a reference to typeof(object).Assembly
+            // 2) a reference to GlobalsType with alias <host> applied recursively.
+            // References returned from ResolveMissingAssembly have <implicit> alias.
+
+            foreach (var (assembly, aliases) in scriptCompilation.GetBoundReferenceManager().GetReferencedAssemblyAliases())
+            {
+                string name = assembly.Identity.Name;
+
+                switch (name)
+                {
+                    case "Microsoft.CodeAnalysis.CSharp.Scripting":
+                    case "Microsoft.CodeAnalysis.CSharp":
+                        // assemblies not referenced
+                        Assert.False(true);
                         break;
 
                     case "Microsoft.CodeAnalysis":
+                    case "System.Collections.Immutable":
+                        // Microsoft.CodeAnalysis.Scripting contains host object and is thus referenced recursively with <host> alias. 
+                        // The script doesn't reference the assemblies explicitly.
+                        AssertEx.SetEqual(new[] { "<implicit>", "<host>" }, aliases);
+                        break;
+
                     default:
-                        AssertEx.SetEqual(new[] { "<implicit>", "<host>" }, assemblyAndAliases.Item2);
+                        if (name == corAssemblyName)
+                        {
+                            // Host object depends on System.Object, thus <host> is applied on CorLib.
+                            AssertEx.SetEqual(new[] { "<host>", "global" }, aliases);
+                        }
+                        else if (name == hostObjectAssemblyName)
+                        {
+                            // Host object is only referenced by the host and thus the assembly is hidden behind <host> alias.
+                            AssertEx.SetEqual(new[] { "<host>" }, aliases);
+                        }
+
                         break;
                 }
             }
@@ -1598,75 +1623,126 @@ new List<ArgumentException>()
         {
             var scriptCompilation = CSharpScript.Create(
                 "typeof(Microsoft.CodeAnalysis.Scripting.Script)",
-                options: ScriptOptions.Default.WithReferences(typeof(CSharpScript).GetTypeInfo().Assembly),
+                options: ScriptOptions.Default.
+                    WithMetadataResolver(TestRuntimeMetadataReferenceResolver.Instance).
+                    WithReferences(typeof(CSharpScript).GetTypeInfo().Assembly),
                 globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
 
             scriptCompilation.VerifyDiagnostics();
 
-            foreach (var assemblyAndAliases in scriptCompilation.GetBoundReferenceManager().GetReferencedAssemblyAliases())
+            string corAssemblyName = typeof(object).GetTypeInfo().Assembly.GetName().Name;
+            string hostObjectAssemblyName = scriptCompilation.ScriptCompilationInfo.GlobalsType.GetTypeInfo().Assembly.GetName().Name;
+
+            // The host adds 
+            // 1) a reference to typeof(object).Assembly
+            // 2) a reference to GlobalsType with alias <host> applied recursively.
+            // References returned from ResolveMissingAssembly have <implicit> alias.
+
+            foreach (var (assembly, aliases) in scriptCompilation.GetBoundReferenceManager().GetReferencedAssemblyAliases())
             {
-                switch (assemblyAndAliases.Item1.Identity.Name)
+                string name = assembly.Identity.Name;
+
+                switch (name)
                 {
-                    case "mscorlib":
-                        AssertEx.SetEqual(new[] { "global", "<host>" }, assemblyAndAliases.Item2);
-                        break;
-
-                    case "Microsoft.CodeAnalysis.Scripting":
-                        AssertEx.SetEqual(new[] { "<host>", "global" }, assemblyAndAliases.Item2);
-                        break;
-
                     case "Microsoft.CodeAnalysis.CSharp.Scripting":
-                        AssertEx.SetEqual(new string[0], assemblyAndAliases.Item2);
+                        // we have an explicit reference to CSharpScript assembly:
+                        AssertEx.SetEqual(Array.Empty<string>(), aliases);
                         break;
 
                     case "Microsoft.CodeAnalysis.CSharp":
-                        AssertEx.SetEqual(new[] { "<implicit>", "global" }, assemblyAndAliases.Item2);
+                        // The script has a recursive reference to Microsoft.CodeAnalysis.CSharp.Scripting, which references these assemblies.
+                        // The script doesn't reference the assembly explicitly.
+                        AssertEx.SetEqual(new[] { "<implicit>", "global" }, aliases);
                         break;
 
                     case "Microsoft.CodeAnalysis":
-                    case "System.IO":
                     case "System.Collections.Immutable":
-                        AssertEx.SetEqual(new[] { "<implicit>", "<host>", "global" }, assemblyAndAliases.Item2);
+                        // The script has a recursive reference to Microsoft.CodeAnalysis.CSharp.Scripting, which references these assemblies.
+                        // Microsoft.CodeAnalysis.Scripting contains host object and is thus referenced recursively with <host> alias. 
+                        // The script doesn't reference the assemblies explicitly.
+                        AssertEx.SetEqual(new[] { "<implicit>", "<host>", "global" }, aliases);
+                        break;
+                   
+                    default:
+                        if (name == corAssemblyName)
+                        {
+                            // Host object depends on System.Object, thus <host> is applied on CorLib.
+                            AssertEx.SetEqual(new[] { "<host>", "global" }, aliases);
+                        }
+                        else if (name == hostObjectAssemblyName)
+                        {
+                            // Host object is defined in an assembly that CSharpScript depends on.
+                            // CSharpScript assembly was references (recursively) hence host object assembly is 
+                            // available to the script (global alias).
+                            AssertEx.SetEqual(new[] { "<host>", "global" }, aliases);
+                        }
+                        
                         break;
                 }
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/6532")]
+        [Fact]
         public void HostObjectAssemblyReference3()
         {
             string source = $@"
 #r ""{typeof(CSharpScript).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName}""
 typeof(Microsoft.CodeAnalysis.Scripting.Script)
 ";
-            var scriptCompilation = CSharpScript.Create(source, globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
+            var scriptCompilation = CSharpScript.Create(
+                source, 
+                ScriptOptions.Default.WithMetadataResolver(TestRuntimeMetadataReferenceResolver.Instance),
+                globalsType: typeof(CommandLineScriptGlobals)).GetCompilation();
 
             scriptCompilation.VerifyDiagnostics();
 
-            foreach (var assemblyAndAliases in scriptCompilation.GetBoundReferenceManager().GetReferencedAssemblyAliases())
+            string corAssemblyName = typeof(object).GetTypeInfo().Assembly.GetName().Name;
+            string hostObjectAssemblyName = scriptCompilation.ScriptCompilationInfo.GlobalsType.GetTypeInfo().Assembly.GetName().Name;
+
+            // The host adds 
+            // 1) a reference to typeof(object).Assembly
+            // 2) a reference to GlobalsType with alias <host> applied recursively.
+            // References returned from ResolveMissingAssembly have <implicit> alias.
+
+            foreach (var (assembly, aliases) in scriptCompilation.GetBoundReferenceManager().GetReferencedAssemblyAliases())
             {
-                switch (assemblyAndAliases.Item1.Identity.Name)
+                string name = assembly.Identity.Name;
+
+                switch (name)
                 {
-                    case "mscorlib":
-                        AssertEx.SetEqual(new[] { "global", "<host>" }, assemblyAndAliases.Item2);
-                        break;
-
                     case "Microsoft.CodeAnalysis.CSharp.Scripting":
-                        AssertEx.SetEqual(new string[0], assemblyAndAliases.Item2);
-                        break;
-
-                    case "Microsoft.CodeAnalysis.Scripting":
-                        AssertEx.SetEqual(new[] { "global", "<host>" }, assemblyAndAliases.Item2);
+                        // we have an explicit reference to CSharpScript assembly:
+                        AssertEx.SetEqual(Array.Empty<string>(), aliases);
                         break;
 
                     case "Microsoft.CodeAnalysis.CSharp":
-                        AssertEx.SetEqual(new[] { "<implicit>", "global" }, assemblyAndAliases.Item2);
+                        // The script has a recursive reference to Microsoft.CodeAnalysis.CSharp.Scripting, which references these assemblies.
+                        // The script doesn't reference the assembly explicitly.
+                        AssertEx.SetEqual(new[] { "<implicit>", "global" }, aliases);
                         break;
 
                     case "Microsoft.CodeAnalysis":
-                    case "System.IO":
                     case "System.Collections.Immutable":
-                        AssertEx.SetEqual(new[] { "<implicit>", "global", "<host>" }, assemblyAndAliases.Item2);
+                        // The script has a recursive reference to Microsoft.CodeAnalysis.CSharp.Scripting, which references these assemblies.
+                        // Microsoft.CodeAnalysis.Scripting contains host object and is thus referenced recursively with <host> alias. 
+                        // The script doesn't reference the assemblies explicitly.
+                        AssertEx.SetEqual(new[] { "<implicit>", "<host>", "global" }, aliases);
+                        break;
+
+                    default:
+                        if (name == corAssemblyName)
+                        {
+                            // Host object depends on System.Object, thus <host> is applied on CorLib.
+                            AssertEx.SetEqual(new[] { "<host>", "global" }, aliases);
+                        }
+                        else if (name == hostObjectAssemblyName)
+                        {
+                            // Host object is defined in an assembly that CSharpScript depends on.
+                            // CSharpScript assembly was references (recursively) hence host object assembly is 
+                            // available to the script (global alias).
+                            AssertEx.SetEqual(new[] { "<host>", "global" }, aliases);
+                        }
+
                         break;
                 }
             }

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -418,7 +418,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
 
             obj = Enumerable.Range(0, 10);
             str = s_formatter.FormatObject(obj, SingleLineOptions);
-            Assert.Equal("RangeIterator { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }", str);
+
+            // the implementation differs between .NET Core and .NET FX
+            if (str.StartsWith("Enumerable"))
+            {
+                Assert.Equal("Enumerable.RangeIterator { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }", str);
+            }
+            else
+            {
+                Assert.Equal("RangeIterator { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }", str);
+            }
         }
 
         [Fact]

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -155,10 +155,11 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
         internal static MetadataReferenceResolver GetMetadataReferenceResolver(CommandLineArguments arguments, TouchedFileLogger loggerOpt)
         {
             return new RuntimeMetadataReferenceResolver(
-                new RelativePathResolver(arguments.ReferencePaths, arguments.BaseDirectory),
-                null,
-                GacFileResolver.IsAvailable ? new GacFileResolver(preferredCulture: CultureInfo.CurrentCulture) : null,
-                (path, properties) =>
+                pathResolver: new RelativePathResolver(arguments.ReferencePaths, arguments.BaseDirectory),
+                packageResolver: null,
+                gacFileResolver: GacFileResolver.IsAvailable ? new GacFileResolver(preferredCulture: CultureInfo.CurrentCulture) : null,
+                corLibDirectoryOpt: RuntimeMetadataReferenceResolver.DefaultCorLibDirectoryOpt,
+                fileReferenceProvider: (path, properties) =>
                 {
                     loggerOpt?.AddRead(path);
                     return MetadataReference.CreateFromFile(path, properties);

--- a/src/Scripting/CoreTest/RuntimeMetadataReferenceResolverTests.cs
+++ b/src/Scripting/CoreTest/RuntimeMetadataReferenceResolverTests.cs
@@ -26,7 +26,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
                 var resolver = new RuntimeMetadataReferenceResolver(
                     new RelativePathResolver(ImmutableArray.Create(directory.Path), baseDirectory: directory.Path),
                     new PackageResolver(ImmutableDictionary<string, ImmutableArray<string>>.Empty.Add("nuget:N/1.0", ImmutableArray.Create(assembly1.Path, assembly2.Path))),
-                    gacFileResolver: null);
+                    gacFileResolver: null,
+                    corLibDirectoryOpt: null);
+
                 // Recognized NuGet reference.
                 var actualReferences = resolver.ResolveReference("nuget:N/1.0", baseFilePath: null, properties: MetadataReferenceProperties.Assembly);
                 AssertEx.SetEqual(actualReferences.SelectAsArray(r => r.FilePath), assembly1.Path, assembly2.Path);
@@ -44,7 +46,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.Interactive
                 resolver = new RuntimeMetadataReferenceResolver(
                     new RelativePathResolver(ImmutableArray.Create(directory.Path), baseDirectory: directory.Path),
                     packageResolver: null,
-                    gacFileResolver: null);
+                    gacFileResolver: null,
+                    corLibDirectoryOpt: null);
+
                 // Unrecognized NuGet reference.
                 actualReferences = resolver.ResolveReference("nuget:N/1.0", baseFilePath: null, properties: MetadataReferenceProperties.Assembly);
                 Assert.True(actualReferences.IsEmpty);

--- a/src/Scripting/CoreTest/ScriptOptionsTests.cs
+++ b/src/Scripting/CoreTest/ScriptOptionsTests.cs
@@ -3,9 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
 using System.Reflection;
+using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -23,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
                 AddReferences("System.Linq").
                 AddReferences("System.Linq");
 
-            Assert.Equal(5, options.MetadataReferences.Length);
+            Assert.Equal((RuntimeMetadataReferenceResolver.DefaultCorLibDirectoryOpt != null) ? 27 : 5, options.MetadataReferences.Length);
         }
 
         [Fact]
@@ -31,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         {
             var moduleRef = ModuleMetadata.CreateFromImage(TestResources.MetadataTests.NetModule01.ModuleCS00).GetReference();
 
-            var options = ScriptOptions.Default;
+            var options = ScriptOptions.Default.WithReferences(ImmutableArray<MetadataReference>.Empty);
             Assert.Throws<ArgumentNullException>("references", () => options.AddReferences((MetadataReference[])null));
             Assert.Throws<ArgumentNullException>("references[0]", () => options.AddReferences(new MetadataReference[] { null }));
 
@@ -54,15 +53,17 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         [Fact]
         public void WithReferences()
         {
-            var options = ScriptOptions.Default.WithReferences("System.Linq", "system.linq");
+            var empty = ScriptOptions.Default.WithReferences(ImmutableArray<MetadataReference>.Empty);
+
+            var options = empty.WithReferences("System.Linq", "system.linq");
             Assert.Equal(2, options.MetadataReferences.Length);
 
-            options = ScriptOptions.Default.WithReferences(typeof(int).GetTypeInfo().Assembly, typeof(int).GetTypeInfo().Assembly);
+            options = empty.WithReferences(typeof(int).GetTypeInfo().Assembly, typeof(int).GetTypeInfo().Assembly);
             Assert.Equal(2, options.MetadataReferences.Length);
 
             var assemblyRef = ModuleMetadata.CreateFromImage(TestResources.SymbolsTests.Methods.CSMethods).GetReference();
 
-            options = ScriptOptions.Default.WithReferences(assemblyRef, assemblyRef);
+            options = empty.WithReferences(assemblyRef, assemblyRef);
             Assert.Equal(2, options.MetadataReferences.Length);
         }
 
@@ -71,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         {
             var moduleRef = ModuleMetadata.CreateFromImage(TestResources.MetadataTests.NetModule01.ModuleCS00).GetReference();
 
-            var options = ScriptOptions.Default;
+            var options = ScriptOptions.Default.WithReferences(ImmutableArray<MetadataReference>.Empty);
             Assert.Throws<ArgumentNullException>("references", () => options.WithReferences((MetadataReference[])null));
             Assert.Throws<ArgumentNullException>("references", () => options.WithReferences((IEnumerable<MetadataReference>)null));
             Assert.Throws<ArgumentNullException>("references", () => options.WithReferences(default(ImmutableArray<MetadataReference>)));

--- a/src/Scripting/CoreTestUtilities/RedirectedOutput.cs
+++ b/src/Scripting/CoreTestUtilities/RedirectedOutput.cs
@@ -2,16 +2,21 @@
 
 using System;
 using System.IO;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Scripting
 {
     public sealed class OutputRedirect : IDisposable
     {
+        private static readonly object s_guard = new object();
+
         private readonly TextWriter _oldOut;
         private readonly StringWriter _newOut;
 
         public OutputRedirect(IFormatProvider formatProvider)
         {
+            Monitor.Enter(s_guard);
+
             _oldOut = Console.Out;
             _newOut = new StringWriter(formatProvider);
             Console.SetOut(_newOut);
@@ -23,6 +28,8 @@ namespace Microsoft.CodeAnalysis.Scripting
         {
             Console.SetOut(_oldOut);
             _newOut.Dispose();
+
+            Monitor.Exit(s_guard);
         }
     }
 }

--- a/src/Scripting/CoreTestUtilities/ScriptingTestUtilities.csproj
+++ b/src/Scripting/CoreTestUtilities/ScriptingTestUtilities.csproj
@@ -50,6 +50,7 @@
     <Compile Include="RedirectedOutput.cs" />
     <Compile Include="ScriptingTestHelpers.cs" />
     <Compile Include="ScriptTaskExtensions.cs" />
+    <Compile Include="TestRuntimeMetadataReferenceResolver.cs" />
     <Compile Include="TestCompilationFactory.cs" />
     <Compile Include="TestConsoleIO.cs" />
     <Compile Include="TestCSharpObjectFormatter.cs" />

--- a/src/Scripting/CoreTestUtilities/TestCompilationFactory.cs
+++ b/src/Scripting/CoreTestUtilities/TestCompilationFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.VisualBasic;
 
@@ -9,28 +10,28 @@ namespace Microsoft.CodeAnalysis.Scripting
     {
         // TODO: we need to clean up and refactor CreateCompilationWithMscorlib in compiler tests 
         // so that it can be used in portable tests.
-        internal static Compilation CreateCSharpCompilationWithMscorlib(string source, string assemblyName)
+        internal static Compilation CreateCSharpCompilationWithCorlib(string source, string assemblyName = null)
         {
             return CSharpCompilation.Create(
-                assemblyName,
+                assemblyName ?? Guid.NewGuid().ToString(),
                 new[] { CSharp.SyntaxFactory.ParseSyntaxTree(source) },
-                new[] { TestReferences.NetFx.v4_0_30319.mscorlib },
+                new[] { TestReferences.NetStandard13.SystemRuntime },
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         }
 
-        internal static Compilation CreateVisualBasicCompilationWithMscorlib(string source, string assemblyName)
+        internal static Compilation CreateVisualBasicCompilationWithCorlib(string source, string assemblyName = null)
         {
             return VisualBasicCompilation.Create(
-                assemblyName,
+                assemblyName ?? Guid.NewGuid().ToString(),
                 new[] { VisualBasic.SyntaxFactory.ParseSyntaxTree(source) },
-                new[] { TestReferences.NetFx.v4_0_30319.mscorlib },
+                new[] { TestReferences.NetStandard13.SystemRuntime },
                 new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         }
 
-        internal static Compilation CreateCSharpCompilation(string source, MetadataReference[] references, string assemblyName, CSharpCompilationOptions options = null)
+        internal static Compilation CreateCSharpCompilation(string source, MetadataReference[] references, string assemblyName = null, CSharpCompilationOptions options = null)
         {
             return CSharpCompilation.Create(
-                assemblyName,
+                assemblyName ?? Guid.NewGuid().ToString(),
                 new[] { CSharp.SyntaxFactory.ParseSyntaxTree(source) },
                 references,
                 options ?? new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));

--- a/src/Scripting/CoreTestUtilities/TestRuntimeMetadataReferenceResolver.cs
+++ b/src/Scripting/CoreTestUtilities/TestRuntimeMetadataReferenceResolver.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace Roslyn.Test.Utilities
+{
+    public sealed class TestRuntimeMetadataReferenceResolver : MetadataReferenceResolver
+    {
+        public static readonly TestRuntimeMetadataReferenceResolver Instance = new TestRuntimeMetadataReferenceResolver();
+        private static readonly MetadataReferenceProperties s_resolvedMissingAssemblyReferenceProperties = MetadataReferenceProperties.Assembly.WithAliases(ImmutableArray.Create("<implicit>"));
+
+        private TestRuntimeMetadataReferenceResolver() { }
+
+        public override bool Equals(object other) => other == Instance;
+        public override int GetHashCode() => 0;
+        public override bool ResolveMissingAssemblies => true;
+
+        public override PortableExecutableReference ResolveMissingAssembly(MetadataReference definition, AssemblyIdentity referenceIdentity)
+        {
+            // resolve assemblies from the directory containing the test and from directory containing corlib
+
+            string name = referenceIdentity.Name;
+            string testDir = Path.GetDirectoryName(GetType().GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName);
+            string testDependencyAssemblyPath = Path.Combine(testDir, name + ".dll");
+            if (File.Exists(testDependencyAssemblyPath))
+            {
+                return MetadataReference.CreateFromFile(testDependencyAssemblyPath, s_resolvedMissingAssemblyReferenceProperties);
+            }
+
+            string fxDir = Path.GetDirectoryName(typeof(object).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName);
+            string fxAssemblyPath = Path.Combine(fxDir, name + ".dll");
+            if (File.Exists(fxAssemblyPath))
+            {
+                return MetadataReference.CreateFromFile(fxAssemblyPath, s_resolvedMissingAssemblyReferenceProperties);
+            }
+
+            return null;
+        }
+
+        public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)
+        {
+            // TODO: currently not handling relative paths, since we don't have tests that use them
+
+            if (File.Exists(reference))
+            {
+                return ImmutableArray.Create(MetadataReference.CreateFromFile(reference, properties));
+            }
+
+            return default(ImmutableArray<PortableExecutableReference>);
+        }
+    }
+}

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -80,7 +80,7 @@ Type ""#help"" for more information.
 
         <Fact()>
         Public Sub TestReferenceDirective()
-            Dim file1 = Temp.CreateFile("1.dll").WriteAllBytes(TestCompilationFactory.CreateVisualBasicCompilationWithMscorlib("
+            Dim file1 = Temp.CreateFile("1.dll").WriteAllBytes(TestCompilationFactory.CreateVisualBasicCompilationWithCorlib("
 public Class C1
 Public Function Foo() As String
     Return ""Bar""

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim buildPaths = New BuildPaths(
                 clientDir:=AppContext.BaseDirectory,
                 workingDir:=If(workingDirectory, AppContext.BaseDirectory),
-                sdkDir:=CorLightup.Desktop.TryGetRuntimeDirectory(),
+                sdkDir:=RuntimeMetadataReferenceResolver.GetCorLibDirectory(),
                 tempDir:=Path.GetTempPath())
 
             Dim compiler = New VisualBasicInteractiveCompiler(

--- a/src/Test/DeployCoreClrTestRuntime/DeployCoreClrTestRuntime.csproj
+++ b/src/Test/DeployCoreClrTestRuntime/DeployCoreClrTestRuntime.csproj
@@ -65,6 +65,10 @@
       <Project>{12a68549-4e8c-42d6-8703-a09335f97997}</Project>
       <Name>Scripting</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Scripting\CSharpTest\CSharpScriptingTest.csproj">
+      <Project>{2dae4406-7a89-4b5f-95c3-bc5422ce47ce}</Project>
+      <Name>CSharpScriptingTest</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Scripting\CSharp\CSharpScripting.csproj">
       <Project>{066f0dbd-c46c-4c20-afec-99829a172625}</Project>
       <Name>CSharpScripting</Name>

--- a/src/Test/Utilities/Desktop/TestHelpers.cs
+++ b/src/Test/Utilities/Desktop/TestHelpers.cs
@@ -121,7 +121,7 @@ public class TestAnalyzer : DiagnosticAnalyzer
                 new SyntaxTree[] { SyntaxFactory.ParseSyntaxTree(analyzerSource) },
                 new MetadataReference[]
                 {
-                    TestBase.SystemRuntimeNetstandard13FacadeRef.Value,
+                    TestReferences.NetStandard13.SystemRuntime,
                     MetadataReference.CreateFromFile(immutable.Path),
                     MetadataReference.CreateFromFile(analyzer.Path)
                 },

--- a/src/Test/Utilities/Shared/Mocks/TestReferences.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestReferences.cs
@@ -534,6 +534,23 @@ public static class TestReferences
         }
     }
 
+    public static class NetStandard13
+    {
+        private static PortableExecutableReference s_systemRuntime;
+        public static PortableExecutableReference SystemRuntime
+        {
+            get
+            {
+                if (s_systemRuntime == null)
+                {
+                    s_systemRuntime = AssemblyMetadata.CreateFromImage(TestResources.NetFX.ReferenceAssemblies_netstandard1_3.System_Runtime).GetReference(display: @"System.Runtime.dll (netstandard13 ref)");
+                }
+
+                return s_systemRuntime;
+            }
+        }
+    }
+
     public static class DiagnosticTests
     {
         public static class ErrTestLib01

--- a/src/Test/Utilities/Shared/TestBase.cs
+++ b/src/Test/Utilities/Shared/TestBase.cs
@@ -526,11 +526,6 @@ namespace Roslyn.Test.Utilities
             }
         }
 
-        public static Lazy<MetadataReference> SystemRuntimeNetstandard13FacadeRef { get; } =
-            new Lazy<MetadataReference>(() => AssemblyMetadata.CreateFromImage(
-                TestResources.NetFX.ReferenceAssemblies_netstandard1_3.System_Runtime)
-                .GetReference(display: "System.Runtime.dll"));
-
         private static MetadataReference s_FSharpTestLibraryRef;
         public static MetadataReference FSharpTestLibraryRef
         {


### PR DESCRIPTION
A couple of product changes:

1) ```#r "AssemblyName"``` and missing assembly resolution look for the assembly in GAC. On .NET Core this check was skipped. Instead of skipping it look for ```AssemblyName.dll``` in the directory containing corlib. 

2) Initialize default ScriptOptions and csi with a set of references that roughly correspond to a public surface of netstandard 2.0 mscorlib. It is still possible to customize ScriptOptions without these references if the user wants to limit access to these APIs.

Enable C# scripting tests on .NET Core.