### PR TITLE
use other diagnostic if available to minimize diff

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -16515,13 +16515,13 @@ a: b: c:Test2(Test1(out int x1), x1);
             CompileAndVerify(compilation, expectedOutput: "11").VerifyDiagnostics(
                 // (11,1): warning CS0164: This label has not been referenced
                 // a: b: c:Test2(Test1(out int x1), x1);
-                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a"),
+                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(11, 1),
                 // (11,4): warning CS0164: This label has not been referenced
                 // a: b: c:Test2(Test1(out int x1), x1);
-                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b"),
+                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(11, 4),
                 // (11,7): warning CS0164: This label has not been referenced
                 // a: b: c:Test2(Test1(out int x1), x1);
-                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "d")
+                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(11, 7)
                 );
 
             var tree = compilation.SyntaxTrees.Single();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -16515,13 +16515,13 @@ a: b: c:Test2(Test1(out int x1), x1);
             CompileAndVerify(compilation, expectedOutput: "11").VerifyDiagnostics(
                 // (11,1): warning CS0164: This label has not been referenced
                 // a: b: c:Test2(Test1(out int x1), x1);
-                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(11, 1),
+                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a"),
                 // (11,4): warning CS0164: This label has not been referenced
                 // a: b: c:Test2(Test1(out int x1), x1);
-                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(11, 4),
+                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b"),
                 // (11,7): warning CS0164: This label has not been referenced
                 // a: b: c:Test2(Test1(out int x1), x1);
-                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(11, 7)
+                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "d")
                 );
 
             var tree = compilation.SyntaxTrees.Single();

--- a/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
@@ -378,8 +378,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public static string GetAssertText(DiagnosticDescription[] expected, IEnumerable<Diagnostic> actual)
         {
-            var includeCompilerOutput = false;
-
             const int CSharp = 1;
             const int VisualBasic = 2;
             var language = actual.Any() && actual.First().Id.StartsWith("CS", StringComparison.Ordinal) ? CSharp : VisualBasic;
@@ -391,7 +389,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             // Write out the 'command line compiler output' including squiggles (easy to read debugging info in the case of a failure).
             // This will be useful for VB, because we can't do the inline comments.
-            if (includeCompilerOutput)
+#if false
             {
                 assertText.AppendLine("Compiler output:");
                 foreach (var d in actual)
@@ -410,7 +408,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     assertText.AppendLine();
                 }
             }
-
+#endif
             // write out the error baseline as method calls
             int i;
             assertText.AppendLine("Expected:");
@@ -463,6 +461,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 }
 
                 var description = new DiagnosticDescription(d, errorCodeOnly: false, showPosition: true);
+                var idx = Array.IndexOf(expected, description);
+                if (idx != -1)
+                {
+                    description = expected[idx];
+                }
                 AppendDiagnosticDescription(assertText, description, indentDepth);
                 AppendDiagnosticDescription(actualText, description, indentDepth);
             }

--- a/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
@@ -387,28 +387,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             StringBuilder assertText = new StringBuilder();
             assertText.AppendLine();
 
-            // Write out the 'command line compiler output' including squiggles (easy to read debugging info in the case of a failure).
-            // This will be useful for VB, because we can't do the inline comments.
-#if false
-            {
-                assertText.AppendLine("Compiler output:");
-                foreach (var d in actual)
-                {
-                    Indent(assertText, 1);
-                    assertText.AppendLine(d.ToString());
-                    var location = d.Location;
-                    var lineText = location.SourceTree.GetText().Lines.GetLineFromPosition(location.SourceSpan.Start).ToString();
-                    assertText.AppendLine(lineText);
-                    var span = location.GetMappedLineSpan();
-                    var startPosition = span.StartLinePosition;
-                    var endPosition = span.EndLinePosition;
-                    assertText.Append(' ', startPosition.Character);
-                    var endCharacter = (startPosition.Line == endPosition.Line) ? endPosition.Character : lineText.Length;
-                    assertText.Append('~', endCharacter - startPosition.Character);
-                    assertText.AppendLine();
-                }
-            }
-#endif
             // write out the error baseline as method calls
             int i;
             assertText.AppendLine("Expected:");

--- a/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
@@ -439,13 +439,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 }
 
                 var description = new DiagnosticDescription(d, errorCodeOnly: false, showPosition: true);
+                var diffDescription = description;
                 var idx = Array.IndexOf(expected, description);
                 if (idx != -1)
                 {
-                    description = expected[idx];
+                    diffDescription = expected[idx];
                 }
                 AppendDiagnosticDescription(assertText, description, indentDepth);
-                AppendDiagnosticDescription(actualText, description, indentDepth);
+                AppendDiagnosticDescription(actualText, diffDescription, indentDepth);
             }
             if (i > 0)
             {


### PR DESCRIPTION
closes #10798

This is a very quick modification to the VerifyDiagnostics diff printer.  The change makes it so that it will try to produce a DiagnosticDescription in the "actual" output if an equivalent DiagnosticDescription occurs in "expected".