### PR TITLE
Adjust scope of variables declared within a ‘for’ condition and ‘for’ incrementors.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ExpressionListVariableBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionListVariableBinder.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Utilities;
+using System.Diagnostics;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed class ExpressionListVariableBinder : LocalScopeBinder
+    {
+        private readonly SeparatedSyntaxList<ExpressionSyntax> _expressions;
+
+        internal ExpressionListVariableBinder(SeparatedSyntaxList<ExpressionSyntax> expressions, Binder next) : base(next)
+        {
+            Debug.Assert(expressions.Count > 0);
+            _expressions = expressions;
+        }
+
+        protected override ImmutableArray<LocalSymbol> BuildLocals()
+        {
+            var builder = ArrayBuilder<LocalSymbol>.GetInstance();
+            ExpressionVariableFinder.FindExpressionVariables(this, builder, _expressions);
+            return builder.ToImmutableAndFree();
+        }
+
+        internal override SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                return _expressions[0];
+            }
+        }
+
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(SyntaxNode scopeDesignator)
+        {
+            if (ScopeDesignator == scopeDesignator)
+            {
+                return this.Locals;
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -41,8 +41,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ExpressionVariableFinder.FindExpressionVariables(this, locals, _syntax.Initializers);
             }
 
-            ExpressionVariableFinder.FindExpressionVariables(this, locals, node: _syntax.Condition);
-            ExpressionVariableFinder.FindExpressionVariables(this, locals, _syntax.Incrementors);
             return locals.ToImmutableAndFree();
         }
 
@@ -66,14 +64,32 @@ namespace Microsoft.CodeAnalysis.CSharp
                 initializer = originalBinder.BindStatementExpressionList(node.Initializers, diagnostics);
             }
 
-            var condition = (node.Condition != null) ? originalBinder.BindBooleanExpression(node.Condition, diagnostics) : null;
-            var increment = originalBinder.BindStatementExpressionList(node.Incrementors, diagnostics);
+            BoundExpression condition = null;
+            var innerLocals = ImmutableArray<LocalSymbol>.Empty;
+            ExpressionSyntax conditionSyntax = node.Condition;
+            if (conditionSyntax != null)
+            {
+                originalBinder = originalBinder.GetBinder(conditionSyntax);
+                condition = originalBinder.BindBooleanExpression(conditionSyntax, diagnostics);
+                innerLocals = originalBinder.GetDeclaredLocalsForScope(conditionSyntax);
+            }
+
+            BoundStatement increment = null;
+            SeparatedSyntaxList<ExpressionSyntax> incrementors = node.Incrementors;
+            if (incrementors.Count > 0)
+            {
+                var scopeDesignator = incrementors.First();
+                var incrementBinder = originalBinder.GetBinder(scopeDesignator);
+                increment = incrementBinder.WrapWithVariablesIfAny(scopeDesignator, incrementBinder.BindStatementExpressionList(incrementors, diagnostics));
+            }
+
             var body = originalBinder.BindPossibleEmbeddedStatement(node.Statement, diagnostics);
 
             Debug.Assert(this.Locals == this.GetDeclaredLocalsForScope(node));
             return new BoundForStatement(node,
                                          this.Locals,
                                          initializer,
+                                         innerLocals,
                                          condition,
                                          increment,
                                          body,

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -856,9 +856,13 @@
   </Node>
 
   <Node Name="BoundForStatement" Base="BoundLoopStatement">
-    <!-- OuterLocals are the locals declared within the loop statement and are in scope throughout the whole loop statement, including the Initializer -->
+    <!-- OuterLocals are the locals declared within the loop Initializer statement and are in scope throughout the whole loop statement -->
     <Field Name="OuterLocals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <Field Name="Initializer" Type="BoundStatement" Null="allow"/>
+    <!-- InnerLocals are the locals declared within the loop Condition and are in scope throughout the Condition, Increment and Body.
+         They are considered to be declared per iteration.
+    -->
+    <Field Name="InnerLocals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <Field Name="Condition" Type="BoundExpression" Null="allow"/>
     <Field Name="Increment" Type="BoundStatement" Null="allow"/>
     <Field Name="Body" Type="BoundStatement"/>

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Binder\EarlyWellKnownAttributeBinder.cs" />
     <Compile Include="Binder\EmbeddedStatementBinder.cs" />
     <Compile Include="Binder\ExecutableCodeBinder.cs" />
+    <Compile Include="Binder\ExpressionListVariableBinder.cs" />
     <Compile Include="Binder\ExtensionMethodScope.cs" />
     <Compile Include="Binder\FixedStatementBinder.cs" />
     <Compile Include="Binder\ForEachEnumeratorInfo.cs" />

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -245,10 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     binder = rootBinder.GetBinder(current);
                 }
-                else if (current is ExpressionSyntax &&
-                            ((current.Parent as LambdaExpressionSyntax)?.Body == current ||
-                             (current.Parent as SwitchStatementSyntax)?.Expression == current ||
-                             (current.Parent as CommonForEachStatementSyntax)?.Expression == current))
+                else if ((current as ExpressionSyntax).IsValidScopeDesignator())
                 {
                     binder = rootBinder.GetBinder(current);
                 }
@@ -303,6 +300,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (LookupPosition.IsBetweenTokens(position, switchStmt.OpenParenToken, switchStmt.OpenBraceToken))
                     {
                         binder = binder.GetBinder(switchStmt.Expression);
+                        Debug.Assert(binder != null);
+                    }
+                    break;
+
+                case SyntaxKind.ForStatement:
+                    var forStmt = (ForStatementSyntax)stmt;
+                    if (LookupPosition.IsBetweenTokens(position, forStmt.SecondSemicolonToken, forStmt.CloseParenToken) &&
+                        forStmt.Incrementors.Count > 0)
+                    {
+                        binder = binder.GetBinder(forStmt.Incrementors.First());
+                        Debug.Assert(binder != null);
+                    }
+                    else if (LookupPosition.IsBetweenTokens(position, forStmt.FirstSemicolonToken, LookupPosition.GetFirstExcludedToken(forStmt)) &&
+                        forStmt.Condition != null)
+                    {
+                        binder = binder.GetBinder(forStmt.Condition);
                         Debug.Assert(binder != null);
                     }
                     break;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1575,7 +1575,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitForStatement(BoundForStatement node)
         {
             DeclareVariables(node.OuterLocals);
+            DeclareVariables(node.InnerLocals);
             var result = base.VisitForStatement(node);
+            ReportUnusedVariables(node.InnerLocals);
             ReportUnusedVariables(node.OuterLocals);
             return result;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
@@ -103,19 +103,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Previous.InstrumentForEachStatementIterationVarDeclaration(original, iterationVarDecl);
         }
 
-        public override BoundStatement InstrumentForStatementGotoEnd(BoundForStatement original, BoundStatement gotoEnd)
+        public override BoundStatement InstrumentForStatementConditionalGotoStartOrBreak(BoundForStatement original, BoundStatement branchBack)
         {
-            return Previous.InstrumentForStatementGotoEnd(original, gotoEnd);
-        }
-
-        public override BoundStatement InstrumentForEachStatementGotoEnd(BoundForEachStatement original, BoundStatement gotoEnd)
-        {
-            return Previous.InstrumentForEachStatementGotoEnd(original, gotoEnd);
-        }
-
-        public override BoundStatement InstrumentForStatementConditionalGotoStart(BoundForStatement original, BoundStatement branchBack)
-        {
-            return Previous.InstrumentForStatementConditionalGotoStart(original, branchBack);
+            return Previous.InstrumentForStatementConditionalGotoStartOrBreak(original, branchBack);
         }
 
         public override BoundStatement InstrumentForEachStatementConditionalGotoStart(BoundForEachStatement original, BoundStatement branchBack)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -256,30 +256,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                   iterationVarDeclSpan);
         }
 
-        public override BoundStatement InstrumentForEachStatementGotoEnd(BoundForEachStatement original, BoundStatement gotoEnd)
-        {
-            return ForStatementCreateGotoEndSequencePoint(base.InstrumentForEachStatementGotoEnd(original, gotoEnd));
-        }
-
-        public override BoundStatement InstrumentForStatementGotoEnd(BoundForStatement original, BoundStatement gotoEnd)
-        {
-            return ForStatementCreateGotoEndSequencePoint(base.InstrumentForStatementGotoEnd(original, gotoEnd));
-        }
-
-        private static BoundStatement ForStatementCreateGotoEndSequencePoint(BoundStatement gotoEnd)
-        {
-            // Mark the initial jump as hidden.
-            // We do it to tell that this is not a part of previous statement.
-            // This jump may be a target of another jump (for example if loops are nested) and that will make 
-            // impression of the previous statement being re-executed
-            return new BoundSequencePoint(null, gotoEnd);
-        }
-
-        public override BoundStatement InstrumentForStatementConditionalGotoStart(BoundForStatement original, BoundStatement branchBack)
+        public override BoundStatement InstrumentForStatementConditionalGotoStartOrBreak(BoundForStatement original, BoundStatement branchBack)
         {
             // hidden sequence point if there is no condition
             return new BoundSequencePoint(original.Condition?.Syntax, 
-                                          base.InstrumentForStatementConditionalGotoStart(original, branchBack));
+                                          base.InstrumentForStatementConditionalGotoStartOrBreak(original, branchBack));
         }
 
         public override BoundStatement InstrumentForEachStatementConditionalGotoStart(BoundForEachStatement original, BoundStatement branchBack)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -155,20 +155,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return iterationVarDecl;
         }
 
-        public virtual BoundStatement InstrumentForStatementGotoEnd(BoundForStatement original, BoundStatement gotoEnd)
-        {
-            Debug.Assert(!original.WasCompilerGenerated);
-            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForStatement);
-            return gotoEnd;
-        }
-
-        public virtual BoundStatement InstrumentForEachStatementGotoEnd(BoundForEachStatement original, BoundStatement gotoEnd)
-        {
-            Debug.Assert(!original.WasCompilerGenerated);
-            Debug.Assert(original.Syntax is CommonForEachStatementSyntax);
-            return gotoEnd;
-        }
-
         public virtual BoundStatement InstrumentForEachStatementConditionalGotoStart(BoundForEachStatement original, BoundStatement branchBack)
         {
             Debug.Assert(!original.WasCompilerGenerated);
@@ -176,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return branchBack;
         }
 
-        public virtual BoundStatement InstrumentForStatementConditionalGotoStart(BoundForStatement original, BoundStatement branchBack)
+        public virtual BoundStatement InstrumentForStatementConditionalGotoStartOrBreak(BoundForStatement original, BoundStatement branchBack)
         {
             Debug.Assert(!original.WasCompilerGenerated);
             Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForStatement);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -469,7 +469,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //     V v = (V)s.Chars[p];   /* OR */   (D1 d1, ...) = (V)s.Chars[p];
             //     /*node.Body*/
             // }
-            BoundStatement result = RewriteForStatement(
+            BoundStatement result = RewriteForStatementWithoutInnerLocals(
                 original: node,
                 outerLocals: ImmutableArray.Create(stringVar, positionVar),
                 rewrittenInitializer: initializer,
@@ -668,7 +668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //     V v = (V)a[p];   /* OR */   (D1 d1, ...) = (V)a[p];
             //     /*node.Body*/
             // }
-            BoundStatement result = RewriteForStatement(
+            BoundStatement result = RewriteForStatementWithoutInnerLocals(
                 original: node,
                 outerLocals: ImmutableArray.Create<LocalSymbol>(arrayVar, positionVar),
                 rewrittenInitializer: initializer,
@@ -854,7 +854,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continueLabel = new GeneratedLabelSymbol("continue"); // Should not affect emitted code since unused
                 }
 
-                forLoop = RewriteForStatement(
+                forLoop = RewriteForStatementWithoutInnerLocals(
                     original: node,
                     outerLocals: ImmutableArray.Create(positionVar[dimension]),
                     rewrittenInitializer: positionVarDecl,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForStatement.cs
@@ -28,16 +28,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return RewriteForStatement(
                 node,
-                node.OuterLocals,
                 rewrittenInitializer,
                 rewrittenCondition,
                 rewrittenIncrement,
-                rewrittenBody,
-                node.BreakLabel,
-                node.ContinueLabel, node.HasErrors);
+                rewrittenBody);
         }
 
-        private BoundStatement RewriteForStatement(
+        private BoundStatement RewriteForStatementWithoutInnerLocals(
             BoundLoopStatement original,
             ImmutableArray<LocalSymbol> outerLocals,
             BoundStatement rewrittenInitializer,
@@ -105,17 +102,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (this.Instrument)
             {
-                switch (original.Kind)
-                {
-                    case BoundKind.ForEachStatement:
-                        gotoEnd = _instrumenter.InstrumentForEachStatementGotoEnd((BoundForEachStatement)original, gotoEnd);
-                        break;
-                    case BoundKind.ForStatement:
-                        gotoEnd = _instrumenter.InstrumentForStatementGotoEnd((BoundForStatement)original, gotoEnd);
-                        break;
-                    default:
-                        throw ExceptionUtilities.UnexpectedValue(original.Kind);
-                }
+                // Mark the initial jump as hidden.
+                // We do it to tell that this is not a part of previous statement.
+                // This jump may be a target of another jump (for example if loops are nested) and that will make 
+                // impression of the previous statement being re-executed
+                gotoEnd = new BoundSequencePoint(null, gotoEnd);
             }
 
             statementBuilder.Add(gotoEnd);
@@ -155,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         branchBack = _instrumenter.InstrumentForEachStatementConditionalGotoStart((BoundForEachStatement)original, branchBack);
                         break;
                     case BoundKind.ForStatement:
-                        branchBack = _instrumenter.InstrumentForStatementConditionalGotoStart((BoundForStatement)original, branchBack);
+                        branchBack = _instrumenter.InstrumentForStatementConditionalGotoStartOrBreak((BoundForStatement)original, branchBack);
                         break;
                     default:
                         throw ExceptionUtilities.UnexpectedValue(original.Kind);
@@ -169,6 +160,108 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var statements = statementBuilder.ToImmutableAndFree();
             return new BoundBlock(syntax, outerLocals, statements, hasErrors);
+        }
+
+        private BoundStatement RewriteForStatement(
+            BoundForStatement node,
+            BoundStatement rewrittenInitializer,
+            BoundExpression rewrittenCondition,
+            BoundStatement rewrittenIncrement,
+            BoundStatement rewrittenBody)
+        {
+            if (node.InnerLocals.IsEmpty)
+            {
+                return RewriteForStatementWithoutInnerLocals(
+                    node,
+                    node.OuterLocals,
+                    rewrittenInitializer,
+                    rewrittenCondition,
+                    rewrittenIncrement,
+                    rewrittenBody,
+                    node.BreakLabel,
+                    node.ContinueLabel, node.HasErrors);
+            }
+
+            // We need to enter inner_scope-block from the top, that is where an instance of a display class will be created
+            // if any local is captured within a lambda.
+
+            // for (initializer; condition; increment)
+            //   body;
+            //
+            // becomes the following (with block added for locals)
+            //
+            // {
+            //   initializer;
+            // start:
+            //   {
+            //     GotoIfFalse condition break;
+            //     body;
+            // continue:
+            //     increment;
+            //     goto start;
+            //   }
+            // break:
+            // }
+
+            Debug.Assert(rewrittenBody != null);
+
+            SyntaxNode syntax = node.Syntax;
+            var statementBuilder = ArrayBuilder<BoundStatement>.GetInstance();
+
+            //  initializer;
+            if (rewrittenInitializer != null)
+            {
+                statementBuilder.Add(rewrittenInitializer);
+            }
+
+            var startLabel = new GeneratedLabelSymbol("start");
+
+            // start:
+            BoundStatement startLabelStatement = new BoundLabelStatement(syntax, startLabel);
+
+            if (Instrument)
+            {
+                startLabelStatement = new BoundSequencePoint(null, startLabelStatement);
+            }
+
+            statementBuilder.Add(startLabelStatement);
+
+            var blockBuilder = ArrayBuilder<BoundStatement>.GetInstance();
+
+            // GotoIfFalse condition break;
+            if (rewrittenCondition != null)
+            {
+                BoundStatement ifNotConditionGotoBreak = new BoundConditionalGoto(rewrittenCondition.Syntax, rewrittenCondition, false, node.BreakLabel);
+
+                if (this.Instrument)
+                {
+                    ifNotConditionGotoBreak = _instrumenter.InstrumentForStatementConditionalGotoStartOrBreak(node, ifNotConditionGotoBreak);
+                }
+
+                blockBuilder.Add(ifNotConditionGotoBreak);
+            }
+
+            // body;
+            blockBuilder.Add(rewrittenBody);
+
+            // continue:
+            //   increment;
+            blockBuilder.Add(new BoundLabelStatement(syntax, node.ContinueLabel));
+            if (rewrittenIncrement != null)
+            {
+                blockBuilder.Add(rewrittenIncrement);
+            }
+
+            // goto start;
+            blockBuilder.Add(new BoundGotoStatement(syntax, startLabel));
+
+            statementBuilder.Add(new BoundBlock(syntax, node.InnerLocals, blockBuilder.ToImmutableAndFree()));
+
+            // break:
+            statementBuilder.Add(new BoundLabelStatement(syntax, node.BreakLabel));
+
+            var statements = statementBuilder.ToImmutableAndFree();
+            return new BoundBlock(syntax, node.OuterLocals, statements, node.HasErrors);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -160,10 +160,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var newOuterLocals = RewriteLocals(node.OuterLocals);
             BoundStatement initializer = (BoundStatement)this.Visit(node.Initializer);
+            var newInnerLocals = RewriteLocals(node.InnerLocals);
             BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
             BoundStatement increment = (BoundStatement)this.Visit(node.Increment);
             BoundStatement body = (BoundStatement)this.Visit(node.Body);
-            return node.Update(newOuterLocals, initializer, condition, increment, body, node.BreakLabel, node.ContinueLabel);
+            return node.Update(newOuterLocals, initializer, newInnerLocals, condition, increment, body, node.BreakLabel, node.ContinueLabel);
         }
 
         public override BoundNode VisitDoStatement(BoundDoStatement node)

--- a/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
@@ -329,7 +329,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             }
         }
 
-        private static SyntaxToken GetFirstExcludedToken(StatementSyntax statement)
+        internal static SyntaxToken GetFirstExcludedToken(StatementSyntax statement)
         {
             Debug.Assert(statement != null);
             switch (statement.Kind())

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5624,23 +5624,29 @@ class Program
                 // (7,19): error CS8185: A declaration is not allowed in this context.
                 //         for (; ; (int x1, int x2) = t)
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int x1").WithLocation(7, 19),
-                // (9,38): error CS0165: Use of unassigned local variable 'x1'
+                // (9,38): error CS0103: The name 'x1' does not exist in the current context
                 //             System.Console.WriteLine(x1);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(9, 38),
-                // (10,38): error CS0165: Use of unassigned local variable 'x2'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(9, 38),
+                // (10,38): error CS0103: The name 'x2' does not exist in the current context
                 //             System.Console.WriteLine(x2);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x2").WithArguments("x2").WithLocation(10, 38)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x2").WithArguments("x2").WithLocation(10, 38)
             );
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
 
             var x1 = GetDeconstructionVariable(tree, "x1");
             var x1Ref = GetReference(tree, "x1");
-            VerifyModelForDeconstructionLocal(model, x1, x1Ref);
+            VerifyModelForDeconstructionLocal(model, x1);
+            var symbolInfo = model.GetSymbolInfo(x1Ref);
+            Assert.Null(symbolInfo.Symbol);
+            Assert.Empty(symbolInfo.CandidateSymbols);
 
             var x2 = GetDeconstructionVariable(tree, "x2");
             var x2Ref = GetReference(tree, "x2");
-            VerifyModelForDeconstructionLocal(model, x2, x2Ref);
+            VerifyModelForDeconstructionLocal(model, x2);
+            symbolInfo = model.GetSymbolInfo(x2Ref);
+            Assert.Null(symbolInfo.Symbol);
+            Assert.Empty(symbolInfo.CandidateSymbols);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -1215,6 +1215,12 @@ public class Cls
                     }
                     break;
 
+                case SyntaxKind.PreIncrementExpression:
+                case SyntaxKind.PostIncrementExpression:
+                case SyntaxKind.PreDecrementExpression:
+                case SyntaxKind.PostDecrementExpression:
+                    return true;
+
                 default:
                     return false;
             }
@@ -6141,48 +6147,39 @@ public class X
                 // (109,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
                 //             var y12 = 12;
                 Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "var y12 = 12;").WithLocation(109, 13),
-                // (16,19): error CS0165: Use of unassigned local variable 'x1'
+                // (16,19): error CS0103: The name 'x1' does not exist in the current context
                 //             Dummy(x1);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(16, 19),
-                // (25,19): error CS0165: Use of unassigned local variable 'x2'
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(16, 19),
+                // (25,19): error CS0103: The name 'x2' does not exist in the current context
                 //             Dummy(x2);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x2").WithArguments("x2").WithLocation(25, 19),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x2").WithArguments("x2").WithLocation(25, 19),
                 // (34,47): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x4) && x4)
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(34, 47),
-                // (36,19): error CS0165: Use of unassigned local variable 'x4'
-                //             Dummy(x4);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x4").WithArguments("x4").WithLocation(36, 19),
                 // (42,20): error CS0841: Cannot use local variable 'x6' before it is declared
                 //              Dummy(x6 && TakeOutParam(true, out var x6))
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(42, 20),
-                // (44,19): error CS0165: Use of unassigned local variable 'x6'
+                // (44,19): error CS0103: The name 'x6' does not exist in the current context
                 //             Dummy(x6);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x6").WithArguments("x6").WithLocation(44, 19),
-                // (53,17): error CS0136: A local or parameter named 'x7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-                //             var x7 = 12;
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x7").WithArguments("x7").WithLocation(53, 17),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x6").WithArguments("x6").WithLocation(44, 19),
+                // (63,19): error CS0103: The name 'x8' does not exist in the current context
+                //             Dummy(x8);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(63, 19),
                 // (65,34): error CS0103: The name 'x8' does not exist in the current context
                 //         System.Console.WriteLine(x8);
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(65, 34),
                 // (65,9): warning CS0162: Unreachable code detected
                 //         System.Console.WriteLine(x8);
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(65, 9),
-                // (63,19): error CS0165: Use of unassigned local variable 'x8'
-                //             Dummy(x8);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x8").WithArguments("x8").WithLocation(63, 19),
-                // (76,51): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-                //                  Dummy(TakeOutParam(true, out var x9) && x9) // 2
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(76, 51),
+                // (74,19): error CS0103: The name 'x9' does not exist in the current context
+                //             Dummy(x9);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x9").WithArguments("x9").WithLocation(74, 19),
+                // (78,23): error CS0103: The name 'x9' does not exist in the current context
+                //                 Dummy(x9);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x9").WithArguments("x9").WithLocation(78, 23),
                 // (71,14): warning CS0162: Unreachable code detected
                 //              Dummy(TakeOutParam(true, out var x9) && x9)
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "Dummy").WithLocation(71, 14),
-                // (74,19): error CS0165: Use of unassigned local variable 'x9'
-                //             Dummy(x9);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x9").WithArguments("x9").WithLocation(74, 19),
-                // (78,23): error CS0165: Use of unassigned local variable 'x9'
-                //                 Dummy(x9);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x9").WithArguments("x9").WithLocation(78, 23),
                 // (85,33): error CS0103: The name 'y10' does not exist in the current context
                 //              Dummy(TakeOutParam(y10, out var x10))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y10").WithArguments("y10").WithLocation(85, 33),
@@ -6192,12 +6189,12 @@ public class X
                 // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
                 //             var y12 = 12;
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
-                // (124,44): error CS0128: A local variable named 'x14' is already defined in this scope
+                // (124,44): error CS0128: A local variable or function named 'x14' is already defined in this scope
                 //                    TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 44),
-                // (128,19): error CS0165: Use of unassigned local variable 'x14'
+                // (128,19): error CS0103: The name 'x14' does not exist in the current context
                 //             Dummy(x14);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x14").WithArguments("x14").WithLocation(128, 19)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x14").WithArguments("x14").WithLocation(128, 19)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -6206,23 +6203,27 @@ public class X
             var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
             var x1Ref = GetReferences(tree, "x1").ToArray();
             Assert.Equal(2, x1Ref.Length);
-            VerifyModelForOutVar(model, x1Decl, x1Ref);
+            VerifyModelForOutVar(model, x1Decl, x1Ref[0]);
+            VerifyNotInScope(model, x1Ref[1]);
 
             var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
             var x2Ref = GetReferences(tree, "x2").ToArray();
             Assert.Equal(2, x2Ref.Length);
-            VerifyModelForOutVar(model, x2Decl, x2Ref);
+            VerifyModelForOutVar(model, x2Decl, x2Ref[0]);
+            VerifyNotInScope(model, x2Ref[1]);
 
             var x4Decl = GetOutVarDeclarations(tree, "x4").Single();
             var x4Ref = GetReferences(tree, "x4").ToArray();
             Assert.Equal(3, x4Ref.Length);
             VerifyNotAnOutLocal(model, x4Ref[0]);
-            VerifyModelForOutVar(model, x4Decl, x4Ref[1], x4Ref[2]);
+            VerifyModelForOutVar(model, x4Decl, x4Ref[1]);
+            VerifyNotAnOutLocal(model, x4Ref[2]);
 
             var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
             var x6Ref = GetReferences(tree, "x6").ToArray();
             Assert.Equal(2, x6Ref.Length);
-            VerifyModelForOutVar(model, x6Decl, x6Ref);
+            VerifyModelForOutVar(model, x6Decl, x6Ref[0]);
+            VerifyNotInScope(model, x6Ref[1]);
 
             var x7Decl = GetOutVarDeclarations(tree, "x7").Single();
             var x7Ref = GetReferences(tree, "x7").ToArray();
@@ -6233,15 +6234,18 @@ public class X
             var x8Decl = GetOutVarDeclarations(tree, "x8").Single();
             var x8Ref = GetReferences(tree, "x8").ToArray();
             Assert.Equal(3, x8Ref.Length);
-            VerifyModelForOutVar(model, x8Decl, x8Ref[0], x8Ref[1]);
+            VerifyModelForOutVar(model, x8Decl, x8Ref[0]);
+            VerifyNotInScope(model, x8Ref[1]);
             VerifyNotInScope(model, x8Ref[2]);
 
             var x9Decl = GetOutVarDeclarations(tree, "x9").ToArray();
             var x9Ref = GetReferences(tree, "x9").ToArray();
             Assert.Equal(2, x9Decl.Length);
             Assert.Equal(4, x9Ref.Length);
-            VerifyModelForOutVar(model, x9Decl[0], x9Ref[0], x9Ref[1]);
-            VerifyModelForOutVar(model, x9Decl[1], x9Ref[2], x9Ref[3]);
+            VerifyModelForOutVar(model, x9Decl[0], x9Ref[0]);
+            VerifyNotInScope(model, x9Ref[1]);
+            VerifyModelForOutVar(model, x9Decl[1], x9Ref[2]);
+            VerifyNotInScope(model, x9Ref[3]);
 
             var y10Ref = GetReferences(tree, "y10").ToArray();
             Assert.Equal(2, y10Ref.Length);
@@ -6255,8 +6259,9 @@ public class X
             var x14Ref = GetReferences(tree, "x14").ToArray();
             Assert.Equal(2, x14Decl.Length);
             Assert.Equal(2, x14Ref.Length);
-            VerifyModelForOutVar(model, x14Decl[0], x14Ref);
+            VerifyModelForOutVar(model, x14Decl[0], x14Ref[0]);
             VerifyModelForOutVarDuplicateInSameScope(model, x14Decl[1]);
+            VerifyNotInScope(model, x14Ref[1]);
         }
 
         [Fact]
@@ -6885,7 +6890,7 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (13,47): error CS0128: A local variable named 'x1' is already defined in this scope
+                // (13,47): error CS0128: A local variable or function named 'x1' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x1) && x1)
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(13, 47),
                 // (13,54): error CS0841: Cannot use local variable 'x1' before it is declared
@@ -6894,96 +6899,108 @@ public class X
                 // (13,54): error CS0165: Use of unassigned local variable 'x1'
                 //              Dummy(TakeOutParam(true, out var x1) && x1)
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(13, 54),
-                // (21,47): error CS0128: A local variable named 'x2' is already defined in this scope
+                // (21,47): error CS0136: A local or parameter named 'x2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x2) && x2)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(21, 47),
-                // (29,47): error CS0128: A local variable named 'x3' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x2").WithArguments("x2").WithLocation(21, 47),
+                // (20,18): warning CS0219: The variable 'x2' is assigned but its value is never used
+                //         for (var x2 = true;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x2").WithArguments("x2").WithLocation(20, 18),
+                // (29,47): error CS0136: A local or parameter named 'x3' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x3) && x3)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x3").WithArguments("x3").WithLocation(29, 47),
-                // (37,47): error CS0128: A local variable named 'x4' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x3").WithArguments("x3").WithLocation(29, 47),
+                // (28,18): warning CS0219: The variable 'x3' is assigned but its value is never used
+                //         for (var x3 = true;;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x3").WithArguments("x3").WithLocation(28, 18),
+                // (37,47): error CS0128: A local variable or function named 'x4' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x4) && x4)
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(37, 47),
                 // (37,54): error CS0165: Use of unassigned local variable 'x4'
                 //              Dummy(TakeOutParam(true, out var x4) && x4)
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "x4").WithArguments("x4").WithLocation(37, 54),
-                // (45,47): error CS0128: A local variable named 'x5' is already defined in this scope
+                // (45,47): error CS0136: A local or parameter named 'x5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x5) && x5)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(45, 47),
-                // (53,47): error CS0128: A local variable named 'x6' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x5").WithArguments("x5").WithLocation(45, 47),
+                // (44,19): warning CS0219: The variable 'x5' is assigned but its value is never used
+                //         for (bool x5 = true;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x5").WithArguments("x5").WithLocation(44, 19),
+                // (53,47): error CS0136: A local or parameter named 'x6' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x6) && x6)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x6").WithArguments("x6").WithLocation(53, 47),
-                // (61,47): error CS0128: A local variable named 'x7' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x6").WithArguments("x6").WithLocation(53, 47),
+                // (52,19): warning CS0219: The variable 'x6' is assigned but its value is never used
+                //         for (bool x6 = true;;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x6").WithArguments("x6").WithLocation(52, 19),
+                // (61,47): error CS0128: A local variable or function named 'x7' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x7) && x7)
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x7").WithArguments("x7").WithLocation(61, 47),
-                // (69,52): error CS0128: A local variable named 'x8' is already defined in this scope
+                // (69,52): error CS0128: A local variable or function named 'x8' is already defined in this scope
                 //              b2 = Dummy(TakeOutParam(true, out var x8) && x8);
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(69, 52),
-                // (70,47): error CS0128: A local variable named 'x8' is already defined in this scope
+                // (70,47): error CS0136: A local or parameter named 'x8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x8) && x8);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(70, 47),
-                // (71,47): error CS0128: A local variable named 'x8' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x8").WithArguments("x8").WithLocation(70, 47),
+                // (71,47): error CS0136: A local or parameter named 'x8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x8) && x8))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(71, 47),
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x8").WithArguments("x8").WithLocation(71, 47),
                 // (77,23): error CS0841: Cannot use local variable 'x9' before it is declared
                 //         for (bool b = x9, 
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x9").WithArguments("x9").WithLocation(77, 23),
-                // (79,47): error CS0128: A local variable named 'x9' is already defined in this scope
+                // (79,47): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x9) && x9);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x9").WithArguments("x9").WithLocation(79, 47),
-                // (80,47): error CS0128: A local variable named 'x9' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(79, 47),
+                // (80,47): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x9) && x9))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x9").WithArguments("x9").WithLocation(80, 47),
-                // (86,22): error CS0841: Cannot use local variable 'x10' before it is declared
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(80, 47),
+                // (86,22): error CS0103: The name 'x10' does not exist in the current context
                 //         for (var b = x10;
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x10").WithArguments("x10").WithLocation(86, 22),
-                // (88,47): error CS0128: A local variable named 'x10' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x10").WithArguments("x10").WithLocation(86, 22),
+                // (88,47): error CS0128: A local variable or function named 'x10' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x10) && x10);
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x10").WithArguments("x10").WithLocation(88, 47),
-                // (89,47): error CS0128: A local variable named 'x10' is already defined in this scope
+                // (89,47): error CS0136: A local or parameter named 'x10' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x10) && x10))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x10").WithArguments("x10").WithLocation(89, 47),
-                // (95,23): error CS0841: Cannot use local variable 'x11' before it is declared
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x10").WithArguments("x10").WithLocation(89, 47),
+                // (95,23): error CS0103: The name 'x11' does not exist in the current context
                 //         for (bool b = x11;
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x11").WithArguments("x11").WithLocation(95, 23),
-                // (97,47): error CS0128: A local variable named 'x11' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x11").WithArguments("x11").WithLocation(95, 23),
+                // (97,47): error CS0128: A local variable or function named 'x11' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x11) && x11);
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x11").WithArguments("x11").WithLocation(97, 47),
-                // (98,47): error CS0128: A local variable named 'x11' is already defined in this scope
+                // (98,47): error CS0136: A local or parameter named 'x11' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x11) && x11))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x11").WithArguments("x11").WithLocation(98, 47),
-                // (104,20): error CS0841: Cannot use local variable 'x12' before it is declared
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x11").WithArguments("x11").WithLocation(98, 47),
+                // (104,20): error CS0103: The name 'x12' does not exist in the current context
                 //         for (Dummy(x12);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x12").WithArguments("x12").WithLocation(104, 20),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x12").WithArguments("x12").WithLocation(104, 20),
                 // (105,20): error CS0841: Cannot use local variable 'x12' before it is declared
                 //              Dummy(x12) &&
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x12").WithArguments("x12").WithLocation(105, 20),
-                // (107,47): error CS0128: A local variable named 'x12' is already defined in this scope
+                // (107,47): error CS0136: A local or parameter named 'x12' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x12) && x12))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x12").WithArguments("x12").WithLocation(107, 47),
-                // (113,22): error CS0841: Cannot use local variable 'x13' before it is declared
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x12").WithArguments("x12").WithLocation(107, 47),
+                // (113,22): error CS0103: The name 'x13' does not exist in the current context
                 //         for (var b = x13;
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x13").WithArguments("x13").WithLocation(113, 22),
-                // (114,20): error CS0841: Cannot use local variable 'x13' before it is declared
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x13").WithArguments("x13").WithLocation(113, 22),
+                // (114,20): error CS0103: The name 'x13' does not exist in the current context
                 //              Dummy(x13);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x13").WithArguments("x13").WithLocation(114, 20),
-                // (116,47): error CS0128: A local variable named 'x13' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x13").WithArguments("x13").WithLocation(114, 20),
+                // (116,47): error CS0128: A local variable or function named 'x13' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x13) && x13))
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x13").WithArguments("x13").WithLocation(116, 47),
-                // (122,23): error CS0841: Cannot use local variable 'x14' before it is declared
+                // (122,23): error CS0103: The name 'x14' does not exist in the current context
                 //         for (bool b = x14;
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x14").WithArguments("x14").WithLocation(122, 23),
-                // (123,20): error CS0841: Cannot use local variable 'x14' before it is declared
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x14").WithArguments("x14").WithLocation(122, 23),
+                // (123,20): error CS0103: The name 'x14' does not exist in the current context
                 //              Dummy(x14);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x14").WithArguments("x14").WithLocation(123, 20),
-                // (125,47): error CS0128: A local variable named 'x14' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x14").WithArguments("x14").WithLocation(123, 20),
+                // (125,47): error CS0128: A local variable or function named 'x14' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x14) && x14))
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(125, 47),
-                // (131,20): error CS0841: Cannot use local variable 'x15' before it is declared
+                // (131,20): error CS0103: The name 'x15' does not exist in the current context
                 //         for (Dummy(x15);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(131, 20),
-                // (132,20): error CS0841: Cannot use local variable 'x15' before it is declared
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x15").WithArguments("x15").WithLocation(131, 20),
+                // (132,20): error CS0103: The name 'x15' does not exist in the current context
                 //              Dummy(x15);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(132, 20),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x15").WithArguments("x15").WithLocation(132, 20),
                 // (133,20): error CS0841: Cannot use local variable 'x15' before it is declared
                 //              Dummy(x15),
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(133, 20)
@@ -6999,13 +7016,11 @@ public class X
 
             var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
             var x2Ref = GetReferences(tree, "x2").Single();
-            VerifyModelForOutVarDuplicateInSameScope(model, x2Decl);
-            VerifyNotAnOutLocal(model, x2Ref);
+            VerifyModelForOutVar(model, x2Decl, x2Ref);
 
             var x3Decl = GetOutVarDeclarations(tree, "x3").Single();
             var x3Ref = GetReferences(tree, "x3").Single();
-            VerifyModelForOutVarDuplicateInSameScope(model, x3Decl);
-            VerifyNotAnOutLocal(model, x3Ref);
+            VerifyModelForOutVar(model, x3Decl, x3Ref);
 
             var x4Decl = GetOutVarDeclarations(tree, "x4").Single();
             var x4Ref = GetReferences(tree, "x4").Single();
@@ -7014,13 +7029,11 @@ public class X
 
             var x5Decl = GetOutVarDeclarations(tree, "x5").Single();
             var x5Ref = GetReferences(tree, "x5").Single();
-            VerifyModelForOutVarDuplicateInSameScope(model, x5Decl);
-            VerifyNotAnOutLocal(model, x5Ref);
+            VerifyModelForOutVar(model, x5Decl, x5Ref);
 
             var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
             var x6Ref = GetReferences(tree, "x6").Single();
-            VerifyModelForOutVarDuplicateInSameScope(model, x6Decl);
-            VerifyNotAnOutLocal(model, x6Ref);
+            VerifyModelForOutVar(model, x6Decl, x6Ref);
 
             var x7Decl = GetOutVarDeclarations(tree, "x7").Single();
             var x7Ref = GetReferences(tree, "x7").Single();
@@ -7031,60 +7044,131 @@ public class X
             var x8Ref = GetReferences(tree, "x8").ToArray();
             Assert.Equal(4, x8Decl.Length);
             Assert.Equal(4, x8Ref.Length);
-            VerifyModelForOutVar(model, x8Decl[0], x8Ref);
+            VerifyModelForOutVar(model, x8Decl[0], x8Ref[0], x8Ref[1]);
             VerifyModelForOutVarDuplicateInSameScope(model, x8Decl[1]);
-            VerifyModelForOutVarDuplicateInSameScope(model, x8Decl[2]);
-            VerifyModelForOutVarDuplicateInSameScope(model, x8Decl[3]);
+            VerifyModelForOutVar(model, x8Decl[2], x8Ref[2]);
+            VerifyModelForOutVar(model, x8Decl[3], x8Ref[3]);
 
             var x9Decl = GetOutVarDeclarations(tree, "x9").ToArray();
             var x9Ref = GetReferences(tree, "x9").ToArray();
             Assert.Equal(3, x9Decl.Length);
             Assert.Equal(4, x9Ref.Length);
-            VerifyModelForOutVar(model, x9Decl[0], x9Ref);
-            VerifyModelForOutVarDuplicateInSameScope(model, x9Decl[1]);
-            VerifyModelForOutVarDuplicateInSameScope(model, x9Decl[2]);
+            VerifyModelForOutVarWithoutDataFlow(model, x9Decl[0], x9Ref[0], x9Ref[1]);
+            VerifyModelForOutVarWithoutDataFlow(model, x9Decl[1], x9Ref[2]);
+            VerifyModelForOutVarWithoutDataFlow(model, x9Decl[2], x9Ref[3]);
 
             var x10Decl = GetOutVarDeclarations(tree, "x10").ToArray();
             var x10Ref = GetReferences(tree, "x10").ToArray();
             Assert.Equal(3, x10Decl.Length);
             Assert.Equal(4, x10Ref.Length);
-            VerifyModelForOutVar(model, x10Decl[0], x10Ref);
+            VerifyNotInScope(model, x10Ref[0]);
+            VerifyModelForOutVar(model, x10Decl[0], x10Ref[1], x10Ref[2]);
             VerifyModelForOutVarDuplicateInSameScope(model, x10Decl[1]);
-            VerifyModelForOutVarDuplicateInSameScope(model, x10Decl[2]);
+            VerifyModelForOutVar(model, x10Decl[2], x10Ref[3]);
 
             var x11Decl = GetOutVarDeclarations(tree, "x11").ToArray();
             var x11Ref = GetReferences(tree, "x11").ToArray();
             Assert.Equal(3, x11Decl.Length);
             Assert.Equal(4, x11Ref.Length);
-            VerifyModelForOutVar(model, x11Decl[0], x11Ref);
+            VerifyNotInScope(model, x11Ref[0]);
+            VerifyModelForOutVar(model, x11Decl[0], x11Ref[1], x11Ref[2]);
             VerifyModelForOutVarDuplicateInSameScope(model, x11Decl[1]);
-            VerifyModelForOutVarDuplicateInSameScope(model, x11Decl[2]);
+            VerifyModelForOutVar(model, x11Decl[2], x11Ref[3]);
 
             var x12Decl = GetOutVarDeclarations(tree, "x12").ToArray();
             var x12Ref = GetReferences(tree, "x12").ToArray();
             Assert.Equal(2, x12Decl.Length);
             Assert.Equal(4, x12Ref.Length);
-            VerifyModelForOutVar(model, x12Decl[0], x12Ref);
-            VerifyModelForOutVarDuplicateInSameScope(model, x12Decl[1]);
+            VerifyNotInScope(model, x12Ref[0]);
+            VerifyModelForOutVar(model, x12Decl[0], x12Ref[1], x12Ref[2]);
+            VerifyModelForOutVar(model, x12Decl[1], x12Ref[3]);
 
             var x13Decl = GetOutVarDeclarations(tree, "x13").ToArray();
             var x13Ref = GetReferences(tree, "x13").ToArray();
             Assert.Equal(2, x13Decl.Length);
             Assert.Equal(4, x13Ref.Length);
-            VerifyModelForOutVar(model, x13Decl[0], x13Ref);
+            VerifyNotInScope(model, x13Ref[0]);
+            VerifyNotInScope(model, x13Ref[1]);
+            VerifyModelForOutVar(model, x13Decl[0], x13Ref[2], x13Ref[3]);
             VerifyModelForOutVarDuplicateInSameScope(model, x13Decl[1]);
 
             var x14Decl = GetOutVarDeclarations(tree, "x14").ToArray();
             var x14Ref = GetReferences(tree, "x14").ToArray();
             Assert.Equal(2, x14Decl.Length);
             Assert.Equal(4, x14Ref.Length);
-            VerifyModelForOutVar(model, x14Decl[0], x14Ref);
+            VerifyNotInScope(model, x14Ref[0]);
+            VerifyNotInScope(model, x14Ref[1]);
+            VerifyModelForOutVar(model, x14Decl[0], x14Ref[2], x14Ref[3]);
             VerifyModelForOutVarDuplicateInSameScope(model, x14Decl[1]);
 
             var x15Decl = GetOutVarDeclarations(tree, "x15").Single();
             var x15Ref = GetReferences(tree, "x15").ToArray();
             Assert.Equal(4, x15Ref.Length);
-            VerifyModelForOutVar(model, x15Decl, x15Ref);
+            VerifyNotInScope(model, x15Ref[0]);
+            VerifyNotInScope(model, x15Ref[1]);
+            VerifyModelForOutVar(model, x15Decl, x15Ref[2], x15Ref[3]);
+        }
+
+        [Fact]
+        public void Scope_For_07()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    bool Dummy(params object[] x) {return true;}
+
+    void Test1()
+    {
+        for (;;
+             Dummy(x1),
+             Dummy(TakeOutParam(true, out var x1) && x1))
+        {}
+    }
+
+    void Test2()
+    {
+        for (;;
+             Dummy(TakeOutParam(true, out var x2) && x2),
+             Dummy(TakeOutParam(true, out var x2) && x2))
+        {}
+    }
+
+    static bool TakeOutParam(object y, out bool x) 
+    {
+        x = true;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            compilation.VerifyDiagnostics(
+                // (13,20): error CS0841: Cannot use local variable 'x1' before it is declared
+                //              Dummy(x1),
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x1").WithArguments("x1").WithLocation(13, 20),
+                // (22,47): error CS0128: A local variable or function named 'x2' is already defined in this scope
+                //              Dummy(TakeOutParam(true, out var x2) && x2))
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(22, 47)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+            var x2Decl = GetOutVarDeclarations(tree, "x2").ToArray();
+            var x2Ref = GetReferences(tree, "x2").ToArray();
+            Assert.Equal(2, x2Decl.Length);
+            Assert.Equal(2, x2Ref.Length);
+            VerifyModelForOutVar(model, x2Decl[0], x2Ref);
+            VerifyModelForOutVarDuplicateInSameScope(model, x2Decl[1]);
         }
 
         [Fact]
@@ -7100,7 +7184,7 @@ public class X
 
         for (Dummy(f, TakeOutParam((f ? 10 : 20), out var x0), x0); 
              Dummy(f, TakeOutParam((f ? 1 : 2), out var x1), x1); 
-             Dummy(f, TakeOutParam((f ? 100 : 200), out var x2), x2))
+             Dummy(f, TakeOutParam((f ? 100 : 200), out var x2), x2), Dummy(true, null, x2))
         {
             System.Console.WriteLine(x0);
             System.Console.WriteLine(x1);
@@ -7128,7 +7212,282 @@ public class X
 10
 1
 200
+200
 2");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x0Decl = GetOutVarDeclarations(tree, "x0").Single();
+            var x0Ref = GetReferences(tree, "x0").ToArray();
+            Assert.Equal(2, x0Ref.Length);
+            VerifyModelForOutVar(model, x0Decl, x0Ref);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+            var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
+            var x2Ref = GetReferences(tree, "x2").ToArray();
+            Assert.Equal(2, x2Ref.Length);
+            VerifyModelForOutVar(model, x2Decl, x2Ref);
+        }
+
+        [Fact]
+        public void For_02()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        bool f = true;
+
+        for (Dummy(f, TakeOutParam((f ? 10 : 20), out var x0), x0); 
+             Dummy(f, TakeOutParam((f ? 1 : 2), out var x1), x1); 
+             f = false, Dummy(f, TakeOutParam((f ? 100 : 200), out var x2), x2), Dummy(true, null, x2))
+        {
+            System.Console.WriteLine(x0);
+            System.Console.WriteLine(x1);
+        }
+    }
+
+    static bool Dummy(bool x, object y, object z) 
+    {
+        System.Console.WriteLine(z);
+        return x;
+    }
+
+    static bool TakeOutParam(int y, out int x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"10
+1
+10
+1
+200
+200
+2");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x0Decl = GetOutVarDeclarations(tree, "x0").Single();
+            var x0Ref = GetReferences(tree, "x0").ToArray();
+            Assert.Equal(2, x0Ref.Length);
+            VerifyModelForOutVar(model, x0Decl, x0Ref);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+            var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
+            var x2Ref = GetReferences(tree, "x2").ToArray();
+            Assert.Equal(2, x2Ref.Length);
+            VerifyModelForOutVar(model, x2Decl, x2Ref);
+        }
+
+        [Fact]
+        public void For_03()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        var l = new System.Collections.Generic.List<System.Action>();
+
+        for (TakeOutParam(1, out var x0); Dummy(x0 < 3, TakeOutParam(x0*10, out var x1), x1); x0++)
+        {
+            l.Add(() => System.Console.WriteLine(""{0} {1}"", x0, x1));
+        }
+
+        System.Console.WriteLine(""--"");
+
+        foreach (var d in l)
+        {
+            d();
+        }
+    }
+
+    static bool Dummy(bool x, object y, object z) 
+    {
+        System.Console.WriteLine(z);
+        return x;
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"10
+20
+30
+--
+3 10
+3 20
+");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x0Decl = GetOutVarDeclarations(tree, "x0").ToArray();
+            var x0Ref = GetReferences(tree, "x0").ToArray();
+            Assert.Equal(1, x0Decl.Length);
+            Assert.Equal(4, x0Ref.Length);
+            VerifyModelForOutVar(model, x0Decl[0], x0Ref);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
+        public void For_04()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        var l = new System.Collections.Generic.List<System.Action>();
+
+        for (TakeOutParam(1, out var x0); Dummy(x0 < 3, TakeOutParam(x0*10, out var x1), x1, l, () => System.Console.WriteLine(""{0} {1}"", x0, x1)); x0++)
+        {
+        }
+
+        System.Console.WriteLine(""--"");
+
+        foreach (var d in l)
+        {
+            d();
+        }
+    }
+
+    static bool Dummy(bool x, object y, object z, System.Collections.Generic.List<System.Action> l, System.Action d) 
+    {
+        l.Add(d);
+        System.Console.WriteLine(z);
+        return x;
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"10
+20
+30
+--
+3 10
+3 20
+3 30
+");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x0Decl = GetOutVarDeclarations(tree, "x0").ToArray();
+            var x0Ref = GetReferences(tree, "x0").ToArray();
+            Assert.Equal(1, x0Decl.Length);
+            Assert.Equal(4, x0Ref.Length);
+            VerifyModelForOutVar(model, x0Decl[0], x0Ref);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
+        public void For_05()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        var l = new System.Collections.Generic.List<System.Action>();
+
+        for (TakeOutParam(1, out var x0); Dummy(x0 < 3, TakeOutParam(x0*10, out var x1), x1, l, () => System.Console.WriteLine(""{0} {1}"", x0, x1)); x0++)
+        {
+            l.Add(() => System.Console.WriteLine(""{0} {1}"", x0, x1));
+        }
+
+        System.Console.WriteLine(""--"");
+
+        foreach (var d in l)
+        {
+            d();
+        }
+    }
+
+    static bool Dummy(bool x, object y, object z, System.Collections.Generic.List<System.Action> l, System.Action d) 
+    {
+        l.Add(d);
+        System.Console.WriteLine(z);
+        return x;
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"10
+20
+30
+--
+3 10
+3 10
+3 20
+3 20
+3 30
+");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x0Decl = GetOutVarDeclarations(tree, "x0").ToArray();
+            var x0Ref = GetReferences(tree, "x0").ToArray();
+            Assert.Equal(1, x0Decl.Length);
+            Assert.Equal(5, x0Ref.Length);
+            VerifyModelForOutVar(model, x0Decl[0], x0Ref);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(3, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl[0], x1Ref);
         }
 
         [Fact]
@@ -19382,36 +19741,33 @@ public class X
                                       };
 
             compilation.GetDiagnostics().Where(d => !exclude.Contains(d.Code)).Verify(
-                // (13,47): error CS0128: A local variable named 'x4' is already defined in this scope
+                // (13,47): error CS0128: A local variable or function named 'x4' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x4) && x4)
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(13, 47),
-                // (21,47): error CS0128: A local variable named 'x7' is already defined in this scope
+                // (21,47): error CS0128: A local variable or function named 'x7' is already defined in this scope
                 //              Dummy(TakeOutParam(true, out var x7) && x7)
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x7").WithArguments("x7").WithLocation(21, 47),
                 // (20,19): warning CS0219: The variable 'x7' is assigned but its value is never used
                 //         for (bool x7 = true, b(
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x7").WithArguments("x7").WithLocation(20, 19),
-                // (29,52): error CS0128: A local variable named 'x8' is already defined in this scope
+                // (29,52): error CS0128: A local variable or function named 'x8' is already defined in this scope
                 //                b2(Dummy(TakeOutParam(true, out var x8) && x8));
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(29, 52),
-                // (30,47): error CS0128: A local variable named 'x8' is already defined in this scope
+                // (30,47): error CS0136: A local or parameter named 'x8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x8) && x8);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(30, 47),
-                // (31,47): error CS0128: A local variable named 'x8' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x8").WithArguments("x8").WithLocation(30, 47),
+                // (31,47): error CS0136: A local or parameter named 'x8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x8) && x8))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(31, 47),
-                // (30,54): error CS0165: Use of unassigned local variable 'x8'
-                //              Dummy(TakeOutParam(true, out var x8) && x8);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x8").WithArguments("x8").WithLocation(30, 54),
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x8").WithArguments("x8").WithLocation(31, 47),
                 // (37,23): error CS0841: Cannot use local variable 'x9' before it is declared
                 //         for (bool b = x9, 
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x9").WithArguments("x9").WithLocation(37, 23),
-                // (39,47): error CS0128: A local variable named 'x9' is already defined in this scope
+                // (39,47): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x9) && x9);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x9").WithArguments("x9").WithLocation(39, 47),
-                // (40,47): error CS0128: A local variable named 'x9' is already defined in this scope
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(39, 47),
+                // (40,47): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //              Dummy(TakeOutParam(true, out var x9) && x9))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x9").WithArguments("x9").WithLocation(40, 47)
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(40, 47)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -19435,19 +19791,19 @@ public class X
             Assert.Equal(4, x8Ref.Length);
             AssertContainedInDeclaratorArguments(x8Decl[0]);
             AssertContainedInDeclaratorArguments(x8Decl[1]);
-            VerifyModelForOutVarWithoutDataFlow(model, x8Decl[0], x8Ref);
+            VerifyModelForOutVarWithoutDataFlow(model, x8Decl[0], x8Ref[0], x8Ref[1]);
             VerifyModelForOutVarDuplicateInSameScope(model, x8Decl[1]);
-            VerifyModelForOutVarDuplicateInSameScope(model, x8Decl[2]);
-            VerifyModelForOutVarDuplicateInSameScope(model, x8Decl[3]);
+            VerifyModelForOutVar(model, x8Decl[2], x8Ref[2]);
+            VerifyModelForOutVar(model, x8Decl[3], x8Ref[3]);
 
             var x9Decl = GetOutVarDeclarations(tree, "x9").ToArray();
             var x9Ref = GetReferences(tree, "x9").ToArray();
             Assert.Equal(3, x9Decl.Length);
             Assert.Equal(4, x9Ref.Length);
             AssertContainedInDeclaratorArguments(x9Decl[0]);
-            VerifyModelForOutVarWithoutDataFlow(model, x9Decl[0], x9Ref);
-            VerifyModelForOutVarDuplicateInSameScope(model, x9Decl[1]);
-            VerifyModelForOutVarDuplicateInSameScope(model, x9Decl[2]);
+            VerifyModelForOutVarWithoutDataFlow(model, x9Decl[0], x9Ref[0], x9Ref[1]);
+            VerifyModelForOutVar(model, x9Decl[1], x9Ref[2]);
+            VerifyModelForOutVar(model, x9Decl[2], x9Ref[3]);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
@@ -8039,24 +8039,39 @@ public class X
     // (109,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
     //             var y12 = 12;
     Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "var y12 = 12;").WithLocation(109, 13),
+    // (16,19): error CS0103: The name 'x1' does not exist in the current context
+    //             Dummy(x1);
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(16, 19),
+    // (25,19): error CS0103: The name 'x2' does not exist in the current context
+    //             Dummy(x2);
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x2").WithArguments("x2").WithLocation(25, 19),
     // (34,32): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x4 && x4)
     Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(34, 32),
     // (42,20): error CS0841: Cannot use local variable 'x6' before it is declared
     //              Dummy(x6 && true is var x6)
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(42, 20),
-    // (53,17): error CS0136: A local or parameter named 'x7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-    //             var x7 = 12;
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x7").WithArguments("x7").WithLocation(53, 17),
+    // (44,19): error CS0103: The name 'x6' does not exist in the current context
+    //             Dummy(x6);
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x6").WithArguments("x6").WithLocation(44, 19),
+    // (63,19): error CS0103: The name 'x8' does not exist in the current context
+    //             Dummy(x8);
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(63, 19),
     // (65,34): error CS0103: The name 'x8' does not exist in the current context
     //         System.Console.WriteLine(x8);
     Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(65, 34),
     // (65,9): warning CS0162: Unreachable code detected
     //         System.Console.WriteLine(x8);
     Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(65, 9),
-    // (76,36): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-    //                  Dummy(true is var x9 && x9) // 2
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(76, 36),
+    // (74,19): error CS0103: The name 'x9' does not exist in the current context
+    //             Dummy(x9);
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x9").WithArguments("x9").WithLocation(74, 19),
+    // (78,23): error CS0103: The name 'x9' does not exist in the current context
+    //                 Dummy(x9);
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x9").WithArguments("x9").WithLocation(78, 23),
+    // (71,14): warning CS0162: Unreachable code detected
+    //              Dummy(true is var x9 && x9)
+    Diagnostic(ErrorCode.WRN_UnreachableCode, "Dummy").WithLocation(71, 14),
     // (85,20): error CS0103: The name 'y10' does not exist in the current context
     //              Dummy(y10 is var x10)
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y10").WithArguments("y10").WithLocation(85, 20),
@@ -8066,36 +8081,12 @@ public class X
     // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
     //             var y12 = 12;
     Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
-    // (124,29): error CS0128: A local variable named 'x14' is already defined in this scope
+    // (124,29): error CS0128: A local variable or function named 'x14' is already defined in this scope
     //                    2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 29),
-    // (16,19): error CS0165: Use of unassigned local variable 'x1'
-    //             Dummy(x1);
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(16, 19),
-    // (25,19): error CS0165: Use of unassigned local variable 'x2'
-    //             Dummy(x2);
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "x2").WithArguments("x2").WithLocation(25, 19),
-    // (36,19): error CS0165: Use of unassigned local variable 'x4'
-    //             Dummy(x4);
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "x4").WithArguments("x4").WithLocation(36, 19),
-    // (44,19): error CS0165: Use of unassigned local variable 'x6'
-    //             Dummy(x6);
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "x6").WithArguments("x6").WithLocation(44, 19),
-    // (63,19): error CS0165: Use of unassigned local variable 'x8'
-    //             Dummy(x8);
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "x8").WithArguments("x8").WithLocation(63, 19),
-    // (71,14): warning CS0162: Unreachable code detected
-    //              Dummy(true is var x9 && x9)
-    Diagnostic(ErrorCode.WRN_UnreachableCode, "Dummy").WithLocation(71, 14),
-    // (74,19): error CS0165: Use of unassigned local variable 'x9'
-    //             Dummy(x9);
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "x9").WithArguments("x9").WithLocation(74, 19),
-    // (78,23): error CS0165: Use of unassigned local variable 'x9'
-    //                 Dummy(x9);
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "x9").WithArguments("x9").WithLocation(78, 23),
-    // (128,19): error CS0165: Use of unassigned local variable 'x14'
+    // (128,19): error CS0103: The name 'x14' does not exist in the current context
     //             Dummy(x14);
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "x14").WithArguments("x14").WithLocation(128, 19)
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x14").WithArguments("x14").WithLocation(128, 19)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -8104,23 +8095,27 @@ public class X
             var x1Decl = GetPatternDeclarations(tree, "x1").Single();
             var x1Ref = GetReferences(tree, "x1").ToArray();
             Assert.Equal(2, x1Ref.Length);
-            VerifyModelForDeclarationPattern(model, x1Decl, x1Ref);
+            VerifyModelForDeclarationPattern(model, x1Decl, x1Ref[0]);
+            VerifyNotInScope(model, x1Ref[1]);
 
             var x2Decl = GetPatternDeclarations(tree, "x2").Single();
             var x2Ref = GetReferences(tree, "x2").ToArray();
             Assert.Equal(2, x2Ref.Length);
-            VerifyModelForDeclarationPattern(model, x2Decl, x2Ref);
+            VerifyModelForDeclarationPattern(model, x2Decl, x2Ref[0]);
+            VerifyNotInScope(model, x2Ref[1]);
 
             var x4Decl = GetPatternDeclarations(tree, "x4").Single();
             var x4Ref = GetReferences(tree, "x4").ToArray();
             Assert.Equal(3, x4Ref.Length);
             VerifyNotAPatternLocal(model, x4Ref[0]);
-            VerifyModelForDeclarationPattern(model, x4Decl, x4Ref[1], x4Ref[2]);
+            VerifyModelForDeclarationPattern(model, x4Decl, x4Ref[1]);
+            VerifyNotAPatternLocal(model, x4Ref[2]);
 
             var x6Decl = GetPatternDeclarations(tree, "x6").Single();
             var x6Ref = GetReferences(tree, "x6").ToArray();
             Assert.Equal(2, x6Ref.Length);
-            VerifyModelForDeclarationPattern(model, x6Decl, x6Ref);
+            VerifyModelForDeclarationPattern(model, x6Decl, x6Ref[0]);
+            VerifyNotInScope(model, x6Ref[1]);
 
             var x7Decl = GetPatternDeclarations(tree, "x7").Single();
             var x7Ref = GetReferences(tree, "x7").ToArray();
@@ -8131,15 +8126,18 @@ public class X
             var x8Decl = GetPatternDeclarations(tree, "x8").Single();
             var x8Ref = GetReferences(tree, "x8").ToArray();
             Assert.Equal(3, x8Ref.Length);
-            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref[0], x8Ref[1]);
+            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref[0]);
+            VerifyNotInScope(model, x8Ref[1]);
             VerifyNotInScope(model, x8Ref[2]);
 
             var x9Decl = GetPatternDeclarations(tree, "x9").ToArray();
             var x9Ref = GetReferences(tree, "x9").ToArray();
             Assert.Equal(2, x9Decl.Length);
             Assert.Equal(4, x9Ref.Length);
-            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref[0], x9Ref[1]);
-            VerifyModelForDeclarationPattern(model, x9Decl[1], x9Ref[2], x9Ref[3]);
+            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref[0]);
+            VerifyNotInScope(model, x9Ref[1]);
+            VerifyModelForDeclarationPattern(model, x9Decl[1], x9Ref[2]);
+            VerifyNotInScope(model, x9Ref[3]);
 
             var y10Ref = GetReferences(tree, "y10").ToArray();
             Assert.Equal(2, y10Ref.Length);
@@ -8153,8 +8151,9 @@ public class X
             var x14Ref = GetReferences(tree, "x14").ToArray();
             Assert.Equal(2, x14Decl.Length);
             Assert.Equal(2, x14Ref.Length);
-            VerifyModelForDeclarationPattern(model, x14Decl[0], x14Ref);
+            VerifyModelForDeclarationPattern(model, x14Decl[0], x14Ref[0]);
             VerifyModelForDeclarationPatternDuplicateInSameScope(model, x14Decl[1]);
+            VerifyNotInScope(model, x14Ref[1]);
         }
 
         [Fact]
@@ -8765,7 +8764,7 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (13,32): error CS0128: A local variable named 'x1' is already defined in this scope
+    // (13,32): error CS0128: A local variable or function named 'x1' is already defined in this scope
     //              Dummy(true is var x1 && x1)
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(13, 32),
     // (13,38): error CS0841: Cannot use local variable 'x1' before it is declared
@@ -8774,96 +8773,108 @@ public class X
     // (13,38): error CS0165: Use of unassigned local variable 'x1'
     //              Dummy(true is var x1 && x1)
     Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(13, 38),
-    // (21,32): error CS0128: A local variable named 'x2' is already defined in this scope
+    // (21,32): error CS0136: A local or parameter named 'x2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x2 && x2)
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(21, 32),
-    // (29,32): error CS0128: A local variable named 'x3' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x2").WithArguments("x2").WithLocation(21, 32),
+    // (20,18): warning CS0219: The variable 'x2' is assigned but its value is never used
+    //         for (var x2 = true;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x2").WithArguments("x2").WithLocation(20, 18),
+    // (29,32): error CS0136: A local or parameter named 'x3' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x3 && x3)
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x3").WithArguments("x3").WithLocation(29, 32),
-    // (37,32): error CS0128: A local variable named 'x4' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x3").WithArguments("x3").WithLocation(29, 32),
+    // (28,18): warning CS0219: The variable 'x3' is assigned but its value is never used
+    //         for (var x3 = true;;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x3").WithArguments("x3").WithLocation(28, 18),
+    // (37,32): error CS0128: A local variable or function named 'x4' is already defined in this scope
     //              Dummy(true is var x4 && x4)
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(37, 32),
     // (37,38): error CS0165: Use of unassigned local variable 'x4'
     //              Dummy(true is var x4 && x4)
     Diagnostic(ErrorCode.ERR_UseDefViolation, "x4").WithArguments("x4").WithLocation(37, 38),
-    // (45,32): error CS0128: A local variable named 'x5' is already defined in this scope
+    // (45,32): error CS0136: A local or parameter named 'x5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x5 && x5)
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(45, 32),
-    // (53,32): error CS0128: A local variable named 'x6' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x5").WithArguments("x5").WithLocation(45, 32),
+    // (44,19): warning CS0219: The variable 'x5' is assigned but its value is never used
+    //         for (bool x5 = true;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x5").WithArguments("x5").WithLocation(44, 19),
+    // (53,32): error CS0136: A local or parameter named 'x6' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x6 && x6)
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x6").WithArguments("x6").WithLocation(53, 32),
-    // (61,32): error CS0128: A local variable named 'x7' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x6").WithArguments("x6").WithLocation(53, 32),
+    // (52,19): warning CS0219: The variable 'x6' is assigned but its value is never used
+    //         for (bool x6 = true;;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x6").WithArguments("x6").WithLocation(52, 19),
+    // (61,32): error CS0128: A local variable or function named 'x7' is already defined in this scope
     //              Dummy(true is var x7 && x7)
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x7").WithArguments("x7").WithLocation(61, 32),
-    // (69,37): error CS0128: A local variable named 'x8' is already defined in this scope
+    // (69,37): error CS0128: A local variable or function named 'x8' is already defined in this scope
     //              b2 = Dummy(true is var x8 && x8);
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(69, 37),
-    // (70,32): error CS0128: A local variable named 'x8' is already defined in this scope
+    // (70,32): error CS0136: A local or parameter named 'x8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x8 && x8);
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(70, 32),
-    // (71,32): error CS0128: A local variable named 'x8' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x8").WithArguments("x8").WithLocation(70, 32),
+    // (71,32): error CS0136: A local or parameter named 'x8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x8 && x8))
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(71, 32),
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x8").WithArguments("x8").WithLocation(71, 32),
     // (77,23): error CS0841: Cannot use local variable 'x9' before it is declared
     //         for (bool b = x9, 
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x9").WithArguments("x9").WithLocation(77, 23),
-    // (79,32): error CS0128: A local variable named 'x9' is already defined in this scope
+    // (79,32): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x9 && x9);
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x9").WithArguments("x9").WithLocation(79, 32),
-    // (80,32): error CS0128: A local variable named 'x9' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(79, 32),
+    // (80,32): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x9 && x9))
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x9").WithArguments("x9").WithLocation(80, 32),
-    // (86,22): error CS0841: Cannot use local variable 'x10' before it is declared
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(80, 32),
+    // (86,22): error CS0103: The name 'x10' does not exist in the current context
     //         for (var b = x10;
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x10").WithArguments("x10").WithLocation(86, 22),
-    // (88,32): error CS0128: A local variable named 'x10' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x10").WithArguments("x10").WithLocation(86, 22),
+    // (88,32): error CS0128: A local variable or function named 'x10' is already defined in this scope
     //              Dummy(true is var x10 && x10);
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x10").WithArguments("x10").WithLocation(88, 32),
-    // (89,32): error CS0128: A local variable named 'x10' is already defined in this scope
+    // (89,32): error CS0136: A local or parameter named 'x10' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x10 && x10))
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x10").WithArguments("x10").WithLocation(89, 32),
-    // (95,23): error CS0841: Cannot use local variable 'x11' before it is declared
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x10").WithArguments("x10").WithLocation(89, 32),
+    // (95,23): error CS0103: The name 'x11' does not exist in the current context
     //         for (bool b = x11;
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x11").WithArguments("x11").WithLocation(95, 23),
-    // (97,32): error CS0128: A local variable named 'x11' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x11").WithArguments("x11").WithLocation(95, 23),
+    // (97,32): error CS0128: A local variable or function named 'x11' is already defined in this scope
     //              Dummy(true is var x11 && x11);
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x11").WithArguments("x11").WithLocation(97, 32),
-    // (98,32): error CS0128: A local variable named 'x11' is already defined in this scope
+    // (98,32): error CS0136: A local or parameter named 'x11' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x11 && x11))
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x11").WithArguments("x11").WithLocation(98, 32),
-    // (104,20): error CS0841: Cannot use local variable 'x12' before it is declared
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x11").WithArguments("x11").WithLocation(98, 32),
+    // (104,20): error CS0103: The name 'x12' does not exist in the current context
     //         for (Dummy(x12);
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x12").WithArguments("x12").WithLocation(104, 20),
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x12").WithArguments("x12").WithLocation(104, 20),
     // (105,20): error CS0841: Cannot use local variable 'x12' before it is declared
     //              Dummy(x12) &&
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x12").WithArguments("x12").WithLocation(105, 20),
-    // (107,32): error CS0128: A local variable named 'x12' is already defined in this scope
+    // (107,32): error CS0136: A local or parameter named 'x12' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //              Dummy(true is var x12 && x12))
-    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x12").WithArguments("x12").WithLocation(107, 32),
-    // (113,22): error CS0841: Cannot use local variable 'x13' before it is declared
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x12").WithArguments("x12").WithLocation(107, 32),
+    // (113,22): error CS0103: The name 'x13' does not exist in the current context
     //         for (var b = x13;
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x13").WithArguments("x13").WithLocation(113, 22),
-    // (114,20): error CS0841: Cannot use local variable 'x13' before it is declared
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x13").WithArguments("x13").WithLocation(113, 22),
+    // (114,20): error CS0103: The name 'x13' does not exist in the current context
     //              Dummy(x13);
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x13").WithArguments("x13").WithLocation(114, 20),
-    // (116,32): error CS0128: A local variable named 'x13' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x13").WithArguments("x13").WithLocation(114, 20),
+    // (116,32): error CS0128: A local variable or function named 'x13' is already defined in this scope
     //              Dummy(true is var x13 && x13))
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x13").WithArguments("x13").WithLocation(116, 32),
-    // (122,23): error CS0841: Cannot use local variable 'x14' before it is declared
+    // (122,23): error CS0103: The name 'x14' does not exist in the current context
     //         for (bool b = x14;
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x14").WithArguments("x14").WithLocation(122, 23),
-    // (123,20): error CS0841: Cannot use local variable 'x14' before it is declared
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x14").WithArguments("x14").WithLocation(122, 23),
+    // (123,20): error CS0103: The name 'x14' does not exist in the current context
     //              Dummy(x14);
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x14").WithArguments("x14").WithLocation(123, 20),
-    // (125,32): error CS0128: A local variable named 'x14' is already defined in this scope
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x14").WithArguments("x14").WithLocation(123, 20),
+    // (125,32): error CS0128: A local variable or function named 'x14' is already defined in this scope
     //              Dummy(true is var x14 && x14))
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(125, 32),
-    // (131,20): error CS0841: Cannot use local variable 'x15' before it is declared
+    // (131,20): error CS0103: The name 'x15' does not exist in the current context
     //         for (Dummy(x15);
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(131, 20),
-    // (132,20): error CS0841: Cannot use local variable 'x15' before it is declared
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x15").WithArguments("x15").WithLocation(131, 20),
+    // (132,20): error CS0103: The name 'x15' does not exist in the current context
     //              Dummy(x15);
-    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(132, 20),
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "x15").WithArguments("x15").WithLocation(132, 20),
     // (133,20): error CS0841: Cannot use local variable 'x15' before it is declared
     //              Dummy(x15),
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(133, 20)
@@ -8879,13 +8890,11 @@ public class X
 
             var x2Decl = GetPatternDeclarations(tree, "x2").Single();
             var x2Ref = GetReferences(tree, "x2").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x2Decl);
-            VerifyNotAPatternLocal(model, x2Ref);
+            VerifyModelForDeclarationPattern(model, x2Decl, x2Ref);
 
             var x3Decl = GetPatternDeclarations(tree, "x3").Single();
             var x3Ref = GetReferences(tree, "x3").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x3Decl);
-            VerifyNotAPatternLocal(model, x3Ref);
+            VerifyModelForDeclarationPattern(model, x3Decl, x3Ref);
 
             var x4Decl = GetPatternDeclarations(tree, "x4").Single();
             var x4Ref = GetReferences(tree, "x4").Single();
@@ -8894,13 +8903,11 @@ public class X
 
             var x5Decl = GetPatternDeclarations(tree, "x5").Single();
             var x5Ref = GetReferences(tree, "x5").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x5Decl);
-            VerifyNotAPatternLocal(model, x5Ref);
+            VerifyModelForDeclarationPattern(model, x5Decl, x5Ref);
 
             var x6Decl = GetPatternDeclarations(tree, "x6").Single();
             var x6Ref = GetReferences(tree, "x6").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x6Decl);
-            VerifyNotAPatternLocal(model, x6Ref);
+            VerifyModelForDeclarationPattern(model, x6Decl, x6Ref);
 
             var x7Decl = GetPatternDeclarations(tree, "x7").Single();
             var x7Ref = GetReferences(tree, "x7").Single();
@@ -8911,60 +8918,125 @@ public class X
             var x8Ref = GetReferences(tree, "x8").ToArray();
             Assert.Equal(4, x8Decl.Length);
             Assert.Equal(4, x8Ref.Length);
-            VerifyModelForDeclarationPattern(model, x8Decl[0], x8Ref);
+            VerifyModelForDeclarationPattern(model, x8Decl[0], x8Ref[0], x8Ref[1]);
             VerifyModelForDeclarationPatternDuplicateInSameScope(model, x8Decl[1]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x8Decl[2]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x8Decl[3]);
+            VerifyModelForDeclarationPattern(model, x8Decl[2], x8Ref[2]);
+            VerifyModelForDeclarationPattern(model, x8Decl[3], x8Ref[3]);
 
             var x9Decl = GetPatternDeclarations(tree, "x9").ToArray();
             var x9Ref = GetReferences(tree, "x9").ToArray();
             Assert.Equal(3, x9Decl.Length);
             Assert.Equal(4, x9Ref.Length);
-            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x9Decl[1]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x9Decl[2]);
+            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref[0], x9Ref[1]);
+            VerifyModelForDeclarationPattern(model, x9Decl[1], x9Ref[2]);
+            VerifyModelForDeclarationPattern(model, x9Decl[2], x9Ref[3]);
 
             var x10Decl = GetPatternDeclarations(tree, "x10").ToArray();
             var x10Ref = GetReferences(tree, "x10").ToArray();
             Assert.Equal(3, x10Decl.Length);
             Assert.Equal(4, x10Ref.Length);
-            VerifyModelForDeclarationPattern(model, x10Decl[0], x10Ref);
+            VerifyNotInScope(model, x10Ref[0]);
+            VerifyModelForDeclarationPattern(model, x10Decl[0], x10Ref[1], x10Ref[2]);
             VerifyModelForDeclarationPatternDuplicateInSameScope(model, x10Decl[1]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x10Decl[2]);
+            VerifyModelForDeclarationPattern(model, x10Decl[2], x10Ref[3]);
 
             var x11Decl = GetPatternDeclarations(tree, "x11").ToArray();
             var x11Ref = GetReferences(tree, "x11").ToArray();
             Assert.Equal(3, x11Decl.Length);
             Assert.Equal(4, x11Ref.Length);
-            VerifyModelForDeclarationPattern(model, x11Decl[0], x11Ref);
+            VerifyNotInScope(model, x11Ref[0]);
+            VerifyModelForDeclarationPattern(model, x11Decl[0], x11Ref[1], x11Ref[2]);
             VerifyModelForDeclarationPatternDuplicateInSameScope(model, x11Decl[1]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x11Decl[2]);
+            VerifyModelForDeclarationPattern(model, x11Decl[2], x11Ref[3]);
 
             var x12Decl = GetPatternDeclarations(tree, "x12").ToArray();
             var x12Ref = GetReferences(tree, "x12").ToArray();
             Assert.Equal(2, x12Decl.Length);
             Assert.Equal(4, x12Ref.Length);
-            VerifyModelForDeclarationPattern(model, x12Decl[0], x12Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x12Decl[1]);
+            VerifyNotInScope(model, x12Ref[0]);
+            VerifyModelForDeclarationPattern(model, x12Decl[0], x12Ref[1], x12Ref[2]);
+            VerifyModelForDeclarationPattern(model, x12Decl[1], x12Ref[3]);
 
             var x13Decl = GetPatternDeclarations(tree, "x13").ToArray();
             var x13Ref = GetReferences(tree, "x13").ToArray();
             Assert.Equal(2, x13Decl.Length);
             Assert.Equal(4, x13Ref.Length);
-            VerifyModelForDeclarationPattern(model, x13Decl[0], x13Ref);
+            VerifyNotInScope(model, x13Ref[0]);
+            VerifyNotInScope(model, x13Ref[1]);
+            VerifyModelForDeclarationPattern(model, x13Decl[0], x13Ref[2], x13Ref[3]);
             VerifyModelForDeclarationPatternDuplicateInSameScope(model, x13Decl[1]);
 
             var x14Decl = GetPatternDeclarations(tree, "x14").ToArray();
             var x14Ref = GetReferences(tree, "x14").ToArray();
             Assert.Equal(2, x14Decl.Length);
             Assert.Equal(4, x14Ref.Length);
-            VerifyModelForDeclarationPattern(model, x14Decl[0], x14Ref);
+            VerifyNotInScope(model, x14Ref[0]);
+            VerifyNotInScope(model, x14Ref[1]);
+            VerifyModelForDeclarationPattern(model, x14Decl[0], x14Ref[2], x14Ref[3]);
             VerifyModelForDeclarationPatternDuplicateInSameScope(model, x14Decl[1]);
 
             var x15Decl = GetPatternDeclarations(tree, "x15").Single();
             var x15Ref = GetReferences(tree, "x15").ToArray();
             Assert.Equal(4, x15Ref.Length);
-            VerifyModelForDeclarationPattern(model, x15Decl, x15Ref);
+            VerifyNotInScope(model, x15Ref[0]);
+            VerifyNotInScope(model, x15Ref[1]);
+            VerifyModelForDeclarationPattern(model, x15Decl, x15Ref[2], x15Ref[3]);
+        }
+
+        [Fact]
+        public void ScopeOfPatternVariables_For_07()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    bool Dummy(params object[] x) {return true;}
+
+    void Test1()
+    {
+        for (;;
+             Dummy(x1),
+             Dummy(true is var x1 && x1))
+        {}
+    }
+
+    void Test2()
+    {
+        for (;;
+             Dummy(true is var x2 && x2),
+             Dummy(true is var x2 && x2))
+        {}
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            compilation.VerifyDiagnostics(
+                // (13,20): error CS0841: Cannot use local variable 'x1' before it is declared
+                //              Dummy(x1),
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x1").WithArguments("x1").WithLocation(13, 20),
+                // (22,32): error CS0128: A local variable or function named 'x2' is already defined in this scope
+                //              Dummy(true is var x2 && x2))
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(22, 32)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetPatternDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl, x1Ref);
+
+            var x2Decl = GetPatternDeclarations(tree, "x2").ToArray();
+            var x2Ref = GetReferences(tree, "x2").ToArray();
+            Assert.Equal(2, x2Decl.Length);
+            Assert.Equal(2, x2Ref.Length);
+            VerifyModelForDeclarationPattern(model, x2Decl[0], x2Ref);
+            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x2Decl[1]);
         }
 
         [Fact]
@@ -10552,353 +10624,6 @@ a: b: c:Dummy(11 is var x1, x1);
             Assert.Equal(1, x1Ref.Length);
             VerifyModelForDeclarationPattern(model, x1Decl, x1Ref);
             Assert.Equal("System.Int32", model.GetTypeInfo(x1Ref[0]).Type.ToTestDisplayString());
-        }
-
-        [Fact]
-        public void Scope_For_06()
-        {
-            var source =
-@"
-public class X
-{
-    static bool Data = true;
-    public static void Main()
-    {
-    }
-
-    bool Dummy(params object[] x) {return true;}
-
-    void Test1()
-    {
-        for (var x1 =
-             Dummy(Dummy(true, Data is var x1) && x1)
-             ;;)
-        {}
-    }
-
-    void Test2()
-    {
-        for (var x2 = true;
-             Dummy(Dummy(true, Data is var x2) && x2)
-             ;)
-        {}
-    }
-
-    void Test3()
-    {
-        for (var x3 = true;;
-             Dummy(Dummy(true, Data is var x3) && x3)
-             )
-        {}
-    }
-
-    void Test4()
-    {
-        for (bool x4 =
-             Dummy(Dummy(true, Data is var x4) && x4)
-             ;;)
-        {}
-    }
-
-    void Test5()
-    {
-        for (bool x5 = true;
-             Dummy(Dummy(true, Data is var x5) && x5)
-             ;)
-        {}
-    }
-
-    void Test6()
-    {
-        for (bool x6 = true;;
-             Dummy(Dummy(true, Data is var x6) && x6)
-             )
-        {}
-    }
-
-    void Test7()
-    {
-        for (bool x7 = true, b =
-             Dummy(Dummy(true, Data is var x7) && x7)
-             ;;)
-        {}
-    }
-
-    void Test8()
-    {
-        for (bool b1 = Dummy(Dummy(true, Data is var x8) && x8), 
-             b2 = Dummy(Dummy(true, Data is var x8) && x8);
-             Dummy(Dummy(true, Data is var x8) && x8);
-             Dummy(Dummy(true, Data is var x8) && x8))
-        {}
-    }
-
-    void Test9()
-    {
-        for (bool b = x9, 
-             b2 = Dummy(Dummy(true, Data is var x9) && x9);
-             Dummy(Dummy(true, Data is var x9) && x9);
-             Dummy(Dummy(true, Data is var x9) && x9))
-        {}
-    }
-
-    void Test10()
-    {
-        for (var b = x10;
-             Dummy(Dummy(true, Data is var x10) && x10) &&
-             Dummy(Dummy(true, Data is var x10) && x10);
-             Dummy(Dummy(true, Data is var x10) && x10))
-        {}
-    }
-
-    void Test11()
-    {
-        for (bool b = x11;
-             Dummy(Dummy(true, Data is var x11) && x11) &&
-             Dummy(Dummy(true, Data is var x11) && x11);
-             Dummy(Dummy(true, Data is var x11) && x11))
-        {}
-    }
-
-    void Test12()
-    {
-        for (Dummy(x12);
-             Dummy(x12) &&
-             Dummy(Dummy(true, Data is var x12) && x12);
-             Dummy(Dummy(true, Data is var x12) && x12))
-        {}
-    }
-
-    void Test13()
-    {
-        for (var b = x13;
-             Dummy(x13);
-             Dummy(Dummy(true, Data is var x13) && x13),
-             Dummy(Dummy(true, Data is var x13) && x13))
-        {}
-    }
-
-    void Test14()
-    {
-        for (bool b = x14;
-             Dummy(x14);
-             Dummy(Dummy(true, Data is var x14) && x14),
-             Dummy(Dummy(true, Data is var x14) && x14))
-        {}
-    }
-
-    void Test15()
-    {
-        for (Dummy(x15);
-             Dummy(x15);
-             Dummy(x15),
-             Dummy(Dummy(true, Data is var x15) && x15))
-        {}
-    }
-}
-";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
-            compilation.VerifyDiagnostics(
-                // (14,44): error CS0128: A local variable named 'x1' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x1) && x1)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(14, 44),
-                // (14,51): error CS0841: Cannot use local variable 'x1' before it is declared
-                //              Dummy(Dummy(true, Data is var x1) && x1)
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x1").WithArguments("x1").WithLocation(14, 51),
-                // (14,51): error CS0165: Use of unassigned local variable 'x1'
-                //              Dummy(Dummy(true, Data is var x1) && x1)
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(14, 51),
-                // (22,44): error CS0128: A local variable named 'x2' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x2) && x2)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(22, 44),
-                // (30,44): error CS0128: A local variable named 'x3' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x3) && x3)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x3").WithArguments("x3").WithLocation(30, 44),
-                // (38,44): error CS0128: A local variable named 'x4' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x4) && x4)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(38, 44),
-                // (38,51): error CS0165: Use of unassigned local variable 'x4'
-                //              Dummy(Dummy(true, Data is var x4) && x4)
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x4").WithArguments("x4").WithLocation(38, 51),
-                // (46,44): error CS0128: A local variable named 'x5' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x5) && x5)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(46, 44),
-                // (54,44): error CS0128: A local variable named 'x6' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x6) && x6)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x6").WithArguments("x6").WithLocation(54, 44),
-                // (62,44): error CS0128: A local variable named 'x7' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x7) && x7)
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x7").WithArguments("x7").WithLocation(62, 44),
-                // (70,49): error CS0128: A local variable named 'x8' is already defined in this scope
-                //              b2 = Dummy(Dummy(true, Data is var x8) && x8);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(70, 49),
-                // (71,44): error CS0128: A local variable named 'x8' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x8) && x8);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(71, 44),
-                // (72,44): error CS0128: A local variable named 'x8' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x8) && x8))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(72, 44),
-                // (78,23): error CS0841: Cannot use local variable 'x9' before it is declared
-                //         for (bool b = x9, 
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x9").WithArguments("x9").WithLocation(78, 23),
-                // (80,44): error CS0128: A local variable named 'x9' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x9) && x9);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x9").WithArguments("x9").WithLocation(80, 44),
-                // (81,44): error CS0128: A local variable named 'x9' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x9) && x9))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x9").WithArguments("x9").WithLocation(81, 44),
-                // (87,22): error CS0841: Cannot use local variable 'x10' before it is declared
-                //         for (var b = x10;
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x10").WithArguments("x10").WithLocation(87, 22),
-                // (89,44): error CS0128: A local variable named 'x10' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x10) && x10);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x10").WithArguments("x10").WithLocation(89, 44),
-                // (90,44): error CS0128: A local variable named 'x10' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x10) && x10))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x10").WithArguments("x10").WithLocation(90, 44),
-                // (96,23): error CS0841: Cannot use local variable 'x11' before it is declared
-                //         for (bool b = x11;
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x11").WithArguments("x11").WithLocation(96, 23),
-                // (98,44): error CS0128: A local variable named 'x11' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x11) && x11);
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x11").WithArguments("x11").WithLocation(98, 44),
-                // (99,44): error CS0128: A local variable named 'x11' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x11) && x11))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x11").WithArguments("x11").WithLocation(99, 44),
-                // (105,20): error CS0841: Cannot use local variable 'x12' before it is declared
-                //         for (Dummy(x12);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x12").WithArguments("x12").WithLocation(105, 20),
-                // (106,20): error CS0841: Cannot use local variable 'x12' before it is declared
-                //              Dummy(x12) &&
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x12").WithArguments("x12").WithLocation(106, 20),
-                // (108,44): error CS0128: A local variable named 'x12' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x12) && x12))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x12").WithArguments("x12").WithLocation(108, 44),
-                // (114,22): error CS0841: Cannot use local variable 'x13' before it is declared
-                //         for (var b = x13;
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x13").WithArguments("x13").WithLocation(114, 22),
-                // (115,20): error CS0841: Cannot use local variable 'x13' before it is declared
-                //              Dummy(x13);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x13").WithArguments("x13").WithLocation(115, 20),
-                // (117,44): error CS0128: A local variable named 'x13' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x13) && x13))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x13").WithArguments("x13").WithLocation(117, 44),
-                // (123,23): error CS0841: Cannot use local variable 'x14' before it is declared
-                //         for (bool b = x14;
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x14").WithArguments("x14").WithLocation(123, 23),
-                // (124,20): error CS0841: Cannot use local variable 'x14' before it is declared
-                //              Dummy(x14);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x14").WithArguments("x14").WithLocation(124, 20),
-                // (126,44): error CS0128: A local variable named 'x14' is already defined in this scope
-                //              Dummy(Dummy(true, Data is var x14) && x14))
-                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(126, 44),
-                // (132,20): error CS0841: Cannot use local variable 'x15' before it is declared
-                //         for (Dummy(x15);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(132, 20),
-                // (133,20): error CS0841: Cannot use local variable 'x15' before it is declared
-                //              Dummy(x15);
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(133, 20),
-                // (134,20): error CS0841: Cannot use local variable 'x15' before it is declared
-                //              Dummy(x15),
-                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x15").WithArguments("x15").WithLocation(134, 20)
-                );
-
-            var tree = compilation.SyntaxTrees.Single();
-            var model = compilation.GetSemanticModel(tree);
-
-            var x1Decl = GetPatternDeclarations(tree, "x1").Single();
-            var x1Ref = GetReferences(tree, "x1").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x1Decl);
-            VerifyNotAPatternLocal(model, x1Ref);
-
-            var x2Decl = GetPatternDeclarations(tree, "x2").Single();
-            var x2Ref = GetReferences(tree, "x2").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x2Decl);
-            VerifyNotAPatternLocal(model, x2Ref);
-
-            var x3Decl = GetPatternDeclarations(tree, "x3").Single();
-            var x3Ref = GetReferences(tree, "x3").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x3Decl);
-            VerifyNotAPatternLocal(model, x3Ref);
-
-            var x4Decl = GetPatternDeclarations(tree, "x4").Single();
-            var x4Ref = GetReferences(tree, "x4").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl);
-            VerifyNotAPatternLocal(model, x4Ref);
-
-            var x5Decl = GetPatternDeclarations(tree, "x5").Single();
-            var x5Ref = GetReferences(tree, "x5").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x5Decl);
-            VerifyNotAPatternLocal(model, x5Ref);
-
-            var x6Decl = GetPatternDeclarations(tree, "x6").Single();
-            var x6Ref = GetReferences(tree, "x6").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x6Decl);
-            VerifyNotAPatternLocal(model, x6Ref);
-
-            var x7Decl = GetPatternDeclarations(tree, "x7").Single();
-            var x7Ref = GetReferences(tree, "x7").Single();
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x7Decl);
-            VerifyNotAPatternLocal(model, x7Ref);
-
-            var x8Decl = GetPatternDeclarations(tree, "x8").ToArray();
-            var x8Ref = GetReferences(tree, "x8").ToArray();
-            Assert.Equal(4, x8Decl.Length);
-            Assert.Equal(4, x8Ref.Length);
-            VerifyModelForDeclarationPattern(model, x8Decl[0], x8Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x8Decl[1]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x8Decl[2]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x8Decl[3]);
-
-            var x9Decl = GetPatternDeclarations(tree, "x9").ToArray();
-            var x9Ref = GetReferences(tree, "x9").ToArray();
-            Assert.Equal(3, x9Decl.Length);
-            Assert.Equal(4, x9Ref.Length);
-            VerifyModelForDeclarationPattern(model, x9Decl[0], x9Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x9Decl[1]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x9Decl[2]);
-
-            var x10Decl = GetPatternDeclarations(tree, "x10").ToArray();
-            var x10Ref = GetReferences(tree, "x10").ToArray();
-            Assert.Equal(3, x10Decl.Length);
-            Assert.Equal(4, x10Ref.Length);
-            VerifyModelForDeclarationPattern(model, x10Decl[0], x10Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x10Decl[1]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x10Decl[2]);
-
-            var x11Decl = GetPatternDeclarations(tree, "x11").ToArray();
-            var x11Ref = GetReferences(tree, "x11").ToArray();
-            Assert.Equal(3, x11Decl.Length);
-            Assert.Equal(4, x11Ref.Length);
-            VerifyModelForDeclarationPattern(model, x11Decl[0], x11Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x11Decl[1]);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x11Decl[2]);
-
-            var x12Decl = GetPatternDeclarations(tree, "x12").ToArray();
-            var x12Ref = GetReferences(tree, "x12").ToArray();
-            Assert.Equal(2, x12Decl.Length);
-            Assert.Equal(4, x12Ref.Length);
-            VerifyModelForDeclarationPattern(model, x12Decl[0], x12Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x12Decl[1]);
-
-            var x13Decl = GetPatternDeclarations(tree, "x13").ToArray();
-            var x13Ref = GetReferences(tree, "x13").ToArray();
-            Assert.Equal(2, x13Decl.Length);
-            Assert.Equal(4, x13Ref.Length);
-            VerifyModelForDeclarationPattern(model, x13Decl[0], x13Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x13Decl[1]);
-
-            var x14Decl = GetPatternDeclarations(tree, "x14").ToArray();
-            var x14Ref = GetReferences(tree, "x14").ToArray();
-            Assert.Equal(2, x14Decl.Length);
-            Assert.Equal(4, x14Ref.Length);
-            VerifyModelForDeclarationPattern(model, x14Decl[0], x14Ref);
-            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x14Decl[1]);
-
-            var x15Decl = GetPatternDeclarations(tree, "x15").Single();
-            var x15Ref = GetReferences(tree, "x15").ToArray();
-            Assert.Equal(4, x15Ref.Length);
-            VerifyModelForDeclarationPattern(model, x15Decl, x15Ref);
         }
 
         [Fact]


### PR DESCRIPTION
Variables declared within a ‘for’ condition are in scope only inside the condition, incrementors and body of the loop.
Variables declared within ‘for’ incrementors are in scope only inside the incrementors.

Customer scenario
See #15529.

Bugs this fixes:
Fixes #15630.

Workarounds, if any
Explicitly copy values to locals declared within the body of the loop and use those in lambdas instead.

Risk
Low

Performance impact
Low.

Is this a regression from a previous update?
No

Root cause analysis:
Design change for a new feature.

How was the bug found?
Requested by a customer.

@dotnet/roslyn-compiler Please review.
