### PR TITLE
Avoid showing the builder while typing type args

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
@@ -730,6 +730,27 @@ class C {
             await VerifyNotBuilderAsync(markup);
         }
 
+        [WorkItem(15443, "https://github.com/dotnet/roslyn/issues/15443")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotBuilderInTypeArgument()
+        {
+            var markup = @"
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        class N { }
+        static void Main(string[] args)
+        {
+            Program.N n = Load<Program.$$
+        }
+
+        static T Load<T>() => default(T);
+    }
+}";
+            await VerifyNotBuilderAsync(markup);
+        }
+
         private async Task VerifyNotBuilderAsync(string markup)
         {
             await VerifyWorkerAsync(markup, isBuilder: false);

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -894,7 +894,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var otherSideTypes = GetTypes(otherSide);
                 if (otherSideTypes.Any())
                 {
-                    return otherSideTypes;
+                    // Don't infer delegate types. They're unlikely to be what the
+                    // user needs and can cause lambda suggestion mode while
+                    // typing type arguments:
+                    // https://github.com/dotnet/roslyn/issues/14492
+                    return otherSideTypes.Where(t => !t.InferredType.IsDelegateType());
                 }
 
                 // For &, &=, |, |=, ^, and ^=, since we couldn't infer the type of either side, 

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -894,11 +894,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var otherSideTypes = GetTypes(otherSide);
                 if (otherSideTypes.Any())
                 {
-                    // Don't infer delegate types. They're unlikely to be what the
+                    // Don't infer delegate types except in assignments. They're unlikely to be what the
                     // user needs and can cause lambda suggestion mode while
                     // typing type arguments:
                     // https://github.com/dotnet/roslyn/issues/14492
-                    return otherSideTypes.Where(t => !t.InferredType.IsDelegateType());
+                    if (!(binop is AssignmentExpressionSyntax))
+                    {
+                        otherSideTypes = otherSideTypes.Where(t => !t.InferredType.IsDelegateType());
+                    }
+
+                    return otherSideTypes;
                 }
 
                 // For &, &=, |, |=, ^, and ^=, since we couldn't infer the type of either side, 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14492

Tag @dotnet/roslyn-ide for review