### PR TITLE
Do not optimize 'default(T)?.X' into 'null' when 'T' is unconstrained.

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -355,12 +355,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             var receiver = expression.Receiver;
 
-            if (receiver.IsDefaultValue() && receiver.Type.IsReferenceType)
-            {
-                EmitDefaultValue(expression.Type, used, expression.Syntax);
-                return;
-            }
-
             var receiverType = receiver.Type;
             LocalDefinition receiverTemp = null;
             Debug.Assert(!receiverType.IsValueType ||

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             var receiver = expression.Receiver;
 
-            if (receiver.IsDefaultValue())
+            if (receiver.IsDefaultValue() && receiver.Type.IsReferenceType)
             {
                 EmitDefaultValue(expression.Type, used, expression.Syntax);
                 return;
@@ -384,15 +384,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             object doneLabel = new object();
             LocalDefinition cloneTemp = null;
 
+            var unconstrainedReceiver = !receiverType.IsReferenceType && !receiverType.IsValueType;
+
             // we need a copy if we deal with nonlocal value (to capture the value)
             // or if we have a ref-constrained T (to do box just once) 
             // or if we deal with stack local (reads are destructive)
+            // or if we have default(T) (to do box just once)
             var nullCheckOnCopy = LocalRewriter.CanChangeValueBetweenReads(receiver, localsMayBeAssignedOrCaptured: false) ||
                                    (receiverType.IsReferenceType && receiverType.TypeKind == TypeKind.TypeParameter) ||
-                                   (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol));
-
-            var unconstrainedReceiver = !receiverType.IsReferenceType && !receiverType.IsValueType;
-
+                                   (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol)) ||
+                                   (receiver.IsDefaultValue() && unconstrainedReceiver);
 
             // ===== RECEIVER
             if (nullCheckOnCopy)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -39,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiverType = loweredReceiver.Type;
 
             // Check trivial case
-            if (loweredReceiver.IsDefaultValue())
+            if (loweredReceiver.IsDefaultValue() && receiverType.IsReferenceType)
             {
                 return _factory.Default(node.Type);
             }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -7017,6 +7017,133 @@ class Program
         }
 
         [Fact, WorkItem(15670, "https://github.com/dotnet/roslyn/issues/15670")]
+        public void ConditionalAccessOffOfInterfaceConstrainedDefault1()
+        {
+            var source = @"
+using System;
+
+public class Test<T> where T : IComparable
+{
+    public string Run()
+    {
+        return default(T)?.ToString();
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(""--"");
+        Console.WriteLine(new Test<string>().Run());
+        Console.WriteLine(""--"");
+        Console.WriteLine(new Test<int>().Run());
+        Console.WriteLine(""--"");
+    }
+}
+";
+            var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
+@"--
+
+--
+0
+--");
+
+            verifier.VerifyIL("Test<T>.Run", @"
+{
+  // Code size       65 (0x41)
+  .maxstack  2
+  .locals init (T V_0,
+                T V_1,
+                string V_2)
+  IL_0000:  nop
+  IL_0001:  ldloca.s   V_0
+  IL_0003:  initobj    ""T""
+  IL_0009:  ldloc.0
+  IL_000a:  stloc.0
+  IL_000b:  ldloca.s   V_0
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  initobj    ""T""
+  IL_0015:  ldloc.1
+  IL_0016:  box        ""T""
+  IL_001b:  brtrue.s   IL_0031
+  IL_001d:  ldobj      ""T""
+  IL_0022:  stloc.1
+  IL_0023:  ldloca.s   V_1
+  IL_0025:  ldloc.1
+  IL_0026:  box        ""T""
+  IL_002b:  brtrue.s   IL_0031
+  IL_002d:  pop
+  IL_002e:  ldnull
+  IL_002f:  br.s       IL_003c
+  IL_0031:  constrained. ""T""
+  IL_0037:  callvirt   ""string object.ToString()""
+  IL_003c:  stloc.2
+  IL_003d:  br.s       IL_003f
+  IL_003f:  ldloc.2
+  IL_0040:  ret
+}");
+        }
+
+        [Fact, WorkItem(15670, "https://github.com/dotnet/roslyn/issues/15670")]
+        public void ConditionalAccessOffOfInterfaceConstrainedDefault2()
+        {
+            var source = @"
+using System;
+
+public class Test<T> where T : IComparable
+{
+    public string Run()
+    {
+        var v = default(T);
+        return v?.ToString();
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(""--"");
+        Console.WriteLine(new Test<string>().Run());
+        Console.WriteLine(""--"");
+        Console.WriteLine(new Test<int>().Run());
+        Console.WriteLine(""--"");
+    }
+}
+";
+            var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
+@"--
+
+--
+0
+--");
+
+            verifier.VerifyIL("Test<T>.Run", @"
+{
+  // Code size       38 (0x26)
+  .maxstack  1
+  .locals init (T V_0, //v
+                string V_1)
+  IL_0000:  nop
+  IL_0001:  ldloca.s   V_0
+  IL_0003:  initobj    ""T""
+  IL_0009:  ldloc.0
+  IL_000a:  box        ""T""
+  IL_000f:  brtrue.s   IL_0014
+  IL_0011:  ldnull
+  IL_0012:  br.s       IL_0021
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  constrained. ""T""
+  IL_001c:  callvirt   ""string object.ToString()""
+  IL_0021:  stloc.1
+  IL_0022:  br.s       IL_0024
+  IL_0024:  ldloc.1
+  IL_0025:  ret
+}");
+        }
+
+        [Fact, WorkItem(15670, "https://github.com/dotnet/roslyn/issues/15670")]
         public void ConditionalAccessOffOfClassConstrainedDefault1()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -7017,7 +7017,7 @@ class Program
         }
 
         [Fact, WorkItem(15670, "https://github.com/dotnet/roslyn/issues/15670")]
-        public void ConditionalAccessOffOfClassconstrainedDefault1()
+        public void ConditionalAccessOffOfClassConstrainedDefault1()
         {
             var source = @"
 using System;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -6907,12 +6907,20 @@ class Program
 {
     static void Main()
     {
+        Console.WriteLine(""--"");
+        Console.WriteLine(new Test<string>().Run());
+        Console.WriteLine(""--"");
         Console.WriteLine(new Test<int>().Run());
+        Console.WriteLine(""--"");
     }
 }
 ";
             var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
-@"0");
+@"--
+
+--
+0
+--");
 
             verifier.VerifyIL("Test<T>.Run", @"
 {
@@ -6969,12 +6977,20 @@ class Program
 {
     static void Main()
     {
+        Console.WriteLine(""--"");
+        Console.WriteLine(new Test<string>().Run());
+        Console.WriteLine(""--"");
         Console.WriteLine(new Test<int>().Run());
+        Console.WriteLine(""--"");
     }
 }
 ";
             var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
-@"0");
+@"--
+
+--
+0
+--");
 
             verifier.VerifyIL("Test<T>.Run", @"
 {
@@ -7018,12 +7034,16 @@ class Program
 {
     static void Main()
     {
+        Console.WriteLine(""--"");
         Console.WriteLine(new Test<string>().Run());
+        Console.WriteLine(""--"");
     }
 }
 ";
             var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
-@"");
+@"--
+
+--");
 
             verifier.VerifyIL("Test<T>.Run", @"
 {
@@ -7058,12 +7078,16 @@ class Program
 {
     static void Main()
     {
+        Console.WriteLine(""--"");
         Console.WriteLine(new Test<string>().Run());
+        Console.WriteLine(""--"");
     }
 }
 ";
             var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
-@"");
+@"--
+
+--");
 
             verifier.VerifyIL("Test<T>.Run", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.UnitTests.Emit;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -6890,6 +6886,206 @@ namespace ConsoleApplication9
   IL_000d:  ldarg.0
   IL_000e:  call       ""T ConsoleApplication9.Program.A<T>.Value.get""
   IL_0013:  ret
+}");
+        }
+
+        [Fact, WorkItem(15670, "https://github.com/dotnet/roslyn/issues/15670")]
+        public void ConditionalAccessOffOfUnconstrainedDefault1()
+        {
+            var source = @"
+using System;
+
+public class Test<T>
+{
+    public string Run()
+    {
+        return default(T)?.ToString();
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new Test<int>().Run());
+    }
+}
+";
+            var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
+@"0");
+
+            verifier.VerifyIL("Test<T>.Run", @"
+{
+  // Code size       65 (0x41)
+  .maxstack  2
+  .locals init (T V_0,
+                T V_1,
+                string V_2)
+  IL_0000:  nop
+  IL_0001:  ldloca.s   V_0
+  IL_0003:  initobj    ""T""
+  IL_0009:  ldloc.0
+  IL_000a:  stloc.0
+  IL_000b:  ldloca.s   V_0
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  initobj    ""T""
+  IL_0015:  ldloc.1
+  IL_0016:  box        ""T""
+  IL_001b:  brtrue.s   IL_0031
+  IL_001d:  ldobj      ""T""
+  IL_0022:  stloc.1
+  IL_0023:  ldloca.s   V_1
+  IL_0025:  ldloc.1
+  IL_0026:  box        ""T""
+  IL_002b:  brtrue.s   IL_0031
+  IL_002d:  pop
+  IL_002e:  ldnull
+  IL_002f:  br.s       IL_003c
+  IL_0031:  constrained. ""T""
+  IL_0037:  callvirt   ""string object.ToString()""
+  IL_003c:  stloc.2
+  IL_003d:  br.s       IL_003f
+  IL_003f:  ldloc.2
+  IL_0040:  ret
+}");
+        }
+
+        [Fact, WorkItem(15670, "https://github.com/dotnet/roslyn/issues/15670")]
+        public void ConditionalAccessOffOfUnconstrainedDefault2()
+        {
+            var source = @"
+using System;
+
+public class Test<T>
+{
+    public string Run()
+    {
+        var v = default(T);
+        return v?.ToString();
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new Test<int>().Run());
+    }
+}
+";
+            var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
+@"0");
+
+            verifier.VerifyIL("Test<T>.Run", @"
+{
+  // Code size       38 (0x26)
+  .maxstack  1
+  .locals init (T V_0, //v
+                string V_1)
+  IL_0000:  nop
+  IL_0001:  ldloca.s   V_0
+  IL_0003:  initobj    ""T""
+  IL_0009:  ldloc.0
+  IL_000a:  box        ""T""
+  IL_000f:  brtrue.s   IL_0014
+  IL_0011:  ldnull
+  IL_0012:  br.s       IL_0021
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  constrained. ""T""
+  IL_001c:  callvirt   ""string object.ToString()""
+  IL_0021:  stloc.1
+  IL_0022:  br.s       IL_0024
+  IL_0024:  ldloc.1
+  IL_0025:  ret
+}");
+        }
+
+        [Fact, WorkItem(15670, "https://github.com/dotnet/roslyn/issues/15670")]
+        public void ConditionalAccessOffOfClassconstrainedDefault1()
+        {
+            var source = @"
+using System;
+
+public class Test<T> where T : class
+{
+    public string Run()
+    {
+        return default(T)?.ToString();
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new Test<string>().Run());
+    }
+}
+";
+            var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
+@"");
+
+            verifier.VerifyIL("Test<T>.Run", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (string V_0)
+  IL_0000:  nop
+  IL_0001:  ldnull
+  IL_0002:  stloc.0
+  IL_0003:  br.s       IL_0005
+  IL_0005:  ldloc.0
+  IL_0006:  ret
+}");
+        }
+
+        [Fact, WorkItem(15670, "https://github.com/dotnet/roslyn/issues/15670")]
+        public void ConditionalAccessOffOfClassConstrainedDefault2()
+        {
+            var source = @"
+using System;
+
+public class Test<T> where T : class
+{
+    public string Run()
+    {
+        var v = default(T);
+        return v?.ToString();
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(new Test<string>().Run());
+    }
+}
+";
+            var verifier = CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput:
+@"");
+
+            verifier.VerifyIL("Test<T>.Run", @"
+{
+  // Code size       32 (0x20)
+  .maxstack  2
+  .locals init (T V_0, //v
+                string V_1)
+  IL_0000:  nop
+  IL_0001:  ldloca.s   V_0
+  IL_0003:  initobj    ""T""
+  IL_0009:  ldloc.0
+  IL_000a:  box        ""T""
+  IL_000f:  dup
+  IL_0010:  brtrue.s   IL_0016
+  IL_0012:  pop
+  IL_0013:  ldnull
+  IL_0014:  br.s       IL_001b
+  IL_0016:  callvirt   ""string object.ToString()""
+  IL_001b:  stloc.1
+  IL_001c:  br.s       IL_001e
+  IL_001e:  ldloc.1
+  IL_001f:  ret
 }");
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15670