### PR TITLE
Fix issue with IVsNavInfo for projects within solution folders

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/VsNavInfo/NavInfoFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/VsNavInfo/NavInfoFactory.cs
@@ -214,6 +214,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.VsNavIn
             if (hierarchy.TryGetParentHierarchy(out var parentHierarchy) && !(parentHierarchy is IVsSolution))
             {
                 var builder = SharedPools.Default<StringBuilder>().AllocateAndClear();
+                builder.Append(result);
 
                 while (parentHierarchy != null && !(parentHierarchy is IVsSolution))
                 {


### PR DESCRIPTION
Fixes #14462

In the VS 2015 Update 1 timeframe, I introduced a bug when moving code from new'ing up a StringBuilder to using a pooled StringBuilder. When it was new'ed up, the StringBuilder had been initialized with a value. When moving to a pooled StringBuilder, I forgot to initialize it with that value. This has the effect of producing an invalid IVsNavInfo for items in solution folders, which results in various features being broken in Class View and Object Browser (such as drag-drop from Class View into Class Designer).

For reference, here's the original code before using a pooled StringBuilder:

```C#
var builder = new StringBuilder(result);

while (parentHierarchy != null && !(parentHierarchy is IVsSolution))
{
    if (parentHierarchy.TryGetName(out var parentName))
    {
        builder.Insert(0, parentName + "\\");
    }

    if (!parentHierarchy.TryGetParentHierarchy(out parentHierarchy))
    {
        break;
    }
}

result = builder.ToString();
```

Tagging @dotnet/roslyn-ide for review.

Note: creating a test here is tricky. We don't have any facilities for creating solution folders in our test infrastructure. The would require a VS integration test.