### PR TITLE
Catch null SyntaxNodes in CodeLens

### DIFF
--- a/src/VisualStudio/Core/Next/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Next/CodeLens/RemoteCodeLensReferencesService.cs
@@ -20,6 +20,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         public async Task<ReferenceCount> GetReferenceCountAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode, int maxSearchResults,
             CancellationToken cancellationToken)
         {
+            if (syntaxNode == null)
+            {
+                return null;
+            }
+
             var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().GetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
             if (remoteHostClient == null)
             {
@@ -37,6 +42,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         public async Task<IEnumerable<ReferenceLocationDescriptor>> FindReferenceLocationsAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
+            if (syntaxNode == null)
+            {
+                return null;
+            }
+
             var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().GetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
             if (remoteHostClient == null)
             {
@@ -54,6 +64,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         public async Task<IEnumerable<ReferenceMethodDescriptor>> FindReferenceMethodsAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
+            if (syntaxNode == null)
+            {
+                return null;
+            }
+
             var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().GetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
             if (remoteHostClient == null)
             {
@@ -71,6 +86,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         public async Task<string> GetFullyQualifiedName(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
+            if (syntaxNode == null)
+            {
+                return null;
+            }
+
             var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().GetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
             if (remoteHostClient == null)
             {


### PR DESCRIPTION
**Customer scenario**

We've seen crashes but haven't isolated a situation where the location of a CodeLens invocation results in a null SyntaxNode. This is a defensive fix that will prevent a crash, the CodeLens indicator just won't come up.

**Bugs this fixes:** 

Github #15340

**Workarounds, if any**

None, if you hit this case, you crash VS.

**Risk**

Very safe in that we're just validating a parameter and returning a valid value (all callers handle null returns already).

**Performance impact**

None

**Is this a regression from a previous update?**

This is a crash that was introduced when we moved CodeLens over to OOP.

**Root cause analysis:**

We haven't been able to isolate the cause of the null SyntaxNode yet.

**How was the bug found?**

Internal customer reported.
