### PR TITLE
Port 3 fixes from master to rc2

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -46,7 +46,6 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 _listener = listener;
                 _optionService = _registration.GetService<IOptionService>();
-                _optionService.OptionChanged += OnOptionChanged;
 
                 // event and worker queues
                 _shutdownNotificationSource = new CancellationTokenSource();
@@ -74,6 +73,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     _registration.Workspace.DocumentOpened += OnDocumentOpened;
                     _registration.Workspace.DocumentClosed += OnDocumentClosed;
                 }
+
+                // subscribe to option changed event after all required fields are set
+                // otherwise, we can get null exception when running OnOptionChanged handler
+                _optionService.OptionChanged += OnOptionChanged;
             }
 
             public int CorrelationId

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.SymbolSearch;
@@ -68,7 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             RegisterMiscellaneousFilesWorkspaceInformation(_miscellaneousFilesWorkspace);
 
             this.Workspace = this.CreateWorkspace();
-            if (this.Workspace != null)
+            if (IsInIdeMode(this.Workspace))
             {
                 // make sure solution crawler start once everything has been setup.
                 // this also should be started before any of workspace events start firing
@@ -132,7 +133,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 _miscellaneousFilesWorkspace.StopSolutionCrawler();
             }
 
-            if (this.Workspace != null)
+            if (IsInIdeMode(this.Workspace))
             {
                 this.Workspace.StopSolutionCrawler();
 
@@ -150,6 +151,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         }
 
         protected abstract string RoslynLanguageName { get; }
+
+        private bool IsInIdeMode(Workspace workspace)
+        {
+            return workspace != null && !IsInCommandLineMode();
+        }
+
+        private bool IsInCommandLineMode()
+        {
+            var shell = (IVsShell)this.GetService(typeof(SVsShell));
+
+            object result;
+            if (ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out result)))
+            {
+                return (bool)result;
+            }
+
+            return false;
+        }
 
         private void EnableRemoteHostClientService()
         {

--- a/src/Workspaces/Remote/Core/Services/SolutionService.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionService.cs
@@ -57,6 +57,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async Task<Solution> GetSolutionAsync(Checksum solutionChecksum, OptionSet optionSet, CancellationToken cancellationToken)
         {
+            if (optionSet == null)
+            {
+                return await GetSolutionAsync(solutionChecksum, cancellationToken).ConfigureAwait(false);
+            }
+
             // since option belong to workspace, we can't share solution
 
             // create new solution

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.GetOptionSetChecksum(), CancellationToken).ConfigureAwait(false);
 
                     // entry point for diagnostic service
-                    var solution = await GetSolutionAsync().ConfigureAwait(false);
+                    var solution = await GetSolutionWithSpecificOptionsAsync(optionSet).ConfigureAwait(false);
 
                     var projectId = arguments.GetProjectId();
                     var analyzers = await GetHostAnalyzerReferences(arguments.GetHostAnalyzerChecksums()).ConfigureAwait(false);

--- a/src/Workspaces/Remote/ServiceHub/Services/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ServiceHubServiceBase.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Options;
 using Roslyn.Utilities;
 using StreamJsonRpc;
 
@@ -64,6 +65,12 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             Contract.ThrowIfNull(_solutionChecksumOpt);
             return RoslynServices.SolutionService.GetSolutionAsync(_solutionChecksumOpt, CancellationToken);
+        }
+
+        protected Task<Solution> GetSolutionWithSpecificOptionsAsync(OptionSet options)
+        {
+            Contract.ThrowIfNull(_solutionChecksumOpt);
+            return RoslynServices.SolutionService.GetSolutionAsync(_solutionChecksumOpt, options, CancellationToken);
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
**Customer scenario**

it fixes 2 customer issues.

1. random crash when user builds solution using special "devenv /build" command line argument (#15490)
2. various issues reported from new OOP features released in RC (#14978, #15110).

**Bugs this fixes:** 
#15490, #14978, #15110

**Workarounds, if any**
there is no workaround. these fixes are better to be in early so that we can catch more issues before RTM.

**Risk**

Fix for the first issue is very low risk. simple and very specific fix. no broad impact.
Fix for the second issue will not make OOP any less stable than before. it either makes it more stable or let us have better dump if it happens again. 

**Performance impact**

these fixes are not related to any major perf releated code.

**Is this a regression from a previous update?**
No. both of them are issues we first found out. especially second fix is for feature which released in RC.

**Root cause analysis:**
issue for the first fix is due to a race. 
OOP related issues has multiple root causes. one is due to some failure in service hub, another is due to us not setting option correctly in some code path or not catching exception we should have and etc.

How did we miss it?  What tests are we adding to guard against it in the future?
race is hard to test and catch. OOP is new feature so there were missing test holes and pattern we didn't thought of.

unit tests are added for found issues.

**How was the bug found?**
customer reports and watsons.
