### PR TITLE
handle exceptions that may occur while fetching editorconfig settings

### DIFF
--- a/src/EditorFeatures/Next/EditorFeatures.Next.csproj
+++ b/src/EditorFeatures/Next/EditorFeatures.Next.csproj
@@ -63,6 +63,8 @@
     <Compile Include="IntelliSense\Completion\Presentation\Roslyn15CompletionSet.cs" />
     <Compile Include="IntelliSense\Completion\Presentation\VisualStudio15CompletionSetFactory.cs" />
     <Compile Include="IntelliSense\Completion\Presentation\VisualStudio15CompletionSet.cs" />
+    <Compile Include="Options\EditorConfigDocumentOptionsProvider.DocumentOptions.cs" />
+    <Compile Include="Options\EditorConfigDocumentOptionsProvider.EmptyCodingConventionContext.cs" />
     <Compile Include="Structure\BlockContextProvider.cs" />
     <Compile Include="Structure\VisualStudio15StructureTaggerProvider.cs" />
     <Compile Include="Options\EditorConfigDocumentOptionsProviderFactory.cs" />

--- a/src/EditorFeatures/Next/Options/EditorConfigDocumentOptionsProvider.DocumentOptions.cs
+++ b/src/EditorFeatures/Next/Options/EditorConfigDocumentOptionsProvider.DocumentOptions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.CodingConventions;
+
+namespace Microsoft.CodeAnalysis.Editor.Options
+{
+    internal sealed partial class EditorConfigDocumentOptionsProvider : IDocumentOptionsProvider
+    {
+        private class DocumentOptions : IDocumentOptions
+        {
+            private ICodingConventionsSnapshot _codingConventionSnapshot;
+
+            public DocumentOptions(ICodingConventionsSnapshot codingConventionSnapshot)
+            {
+                _codingConventionSnapshot = codingConventionSnapshot;
+            }
+
+            public bool TryGetDocumentOption(Document document, OptionKey option, out object value)
+            {
+                var editorConfigPersistence = option.Option.StorageLocations.OfType<EditorConfigStorageLocation>().SingleOrDefault();
+
+                if (editorConfigPersistence == null)
+                {
+                    value = null;
+                    return false;
+                }
+
+                if (_codingConventionSnapshot.TryGetConventionValue(editorConfigPersistence.KeyName, out value))
+                {
+                    try
+                    {
+                        value = editorConfigPersistence.ParseValue(value.ToString(), option.Option.Type);
+                        return true;
+                    }
+                    catch (Exception)
+                    {
+                        // TODO: report this somewhere?
+                        return false;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Next/Options/EditorConfigDocumentOptionsProvider.EmptyCodingConventionContext.cs
+++ b/src/EditorFeatures/Next/Options/EditorConfigDocumentOptionsProvider.EmptyCodingConventionContext.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.CodingConventions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.Options
+{
+    internal sealed partial class EditorConfigDocumentOptionsProvider
+    {
+        private class EmptyCodingConventionContext : ICodingConventionContext
+        {
+            public static ICodingConventionContext Instance { get; } = new EmptyCodingConventionContext();
+
+            public ICodingConventionsSnapshot CurrentConventions { get; } = EmptyCodingConventionsSnapshot.Instance;
+
+#pragma warning disable CS0067
+            public event CodingConventionsChangedAsyncEventHandler CodingConventionsChangedAsync;
+#pragma warning restore CS0067
+
+            public void Dispose() { }
+
+            public Task WriteConventionValueAsync(string conventionName, string conventionValue, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            private class EmptyCodingConventionsSnapshot : ICodingConventionsSnapshot
+            {
+                public static EmptyCodingConventionsSnapshot Instance { get; } = new EmptyCodingConventionsSnapshot();
+
+                public IReadOnlyDictionary<string, object> AllRawConventions { get; } =
+                    (IReadOnlyDictionary<string, object>)SpecializedCollections.EmptyDictionary<string, object>();
+
+                public IUniversalCodingConventions UniversalConventions { get; } = EmptyUniversalCodingConventions.Instance;
+
+                public int Version => 0;
+
+                public bool TryGetConventionValue<T>(string conventionName, out T conventionValue)
+                {
+                    conventionValue = default(T);
+                    return false;
+                }
+
+                private class EmptyUniversalCodingConventions : IUniversalCodingConventions
+                {
+                    public static EmptyUniversalCodingConventions Instance { get; } = new EmptyUniversalCodingConventions();
+
+                    public bool TryGetAllowTrailingWhitespace(out bool allowTrailingWhitespace)
+                    {
+                        allowTrailingWhitespace = false;
+                        return false;
+                    }
+
+                    public bool TryGetEncoding(out Encoding encoding)
+                    {
+                        encoding = null;
+                        return false;
+                    }
+
+                    public bool TryGetIndentSize(out int indentSize)
+                    {
+                        indentSize = default(int);
+                        return false;
+                    }
+
+                    public bool TryGetIndentStyle(out IndentStyle indentStyle)
+                    {
+                        indentStyle = default(IndentStyle);
+                        return false;
+                    }
+
+                    public bool TryGetLineEnding(out string lineEnding)
+                    {
+                        lineEnding = null;
+                        return false;
+                    }
+
+                    public bool TryGetRequireFinalNewline(out bool requireFinalNewline)
+                    {
+                        requireFinalNewline = false;
+                        return false;
+                    }
+
+                    public bool TryGetTabWidth(out int tabWidth)
+                    {
+                        tabWidth = default(int);
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Shared/Utilities/IOUtilities.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/IOUtilities.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
@@ -22,6 +23,19 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             try
             {
                 return function();
+            }
+            catch (Exception e) when (IsNormalIOException(e))
+            {
+            }
+
+            return defaultValue;
+        }
+
+        public static async Task<T> PerformIOAsync<T>(Func<Task<T>> function, T defaultValue = default(T))
+        {
+            try
+            {
+                return await function().ConfigureAwait(false);
             }
             catch (Exception e) when (IsNormalIOException(e))
             {


### PR DESCRIPTION
**Customer scenario**

If the editor config file is being used by another process in such a way that it is inaccessible to Visual Studio, Visual Studio will crash

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/15096

**Workarounds, if any**

none

**Risk**

This fix will need to be approved by @jasonmalinowski or someone who has a deep understanding to the threading logic in the workspace layer as it changes the semantics somewhat.

**Performance impact**

Low, this change only catches exceptions that were previously unhandled.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

The VS APIs will leak exceptions to the caller if there is any File IO issue.  We were unaware that this contract was in place for the caller.

**How was the bug found?**

Found in integration test run.
