### PR TITLE
Fix crash in Structure-Visualizer when blocks were on hte same line.

### DIFF
--- a/src/EditorFeatures/Next/Structure/BlockContextProvider.cs
+++ b/src/EditorFeatures/Next/Structure/BlockContextProvider.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Implementation.Structure;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Adornments;
 using Microsoft.VisualStudio.Text.Editor;
@@ -135,16 +136,24 @@ namespace Microsoft.CodeAnalysis.Editor.Structure
 
                 for (var i = 0; i < blockTags.Count; i++)
                 {
+                    var blockTag = blockTags[i];
+                    var fullStatementSpan = blockTag.StatementSpan;
+                    
+                    if (blockTag.Parent != null &&
+                        textSnapshot.AreOnSameLine(fullStatementSpan.Start, blockTag.Parent.StatementSpan.Start))
+                    {
+                        // Ignore block tags on the same line as their parent.  We'll have already included
+                        // the contents of the line when we added the parent tag, and the editor will crash
+                        // if we create overlapping spans in the projection buffer.
+                        continue;
+                    }
+
                     if (i > 0)
                     {
                         objects.Add("\r\n");
                     }
 
-                    var blockTag = blockTags[i];
-                    var fullStatementSpan = blockTag.StatementSpan;
-                    var collapseSpan = blockTag.Span;
-
-                    var statementLine = textSnapshot.GetLineFromPosition(blockTag.StatementSpan.Start);
+                    var statementLine = textSnapshot.GetLineFromPosition(fullStatementSpan.Start);
 
                     var lineStart = statementLine.Start.Position;
                     var lineEnd = statementLine.End.Position;
@@ -153,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Editor.Structure
                     var mappingSpan = headerSpan.CreateTrackingSpan(SpanTrackingMode.EdgeExclusive);
 
                     objects.Add(mappingSpan);
-                    if (statementLine.End.Position < collapseSpan.Start)
+                    if (lineEnd < blockTag.Span.Start)
                     {
                         // If we had to cut off the line, then add a ... to indicate as such.
                         objects.Add("...");

--- a/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotExtensions.cs
@@ -155,5 +155,8 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         {
             return snapshot.GetText(position, 1)[0];
         }
+
+        public static bool AreOnSameLine(this ITextSnapshot snapshot, int x1, int x2)
+            => snapshot.GetLineNumberFromPosition(x1) == snapshot.GetLineNumberFromPosition(x2);
     }
 }

--- a/src/EditorFeatures/VisualBasic/AutomaticEndConstructCorrection/AutomaticEndConstructCorrector.vb
+++ b/src/EditorFeatures/VisualBasic/AutomaticEndConstructCorrection/AutomaticEndConstructCorrector.vb
@@ -150,8 +150,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticEndConstructCorrect
         End Function
 
         Private Shared Function IsChangeOnSameLine(snapshot As ITextSnapshot, change As ITextChange) As Boolean
-            ' changes on same line
-            Return snapshot.GetLineNumberFromPosition(change.NewPosition) = snapshot.GetLineNumberFromPosition(change.NewEnd)
+            Return snapshot.AreOnSameLine(change.NewPosition, change.NewEnd)
         End Function
 
         Private Function IsChangeOnCorrectToken(token As SyntaxToken) As Boolean


### PR DESCRIPTION
**Customer scenario**

Customer writes code with several C# block constructs on the same line.  i.e. something like:

```c#
if (foo) if (bar)
{

}
```

They then hover on the structure visualizer we create between { and }.  VS crashes.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/292962

**Workarounds, if any**

Customer does not write code like this.  Or they do not hover on the structure guide.  Both are quite onerous restrictions.

**Risk**

Extremely low.

**Performance impact**

None.  We're just doing a simple check to ensure we don't create overlapping structure spans when this happens.

**Is this a regression from a previous update?**

No.  Structure guides are new to VS2017.

**Root cause analysis:**

We create the tooltip contents when someone hovers over a structure guide.  i.e.:

![image](https://cloud.githubusercontent.com/assets/4564579/20946982/da4b8904-bbc1-11e6-9fad-1d439e2b9472.png)

To do this, we grab all the blocks we're in and we get the text of the line they start on.  We then create a projection buffer to stitch all these lines together.   When two blocks were on the same line, that means we had a projection buffer mapping the same span of text twice.  That's not something projection buffers support, which caused a crash.

**How was the bug found?**

Watsons.  This is the 13'th most common VS crash.