### PR TITLE
Allow reference types to return ref this

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1574,7 +1574,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // We will already have given an error for "this" used outside of a constructor, 
                 // instance method, or instance accessor. Assume that "this" is a variable if it is in a struct.
-                if (!thisref.Type.IsValueType || kind == BindValueKind.RefReturn)
+                if (!thisref.Type.IsValueType ^ kind == BindValueKind.RefReturn)
                 {
                     // CONSIDER: the Dev10 name has angle brackets (i.e. "<this>")
                     Error(diagnostics, GetThisLvalueError(kind), node, ThisParameterSymbol.SymbolName);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -998,5 +998,23 @@ class C
                 expectedOutput: "frog",
                 additionalRefs: new[] { SystemCoreRef, CSharpRef }).VerifyDiagnostics();
         }
+
+        [Fact]
+        public void RefReturnThisInClass()
+        {
+            var text = @"
+public class Test
+{
+    public class C
+    {
+        public ref C Foo()
+        {
+            return ref this;
+        }
+    }
+}";
+            var comp = CreateCompilationRef(text);
+            comp.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
`return ref this` should be allowed in classes, hence the misleading error message.
```cs
public class C {
    public ref C M() {
        return ref this;
    }
}
```

`error CS8170: Struct members cannot return 'this' or other instance members by reference`