### PR TITLE
Add editorconfig option for PreferExplicitTupleName

### DIFF
--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
@@ -129,6 +129,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(CodeStyleOptions),
             nameof(PreferExplicitTupleNames),
             defaultValue: TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferExplicitTupleNames"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("dotnet_style_explicit_tuple_names"),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferExplicitTupleNames") });
     }
 }


### PR DESCRIPTION
**Customer scenario**

Allows the user to specify that they want to use explicit tuple names using editorconfig

**Bugs this fixes:** 

#15307

**Workarounds, if any**

Use can specify this option manually in VS.  Changing the option manually for each project.

**Risk**

Low, , it is reusing all existing editoconfig code.

**Performance impact**

Low, it is reusing all existing editoconfig code.

**Is this a regression from a previous update?**

No, this is a follow up to this option being added in PR #15202

**Root cause analysis:**

editor config support for code style options was in review when this was merged into master.

**How was the bug found?**

bug was filed as part of PR #15202
