### PR TITLE
Don't search for files looking for a predefined type when the type we're looking at is not predefined itself.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -87,6 +87,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             PredefinedType predefinedType,
             CancellationToken cancellationToken)
         {
+            if (predefinedType == PredefinedType.None)
+            {
+                return SpecializedTasks.EmptyImmutableArray<Document>();
+            }
+
             return FindDocumentsAsync(project, documents, async (d, c) =>
             {
                 var info = await SyntaxTreeIndex.GetIndexAsync(d, c).ConfigureAwait(false);
@@ -94,7 +99,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             }, cancellationToken);
         }
 
-        protected async Task<ImmutableArray<Document>> FindDocumentsAsync(
+        protected Task<ImmutableArray<Document>> FindDocumentsAsync(
             Project project,
             IImmutableSet<Document> documents,
             PredefinedOperator op,
@@ -102,14 +107,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         {
             if (op == PredefinedOperator.None)
             {
-                return ImmutableArray<Document>.Empty;
+                return SpecializedTasks.EmptyImmutableArray<Document>();
             }
 
-            return await FindDocumentsAsync(project, documents, async (d, c) =>
+            return FindDocumentsAsync(project, documents, async (d, c) =>
             {
                 var info = await SyntaxTreeIndex.GetIndexAsync(d, c).ConfigureAwait(false);
                 return info.ContainsPredefinedOperator(op);
-            }, cancellationToken).ConfigureAwait(false);
+            }, cancellationToken);
         }
 
         protected static bool IdentifiersMatch(ISyntaxFactsService syntaxFacts, string name, SyntaxToken token)


### PR DESCRIPTION
Before this, this bug would make us generate a search task per document in your solution.  Now, each search task would complete very quickly.  But we were still creating many thousands of tasks, which the threadpool did have to process.

I noticed this trying to debug through a scenario when i hit a search function thousands of times instead of only a handful. 

This also exacerbates the FAR experience because *currently* the FAR ui updates the progress bar each time we report that we've processed a file.  We would essentially always say we needed to process each file in the solution, even if we really only needed to processs a small handful.  The editor bug tracking this is: https://devdiv.visualstudio.com/DevDiv/_workitems?id=359162&fullScreen=false&_a=edit  However, it's still appropriate for us to not queue up thousands of pieces of unnecessary work.