### PR TITLE
Prevent thread starvation during parallel file reads

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
@@ -26,15 +26,7 @@ namespace Roslyn.Utilities
 
         internal static PooledStream CreateReadableStream(Stream stream, CancellationToken cancellationToken)
         {
-            return CreateReadableStream(stream, /*length*/ -1, cancellationToken);
-        }
-
-        internal static PooledStream CreateReadableStream(Stream stream, long length, CancellationToken cancellationToken)
-        {
-            if (length == -1)
-            {
-                length = stream.Length;
-            }
+            long length = stream.Length;
 
             long chunkCount = (length + ChunkSize - 1) / ChunkSize;
             byte[][] chunks = new byte[chunkCount][];
@@ -76,17 +68,9 @@ namespace Roslyn.Utilities
             }
         }
 
-        internal static Task<PooledStream> CreateReadableStreamAsync(Stream stream, CancellationToken cancellationToken)
+        internal async static Task<PooledStream> CreateReadableStreamAsync(Stream stream, CancellationToken cancellationToken)
         {
-            return CreateReadableStreamAsync(stream, /*length*/ -1, cancellationToken);
-        }
-
-        internal static async Task<PooledStream> CreateReadableStreamAsync(Stream stream, long length, CancellationToken cancellationToken)
-        {
-            if (length == -1)
-            {
-                length = stream.Length;
-            }
+            long length = stream.Length;
 
             long chunkCount = (length + ChunkSize - 1) / ChunkSize;
             byte[][] chunks = new byte[chunkCount][];

--- a/src/Workspaces/CoreTest/UtilityTest/SerializableBytesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SerializableBytesTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
     public class SerializableBytesTests
     {
         [Fact]
-        public void ReadableStreamTest1()
+        public void ReadableStreamTestReadAByteAtATime()
         {
             using (var expected = new MemoryStream())
             {
@@ -36,32 +36,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void ReadableStreamTest2()
-        {
-            using (var expected = new MemoryStream())
-            {
-                for (var i = 0; i < 10000; i++)
-                {
-                    expected.WriteByte((byte)(i % byte.MaxValue));
-                }
-
-                expected.Position = 0;
-                using (var stream = SerializableBytes.CreateReadableStream(expected, 1000, CancellationToken.None))
-                {
-                    Assert.Equal(1000, stream.Length);
-
-                    expected.Position = 0;
-                    stream.Position = 0;
-                    for (var i = 0; i < 1000; i++)
-                    {
-                        Assert.Equal(expected.ReadByte(), stream.ReadByte());
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public void ReadableStreamTest3()
+        public void ReadableStreamTestReadChunks()
         {
             using (var expected = new MemoryStream())
             {
@@ -96,7 +71,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void ReadableStreamTest4()
+        public void ReadableStreamTestReadRandomBytes()
         {
             using (var expected = new MemoryStream())
             {

--- a/src/Workspaces/CoreTest/UtilityTest/SerializableBytesTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/SerializableBytesTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 {
                     Assert.Equal(expected.Length, stream.Length);
 
-                    var random = new Random(Environment.TickCount);
+                    var random = new Random(0);
                     for (var i = 0; i < 100; i++)
                     {
                         var position = random.Next((int)expected.Length);
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 using (var stream = SerializableBytes.CreateWritableStream())
                 {
-                    var random = new Random(Environment.TickCount);
+                    var random = new Random(0);
                     for (var i = 0; i < 100; i++)
                     {
                         var position = random.Next(10000);
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 using (var stream = SerializableBytes.CreateWritableStream())
                 {
-                    var random = new Random(Environment.TickCount);
+                    var random = new Random(0);
                     for (var i = 0; i < 100; i++)
                     {
                         var position = random.Next(10000);
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             Assert.Equal(expected.Length, stream.Length);
 
-            var random = new Random(Environment.TickCount);
+            var random = new Random(0);
 
             expected.Position = 0;
             stream.Position = 0;


### PR DESCRIPTION
We've seen a performance issue where the user gets a temporary hang and a symptom of this is an excessive number of blocked thread pool threads on IO. This was because synchronous work is assuming another thread pool thread is available to complete the work. By tweaking how we do the reads, we can work around this issue.

For reviewing, take this a commit at a time. The first three commits are just small tweaks I needed to ensure my sanity while inspecting this code, and last is what actually does the magic.

Fixes https://connect.microsoft.com/VisualStudio/feedback/details/2087450/visual-studio-hangs-on-build-save-and-start-for-xaml-projects-microsoft-visual-studio-is-busy