### PR TITLE
Analyzer install script fixes

### DIFF
--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/install.ps1
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/install.ps1
@@ -9,7 +9,7 @@ if($project.Object.SupportsPackageDependencyResolution)
     }
 }
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/install.ps1
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/install.ps1
@@ -16,7 +16,7 @@ foreach($analyzersPath in $analyzersPaths)
     if (Test-Path $analyzersPath)
     {
         # Install the language agnostic analyzers.
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -47,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/uninstall.ps1
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/uninstall.ps1
@@ -9,7 +9,7 @@ if($project.Object.SupportsPackageDependencyResolution)
     }
 }
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/uninstall.ps1
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/uninstall.ps1
@@ -16,7 +16,7 @@ foreach($analyzersPath in $analyzersPaths)
     # Uninstall the language agnostic analyzers.
     if (Test-Path $analyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -47,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/uninstall.ps1
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/uninstall.ps1
@@ -32,7 +32,7 @@ if($project.Type -eq "C#")
 {
     $languageFolder = "cs"
 }
-if($project.Type -eq " VB.NET")
+if($project.Type -eq "VB.NET")
 {
     $languageFolder = "vb"
 }

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/uninstall.ps1
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/tools/uninstall.ps1
@@ -51,7 +51,14 @@ foreach($analyzersPath in $analyzersPaths)
         {
             if($project.Object.AnalyzerReferences)
             {
-                $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+                try
+                {
+                    $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+                }
+                catch
+                {
+
+                }
             }
         }
     }

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/install.ps1
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/install.ps1
@@ -9,7 +9,7 @@ if($project.Object.SupportsPackageDependencyResolution)
     }
 }
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/install.ps1
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/install.ps1
@@ -16,7 +16,7 @@ foreach($analyzersPath in $analyzersPaths)
     if (Test-Path $analyzersPath)
     {
         # Install the language agnostic analyzers.
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -47,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/uninstall.ps1
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/uninstall.ps1
@@ -9,7 +9,7 @@ if($project.Object.SupportsPackageDependencyResolution)
     }
 }
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/uninstall.ps1
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/uninstall.ps1
@@ -16,7 +16,7 @@ foreach($analyzersPath in $analyzersPaths)
     # Uninstall the language agnostic analyzers.
     if (Test-Path $analyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -47,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/uninstall.ps1
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/uninstall.ps1
@@ -32,7 +32,7 @@ if($project.Type -eq "C#")
 {
     $languageFolder = "cs"
 }
-if($project.Type -eq " VB.NET")
+if($project.Type -eq "VB.NET")
 {
     $languageFolder = "vb"
 }

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/uninstall.ps1
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/tools/uninstall.ps1
@@ -51,7 +51,14 @@ foreach($analyzersPath in $analyzersPaths)
         {
             if($project.Object.AnalyzerReferences)
             {
-                $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+                try
+                {
+                    $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+                }
+                catch
+                {
+
+                }
             }
         }
     }

--- a/src/Setup/PowerShell/install.ps1
+++ b/src/Setup/PowerShell/install.ps1
@@ -1,13 +1,22 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+if($project.Object.SupportsPackageDependencyResolution)
+{
+    if($project.Object.SupportsPackageDependencyResolution())
+    {
+        # Do not install analyzers via install.ps1, instead let the project system handle it.
+        return
+    }
+}
+
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {
-    # Install the language agnostic analyzers.
     if (Test-Path $analyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        # Install the language agnostic analyzers.
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -38,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Setup/PowerShell/uninstall.ps1
+++ b/src/Setup/PowerShell/uninstall.ps1
@@ -1,13 +1,22 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+if($project.Object.SupportsPackageDependencyResolution)
+{
+    if($project.Object.SupportsPackageDependencyResolution())
+    {
+        # Do not uninstall analyzers via uninstall.ps1, instead let the project system handle it.
+        return
+    }
+}
+
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {
     # Uninstall the language agnostic analyzers.
     if (Test-Path $analyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -38,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/install.ps1
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/install.ps1
@@ -16,7 +16,7 @@ foreach($analyzersPath in $analyzersPaths)
     if (Test-Path $analyzersPath)
     {
         # Install the language agnostic analyzers.
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -47,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/install.ps1
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/install.ps1
@@ -1,6 +1,6 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/install.ps1
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/install.ps1
@@ -1,12 +1,21 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
+if($project.Object.SupportsPackageDependencyResolution)
+{
+    if($project.Object.SupportsPackageDependencyResolution())
+    {
+        # Do not install analyzers via install.ps1, instead let the project system handle it.
+        return
+    }
+}
+
 $analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {
-    # Install the language agnostic analyzers.
     if (Test-Path $analyzersPath)
     {
+        # Install the language agnostic analyzers.
         foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
         {
             if($project.Object.AnalyzerReferences)

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/uninstall.ps1
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/uninstall.ps1
@@ -16,7 +16,7 @@ foreach($analyzersPath in $analyzersPaths)
     # Uninstall the language agnostic analyzers.
     if (Test-Path $analyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -47,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/uninstall.ps1
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/uninstall.ps1
@@ -1,6 +1,6 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/uninstall.ps1
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/uninstall.ps1
@@ -1,5 +1,14 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
+if($project.Object.SupportsPackageDependencyResolution)
+{
+    if($project.Object.SupportsPackageDependencyResolution())
+    {
+        # Do not uninstall analyzers via uninstall.ps1, instead let the project system handle it.
+        return
+    }
+}
+
 $analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/install.ps1
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/install.ps1
@@ -16,7 +16,7 @@ foreach($analyzersPath in $analyzersPaths)
     if (Test-Path $analyzersPath)
     {
         # Install the language agnostic analyzers.
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -47,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/install.ps1
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/install.ps1
@@ -1,6 +1,6 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/install.ps1
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/install.ps1
@@ -1,12 +1,21 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
+if($project.Object.SupportsPackageDependencyResolution)
+{
+    if($project.Object.SupportsPackageDependencyResolution())
+    {
+        # Do not install analyzers via install.ps1, instead let the project system handle it.
+        return
+    }
+}
+
 $analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {
-    # Install the language agnostic analyzers.
     if (Test-Path $analyzersPath)
     {
+        # Install the language agnostic analyzers.
         foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
         {
             if($project.Object.AnalyzerReferences)

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/uninstall.ps1
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/uninstall.ps1
@@ -16,7 +16,7 @@ foreach($analyzersPath in $analyzersPaths)
     # Uninstall the language agnostic analyzers.
     if (Test-Path $analyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$analyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {
@@ -47,7 +47,7 @@ foreach($analyzersPath in $analyzersPaths)
     $languageAnalyzersPath = join-path $analyzersPath $languageFolder
     if (Test-Path $languageAnalyzersPath)
     {
-        foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+        foreach ($analyzerFilePath in Get-ChildItem -Path "$languageAnalyzersPath\*.dll" -Exclude *.resources.dll)
         {
             if($project.Object.AnalyzerReferences)
             {

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/uninstall.ps1
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/uninstall.ps1
@@ -1,6 +1,6 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
-$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers" ) * -Resolve
+$analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)
 {

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/uninstall.ps1
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/tools/uninstall.ps1
@@ -1,5 +1,14 @@
 ﻿param($installPath, $toolsPath, $package, $project)
 
+if($project.Object.SupportsPackageDependencyResolution)
+{
+    if($project.Object.SupportsPackageDependencyResolution())
+    {
+        # Do not uninstall analyzers via uninstall.ps1, instead let the project system handle it.
+        return
+    }
+}
+
 $analyzersPaths = Join-Path (Join-Path (Split-Path -Path $toolsPath -Parent) "analyzers") * -Resolve
 
 foreach($analyzersPath in $analyzersPaths)


### PR DESCRIPTION
**Customer scenario**

Analyzers that are localized with satellite assemblies so users can review messages in their own language are improperly installed to packages.config based projects, leaving extra analyzer assemblies listed in Solution Explorer.

Also, removal of VB-specific analyzers fail.

Finally, the several copies of install.ps1 and uninstall.ps1 have grown out of sync. This PR makes them perfectly in sync with each other.

**Bugs this fixes:** 

Not filed. I figured I'd offer the fix instead of the bug. But there is a mail thread to the rosdisc DL with the subject line: "Analyzer satellite assembly showing up in SE"

**Workarounds, if any**

The user can hand edit the install.ps1 and uninstall.ps1 script files that comes in the template or samples.

**Risk**

If an error is introduced by this, it won't immediately regress anything. But developers of analyzers that use the templates may hit a failure to install packages that they'll need to manually fix.

**Performance impact**

None.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

I suppose localized analyzers isn't something Roslyn has tested.
And uninstalling VB analyzers from packages.config projects using the sample uninstall.ps1 script also wasn't tested.

**How was the bug found?**

I'm developing analyzers that are localized to several cultures and noticed this when I installed them as part of testing.