### PR TITLE
Inherit unsafe regions in local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -35,23 +35,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static BinderFlags GetFlags(MethodSymbol owner, Binder enclosing)
-        {
-            var flags = enclosing.Flags;
-
-            var isUnsafe = (owner as LocalFunctionSymbol)?.IsUnsafe;
-            if (isUnsafe.HasValue)
-            {
-                // only modify unsafe flag if owner has an explicit way of specifying unsafe-ness
-                // (i.e. lambdas retain the unsafe-ness of the containing block)
-                flags = (flags & ~BinderFlags.UnsafeRegion) | (isUnsafe.Value ? BinderFlags.UnsafeRegion : 0);
-            }
-
-            return flags;
-        }
-
         public InMethodBinder(MethodSymbol owner, Binder enclosing)
-            : base(enclosing, GetFlags(owner, enclosing))
+            : base(enclosing)
         {
             Debug.Assert((object)owner != null);
             _methodSymbol = owner;

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -230,6 +230,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ? new WithMethodTypeParametersBinder(match, _enclosing)
                         : _enclosing;
 
+                    binder = binder.WithUnsafeRegionIfNecessary(node.Modifiers);
+
                     Visit(body, new InMethodBinder(match, binder));
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -268,8 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new LocalFunctionSymbol(
                 this,
                 this.ContainingMemberOrLambda,
-                declaration,
-                this.InUnsafeRegion);
+                declaration);
         }
 
         protected void BuildLabels(SyntaxList<StatementSyntax> statements, ref ArrayBuilder<LabelSymbol> labels)

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -268,7 +268,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new LocalFunctionSymbol(
                 this,
                 this.ContainingMemberOrLambda,
-                declaration);
+                declaration,
+                this.InUnsafeRegion);
         }
 
         protected void BuildLabels(SyntaxList<StatementSyntax> statements, ref ArrayBuilder<LabelSymbol> labels)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -78,6 +78,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var diagnostics = DiagnosticBag.GetInstance();
 
+            ScopeBinder = binder;
+
+            binder = binder.WithUnsafeRegionIfNecessary(syntax.Modifiers);
+
             if (_syntax.TypeParameterList != null)
             {
                 binder = new WithMethodTypeParametersBinder(this, binder);
@@ -102,10 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Binder that owns the scope for the local function symbol, namely the scope where the
         /// local function is declared.
         /// </summary>
-        internal Binder ScopeBinder => _syntax.TypeParameterList == null
-            ? _binder
-            : _binder.Next; // If there are type parameters, this binder is wrapped
-                            // in a WithMethodTypeParametersBinder
+        internal Binder ScopeBinder { get; }
 
         internal void GrabDiagnostics(DiagnosticBag addTo)
         {
@@ -156,7 +157,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var diagnostics = DiagnosticBag.GetInstance();
             SyntaxToken arglistToken;
-            var parameters = ParameterHelpers.MakeParameters(_binder, this, _syntax.ParameterList, true, out arglistToken, diagnostics, true);
+            var parameters = ParameterHelpers.MakeParameters(
+                _binder,
+                this,
+                _syntax.ParameterList,
+                allowRefOrOut: true,
+                arglistToken: out arglistToken,
+                diagnostics: diagnostics,
+                beStrict: true);
+
             var isVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
             if (IsAsync && diagnostics.IsEmptyWithoutResolution)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -66,7 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public LocalFunctionSymbol(
             Binder binder,
             Symbol containingSymbol,
-            LocalFunctionStatementSyntax syntax)
+            LocalFunctionStatementSyntax syntax,
+            bool inUnsafeRegion)
         {
             _syntax = syntax;
             _containingSymbol = containingSymbol;
@@ -75,6 +76,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 DeclarationModifiers.Private |
                 DeclarationModifiers.Static |
                 syntax.Modifiers.ToDeclarationModifiers();
+
+            this.IsUnsafe = inUnsafeRegion || _declarationModifiers.HasFlag(DeclarationModifiers.Unsafe);
 
             var diagnostics = DiagnosticBag.GetInstance();
 
@@ -299,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool IsExtern => (_declarationModifiers & DeclarationModifiers.Extern) != 0;
 
-        public bool IsUnsafe => (_declarationModifiers & DeclarationModifiers.Unsafe) != 0;
+        public bool IsUnsafe { get; }
 
         internal bool IsExpressionBodied => _syntax.Body == null && _syntax.ExpressionBody != null;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -66,8 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public LocalFunctionSymbol(
             Binder binder,
             Symbol containingSymbol,
-            LocalFunctionStatementSyntax syntax,
-            bool inUnsafeRegion)
+            LocalFunctionStatementSyntax syntax)
         {
             _syntax = syntax;
             _containingSymbol = containingSymbol;
@@ -76,8 +75,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 DeclarationModifiers.Private |
                 DeclarationModifiers.Static |
                 syntax.Modifiers.ToDeclarationModifiers();
-
-            this.IsUnsafe = inUnsafeRegion || _declarationModifiers.HasFlag(DeclarationModifiers.Unsafe);
 
             var diagnostics = DiagnosticBag.GetInstance();
 
@@ -302,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool IsExtern => (_declarationModifiers & DeclarationModifiers.Extern) != 0;
 
-        public bool IsUnsafe { get; }
+        public bool IsUnsafe => (_declarationModifiers & DeclarationModifiers.Unsafe) != 0;
 
         internal bool IsExpressionBodied => _syntax.Body == null && _syntax.ExpressionBody != null;
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3073,6 +3073,46 @@ class Program
         }
 
         [Fact]
+        public void UnsafeCalls()
+        {
+            var src = @"
+using System;
+class C
+{
+    public static void Main(string[] args)
+    {
+        int x = 2;
+        int y = 0;
+
+        unsafe void Local(ref int x2)
+        {
+            fixed (int* ptr = &x2)
+            {
+                Local2(ptr);
+            }
+        }
+        unsafe int* Local2(int* ptr)
+        {
+            (*ptr)++;
+            y++;
+
+            return null;
+        }
+
+        while (x < 10)
+        {
+            Local(ref x);
+            x++;
+        }
+
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+    }
+}";
+            VerifyOutput(src, "10\r\n4", TestOptions.ReleaseExe.WithAllowUnsafe(true));
+        }
+
+        [Fact]
         [WorkItem(15322, "https://github.com/dotnet/roslyn/issues/15322")]
         public void UseBeforeDeclaration()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -306,21 +306,12 @@ class C
                 // (8,37): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //         IEnumerable<int> Local(int* a) { yield break; }
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(8, 37),
-                // (8,26): error CS1629: Unsafe code may not appear in iterators
-                //         IEnumerable<int> Local(int* a) { yield break; }
-                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local").WithLocation(8, 26),
                 // (17,41): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //             IEnumerable<int> Local(int* x) { yield break; }
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "x").WithLocation(17, 41),
-                // (17,30): error CS1629: Unsafe code may not appear in iterators
-                //             IEnumerable<int> Local(int* x) { yield break; }
-                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local").WithLocation(17, 30),
                 // (27,37): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //         IEnumerable<int> Local(int* a) { yield break; }
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(27, 37),
-                // (27,26): error CS1629: Unsafe code may not appear in iterators
-                //         IEnumerable<int> Local(int* a) { yield break; }
-                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local").WithLocation(27, 26),
                 // (33,44): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //     public unsafe IEnumerable<int> M4(int* a)
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(33, 44),
@@ -338,10 +329,7 @@ class C
                 Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local(&x)").WithLocation(39, 17),
                 // (37,45): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //                 IEnumerable<int> Local(int* b) { yield break; }
-                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "b").WithLocation(37, 45),
-                // (37,34): error CS1629: Unsafe code may not appear in iterators
-                //                 IEnumerable<int> Local(int* b) { yield break; }
-                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local").WithLocation(37, 34));
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "b").WithLocation(37, 45));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -306,21 +306,27 @@ class C
                 // (8,37): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //         IEnumerable<int> Local(int* a) { yield break; }
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(8, 37),
+                // (8,26): error CS1629: Unsafe code may not appear in iterators
+                //         IEnumerable<int> Local(int* a) { yield break; }
+                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local").WithLocation(8, 26),
                 // (17,41): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //             IEnumerable<int> Local(int* x) { yield break; }
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "x").WithLocation(17, 41),
+                // (17,30): error CS1629: Unsafe code may not appear in iterators
+                //             IEnumerable<int> Local(int* x) { yield break; }
+                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local").WithLocation(17, 30),
                 // (27,37): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //         IEnumerable<int> Local(int* a) { yield break; }
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(27, 37),
+                // (27,26): error CS1629: Unsafe code may not appear in iterators
+                //         IEnumerable<int> Local(int* a) { yield break; }
+                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local").WithLocation(27, 26),
                 // (33,44): error CS1637: Iterators cannot have unsafe parameters or yield types
                 //     public unsafe IEnumerable<int> M4(int* a)
                 Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "a").WithLocation(33, 44),
                 // (33,36): error CS1629: Unsafe code may not appear in iterators
                 //     public unsafe IEnumerable<int> M4(int* a)
                 Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "M4").WithLocation(33, 36),
-                // (37,45): error CS1637: Iterators cannot have unsafe parameters or yield types
-                //                 IEnumerable<int> Local(int* b) { yield break; }
-                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "b").WithLocation(37, 45),
                 // (37,40): error CS1629: Unsafe code may not appear in iterators
                 //                 IEnumerable<int> Local(int* b) { yield break; }
                 Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "int*").WithLocation(37, 40),
@@ -329,7 +335,13 @@ class C
                 Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "&x").WithLocation(39, 23),
                 // (39,17): error CS1629: Unsafe code may not appear in iterators
                 //                 Local(&x);
-                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local(&x)").WithLocation(39, 17));
+                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local(&x)").WithLocation(39, 17),
+                // (37,45): error CS1637: Iterators cannot have unsafe parameters or yield types
+                //                 IEnumerable<int> Local(int* b) { yield break; }
+                Diagnostic(ErrorCode.ERR_UnsafeIteratorArgType, "b").WithLocation(37, 45),
+                // (37,34): error CS1629: Unsafe code may not appear in iterators
+                //                 IEnumerable<int> Local(int* b) { yield break; }
+                Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "Local").WithLocation(37, 34));
         }
 
         [Fact]
@@ -939,11 +951,7 @@ class Program
     }
 }
 ";
-            VerifyDiagnostics(source, TestOptions.ReleaseExe.WithAllowUnsafe(true),
-    // (11,32): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
-    //             Console.WriteLine(*&x);
-    Diagnostic(ErrorCode.ERR_UnsafeNeeded, "&x").WithLocation(11, 32)
-    );
+            VerifyDiagnostics(source, TestOptions.ReleaseExe.WithAllowUnsafe(true));
         }
 
         [Fact]
@@ -2081,6 +2089,96 @@ class C
                 //             return 2;
                 Diagnostic(ErrorCode.ERR_ParamUnassigned, "return 2;").WithArguments("x").WithLocation(17, 13)
                 );
+        }
+
+        [Fact]
+        [WorkItem(13172, "https://github.com/dotnet/roslyn/issues/13172")]
+        public void InheritUnsafeContext()
+        {
+            var comp = CreateCompilationWithMscorlib46(@"
+using System;
+using System.Threading.Tasks;
+class C
+{
+    public void M1()
+    {
+        async Task<IntPtr> Local()
+        {
+            await Task.Delay(0);
+            return (IntPtr)(void*)null;
+        }
+        var _ = Local();
+    }
+
+    public void M2()
+    {
+        unsafe
+        {
+            async Task<IntPtr> Local()
+            {
+                await Task.Delay(1);
+                return (IntPtr)(void*)null;
+            }
+            var _ = Local();
+        }
+    }
+
+    public unsafe void M3()
+    {
+        async Task<IntPtr> Local()
+        {
+            await Task.Delay(2);
+            return (IntPtr)(void*)null;
+        }
+        var _ = Local();
+    }
+}
+
+unsafe class D
+{
+    int* p = null;
+    public void M()
+    {
+        async Task<IntPtr> Local()
+        {
+            await Task.Delay(3);
+            return (IntPtr)p;
+        }
+        var _ = Local();
+    }
+
+    public unsafe void M2()
+    {
+        unsafe
+        {
+            async Task<IntPtr> Local()
+            {
+                await Task.Delay(4);
+                return (IntPtr)(void*)null;
+            }
+            var _ = Local();
+        }
+    }
+}", options: TestOptions.UnsafeDebugDll);
+            comp.VerifyDiagnostics(                
+                // (11,29): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+                //             return (IntPtr)(void*)null;
+                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "void*").WithLocation(11, 29),
+                // (11,28): error CS0214: Pointers and fixed size buffers may only be used in an unsafe context
+                //             return (IntPtr)(void*)null;
+                Diagnostic(ErrorCode.ERR_UnsafeNeeded, "(void*)null").WithLocation(11, 28),
+                // (47,13): error CS4004: Cannot await in an unsafe context
+                //             await Task.Delay(3);
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(3)").WithLocation(47, 13),
+                // (22,17): error CS4004: Cannot await in an unsafe context
+                //                 await Task.Delay(1);
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(1)").WithLocation(22, 17),
+                // (59,17): error CS4004: Cannot await in an unsafe context
+                //                 await Task.Delay(4);
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(4)").WithLocation(59, 17),
+                // (33,13): error CS4004: Cannot await in an unsafe context
+                //             await Task.Delay(2);
+                Diagnostic(ErrorCode.ERR_AwaitInUnsafeContext, "await Task.Delay(2)").WithLocation(33, 13));
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

When local functions are declared in unsafe regions (unsafe statement,
unsafe member, unsafe type), their bodies should be considered unsafe
regions, even if unsafe is not a declaration modifier on the local
function.

**Bugs this fixes:** 

Fixes #13172

**Workarounds, if any**

Explicitly add the `unsafe` modifier to every local function.

**Risk**

Only affects unsafe handling for local functions. Other test cases already handle unsafe code executed in local functions, this simply adds another way to mark the local function unsafe.

**Performance impact**

Low -- an extra parameter in a method call and a single boolean field for every local function symbol.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

It was initially unclear whether or not this would be by design.

**How was the bug found?**

Customer reported.
