### PR TITLE
Improve speculation for AsNewClauseSyntax [fixes crash]

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -174,6 +174,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
                 Me._speculativeModel = GetSemanticModelForNode(newNode, Me._semanticModel)
                 Debug.Assert(_speculativeModel IsNot Nothing, "expanding a syntax node which cannot be speculated?")
 
+                ' There are cases when we change the type of node to make speculation work (e.g.,
+                ' for AsNewClauseSyntax), so getting the newNode from the _speculativeModel 
+                ' ensures the final node replacing the original node is found.
+                newNode = Me._speculativeModel.SyntaxTree.GetRoot(_cancellationToken).GetAnnotatedNodes(Of SyntaxNode)(annotation).First()
+
                 Dim oldSpan = originalNode.Span
 
                 Dim expandParameter = originalNode.GetAncestorsOrThis(Of LambdaExpressionSyntax).Count() = 0

--- a/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Utilities/SpeculationAnalyzer.vb
@@ -140,6 +140,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Utilities
                 Case SyntaxKind.RangeArgument
                     semanticModel.TryGetSpeculativeSemanticModel(position, DirectCast(nodeToSpeculate, RangeArgumentSyntax), speculativeModel)
                     Return speculativeModel
+
+                Case SyntaxKind.AsNewClause
+                    ' Speculation is not supported for AsNewClauseSyntax nodes.
+                    ' Generate an EqualsValueSyntax node with the inner NewExpression of the AsNewClauseSyntax node for speculation.
+
+                    Dim asNewClauseNode = DirectCast(nodeToSpeculate, AsNewClauseSyntax)
+                    nodeToSpeculate = SyntaxFactory.EqualsValue(asNewClauseNode.NewExpression)
+                    nodeToSpeculate = asNewClauseNode.CopyAnnotationsTo(nodeToSpeculate)
+                    semanticModel.TryGetSpeculativeSemanticModel(position, DirectCast(nodeToSpeculate, EqualsValueSyntax), speculativeModel)
+                    Return speculativeModel
             End Select
 
             ' CONSIDER: Do we care about this case?


### PR DESCRIPTION
Fixes #14554

**Customer scenario**

A crash occurs any time rename does conflict detection in an AsNewClause in VB. This means that the AsNewClause would have to have some code in it with identifiers that could possibly conflict with the name of an identifier being renamed. The easiest way to get into this situation is to have executable code in your AsNewClause (being passed to an Action or Func parameter on the constructor). I would guess that this is a fairly infrequent problem, but it was reported by a customer.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/14554

**Workarounds, if any**

If the conflicting name isn't the final new name in the rename session and just happens to be on the path from old name to new name, then the user can avoid passing through the conflicting name on the way to the new name, but that's a pretty convoluted workaround. In the case where the final new name of the rename session actually matches the identifier in the AsNewClause, the workaround is to do the rename manually.

**Risk**

Moderate. The change to the VisualBasicRenameRewriterLanguageService should have no effect on cases that don't involve AsNewClauses (so probably no regressions there). The change to SpeculationAnalyzer ensures we return a non-null speculative model instead of a null one when we encounter an AsNewClause. This could possibly impact other consumers.

**Performance impact**

Low perf impact, it's doing the same sort of speculative semantic model work that other parts of the rename process already do.

**Is this a regression from a previous update?**

At one point, we had an overload of GetSpeculativeSemanticModel for AsNewClauses, but it was reverted in http://vstfdevdiv:8080/DevDiv2/Roslyn/_versionControl/changeset/995416?_a=summary due to http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems?id=680657&_a=edit

**Root cause analysis:**

The compiler doesn't offer an API to speculate on AsNewClauses, so a workaround was implemented to rewrite AsNewClauses to EqualsValueClauses during features that need to speculate on AsNewClauses. This workaround was not implemented in all of the required locations. I added a Rename test to ensure the crash no longer happens. A better fix could be implemented by fixing https://github.com/dotnet/roslyn/issues/15593, but that isn't currently on the schedule.

**How was the bug found?**

Customer reported.