### PR TITLE
Re-fix test indicators in RC2

### DIFF
--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -263,18 +263,12 @@ namespace Microsoft.CodeAnalysis.CodeLens
         public async Task<string> GetFullyQualifiedName(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
-            var commonLocation = syntaxNode.GetLocation();
-            var document = solution.GetDocument(commonLocation.SourceTree);
-
-            if (document == null)
-            {
-                return null;
-            }
-
             using (solution.Services.CacheService?.EnableCaching(document.Project.Id))
             {
+                var document = solution.GetDocument(syntaxNode.GetLocation().SourceTree);
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                return GetEnclosingMethod(semanticModel, commonLocation, cancellationToken)?.ToDisplayString(MethodDisplayFormat);
+
+                return semanticModel.GetDeclaredSymbol(syntaxNode, cancellationToken)?.ToDisplayString(MethodDisplayFormat);
             }
         }
     }

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -263,9 +263,10 @@ namespace Microsoft.CodeAnalysis.CodeLens
         public async Task<string> GetFullyQualifiedName(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
+            var document = solution.GetDocument(syntaxNode.GetLocation().SourceTree);
+
             using (solution.Services.CacheService?.EnableCaching(document.Project.Id))
             {
-                var document = solution.GetDocument(syntaxNode.GetLocation().SourceTree);
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
                 return semanticModel.GetDeclaredSymbol(syntaxNode, cancellationToken)?.ToDisplayString(MethodDisplayFormat);


### PR DESCRIPTION
**Customer scenario**

When the user has a project with unit tests, the CodeLens indicator for test status will not show up above unit test methods.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=296433

**Workarounds, if any**

None. The indicator will not appear under any circumstances.

**Risk**

Low. This bug was caused by a bug fix that went out in RC that was accidentally removed when merging the RC branch into master. This simply restores code that is shipping already in RC.

**Performance impact**

None.

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

The original fix was made in the dev15-rc branch. There were independent changes made in the master branch to related code. When dev15-rc was merged into master, the original fix was accidentally removed by the person doing the merge.

**How was the bug found?**

Testing by the test indicator team.
