### PR TITLE
Don't offer to inline a variable if it would cause a definite assignment error.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/UsePatternMatching/CSharpAsAndNullCheckTests.cs
@@ -362,5 +362,74 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestDefiniteAssignment1()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    void M()
+    {
+        [|var|] x = o as string;
+        if (x != null && x.Length > 0)
+        {
+        }
+        else if (x != null)
+        {
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestDefiniteAssignment2()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    void M()
+    {
+        [|var|] x = o as string;
+        if (x != null && x.Length > 0)
+        {
+        }
+
+        Console.WriteLine(x);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTypeCheck)]
+        public async Task TestDefiniteAssignment3()
+        {
+            await TestAsync(
+@"class C
+{
+    void M()
+    {
+        [|var|] x = o as string;
+        if (x != null && x.Length > 0)
+        {
+        }
+
+        x = null;
+        Console.WriteLine(x);
+    }
+}",
+
+@"class C
+{
+    void M()
+    {
+        if (o is string x && x.Length > 0)
+        {
+        }
+
+        x = null;
+        Console.WriteLine(x);
+    }
+}");
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Customer writes code.  We give them a suggesiton that their code can be simplified.  However, simplifying ends up breaking their code.  This is problematic especially as the user may use 'fix all' to bulk fix this suggestion in their project/solution.

**Bugs this fixes:** 

No bug currently.  Reported by Kaseyu on her own project.

**Workarounds, if any**

User does not invoke the suggestion.  But confidence is lowered in our refactorings.

**Risk**
**Performance impact**

Low.  We just do a little more analysis to validate that our suggestion won' tbreak their code.

**Is this a regression from a previous update?**

No.  This is a new feature.

**Root cause analysis:**

We didn't think about all the possible cases where this code fix might be applied in.  Several new tests are being added to make sure this doesn't regress.

**How was the bug found?**

Customer (i.e. Kasey).
