### PR TITLE
Remove EmitContext from ITypeReference.TypeCode

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/ArrayTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/ArrayTypeSymbolAdapter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         bool Cci.ITypeReference.IsValueType => false;
 
         TypeDefinitionHandle Cci.ITypeReference.TypeDef => default(TypeDefinitionHandle);
-        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context) => Cci.PrimitiveTypeCode.NotPrimitive;
+        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode => Cci.PrimitiveTypeCode.NotPrimitive;
 
         Cci.ITypeDefinition Cci.ITypeReference.GetResolvedType(EmitContext context) => null;
         Cci.IGenericMethodParameterReference Cci.ITypeReference.AsGenericMethodParameterReference => null;

--- a/src/Compilers/CSharp/Portable/Emitter/Model/DynamicTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/DynamicTypeSymbolAdapter.cs
@@ -29,9 +29,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context)
+        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode
         {
-            return Cci.PrimitiveTypeCode.NotPrimitive;
+            get { return Cci.PrimitiveTypeCode.NotPrimitive; }
         }
 
         TypeDefinitionHandle Cci.ITypeReference.TypeDef

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeReference.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeReference.cs
@@ -65,9 +65,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return null;
         }
 
-        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context)
+        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode
         {
-            return Cci.PrimitiveTypeCode.NotPrimitive;
+            get
+            {
+                return Cci.PrimitiveTypeCode.NotPrimitive;
+            }
         }
 
         TypeDefinitionHandle Cci.ITypeReference.TypeDef

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -43,16 +43,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return AsTypeDefinitionImpl(moduleBeingBuilt);
         }
 
-        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context)
+        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode
         {
-            Debug.Assert(this.IsDefinitionOrDistinct());
-
-            if (this.IsDefinition)
+            get
             {
-                return this.PrimitiveTypeCode;
-            }
+                Debug.Assert(this.IsDefinitionOrDistinct());
 
-            return Cci.PrimitiveTypeCode.NotPrimitive;
+                if (this.IsDefinition)
+                {
+                    return this.PrimitiveTypeCode;
+                }
+
+                return Cci.PrimitiveTypeCode.NotPrimitive;
+            }
         }
 
         TypeDefinitionHandle Cci.ITypeReference.TypeDef

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PointerTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PointerTypeSymbolAdapter.cs
@@ -38,9 +38,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context)
+        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode
         {
-            return Cci.PrimitiveTypeCode.Pointer;
+            get { return Cci.PrimitiveTypeCode.Pointer; }
         }
 
         TypeDefinitionHandle Cci.ITypeReference.TypeDef

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -34,9 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return null;
         }
 
-        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context)
+        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode
         {
-            return Cci.PrimitiveTypeCode.NotPrimitive;
+            get { return Cci.PrimitiveTypeCode.NotPrimitive; }
         }
 
         TypeDefinitionHandle Cci.ITypeReference.TypeDef

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public Cci.ITypeDefinition GetResolvedType(EmitContext context) => this;
 
-        public Cci.PrimitiveTypeCode TypeCode(EmitContext context) => Cci.PrimitiveTypeCode.NotPrimitive;
+        public Cci.PrimitiveTypeCode TypeCode => Cci.PrimitiveTypeCode.NotPrimitive;
 
         public TypeDefinitionHandle TypeDef
         {

--- a/src/Compilers/Core/Portable/Emit/ErrorType.cs
+++ b/src/Compilers/Core/Portable/Emit/ErrorType.cs
@@ -72,9 +72,12 @@ namespace Microsoft.CodeAnalysis.Emit
             return null;
         }
 
-        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context)
+        Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode
         {
-            return Cci.PrimitiveTypeCode.NotPrimitive;
+            get
+            {
+                return Cci.PrimitiveTypeCode.NotPrimitive;
+            }
         }
 
         TypeDefinitionHandle Cci.ITypeReference.TypeDef

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -567,9 +567,12 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 return this;
             }
 
-            Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context)
+            Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode
             {
-                return Cci.PrimitiveTypeCode.NotPrimitive;
+                get
+                {
+                    return Cci.PrimitiveTypeCode.NotPrimitive;
+                }
             }
 
             TypeDefinitionHandle Cci.ITypeReference.TypeDef

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedTypeParameter.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedTypeParameter.cs
@@ -126,9 +126,12 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 return null;
             }
 
-            Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode(EmitContext context)
+            Cci.PrimitiveTypeCode Cci.ITypeReference.TypeCode
             {
-                return Cci.PrimitiveTypeCode.NotPrimitive;
+                get
+                {
+                    return Cci.PrimitiveTypeCode.NotPrimitive;
+                }
             }
 
             TypeDefinitionHandle Cci.ITypeReference.TypeDef

--- a/src/Compilers/Core/Portable/PEWriter/InheritedTypeParameter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/InheritedTypeParameter.cs
@@ -232,9 +232,9 @@ namespace Microsoft.Cci
             throw ExceptionUtilities.Unreachable;
         }
 
-        public PrimitiveTypeCode TypeCode(EmitContext context)
+        public PrimitiveTypeCode TypeCode
         {
-            return PrimitiveTypeCode.NotPrimitive;
+            get { return PrimitiveTypeCode.NotPrimitive; }
         }
 
         #endregion

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Cci
             SerializeCustomModifiers(encoder, localConstant.CustomModifiers);
 
             var type = localConstant.Type;
-            var typeCode = type.TypeCode(Context);
+            var typeCode = type.TypeCode;
 
             object value = localConstant.CompileTimeValue.Value;
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1235,7 +1235,7 @@ namespace Microsoft.Cci
 
         internal PrimitiveTypeCode GetConstantTypeCode(ILocalDefinition constant)
         {
-            return constant.CompileTimeValue.Type.TypeCode(Context);
+            return constant.CompileTimeValue.Type.TypeCode;
         }
 
         private BlobHandle GetPermissionSetBlobHandle(ImmutableArray<ICustomAttribute> permissionSet)
@@ -3635,7 +3635,7 @@ namespace Microsoft.Cci
 
                 // TYPEDREF is only allowed in RetType, Param, LocalVarSig signatures
                 Debug.Assert(!module.IsPlatformType(typeReference, PlatformType.SystemTypedReference));
-				
+
                 var modifiedTypeReference = typeReference as IModifiedTypeReference;
                 if (modifiedTypeReference != null)
                 {
@@ -3644,7 +3644,7 @@ namespace Microsoft.Cci
                     continue;
                 }
 
-                var primitiveType = typeReference.TypeCode(Context);
+                var primitiveType = typeReference.TypeCode;
                 if (primitiveType != PrimitiveTypeCode.Pointer && primitiveType != PrimitiveTypeCode.NotPrimitive)
                 {
                     SerializePrimitiveType(encoder, primitiveType);
@@ -3837,7 +3837,7 @@ namespace Microsoft.Cci
             // ELEMENT_TYPE_U4, ELEMENT_TYPE_I8, ELEMENT_TYPE_U8, ELEMENT_TYPE_R4, ELEMENT_TYPE_R8, ELEMENT_TYPE_STRING.
             // An enum is specified as a single byte 0x55 followed by a SerString.
 
-            var primitiveType = typeReference.TypeCode(Context);
+            var primitiveType = typeReference.TypeCode;
             if (primitiveType != PrimitiveTypeCode.NotPrimitive)
             {
                 SerializePrimitiveType(encoder, primitiveType);

--- a/src/Compilers/Core/Portable/PEWriter/ModifiedTypeReference.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ModifiedTypeReference.cs
@@ -55,9 +55,9 @@ namespace Microsoft.Cci
             throw ExceptionUtilities.Unreachable;
         }
 
-        PrimitiveTypeCode ITypeReference.TypeCode(EmitContext context)
+        PrimitiveTypeCode ITypeReference.TypeCode
         {
-            return PrimitiveTypeCode.NotPrimitive;
+            get { return PrimitiveTypeCode.NotPrimitive; }
         }
 
         TypeDefinitionHandle ITypeReference.TypeDef

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Cci
 
         public override void Visit(INamespaceTypeReference namespaceTypeReference)
         {
-            if (!this.typeReferenceNeedsToken && namespaceTypeReference.TypeCode(Context) != PrimitiveTypeCode.NotPrimitive)
+            if (!this.typeReferenceNeedsToken && namespaceTypeReference.TypeCode != PrimitiveTypeCode.NotPrimitive)
             {
                 return;
             }
@@ -416,7 +416,7 @@ namespace Microsoft.Cci
 
             INestedTypeReference/*?*/ nestedTypeReference = typeReference.AsNestedTypeReference;
             if (this.typeReferenceNeedsToken || nestedTypeReference != null ||
-              (typeReference.TypeCode(Context) == PrimitiveTypeCode.NotPrimitive && typeReference.AsNamespaceTypeReference != null))
+              (typeReference.TypeCode == PrimitiveTypeCode.NotPrimitive && typeReference.AsNamespaceTypeReference != null))
             {
                 ISpecializedNestedTypeReference/*?*/ specializedNestedTypeReference = nestedTypeReference?.AsSpecializedNestedTypeReference;
                 if (specializedNestedTypeReference != null)

--- a/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
+++ b/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
@@ -202,9 +202,9 @@ namespace Microsoft.Cci
             return this;
         }
 
-        PrimitiveTypeCode ITypeReference.TypeCode(EmitContext context)
+        PrimitiveTypeCode ITypeReference.TypeCode
         {
-            throw ExceptionUtilities.Unreachable;
+            get { throw ExceptionUtilities.Unreachable; }
         }
 
         ushort INamedTypeReference.GenericParameterCount

--- a/src/Compilers/Core/Portable/PEWriter/Types.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Types.cs
@@ -605,7 +605,7 @@ namespace Microsoft.Cci
         /// Unless the value of TypeCode is PrimitiveTypeCode.NotPrimitive, the type corresponds to a "primitive" CLR type (such as System.Int32) and
         /// the type code identifies which of the primitive types it corresponds to.
         /// </summary>
-        PrimitiveTypeCode TypeCode(EmitContext context);
+        PrimitiveTypeCode TypeCode { get; }
 
         /// <summary>
         /// TypeDefs defined in modules linked to the assembly being emitted are listed in the ExportedTypes table.

--- a/src/Compilers/VisualBasic/Portable/Emit/ArrayTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/ArrayTypeSymbolAdapter.vb
@@ -61,9 +61,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
-        Private Function ITypeReferenceTypeCode(context As EmitContext) As Cci.PrimitiveTypeCode Implements Cci.ITypeReference.TypeCode
-            Return Cci.PrimitiveTypeCode.NotPrimitive
-        End Function
+        Private ReadOnly Property ITypeReferenceTypeCode As Cci.PrimitiveTypeCode Implements Cci.ITypeReference.TypeCode
+            Get
+                Return Cci.PrimitiveTypeCode.NotPrimitive
+            End Get
+        End Property
 
         Private ReadOnly Property ITypeReferenceTypeDef As TypeDefinitionHandle Implements Cci.ITypeReference.TypeDef
             Get

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeReference.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeReference.vb
@@ -51,9 +51,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return Nothing
         End Function
 
-        Private Function ITypeReferenceTypeCode(context As EmitContext) As Cci.PrimitiveTypeCode Implements Cci.ITypeReference.TypeCode
-            Return Cci.PrimitiveTypeCode.NotPrimitive
-        End Function
+        Private ReadOnly Property ITypeReferenceTypeCode As Cci.PrimitiveTypeCode Implements Cci.ITypeReference.TypeCode
+            Get
+                Return Cci.PrimitiveTypeCode.NotPrimitive
+            End Get
+        End Property
 
         Private ReadOnly Property ITypeReferenceTypeDef As TypeDefinitionHandle Implements Cci.ITypeReference.TypeDef
             Get

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -42,14 +42,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return AsTypeDefinitionImpl(moduleBeingBuilt)
         End Function
 
-        Private Function ITypeReferenceTypeCode(context As EmitContext) As Cci.PrimitiveTypeCode Implements ITypeReference.TypeCode
-            Debug.Assert(Not Me.IsAnonymousType)
-            Debug.Assert(Me.IsDefinitionOrDistinct())
-            If Me.IsDefinition Then
-                Return Me.PrimitiveTypeCode
-            End If
-            Return Cci.PrimitiveTypeCode.NotPrimitive
-        End Function
+        Private ReadOnly Property ITypeReferenceTypeCode As Cci.PrimitiveTypeCode Implements ITypeReference.TypeCode
+            Get
+                Debug.Assert(Not Me.IsAnonymousType)
+                Debug.Assert(Me.IsDefinitionOrDistinct())
+                If Me.IsDefinition Then
+                    Return Me.PrimitiveTypeCode
+                End If
+                Return Cci.PrimitiveTypeCode.NotPrimitive
+            End Get
+        End Property
 
         Private ReadOnly Property ITypeReferenceTypeDef As TypeDefinitionHandle Implements ITypeReference.TypeDef
             Get

--- a/src/Compilers/VisualBasic/Portable/Emit/TypeParameterSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/TypeParameterSymbolAdapter.vb
@@ -32,9 +32,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
-        Private Function ITypeReferenceTypeCode(context As EmitContext) As Cci.PrimitiveTypeCode Implements ITypeReference.TypeCode
-            Return Cci.PrimitiveTypeCode.NotPrimitive
-        End Function
+        Private ReadOnly Property ITypeReferenceTypeCode As Cci.PrimitiveTypeCode Implements ITypeReference.TypeCode
+            Get
+                Return Cci.PrimitiveTypeCode.NotPrimitive
+            End Get
+        End Property
 
         Private ReadOnly Property ITypeReferenceTypeDef As TypeDefinitionHandle Implements ITypeReference.TypeDef
             Get

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/NamespaceTypeDefinitionNoBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/NamespaceTypeDefinitionNoBase.cs
@@ -113,6 +113,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 
         IEnumerable<TypeReferenceWithAttributes> ITypeDefinition.Interfaces(EmitContext context) => UnderlyingType.Interfaces(context);
 
-        Cci.PrimitiveTypeCode ITypeReference.TypeCode(EmitContext context) => UnderlyingType.TypeCode(context);
+        Cci.PrimitiveTypeCode ITypeReference.TypeCode => UnderlyingType.TypeCode;
     }
 }


### PR DESCRIPTION
**Customer scenario**

Removing dead code to help Watson investigations.  This particular method showed up as a part of a Watson dump investigation.  It's presence forced us to consider possibilities around when two similar APIs could return different values based on the content of the EmitContext parameter.  In reality though EmitContext is never used in these implementations and the compiler team was just wasting time investigating this possibility.  

Removing to add clarity to this scenario and make future Watson hits easier to process. 

**Risk**

None.  It's removing dead code. 

**Performance impact**

None. 

This parameter is no longer necessary for any implementation of ITypeReference.  The presence of this parameter cause the compiler team to spend a considerable amount of time digging down a wrong path in a watson bug.  Removing because it's dead code and makes the calling code cleaner to process.