### PR TITLE
Improve added reference encoding in project file.

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
@@ -529,12 +529,8 @@ namespace Microsoft.CodeAnalysis.MSBuild
             {
                 if (string.IsNullOrEmpty(s_frameworkRoot))
                 {
-                    s_frameworkRoot = Environment.GetEnvironmentVariable("FrameworkDir");
-
-                    if (string.IsNullOrEmpty(s_frameworkRoot))
-                    {
-                        s_frameworkRoot = Path.Combine(Environment.GetEnvironmentVariable("SystemRoot"), "Microsoft.Net", "Framework");
-                    }
+                    var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+                    s_frameworkRoot = Path.GetDirectoryName(runtimeDir); // back out one directory level to be root path of all framework versions
                 }
 
                 return s_frameworkRoot;

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -2829,7 +2829,7 @@ class C { }";
 
             var projFile = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             var projFileText = File.ReadAllText(projFile);
-            Assert.Equal(false, projFileText.Contains(@"<Reference Include=""System.Xaml"));
+            Assert.Equal(false, projFileText.Contains(@"System.Xaml"));
 
             using (var ws = MSBuildWorkspace.Create())
             {
@@ -2841,24 +2841,58 @@ class C { }";
                 // add reference to System.Xaml
                 ws.TryApplyChanges(project.AddMetadataReference(mref).Solution);
                 projFileText = File.ReadAllText(projFile);
-                Assert.Equal(true, projFileText.Contains(@"<Reference Include=""System.Xaml"));
+                Assert.Equal(true, projFileText.Contains(@"<Reference Include=""System.Xaml,"));
 
                 // remove reference to System.Xaml
                 ws.TryApplyChanges(ws.CurrentSolution.GetProject(project.Id).RemoveMetadataReference(mref).Solution);
                 projFileText = File.ReadAllText(projFile);
-                Assert.Equal(false, projFileText.Contains(@"<Reference Include=""System.Xaml"));
+                Assert.Equal(false, projFileText.Contains(@"<Reference Include=""System.Xaml,"));
             }
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
-        public void TestAddRemoveMetadataReference_NonGAC()
+        public void TestAddRemoveMetadataReference_ReferenceAssembly()
+        {
+            CreateFiles(GetMultiProjectSolutionFiles()
+                .WithFile(@"CSharpProject\CSharpProject.csproj", GetResourceText(@"CSharpProject_CSharpProject_WithSystemNumerics.csproj")));
+
+            var csProjFile = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
+            var csProjFileText = File.ReadAllText(csProjFile);
+            Assert.Equal(true, csProjFileText.Contains(@"<Reference Include=""System.Numerics"""));
+
+            var vbProjFile = GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj");
+            var vbProjFileText = File.ReadAllText(vbProjFile);
+            Assert.Equal(false, vbProjFileText.Contains(@"System.Numerics"));
+
+            using (var ws = MSBuildWorkspace.Create())
+            {
+                var solution = ws.OpenSolutionAsync(GetSolutionFileName("TestSolution.sln")).Result;
+                var csProject = solution.Projects.First(p => p.Language == LanguageNames.CSharp);
+                var vbProject = solution.Projects.First(p => p.Language == LanguageNames.VisualBasic);
+
+                var numericsMetadata = csProject.MetadataReferences.Single(m => m.Display.Contains("System.Numerics"));
+
+                // add reference to System.Xaml
+                ws.TryApplyChanges(vbProject.AddMetadataReference(numericsMetadata).Solution);
+                var newVbProjFileText = File.ReadAllText(vbProjFile);
+                Assert.Equal(true, newVbProjFileText.Contains(@"<Reference Include=""System.Numerics"""));
+
+                // remove reference MyAssembly.dll
+                ws.TryApplyChanges(ws.CurrentSolution.GetProject(vbProject.Id).RemoveMetadataReference(numericsMetadata).Solution);
+                var newVbProjFileText2 = File.ReadAllText(vbProjFile);
+                Assert.Equal(false, newVbProjFileText2.Contains(@"<Reference Include=""System.Numerics"""));
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestAddRemoveMetadataReference_NonGACorRefAssembly()
         {
             CreateFiles(GetSimpleCSharpSolutionFiles()
                 .WithFile(@"References\MyAssembly.dll", GetResourceBytes("EmptyLibrary.dll")));
 
             var projFile = GetSolutionFileName(@"CSharpProject\CSharpProject.csproj");
             var projFileText = File.ReadAllText(projFile);
-            Assert.Equal(false, projFileText.Contains(@"<Reference Include=""..\References\MyAssembly.dll"));
+            Assert.Equal(false, projFileText.Contains(@"MyAssembly"));
 
             using (var ws = MSBuildWorkspace.Create())
             {
@@ -2871,12 +2905,14 @@ class C { }";
                 // add reference to MyAssembly.dll
                 ws.TryApplyChanges(project.AddMetadataReference(mref).Solution);
                 projFileText = File.ReadAllText(projFile);
-                Assert.Equal(true, projFileText.Contains(@"<Reference Include=""..\References\MyAssembly.dll"));
+                Assert.Equal(true, projFileText.Contains(@"<Reference Include=""MyAssembly"""));
+                Assert.Equal(true, projFileText.Contains(@"<HintPath>..\References\MyAssembly.dll"));
 
                 // remove reference MyAssembly.dll
                 ws.TryApplyChanges(ws.CurrentSolution.GetProject(project.Id).RemoveMetadataReference(mref).Solution);
                 projFileText = File.ReadAllText(projFile);
-                Assert.Equal(false, projFileText.Contains(@"<Reference Include=""..\References\MyAssembly.dll"));
+                Assert.Equal(false, projFileText.Contains(@"<Reference Include=""MyAssembly"""));
+                Assert.Equal(false, projFileText.Contains(@"<HintPath>..\References\MyAssembly.dll"));
             }
         }
 

--- a/src/Workspaces/CoreTestUtilities/TestFiles/CSharpProject_CSharpProject_WithSystemNumerics.csproj
+++ b/src/Workspaces/CoreTestUtilities/TestFiles/CSharpProject_CSharpProject_WithSystemNumerics.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{686DD036-86AA-443E-8A10-DDB43266A8C4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CSharpProject</RootNamespace>
+    <AssemblyName>CSharpProject</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AssemblyOriginatorKeyFile>snKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CSharpClass.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Workspaces/CoreTestUtilities/WorkspacesTestUtilities.csproj
+++ b/src/Workspaces/CoreTestUtilities/WorkspacesTestUtilities.csproj
@@ -333,5 +333,10 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TestFiles\CSharpProject_CSharpProject_WithSystemNumerics.csproj">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="..\..\..\build\Targets\Imports.targets" />
 </Project>


### PR DESCRIPTION
This fixes issue #5959

When a workspace change adds a metadata reference to a project, this fix produces a simpler encoding of reference nodes in the project file when the assembly is a known framework assembly.  It also changes encoding of other reference paths to use HintPath to describe the relative full path and leaves the Include attribute with just the assembly name, which is what happens when you add a reference in VS.

@dotnet/roslyn-ide please review