### PR TITLE
Permit a throw expression as the body of an expression-bodied lambda

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -689,11 +689,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var binaryParent = (BinaryExpressionSyntax)parent;
                         return node == binaryParent.Right;
                     }
-                case SyntaxKind.ArrowExpressionClause: // =>
-                    {
-                        var arrowClauseParent = (ArrowExpressionClauseSyntax)parent;
-                        return node == arrowClauseParent.Expression;
-                    }
+                case SyntaxKind.ArrowExpressionClause:
+                case SyntaxKind.ParenthesizedLambdaExpression:
+                case SyntaxKind.SimpleLambdaExpression:
+                    return true;
                 // We do not support && and || because
                 // 1. The precedence would not syntactically allow it
                 // 2. It isn't clear what the semantics should be

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -2355,5 +2355,55 @@ class B
             var comp = CreateCompilationWithMscorlibAndSystemCore(src, options: TestOptions.DebugExe);
             CompileAndVerify(comp, expectedOutput: "1");
         }
+
+        [Fact]
+        public void ThrowExpression_Lambda()
+        {
+            var src = @"using System;
+class C
+{
+    public static void Main()
+    {
+        Action a = () => throw new Exception(""1"");
+        try
+        {
+            a();
+        }
+        catch (Exception ex)
+        {
+            Console.Write(ex.Message);
+        }
+        Func<int, int> b = x => throw new Exception(""2"");
+        try
+        {
+            b(0);
+        }
+        catch (Exception ex)
+        {
+            Console.Write(ex.Message);
+        }
+        b = (int x) => throw new Exception(""3"");
+        try
+        {
+            b(0);
+        }
+        catch (Exception ex)
+        {
+            Console.Write(ex.Message);
+        }
+        b = (x) => throw new Exception(""4"");
+        try
+        {
+            b(0);
+        }
+        catch (Exception ex)
+        {
+            Console.Write(ex.Message);
+        }
+    }
+}";
+            var comp = CreateCompilationWithMscorlibAndSystemCore(src, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "1234");
+        }
     }
 }


### PR DESCRIPTION
Fixes #15555

@dotnet/roslyn-compiler Please review. This will be proposed for ask mode after review.