### PR TITLE
Fix DeclaredInside for expression variables and deconstruction

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -794,7 +794,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if ((object)declType != null)
                 {
                     CheckRestrictedTypeInAsync(this.ContainingMemberOrLambda, declType, diagnostics, designation);
-                    return new BoundLocal(designation, localSymbol, constantValueOpt: null, type: declType, hasErrors: hasErrors);
+                    return new BoundLocal(designation, localSymbol, isDeclaration: true, constantValueOpt: null, type: declType, hasErrors: hasErrors);
                 }
 
                 return new DeconstructionVariablePendingInference(designation, localSymbol, receiverOpt: null);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2232,7 +2232,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 CheckRestrictedTypeInAsync(this.ContainingMemberOrLambda, declType, diagnostics, typeSyntax);
 
-                return new BoundLocal(declarationExpression, localSymbol, constantValueOpt: null, type: declType);
+                return new BoundLocal(declarationExpression, localSymbol, isDeclaration:true, constantValueOpt: null, type: declType);
             }
 
             // Is this a field?

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -110,6 +110,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get { return this.LocalSymbol; }
         }
+
+        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type, bool hasErrors)
+            : this(syntax, localSymbol, false, constantValueOpt, type, hasErrors)
+        {
+        }
+
+        public BoundLocal(SyntaxNode syntax, LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type)
+            : this(syntax, localSymbol, false, constantValueOpt, type)
+        {
+        }
+
+        public BoundLocal Update(LocalSymbol localSymbol, ConstantValue constantValueOpt, TypeSymbol type)
+        {
+            return this.Update(localSymbol, this.IsDeclaration, constantValueOpt, type);
+        }
     }
 
     internal partial class BoundFieldAccess

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1007,8 +1007,8 @@
   <Node Name="BoundLocal" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-
     <Field Name="LocalSymbol" Type="LocalSymbol"/>
+    <Field Name="IsDeclaration" Type="bool"/>
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     local.SetType(type);
-                    return new BoundLocal(this.Syntax, local, constantValueOpt: null, type: type, hasErrors: this.HasErrors || inferenceFailed);
+                    return new BoundLocal(this.Syntax, local, isDeclaration: true, constantValueOpt: null, type: type, hasErrors: this.HasErrors || inferenceFailed);
 
                 case SymbolKind.Field:
                     var field = (GlobalExpressionVariable)this.VariableSymbol;

--- a/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     localSymbol.SetType(type);
-                    return new BoundLocal(this.Syntax, localSymbol, constantValueOpt: null, type: type, hasErrors: this.HasErrors || inferenceFailed);
+                    return new BoundLocal(this.Syntax, localSymbol, isDeclaration: true, constantValueOpt: null, type: type, hasErrors: this.HasErrors || inferenceFailed);
 
                 case SymbolKind.Field:
                     var fieldSymbol = (GlobalExpressionVariable)this.VariableSymbol;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -122,16 +122,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitLocalFunctionStatement(node);
         }
 
-        public override BoundNode VisitForEachStatement(BoundForEachStatement node)
+        public override void VisitForEachIterationVariable(BoundForEachStatement node)
         {
             if (IsInside)
             {
-                _variablesDeclared.Add(node.IterationVariableOpt);
+                if (node.IterationVariableOpt != null)
+                {
+                    _variablesDeclared.Add(node.IterationVariableOpt);
+                }
+
+                var leftVariables =
+                    (node.DeconstructionOpt?.DeconstructionAssignment?.LeftVariables)
+                    .GetValueOrDefault().NullToEmpty();
+                foreach (var variable in leftVariables)
+                {
+                    Visit(variable);
+                }
             }
-
-            return base.VisitForEachStatement(node);
         }
-
 
         protected override void VisitCatchBlock(BoundCatchBlock catchBlock, ref LocalState finallyState)
         {
@@ -163,31 +171,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override void VisitLvalue(BoundLocal node)
         {
-            CheckOutVarDeclaration(node);
-            base.VisitLvalue(node);
-        }
-
-        private void CheckOutVarDeclaration(BoundLocal node)
-        {
-            if (IsInside &&
-                !node.WasCompilerGenerated && node.Syntax.Kind() == SyntaxKind.DeclarationExpression)
-            {
-                var declaration = (DeclarationExpressionSyntax)node.Syntax;
-                if (declaration.Designation.Kind() == SyntaxKind.SingleVariableDesignation &&
-                    ((SingleVariableDesignationSyntax)declaration.Designation).Identifier == node.LocalSymbol.IdentifierToken &&
-                    declaration.Parent != null &&
-                    declaration.Parent.Kind() == SyntaxKind.Argument &&
-                    ((ArgumentSyntax)declaration.Parent).RefOrOutKeyword.Kind() == SyntaxKind.OutKeyword)
-                {
-                    _variablesDeclared.Add(node.LocalSymbol);
-                }
-            }
+            VisitLocal(node);
         }
 
         public override BoundNode VisitLocal(BoundLocal node)
         {
-            CheckOutVarDeclaration(node);
-            return base.VisitLocal(node);
+            if (IsInside && node.IsDeclaration)
+            {
+                _variablesDeclared.Add(node.LocalSymbol);
+            }
+
+            return null;
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/RegionAnalysisTests.cs
@@ -5040,6 +5040,65 @@ public class ExportedSymbol
             Assert.Equal(null, GetSymbolNamesJoined(analysis.DataFlowsOut));
         }
 
+        [Fact, WorkItem(14110, "https://github.com/dotnet/roslyn/issues/14110")]
+        public void Test14110()
+        {
+            var dataFlowAnalysisResults = CompileAndAnalyzeDataFlowStatements(@"
+class Program
+{
+    static void Main()
+    {
+        var (a0, b0) = (1, 2);
+        (var c0, int d0) = (3, 4);
+        bool e0 = a0 is int f0;
+        bool g0 = a0 is var h0;
+        M(out int i0);
+        M(out var j0);
+
+/*<bind>*/
+        var (a, b) = (1, 2);
+        (var c, int d) = (3, 4);
+        bool e = a is int f;
+        bool g = a is var h;
+        M(out int i);
+        M(out var j);
+/*</bind>*/
+
+        var (a1, b1) = (1, 2);
+        (var c1, int d1) = (3, 4);
+        bool e1 = a1 is int f1;
+        bool g1 = a1 is var h1;
+        M(out int i1);
+        M(out var j1);
+}
+    static void M(out int z) => throw null;
+}
+");
+            Assert.Equal("a, b, c, d, e, f, g, h, i, j", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+        }
+
+        [Fact, WorkItem(15640, "https://github.com/dotnet/roslyn/issues/15640")]
+        public void Test15640()
+        {
+            var dataFlowAnalysisResults = CompileAndAnalyzeDataFlowStatements(@"
+using System;
+
+class Programand 
+{
+    static void Main()
+    {
+        foreach (var (a0, b0) in new[] { (1, 2) }) {}
+
+/*<bind>*/
+        foreach (var (a, b) in new[] { (1, 2) }) {}
+/*</bind>*/
+
+        foreach (var (a1, b1) in new[] { (1, 2) }) {}
+    }
+}
+");
+            Assert.Equal("a, b", GetSymbolNamesJoined(dataFlowAnalysisResults.VariablesDeclared));
+        }
         #endregion
     }
 }


### PR DESCRIPTION
@dotnet/roslyn-compiler Please review.

**Customer scenario**

`DeclaredInside` is used for extract method, so the bugs fixed here result in incorrect behavior for that IDE feature. Also, it fixes a `NullReferenceException` that would result in an IDE crash when extract method is used in some circumstances.

**Bugs this fixes:** 

Fixes #12940
Fixes #14110
Fixes #15640

**Workarounds, if any**

Don't use extract method (or any other IDE features that use `DeclaredInside`).

**Risk**

Fairly low; the changes are localized to the affected scenarios, and significantly simplify the implementation.

**Performance impact**

Small. Slightly larger node for `BoundLocal`, which is transiently used during semantic analysis and in the `SemanticModel`

**Is this a regression from a previous update?**

No. The bugs have been present as long as the feature implementations have been in the code base.

**Root cause analysis:**

Implementing this API for expression variables has been a known laggard in the implementation of the new features. Because it wasn't implemented, it also wasn't tested. This PR adds tests for the affected scenarios.

**How was the bug found?**

Ad-hoc and unit testing while completing the feature.
