### PR TITLE
Don't assert if an option wasn't initialized that never will be

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Options/LanguageSettingsPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/LanguageSettingsPersister.cs
@@ -231,7 +231,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             // This particular serializer is a bit strange, since we have to initially read things out on the UI thread.
             // Therefore, we refresh the values in the constructor, meaning that this should never get called for our values.
 
-            Contract.ThrowIfTrue(_supportedOptions.Contains(optionKey.Option));
+            Contract.ThrowIfTrue(_supportedOptions.Contains(optionKey.Option) && _languageMap.ContainsKey(optionKey.Language));
 
             value = null;
             return false;

--- a/src/VisualStudio/IntegrationTests/CSharp/CSharpInteractive.cs
+++ b/src/VisualStudio/IntegrationTests/CSharp/CSharpInteractive.cs
@@ -93,5 +93,20 @@ w.Content = g;");
             VerifyLastReplOutput("Hello, World!");
             SubmitText("b = null; w.Close(); w = null;");
         }
+
+        [Fact]
+        public void TypingHelpDirectiveWorks()
+        {
+            InteractiveWindow.ShowWindow(waitForPrompt: true);
+
+            // Directly type #help, rather than sending it through SubmitText. We want to actually test
+            // that completion doesn't interfere and there aren't problems with the content-type switching.
+            VisualStudio.Instance.SendKeys.Send("#help");
+
+            Assert.EndsWith("#help", InteractiveWindow.GetReplText());
+
+            VisualStudio.Instance.SendKeys.Send("\n");
+            InteractiveWindow.WaitForReplOutputContains("REPL commands");
+        }
     }
 }

--- a/src/VisualStudio/IntegrationTests/CSharp/CSharpInteractive.cs
+++ b/src/VisualStudio/IntegrationTests/CSharp/CSharpInteractive.cs
@@ -8,9 +8,9 @@ using Xunit;
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
-    public class CSharpInteractiveDemo : AbstractInteractiveWindowTest
+    public class CSharpInteractive : AbstractInteractiveWindowTest
     {
-        public CSharpInteractiveDemo(VisualStudioInstanceFactory instanceFactory)
+        public CSharpInteractive(VisualStudioInstanceFactory instanceFactory)
             : base(instanceFactory)
         {
         }

--- a/src/VisualStudio/IntegrationTests/CSharp/CSharpInteractiveAsyncOutput.cs
+++ b/src/VisualStudio/IntegrationTests/CSharp/CSharpInteractiveAsyncOutput.cs
@@ -6,9 +6,9 @@ using Xunit;
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
-    public class CSharpAsyncOutput : AbstractInteractiveWindowTest
+    public class CSharpInteractiveAsyncOutput : AbstractInteractiveWindowTest
     {
-        public CSharpAsyncOutput(VisualStudioInstanceFactory instanceFactory)
+        public CSharpInteractiveAsyncOutput(VisualStudioInstanceFactory instanceFactory)
             : base(instanceFactory)
         {
         }

--- a/src/VisualStudio/IntegrationTests/VisualStudioIntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTests/VisualStudioIntegrationTests.csproj
@@ -13,19 +13,21 @@
     <Nonshipping>true</Nonshipping>
     <RoslynProjectType>UnitTest</RoslynProjectType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'"></PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'"></PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+  </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractIntegrationTest.cs" />
     <Compile Include="AbstractInteractiveWindowTest.cs" />
-    <Compile Include="CSharp\CSharpAsyncOutput.cs" />
+    <Compile Include="CSharp\CSharpInteractiveAsyncOutput.cs" />
     <Compile Include="CSharp\CSharpAutomaticBraceCompletion.cs" />
     <Compile Include="CSharp\CSharpBuild.cs" />
     <Compile Include="CSharp\CSharpIntelliSense.cs" />
-    <Compile Include="CSharp\CSharpInteractiveDemo.cs" />
+    <Compile Include="CSharp\CSharpInteractive.cs" />
     <Compile Include="AbstractEditorTest.cs" />
     <Compile Include="SharedIntegrationHostFixture.cs" />
     <Compile Include="VisualBasic\BasicAutomaticBraceCompletion.cs" />

--- a/src/VisualStudio/TestUtilities/InProcess/InteractiveWindow_InProc.cs
+++ b/src/VisualStudio/TestUtilities/InProcess/InteractiveWindow_InProc.cs
@@ -169,5 +169,18 @@ namespace Roslyn.VisualStudio.Test.Utilities.InProcess
                 await Task.Delay(50);
             }
         }
+
+        public void WaitForReplOutputContains(string outputText)
+        {
+            WaitForReplOutputContainsAsync(outputText).Wait();
+        }
+
+        private async Task WaitForReplOutputContainsAsync(string outputText)
+        {
+            while (!GetReplText().Contains(outputText))
+            {
+                await Task.Delay(50);
+            }
+        }
     }
 }

--- a/src/VisualStudio/TestUtilities/Input/SendKeys.cs
+++ b/src/VisualStudio/TestUtilities/Input/SendKeys.cs
@@ -15,7 +15,7 @@ namespace Roslyn.VisualStudio.Test.Utilities.Input
             _visualStudioInstance = visualStudioInstance;
         }
 
-        public void Send(object[] keys)
+        public void Send(params object[] keys)
         {
             var inputs = new List<NativeMethods.INPUT>(keys.Length);
 

--- a/src/VisualStudio/TestUtilities/Input/SendKeys.cs
+++ b/src/VisualStudio/TestUtilities/Input/SendKeys.cs
@@ -203,6 +203,8 @@ namespace Roslyn.VisualStudio.Test.Utilities.Input
                     IntegrationHelper.UnblockInput();
                 }
             }
+
+            _visualStudioInstance.WaitForApplicationIdle();
         }
     }
 }

--- a/src/VisualStudio/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -71,7 +71,6 @@ namespace Roslyn.VisualStudio.Test.Utilities.OutOfProcess
         {
             Activate();
             VisualStudioInstance.SendKeys.Send(keys);
-            VisualStudioInstance.WaitForApplicationIdle();
         }
     }
 }

--- a/src/VisualStudio/TestUtilities/OutOfProcess/InteractiveWindow_OutOfProc.cs
+++ b/src/VisualStudio/TestUtilities/OutOfProcess/InteractiveWindow_OutOfProc.cs
@@ -65,6 +65,11 @@ namespace Roslyn.VisualStudio.Test.Utilities.OutOfProcess
             _inProc.WaitForReplOutput(outputText);
         }
 
+        public void WaitForReplOutputContains(string outputText)
+        {
+            _inProc.WaitForReplOutputContains(outputText);
+        }
+
         public void CleanUpInteractiveWindow()
         {
             _inProc.CloseWindow();


### PR DESCRIPTION
The TryFetch call should never get called for options we'll initialize during the constructor, which is what this assert was intended to catch. But we'd still fire if we saw a language we didn't know about. Although this has caught some legitimate bugs, at this point it's not terribly valuable, and also hurts cases where other languages (like interactive commands) don't need this in the first place.

**Customer scenario**

Typing "#help" in the interactive window does strange things, and might crash.

**Bugs this fixes:** dotnet/roslyn#14976.

**Workarounds, if any**: none.

**Risk** : low, this is just adjusting an assert.

**Performance impact**: none.

**Is this a regression from a previous update?** yes. This was regressed in the RC release when some core architectural work for .editorconfig landed.

**Root cause analysis:** The code that deals with languages fetching and updating core options (in this case, "should we show intellisense?") was updated. A new retail assert was included, which would fail if a language that was using Roslyn wasn't added to a new list. We caught the new ones pretty quickly, but interactive commands are a subtle part of our architecture.

**How was the bug found?** Internal ad-hoc testing.