### PR TITLE
ArgumentOutOfRangeException in MetadataHelpers.GetInfoForImmediateNamespaceMembers if namespace is empty string

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamespaceSymbol.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // A sequence with information about namespaces immediately contained within this namespace.
             // For each pair:
             //    Key - contains simple name of a child namespace.
-            //    Value – contains a sequence similar to the one passed to this function, but
+            //    Value - contains a sequence similar to the one passed to this function, but
             //            calculated for the child namespace. 
             IEnumerable<KeyValuePair<string, IEnumerable<IGrouping<string, TypeDefinitionHandle>>>> nestedNamespaces = null;
             bool isGlobalNamespace = this.IsGlobalNamespace;
@@ -214,13 +214,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             if (this.lazyNamespaces == null)
             {
-                var children = from child in childNamespaces
-                               select new PENestedNamespaceSymbol(child.Key, this, child.Value);
-
                 var namespaces = new Dictionary<string, PENestedNamespaceSymbol>(StringOrdinalComparer.Instance);
 
-                foreach (var c in children)
+                foreach (var child in childNamespaces)
                 {
+                    var c = new PENestedNamespaceSymbol(child.Key, this, child.Value);
                     namespaces.Add(c.Name, c);
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             PENamespaceSymbol containingNamespace,
             IEnumerable<IGrouping<string, TypeDefinitionHandle>> typesByNS)
         {
-            Debug.Assert(name != null && name.Length > 0);
+            Debug.Assert(name != null);
             Debug.Assert((object)containingNamespace != null);
             Debug.Assert(typesByNS != null);
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataTypeTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -487,6 +486,84 @@ class Test : StaticModClass
             Assert.Equal("<I<System.Int32>.F>d__0", stateMachineClass.Name); // The name has been reconstructed correctly.
             Assert.Equal("C.<I<System.Int32>.F>d__0", stateMachineClass.ToTestDisplayString()); // SymbolDisplay works.
             Assert.Equal(stateMachineClass, comp.GetTypeByMetadataName("C+<I<System.Int32>.F>d__0")); // GetTypeByMetadataName works.
+        }
+
+        [Fact]
+        public void EmptyNamespaceNames()
+        {
+            var ilSource =
+@".class public A
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+}
+.namespace '.N'
+{
+  .class public B
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace '.'
+{
+  .class public C
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace '..'
+{
+  .class public D
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace '..N'
+{
+  .class public E
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace N.M
+{
+  .class public F
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace 'N.M.'
+{
+  .class public G
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace 'N.M..'
+{
+  .class public H
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}";
+            var comp = CreateCompilationWithCustomILSource("", ilSource);
+            comp.VerifyDiagnostics();
+            var builder = ArrayBuilder<string>.GetInstance();
+            var module = comp.GetMember<NamedTypeSymbol>("A").ContainingModule;
+            GetAllNamespaceNames(builder, module.GlobalNamespace);
+            Assert.Equal(new[] { "<global namespace>", "", ".", "..N", ".N", "N", "N.M", "N.M." }, builder);
+        }
+
+        private static void GetAllNamespaceNames(ArrayBuilder<string> builder, NamespaceSymbol @namespace)
+        {
+            builder.Add(@namespace.ToTestDisplayString());
+            foreach (var member in @namespace.GetMembers())
+            {
+                if (member.Kind != SymbolKind.Namespace)
+                {
+                    continue;
+                }
+                GetAllNamespaceNames(builder, (NamespaceSymbol)member);
+            }
         }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataHelpers.cs
@@ -685,7 +685,7 @@ namespace Microsoft.CodeAnalysis
         /// A sequence with information about namespaces immediately contained within this namespace.
         /// For each pair:
         ///   Key - contains simple name of a child namespace.
-        ///   Value – contains a sequence similar to the one passed to this function, but
+        ///   Value - contains a sequence similar to the one passed to this function, but
         ///           calculated for the child namespace. 
         /// </param>
         /// <remarks></remarks>

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.vb
@@ -181,10 +181,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim myCaseCorrectedNSName As String = symbol.Name
             Dim myCaseCorrectedParentNSName As String = String.Empty
 
-            If Not symbol.IsGlobalNamespace AndAlso myCaseCorrectedNSName.IsEmpty() Then
-                myCaseCorrectedNSName = StringConstants.NamedSymbolErrorName
-            End If
-
             If Not emittedName.IsEmpty Then
                 Dim nsIdx = emittedName.LastIndexOf("."c)
                 If nsIdx > -1 Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamespaceSymbol.vb
@@ -162,7 +162,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             ' A sequence with information about namespaces immediately contained within this namespace.
             ' For each pair:
             '    Key - contains simple name of a child namespace.
-            '    Value – contains a sequence similar to the one passed to this function, but
+            '    Value - contains a sequence similar to the one passed to this function, but
             '            calculated for the child namespace. 
             Dim nestedNamespaces As IEnumerable(Of KeyValuePair(Of String, IEnumerable(Of IGrouping(Of String, TypeDefinitionHandle)))) = Nothing
 
@@ -189,13 +189,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
         )
             If m_lazyMembers Is Nothing Then
 
-                Dim namespaces = (From child In childNamespaces
-                                  Select New PENestedNamespaceSymbol(child.Key, Me, child.Value))
-
                 Dim members As New Dictionary(Of String, ImmutableArray(Of Symbol))(CaseInsensitiveComparison.Comparer)
 
                 ' Add namespaces
-                For Each ns In namespaces
+                For Each child In childNamespaces
+                    Dim ns = New PENestedNamespaceSymbol(child.Key, Me, child.Value)
                     members.Add(ns.Name, ImmutableArray.Create(Of Symbol)(ns))
                 Next
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENestedNamespaceSymbol.vb
@@ -70,7 +70,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             containingNamespace As PENamespaceSymbol,
             typesByNS As IEnumerable(Of IGrouping(Of String, TypeDefinitionHandle))
         )
-            Debug.Assert(name IsNot Nothing AndAlso name.Length > 0)
+            Debug.Assert(name IsNot Nothing)
             Debug.Assert(containingNamespace IsNot Nothing)
             Debug.Assert(typesByNS IsNot Nothing)
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/MetadataTypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/MetadataTypeTests.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports CompilationCreationTestHelpers
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text
@@ -1146,6 +1147,86 @@ End Class
             Assert.Equal("<I<System.Int32>.F>d__0", stateMachineClass.Name) ' The name has been reconstructed correctly.
             Assert.Equal("C.<I<System.Int32>.F>d__0", stateMachineClass.ToTestDisplayString()) ' SymbolDisplay works.
             Assert.Equal(stateMachineClass, comp.GetTypeByMetadataName("C+<I<System.Int32>.F>d__0")) ' GetTypeByMetadataName works.
+        End Sub
+
+        <WorkItem(233668, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems#_a=edit&id=233668")>
+        <Fact>
+        Public Sub EmptyNamespaceNames()
+            Dim ilSource = <![CDATA[
+.class public A
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+}
+.namespace '.N'
+{
+  .class public B
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace '.'
+{
+  .class public C
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace '..'
+{
+  .class public D
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace '..N'
+{
+  .class public E
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace N.M
+{
+  .class public F
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace 'N.M.'
+{
+  .class public G
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+.namespace 'N.M..'
+{
+  .class public H
+  {
+    .method public hidebysig specialname rtspecialname instance void .ctor() { ret }
+  }
+}
+]]>.Value
+            Dim vbSource =
+                <compilation>
+                    <file name="a.vb"/>
+                </compilation>
+            Dim comp = CreateCompilationWithCustomILSource(vbSource, ilSource)
+            comp.AssertTheseDiagnostics()
+            Dim builder = ArrayBuilder(Of String).GetInstance()
+            Dim [module] = comp.GetMember(Of NamedTypeSymbol)("A").ContainingModule
+            GetAllNamespaceNames(builder, [module].GlobalNamespace)
+            Assert.Equal({"Global", "", ".", "..N", ".N", "N", "N.M", "N.M."}, builder)
+        End Sub
+
+        Private Shared Sub GetAllNamespaceNames(builder As ArrayBuilder(Of String), [namespace] As NamespaceSymbol)
+            builder.Add([namespace].ToTestDisplayString())
+            For Each member In [namespace].GetMembers()
+                If member.Kind <> SymbolKind.Namespace Then
+                    Continue For
+                End If
+                GetAllNamespaceNames(builder, DirectCast(member, NamespaceSymbol))
+            Next
         End Sub
 
     End Class


### PR DESCRIPTION
**Customer scenario**
In a VB project, reference types from an assembly that contains a namespace with an empty string.

**Bugs this fixes:** 
Fixes 233668.

**Workarounds, if any**
Avoid referencing the assembly.

**Risk**
Low risk. The change is limited to empty namespaces in VB.

**Performance impact**
No performance impact.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
Crash report. Unit tests added.