### PR TITLE
Fix local function capturing by another local function

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -665,7 +665,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // functions is performed in RemapLambdaOrLocalFunction, rather than here
                     // (since struct frame pointers should never be captured, but instead be
                     // passed in a list to the needed local functions).
-                    !(_innermostFramePointer is LocalSymbol local && local.Type.IsValueType))
+                    !(_innermostFramePointer.Kind == SymbolKind.Local &&
+                      ((LocalSymbol)_innermostFramePointer).Type.IsValueType))
                 {
                     var capturedFrame = LambdaCapturedVariable.Create(frame, _innermostFramePointer, ref _synthesizedFieldNameIdDispenser);
                     FieldSymbol frameParent = capturedFrame.AsMember(frameType);

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Attributes\AttributeTests_Synthesized.cs" />
     <Compile Include="Attributes\AttributeTests_Tuples.cs" />
     <Compile Include="Attributes\AttributeTests_WellKnownAttributes.cs" />
+    <Compile Include="CodeGen\CodeGenCapturing.cs" />
     <Compile Include="Emit\DesktopStrongNameProviderTests.cs" />
     <Compile Include="Attributes\InternalsVisibleToAndStrongNameTests.cs" />
     <Compile Include="Attributes\WellKnownAttributesTestBase.cs" />

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
@@ -416,6 +416,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 
             var fields = methods.First().CaptureContext.VariablesByScope[0];
 
+            const int PartitionSize = 50;
             const string ClassFmt = @"
 using System;
 public class C
@@ -425,7 +426,7 @@ public class C
                 => new StringBuilder(string.Format(ClassFmt,
                     string.Join("\r\n", fields.Select(f => $"public int {f} = 0;"))));
 
-            Parallel.ForEach(Partitioner.Create(0, methods.Count), (range, state) =>
+            Parallel.ForEach(Partitioner.Create(0, methods.Count, PartitionSize), (range, state) =>
             {
                 var methodsText = GetClassStart();
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
@@ -149,23 +149,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         {
             Assert.Equal(new[]
             {
-                new[] { 0 },
-                new[] { 1 },
-                new[] { 2 },
-                new[] { 3 }
+                ImmutableList<int>.Empty.Add(0),
+                ImmutableList<int>.Empty.Add(1),
+                ImmutableList<int>.Empty.Add(2),
+                ImmutableList<int>.Empty.Add(3)
             }, GenerateAllSetCombinations(3, 1));
             Assert.Equal(new[]
             {
-                new[] {0, 0},
-                new[] {0, 1},
-                new[] {0, 2},
-                new[] {0, 3},
-                new[] {1, 0},
-                new[] {1, 1},
-                new[] {1, 2},
-                new[] {2, 0},
-                new[] {2, 1},
-                new[] {3, 0}
+                ImmutableList<int>.Empty.Add(0).Add(0),
+                ImmutableList<int>.Empty.Add(0).Add(1),
+                ImmutableList<int>.Empty.Add(0).Add(2),
+                ImmutableList<int>.Empty.Add(0).Add(3),
+                ImmutableList<int>.Empty.Add(1).Add(0),
+                ImmutableList<int>.Empty.Add(1).Add(1),
+                ImmutableList<int>.Empty.Add(1).Add(2),
+                ImmutableList<int>.Empty.Add(2).Add(0),
+                ImmutableList<int>.Empty.Add(2).Add(1),
+                ImmutableList<int>.Empty.Add(3).Add(0)
             }, GenerateAllSetCombinations(3, 2));
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
@@ -1,0 +1,478 @@
+﻿
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using System.Collections;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    public class CodeGenCapturing : CSharpTestBase
+    {
+        private class CaptureContext
+        {
+            // Stores a mapping from scope index (0-based count of scopes
+            // from `this` to most nested scope)
+            public readonly List<IList<string>> VariablesByScope = new List<IList<string>>();
+
+            private CaptureContext() { }
+
+            public CaptureContext(int MaxVariables)
+            {
+                // Fields are shared among methods, so we also share them in the
+                // capture context when cloning
+                var fieldsBuilder = ImmutableArray.CreateBuilder<string>(MaxVariables);
+                for (int i = 0; i < MaxVariables; i++)
+                {
+                    fieldsBuilder.Add($"field_{i}");
+                }
+                VariablesByScope.Add(fieldsBuilder.MoveToImmutable());
+            }
+
+            public void Add(int depth, string varName)
+            {
+                if (VariablesByScope.Count <= depth ||
+                    VariablesByScope[depth] == null)
+                {
+                    VariablesByScope.Insert(depth, new List<string>() { varName });
+                }
+                else
+                {
+                    VariablesByScope[depth].Add(varName);
+                }
+            }
+
+            public CaptureContext Clone()
+            {
+                var fields = VariablesByScope[0];
+                var newCtx = new CaptureContext();
+                newCtx.VariablesByScope.Add(fields);
+                newCtx.VariablesByScope.AddRange(
+                    this.VariablesByScope
+                    .Skip(1)
+                    .Select(list => list == null ? null : new List<string>(list)));
+                newCtx.CaptureNameIndex = this.CaptureNameIndex;
+                return newCtx;
+            }
+
+            public int CaptureNameIndex = 0;
+        }
+
+        private string MakeLocalFunc(int nameIndex, string captureExpression)
+            => $@"int Local_{nameIndex}() => {captureExpression};";
+
+        private string MakeCaptureExpression(IList<int> varsToCapture, CaptureContext ctx)
+        {
+            var varNames = new List<string>();
+            for (int varDepth = 0; varDepth < varsToCapture.Count; varDepth++)
+            {
+                var variablesByScope = ctx.VariablesByScope;
+                // Do we have any variables in this scope depth?
+                // If not, initialize an empty list
+                if (variablesByScope.Count <= varDepth)
+                {
+                    variablesByScope.Add(new List<string>());
+                }
+
+                var varsAtCurrentDepth = variablesByScope[varDepth];
+
+                int numToCapture = varsToCapture[varDepth];
+                int numVarsAvailable = variablesByScope[varDepth].Count;
+                // If we have enough variables to capture in the context
+                // just add them
+                if (numVarsAvailable >= numToCapture)
+                {
+                    // Capture the last variables added since if there are more
+                    // vars in the context than the max vars to capture we'll never
+                    // have code coverage of the newest vars added to the context.
+                    varNames.AddRange(varsAtCurrentDepth
+                        .Skip(numVarsAvailable - numToCapture)
+                        .Take(numToCapture));
+                }
+                else
+                {
+                    // Not enough variables in the context -- add more
+                    for (int i = 0; i < numToCapture - numVarsAvailable; i++)
+                    {
+                        varsAtCurrentDepth.Add($"captureVar_{ctx.CaptureNameIndex++}");
+                    }
+
+                    varNames.AddRange(varsAtCurrentDepth);
+                }
+            }
+
+            return varNames.Count == 0 ? "0" : string.Join(" + ", varNames);
+        }
+
+        /// <summary>
+        /// Generates all combinations of distributing a sum to a list of subsets.
+        /// </summary>
+        private IEnumerable<IList<int>> GenerateAllSetCombinations(int sum, int numSubsets)
+        {
+            Assert.True(numSubsets > 0);
+            return GenerateAll(sum, 0, Array.Empty<int>());
+
+            IEnumerable<int[]> GenerateAll(
+                int remainingSum,
+                int setIndex, // 0-based index of subset we're generating
+                int[] setsSoFar)
+            {
+                for (int i = 0; i <= remainingSum; i++)
+                {
+                    var newArray = new int[setIndex + 1];
+                    Array.Copy(setsSoFar, newArray, setIndex);
+                    newArray[setIndex] = i;
+                    if (setIndex == numSubsets - 1)
+                    {
+                        yield return newArray;
+                    }
+                    else
+                    {
+                        foreach (var captures in GenerateAll(remainingSum - i,
+                                                             setIndex + 1,
+                                                             newArray))
+                        {
+                            yield return captures;
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void GenerateAllTest()
+        {
+            Assert.Equal(new[]
+            {
+                new[] { 0 },
+                new[] { 1 },
+                new[] { 2 },
+                new[] { 3 }
+            }, GenerateAllSetCombinations(3, 1));
+            Assert.Equal(new[]
+            {
+                new[] {0, 0},
+                new[] {0, 1},
+                new[] {0, 2},
+                new[] {0, 3},
+                new[] {1, 0},
+                new[] {1, 1},
+                new[] {1, 2},
+                new[] {2, 0},
+                new[] {2, 1},
+                new[] {3, 0}
+            }, GenerateAllSetCombinations(3, 2));
+        }
+
+        [Fact]
+        public void ExpressionGeneratorTest01()
+        {
+            var ctx = new CaptureContext(1);
+            int[] captures = { 1 }; // Capture 1 var at the 0 depth
+            var expr = MakeCaptureExpression(captures, ctx);
+            Assert.Equal("field_0", expr);
+            VerifyContext(new[]
+            {
+                new[] { "field_0"}
+            }, ctx.VariablesByScope);
+
+            ctx = new CaptureContext(3);
+            captures = new[] { 3 }; // Capture 3 vars at 0 depth
+            expr = MakeCaptureExpression(captures, ctx);
+            Assert.Equal("field_0 + field_1 + field_2", expr);
+            VerifyContext(new[]
+            {
+                new[] { "field_0", "field_1", "field_2" }
+            }, ctx.VariablesByScope);
+
+            ctx = new CaptureContext(3);
+            captures = new[] { 1, 1, 1 }; // Capture 1 var at each of 3 depths
+            expr = MakeCaptureExpression(captures, ctx);
+            Assert.Equal("field_2 + captureVar_0 + captureVar_1", expr);
+            VerifyContext(new[]
+            {
+                new[] { "field_0", "field_1", "field_2"},
+                new[] { "captureVar_0"},
+                new[] { "captureVar_1"}
+            }, ctx.VariablesByScope);
+
+            void VerifyContext(IList<IEnumerable<string>> expectedCtx, List<IList<string>> actualCtx)
+            {
+                Assert.Equal(expectedCtx.Count, ctx.VariablesByScope.Count);
+                for (int depth = 0; depth < expectedCtx.Count; depth++)
+                {
+                    AssertEx.Equal(expectedCtx[depth], ctx.VariablesByScope[depth]);
+                }
+            }
+        }
+        private struct LayoutEnumerator : IEnumerator<(int depth, int localFuncIndex)>
+        {
+            private readonly IList<int> _layout;
+            private (int depth, int localFuncIndex) _current;
+
+            public LayoutEnumerator(IList<int> layout)
+            {
+                _layout = layout;
+                _current = (-1, -1);
+            }
+
+            public (int depth, int localFuncIndex) Current => _current;
+
+            object IEnumerator.Current => throw new NotImplementedException();
+
+            public void Dispose() => throw new NotImplementedException();
+
+            public bool MoveNext()
+            {
+                if (_current.depth < 0)
+                {
+                    return FindNonEmptyDepth(0, _layout, out _current);
+                }
+                else
+                {
+                    int newIndex = _current.localFuncIndex + 1;
+                    if (newIndex == _layout[_current.depth])
+                    {
+                        return FindNonEmptyDepth(_current.depth + 1, _layout, out _current);
+                    }
+
+                    _current = (_current.depth, newIndex);
+                    return true;
+                }
+
+                bool FindNonEmptyDepth(int startingDepth, IList<int> layout, out (int depth, int localFuncIndex) newCurrent)
+                {
+                    for (int depth = startingDepth; depth < layout.Count; depth++)
+                    {
+                        if (layout[depth] > 0)
+                        {
+                            newCurrent = (depth, 0);
+                            return true;
+                        }
+                    }
+                    newCurrent = (layout.Count, 0);
+                    return false;
+                }
+            }
+
+            public void Reset() => throw new NotImplementedException();
+        }
+
+        private class MethodInfo
+        {
+            public MethodInfo(int MaxCaptures)
+            {
+                LocalFuncs = new List<IList<string>>();
+                CaptureContext = new CaptureContext(MaxCaptures);
+            }
+
+            private MethodInfo() { }
+
+            public List<IList<string>> LocalFuncs { get; private set; }
+
+            public CaptureContext CaptureContext { get; private set; }
+
+            public int TotalLocalFuncs { get; set; }
+
+            public MethodInfo Clone()
+            {
+                return new MethodInfo
+                {
+                    LocalFuncs = this.LocalFuncs
+                        .Select(x => x == null 
+                                     ? null 
+                                     : (IList<string>)new List<string>(x)).ToList(),
+                    CaptureContext = this.CaptureContext.Clone()
+                };
+            }
+        }
+
+        private IEnumerable<MethodInfo> MakeMethodsWithLayout(IList<int> localFuncLayout)
+        {
+            const int MaxCaptures = 3;
+
+            var enumerator = new LayoutEnumerator(localFuncLayout);
+            if (!enumerator.MoveNext())
+            {
+                return Array.Empty<MethodInfo>();
+            }
+
+            var methods = new List<MethodInfo>();
+            DfsLayout(enumerator, new MethodInfo(MaxCaptures), 0);
+            return methods;
+
+            // Note that the enumerator is a struct, so every new var
+            // is a copy
+            void DfsLayout(LayoutEnumerator e, MethodInfo methodSoFar, int localFuncNameIndex)
+            {
+                var (depth, localFuncIndex) = e.Current;
+
+                bool isLastFunc = !e.MoveNext();
+
+                foreach (var captureCombo in GenerateAllSetCombinations(MaxCaptures, depth + 1))
+                {
+                    var copy = methodSoFar.Clone();
+                    var expr = MakeCaptureExpression(captureCombo, copy.CaptureContext);
+                    if (depth >= copy.LocalFuncs.Count)
+                    {
+                        copy.LocalFuncs.AddRange(Enumerable.Repeat<List<string>>(null, depth - copy.LocalFuncs.Count));
+                        copy.LocalFuncs.Insert(depth, new List<string>());
+                    }
+                    copy.LocalFuncs[depth].Add($"int Local_{localFuncNameIndex}() => {expr};");
+
+                    if (!isLastFunc)
+                    {
+                        DfsLayout(e, copy, localFuncNameIndex + 1);
+                    }
+                    else
+                    {
+                        copy.TotalLocalFuncs = localFuncNameIndex + 1;
+                        methods.Add(copy);
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<MethodInfo> MakeAllMethods()
+        {
+            const int MaxDepth = 3;
+            const int MaxLocalFuncs = 3;
+
+            // Set combinations indicate what depth we will place local functions
+            // at. For instance, { 0, 1 } indicates 0 local functions at method
+            // depth and 1 local function at one nested scope below method level.
+            foreach (var localFuncLayout in GenerateAllSetCombinations(MaxLocalFuncs, MaxDepth + 1))
+            {
+                // Given a local function map, we need to generate capture
+                // expressions for each local func at each depth
+                foreach (var method in MakeMethodsWithLayout(localFuncLayout))
+                    yield return method;
+            }
+        }
+
+        private void SerializeMethod(MethodInfo methodInfo, StringBuilder builder, ref int methodIndex)
+        {
+            int totalLocalFuncs = methodInfo.TotalLocalFuncs;
+            if (totalLocalFuncs == 0)
+            {
+                return;
+            }
+
+            var methodText = new StringBuilder();
+            var localFuncs = methodInfo.LocalFuncs;
+            for (int depth = 0; depth < localFuncs.Count; depth++)
+            {
+                if (depth > 0)
+                {
+                    methodText.Append(' ', 4 * (depth + 1));
+                    methodText.AppendLine("{");
+                }
+
+                var captureVars = methodInfo.CaptureContext.VariablesByScope;
+                if (captureVars.Count > (depth + 1) &&
+                    captureVars[depth + 1] != null)
+                {
+                    foreach (var captureVar in captureVars[depth + 1])
+                    {
+                        methodText.Append(' ', 4 * (depth + 2));
+                        methodText.AppendLine($"int {captureVar} = 0;");
+                    }
+                }
+
+                if (localFuncs[depth] != null)
+                {
+                    foreach (var localFunc in localFuncs[depth])
+                    {
+                        methodText.Append(' ', 4 * (depth + 2));
+                        methodText.AppendLine(localFunc);
+                    }
+                }
+            }
+
+            var localFuncCalls = string.Join(" + ",
+                Enumerable.Range(0, totalLocalFuncs).Select(f => $"Local_{f}()"));
+            methodText.AppendLine($"Console.WriteLine({localFuncCalls});");
+
+            for (int depth = localFuncs.Count - 1; depth > 0; depth--)
+            {
+                methodText.Append(' ', 4 * (depth + 1));
+                methodText.AppendLine("}");
+            }
+
+            builder.Append($@"
+    public void M_{methodIndex++}()
+    {{
+{methodText.ToString()}
+    }}");
+
+        }
+
+        [Fact]
+        public void AllCaptureTests()
+        {
+            var methods = MakeAllMethods();
+
+            var fields = methods.First().CaptureContext.VariablesByScope[0];
+            var fieldClass = $@"
+partial class C
+{{
+    {string.Join("\r\n", fields.Select(f => $"int {f} = 0;"))}
+}}";
+
+            const int ChunkSize = 50;
+
+            var methodsText = new StringBuilder();
+            int methodIndex = 0;
+
+            int chunkStart = 0;
+
+            foreach (var methodInfo in methods)
+            {
+                SerializeMethod(methodInfo, methodsText, ref methodIndex);
+
+                if (methodIndex % ChunkSize == 0)
+                {
+                    RunChunkedTest(methodsText.ToString(),
+                                   chunkStart,
+                                   methodIndex - chunkStart);
+
+                    methodsText = new StringBuilder();
+                    chunkStart = methodIndex;
+                }
+            }
+
+            if (methodIndex % ChunkSize != 0)
+            {
+                RunChunkedTest(methodsText.ToString(),
+                               chunkStart,
+                               methodIndex - chunkStart);
+            }
+
+            void RunChunkedTest(string text, int chunkStartIndex, int numMethods)
+            {
+                var src = $@"
+using System;
+partial class C
+{{
+    {text}
+
+    public static void Main(string[] args)
+    {{
+        var c = new C();
+        {string.Join("\r\n        ",
+                Enumerable.Range(chunkStartIndex, numMethods)
+                          .Select(i => $"c.M_{i}();"))}
+    }}
+}}
+{fieldClass}";
+                CompileAndVerify(src,
+                    expectedOutput: string.Join("\r\n", Enumerable.Repeat("0", numMethods)));
+            }
+        }
+
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
@@ -416,7 +416,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 
             var fields = methods.First().CaptureContext.VariablesByScope[0];
 
-            const int PartitionSize = 50;
+            const int PartitionSize = 500;
             const string ClassFmt = @"
 using System;
 public class C

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCapturing.cs
@@ -64,10 +64,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             public int CaptureNameIndex = 0;
         }
 
-        private string MakeLocalFunc(int nameIndex, string captureExpression)
+        private static string MakeLocalFunc(int nameIndex, string captureExpression)
             => $@"int Local_{nameIndex}() => {captureExpression};";
 
-        private string MakeCaptureExpression(IList<int> varsToCapture, CaptureContext ctx)
+        private static string MakeCaptureExpression(IList<int> varsToCapture, CaptureContext ctx)
         {
             var varNames = new List<string>();
             for (int varDepth = 0; varDepth < varsToCapture.Count; varDepth++)
@@ -114,30 +114,28 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         /// Generates all combinations of distributing a sum to a list of subsets.
         /// This is equivalent to the "stars and bars" combinatorics construction.
         /// </summary>
-        private IEnumerable<IList<int>> GenerateAllSetCombinations(int sum, int numSubsets)
+        private static IEnumerable<IList<int>> GenerateAllSetCombinations(int sum, int numSubsets)
         {
             Assert.True(numSubsets > 0);
-            return GenerateAll(sum, 0, Array.Empty<int>());
+            return GenerateAll(sum, 0, ImmutableList<int>.Empty);
 
-            IEnumerable<int[]> GenerateAll(
+            IEnumerable<ImmutableList<int>> GenerateAll(
                 int remainingSum,
                 int setIndex, // 0-based index of subset we're generating
-                int[] setsSoFar)
+                ImmutableList<int> setsSoFar)
             {
                 for (int i = 0; i <= remainingSum; i++)
                 {
-                    var newArray = new int[setIndex + 1];
-                    Array.Copy(setsSoFar, newArray, setIndex);
-                    newArray[setIndex] = i;
+                    var newSets = setsSoFar.Add(i);
                     if (setIndex == numSubsets - 1)
                     {
-                        yield return newArray;
+                        yield return newSets;
                     }
                     else
                     {
                         foreach (var captures in GenerateAll(remainingSum - i,
                                                              setIndex + 1,
-                                                             newArray))
+                                                             newSets))
                         {
                             yield return captures;
                         }
@@ -294,7 +292,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             }
         }
 
-        private IEnumerable<MethodInfo> MakeMethodsWithLayout(IList<int> localFuncLayout)
+        private static IEnumerable<MethodInfo> MakeMethodsWithLayout(IList<int> localFuncLayout)
         {
             const int MaxCaptures = 3;
 
@@ -342,7 +340,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             }
         }
 
-        private IEnumerable<MethodInfo> MakeAllMethods()
+        private static IEnumerable<MethodInfo> MakeAllMethods()
         {
             const int MaxDepth = 3;
             const int MaxLocalFuncs = 3;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3093,12 +3093,12 @@ void Assign() { x = 5; }";
             var src = @"
 using System;
 public class C {
-    int instance = 0;
+    int instance = 11;
     public void M() {
         int M() => instance;
 
         {
-            int local = 0;
+            int local = 11;
             bool M2() => local == M();
             Console.WriteLine(M2());
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3086,6 +3086,53 @@ void Assign() { x = 5; }";
             VerifyOutputInMain(src, "5");
         }
 
+        [Fact]
+        [WorkItem(15599, "https://github.com/dotnet/roslyn/issues/15599")]
+        public void NestedLocalFuncCapture()
+        {
+            var src = @"
+using System;
+public class C {
+    int instance = 0;
+    public void M() {
+        int M() => instance;
+
+        {
+            int local = 0;
+            bool M2() => local == M();
+            Console.WriteLine(M2());
+        }
+    }
+
+    public static void Main() => new C().M();
+}";
+            VerifyOutput(src, "True");
+        }
+
+        [Fact]
+        [WorkItem(15599, "https://github.com/dotnet/roslyn/issues/15599")]
+        public void NestedLocalFuncCapture2()
+        {
+            var src = @"
+using System;
+public class C {
+    int instance = 0b1;
+    public void M() {
+        int var1 = 0b10;
+        int M() => var1 + instance;
+
+        {
+            int local = 0b100;
+            int M2() => local + M();
+            Console.WriteLine(M2());
+        }
+    }
+
+    public static void Main() => new C().M();
+}";
+            VerifyOutput(src, "7");
+        }
+
         internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options)
         {
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: options);

--- a/src/Test/Utilities/Desktop/CommonTestBase.cs
+++ b/src/Test/Utilities/Desktop/CommonTestBase.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         }
 
         internal CompilationVerifier CompileAndVerify(
-            string[] sources,
+            IEnumerable<string> sources,
             IEnumerable<MetadataReference> additionalRefs = null,
             IEnumerable<ModuleData> dependencies = null,
             Action<IModuleSymbol> sourceSymbolValidator = null,


### PR DESCRIPTION
**Customer scenario**

See #15599. The program must contain a local function which captures another local function not in the same scope and also captures a variable in a different scope from the captured local function.

The fix is to avoid capturing frame pointers if the frame type is a struct. If the frame is a struct then frame pointers are not captured, like in lambdas, they are passed sequentially to the capturing local function as by-ref parameters.

**Bugs this fixes:** 

#15599

**Workarounds, if any**

Capturing can be avoided and variables can be passed as parameters to local functions, but this workaround is difficult to figure out, since the compiler crashes on the given input.

**Risk**

This change is restricted to scenarios with local function lowering.

**Performance impact**

Low. This change prevents an extra code path from being taken, so if anything it is likely to increase performance.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This is another case where too complex of a scenario (more capturing) doesn't show the problem and not complex enough (less capturing) also doesn't show the problem. It's a Goldilocks bug.

To help catch these bugs, this fix contains a new test that tries to brute force check every possible capturing combination for local functions within a certain complexity bound. When tested against this bug it found the issue independently through two completely different code paths.

**How was the bug found?**

Customer reported.