### PR TITLE
Do not explicitly cast to INamedTypeSymbol

### DIFF
--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -573,8 +573,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 
             private bool HasAccessibleStaticFieldOrProperty(ISymbol symbol, string fieldOrPropertyName)
             {
-                var namedType = (INamedTypeSymbol)symbol;
-                if (namedType != null)
+                if (symbol is INamedTypeSymbol namedType)
                 {
                     var members = namedType.GetMembers(fieldOrPropertyName);
                     var query = from m in members


### PR DESCRIPTION
**Customer scenario**

Users sees a popup indicating an exception has been thrown in visualbasicaddimportcodefixprovider In certain winforms inheritance scenarios.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/4395

**Workarounds, if any**

none

**Risk**

Low, this is a very minor change

**Performance impact**

Low, this prevents a codefix crash this should have no impact on performance

**Is this a regression from a previous update?**

This was first reported in Update 3.  The logic for this code has had the same defect since Dev14 RTM.

**Root cause analysis:**

 We are given a PEMethodSymbol by the compiler instead of a INamedTypeSymbol for certain winforms inheritance cases.  We had the incorrect assumption that we would only get INamedTypeSymbols.

**How was the bug found?**

customer reported
