### PR TITLE
Enforce central build properties

### DIFF
--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -154,12 +154,9 @@ namespace BuildBoss
                 return true;
             }
 
-            return true;
-            /* Disabled while staging the closed / open change. 
             var allGood = CheckForProperty(textWriter, "CopyNuGetImplementations");
             allGood &= CheckForProperty(textWriter, "UseCommonOutputDirectory");
             return allGood;
-            */
         }
 
         /// <summary>


### PR DESCRIPTION
I recently did some work to centralize a couple of deployment properties in MSbuild: UseCommonOutputDirectory and CopyNuGetImplementations.  Individual projects should not be using these properties anymore as they are centrally controlled.  This just enforces that restriction.

**Customer scenario**

None: this is an infrastructure change

**Bugs this fixes:** 

None: this enforces projects are following our build correctness rules

**Risk**

None

**Performance impact**

None

