### PR TITLE
Don't instrument methods marked with ExcludeFromCodeCoverageAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol createPayload = GetCreatePayload(methodBodyFactory.Compilation, methodBody.Syntax, diagnostics);
 
             // Do not instrument any methods if CreatePayload is not present.
-            if (createPayload is null)
+            if ((object)createPayload == null)
             {
                 return null;
             }
@@ -99,9 +99,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Skip lambdas and local functions. They can't have custom attributes.
-            method = method.ContainingNonLambdaMember() as MethodSymbol;
-            if ((object)method != null)
+            var nonLambda = method.ContainingNonLambdaMember();
+            if (nonLambda?.Kind == SymbolKind.Method)
             {
+                method = (MethodSymbol)nonLambda;
+
                 if (method.IsDirectlyExcludedFromCodeCoverage)
                 {
                     return true;

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -32,20 +33,33 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // Do not instrument implicitly-declared methods, except for constructors.
             // Instrument implicit constructors in order to instrument member initializers.
-            if (!method.IsImplicitlyDeclared || method.IsImplicitConstructor)
+            if (method.IsImplicitlyDeclared && !method.IsImplicitConstructor)
             {
-                MethodSymbol createPayload = GetCreatePayload(methodBodyFactory.Compilation, methodBody.Syntax, diagnostics);
-
-                // Do not instrument any methods if CreatePayload is not present.
-                // Do not instrument CreatePayload if it is part of the current compilation (which occurs only during testing).
-                // CreatePayload will fail at run time with an infinite recursion if it Is instrumented.
-                if ((object)createPayload != null && !method.Equals(createPayload))
-                {
-                    return new DynamicAnalysisInjector(method, methodBody, methodBodyFactory, createPayload, diagnostics, debugDocumentProvider, previous);
-                }
+                return null;
             }
 
-            return null;
+            // Do not instrument methods marked with or in scope of ExcludeFromCodeCoverageAttribute.
+            if (IsExcludedFromCodeCoverage(method))
+            {
+                return null;
+            }
+
+            MethodSymbol createPayload = GetCreatePayload(methodBodyFactory.Compilation, methodBody.Syntax, diagnostics);
+
+            // Do not instrument any methods if CreatePayload is not present.
+            if (createPayload is null)
+            {
+                return null;
+            }
+
+            // Do not instrument CreatePayload if it is part of the current compilation (which occurs only during testing).
+            // CreatePayload will fail at run time with an infinite recursion if it is instrumented.
+            if (method.Equals(createPayload))
+            {
+                return null;
+            }
+
+            return new DynamicAnalysisInjector(method, methodBody, methodBodyFactory, createPayload, diagnostics, debugDocumentProvider, previous);
         }
 
         private DynamicAnalysisInjector(MethodSymbol method, BoundStatement methodBody, SyntheticBoundNodeFactory methodBodyFactory, MethodSymbol createPayload, DiagnosticBag diagnostics, DebugDocumentProvider debugDocumentProvider, Instrumenter previous)
@@ -69,6 +83,50 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 _methodEntryInstrumentation = AddAnalysisPoint(syntax, SkipAttributes(syntax), methodBodyFactory);
             }
+        }
+
+        private static bool IsExcludedFromCodeCoverage(MethodSymbol method)
+        {
+            var containingType = method.ContainingType;
+            while ((object)containingType != null)
+            {
+                if (containingType.IsDirectlyExcludedFromCodeCoverage)
+                {
+                    return true;
+                }
+
+                containingType = containingType.ContainingType;
+            }
+
+            // Skip lambdas and local functions. They can't have custom attributes.
+            method = method.ContainingNonLambdaMember() as MethodSymbol;
+            if ((object)method != null)
+            {
+                if (method.IsDirectlyExcludedFromCodeCoverage)
+                {
+                    return true;
+                }
+
+                var associatedSymbol = method.AssociatedSymbol;
+                switch (associatedSymbol?.Kind)
+                {
+                    case SymbolKind.Property:
+                        if (((PropertySymbol)associatedSymbol).IsDirectlyExcludedFromCodeCoverage)
+                        {
+                            return true;
+                        }
+                        break;
+
+                    case SymbolKind.Event:
+                        if (((EventSymbol)associatedSymbol).IsDirectlyExcludedFromCodeCoverage)
+                        {
+                            return true;
+                        }
+                        break;
+                }
+            }
+
+            return false;
         }
 
         public override BoundStatement CreateBlockPrologue(BoundBlock original, out LocalSymbol synthesizedLocal)

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -81,6 +81,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract bool IsWindowsRuntimeEvent { get; }
 
         /// <summary>
+        /// True if the event itself is excluded from code covarage instrumentation.
+        /// True for source events marked with <see cref="AttributeDescription.ExcludeFromCodeCoverageAttribute"/>.
+        /// </summary>
+        internal virtual bool IsDirectlyExcludedFromCodeCoverage { get => false; }
+
+        /// <summary>
         /// True if this symbol has a special name (metadata flag SpecialName is set).
         /// </summary>
         internal abstract bool HasSpecialName { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -78,6 +78,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// True if the method itself is excluded from code covarage instrumentation.
+        /// True for source methods marked with <see cref="AttributeDescription.ExcludeFromCodeCoverageAttribute"/>.
+        /// </summary>
+        internal virtual bool IsDirectlyExcludedFromCodeCoverage { get => false; }
+
+        /// <summary>
         /// Returns true if this method is an extension method. 
         /// </summary>
         public abstract bool IsExtensionMethod { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -1143,6 +1143,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         #endregion
 
         /// <summary>
+        /// True if the type itself is excluded from code covarage instrumentation.
+        /// True for source types marked with <see cref="AttributeDescription.ExcludeFromCodeCoverageAttribute"/>.
+        /// </summary>
+        internal virtual bool IsDirectlyExcludedFromCodeCoverage { get => false; }
+
+        /// <summary>
         /// True if this symbol has a special name (metadata flag SpecialName is set).
         /// </summary>
         internal abstract bool HasSpecialName { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PropertySymbol.cs
@@ -159,6 +159,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// True if the property itself is excluded from code covarage instrumentation.
+        /// True for source properties marked with <see cref="AttributeDescription.ExcludeFromCodeCoverageAttribute"/>.
+        /// </summary>
+        internal virtual bool IsDirectlyExcludedFromCodeCoverage { get => false; }
+
+        /// <summary>
         /// True if this symbol has a special name (metadata flag SpecialName is set).
         /// </summary>
         internal abstract bool HasSpecialName { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonEventWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        protected CommonEventWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -285,6 +285,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasSpecialNameAttribute = true;
             }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            {
+                arguments.GetOrCreateData<CommonEventWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
+            }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.TupleElementNamesAttribute))
             {
                 arguments.Diagnostics.Add(ErrorCode.ERR_ExplicitTupleElementNamesAttribute, arguments.AttributeSyntaxOpt.Location);
@@ -307,6 +311,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     DeclaringCompilation.SynthesizeTupleNamesAttribute(Type));
             }
         }
+        
+        internal sealed override bool IsDirectlyExcludedFromCodeCoverage =>
+            GetDecodedWellKnownAttributeData()?.HasExcludeFromCodeCoverageAttribute == true;
 
         internal sealed override bool HasSpecialName
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonFieldWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        protected CommonFieldWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -848,7 +848,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonMethodWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        protected CommonMethodWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -1090,6 +1090,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasSpecialNameAttribute = true;
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            {
+                arguments.GetOrCreateData<CommonMethodWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.ConditionalAttribute))
             {
@@ -1438,6 +1442,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return data != null && data.HasSpecialNameAttribute;
             }
         }
+
+        internal sealed override bool IsDirectlyExcludedFromCodeCoverage =>
+            GetDecodedWellKnownAttributeData()?.HasExcludeFromCodeCoverageAttribute == true;
 
         internal sealed override bool RequiresSecurityObject
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -474,7 +474,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal CommonModuleWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        private CommonModuleWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Forces binding and decoding of attributes.
         /// </remarks>
-        internal TypeWellKnownAttributeData GetDecodedWellKnownAttributeData()
+        private TypeWellKnownAttributeData GetDecodedWellKnownAttributeData()
         {
             var attributesBag = _lazyCustomAttributesBag;
             if (attributesBag == null || !attributesBag.IsDecodedWellKnownAttributeDataComputed)
@@ -652,6 +652,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SerializableAttribute))
             {
                 arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasSerializableAttribute = true;
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            {
+                arguments.GetOrCreateData<TypeWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.StructLayoutAttribute))
             {
@@ -860,6 +864,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return data != null && data.HasSerializableAttribute;
             }
         }
+
+        internal override bool IsDirectlyExcludedFromCodeCoverage =>
+            GetDecodedWellKnownAttributeData()?.HasExcludeFromCodeCoverageAttribute == true;
 
         private bool HasInstanceFields()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1063,6 +1063,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal sealed override bool IsDirectlyExcludedFromCodeCoverage =>
+            GetDecodedWellKnownAttributeData()?.HasExcludeFromCodeCoverageAttribute == true;
+
         internal override bool HasSpecialName
         {
             get
@@ -1151,6 +1154,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SpecialNameAttribute))
             {
                 arguments.GetOrCreateData<CommonPropertyWellKnownAttributeData>().HasSpecialNameAttribute = true;
+            }
+            else if (attribute.IsTargetAttribute(this, AttributeDescription.ExcludeFromCodeCoverageAttribute))
+            {
+                arguments.GetOrCreateData<CommonPropertyWellKnownAttributeData>().HasExcludeFromCodeCoverageAttribute = true;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.DynamicAttribute))
             {

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
@@ -2112,6 +2113,394 @@ public class Program
             }
 
             Assert.True(false);
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_Method()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class C
+{
+    [ExcludeFromCodeCoverage]
+    void M1() { Console.WriteLine(1); }
+
+    void M2() { Console.WriteLine(1); }
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+
+            AssertNotInstrumented(verifier, "C.M1");
+            AssertInstrumented(verifier, "C.M2");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_Ctor()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class C
+{
+    int a = 1;
+
+    [ExcludeFromCodeCoverage]
+    public C() { Console.WriteLine(3); }
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+
+            AssertNotInstrumented(verifier, "C..ctor");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_Cctor()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class C
+{
+    static int a = 1;
+
+    [ExcludeFromCodeCoverage]
+    static C() { Console.WriteLine(3); }
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+            AssertNotInstrumented(verifier, "C..cctor");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_LocalFunctionsAndLambdas_InMethod()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class C
+{
+    [ExcludeFromCodeCoverage]
+    static void M1() { L1(); void L1() { new Action(() => { Console.WriteLine(1); }).Invoke(); } }
+                                                      
+    static void M2() { L2(); void L2() { new Action(() => { Console.WriteLine(2); }).Invoke(); } }
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+
+            AssertNotInstrumented(verifier, "C.M1");
+            AssertNotInstrumented(verifier, "C.<M1>g__L10_0");
+            AssertNotInstrumented(verifier, "C.<>c.<M1>b__0_1");
+
+            AssertInstrumented(verifier, "C.M2");
+            AssertInstrumented(verifier, "C.<>c__DisplayClass1_0.<M2>g__L20"); // M2:L2
+            AssertInstrumented(verifier, "C.<>c__DisplayClass1_0.<M2>b__1"); // M2:L2 lambda
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_LocalFunctionsAndLambdas_InInitializers()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class C
+{
+    Action IF = new Action(() => { Console.WriteLine(1); });
+    Action IP { get; } = new Action(() => { Console.WriteLine(2); });
+
+    static Action SF = new Action(() => { Console.WriteLine(3); });
+    static Action SP { get; } = new Action(() => { Console.WriteLine(4); });
+
+    [ExcludeFromCodeCoverage]
+    C() {}
+
+    static C() {}
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+
+            AssertNotInstrumented(verifier, "C..ctor");
+            AssertNotInstrumented(verifier, "C.<>c.<.ctor>b__8_0");
+            AssertNotInstrumented(verifier, "C.<>c.<.ctor>b__8_1");
+
+            AssertInstrumented(verifier, "C..cctor");
+            AssertInstrumented(verifier, "C.<>c__DisplayClass9_0.<.cctor>b__0");
+            AssertInstrumented(verifier, "C.<>c__DisplayClass9_0.<.cctor>b__1");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_LocalFunctionsAndLambdas_InAccessors()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class C
+{
+    [ExcludeFromCodeCoverage]
+    int P1 
+    { 
+        get { L1(); void L1() { Console.WriteLine(1); } return 1; } 
+        set { L2(); void L2() { Console.WriteLine(2); } } 
+    }
+
+    int P2
+    { 
+        get { L3(); void L3() { Console.WriteLine(3); } return 3; } 
+        set { L4(); void L4() { Console.WriteLine(4); } } 
+    }
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+            
+            AssertNotInstrumented(verifier, "C.P1.get");
+            AssertNotInstrumented(verifier, "C.P1.set");
+            AssertNotInstrumented(verifier, "C.<get_P1>g__L11_0");
+            AssertNotInstrumented(verifier, "C.<set_P1>g__L22_0");
+
+            AssertInstrumented(verifier, "C.P2.get");
+            AssertInstrumented(verifier, "C.P2.set");
+            AssertInstrumented(verifier, "C.<get_P2>g__L34_0");
+            AssertInstrumented(verifier, "C.<set_P2>g__L45_0");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_Type()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+[ExcludeFromCodeCoverage]
+class C
+{
+    int x = 1;
+
+    static C() { }
+
+    void M1() { Console.WriteLine(1); }
+
+    int P { get => 1; set { } }
+
+    event Action E { add { } remove { } }
+}
+
+class D
+{
+    int x = 1;
+
+    static D() { }
+
+    void M1() { Console.WriteLine(1); }
+
+    int P { get => 1; set { } }
+
+    event Action E { add { } remove { } }
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+
+            AssertNotInstrumented(verifier, "C..ctor");
+            AssertNotInstrumented(verifier, "C..cctor");
+            AssertNotInstrumented(verifier, "C.M1");
+            AssertNotInstrumented(verifier, "C.P.get");
+            AssertNotInstrumented(verifier, "C.P.set");
+            AssertNotInstrumented(verifier, "C.E.add");
+            AssertNotInstrumented(verifier, "C.E.remove");
+
+            AssertInstrumented(verifier, "D..ctor");
+            AssertInstrumented(verifier, "D..cctor");
+            AssertInstrumented(verifier, "D.M1");
+            AssertInstrumented(verifier, "D.P.get");
+            AssertInstrumented(verifier, "D.P.set");
+            AssertInstrumented(verifier, "D.E.add");
+            AssertInstrumented(verifier, "D.E.remove");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_NestedType()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class A
+{
+    class B1
+    {
+        [ExcludeFromCodeCoverage]
+        class C
+        {
+            void M1() { Console.WriteLine(1); }
+        }
+
+        void M2() { Console.WriteLine(2); }
+    }
+
+    [ExcludeFromCodeCoverage]
+    partial class B2
+    {
+        partial class C1
+        {
+            void M3() { Console.WriteLine(3); }
+        }
+
+        class C2
+        {
+            void M4() { Console.WriteLine(4); }
+        }
+
+        void M5() { Console.WriteLine(5); }
+    }
+
+    partial class B2
+    {
+        [ExcludeFromCodeCoverage]
+        partial class C1
+        {
+            void M6() { Console.WriteLine(6); }
+        }
+
+        void M7() { Console.WriteLine(7); }
+    }
+
+    void M8() { Console.WriteLine(8); }
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+
+            AssertNotInstrumented(verifier, "A.B1.C.M1");
+            AssertInstrumented(verifier, "A.B1.M2");
+            AssertNotInstrumented(verifier, "A.B2.C1.M3");
+            AssertNotInstrumented(verifier, "A.B2.C2.M4");
+            AssertNotInstrumented(verifier, "A.B2.C1.M6");
+            AssertNotInstrumented(verifier, "A.B2.M7");
+            AssertInstrumented(verifier, "A.M8");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_Accessors()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class C
+{
+    [ExcludeFromCodeCoverage]
+    int P1 { get => 1; set {} }
+          
+    [ExcludeFromCodeCoverage]
+    event Action E1 { add { } remove { } }
+                                            
+    int P2 { get => 1; set {} }
+    event Action E2 { add { } remove { } }
+}
+";
+            var verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+            
+            AssertNotInstrumented(verifier, "C.P1.get");
+            AssertNotInstrumented(verifier, "C.P1.set");
+            AssertNotInstrumented(verifier, "C.E1.add");
+            AssertNotInstrumented(verifier, "C.E1.remove");
+
+            AssertInstrumented(verifier, "C.P2.get");
+            AssertInstrumented(verifier, "C.P2.set");
+            AssertInstrumented(verifier, "C.E2.add");
+            AssertInstrumented(verifier, "C.E2.remove");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_CustomDefinition_Good()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class ExcludeFromCodeCoverageAttribute : Attribute
+    {
+        public ExcludeFromCodeCoverageAttribute() {}
+    }
+}
+
+[ExcludeFromCodeCoverage]
+class C
+{
+    void M() {}
+}
+
+class D
+{
+    void M() {}
+}
+";
+            var c = CreateCompilationWithMscorlib(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+            c.VerifyDiagnostics();
+
+            var verifier = CompileAndVerify(c, emitOptions: EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
+            c.VerifyEmitDiagnostics();
+
+            AssertNotInstrumented(verifier, "C.M");
+            AssertInstrumented(verifier, "D.M");
+        }
+
+        [Fact]
+        public void ExcludeFromCodeCoverageAttribute_CustomDefinition_Bad()
+        {
+            string source = @"
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class ExcludeFromCodeCoverageAttribute : Attribute
+    {
+        public ExcludeFromCodeCoverageAttribute(int x) {}
+    }
+}
+
+[ExcludeFromCodeCoverage(1)]
+class C
+{
+    void M() {}
+}
+
+class D
+{
+    void M() {}
+}
+";
+            var c = CreateCompilationWithMscorlib(source + InstrumentationHelperSource, options: TestOptions.ReleaseDll);
+            c.VerifyDiagnostics();
+
+            var verifier = CompileAndVerify(c, emitOptions: EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
+            c.VerifyEmitDiagnostics();
+
+            AssertInstrumented(verifier, "C.M");
+            AssertInstrumented(verifier, "D.M");
+        }
+
+        private static void AssertNotInstrumented(CompilationVerifier verifier, string qualifiedMethodName)
+            => AssertInstrumented(verifier, qualifiedMethodName, expected: false);
+
+        private static void AssertInstrumented(CompilationVerifier verifier, string qualifiedMethodName, bool expected = true)
+        {
+            string il = verifier.VisualizeIL(qualifiedMethodName);
+
+            // Tests using this helper are constructed such that instrumented methods contain a call to CreatePayload, 
+            // lambdas a reference to payload bool array.
+            bool instrumented = il.Contains("CreatePayload") || il.Contains("bool[]");
+
+            Assert.True(expected == instrumented, $"Method '{qualifiedMethodName}' should {(expected ? "be" : "not be")} instrumented. Actual IL:{Environment.NewLine}{il}");
         }
 
         private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, CompilationOptions options = null)

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -393,6 +393,8 @@ namespace Microsoft.CodeAnalysis
             s_signature_HasThis_Void_String_DeprecationType_UInt32_String,
         };
 
+        private static readonly byte[][] s_signaturesOfExcludeFromCodeCoverageAttribute = { s_signature_HasThis_Void };
+
         // early decoded attributes:
         internal static readonly AttributeDescription OptionalAttribute = new AttributeDescription("System.Runtime.InteropServices", "OptionalAttribute", s_signaturesOfOptionalAttribute);
         internal static readonly AttributeDescription ComImportAttribute = new AttributeDescription("System.Runtime.InteropServices", "ComImportAttribute", s_signaturesOfComImportAttribute);
@@ -500,5 +502,6 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription AssemblyConfigurationAttribute = new AttributeDescription("System.Reflection", "AssemblyConfigurationAttribute", s_signaturesOfAssemblyConfigurationAttribute);
         internal static readonly AttributeDescription AssemblyAlgorithmIdAttribute = new AttributeDescription("System.Reflection", "AssemblyAlgorithmIdAttribute", s_signaturesOfAssemblyAlgorithmIdAttribute);
         internal static readonly AttributeDescription DeprecatedAttribute = new AttributeDescription("Windows.Foundation.Metadata", "DeprecatedAttribute", s_signaturesOfDeprecatedAttribute);
+        internal static readonly AttributeDescription ExcludeFromCodeCoverageAttribute = new AttributeDescription("System.Diagnostics.CodeAnalysis", "ExcludeFromCodeCoverageAttribute", s_signaturesOfExcludeFromCodeCoverageAttribute);
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonEventWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonEventWellKnownAttributeData.cs
@@ -27,5 +27,25 @@ namespace Microsoft.CodeAnalysis
             }
         }
         #endregion
+
+        #region ExcludeFromCodeCoverageAttribute
+
+        private bool _hasExcludeFromCodeCoverageAttribute;
+        public bool HasExcludeFromCodeCoverageAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasExcludeFromCodeCoverageAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasExcludeFromCodeCoverageAttribute = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonMethodWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonMethodWellKnownAttributeData.cs
@@ -213,5 +213,25 @@ namespace Microsoft.CodeAnalysis
             }
         }
         #endregion
+
+        #region ExcludeFromCodeCoverageAttribute
+
+        private bool _hasExcludeFromCodeCoverageAttribute;
+        public bool HasExcludeFromCodeCoverageAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasExcludeFromCodeCoverageAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasExcludeFromCodeCoverageAttribute = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonPropertyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonPropertyWellKnownAttributeData.cs
@@ -27,5 +27,25 @@ namespace Microsoft.CodeAnalysis
             }
         }
         #endregion
+
+        #region ExcludeFromCodeCoverageAttribute
+
+        private bool _hasExcludeFromCodeCoverageAttribute;
+        public bool HasExcludeFromCodeCoverageAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasExcludeFromCodeCoverageAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasExcludeFromCodeCoverageAttribute = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonTypeWellKnownAttributeData.cs
@@ -226,5 +226,25 @@ namespace Microsoft.CodeAnalysis
             }
         }
         #endregion
+
+        #region ExcludeFromCodeCoverageAttribute
+
+        private bool _hasExcludeFromCodeCoverageAttribute;
+        public bool HasExcludeFromCodeCoverageAttribute
+        {
+            get
+            {
+                VerifySealed(expected: true);
+                return _hasExcludeFromCodeCoverageAttribute;
+            }
+            set
+            {
+                VerifySealed(expected: false);
+                _hasExcludeFromCodeCoverageAttribute = value;
+                SetDataStored();
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -22,6 +22,10 @@ Public MustInherit Class BasicTestBase
         Return DirectCast(MyBase.GetCompilationForEmit(source, additionalRefs, options, parseOptions), VisualBasicCompilation)
     End Function
 
+    Public Function XCDataToString(Optional data As XCData = Nothing) As String
+        Return data?.Value.Replace(vbLf, Environment.NewLine)
+    End Function
+
     Private Function Translate(action As Action(Of ModuleSymbol)) As Action(Of IModuleSymbol)
         If action IsNot Nothing Then
             Return Sub(m) action(DirectCast(m, ModuleSymbol))
@@ -30,11 +34,10 @@ Public MustInherit Class BasicTestBase
         End If
     End Function
 
-    ' TODO (tomat): TestEmitOptions.All
     Friend Shadows Function CompileAndVerify(
         source As XElement,
         expectedOutput As XCData,
-        Optional additionalRefs() As MetadataReference = Nothing,
+        Optional additionalRefs As MetadataReference() = Nothing,
         Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
         Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional validator As Action(Of PEAssembly) = Nothing,
@@ -46,13 +49,9 @@ Public MustInherit Class BasicTestBase
         Optional verify As Boolean = True
     ) As CompilationVerifier
 
-        If parseOptions Is Nothing AndAlso options IsNot Nothing Then
-            parseOptions = options.ParseOptions
-        End If
-
         Return CompileAndVerify(
             source,
-            If(expectedOutput IsNot Nothing, expectedOutput.Value.Replace(vbLf, Environment.NewLine), Nothing),
+            XCDataToString(expectedOutput),
             additionalRefs,
             dependencies,
             sourceSymbolValidator,
@@ -65,7 +64,6 @@ Public MustInherit Class BasicTestBase
             verify)
     End Function
 
-    ' TODO (tomat): remove - here only to override emitters default
     Friend Shadows Function CompileAndVerify(
         compilation As Compilation,
         Optional manifestResources As IEnumerable(Of ResourceDescription) = Nothing,
@@ -75,6 +73,7 @@ Public MustInherit Class BasicTestBase
         Optional symbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional expectedOutput As String = Nothing,
+        Optional emitOptions As EmitOptions = Nothing,
         Optional verify As Boolean = True) As CompilationVerifier
 
         Return MyBase.CompileAndVerify(
@@ -86,36 +85,39 @@ Public MustInherit Class BasicTestBase
             Translate(symbolValidator),
             expectedSignatures,
             expectedOutput,
-            Nothing,
+            emitOptions,
             verify)
     End Function
 
     Friend Shadows Function CompileAndVerify(
         compilation As Compilation,
         expectedOutput As XCData,
+        Optional manifestResources As IEnumerable(Of ResourceDescription) = Nothing,
         Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
         Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional validator As Action(Of PEAssembly) = Nothing,
         Optional symbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional expectedSignatures As SignatureDescription() = Nothing,
+        Optional emitOptions As EmitOptions = Nothing,
         Optional verify As Boolean = True) As CompilationVerifier
 
         Return CompileAndVerify(
             compilation,
-            Nothing,
+            manifestResources,
             dependencies,
             sourceSymbolValidator,
             validator,
             symbolValidator,
             expectedSignatures,
-            If(expectedOutput IsNot Nothing, expectedOutput.Value.Replace(vbLf, Environment.NewLine), Nothing),
+            XCDataToString(expectedOutput),
+            emitOptions,
             verify)
     End Function
 
     Friend Shadows Function CompileAndVerify(
         source As XElement,
         Optional expectedOutput As String = Nothing,
-        Optional additionalRefs() As MetadataReference = Nothing,
+        Optional additionalRefs As MetadataReference() = Nothing,
         Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
         Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional validator As Action(Of PEAssembly) = Nothing,
@@ -146,7 +148,6 @@ Public MustInherit Class BasicTestBase
 
     End Function
 
-    ' TODO: EmitOptions.All
     Friend Shadows Function CompileAndVerify(
         source As XElement,
         allReferences As IEnumerable(Of MetadataReference),
@@ -166,7 +167,44 @@ Public MustInherit Class BasicTestBase
             options = If(expectedOutput Is Nothing, TestOptions.ReleaseDll, TestOptions.ReleaseExe)
         End If
 
-        Dim compilation = CompilationUtils.CreateCompilationWithReferences(source, references:=allReferences, options:=options, parseOptions:=parseOptions)
+        Dim assemblyName As String = Nothing
+        Dim sourceTrees = ParseSouceXml(source, parseOptions, assemblyName)
+        Dim compilation = CreateCompilation(sourceTrees, allReferences, options, assemblyName)
+
+        Return MyBase.CompileAndVerify(
+            compilation,
+            Nothing,
+            dependencies,
+            Translate(sourceSymbolValidator),
+            validator,
+            Translate(symbolValidator),
+            expectedSignatures,
+            expectedOutput,
+            emitOptions,
+            verify)
+    End Function
+
+    Friend Shadows Function CompileAndVerify(
+        source As String,
+        allReferences As IEnumerable(Of MetadataReference),
+        Optional expectedOutput As String = Nothing,
+        Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
+        Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
+        Optional validator As Action(Of PEAssembly) = Nothing,
+        Optional symbolValidator As Action(Of ModuleSymbol) = Nothing,
+        Optional expectedSignatures As SignatureDescription() = Nothing,
+        Optional options As VisualBasicCompilationOptions = Nothing,
+        Optional parseOptions As VisualBasicParseOptions = Nothing,
+        Optional emitOptions As EmitOptions = Nothing,
+        Optional assemblyName As String = Nothing,
+        Optional verify As Boolean = True
+    ) As CompilationVerifier
+
+        If options Is Nothing Then
+            options = If(expectedOutput Is Nothing, TestOptions.ReleaseDll, TestOptions.ReleaseExe)
+        End If
+
+        Dim compilation = CreateCompilation(source, allReferences, options, assemblyName, parseOptions)
 
         Return MyBase.CompileAndVerify(
             compilation,
@@ -208,7 +246,6 @@ Public MustInherit Class BasicTestBase
             verify:=OSVersion.IsWin8)
     End Function
 
-    ' TODO (tomat): TestEmitOptions.All
     Friend Shadows Function CompileAndVerifyOnWin8Only(
         source As XElement,
         expectedOutput As XCData,
@@ -225,7 +262,7 @@ Public MustInherit Class BasicTestBase
         Return CompileAndVerifyOnWin8Only(
             source,
             allReferences,
-            If(expectedOutput IsNot Nothing, expectedOutput.Value.Replace(vbLf, Environment.NewLine), Nothing),
+            XCDataToString(expectedOutput),
             dependencies,
             sourceSymbolValidator,
             validator,

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -15,7 +15,11 @@ Imports Xunit
 
 Friend Module CompilationUtils
 
-    Public Function CreateCompilation(trees As IEnumerable(Of SyntaxTree),
+    Private Function ParseSources(sources As IEnumerable(Of String), parseOptions As VisualBasicParseOptions) As IEnumerable(Of SyntaxTree)
+        Return sources.Select(Function(s) VisualBasicSyntaxTree.ParseText(s, parseOptions))
+    End Function
+
+    Public Function CreateCompilation(sourceTrees As IEnumerable(Of SyntaxTree),
                                       Optional references As IEnumerable(Of MetadataReference) = Nothing,
                                       Optional options As VisualBasicCompilationOptions = Nothing,
                                       Optional assemblyName As String = Nothing) As VisualBasicCompilation
@@ -30,40 +34,61 @@ Friend Module CompilationUtils
 
         Return VisualBasicCompilation.Create(
                 If(assemblyName, GetUniqueName()),
-                trees,
+                sourceTrees,
                 references,
                 options)
     End Function
 
-    Public Function CreateCompilationWithMscorlib(sourceTrees As IEnumerable(Of String),
+    Public Function CreateCompilation(sources As IEnumerable(Of String),
+                                      Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                      Optional options As VisualBasicCompilationOptions = Nothing,
+                                      Optional assemblyName As String = Nothing,
+                                      Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
+
+        Return CreateCompilation(ParseSources(sources, parseOptions), references, options, assemblyName)
+    End Function
+
+    Public Function CreateCompilation(source As String,
+                                      Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                      Optional options As VisualBasicCompilationOptions = Nothing,
+                                      Optional assemblyName As String = Nothing,
+                                      Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
+
+        Return CreateCompilation({source}, references, options, assemblyName, parseOptions)
+    End Function
+
+    Public Function CreateCompilationWithMscorlib(sourceTrees As IEnumerable(Of SyntaxTree),
+                                                  Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                                  Optional options As VisualBasicCompilationOptions = Nothing,
+                                                  Optional assemblyName As String = Nothing) As VisualBasicCompilation
+
+        Dim metadataReferences = If(references Is Nothing, {MscorlibRef}, {MscorlibRef}.Concat(references))
+        assemblyName = If(assemblyName, GetUniqueName())
+
+#If Test_IOperation_Interface Then
+        Dim compilationForOperationWalking = VisualBasicCompilation.Create(assemblyName, sourceTrees, metadataReferences, options)
+        WalkOperationTrees(compilationForOperationWalking)
+#End If
+
+        Return VisualBasicCompilation.Create(assemblyName, sourceTrees, metadataReferences, options)
+    End Function
+
+    Public Function CreateCompilationWithMscorlib(sources As IEnumerable(Of String),
                                                   Optional references As IEnumerable(Of MetadataReference) = Nothing,
                                                   Optional options As VisualBasicCompilationOptions = Nothing,
                                                   Optional assemblyName As String = Nothing,
                                                   Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
 
-        Dim syntaxTrees = sourceTrees.Select(Function(s) VisualBasicSyntaxTree.ParseText(s, parseOptions))
-        Dim metadataReferences = If(references Is Nothing, {MscorlibRef}, {MscorlibRef}.Concat(references))
-
-#If Test_IOperation_Interface Then
-        Dim compilationForOperationWalking = VisualBasicCompilation.Create(If(assemblyName, "TestOperation"), syntaxTrees, metadataReferences, options)
-        WalkOperationTrees(compilationForOperationWalking)
-#End If
-
-        Return VisualBasicCompilation.Create(If(assemblyName, "Test"), syntaxTrees, metadataReferences, options)
+        Return CreateCompilationWithMscorlib(ParseSources(sources, parseOptions), references, options, assemblyName)
     End Function
 
-    Public Function CreateCompilationWithMscorlib(sourceTrees As IEnumerable(Of SyntaxTree),
+    Public Function CreateCompilationWithMscorlib(source As String,
                                                   Optional references As IEnumerable(Of MetadataReference) = Nothing,
-                                                  Optional options As VisualBasicCompilationOptions = Nothing) As VisualBasicCompilation
+                                                  Optional options As VisualBasicCompilationOptions = Nothing,
+                                                  Optional assemblyName As String = Nothing,
+                                                  Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
 
-        Dim metadataReferences = If(references Is Nothing, {MscorlibRef}, {MscorlibRef}.Concat(references))
-
-#If Test_IOperation_Interface Then
-        Dim compilationForOperationWalking = VisualBasicCompilation.Create(GetUniqueName(), sourceTrees, metadataReferences, options)
-        WalkOperationTrees(compilationForOperationWalking)
-#End If
-
-        Return VisualBasicCompilation.Create(GetUniqueName(), sourceTrees, metadataReferences, options)
+        Return CreateCompilationWithMscorlib({source}, references, options, assemblyName, parseOptions)
     End Function
 
     Public Function CreateCompilationWithMscorlib45(sourceTrees As IEnumerable(Of SyntaxTree),
@@ -105,17 +130,15 @@ Friend Module CompilationUtils
     Public Function CreateCompilationWithMscorlib(sources As XElement,
                                                   Optional options As VisualBasicCompilationOptions = Nothing,
                                                   Optional references As IEnumerable(Of MetadataReference) = Nothing,
-                                                  Optional ByRef spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing,
                                                   Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
-        Return CreateCompilationWithReferences(sources, If(references IsNot Nothing, {MscorlibRef}.Concat(references), {MscorlibRef}), options, spans, parseOptions:=parseOptions)
+        Return CreateCompilationWithReferences(sources, If(references IsNot Nothing, {MscorlibRef}.Concat(references), {MscorlibRef}), options, parseOptions:=parseOptions)
     End Function
 
     Public Function CreateCompilationWithMscorlibAndReferences(sources As XElement,
                                                                references As IEnumerable(Of MetadataReference),
                                                                Optional options As VisualBasicCompilationOptions = Nothing,
-                                                               Optional ByRef spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing,
                                                                Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
-        Return CreateCompilationWithReferences(sources, {MscorlibRef}.Concat(references), options, spans, parseOptions:=parseOptions)
+        Return CreateCompilationWithReferences(sources, {MscorlibRef}.Concat(references), options, parseOptions:=parseOptions)
     End Function
 
     ''' <summary>
@@ -221,23 +244,29 @@ Friend Module CompilationUtils
     Public Function CreateCompilationWithReferences(sources As XElement,
                                                     references As IEnumerable(Of MetadataReference),
                                                     Optional options As VisualBasicCompilationOptions = Nothing,
-                                                    Optional ByRef spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing,
                                                     Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
-        Dim assemblyName As String = sources.@name
-        If assemblyName Is Nothing Then
-            assemblyName = GetUniqueName()
+        Dim assemblyName As String = Nothing
+        Dim sourceTrees = ParseSouceXml(sources, parseOptions, assemblyName)
+        Return CreateCompilationWithReferences(sourceTrees, references, options, assemblyName)
+    End Function
+
+    Public Function ParseSouceXml(sources As XElement,
+                                  parseOptions As VisualBasicParseOptions,
+                                  Optional ByRef assemblyName As String = Nothing,
+                                  Optional ByRef spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing) As IEnumerable(Of SyntaxTree)
+
+        If sources.@name IsNot Nothing Then
+            assemblyName = sources.@name
         End If
 
         Dim sourcesTreesAndSpans = From f In sources.<file> Select CreateParseTreeAndSpans(f, parseOptions)
-        Dim sourceTrees = From t In sourcesTreesAndSpans Select t.Item1
-        spans = From t In sourcesTreesAndSpans Select t.Item2
-
-        Return CreateCompilationWithReferences(sourceTrees, references, options, assemblyName)
+        spans = From t In sourcesTreesAndSpans Select s = t.spans
+        Return From t In sourcesTreesAndSpans Select t.tree
     End Function
 
     Public Function ToSourceTrees(compilationSources As XElement, Optional parseOptions As VisualBasicParseOptions = Nothing) As IEnumerable(Of SyntaxTree)
         Dim sourcesTreesAndSpans = From f In compilationSources.<file> Select CreateParseTreeAndSpans(f, parseOptions)
-        Return From t In sourcesTreesAndSpans Select t.Item1
+        Return From t In sourcesTreesAndSpans Select t.tree
     End Function
 
     Public Function CreateCompilationWithReferences(sourceTree As SyntaxTree,
@@ -276,10 +305,9 @@ Friend Module CompilationUtils
     ''' &lt;/compilation&gt;
     ''' </param>
     Public Function CreateCompilationWithoutReferences(sources As XElement,
-                                                           Optional options As VisualBasicCompilationOptions = Nothing,
-                                                           Optional ByRef spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing,
-                                                           Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
-        Return CreateCompilationWithReferences(sources, DirectCast({}, IEnumerable(Of MetadataReference)), options, spans, parseOptions)
+                                                       Optional options As VisualBasicCompilationOptions = Nothing,
+                                                       Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
+        Return CreateCompilationWithReferences(sources, DirectCast({}, IEnumerable(Of MetadataReference)), options, parseOptions)
     End Function
 
     Public Function CreateCompilation(
@@ -368,13 +396,13 @@ Friend Module CompilationUtils
         End If
 
         If ilSource Is Nothing Then
-            Return CreateCompilationWithMscorlibAndReferences(sources, references, options, spans, parseOptions)
+            Return CreateCompilationWithMscorlibAndReferences(sources, references, options, parseOptions)
         End If
 
         ilReference = CreateReferenceFromIlCode(ilSource, appendDefaultHeader, ilImage)
         references.Add(ilReference)
 
-        Return CreateCompilationWithMscorlibAndReferences(sources, references, options, spans, parseOptions)
+        Return CreateCompilationWithMscorlibAndReferences(sources, references, options, parseOptions)
     End Function
 
     Public Function CreateReferenceFromIlCode(ilSource As String, Optional appendDefaultHeader As Boolean = True, <Out> Optional ByRef ilImage As ImmutableArray(Of Byte) = Nothing) As MetadataReference
@@ -615,16 +643,14 @@ Friend Module CompilationUtils
     ''' source
     ''' &lt;/file&gt;
     ''' </param>
-    ''' <returns></returns>
-    ''' <remarks></remarks>
-    Public Function CreateParseTreeAndSpans(programElement As XElement, Optional parseOptions As VisualBasicParseOptions = Nothing) As Tuple(Of SyntaxTree, IList(Of TextSpan))
+    Public Function CreateParseTreeAndSpans(programElement As XElement, Optional parseOptions As VisualBasicParseOptions = Nothing) As (tree As SyntaxTree, spans As IList(Of TextSpan))
         Dim codeWithMarker As String = FilterString(programElement.Value)
         Dim codeWithoutMarker As String = Nothing
         Dim spans As IList(Of TextSpan) = Nothing
         MarkupTestFile.GetSpans(codeWithMarker, codeWithoutMarker, spans)
 
         Dim text = SourceText.From(codeWithoutMarker, Encoding.UTF8)
-        Return New Tuple(Of SyntaxTree, IList(Of TextSpan))(VisualBasicSyntaxTree.ParseText(text, parseOptions, If(programElement.@name, "")), spans)
+        Return (VisualBasicSyntaxTree.ParseText(text, parseOptions, If(programElement.@name, "")), spans)
     End Function
 
     ' Find a node inside a tree.

--- a/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
@@ -103,8 +103,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End While
 
             ' Skip lambdas. They can't have custom attributes.
-            method = TryCast(method.ContainingNonLambdaMember(), MethodSymbol)
-            If method IsNot Nothing Then
+            Dim nonLambda = method.ContainingNonLambdaMember()
+            If nonLambda?.Kind = SymbolKind.Method Then
+                method = DirectCast(nonLambda, MethodSymbol)
+
                 If method.IsDirectlyExcludedFromCodeCoverage Then
                     Return True
                 End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
@@ -31,19 +31,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Shared Function TryCreate(method As MethodSymbol, methodBody As BoundStatement, methodBodyFactory As SyntheticBoundNodeFactory, diagnostics As DiagnosticBag, debugDocumentProvider As DebugDocumentProvider, previous As Instrumenter) As DynamicAnalysisInjector
             ' Do not instrument implicitly-declared methods, except for constructors.
             ' Instrument implicit constructors in order to instrument member initializers.
-            If Not method.IsImplicitlyDeclared OrElse method.IsAnyConstructor Then
-                Dim createPayload As MethodSymbol = GetCreatePayload(methodBodyFactory.Compilation, methodBody.Syntax, diagnostics)
-
-                ' Do not instrument any methods if CreatePayload is not present.
-                ' Do not instrument CreatePayload if it is part of the current compilation (which occurs only during testing).
-                ' Do not instrument if the syntax node does not have a valid mapped line span.
-                ' CreatePayload will fail at run time with an infinite recursion if it Is instrumented.
-                If createPayload IsNot Nothing AndAlso Not method.Equals(createPayload) AndAlso HasValidMappedLineSpan(methodBody.Syntax) Then
-                    Return New DynamicAnalysisInjector(method, methodBody, methodBodyFactory, createPayload, diagnostics, debugDocumentProvider, previous)
-                End If
+            If method.IsImplicitlyDeclared AndAlso Not method.IsAnyConstructor Then
+                Return Nothing
             End If
 
-            Return Nothing
+            ' Do not instrument if the syntax node does not have a valid mapped line span.
+            If Not HasValidMappedLineSpan(methodBody.Syntax) Then
+                Return Nothing
+            End If
+
+            ' Do not instrument methods marked with or in scope of ExcludeFromCodeCoverageAttribute
+            If IsExcludedFromCodeCoverage(method) Then
+                Return Nothing
+            End If
+
+            Dim createPayload As MethodSymbol = GetCreatePayload(methodBodyFactory.Compilation, methodBody.Syntax, diagnostics)
+
+            ' Do not instrument any methods if CreatePayload is not present.
+            If createPayload Is Nothing Then
+                Return Nothing
+            End If
+
+            ' Do not instrument CreatePayload if it is part of the current compilation (which occurs only during testing).
+            ' CreatePayload will fail at run time with an infinite recursion if it is instrumented.
+            If method.Equals(createPayload) Then
+                Return Nothing
+            End If
+
+            Return New DynamicAnalysisInjector(method, methodBody, methodBodyFactory, createPayload, diagnostics, debugDocumentProvider, previous)
         End Function
 
         Private Shared Function HasValidMappedLineSpan(syntax As SyntaxNode) As Boolean
@@ -75,6 +90,42 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 _methodEntryInstrumentation = AddAnalysisPoint(bodySyntax, SkipAttributes(bodySyntax), methodBodyFactory)
             End If
         End Sub
+
+        Private Shared Function IsExcludedFromCodeCoverage(method As MethodSymbol) As Boolean
+            Dim containingType = method.ContainingType
+
+            While containingType IsNot Nothing
+                If containingType.IsDirectlyExcludedFromCodeCoverage Then
+                    Return True
+                End If
+
+                containingType = containingType.ContainingType
+            End While
+
+            ' Skip lambdas. They can't have custom attributes.
+            method = TryCast(method.ContainingNonLambdaMember(), MethodSymbol)
+            If method IsNot Nothing Then
+                If method.IsDirectlyExcludedFromCodeCoverage Then
+                    Return True
+                End If
+
+                Dim associatedSymbol = method.AssociatedSymbol
+                Select Case associatedSymbol?.Kind
+                    Case SymbolKind.Property
+                        If DirectCast(associatedSymbol, PropertySymbol).IsDirectlyExcludedFromCodeCoverage Then
+                            Return True
+                        End If
+
+                    Case SymbolKind.Event
+                        If DirectCast(associatedSymbol, EventSymbol).IsDirectlyExcludedFromCodeCoverage Then
+                            Return True
+                        End If
+                End Select
+            End If
+
+            Return False
+        End Function
+
 
         Public Overrides Function CreateBlockPrologue(trueOriginal As BoundBlock, original As BoundBlock, ByRef synthesizedLocal As LocalSymbol) As BoundStatement
             Dim previousPrologue As BoundStatement = MyBase.CreateBlockPrologue(trueOriginal, original, synthesizedLocal)

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -59,6 +59,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public MustOverride ReadOnly Property RaiseMethod As MethodSymbol
 
         ''' <summary>
+        ''' True if the event itself Is excluded from code covarage instrumentation.
+        ''' True for source events marked with <see cref="AttributeDescription.ExcludeFromCodeCoverageAttribute"/>.
+        ''' </summary>
+        Friend Overridable ReadOnly Property IsDirectlyExcludedFromCodeCoverage As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        ''' <summary>
         '''  True if this symbol has a special name (metadata flag SpecialName is set).
         ''' </summary>
         Friend MustOverride ReadOnly Property HasSpecialName As Boolean

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -240,6 +240,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         ''' <summary>
+        ''' True if the method itself Is excluded from code covarage instrumentation.
+        ''' True for source methods marked with <see cref="AttributeDescription.ExcludeFromCodeCoverageAttribute"/>.
+        ''' </summary>
+        Friend Overridable ReadOnly Property IsDirectlyExcludedFromCodeCoverage As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        ''' <summary>
         ''' True if this symbol has a special name (metadata flag SpecialName is set).
         ''' </summary>
         ''' <remarks>

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -166,6 +166,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         ''' <summary>
+        ''' True if the type itself Is excluded from code covarage instrumentation.
+        ''' True for source types marked with <see cref="AttributeDescription.ExcludeFromCodeCoverageAttribute"/>.
+        ''' </summary>
+        Friend Overridable ReadOnly Property IsDirectlyExcludedFromCodeCoverage As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        ''' <summary>
         ''' Should the name returned by Name property be mangled with [`arity] suffix in order to get metadata name.
         ''' Must return False for a type with Arity == 0.
         ''' </summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/PropertySymbol.vb
@@ -82,6 +82,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         ''' <summary>
+        ''' True if the property itself Is excluded from code covarage instrumentation.
+        ''' True for source properties marked with <see cref="AttributeDescription.ExcludeFromCodeCoverageAttribute"/>.
+        ''' </summary>
+        Friend Overridable ReadOnly Property IsDirectlyExcludedFromCodeCoverage As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        ''' <summary>
         '''  True if this symbol has a special name (metadata flag SpecialName is set).
         ''' </summary>
         Friend MustOverride ReadOnly Property HasSpecialName As Boolean

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
@@ -665,10 +665,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
                 arguments.GetOrCreateData(Of EventWellKnownAttributeData).HasSpecialNameAttribute = True
+            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+                arguments.GetOrCreateData(Of EventWellKnownAttributeData).HasExcludeFromCodeCoverageAttribute = True
             End If
 
             MyBase.DecodeWellKnownAttribute(arguments)
         End Sub
+
+        Friend NotOverridable Overrides ReadOnly Property IsDirectlyExcludedFromCodeCoverage As Boolean
+            Get
+                Dim data = GetDecodedWellKnownAttributeData()
+                Return data IsNot Nothing AndAlso data.HasExcludeFromCodeCoverageAttribute
+            End Get
+        End Property
 
         Friend Overrides ReadOnly Property HasSpecialName As Boolean
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -1702,6 +1702,8 @@ lReportErrorOnTwoTokens:
 
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasSpecialNameAttribute = True
+            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+                arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasExcludeFromCodeCoverageAttribute = True
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SuppressUnmanagedCodeSecurityAttribute) Then
                 arguments.GetOrCreateData(Of MethodWellKnownAttributeData)().HasSuppressUnmanagedCodeSecurityAttribute = True
             ElseIf attrData.IsSecurityAttribute(Me.DeclaringCompilation) Then
@@ -1925,6 +1927,13 @@ lReportErrorOnTwoTokens:
 
             Return SpecializedCollections.EmptyEnumerable(Of SecurityAttribute)()
         End Function
+
+        Friend NotOverridable Overrides ReadOnly Property IsDirectlyExcludedFromCodeCoverage As Boolean
+            Get
+                Dim data = GetDecodedWellKnownAttributeData()
+                Return data IsNot Nothing AndAlso data.HasExcludeFromCodeCoverageAttribute
+            End Get
+        End Property
 
         Friend Overrides ReadOnly Property HasRuntimeSpecialName As Boolean
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -2211,7 +2211,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SerializableAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSerializableAttribute = True
-
+                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+                    arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasExcludeFromCodeCoverageAttribute = True
                 ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
                     arguments.GetOrCreateData(Of CommonTypeWellKnownAttributeData)().HasSpecialNameAttribute = True
 
@@ -2328,6 +2329,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                                  diagnostics)
             End If
         End Sub
+
+        Friend NotOverridable Overrides ReadOnly Property IsDirectlyExcludedFromCodeCoverage As Boolean
+            Get
+                Dim data = GetDecodedWellKnownAttributeData()
+                Return data IsNot Nothing AndAlso data.HasExcludeFromCodeCoverageAttribute
+            End Get
+        End Property
 
         Friend NotOverridable Overrides ReadOnly Property HasSpecialName As Boolean
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
@@ -576,6 +576,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 If attrData.IsTargetAttribute(Me, AttributeDescription.SpecialNameAttribute) Then
                     arguments.GetOrCreateData(Of CommonPropertyWellKnownAttributeData).HasSpecialNameAttribute = True
                     Return
+                ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.ExcludeFromCodeCoverageAttribute) Then
+                    arguments.GetOrCreateData(Of CommonPropertyWellKnownAttributeData).HasExcludeFromCodeCoverageAttribute = True
+                    Return
                 ElseIf Not IsWithEvents AndAlso attrData.IsTargetAttribute(Me, AttributeDescription.DebuggerHiddenAttribute) Then
                     ' if neither getter or setter is marked by DebuggerHidden Dev11 reports a warning
                     If Not (_getMethod IsNot Nothing AndAlso DirectCast(_getMethod, SourcePropertyAccessorSymbol).HasDebuggerHiddenAttribute OrElse
@@ -588,6 +591,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             MyBase.DecodeWellKnownAttribute(arguments)
         End Sub
+
+        Friend Overrides ReadOnly Property IsDirectlyExcludedFromCodeCoverage As Boolean
+            Get
+                Dim data = GetDecodedWellKnownAttributeData()
+                Return data IsNot Nothing AndAlso data.HasExcludeFromCodeCoverageAttribute
+            End Get
+        End Property
 
         Friend Overrides ReadOnly Property HasSpecialName As Boolean
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
@@ -415,5 +415,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return vbSymbol
         End Function
 
+        <Extension>
+        Friend Function ContainingNonLambdaMember(member As Symbol) As Symbol
+            While member?.Kind = SymbolKind.Method AndAlso DirectCast(member, MethodSymbol).MethodKind = MethodKind.AnonymousFunction
+                member = member.ContainingSymbol
+            End While
+
+            Return member
+        End Function
     End Module
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
@@ -1,24 +1,17 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
 Imports System.Collections.Immutable
-Imports System.Linq
-Imports System.Reflection.PortableExecutable
 Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis.Emit
-Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
-Imports Roslyn.Test.Utilities
-Imports Xunit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.DynamicAnalysis.UnitTests
 
     Public Class DynamicInstrumentationTests
         Inherits BasicTestBase
 
-        ReadOnly InstrumentationHelperSource As XElement = <file name="c.vb">
-                                                               <![CDATA[
+        Const InstrumentationHelperSourceStr As String = "
 Namespace Microsoft.CodeAnalysis.Runtime
 
     Public Class Instrumentation
@@ -44,15 +37,15 @@ Namespace Microsoft.CodeAnalysis.Runtime
         End Function
 
         Public Shared Sub FlushPayload()
-            System.Console.WriteLine("Flushing")
+            System.Console.WriteLine(""Flushing"")
             If _payloads Is Nothing Then
                 Return
             End If
             For i As Integer = 0 To _payloads.Length - 1
                 Dim payload As Boolean() = _payloads(i)
                 if payload IsNot Nothing
-                    System.Console.WriteLine("Method " & i.ToString())
-                    System.Console.WriteLine("File " & _fileIndices(i).ToString())
+                    System.Console.WriteLine(""Method "" & i.ToString())
+                    System.Console.WriteLine(""File "" & _fileIndices(i).ToString())
                     For j As Integer = 0 To payload.Length - 1
                         System.Console.WriteLine(payload(j))
                         payload(j) = False
@@ -62,9 +55,11 @@ Namespace Microsoft.CodeAnalysis.Runtime
         End Sub
     End Class
 End Namespace
-]]>
-                                                           </file>
+"
 
+        ReadOnly InstrumentationHelperSource As XElement = <file name="c.vb">
+                                                               <%= InstrumentationHelperSourceStr %>
+                                                           </file>
         <Fact>
         Public Sub SimpleCoverage()
             Dim testSource As XElement = <file name="c.vb">
@@ -1645,14 +1640,502 @@ End Class
             Assert.True(False)
         End Sub
 
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_Method()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+Class C
+    <ExcludeFromCodeCoverage>
+    Sub M1()
+        Console.WriteLine(1)
+    End Sub
+
+    Sub M2()
+        Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+            AssertNotInstrumented(verifier, "C.M1")
+            AssertInstrumented(verifier, "C.M2")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_Ctor()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+Class C
+    Dim a As Integer = 1
+
+    <ExcludeFromCodeCoverage>
+    Public Sub New()
+        Console.WriteLine(3)
+    End Sub
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+            AssertNotInstrumented(verifier, "C..ctor")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_Cctor()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+Class C
+    Shared a As Integer = 1
+
+    <ExcludeFromCodeCoverage>
+    Shared Sub New()
+        Console.WriteLine(3)
+    End Sub
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+            AssertNotInstrumented(verifier, "C..cctor")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_Lambdas_InMethod()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+Class C
+    <ExcludeFromCodeCoverage>
+    Shared Sub M1()
+        Dim s = New Action(Sub() Console.WriteLine(1))
+        s.Invoke()
+    End Sub
+
+    Shared Sub M2()
+        Dim s = New Action(Sub() Console.WriteLine(2))
+        s.Invoke()
+    End Sub
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+
+            AssertNotInstrumented(verifier, "C.M1")
+            AssertNotInstrumented(verifier, "C._Closure$__._Lambda$__1-0")
+
+            AssertInstrumented(verifier, "C.M2")
+            AssertInstrumented(verifier, "C._Closure$__2-0._Lambda$__0")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_Lambdas_InInitializers()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+Class C
+    Dim [IF] As Action = Sub() Console.WriteLine(1)
+
+    ReadOnly Property IP As Action = Sub() Console.WriteLine(2)
+
+    Shared SF As Action = Sub() Console.WriteLine(3)
+
+    Shared ReadOnly Property SP As Action = Sub() Console.WriteLine(4)
+
+    <ExcludeFromCodeCoverage>
+    Sub New()
+    End Sub
+
+    Shared Sub New()
+    End Sub
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+            verifier.VerifyDiagnostics()
+
+            AssertNotInstrumented(verifier, "C..ctor")
+            AssertNotInstrumented(verifier, "C._Closure$__._Lambda$__8-0")
+            AssertNotInstrumented(verifier, "C._Closure$__._Lambda$__8-1")
+
+            AssertInstrumented(verifier, "C..cctor")
+            AssertInstrumented(verifier, "C._Closure$__9-0._Lambda$__0")
+            AssertInstrumented(verifier, "C._Closure$__9-0._Lambda$__1")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_Lambdas_InAccessors()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+Class C
+
+    <ExcludeFromCodeCoverage>
+    Property P1 As Integer
+        Get
+            Dim s = Sub() Console.WriteLine(1)
+            s()
+            Return 1
+        End Get
+
+        Set
+            Dim s = Sub() Console.WriteLine(2)
+            s()
+        End Set
+    End Property
+
+    Property P2 As Integer
+        Get
+            Dim s = Sub() Console.WriteLine(3)
+            s()
+            Return 3
+        End Get
+
+        Set
+            Dim s = Sub() Console.WriteLine(4)
+            s()
+        End Set
+    End Property
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+
+            AssertNotInstrumented(verifier, "C.get_P1")
+            AssertNotInstrumented(verifier, "C.set_P1")
+            AssertNotInstrumented(verifier, "C._Closure$__._Lambda$__2-0")
+            AssertNotInstrumented(verifier, "C._Closure$__._Lambda$__3-0")
+
+            AssertInstrumented(verifier, "C.get_P2")
+            AssertInstrumented(verifier, "C.set_P2")
+            AssertInstrumented(verifier, "C._Closure$__6-0._Lambda$__0")
+            AssertInstrumented(verifier, "C._Closure$__5-0._Lambda$__0")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_Type()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+<ExcludeFromCodeCoverage>
+Class C
+    Dim x As Integer = 1
+
+    Shared Sub New()
+    End Sub
+
+    Sub M1()
+        Console.WriteLine(1)
+    End Sub
+
+    Property P As Integer
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+
+    Custom Event E As Action
+        AddHandler(v As Action)
+        End AddHandler
+
+        RemoveHandler(v As Action)
+        End RemoveHandler
+
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+
+Class D
+    Dim x As Integer = 1
+
+    Shared Sub New()
+    End Sub
+
+    Sub M1()
+        Console.WriteLine(1)
+    End Sub
+
+    Property P As Integer
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+
+    Custom Event E As Action
+        AddHandler(v As Action)
+        End AddHandler
+
+        RemoveHandler(v As Action)
+        End RemoveHandler
+
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+
+            AssertNotInstrumented(verifier, "C..ctor")
+            AssertNotInstrumented(verifier, "C..cctor")
+            AssertNotInstrumented(verifier, "C.M1")
+            AssertNotInstrumented(verifier, "C.get_P")
+            AssertNotInstrumented(verifier, "C.set_P")
+            AssertNotInstrumented(verifier, "C.add_E")
+            AssertNotInstrumented(verifier, "C.remove_E")
+            AssertNotInstrumented(verifier, "C.raise_E")
+
+            AssertInstrumented(verifier, "D..ctor")
+            AssertInstrumented(verifier, "D..cctor")
+            AssertInstrumented(verifier, "D.M1")
+            AssertInstrumented(verifier, "D.get_P")
+            AssertInstrumented(verifier, "D.set_P")
+            AssertInstrumented(verifier, "D.add_E")
+            AssertInstrumented(verifier, "D.remove_E")
+            AssertInstrumented(verifier, "D.raise_E")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_NestedType()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+Class A
+    Class B1
+        <ExcludeFromCodeCoverage>
+        Class C
+            Sub M1()
+                Console.WriteLine(1)
+            End Sub
+        End Class
+
+        Sub M2()
+            Console.WriteLine(2)
+        End Sub
+    End Class
+
+    <ExcludeFromCodeCoverage>
+    Partial Class B2
+        Partial Class C1
+            Sub M3()
+                Console.WriteLine(3)
+            End Sub
+        End Class
+
+        Class C2
+            Sub M4()
+                Console.WriteLine(4)
+            End Sub
+        End Class
+
+        Sub M5()
+            Console.WriteLine(5)
+        End Sub
+    End Class
+
+    Partial Class B2
+        <ExcludeFromCodeCoverage>
+        Partial Class C1
+            Sub M6()
+                Console.WriteLine(6)
+            End Sub
+        End Class
+
+        Sub M7()
+            Console.WriteLine(7)
+        End Sub
+    End Class
+
+    Sub M8()
+        Console.WriteLine(8)
+    End Sub
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+            AssertNotInstrumented(verifier, "A.B1.C.M1")
+            AssertInstrumented(verifier, "A.B1.M2")
+            AssertNotInstrumented(verifier, "A.B2.C1.M3")
+            AssertNotInstrumented(verifier, "A.B2.C2.M4")
+            AssertNotInstrumented(verifier, "A.B2.C1.M6")
+            AssertNotInstrumented(verifier, "A.B2.M7")
+            AssertInstrumented(verifier, "A.M8")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_Accessors()
+            Dim source = "
+Imports System
+Imports System.Diagnostics.CodeAnalysis
+
+Class C
+    <ExcludeFromCodeCoverage>
+    Property P1 As Integer
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+          
+    <ExcludeFromCodeCoverage>
+    Custom Event E1 As Action
+        AddHandler(v As Action)
+        End AddHandler
+
+        RemoveHandler(v As Action)
+        End RemoveHandler
+
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+                                            
+    Property P2 As Integer
+        Get
+            Return 2
+        End Get
+        Set
+        End Set
+    End Property
+
+    Custom Event E2 As Action
+        AddHandler(v As Action)
+        End AddHandler
+
+        RemoveHandler(v As Action)
+        End RemoveHandler
+
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+"
+            Dim verifier = CompileAndVerify(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+
+            AssertNotInstrumented(verifier, "C.get_P1")
+            AssertNotInstrumented(verifier, "C.set_P1")
+            AssertNotInstrumented(verifier, "C.add_E1")
+            AssertNotInstrumented(verifier, "C.remove_E1")
+            AssertNotInstrumented(verifier, "C.raise_E1")
+
+            AssertInstrumented(verifier, "C.get_P2")
+            AssertInstrumented(verifier, "C.set_P2")
+            AssertInstrumented(verifier, "C.add_E2")
+            AssertInstrumented(verifier, "C.remove_E2")
+            AssertInstrumented(verifier, "C.raise_E2")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_CustomDefinition_Good()
+            Dim source = "
+Imports System.Diagnostics.CodeAnalysis
+
+Namespace System.Diagnostics.CodeAnalysis
+
+    <AttributeUsage(AttributeTargets.Class)>
+    Public Class ExcludeFromCodeCoverageAttribute
+        Inherits Attribute
+
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace
+
+<ExcludeFromCodeCoverage>
+Class C
+    Sub M()
+    End Sub
+End Class
+
+Class D
+    Sub M()
+    End Sub
+End Class
+"
+            Dim c = CreateCompilationWithMscorlib(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+            c.VerifyDiagnostics()
+
+            Dim verifier = CompileAndVerify(c, emitOptions:=EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)))
+            c.VerifyEmitDiagnostics()
+
+            AssertNotInstrumented(verifier, "C.M")
+            AssertInstrumented(verifier, "D.M")
+        End Sub
+
+        <Fact>
+        Public Sub ExcludeFromCodeCoverageAttribute_CustomDefinition_Bad()
+            Dim source = "
+Imports System.Diagnostics.CodeAnalysis
+
+Namespace System.Diagnostics.CodeAnalysis
+
+    <AttributeUsage(AttributeTargets.Class)>
+    Public Class ExcludeFromCodeCoverageAttribute
+        Inherits Attribute
+
+        Public Sub New(x As Integer)
+        End Sub
+    End Class
+End Namespace
+
+<ExcludeFromCodeCoverage(1)>
+Class C
+    Sub M()
+    End Sub
+End Class
+
+Class D
+    Sub M()
+    End Sub
+End Class
+"
+            Dim c = CreateCompilationWithMscorlib(source & InstrumentationHelperSourceStr, options:=TestOptions.ReleaseDll)
+            c.VerifyDiagnostics()
+
+            Dim verifier = CompileAndVerify(c, emitOptions:=EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)))
+            c.VerifyEmitDiagnostics()
+
+            AssertInstrumented(verifier, "C.M")
+            AssertInstrumented(verifier, "D.M")
+        End Sub
+
+        Private Shared Sub AssertNotInstrumented(verifier As CompilationVerifier, qualifiedMethodName As String)
+            AssertInstrumented(verifier, qualifiedMethodName, expected:=False)
+        End Sub
+
+        Private Shared Sub AssertInstrumented(verifier As CompilationVerifier, qualifiedMethodName As String, Optional expected As Boolean = True)
+            Dim il = verifier.VisualizeIL(qualifiedMethodName)
+
+            ' Tests using this helper are constructed such that instrumented methods contain a call to CreatePayload, 
+            ' lambdas a reference to payload Boolean array.
+            Dim instrumented = il.Contains("CreatePayload") OrElse il.Contains("As Boolean()")
+
+            Assert.True(expected = instrumented, $"Method '{qualifiedMethodName}' should {If(expected, "be", "not be")} instrumented. Actual IL:{Environment.NewLine}{il}")
+        End Sub
+
         Private Function CreateCompilation(source As XElement) As Compilation
-            Return CompilationUtils.CreateCompilationWithReferences(source, references:=New MetadataReference() {}, options:=TestOptions.ReleaseExe.WithDeterministic(True))
+            Return CreateCompilationWithReferences(source, references:=New MetadataReference() {}, options:=TestOptions.ReleaseExe.WithDeterministic(True))
         End Function
 
-        Private Overloads Function CompileAndVerify(source As XElement, expectedOutput As XCData, Optional options As VisualBasicCompilationOptions = Nothing) As CompilationVerifier
-            Return MyBase.CompileAndVerify(source, expectedOutput:=expectedOutput, additionalRefs:=s_refs, options:=If(options IsNot Nothing, options, TestOptions.ReleaseExe).WithDeterministic(True), emitOptions:=EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)))
+        Private Overloads Function CompileAndVerify(source As XElement, Optional expectedOutput As XCData = Nothing, Optional options As VisualBasicCompilationOptions = Nothing) As CompilationVerifier
+            Return CompileAndVerify(source,
+                                    LatestVbReferences,
+                                    XCDataToString(expectedOutput),
+                                    options:=If(options, TestOptions.ReleaseExe).WithDeterministic(True),
+                                    emitOptions:=EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)))
         End Function
 
-        Private Shared ReadOnly s_refs As MetadataReference() = New MetadataReference() {MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929}
+        Private Overloads Function CompileAndVerify(source As String, Optional expectedOutput As String = Nothing, Optional options As VisualBasicCompilationOptions = Nothing) As CompilationVerifier
+            Return CompileAndVerify(source,
+                                    LatestVbReferences,
+                                    expectedOutput,
+                                    options:=If(options, TestOptions.ReleaseExe).WithDeterministic(True),
+                                    emitOptions:=EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)))
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/FlowTestBase.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/FlowAnalysis/FlowTestBase.vb
@@ -77,17 +77,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         Protected Function CompileAndGetModelAndSpan(program As XElement, startNodes As List(Of VisualBasicSyntaxNode), endNodes As List(Of VisualBasicSyntaxNode), ilSource As XCData, errors As XElement, Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
             Debug.Assert(program.<file>.Count = 1, "Only one file can be in the compilation.")
-            Dim spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing
-            Dim comp = CompilationUtils.CreateCompilationWithCustomILSource(program,
-                                                                            If(ilSource IsNot Nothing, ilSource.Value, Nothing),
-                                                                            options:=Nothing,
-                                                                            spans:=spans,
-                                                                            includeVbRuntime:=True,
-                                                                            includeSystemCore:=True,
-                                                                            parseOptions:=parseOptions)
-            If errors IsNot Nothing Then
-                CompilationUtils.AssertTheseDiagnostics(comp, errors)
+
+            Dim references = {MscorlibRef, MsvbRef, SystemCoreRef}
+            If ilSource IsNot Nothing Then
+                Dim ilImage As ImmutableArray(Of Byte) = Nothing
+                references = references.Concat(CreateReferenceFromIlCode(ilSource?.Value, appendDefaultHeader:=True, ilImage:=ilImage)).ToArray()
             End If
+
+            Dim assemblyName As String = Nothing
+            Dim spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing
+            Dim trees = ParseSouceXml(program, parseOptions, assemblyName, spans)
+
+            Dim comp = CreateCompilation(trees, references, Nothing, assemblyName)
+
+            If errors IsNot Nothing Then
+                AssertTheseDiagnostics(comp, errors)
+            End If
+
             Debug.Assert(spans.Count = 1 AndAlso spans(0).Count = 1, "Exactly one region must be selected")
             Dim span = spans.Single.Single
             FindRegionNodes(comp.SyntaxTrees(0), span, startNodes, endNodes)

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -1665,8 +1665,8 @@ End Structure"
     Shared Sub M(a As A, b As B, c As C)
     End Sub
 End Class"
-            Dim comp0 = CreateCompilationWithMscorlib({source0}, options:=TestOptions.DebugDll)
-            Dim comp1 = CreateCompilationWithMscorlib({source1}, options:=TestOptions.DebugDll, references:={comp0.EmitToImageReference()})
+            Dim comp0 = CreateCompilationWithMscorlib({source0}, options:=TestOptions.DebugDll, assemblyName:="Test")
+            Dim comp1 = CreateCompilationWithMscorlib({source1}, options:=TestOptions.DebugDll, references:={comp0.EmitToImageReference()}, assemblyName:="Test")
 
             ' no reference to compilation0
             WithRuntimeInstance(comp1, {MscorlibRef},

--- a/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
@@ -177,19 +177,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 int callerLine,
                 bool escapeQuotes)
             {
-                // TODO: Currently the qualifiedMethodName is a symbol display name while PDB need metadata name.
-                // So we need to pass the PDB metadata name of the method to sequencePoints (instead of just bool).
-
-                var methodData = _testData.GetMethodData(qualifiedMethodName);
-
-                // verify IL emitted via CCI, if any:
-                string actualCciIL = VisualizeIL(methodData, realIL, sequencePoints, useRefEmitter: false);
-                AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualCciIL, escapeQuotes, callerPath, callerLine);
-
-                // verify IL emitted via ReflectionEmitter, if any:
-                string actualRefEmitIL = VisualizeIL(methodData, realIL, sequencePoints, useRefEmitter: true);
-                AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualRefEmitIL, escapeQuotes, callerPath, callerLine);
-
+                string actualIL = VisualizeIL(qualifiedMethodName, realIL, sequencePoints);
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualIL, escapeQuotes, callerPath, callerLine);
                 return this;
             }
 
@@ -249,12 +238,15 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 return SymReaderFactory.CreateReader(pdbStream, metadataReaderOpt: null, metadataMemoryOwnerOpt: null);
             }
 
-            public string VisualizeIL(string qualifiedMethodName, bool realIL = false, string sequencePoints = null, bool useRefEmitter = false)
+            public string VisualizeIL(string qualifiedMethodName, bool realIL = false, string sequencePoints = null)
             {
-                return VisualizeIL(_testData.GetMethodData(qualifiedMethodName), realIL, sequencePoints, useRefEmitter);
+                // TODO: Currently the qualifiedMethodName is a symbol display name while PDB need metadata name.
+                // So we need to pass the PDB metadata name of the method to sequencePoints (instead of just bool).
+
+                return VisualizeIL(_testData.GetMethodData(qualifiedMethodName), realIL, sequencePoints);
             }
 
-            internal string VisualizeIL(CompilationTestData.MethodData methodData, bool realIL, string sequencePoints = null, bool useRefEmitter = false)
+            internal string VisualizeIL(CompilationTestData.MethodData methodData, bool realIL, string sequencePoints = null)
             {
                 Dictionary<int, string> markers = null;
 


### PR DESCRIPTION
**Customer scenario**

Methods marked with ExcludeFromCodeCoverageAttribute should not be instrumented for code coverage.

The attribute is available on .NET Framework 4.0+ and NetStandard 2.0. Unfortuantely, it's not available in NetStandard 1.x. However the customer can define the attribute in source if they want to use it and is not available on the target Framework.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/testimpact/issues/1120

**Workarounds, if any**

None. 

**Risk**

Small.

**Performance impact**

None.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

N/A

**How was the bug found?**

Exploratory testing.