### PR TITLE
add options back to diagnostics

### DIFF
--- a/src/Workspaces/Remote/Core/Services/SolutionService.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionService.cs
@@ -58,6 +58,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async Task<Solution> GetSolutionAsync(Checksum solutionChecksum, OptionSet optionSet, CancellationToken cancellationToken)
         {
+            if (optionSet == null)
+            {
+                return await GetSolutionAsync(solutionChecksum, cancellationToken).ConfigureAwait(false);
+            }
+
             // since option belong to workspace, we can't share solution
 
             // create new solution

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.GetOptionSetChecksum(), CancellationToken).ConfigureAwait(false);
 
                     // entry point for diagnostic service
-                    var solution = await GetSolutionAsync().ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(optionSet).ConfigureAwait(false);
 
                     var projectId = arguments.GetProjectId();
                     var analyzers = await GetHostAnalyzerReferences(arguments.GetHostAnalyzerChecksums()).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.GetOptionSetChecksum(), CancellationToken).ConfigureAwait(false);
 
                     // entry point for diagnostic service
-                    var solution = await GetSolutionAsync(optionSet).ConfigureAwait(false);
+                    var solution = await GetSolutionWithSpecificOptionsAsync(optionSet).ConfigureAwait(false);
 
                     var projectId = arguments.GetProjectId();
                     var analyzers = await GetHostAnalyzerReferences(arguments.GetHostAnalyzerChecksums()).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ServiceHubServiceBase.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Options;
 using Roslyn.Utilities;
 using StreamJsonRpc;
 
@@ -60,10 +61,10 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        protected Task<Solution> GetSolutionAsync()
+        protected Task<Solution> GetSolutionAsync(OptionSet options = null)
         {
             Contract.ThrowIfNull(_solutionChecksumOpt);
-            return RoslynServices.SolutionService.GetSolutionAsync(_solutionChecksumOpt, CancellationToken);
+            return RoslynServices.SolutionService.GetSolutionAsync(_solutionChecksumOpt, options, CancellationToken);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Workspaces/Remote/ServiceHub/Services/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ServiceHubServiceBase.cs
@@ -61,7 +61,13 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        protected Task<Solution> GetSolutionAsync(OptionSet options = null)
+        protected Task<Solution> GetSolutionAsync()
+        {
+            Contract.ThrowIfNull(_solutionChecksumOpt);
+            return RoslynServices.SolutionService.GetSolutionAsync(_solutionChecksumOpt, CancellationToken);
+        }
+
+        protected Task<Solution> GetSolutionWithSpecificOptionsAsync(OptionSet options)
         {
             Contract.ThrowIfNull(_solutionChecksumOpt);
             return RoslynServices.SolutionService.GetSolutionAsync(_solutionChecksumOpt, options, CancellationToken);


### PR DESCRIPTION
looks like my previous refactoring - [link](https://github.com/dotnet/roslyn/commit/b4941197495edfef28698246ff5303c1cfa99ab3#diff-34b1790434d03262ef0e31a49e147b33R36) - removed options

this put options back.

I am working on enabling d15 unit tests back on in another PR which will include unit test to prevent this from happening again.