### PR TITLE
fix watson bug for OOP serialization

### DIFF
--- a/src/Workspaces/CSharp/Portable/Execution/CSharpOptionsSerializationService.cs
+++ b/src/Workspaces/CSharp/Portable/Execution/CSharpOptionsSerializationService.cs
@@ -84,8 +84,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Execution
             var languageVersion = (LanguageVersion)reader.ReadInt32();
             var preprocessorSymbolNames = reader.ReadArray<string>();
 
-            var options = new CSharpParseOptions(languageVersion, documentationMode, kind, preprocessorSymbolNames);
-            return options.WithFeatures(features);
+            var options = new CSharpParseOptions(languageVersion, documentationMode, kind);
+
+            // use WithPreprocessorSymbols instead of constructor to bypass preprocessor validation.
+            // https://github.com/dotnet/roslyn/issues/15797
+            return options.WithPreprocessorSymbols(preprocessorSymbolNames)
+                          .WithFeatures(features);
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Customer has preprocessor defined for his csproj project which is actually invalid preprocessor

**Bugs this fixes:** 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/295512

**Workarounds, if any**

no workaround

**Risk**

no risk. IDE already allow to set such preprocessor on CSharpParseOptions.

**Performance impact**

N/A

**Is this a regression from a previous update?**

no

**Root cause analysis:**

root issue is this
https://github.com/dotnet/roslyn/issues/15797

but regardless, if such option exist, then serialization should be able to clone it over RPC.

**How was the bug found?**

Watson
