### PR TITLE
Updating the BuildNumber to be 00065535.0 if no BuildNumber was specied.

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- This controls the version numbers of the build that we are producing -->
@@ -22,9 +24,11 @@
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
     <Error Condition="'$(BuildNumber)' == '' AND '$(OfficialBuild)' == 'true'">A build number must be specified for a signed build.</Error>
 
-    <!-- When a build number is not specified, then we should default back to '00000000.0', which is a build number in the
-         same format as provided by MicroBuild v2, but with all digits set to zero. -->
-    <BuildNumber Condition="'$(BuildNumber)' == ''">00000000.0</BuildNumber>
+    <!-- When a build number is not specified, then we should default back to '00065535.0', which is a build number in the
+         same format as provided by MicroBuild v2, but greater than any that MicroBuild v2 will produce, and is still compatible
+         with the Win32 file version limitations. This is required so that builds done locally, where '$(OfficialBuild)' == 'true',
+         can still be deployed to VS and override the version that is globally installed. -->
+    <BuildNumber Condition="'$(BuildNumber)' == ''">00065535.0</BuildNumber>
     <!-- When a build number is specified, it needs to be in the format of 'x.y' -->
     <Error Condition="$(BuildNumber.Split('.').Length) != 2">BuildNumber should have two parts (in the form of 'x.y')</Error>
 


### PR DESCRIPTION
FYI. @jasonmalinowski, @jmarolf, @tmeschter, @dotnet/roslyn-infrastructure 

For `-OfficialBuild` where `BuildNumber` was not specified, we were specifying our own value of `00000000.0`. This caused our VSIX to have a version of `$(RoslynFileVersionBase).$(BuildNumberFiveDigitDateStamp)$(BuildNumberBuildOfTheDayPadded)` (so 2.0.0.0000000 currently).

If you are trying to deploy said bits onto a Dev15 build (say today's, which has 2.0.0.6120504), the installation will fail because the version you are attempting to deploy is less than the version installed.

This sets our value to be `00065535.0`, which results in a BuildNumberFiveDigitDateStamp of `65535` and a BuildNumberBuildOfTheDayPadded of `00`. This gives us a VSIX version of `2.0.0.6553500`, which is higher than any build number provided by MicroBuild v2 and is still compliant with the Win32 versioning limitations (65535 will be used in the file version).

We can freely uninstall locally installed versions (since they don't require admin privileges to uninstall, like globally installed ones do). So it is not a concern if the locally installed version is less than or equal to the version we are attempting to deploy (only that it is greater than the globally installed one).