### PR TITLE
Update to latest RoslynTools.Microsoft.VSIXExpInstaller

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -22,8 +22,8 @@
     <MicrosoftDiaSymReaderNativeVersion>1.5.0-beta1</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0-beta1-60831-01</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftVisualBasicVersion>10.0.1</MicrosoftVisualBasicVersion>
-    <RoslynToolsMicrosoftLocateVSVersion>0.2.0-beta</RoslynToolsMicrosoftLocateVSVersion>
-    <RoslynToolsMicrosoftSignToolVersion>0.2.0-beta</RoslynToolsMicrosoftSignToolVersion>
+    <RoslynToolsMicrosoftLocateVSVersion>0.2.2-beta</RoslynToolsMicrosoftLocateVSVersion>
+    <RoslynToolsMicrosoftSignToolVersion>0.2.2-beta</RoslynToolsMicrosoftSignToolVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.2.2-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
     <SystemAppContextVersion>4.1.0</SystemAppContextVersion>
     <SystemCollectionsVersion>4.0.11</SystemCollectionsVersion>

--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -24,7 +24,7 @@
     <MicrosoftVisualBasicVersion>10.0.1</MicrosoftVisualBasicVersion>
     <RoslynToolsMicrosoftLocateVSVersion>0.2.0-beta</RoslynToolsMicrosoftLocateVSVersion>
     <RoslynToolsMicrosoftSignToolVersion>0.2.0-beta</RoslynToolsMicrosoftSignToolVersion>
-    <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.2.1-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
+    <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.2.2-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
     <SystemAppContextVersion>4.1.0</SystemAppContextVersion>
     <SystemCollectionsVersion>4.0.11</SystemCollectionsVersion>
     <SystemCollectionsConcurrentVersion>4.0.12</SystemCollectionsConcurrentVersion>

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -15,7 +15,7 @@
     "RoslynDependencies.OptimizationData": "2.0.0-rc-61101-16",
     "RoslynTools.Microsoft.LocateVS": "0.2.0-beta",
     "RoslynTools.Microsoft.SignTool": "0.2.0-beta",
-    "RoslynTools.Microsoft.VSIXExpInstaller": "0.2.1-beta",
+    "RoslynTools.Microsoft.VSIXExpInstaller": "0.2.2-beta",
     "GitLink": "2.3.0"
 
   },

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -13,8 +13,8 @@
     "xunit.runner.console": "2.2.0-beta1-build3239",
     "Roslyn.Build.Util": "0.9.4-portable",
     "RoslynDependencies.OptimizationData": "2.0.0-rc-61101-16",
-    "RoslynTools.Microsoft.LocateVS": "0.2.0-beta",
-    "RoslynTools.Microsoft.SignTool": "0.2.0-beta",
+    "RoslynTools.Microsoft.LocateVS": "0.2.2-beta",
+    "RoslynTools.Microsoft.SignTool": "0.2.2-beta",
     "RoslynTools.Microsoft.VSIXExpInstaller": "0.2.2-beta",
     "GitLink": "2.3.0"
 


### PR DESCRIPTION
Pick up the latest RoslynTools.Microsoft.VSIXExpInstaller for installing VSIXes on Dev15 builds. This one has some fixes needed to get things to work properly with RC bits.