### PR TITLE
Ensure that an attempt to embed a generic type from PIA results in an error.

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/GenericTypeInstanceReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/GenericTypeInstanceReference.cs
@@ -41,13 +41,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return builder.ToImmutableAndFree();
         }
 
-        Cci.INamedTypeReference Cci.IGenericTypeInstanceReference.GenericType
+        Cci.INamedTypeReference Cci.IGenericTypeInstanceReference.GetGenericType(EmitContext context)
         {
-            get
-            {
-                System.Diagnostics.Debug.Assert(UnderlyingNamedType.OriginalDefinition.IsDefinition);
-                return UnderlyingNamedType.OriginalDefinition;
-            }
+            System.Diagnostics.Debug.Assert(UnderlyingNamedType.OriginalDefinition.IsDefinition);
+            PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
+            return moduleBeingBuilt.Translate(UnderlyingNamedType.OriginalDefinition, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt, 
+                                              diagnostics: context.Diagnostics, needDeclaration: true);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -916,33 +916,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return builder.ToImmutableAndFree();
         }
 
-        Cci.INamedTypeReference Cci.IGenericTypeInstanceReference.GenericType
+        Cci.INamedTypeReference Cci.IGenericTypeInstanceReference.GetGenericType(EmitContext context)
         {
-            get
-            {
-                Debug.Assert(((Cci.ITypeReference)this).AsGenericTypeInstanceReference != null);
-                return GenericTypeImpl;
-            }
+            Debug.Assert(((Cci.ITypeReference)this).AsGenericTypeInstanceReference != null);
+            return GenericTypeImpl(context);
         }
 
-        private Cci.INamedTypeReference GenericTypeImpl
+        private Cci.INamedTypeReference GenericTypeImpl(EmitContext context)
         {
-            get
-            {
-                return this.OriginalDefinition;
-            }
+            PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
+            return moduleBeingBuilt.Translate(this.OriginalDefinition, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt, 
+                                              diagnostics: context.Diagnostics, needDeclaration:true); 
         }
 
-        Cci.INestedTypeReference Cci.ISpecializedNestedTypeReference.UnspecializedVersion
+        Cci.INestedTypeReference Cci.ISpecializedNestedTypeReference.GetUnspecializedVersion(EmitContext context)
         {
-            get
-            {
-                Debug.Assert(((Cci.ITypeReference)this).AsSpecializedNestedTypeReference != null);
-                var result = GenericTypeImpl.AsNestedTypeReference;
+            Debug.Assert(((Cci.ITypeReference)this).AsSpecializedNestedTypeReference != null);
+            var result = GenericTypeImpl(context).AsNestedTypeReference;
 
-                Debug.Assert(result != null);
-                return result;
-            }
+            Debug.Assert(result != null);
+            return result;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedGenericNestedTypeInstanceReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedGenericNestedTypeInstanceReference.cs
@@ -40,13 +40,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return builder.ToImmutableAndFree();
         }
 
-        Cci.INamedTypeReference Cci.IGenericTypeInstanceReference.GenericType
+        Cci.INamedTypeReference Cci.IGenericTypeInstanceReference.GetGenericType(EmitContext context)
         {
-            get
-            {
-                System.Diagnostics.Debug.Assert(UnderlyingNamedType.OriginalDefinition.IsDefinition);
-                return this.UnderlyingNamedType.OriginalDefinition;
-            }
+            System.Diagnostics.Debug.Assert(UnderlyingNamedType.OriginalDefinition.IsDefinition);
+            PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
+            return moduleBeingBuilt.Translate(this.UnderlyingNamedType.OriginalDefinition, syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt, 
+                                              diagnostics: context.Diagnostics, needDeclaration: true);
         }
 
         public override Cci.IGenericTypeInstanceReference AsGenericTypeInstanceReference

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedNestedTypeReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SpecializedNestedTypeReference.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.Emit;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.Emit
 {
@@ -18,13 +19,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         {
         }
 
-        Cci.INestedTypeReference Cci.ISpecializedNestedTypeReference.UnspecializedVersion
+        Cci.INestedTypeReference Cci.ISpecializedNestedTypeReference.GetUnspecializedVersion(EmitContext context)
         {
-            get
-            {
-                System.Diagnostics.Debug.Assert(UnderlyingNamedType.OriginalDefinition.IsDefinition);
-                return this.UnderlyingNamedType.OriginalDefinition;
-            }
+            Debug.Assert(UnderlyingNamedType.OriginalDefinition.IsDefinition);
+            var result = ((PEModuleBuilder)context.Module).Translate(this.UnderlyingNamedType.OriginalDefinition, 
+                                          (CSharpSyntaxNode)context.SyntaxNodeOpt, context.Diagnostics, needDeclaration: true).AsNestedTypeReference;
+
+            Debug.Assert(result != null);
+            return result;
         }
 
         public override void Dispatch(Cci.MetadataVisitor visitor)

--- a/src/Compilers/Core/Portable/PEWriter/ITypeReferenceExtensions.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ITypeReferenceExtensions.cs
@@ -21,18 +21,18 @@ namespace Microsoft.Cci
             }
         }
 
-        internal static ITypeReference GetUninstantiatedGenericType(this ITypeReference typeReference)
+        internal static ITypeReference GetUninstantiatedGenericType(this ITypeReference typeReference, EmitContext context)
         {
             IGenericTypeInstanceReference genericTypeInstanceReference = typeReference.AsGenericTypeInstanceReference;
             if (genericTypeInstanceReference != null)
             {
-                return genericTypeInstanceReference.GenericType;
+                return genericTypeInstanceReference.GetGenericType(context);
             }
 
             ISpecializedNestedTypeReference specializedNestedType = typeReference.AsSpecializedNestedTypeReference;
             if (specializedNestedType != null)
             {
-                return specializedNestedType.UnspecializedVersion;
+                return specializedNestedType.GetUnspecializedVersion(context);
             }
 
             return typeReference;

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2733,7 +2733,7 @@ namespace Microsoft.Cci
                     ISpecializedNestedTypeReference sneTypeRef = nestedTypeRef.AsSpecializedNestedTypeReference;
                     if (sneTypeRef != null)
                     {
-                        scopeTypeRef = sneTypeRef.UnspecializedVersion.GetContainingType(Context);
+                        scopeTypeRef = sneTypeRef.GetUnspecializedVersion(Context).GetContainingType(Context);
                     }
                     else
                     {
@@ -3712,7 +3712,7 @@ namespace Microsoft.Cci
 
                 if (typeReference.IsTypeSpecification())
                 {
-                    ITypeReference uninstantiatedTypeReference = typeReference.GetUninstantiatedGenericType();
+                    ITypeReference uninstantiatedTypeReference = typeReference.GetUninstantiatedGenericType(Context);
 
                     // Roslyn's uninstantiated type is the same object as the instantiated type for
                     // types closed over their type parameters, so to speak.
@@ -3933,7 +3933,7 @@ namespace Microsoft.Cci
             ISpecializedNestedTypeReference specializedNestedType = nestedType.AsSpecializedNestedTypeReference;
             if (specializedNestedType != null)
             {
-                nestedType = specializedNestedType.UnspecializedVersion;
+                nestedType = specializedNestedType.GetUnspecializedVersion(Context);
             }
 
             int result = 0;

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Cci
                 }
             }
 
-            this.Visit(genericTypeInstanceReference.GenericType);
+            this.Visit(genericTypeInstanceReference.GetGenericType(Context));
             this.Visit(genericTypeInstanceReference.GetGenericArguments(Context));
         }
 
@@ -421,7 +421,7 @@ namespace Microsoft.Cci
                 ISpecializedNestedTypeReference/*?*/ specializedNestedTypeReference = nestedTypeReference?.AsSpecializedNestedTypeReference;
                 if (specializedNestedTypeReference != null)
                 {
-                    INestedTypeReference unspecializedNestedTypeReference = specializedNestedTypeReference.UnspecializedVersion;
+                    INestedTypeReference unspecializedNestedTypeReference = specializedNestedTypeReference.GetUnspecializedVersion(Context);
                     if (_alreadyHasToken.Add(unspecializedNestedTypeReference))
                     {
                         RecordTypeReference(unspecializedNestedTypeReference);

--- a/src/Compilers/Core/Portable/PEWriter/TypeNameSerializer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/TypeNameSerializer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Cci
 
             if (typeReference.IsTypeSpecification())
             {
-                ITypeReference uninstantiatedTypeReference = typeReference.GetUninstantiatedGenericType();
+                ITypeReference uninstantiatedTypeReference = typeReference.GetUninstantiatedGenericType(context);
 
                 ArrayBuilder<ITypeReference> consolidatedTypeArguments = ArrayBuilder<ITypeReference>.GetInstance();
                 typeReference.GetConsolidatedTypeArguments(consolidatedTypeArguments, context);
@@ -158,7 +158,7 @@ namespace Microsoft.Cci
             IGenericTypeInstanceReference genInst = typeReference.AsGenericTypeInstanceReference;
             if (genInst != null)
             {
-                AppendAssemblyQualifierIfNecessary(sb, genInst.GenericType, out isAssemQualified, context);
+                AppendAssemblyQualifierIfNecessary(sb, genInst.GetGenericType(context), out isAssemQualified, context);
                 return;
             }
 

--- a/src/Compilers/Core/Portable/PEWriter/Types.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Types.cs
@@ -209,11 +209,8 @@ namespace Microsoft.Cci
         /// Returns the generic type of which this type is an instance.
         /// Equivalent to Symbol.OriginalDefinition
         /// </summary>
-        INamedTypeReference GenericType
-        {
-            get;
-            // ^ ensures result.ResolvedType.IsGeneric;
-        }
+        INamedTypeReference GetGenericType(EmitContext context);
+        // ^ ensures result.ResolvedType.IsGeneric;
     }
 
     /// <summary>
@@ -323,10 +320,7 @@ namespace Microsoft.Cci
         /// type of a generic type instance), then the unspecialized member refers to a member from the unspecialized containing type. (I.e. the unspecialized member always
         /// corresponds to a definition that is not obtained via specialization.)
         /// </summary>
-        INestedTypeReference/*!*/ UnspecializedVersion
-        {
-            get;
-        }
+        INestedTypeReference/*!*/ GetUnspecializedVersion(EmitContext context);
     }
 
     /// <summary>

--- a/src/Compilers/VisualBasic/Portable/Emit/GenericTypeInstanceReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/GenericTypeInstanceReference.vb
@@ -44,11 +44,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return builder.ToImmutableAndFree
         End Function
 
-        Private ReadOnly Property IGenericTypeInstanceReferenceGenericType As Cci.INamedTypeReference Implements Cci.IGenericTypeInstanceReference.GenericType
-            Get
-                Debug.Assert(m_UnderlyingNamedType.OriginalDefinition Is m_UnderlyingNamedType.OriginalDefinition.OriginalDefinition)
-                Return m_UnderlyingNamedType.OriginalDefinition
-            End Get
-        End Property
+        Private Function IGenericTypeInstanceReferenceGetGenericType(context As EmitContext) As Cci.INamedTypeReference Implements Cci.IGenericTypeInstanceReference.GetGenericType
+            Debug.Assert(m_UnderlyingNamedType.OriginalDefinition Is m_UnderlyingNamedType.OriginalDefinition.OriginalDefinition)
+            Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
+            Return moduleBeingBuilt.Translate(m_UnderlyingNamedType.OriginalDefinition, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
+                                              diagnostics:=context.Diagnostics, needDeclaration:=True)
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -877,27 +877,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return builder.ToImmutableAndFree
         End Function
 
-        Private ReadOnly Property IGenericTypeInstanceReferenceGenericType As INamedTypeReference Implements IGenericTypeInstanceReference.GenericType
+        Private Function IGenericTypeInstanceReferenceGetGenericType(context As EmitContext) As INamedTypeReference Implements IGenericTypeInstanceReference.GetGenericType
+            Debug.Assert((DirectCast(Me, ITypeReference)).AsGenericTypeInstanceReference IsNot Nothing)
+            Return GenericTypeImpl(context)
+        End Function
+
+        Private ReadOnly Property GenericTypeImpl(context As EmitContext) As INamedTypeReference
             Get
-                Debug.Assert((DirectCast(Me, ITypeReference)).AsGenericTypeInstanceReference IsNot Nothing)
-                Return GenericTypeImpl
+                Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
+                Return moduleBeingBuilt.Translate(Me.OriginalDefinition, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
+                                                  diagnostics:=context.Diagnostics, needDeclaration:=True)
             End Get
         End Property
 
-        Private ReadOnly Property GenericTypeImpl As INamedTypeReference
-            Get
-                Return Me.OriginalDefinition
-            End Get
-        End Property
+        Private Function ISpecializedNestedTypeReferenceGetUnspecializedVersion(context As EmitContext) As INestedTypeReference Implements ISpecializedNestedTypeReference.GetUnspecializedVersion
+            Debug.Assert((DirectCast(Me, ITypeReference)).AsSpecializedNestedTypeReference IsNot Nothing)
 
-        Private ReadOnly Property ISpecializedNestedTypeReferenceUnspecializedVersion As INestedTypeReference Implements ISpecializedNestedTypeReference.UnspecializedVersion
-            Get
-                Debug.Assert((DirectCast(Me, ITypeReference)).AsSpecializedNestedTypeReference IsNot Nothing)
-
-                Dim result = GenericTypeImpl.AsNestedTypeReference
-                Debug.Assert(result IsNot Nothing)
-                Return result
-            End Get
-        End Property
+            Dim result = GenericTypeImpl(context).AsNestedTypeReference
+            Debug.Assert(result IsNot Nothing)
+            Return result
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Emit/SpecializedGenericNestedTypeInstanceReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SpecializedGenericNestedTypeInstanceReference.vb
@@ -39,12 +39,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return builder.ToImmutableAndFree()
         End Function
 
-        Private ReadOnly Property IGenericTypeInstanceReferenceGenericType As Cci.INamedTypeReference Implements Cci.IGenericTypeInstanceReference.GenericType
-            Get
-                Debug.Assert(m_UnderlyingNamedType.OriginalDefinition Is m_UnderlyingNamedType.OriginalDefinition.OriginalDefinition)
-                Return m_UnderlyingNamedType.OriginalDefinition
-            End Get
-        End Property
+        Private Function IGenericTypeInstanceReferenceGetGenericType(context As EmitContext) As Cci.INamedTypeReference Implements Cci.IGenericTypeInstanceReference.GetGenericType
+            Debug.Assert(m_UnderlyingNamedType.OriginalDefinition Is m_UnderlyingNamedType.OriginalDefinition.OriginalDefinition)
+            Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
+            Return moduleBeingBuilt.Translate(m_UnderlyingNamedType.OriginalDefinition, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
+                                              diagnostics:=context.Diagnostics, needDeclaration:=True)
+        End Function
 
         Public Overrides ReadOnly Property AsGenericTypeInstanceReference As Cci.IGenericTypeInstanceReference
             Get

--- a/src/Compilers/VisualBasic/Portable/Emit/SpecializedNestedTypeReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SpecializedNestedTypeReference.vb
@@ -19,12 +19,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             MyBase.New(underlyingNamedType)
         End Sub
 
-        Private ReadOnly Property ISpecializedNestedTypeReferenceUnspecializedVersion As Cci.INestedTypeReference Implements Cci.ISpecializedNestedTypeReference.UnspecializedVersion
-            Get
-                Debug.Assert(m_UnderlyingNamedType.OriginalDefinition Is m_UnderlyingNamedType.OriginalDefinition.OriginalDefinition)
-                Return m_UnderlyingNamedType.OriginalDefinition
-            End Get
-        End Property
+        Private Function ISpecializedNestedTypeReferenceGetUnspecializedVersion(context As EmitContext) As Cci.INestedTypeReference Implements Cci.ISpecializedNestedTypeReference.GetUnspecializedVersion
+            Debug.Assert(m_UnderlyingNamedType.OriginalDefinition Is m_UnderlyingNamedType.OriginalDefinition.OriginalDefinition)
+            Dim result = (DirectCast(context.Module, PEModuleBuilder)).Translate(m_UnderlyingNamedType.OriginalDefinition, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
+                                                                                 diagnostics:=context.Diagnostics, needDeclaration:=True).AsNestedTypeReference
+            Debug.Assert(result IsNot Nothing)
+            Return result
+        End Function
 
         Public Overrides Sub Dispatch(visitor As Cci.MetadataVisitor)
             visitor.Visit(DirectCast(Me, Cci.ISpecializedNestedTypeReference))


### PR DESCRIPTION
**Customer scenario**
Customer implicitly references a generic type defined in a linked (/link) assembly. Implicitly meaning that the customer inherits from an interface, which uses the type in one of its members, or the customer references a structure, which uses the type in one of its members, but never actually references the generic type itself. No error is reported, the type is not embedded, the assembly is referenced by the resulting binary as if it was referenced rather than linked. However, other types from the same assembly might still be embedded into the resulting binary.

**Bugs this fixes:** 
Fixes #13200.

**Workarounds, if any**
Avoid an implicit reference to a generic type defined in a linked (/link) assembly.

**Risk**
Low.

**Performance impact**
Low perf impact because no extra allocations and no complexity added.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
A test gap for a non-common error scenario. Added unit-tests to close the gap.

**How was the bug found?**
Ad hoc testing


@dotnet/roslyn-compiler Please review.