### PR TITLE
Variable declared within a while’ condition should be in scope only within the loop.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -274,8 +274,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (node.Kind())
             {
                 case SyntaxKind.ExpressionStatement:
-                case SyntaxKind.WhileStatement:
-                case SyntaxKind.DoStatement:
                 case SyntaxKind.LockStatement:
                 case SyntaxKind.IfStatement:
                 case SyntaxKind.YieldReturnStatement:

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -37,8 +37,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.ReturnStatement:
                 case SyntaxKind.YieldReturnStatement:
                 case SyntaxKind.ExpressionStatement:
-                case SyntaxKind.WhileStatement:
-                case SyntaxKind.DoStatement:
                 case SyntaxKind.LockStatement:
                 case SyntaxKind.IfStatement:
                 case SyntaxKind.SwitchStatement:
@@ -164,16 +162,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitExpressionStatement(ExpressionStatementSyntax node)
         {
             VisitNodeToBind(node.Expression);
-        }
-
-        public override void VisitWhileStatement(WhileStatementSyntax node)
-        {
-            VisitNodeToBind(node.Condition);
-        }
-
-        public override void VisitDoStatement(DoStatementSyntax node)
-        {
-            VisitNodeToBind(node.Condition);
         }
 
         public override void VisitLockStatement(LockStatementSyntax node)

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -740,8 +740,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // but we still want to bind it.  
 
                 case SyntaxKind.ExpressionStatement:
-                case SyntaxKind.WhileStatement:
-                case SyntaxKind.DoStatement:
                 case SyntaxKind.LockStatement:
                 case SyntaxKind.IfStatement:
                 case SyntaxKind.YieldReturnStatement:

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -199,11 +199,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ExpressionVariableFinder.FindExpressionVariables(this, locals, innerStatement, enclosingBinder.GetBinder(switchStatement.Expression) ?? enclosingBinder);
                         break;
 
-                    case SyntaxKind.WhileStatement:
-                    case SyntaxKind.DoStatement:
                     case SyntaxKind.LockStatement:
                         Binder statementBinder = enclosingBinder.GetBinder(innerStatement);
-                        Debug.Assert(statementBinder != null); // Lock, Do and while loops always have binders.
+                        Debug.Assert(statementBinder != null); // Lock always has a binder.
                         ExpressionVariableFinder.FindExpressionVariables(this, locals, innerStatement, statementBinder);
                         break;
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -849,11 +849,13 @@
   </AbstractNode>
 
   <Node Name="BoundDoStatement" Base="BoundLoopStatement">
+    <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <Field Name="Condition" Type="BoundExpression"/>
     <Field Name="Body" Type="BoundStatement"/>
   </Node>
 
   <Node Name="BoundWhileStatement" Base="BoundLoopStatement">
+    <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <Field Name="Condition" Type="BoundExpression"/>
     <Field Name="Body" Type="BoundStatement"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1582,13 +1582,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDoStatement(BoundDoStatement node)
         {
+            DeclareVariables(node.Locals);
             var result = base.VisitDoStatement(node);
+            ReportUnusedVariables(node.Locals);
             return result;
         }
 
         public override BoundNode VisitWhileStatement(BoundWhileStatement node)
         {
+            DeclareVariables(node.Locals);
             var result = base.VisitWhileStatement(node);
+            ReportUnusedVariables(node.Locals);
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
@@ -183,19 +183,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Previous.InstrumentWhileStatementCondition(original, rewrittenCondition, factory);
         }
 
-        public override BoundStatement InstrumentWhileStatementConditionalGotoStart(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
+        public override BoundStatement InstrumentWhileStatementConditionalGotoStartOrBreak(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
         {
-            return Previous.InstrumentWhileStatementConditionalGotoStart(original, ifConditionGotoStart);
-        }
-
-        public override BoundStatement InstrumentWhileStatementGotoContinue(BoundWhileStatement original, BoundStatement gotoContinue)
-        {
-            return Previous.InstrumentWhileStatementGotoContinue(original, gotoContinue);
-        }
-
-        public override BoundStatement InstrumentForEachStatementGotoContinue(BoundForEachStatement original, BoundStatement gotoContinue)
-        {
-            return Previous.InstrumentForEachStatementGotoContinue(original, gotoContinue);
+            return Previous.InstrumentWhileStatementConditionalGotoStartOrBreak(original, ifConditionGotoStart);
         }
 
         public override BoundExpression InstrumentCatchClauseFilter(BoundCatchBlock original, BoundExpression rewrittenFilter, SyntheticBoundNodeFactory factory)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -170,14 +170,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundSequencePointWithSpan(doSyntax, base.InstrumentDoStatementConditionalGotoStart(original, ifConditionGotoStart), span);
         }
 
-        public override BoundStatement InstrumentWhileStatementConditionalGotoStart(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
+        public override BoundStatement InstrumentWhileStatementConditionalGotoStartOrBreak(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
         {
             WhileStatementSyntax whileSyntax = (WhileStatementSyntax)original.Syntax;
             TextSpan conditionSequencePointSpan = TextSpan.FromBounds(
                 whileSyntax.WhileKeyword.SpanStart,
                 whileSyntax.CloseParenToken.Span.End);
 
-            return new BoundSequencePointWithSpan(whileSyntax, base.InstrumentWhileStatementConditionalGotoStart(original, ifConditionGotoStart), conditionSequencePointSpan);
+            return new BoundSequencePointWithSpan(whileSyntax, base.InstrumentWhileStatementConditionalGotoStartOrBreak(original, ifConditionGotoStart), conditionSequencePointSpan);
         }
 
         private static BoundExpression AddConditionSequencePoint(BoundExpression condition, BoundStatement containingStatement, SyntheticBoundNodeFactory factory)
@@ -397,16 +397,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return AddSequencePoint((UsingStatementSyntax)original.Syntax, 
                                     base.InstrumentUsingTargetCapture(original, usingTargetCapture));
-        }
-
-        public override BoundStatement InstrumentForEachStatementGotoContinue(BoundForEachStatement original, BoundStatement gotoContinue)
-        {
-            return new BoundSequencePoint(null, base.InstrumentForEachStatementGotoContinue(original, gotoContinue));
-        }
-
-        public override BoundStatement InstrumentWhileStatementGotoContinue(BoundWhileStatement original, BoundStatement gotoContinue)
-        {
-            return new BoundSequencePoint(null, base.InstrumentWhileStatementGotoContinue(original, gotoContinue));
         }
 
         public override BoundExpression InstrumentCatchClauseFilter(BoundCatchBlock original, BoundExpression rewrittenFilter, SyntheticBoundNodeFactory factory)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -190,9 +190,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return AddDynamicAnalysis(original, base.InstrumentIfStatement(original, rewritten));
         }
 
-        public override BoundStatement InstrumentWhileStatementConditionalGotoStart(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
+        public override BoundStatement InstrumentWhileStatementConditionalGotoStartOrBreak(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
         {
-            return AddDynamicAnalysis(original, base.InstrumentWhileStatementConditionalGotoStart(original, ifConditionGotoStart));
+            return AddDynamicAnalysis(original, base.InstrumentWhileStatementConditionalGotoStartOrBreak(original, ifConditionGotoStart));
         }
 
         public override BoundStatement InstrumentLocalInitialization(BoundLocalDeclaration original, BoundStatement rewritten)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ifConditionGotoStart; 
         }
 
-        public virtual BoundStatement InstrumentWhileStatementConditionalGotoStart(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
+        public virtual BoundStatement InstrumentWhileStatementConditionalGotoStartOrBreak(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
         {
             Debug.Assert(!original.WasCompilerGenerated);
             Debug.Assert(original.Syntax.Kind() == SyntaxKind.WhileStatement);
@@ -260,20 +260,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!original.WasCompilerGenerated);
             Debug.Assert(original.Syntax.Kind() == SyntaxKind.UsingStatement);
             return usingTargetCapture;
-        }
-
-        public virtual BoundStatement InstrumentWhileStatementGotoContinue(BoundWhileStatement original, BoundStatement gotoContinue)
-        {
-            Debug.Assert(!original.WasCompilerGenerated);
-            Debug.Assert(original.Syntax.Kind() == SyntaxKind.WhileStatement);
-            return gotoContinue;
-        }
-
-        public virtual BoundStatement InstrumentForEachStatementGotoContinue(BoundForEachStatement original, BoundStatement gotoContinue)
-        {
-            Debug.Assert(!original.WasCompilerGenerated);
-            Debug.Assert(original.Syntax is CommonForEachStatementSyntax);
-            return gotoContinue;
         }
 
         public virtual BoundExpression InstrumentCatchClauseFilter(BoundCatchBlock original, BoundExpression rewrittenFilter, SyntheticBoundNodeFactory factory)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DoStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DoStatement.cs
@@ -49,11 +49,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             // }
             // break:
 
+            if (node.Locals.IsEmpty)
+            {
+                return BoundStatementList.Synthesized(syntax, node.HasErrors,
+                    new BoundLabelStatement(syntax, startLabel),
+                    rewrittenBody,
+                    new BoundLabelStatement(syntax, node.ContinueLabel),
+                    ifConditionGotoStart,
+                    new BoundLabelStatement(syntax, node.BreakLabel));
+            }
+
             return BoundStatementList.Synthesized(syntax, node.HasErrors,
                 new BoundLabelStatement(syntax, startLabel),
-                rewrittenBody,
-                new BoundLabelStatement(syntax, node.ContinueLabel),
-                ifConditionGotoStart,
+                new BoundBlock(syntax,
+                               node.Locals,
+                               ImmutableArray.Create<BoundStatement>(rewrittenBody,
+                                                                     new BoundLabelStatement(syntax, node.ContinueLabel),
+                                                                     ifConditionGotoStart)),
                 new BoundLabelStatement(syntax, node.BreakLabel));
         }
     }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -166,6 +166,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return node.Update(newOuterLocals, initializer, condition, increment, body, node.BreakLabel, node.ContinueLabel);
         }
 
+        public override BoundNode VisitDoStatement(BoundDoStatement node)
+        {
+            var newLocals = RewriteLocals(node.Locals);
+            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            return node.Update(newLocals, condition, body, node.BreakLabel, node.ContinueLabel);
+        }
+
+        public override BoundNode VisitWhileStatement(BoundWhileStatement node)
+        {
+            var newLocals = RewriteLocals(node.Locals);
+            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
+            BoundStatement body = (BoundStatement)this.Visit(node.Body);
+            return node.Update(newLocals, condition, body, node.BreakLabel, node.ContinueLabel);
+        }
+
         public override BoundNode VisitUsingStatement(BoundUsingStatement node)
         {
             var newLocals = RewriteLocals(node.Locals);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3163,8 +3163,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     case SyntaxKind.ReturnStatement:
                                     case SyntaxKind.ThrowStatement:
                                     case SyntaxKind.SwitchStatement:
-                                    case SyntaxKind.WhileStatement:
-                                    case SyntaxKind.DoStatement:
                                     case SyntaxKind.LockStatement:
                                         ExpressionFieldFinder.FindExpressionVariables(builder.NonTypeNonIndexerMembers,
                                                   innerStatement,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -1632,8 +1632,6 @@ public class X
             System.Console.WriteLine(x1);
             f = false;
         }
-
-        System.Console.WriteLine(x1);
     }
 
     static bool Dummy(bool x, object y, object z) 
@@ -1647,7 +1645,6 @@ public class X
             CompileAndVerify(compilation, expectedOutput:
 @"1
 1
-2
 2");
 
             var tree = compilation.SyntaxTrees.Single();
@@ -1656,7 +1653,7 @@ public class X
             var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
             var x1Ref = GetReferences(tree, "x1").ToArray();
             Assert.Equal(1, x1Decl.Length);
-            Assert.Equal(3, x1Ref.Length);
+            Assert.Equal(2, x1Ref.Length);
             VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
         }
 
@@ -1706,6 +1703,170 @@ public class X
         }
 
         [Fact]
+        public void While_03()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        int f = 1;
+        var l = new System.Collections.Generic.List<System.Action>();
+
+        while (Dummy(f < 3, f is var x1, x1))
+        {
+            l.Add(() => System.Console.WriteLine(x1));
+            f++;
+        }
+
+        System.Console.WriteLine(""--"");
+
+        foreach (var d in l)
+        {
+            d();
+        }
+    }
+
+    static bool Dummy(bool x, object y, object z) 
+    {
+        System.Console.WriteLine(z);
+        return x;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"1
+2
+3
+--
+1
+2
+");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
+        public void While_04()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        int f = 1;
+        var l = new System.Collections.Generic.List<System.Action>();
+
+        while (Dummy(f < 3, f is var x1, x1, l, () => System.Console.WriteLine(x1)))
+        {
+            f++;
+        }
+
+        System.Console.WriteLine(""--"");
+
+        foreach (var d in l)
+        {
+            d();
+        }
+    }
+
+    static bool Dummy(bool x, object y, object z, System.Collections.Generic.List<System.Action> l, System.Action d) 
+    {
+        l.Add(d);
+        System.Console.WriteLine(z);
+        return x;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"1
+2
+3
+--
+1
+2
+3
+");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
+        public void While_05()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        int f = 1;
+        var l = new System.Collections.Generic.List<System.Action>();
+
+        while (Dummy(f < 3, f is var x1, x1, l, () => System.Console.WriteLine(x1)))
+        {
+            l.Add(() => System.Console.WriteLine(x1));
+            f++;
+        }
+
+        System.Console.WriteLine(""--"");
+
+        foreach (var d in l)
+        {
+            d();
+        }
+    }
+
+    static bool Dummy(bool x, object y, object z, System.Collections.Generic.List<System.Action> l, System.Action d) 
+    {
+        l.Add(d);
+        System.Console.WriteLine(z);
+        return x;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"1
+2
+3
+--
+1
+1
+2
+2
+3
+");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(3, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
         public void Do_01()
         {
             var source =
@@ -1721,8 +1882,6 @@ public class X
             f = false;
         }
         while (Dummy(f, (f ? 1 : 2) is var x1, x1));
-
-        System.Console.WriteLine(x1);
     }
 
     static bool Dummy(bool x, object y, object z) 
@@ -1733,8 +1892,7 @@ public class X
 }
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
-            CompileAndVerify(compilation, expectedOutput: @"2
-2");
+            CompileAndVerify(compilation, expectedOutput: @"2");
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -1742,7 +1900,7 @@ public class X
             var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
             var x1Ref = GetReferences(tree, "x1").ToArray();
             Assert.Equal(1, x1Decl.Length);
-            Assert.Equal(2, x1Ref.Length);
+            Assert.Equal(1, x1Ref.Length);
             VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
         }
 
@@ -1791,6 +1949,59 @@ public class X
             Assert.Equal(2, x1Ref.Length);
             VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref[0]);
             VerifyModelForDeclarationPattern(model, x1Decl[1], x1Ref[1]);
+        }
+
+        [Fact]
+        public void Do_03()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        int f = 1;
+        var l = new System.Collections.Generic.List<System.Action>();
+
+        do
+        {
+            ;
+        }
+        while (Dummy(f < 3, (f++) is var x1, x1, l, () => System.Console.WriteLine(x1)));
+
+        System.Console.WriteLine(""--"");
+
+        foreach (var d in l)
+        {
+            d();
+        }
+    }
+
+    static bool Dummy(bool x, object y, object z, System.Collections.Generic.List<System.Action> l, System.Action d) 
+    {
+        l.Add(d);
+        System.Console.WriteLine(z);
+        return x;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            CompileAndVerify(compilation, expectedOutput: @"1
+2
+3
+--
+1
+2
+3");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Global.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Global.cs
@@ -1766,24 +1766,27 @@ class H
                 var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
                 compilation.VerifyDiagnostics(
-                // (6,18): error CS0102: The type 'Script' already contains a definition for 'x2'
-                // while ((2 is int x2)) {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x2").WithArguments("Script", "x2").WithLocation(6, 18),
-                // (9,8): error CS0102: The type 'Script' already contains a definition for 'x3'
-                // object x3;
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x3").WithArguments("Script", "x3").WithLocation(9, 8),
-                // (12,27): error CS0102: The type 'Script' already contains a definition for 'x4'
+                // (3,9): error CS0103: The name 'x1' does not exist in the current context
+                // H.Dummy(x1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(3, 9),
+                // (12,27): error CS0128: A local variable or function named 'x4' is already defined in this scope
                 //                (42 is int x4))) {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x4").WithArguments("Script", "x4").WithLocation(12, 27),
-                // (23,17): error CS0229: Ambiguity between 'x2' and 'x2'
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(12, 27),
+                // (16,28): error CS0136: A local or parameter named 'x5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     H.Dummy("52" is string x5);
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x5").WithArguments("x5").WithLocation(16, 28),
+                // (19,9): error CS0103: The name 'x5' does not exist in the current context
+                // H.Dummy(x5);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(19, 9),
+                // (23,13): error CS0103: The name 'x1' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x2").WithArguments("x2", "x2").WithLocation(23, 17),
-                // (23,21): error CS0229: Ambiguity between 'x3' and 'x3'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(23, 13),
+                // (23,25): error CS0103: The name 'x4' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x3").WithArguments("x3", "x3").WithLocation(23, 21),
-                // (23,25): error CS0229: Ambiguity between 'x4' and 'x4'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x4").WithArguments("x4").WithLocation(23, 25),
+                // (23,29): error CS0103: The name 'x5' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(23, 25)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(23, 29)
                     );
 
                 var tree = compilation.SyntaxTrees.Single();
@@ -1792,28 +1795,35 @@ class H
                 var x1Decl = GetPatternDeclarations(tree, "x1").Single();
                 var x1Ref = GetReferences(tree, "x1").ToArray();
                 Assert.Equal(2, x1Ref.Length);
-                VerifyModelForDeclarationField(model, x1Decl, x1Ref);
+                VerifyModelForDeclarationPattern(model, x1Decl);
+                VerifyNotInScope(model, x1Ref[0]);
+                VerifyNotInScope(model, x1Ref[1]);
 
                 var x2Decl = GetPatternDeclarations(tree, "x2").Single();
                 var x2Ref = GetReferences(tree, "x2").Single();
-                VerifyModelForDeclarationFieldDuplicate(model, x2Decl, x2Ref);
+                VerifyModelForDeclarationPattern(model, x2Decl);
+                VerifyNotAPatternLocal(model, x2Ref);
 
                 var x3Decl = GetPatternDeclarations(tree, "x3").Single();
                 var x3Ref = GetReferences(tree, "x3").Single();
-                VerifyModelForDeclarationFieldDuplicate(model, x3Decl, x3Ref);
+                VerifyModelForDeclarationPattern(model, x3Decl);
+                VerifyNotAPatternLocal(model, x3Ref);
 
                 var x4Decl = GetPatternDeclarations(tree, "x4").ToArray();
                 var x4Ref = GetReferences(tree, "x4").Single();
                 Assert.Equal(2, x4Decl.Length);
-                VerifyModelForDeclarationFieldDuplicate(model, x4Decl[0], x4Ref);
-                VerifyModelForDeclarationFieldDuplicate(model, x4Decl[1], x4Ref);
+                VerifyModelForDeclarationPattern(model, x4Decl[0]);
+                VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl[1]);
+                VerifyNotInScope(model, x4Ref);
 
                 var x5Decl = GetPatternDeclarations(tree, "x5").ToArray();
                 var x5Ref = GetReferences(tree, "x5").ToArray();
                 Assert.Equal(2, x5Decl.Length);
                 Assert.Equal(3, x5Ref.Length);
-                VerifyModelForDeclarationField(model, x5Decl[0], x5Ref[1], x5Ref[2]);
+                VerifyModelForDeclarationPattern(model, x5Decl[0]);
                 VerifyModelForDeclarationPattern(model, x5Decl[1], x5Ref[0]);
+                VerifyNotInScope(model, x5Ref[1]);
+                VerifyNotInScope(model, x5Ref[2]);
             }
 
             {
@@ -1899,24 +1909,27 @@ class H
                 var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
                 compilation.VerifyDiagnostics(
-                // (6,18): error CS0102: The type 'Script' already contains a definition for 'x2'
-                // while ((2 is var x2)) {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x2").WithArguments("Script", "x2").WithLocation(6, 18),
-                // (9,8): error CS0102: The type 'Script' already contains a definition for 'x3'
-                // object x3;
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x3").WithArguments("Script", "x3").WithLocation(9, 8),
-                // (12,27): error CS0102: The type 'Script' already contains a definition for 'x4'
+                // (3,9): error CS0103: The name 'x1' does not exist in the current context
+                // H.Dummy(x1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(3, 9),
+                // (12,27): error CS0128: A local variable or function named 'x4' is already defined in this scope
                 //                (42 is var x4))) {}
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x4").WithArguments("Script", "x4").WithLocation(12, 27),
-                // (23,17): error CS0229: Ambiguity between 'x2' and 'x2'
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(12, 27),
+                // (16,25): error CS0136: A local or parameter named 'x5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     H.Dummy("52" is var x5);
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x5").WithArguments("x5").WithLocation(16, 25),
+                // (19,9): error CS0103: The name 'x5' does not exist in the current context
+                // H.Dummy(x5);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(19, 9),
+                // (23,13): error CS0103: The name 'x1' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x2").WithArguments("x2", "x2").WithLocation(23, 17),
-                // (23,21): error CS0229: Ambiguity between 'x3' and 'x3'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(23, 13),
+                // (23,25): error CS0103: The name 'x4' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x3").WithArguments("x3", "x3").WithLocation(23, 21),
-                // (23,25): error CS0229: Ambiguity between 'x4' and 'x4'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x4").WithArguments("x4").WithLocation(23, 25),
+                // (23,29): error CS0103: The name 'x5' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(23, 25)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(23, 29)
                     );
 
                 var tree = compilation.SyntaxTrees.Single();
@@ -1925,28 +1938,35 @@ class H
                 var x1Decl = GetPatternDeclarations(tree, "x1").Single();
                 var x1Ref = GetReferences(tree, "x1").ToArray();
                 Assert.Equal(2, x1Ref.Length);
-                VerifyModelForDeclarationField(model, x1Decl, x1Ref);
+                VerifyModelForDeclarationPattern(model, x1Decl);
+                VerifyNotInScope(model, x1Ref[0]);
+                VerifyNotInScope(model, x1Ref[1]);
 
                 var x2Decl = GetPatternDeclarations(tree, "x2").Single();
                 var x2Ref = GetReferences(tree, "x2").Single();
-                VerifyModelForDeclarationFieldDuplicate(model, x2Decl, x2Ref);
+                VerifyModelForDeclarationPattern(model, x2Decl);
+                VerifyNotAPatternLocal(model, x2Ref);
 
                 var x3Decl = GetPatternDeclarations(tree, "x3").Single();
                 var x3Ref = GetReferences(tree, "x3").Single();
-                VerifyModelForDeclarationFieldDuplicate(model, x3Decl, x3Ref);
+                VerifyModelForDeclarationPattern(model, x3Decl);
+                VerifyNotAPatternLocal(model, x3Ref);
 
                 var x4Decl = GetPatternDeclarations(tree, "x4").ToArray();
                 var x4Ref = GetReferences(tree, "x4").Single();
                 Assert.Equal(2, x4Decl.Length);
-                VerifyModelForDeclarationFieldDuplicate(model, x4Decl[0], x4Ref);
-                VerifyModelForDeclarationFieldDuplicate(model, x4Decl[1], x4Ref);
+                VerifyModelForDeclarationPattern(model, x4Decl[0]);
+                VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl[1]);
+                VerifyNotInScope(model, x4Ref);
 
                 var x5Decl = GetPatternDeclarations(tree, "x5").ToArray();
                 var x5Ref = GetReferences(tree, "x5").ToArray();
                 Assert.Equal(2, x5Decl.Length);
                 Assert.Equal(3, x5Ref.Length);
-                VerifyModelForDeclarationField(model, x5Decl[0], x5Ref[1], x5Ref[2]);
+                VerifyModelForDeclarationPattern(model, x5Decl[0]);
                 VerifyModelForDeclarationPattern(model, x5Decl[1], x5Ref[0]);
+                VerifyNotInScope(model, x5Ref[1]);
+                VerifyNotInScope(model, x5Ref[2]);
             }
 
             {
@@ -2000,19 +2020,12 @@ class H
         {
             string source =
 @"
-System.Console.WriteLine(x1);
 while ((1 is var x1)) 
 {
-    H.Dummy(""11"" is var x1);
     System.Console.WriteLine(x1);
     break;
 }
-Test();
 
-void Test()
-{
-    System.Console.WriteLine(x1);
-}
 class H
 {
     public static bool Dummy(params object[] x) {return false;}
@@ -2021,63 +2034,16 @@ class H
 
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
-            CompileAndVerify(compilation, expectedOutput:
-@"0
-11
-1").VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput:@"1").VerifyDiagnostics();
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
 
             var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
             var x1Ref = GetReferences(tree, "x1").ToArray();
-            Assert.Equal(2, x1Decl.Length);
-            Assert.Equal(3, x1Ref.Length);
-            VerifyModelForDeclarationField(model, x1Decl[0], x1Ref[0], x1Ref[2]);
-            VerifyModelForDeclarationPattern(model, x1Decl[1], x1Ref[1]);
-        }
-
-        [Fact]
-        public void GlobalCode_WhileStatement_04()
-        {
-            string source =
-@"
-bool x0 = true;
-System.Console.WriteLine(x1);
-while (x0 && (1 is var x1)) 
-    H.Dummy((""11"" is var x1) && (x0 = false), x1);
-Test();
-
-void Test()
-{
-    System.Console.WriteLine(x1);
-}
-
-class H
-{
-    public static void Dummy(object x, object y)
-    {
-        System.Console.WriteLine(y);
-    }
-}
-";
-
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
-
-            CompileAndVerify(compilation, expectedOutput:
-@"0
-11
-1").VerifyDiagnostics();
-
-            var tree = compilation.SyntaxTrees.Single();
-            var model = compilation.GetSemanticModel(tree);
-
-            var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
-            var x1Ref = GetReferences(tree, "x1").ToArray();
-            Assert.Equal(2, x1Decl.Length);
-            Assert.Equal(3, x1Ref.Length);
-            VerifyModelForDeclarationField(model, x1Decl[0], x1Ref[0], x1Ref[2]);
-            VerifyModelForDeclarationPattern(model, x1Decl[1], x1Ref[1]);
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(1, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
         }
 
         [Fact]
@@ -2119,24 +2085,27 @@ class H
                 var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
                 compilation.VerifyDiagnostics(
-                // (6,24): error CS0102: The type 'Script' already contains a definition for 'x2'
-                // do {} while ((2 is int x2));
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x2").WithArguments("Script", "x2").WithLocation(6, 24),
-                // (9,8): error CS0102: The type 'Script' already contains a definition for 'x3'
-                // object x3;
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x3").WithArguments("Script", "x3").WithLocation(9, 8),
-                // (12,33): error CS0102: The type 'Script' already contains a definition for 'x4'
+                // (3,9): error CS0103: The name 'x1' does not exist in the current context
+                // H.Dummy(x1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(3, 9),
+                // (12,33): error CS0128: A local variable or function named 'x4' is already defined in this scope
                 //                      (42 is int x4)));
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x4").WithArguments("Script", "x4").WithLocation(12, 33),
-                // (24,17): error CS0229: Ambiguity between 'x2' and 'x2'
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(12, 33),
+                // (16,28): error CS0136: A local or parameter named 'x5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     H.Dummy("52" is string x5);
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x5").WithArguments("x5").WithLocation(16, 28),
+                // (20,9): error CS0103: The name 'x5' does not exist in the current context
+                // H.Dummy(x5);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(20, 9),
+                // (24,13): error CS0103: The name 'x1' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x2").WithArguments("x2", "x2").WithLocation(24, 17),
-                // (24,21): error CS0229: Ambiguity between 'x3' and 'x3'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(24, 13),
+                // (24,25): error CS0103: The name 'x4' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x3").WithArguments("x3", "x3").WithLocation(24, 21),
-                // (24,25): error CS0229: Ambiguity between 'x4' and 'x4'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x4").WithArguments("x4").WithLocation(24, 25),
+                // (24,29): error CS0103: The name 'x5' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(24, 25)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(24, 29)
                     );
 
                 var tree = compilation.SyntaxTrees.Single();
@@ -2145,28 +2114,35 @@ class H
                 var x1Decl = GetPatternDeclarations(tree, "x1").Single();
                 var x1Ref = GetReferences(tree, "x1").ToArray();
                 Assert.Equal(2, x1Ref.Length);
-                VerifyModelForDeclarationField(model, x1Decl, x1Ref);
+                VerifyModelForDeclarationPattern(model, x1Decl);
+                VerifyNotInScope(model, x1Ref[0]);
+                VerifyNotInScope(model, x1Ref[1]);
 
                 var x2Decl = GetPatternDeclarations(tree, "x2").Single();
                 var x2Ref = GetReferences(tree, "x2").Single();
-                VerifyModelForDeclarationFieldDuplicate(model, x2Decl, x2Ref);
+                VerifyModelForDeclarationPattern(model, x2Decl);
+                VerifyNotAPatternLocal(model, x2Ref);
 
                 var x3Decl = GetPatternDeclarations(tree, "x3").Single();
                 var x3Ref = GetReferences(tree, "x3").Single();
-                VerifyModelForDeclarationFieldDuplicate(model, x3Decl, x3Ref);
+                VerifyModelForDeclarationPattern(model, x3Decl);
+                VerifyNotAPatternLocal(model, x3Ref);
 
                 var x4Decl = GetPatternDeclarations(tree, "x4").ToArray();
                 var x4Ref = GetReferences(tree, "x4").Single();
                 Assert.Equal(2, x4Decl.Length);
-                VerifyModelForDeclarationFieldDuplicate(model, x4Decl[0], x4Ref);
-                VerifyModelForDeclarationFieldDuplicate(model, x4Decl[1], x4Ref);
+                VerifyModelForDeclarationPattern(model, x4Decl[0]);
+                VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl[1]);
+                VerifyNotInScope(model, x4Ref);
 
                 var x5Decl = GetPatternDeclarations(tree, "x5").ToArray();
                 var x5Ref = GetReferences(tree, "x5").ToArray();
                 Assert.Equal(2, x5Decl.Length);
                 Assert.Equal(3, x5Ref.Length);
                 VerifyModelForDeclarationPattern(model, x5Decl[0], x5Ref[0]);
-                VerifyModelForDeclarationField(model, x5Decl[1], x5Ref[1], x5Ref[2]);
+                VerifyModelForDeclarationPattern(model, x5Decl[1]);
+                VerifyNotInScope(model, x5Ref[1]);
+                VerifyNotInScope(model, x5Ref[2]);
             }
 
             {
@@ -2253,24 +2229,27 @@ class H
                 var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
                 compilation.VerifyDiagnostics(
-                // (6,24): error CS0102: The type 'Script' already contains a definition for 'x2'
-                // do {} while ((2 is var x2));
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x2").WithArguments("Script", "x2").WithLocation(6, 24),
-                // (9,8): error CS0102: The type 'Script' already contains a definition for 'x3'
-                // object x3;
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x3").WithArguments("Script", "x3").WithLocation(9, 8),
-                // (12,33): error CS0102: The type 'Script' already contains a definition for 'x4'
+                // (3,9): error CS0103: The name 'x1' does not exist in the current context
+                // H.Dummy(x1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(3, 9),
+                // (12,33): error CS0128: A local variable or function named 'x4' is already defined in this scope
                 //                      (42 is var x4)));
-                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x4").WithArguments("Script", "x4").WithLocation(12, 33),
-                // (24,17): error CS0229: Ambiguity between 'x2' and 'x2'
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(12, 33),
+                // (16,25): error CS0136: A local or parameter named 'x5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     H.Dummy("52" is var x5);
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x5").WithArguments("x5").WithLocation(16, 25),
+                // (20,9): error CS0103: The name 'x5' does not exist in the current context
+                // H.Dummy(x5);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(20, 9),
+                // (24,13): error CS0103: The name 'x1' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x2").WithArguments("x2", "x2").WithLocation(24, 17),
-                // (24,21): error CS0229: Ambiguity between 'x3' and 'x3'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(24, 13),
+                // (24,25): error CS0103: The name 'x4' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x3").WithArguments("x3", "x3").WithLocation(24, 21),
-                // (24,25): error CS0229: Ambiguity between 'x4' and 'x4'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x4").WithArguments("x4").WithLocation(24, 25),
+                // (24,29): error CS0103: The name 'x5' does not exist in the current context
                 //     H.Dummy(x1, x2, x3, x4, x5);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(24, 25)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(24, 29)
                     );
 
                 var tree = compilation.SyntaxTrees.Single();
@@ -2279,28 +2258,35 @@ class H
                 var x1Decl = GetPatternDeclarations(tree, "x1").Single();
                 var x1Ref = GetReferences(tree, "x1").ToArray();
                 Assert.Equal(2, x1Ref.Length);
-                VerifyModelForDeclarationField(model, x1Decl, x1Ref);
+                VerifyModelForDeclarationPattern(model, x1Decl);
+                VerifyNotInScope(model, x1Ref[0]);
+                VerifyNotInScope(model, x1Ref[1]);
 
                 var x2Decl = GetPatternDeclarations(tree, "x2").Single();
                 var x2Ref = GetReferences(tree, "x2").Single();
-                VerifyModelForDeclarationFieldDuplicate(model, x2Decl, x2Ref);
+                VerifyModelForDeclarationPattern(model, x2Decl);
+                VerifyNotAPatternLocal(model, x2Ref);
 
                 var x3Decl = GetPatternDeclarations(tree, "x3").Single();
                 var x3Ref = GetReferences(tree, "x3").Single();
-                VerifyModelForDeclarationFieldDuplicate(model, x3Decl, x3Ref);
+                VerifyModelForDeclarationPattern(model, x3Decl);
+                VerifyNotAPatternLocal(model, x3Ref);
 
                 var x4Decl = GetPatternDeclarations(tree, "x4").ToArray();
                 var x4Ref = GetReferences(tree, "x4").Single();
                 Assert.Equal(2, x4Decl.Length);
-                VerifyModelForDeclarationFieldDuplicate(model, x4Decl[0], x4Ref);
-                VerifyModelForDeclarationFieldDuplicate(model, x4Decl[1], x4Ref);
+                VerifyModelForDeclarationPattern(model, x4Decl[0]);
+                VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl[1]);
+                VerifyNotInScope(model, x4Ref);
 
                 var x5Decl = GetPatternDeclarations(tree, "x5").ToArray();
                 var x5Ref = GetReferences(tree, "x5").ToArray();
                 Assert.Equal(2, x5Decl.Length);
                 Assert.Equal(3, x5Ref.Length);
                 VerifyModelForDeclarationPattern(model, x5Decl[0], x5Ref[0]);
-                VerifyModelForDeclarationField(model, x5Decl[1], x5Ref[1], x5Ref[2]);
+                VerifyModelForDeclarationPattern(model, x5Decl[1]);
+                VerifyNotInScope(model, x5Ref[1]);
+                VerifyNotInScope(model, x5Ref[2]);
             }
 
             {
@@ -2354,19 +2340,19 @@ class H
         {
             string source =
 @"
-System.Console.WriteLine(x1);
+int f = 1;
+
 do
 {
-    H.Dummy(""11"" is var x1);
-    System.Console.WriteLine(x1);
 }
-while ((1 is var x1) && false);
-Test();
+while ((f++ is var x1) && Test(x1) < 3);
 
-void Test()
+int Test(int x)
 {
-    System.Console.WriteLine(x1);
+    System.Console.WriteLine(x);
+    return x;
 }
+
 class H
 {
     public static bool Dummy(params object[] x) {return false;}
@@ -2376,62 +2362,18 @@ class H
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
             CompileAndVerify(compilation, expectedOutput:
-@"0
-11
-1").VerifyDiagnostics();
+@"1
+2
+3").VerifyDiagnostics();
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
 
             var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
             var x1Ref = GetReferences(tree, "x1").ToArray();
-            Assert.Equal(2, x1Decl.Length);
-            Assert.Equal(3, x1Ref.Length);
-            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref[1]);
-            VerifyModelForDeclarationField(model, x1Decl[1], x1Ref[0], x1Ref[2]);
-        }
-
-        [Fact]
-        public void GlobalCode_DoStatement_04()
-        {
-            string source =
-@"
-System.Console.WriteLine(x1);
-do 
-    H.Dummy((""11"" is var x1), x1);
-while ((1 is var x1) && false);
-Test();
-
-void Test()
-{
-    System.Console.WriteLine(x1);
-}
-
-class H
-{
-    public static void Dummy(object x, object y)
-    {
-        System.Console.WriteLine(y);
-    }
-}
-";
-
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
-
-            CompileAndVerify(compilation, expectedOutput:
-@"0
-11
-1").VerifyDiagnostics();
-
-            var tree = compilation.SyntaxTrees.Single();
-            var model = compilation.GetSemanticModel(tree);
-
-            var x1Decl = GetPatternDeclarations(tree, "x1").ToArray();
-            var x1Ref = GetReferences(tree, "x1").ToArray();
-            Assert.Equal(2, x1Decl.Length);
-            Assert.Equal(3, x1Ref.Length);
-            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref[1]);
-            VerifyModelForDeclarationField(model, x1Decl[1], x1Ref[0], x1Ref[2]);
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(1, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
@@ -6864,7 +6864,7 @@ public class X
         var x4 = 11;
         Dummy(x4);
 
-        while (true is var x4 && x4 > 0)
+        while (true is var x4 && x4)
             Dummy(x4);
     }
 
@@ -6947,18 +6947,18 @@ public class X
     // (87,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
     //             var y12 = 12;
     Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "var y12 = 12;").WithLocation(87, 13),
-    // (29,28): error CS0128: A local variable named 'x4' is already defined in this scope
-    //         while (true is var x4 && x4 > 0)
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(29, 28),
+    // (29,28): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+    //         while (true is var x4 && x4)
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(29, 28),
     // (35,16): error CS0841: Cannot use local variable 'x6' before it is declared
     //         while (x6 && true is var x6)
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(35, 16),
     // (43,17): error CS0136: A local or parameter named 'x7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //             var x7 = 12;
     Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x7").WithArguments("x7").WithLocation(43, 17),
-    // (60,19): error CS0841: Cannot use local variable 'x9' before it is declared
-    //             Dummy(x9);
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x9").WithArguments("x9").WithLocation(60, 19),
+    // (53,34): error CS0103: The name 'x8' does not exist in the current context
+    //         System.Console.WriteLine(x8);
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(53, 34),
     // (61,32): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //             while (true is var x9 && x9) // 2
     Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(61, 32),
@@ -6971,7 +6971,7 @@ public class X
     // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
     //             var y12 = 12;
     Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
-    // (99,31): error CS0128: A local variable named 'x14' is already defined in this scope
+    // (99,31): error CS0128: A local variable or function named 'x14' is already defined in this scope
     //                      2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 31)
                 );
@@ -6993,9 +6993,7 @@ public class X
             var x4Ref = GetReferences(tree, "x4").ToArray();
             Assert.Equal(3, x4Ref.Length);
             VerifyNotAPatternLocal(model, x4Ref[0]);
-            VerifyNotAPatternLocal(model, x4Ref[1]);
-            VerifyNotAPatternLocal(model, x4Ref[2]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl);
+            VerifyModelForDeclarationPattern(model, x4Decl, x4Ref[1], x4Ref[2]);
 
             var x6Decl = GetPatternDeclarations(tree, "x6").Single();
             var x6Ref = GetReferences(tree, "x6").ToArray();
@@ -7011,14 +7009,15 @@ public class X
             var x8Decl = GetPatternDeclarations(tree, "x8").Single();
             var x8Ref = GetReferences(tree, "x8").ToArray();
             Assert.Equal(3, x8Ref.Length);
-            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref);
+            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref[0], x8Ref[1]);
+            VerifyNotInScope(model, x8Ref[2]);
 
             var x9Decl = GetPatternDeclarations(tree, "x9").ToArray();
             var x9Ref = GetReferences(tree, "x9").ToArray();
             Assert.Equal(2, x9Decl.Length);
             Assert.Equal(4, x9Ref.Length);
-            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref[0]);
-            VerifyModelForDeclarationPattern(model, x9Decl[1], x9Ref[1], x9Ref[2], x9Ref[3]);
+            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref[0], x9Ref[1]);
+            VerifyModelForDeclarationPattern(model, x9Decl[1], x9Ref[2], x9Ref[3]);
 
             var y10Ref = GetReferences(tree, "y10").ToArray();
             Assert.Equal(2, y10Ref.Length);
@@ -7154,7 +7153,7 @@ public class X
 
         do
             Dummy(x4);
-        while (true is var x4 && x4 > 0);
+        while (true is var x4 && x4);
     }
 
     void Test6()
@@ -7252,9 +7251,12 @@ public class X
     // (22,19): error CS0841: Cannot use local variable 'x2' before it is declared
     //             Dummy(x2);
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x2").WithArguments("x2").WithLocation(22, 19),
-    // (33,28): error CS0128: A local variable named 'x4' is already defined in this scope
-    //         while (true is var x4 && x4 > 0);
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(33, 28),
+    // (33,28): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+    //         while (true is var x4 && x4);
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(33, 28),
+    // (32,19): error CS0841: Cannot use local variable 'x4' before it is declared
+    //             Dummy(x4);
+    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(32, 19),
     // (40,16): error CS0841: Cannot use local variable 'x6' before it is declared
     //         while (x6 && true is var x6);
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(40, 16),
@@ -7267,6 +7269,9 @@ public class X
     // (56,19): error CS0841: Cannot use local variable 'x8' before it is declared
     //             Dummy(x8);
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x8").WithArguments("x8").WithLocation(56, 19),
+    // (59,34): error CS0103: The name 'x8' does not exist in the current context
+    //         System.Console.WriteLine(x8);
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(59, 34),
     // (66,19): error CS0841: Cannot use local variable 'x9' before it is declared
     //             Dummy(x9);
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x9").WithArguments("x9").WithLocation(66, 19),
@@ -7285,7 +7290,7 @@ public class X
     // (97,17): warning CS0219: The variable 'y12' is assigned but its value is never used
     //             var y12 = 12;
     Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(97, 17),
-    // (115,31): error CS0128: A local variable named 'x14' is already defined in this scope
+    // (115,31): error CS0128: A local variable or function named 'x14' is already defined in this scope
     //                      2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(115, 31),
     // (112,19): error CS0841: Cannot use local variable 'x14' before it is declared
@@ -7310,9 +7315,7 @@ public class X
             var x4Ref = GetReferences(tree, "x4").ToArray();
             Assert.Equal(3, x4Ref.Length);
             VerifyNotAPatternLocal(model, x4Ref[0]);
-            VerifyNotAPatternLocal(model, x4Ref[1]);
-            VerifyNotAPatternLocal(model, x4Ref[2]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl);
+            VerifyModelForDeclarationPattern(model, x4Decl, x4Ref[1], x4Ref[2]);
 
             var x6Decl = GetPatternDeclarations(tree, "x6").Single();
             var x6Ref = GetReferences(tree, "x6").ToArray();
@@ -7328,14 +7331,15 @@ public class X
             var x8Decl = GetPatternDeclarations(tree, "x8").Single();
             var x8Ref = GetReferences(tree, "x8").ToArray();
             Assert.Equal(3, x8Ref.Length);
-            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref);
+            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref[0], x8Ref[1]);
+            VerifyNotInScope(model, x8Ref[2]);
 
             var x9Decl = GetPatternDeclarations(tree, "x9").ToArray();
             var x9Ref = GetReferences(tree, "x9").ToArray();
             Assert.Equal(2, x9Decl.Length);
             Assert.Equal(4, x9Ref.Length);
-            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref[0], x9Ref[1], x9Ref[2]);
-            VerifyModelForDeclarationPattern(model, x9Decl[1], x9Ref[3]);
+            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref[1], x9Ref[2]);
+            VerifyModelForDeclarationPattern(model, x9Decl[1], x9Ref[0], x9Ref[3]);
 
             var y10Ref = GetReferences(tree, "y10").ToArray();
             Assert.Equal(2, y10Ref.Length);
@@ -11323,11 +11327,16 @@ public class X
         switch (val)
         {
             case 1 when Dummy(123, Data is var x1):
-                while (Dummy(x1 is var y1)) break;
-                System.Console.WriteLine(y1);
+                while (Dummy(x1 is var y1) && Print(y1)) break;
                 break;
         }
     }
+
+    static bool Print(int x)
+    {
+        System.Console.WriteLine(x);
+        return true;
+    } 
 
     static bool Dummy(params object[] data) 
     {
@@ -11368,11 +11377,16 @@ public class X
             case 1 when Dummy(123, Data is var x1):
                 do
                     val = 0;
-                while (Dummy(x1 is var y1) && false);
-                System.Console.WriteLine(y1);
+                while (Dummy(x1 is var y1) && Print(y1));
                 break;
         }
     }
+
+    static bool Print(int x)
+    {
+        System.Console.WriteLine(x);
+        return false;
+    } 
 
     static bool Dummy(params object[] data)
     {


### PR DESCRIPTION
**Customer scenario**
See #15529.

**Bugs this fixes:** 
Related to #15630.

**Workarounds, if any**
Explicitly copy values to locals declared within the body of the loop and use those in lambdas instead.

**Risk**
Low

**Performance impact**
Low.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Design change for a new feature.

**How was the bug found?**
Requested by a customer.


@dotnet/roslyn-compiler Please review.