### PR TITLE
Improve trivia classification perf when there are huge lists of trivia.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -137,12 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 }
 
                 var trivia = enumerator.Current;
-                if (trivia.FullSpan.End <= classificationSpanStart)
-                {
-                    // Trivia is entirely before the span we're classifying, ignore and move to the next.
-                    continue;
-                }
-                else
+                if (trivia.FullSpan.End > classificationSpanStart)
                 {
                     // Found trivia that is after the text span we're classifying.  
                     break;

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -108,44 +108,79 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 }
             }
 
-            foreach (var trivia in token.LeadingTrivia)
+            ClassifyTriviaList(token.LeadingTrivia);
+            ClassifyTriviaList(token.TrailingTrivia);
+        }
+
+        private void ClassifyTriviaList(SyntaxTriviaList list)
+        {
+            if (list.Count == 0)
             {
-                _cancellationToken.ThrowIfCancellationRequested();
-                ClassifyTrivia(trivia);
+                return;
             }
 
-            foreach (var trivia in token.TrailingTrivia)
+            // We may have long lists of trivia (for example a huge list of // comments after someone
+            // comments out a file).  Try to skip as many as possible if they're not actually in the span
+            // we care about classifying.
+            foreach (var trivia in list)
             {
-                _cancellationToken.ThrowIfCancellationRequested();
-                ClassifyTrivia(trivia);
+                var triviaSpan = trivia.FullSpan;
+                if (ShouldAddSpan(triviaSpan))
+                {
+                    ClassifyTrivia(trivia);
+                }
+                else
+                {
+                    // Stop once we get to any trivia that is past the span we're classifying
+                    if (triviaSpan.Start >= _textSpan.End)
+                    {
+                        return;
+                    }
+                }
             }
         }
 
         private void ClassifyTrivia(SyntaxTrivia trivia)
         {
-            if (trivia.IsRegularComment())
+            switch (trivia.Kind())
             {
-                AddClassification(trivia, ClassificationTypeNames.Comment);
-            }
-            else if (trivia.Kind() == SyntaxKind.DisabledTextTrivia)
-            {
-                AddClassification(trivia, ClassificationTypeNames.ExcludedCode);
-            }
-            else if (trivia.Kind() == SyntaxKind.SkippedTokensTrivia)
-            {
-                ClassifySkippedTokens((SkippedTokensTriviaSyntax)trivia.GetStructure());
-            }
-            else if (trivia.IsDocComment())
-            {
-                ClassifyDocumentationComment((DocumentationCommentTriviaSyntax)trivia.GetStructure());
-            }
-            else if (trivia.Kind() == SyntaxKind.DocumentationCommentExteriorTrivia)
-            {
-                AddClassification(trivia, ClassificationTypeNames.XmlDocCommentDelimiter);
-            }
-            else if (SyntaxFacts.IsPreprocessorDirective(trivia.Kind()))
-            {
-                ClassifyPreprocessorDirective((DirectiveTriviaSyntax)trivia.GetStructure());
+                case SyntaxKind.SingleLineCommentTrivia:
+                case SyntaxKind.MultiLineCommentTrivia:
+                case SyntaxKind.ShebangDirectiveTrivia:
+                    AddClassification(trivia, ClassificationTypeNames.Comment);
+                    return;
+
+                case SyntaxKind.DisabledTextTrivia:
+                    AddClassification(trivia, ClassificationTypeNames.ExcludedCode);
+                    return;
+
+                case SyntaxKind.SkippedTokensTrivia:
+                    ClassifySkippedTokens((SkippedTokensTriviaSyntax)trivia.GetStructure());
+                    return;
+
+                case SyntaxKind.SingleLineDocumentationCommentTrivia:
+                case SyntaxKind.MultiLineDocumentationCommentTrivia:
+                    ClassifyDocumentationComment((DocumentationCommentTriviaSyntax)trivia.GetStructure());
+                    return;
+
+                case SyntaxKind.IfDirectiveTrivia:
+                case SyntaxKind.ElifDirectiveTrivia:
+                case SyntaxKind.ElseDirectiveTrivia:
+                case SyntaxKind.EndIfDirectiveTrivia:
+                case SyntaxKind.RegionDirectiveTrivia:
+                case SyntaxKind.EndRegionDirectiveTrivia:
+                case SyntaxKind.DefineDirectiveTrivia:
+                case SyntaxKind.UndefDirectiveTrivia:
+                case SyntaxKind.ErrorDirectiveTrivia:
+                case SyntaxKind.WarningDirectiveTrivia:
+                case SyntaxKind.LineDirectiveTrivia:
+                case SyntaxKind.PragmaWarningDirectiveTrivia:
+                case SyntaxKind.PragmaChecksumDirectiveTrivia:
+                case SyntaxKind.ReferenceDirectiveTrivia:
+                case SyntaxKind.LoadDirectiveTrivia:
+                case SyntaxKind.BadDirectiveTrivia:
+                    ClassifyPreprocessorDirective((DirectiveTriviaSyntax)trivia.GetStructure());
+                    return;
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -129,6 +129,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             var enumerator = list.GetEnumerator();
             while (true)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
+
                 if (!enumerator.MoveNext())
                 {
                     // Reached the end of the trivia.  It was all before the text span we care about
@@ -146,6 +148,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             // Continue processing trivia from this point on until we get past the 
             do
             {
+                _cancellationToken.ThrowIfCancellationRequested();
+
                 var trivia = enumerator.Current;
                 if (trivia.SpanStart >= _textSpan.End)
                 {

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -136,8 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                     return;
                 }
 
-                var trivia = enumerator.Current;
-                if (trivia.FullSpan.End > classificationSpanStart)
+                if (enumerator.Current.FullSpan.End > classificationSpanStart)
                 {
                     // Found trivia that is after the text span we're classifying.  
                     break;

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -122,8 +122,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
             // We may have long lists of trivia (for example a huge list of // comments after someone
             // comments out a file).  Try to skip as many as possible if they're not actually in the span
             // we care about classifying.
-
-
             var classificationSpanStart = _textSpan.Start;
             var classificationSpanEnd = _textSpan.End;
 

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -185,6 +185,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                     ClassifyDocumentationComment((DocumentationCommentTriviaSyntax)trivia.GetStructure());
                     return;
 
+                case SyntaxKind.DocumentationCommentExteriorTrivia:
+                    AddClassification(trivia, ClassificationTypeNames.XmlDocCommentDelimiter);
+                    return;
+
                 case SyntaxKind.IfDirectiveTrivia:
                 case SyntaxKind.ElifDirectiveTrivia:
                 case SyntaxKind.ElseDirectiveTrivia:

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
                 if (!enumerator.MoveNext())
                 {
-                    // Reached the end of the trivia.  It was all before the text span we care about
+                    // Reached the end of the trivia.  It was all before the span we want to classify.
                     // Stop immediately.
                     return;
                 }
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 }
             }
 
-            // Continue processing trivia from this point on until we get past the 
+            // Continue processing trivia from this point on until we get past the span we want to classify.
             do
             {
                 _cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Huge lists of trivia can occur in some cases.  Either pathological code (i.e. 10k blank spaces), or regular scenarios (like users // commenting out a large section of code).  Improve classification perf in two ways here:

1. Use a switch instead of if/elses to speed up the raw decision about what to do with a piece of trivia.
2. Walk the trivia list as quickly as possible, skipping trivia that are before the span we want to classify, and stopping once we get past the span we want to classify.