### PR TITLE
Revert unapproved fix

### DIFF
--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -263,13 +263,18 @@ namespace Microsoft.CodeAnalysis.CodeLens
         public async Task<string> GetFullyQualifiedName(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
-            var document = solution.GetDocument(syntaxNode.GetLocation().SourceTree);
+            var commonLocation = syntaxNode.GetLocation();
+            var document = solution.GetDocument(commonLocation.SourceTree);
+
+            if (document == null)
+            {
+                return null;
+            }
 
             using (solution.Services.CacheService?.EnableCaching(document.Project.Id))
             {
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-                return semanticModel.GetDeclaredSymbol(syntaxNode, cancellationToken)?.ToDisplayString(MethodDisplayFormat);
+                return GetEnclosingMethod(semanticModel, commonLocation, cancellationToken)?.ToDisplayString(MethodDisplayFormat);
             }
         }
     }


### PR DESCRIPTION
Confused Matt approval with shiproom approval and committed too soon. This undoes the fix that is not yet approved.

@natidea @jasonmalinowski 