### PR TITLE
Ignore use-before-declaration in local functions (#15339)

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -61,7 +61,41 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (reads[slot])
                 {
                     var symbol = variableBySlot[slot].Symbol;
-                    CheckAssigned(symbol, syntax, slot);
+                    CheckIfAssignedDuringLocalFunctionReplay(symbol, syntax, slot);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Check that the given variable is definitely assigned when replaying local function
+        /// reads. If not, produce an error.
+        /// </summary>
+        /// <remarks>
+        /// Specifying the slot manually may be necessary if the symbol is a field,
+        /// in which case <see cref="VariableSlot(Symbol, int)"/> will not know
+        /// which containing slot to look for.
+        /// </remarks>
+        private void CheckIfAssignedDuringLocalFunctionReplay(Symbol symbol, SyntaxNode node, int slot)
+        {
+            Debug.Assert(!IsConditionalState);
+            if ((object)symbol != null)
+            {
+                NoteRead(symbol);
+
+                if (this.State.Reachable)
+                {
+                    if (slot >= this.State.Assigned.Capacity)
+                    {
+                        Normalize(ref this.State);
+                    }
+
+                    if (slot > 0 && !this.State.IsAssigned(slot))
+                    {
+                        // Local functions can "call forward" to after a variable has
+                        // been declared but before it has been assigned, so we can never
+                        // consider the declaration location when reporting errors.
+                        ReportUnassigned(symbol, node, slot, skipIfUseBeforeDeclaration: false);
+                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -896,37 +896,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        /// <summary>
-        /// Check that the given variable is definitely assigned.  If not, produce an error.
-        /// </summary>
-        /// <remarks>
-        /// Specifying the slot manually may be necessary if the symbol is a field,
-        /// in which case <see cref="VariableSlot(Symbol, int)"/> will not know
-        /// which containing slot to look for.
-        /// </remarks>
-        private void CheckAssigned(Symbol symbol, SyntaxNode node, int slot)
-        {
-            Debug.Assert(!IsConditionalState);
-            if ((object)symbol != null)
-            {
-                NoteRead(symbol);
-
-                if (this.State.Reachable)
-                {
-                    if (slot >= this.State.Assigned.Capacity)
-                    {
-                        Normalize(ref this.State);
-                    }
-
-                    if (slot > 0 && !this.State.IsAssigned(slot))
-                    {
-                        ReportUnassigned(symbol, node, slot);
-                    }
-                }
-            }
-        }
-
-        private void ReportUnassigned(Symbol symbol, SyntaxNode node, int? slotOpt)
+        /// <param name="symbol">Symbol to variable that is unassigned.</param>
+        /// <param name="node">Syntax where read occurs.</param>
+        /// <param name="slotOpt">Optional slot where variable is located.</param>
+        /// <param name="skipIfUseBeforeDeclaration">
+        /// True if error reporting should consider the location where the
+        /// variable is declared (for instance, eliding errors about reading
+        /// variables that have not yet been declared).
+        /// </param>
+        private void ReportUnassigned(Symbol symbol, SyntaxNode node, int? slotOpt, bool skipIfUseBeforeDeclaration = true)
         {
             int slot = slotOpt ?? VariableSlot(symbol);
             if (slot <= 0) return;
@@ -949,7 +927,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             if (slot >= _alreadyReported.Capacity) _alreadyReported.EnsureCapacity(nextVariableSlot);
-            if (symbol.Kind == SymbolKind.Local && (symbol.Locations.Length == 0 || node.Span.End < symbol.Locations[0].SourceSpan.Start))
+            if (skipIfUseBeforeDeclaration &&
+                symbol.Kind == SymbolKind.Local &&
+                (symbol.Locations.Length == 0 || node.Span.End < symbol.Locations[0].SourceSpan.Start))
             {
                 // We've already reported the use of a local before its declaration.  No need to emit
                 // another diagnostic for the same issue.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3072,6 +3072,20 @@ class Program
             VerifyOutput(source, "2", TestOptions.ReleaseExe.WithAllowUnsafe(true));
         }
 
+        [Fact]
+        [WorkItem(15322, "https://github.com/dotnet/roslyn/issues/15322")]
+        public void UseBeforeDeclaration()
+        {
+            var src = @"
+Assign();
+Local();
+int x;
+void Local() => System.Console.WriteLine(x);
+void Assign() { x = 5; }";
+
+            VerifyOutputInMain(src, "5");
+        }
+
         internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options)
         {
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: options);


### PR DESCRIPTION
Prior to C# 7 we tried to avoid giving duplicate errors
when the user used a variable before it was declared (which
is both a use-before-declared and a use-before-assigned error),
but the line here is blurred with local functions, which can
use variables before they are declared in subtle ways that can't
be detected based on declaration order in syntax.

It may be possible to provide the earlier behavior, but the
current optimization is definitely insufficient and hides
legitimate errors in user programs.

Fixes #15298
Fixes #15322

(cherry picked from commit 1c8372cea14d7b75e8b55c6c38314291af165d5f)