### PR TITLE
Always queue project removal actions

### DIFF
--- a/src/Test/Utilities/Desktop/ObjectReference.cs
+++ b/src/Test/Utilities/Desktop/ObjectReference.cs
@@ -53,9 +53,9 @@ namespace Roslyn.Test.Utilities
         /// Asserts that the underlying object has been released.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void AssertReleased()
+        public void AssertReleased(Action waitAction = null)
         {
-            ReleaseAndGarbageCollect();
+            ReleaseAndGarbageCollect(waitAction);
 
             Assert.False(_weakReference.IsAlive, "Reference should have been released but was not.");
         }
@@ -64,9 +64,9 @@ namespace Roslyn.Test.Utilities
         /// Asserts that the underlying object is still being held.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void AssertHeld()
+        public void AssertHeld(Action waitAction = null)
         {
-            ReleaseAndGarbageCollect();
+            ReleaseAndGarbageCollect(waitAction);
 
             // Since we are asserting it's still held, if it is held we can just recover our strong reference again
             _strongReference = (T)_weakReference.Target;
@@ -75,7 +75,7 @@ namespace Roslyn.Test.Utilities
 
         // Ensure the mention of the field doesn't result in any local temporaries being created in the parent
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void ReleaseAndGarbageCollect()
+        private void ReleaseAndGarbageCollect(Action waitAction)
         {
             if (_strongReferenceRetrievedOutsideScopedCall)
             {
@@ -92,6 +92,7 @@ namespace Roslyn.Test.Utilities
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
+                waitAction?.Invoke();
             }
         }
 

--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -138,6 +138,10 @@
       <Project>{69f853e5-bd04-4842-984f-fc68cc51f402}</Project>
       <Name>VisualStudioTestUtilities2</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\TestUtilities\VisualStudioTestUtilities.csproj">
+      <Project>{3bed15fd-d608-4573-b432-1569c1026f6d}</Project>
+      <Name>VisualStudioTestUtilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\VisualBasic\Impl\BasicVisualStudio.vbproj">
       <Project>{d49439d7-56d2-450f-a4f0-74cb95d620e6}</Project>
       <Name>BasicVisualStudio</Name>
@@ -185,6 +189,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeModel\AbstractFileCodeElementTests.cs" />

--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -138,10 +138,6 @@
       <Project>{69f853e5-bd04-4842-984f-fc68cc51f402}</Project>
       <Name>VisualStudioTestUtilities2</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\TestUtilities\VisualStudioTestUtilities.csproj">
-      <Project>{3bed15fd-d608-4573-b432-1569c1026f6d}</Project>
-      <Name>VisualStudioTestUtilities</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\VisualBasic\Impl\BasicVisualStudio.vbproj">
       <Project>{d49439d7-56d2-450f-a4f0-74cb95d620e6}</Project>
       <Name>BasicVisualStudio</Name>
@@ -189,7 +185,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeModel\AbstractFileCodeElementTests.cs" />

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/CSharpReferencesTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/CSharpReferencesTests.cs
@@ -28,9 +28,6 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
                 project2.OnImportAdded(@"c:\project1.dll", "project1");
 
                 Assert.Equal(true, project2.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project1.Id));
-
-                project2.Disconnect();
-                project1.Disconnect();
             }
         }
 
@@ -53,9 +50,6 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
 
                 Assert.Equal(true, project1.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project2.Id));
                 Assert.Equal(false, project2.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project1.Id));
-
-                project2.Disconnect();
-                project1.Disconnect();
             }
         }
 
@@ -73,9 +67,6 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
 
                 Assert.Equal(true, project1.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project2.Id));
                 Assert.Equal(false, project2.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project1.Id));
-
-                project2.Disconnect();
-                project1.Disconnect();
             }
         }
 
@@ -99,11 +90,6 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
                 Assert.Equal(true, project2.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project3.Id));
                 Assert.Equal(true, project3.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project4.Id));
                 Assert.Equal(false, project4.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project1.Id));
-
-                project4.Disconnect();
-                project3.Disconnect();
-                project2.Disconnect();
-                project1.Disconnect();
             }
         }
 
@@ -130,9 +116,6 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
 
                 // Verify project reference updated after bin path change.
                 Assert.Equal(true, project2.GetCurrentProjectReferences().Any(pr => pr.ProjectId == project1.Id));
-
-                project2.Disconnect();
-                project1.Disconnect();
             }
         }
     }

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LifetimeTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LifetimeTests.cs
@@ -2,8 +2,12 @@
 
 using System;
 using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Threading;
 using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework;
 using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.Test.Utilities;
 using Xunit;
 
 namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
@@ -22,7 +26,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
                 Assert.Single(environment.Workspace.CurrentSolution.Projects);
 
                 project.UseReference(p => p.Disconnect());
-                project.AssertReleased();
+                project.AssertReleased(() => HostWaitHelper.WaitForDispatchedOperationsToComplete(DispatcherPriority.ApplicationIdle));
             }
         }
     }

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LifetimeTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LifetimeTests.cs
@@ -3,11 +3,9 @@
 using System;
 using System.Linq;
 using System.Threading;
-using System.Windows;
-using System.Windows.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework;
 using Roslyn.Test.Utilities;
-using Roslyn.VisualStudio.Test.Utilities;
 using Xunit;
 
 namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
@@ -17,7 +15,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         [WorkItem(10358, "https://github.com/dotnet/roslyn/issues/10358")]
-        public void DisconnectingAProjectDoesNotLeak()
+        public async Task DisconnectingAProjectDoesNotLeak()
         {
             using (var environment = new TestEnvironment())
             {
@@ -26,7 +24,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
                 Assert.Single(environment.Workspace.CurrentSolution.Projects);
 
                 project.UseReference(p => p.Disconnect());
-                project.AssertReleased(() => HostWaitHelper.WaitForDispatchedOperationsToComplete(DispatcherPriority.ApplicationIdle));
+                await project.AssertReleasedAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -136,7 +136,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private void ScheduleForegroundAffinitizedAction(Action action)
         {
             AssertIsBackground();
+            ScheduleForegroundAffinitizedAction_NoBackgroundAssert(action);
+        }
 
+        private void ScheduleForegroundAffinitizedAction_NoBackgroundAssert(Action action)
+        {
             lock (_gate)
             {
                 _taskForForegroundAffinitizedActions = _taskForForegroundAffinitizedActions.SafeContinueWith(_ => action(), ForegroundTaskScheduler);
@@ -364,7 +368,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// </summary>
         internal void RemoveProject(AbstractProject project)
         {
-            ExecuteOrScheduleForegroundAffinitizedAction(() => RemoveProject_Foreground(project));
+            // always schedule on queue so removal happens after other queued actions.
+            ScheduleForegroundAffinitizedAction_NoBackgroundAssert(() => RemoveProject_Foreground(project));
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
@@ -22,8 +22,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
                 Assert.Contains(New KeyValuePair(Of String, Object)("VBC_VER", PredefinedPreprocessorSymbols.CurrentVersionNumber), options.PreprocessorSymbols)
                 Assert.Contains(New KeyValuePair(Of String, Object)("TARGET", "exe"), options.PreprocessorSymbols)
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -42,8 +40,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
 
                 Assert.Equal(DocumentationMode.Diagnose, options.DocumentationMode)
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -62,8 +58,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
 
                 Assert.Equal(DocumentationMode.Parse, options.DocumentationMode)
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -92,8 +86,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 options = DirectCast(workspaceProject.CompilationOptions, VisualBasicCompilationOptions)
 
                 Assert.False(options.SpecificDiagnosticOptions.ContainsKey("BC1234"))
-
-                project.Disconnect()
             End Using
         End Sub
     End Class

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicProjectTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicProjectTests.vb
@@ -5,6 +5,7 @@ Imports Roslyn.Test.Utilities
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Framework
 Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.VisualBasicHelpers
 Imports Microsoft.CodeAnalysis
+Imports System.Threading.Tasks
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class VisualBasicProjectTests
@@ -27,7 +28,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
         <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
-        Public Sub DisconnectingAProjectDoesNotLeak()
+        Public Async Function DisconnectingAProjectDoesNotLeak() As Task
             Using environment = New TestEnvironment()
                 Dim project = ObjectReference.CreateFromFactory(Function() CreateVisualBasicProject(environment, "Test"))
 
@@ -35,8 +36,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
                 project.UseReference(Sub(p) p.Disconnect())
 
-                project.AssertReleased()
+                Await project.AssertReleasedAsync().ConfigureAwait(False)
             End Using
-        End Sub
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicSpecialReferencesTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicSpecialReferencesTests.vb
@@ -20,8 +20,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("Microsoft.VisualBasic.dll")))
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("mscorlib.dll")))
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("System.dll")))
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -40,8 +38,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("Microsoft.VisualBasic.dll")))
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("mscorlib.dll")))
                 Assert.False(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("System.dll")))
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -60,8 +56,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.False(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("Microsoft.VisualBasic.dll")))
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("mscorlib.dll")))
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("System.dll")))
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -91,8 +85,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 ' It should still reference the VB runtime
                 workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("Microsoft.VisualBasic.dll")))
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -108,8 +100,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 ' We should have no references
                 Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Assert.Empty(workspaceProject.MetadataReferences)
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -137,8 +127,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 ' It still should be referencing it since we're implicitly adding it as a part of the options
                 workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Assert.True(workspaceProject.HasMetadataReference(MockCompilerHost.FullFrameworkCompilerHost.GetWellKnownDllName("Microsoft.VisualBasic.dll")))
-
-                project.Disconnect()
             End Using
         End Sub
 
@@ -157,9 +145,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 project2.AddMetaDataReference("c:\project1.dll", True)
 
                 Assert.Equal(True, project2.GetCurrentProjectReferences().Any(Function(pr) pr.ProjectId = project1.Id))
-
-                project2.Disconnect()
-                project1.Disconnect()
             End Using
         End Sub
 
@@ -181,9 +166,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
                 Assert.Equal(True, project1.GetCurrentProjectReferences().Any(Function(pr) pr.ProjectId = project2.Id))
                 Assert.Equal(False, project2.GetCurrentProjectReferences().Any(Function(pr) pr.ProjectId = project1.Id))
-
-                project2.Disconnect()
-                project1.Disconnect()
             End Using
         End Sub
 
@@ -200,9 +182,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
                 Assert.Equal(True, project1.GetCurrentProjectReferences().Any(Function(pr) pr.ProjectId = project2.Id))
                 Assert.Equal(False, project2.GetCurrentProjectReferences().Any(Function(pr) pr.ProjectId = project1.Id))
-
-                project2.Disconnect()
-                project1.Disconnect()
             End Using
         End Sub
 
@@ -225,11 +204,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.Equal(True, project2.GetCurrentProjectReferences().Any(Function(pr) pr.ProjectId = project3.Id))
                 Assert.Equal(True, project3.GetCurrentProjectReferences().Any(Function(pr) pr.ProjectId = project4.Id))
                 Assert.Equal(False, project4.GetCurrentProjectReferences().Any(Function(pr) pr.ProjectId = project1.Id))
-
-                project4.Disconnect()
-                project3.Disconnect()
-                project2.Disconnect()
-                project1.Disconnect()
             End Using
         End Sub
 


### PR DESCRIPTION
This fixes VSO bug 296548: https://devdiv.visualstudio.com/DevDiv/_workitems?id=296548&_a=edit

The VSO bug is based on watson crash.  The culprit is a race condition in shutting down projects on close with other potential pending project affecting actions that are now being queued to run on UI thread idle.

@dotnet/roslyn-ide, @mavasani please review.
