### PR TITLE
Handle additional cases in MemberSemanticModel.GetQueryEnclosingBinder

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     internal abstract partial class BoundNode
     {
         private readonly BoundKind _kind;
@@ -162,5 +163,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return TreeDumper.DumpCompact(BoundTreeDumperNodeProducer.MakeTree(this));
         }
 #endif
+
+        private string GetDebuggerDisplay()
+        {
+            var result = GetType().Name;
+            if (Syntax != null)
+            {
+                result += " " + Syntax.ToString();
+            }
+            return result;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundQueryClause.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundQueryClause.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1349,21 +1349,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundNode boundOuterExpression = this.Bind(incrementalBinder, nodeToBind, _ignoredDiagnostics);
                     GuardedAddBoundTreeAndGetBoundNodeFromMap(innerLambda, boundOuterExpression);
                 }
-            }
 
-            // If there is a bug in the binder such that we "lose" a sub-expression containing a
-            // lambda, and never put bound state for it into the bound tree, then the bound lambda
-            // that comes back from the map lookup will be null. This can occur in error recovery
-            // situations.  If it is null, we fall back to the outer binder.
+                // If there is a bug in the binder such that we "lose" a sub-expression containing a
+                // lambda, and never put bound state for it into the bound tree, then the bound lambda
+                // that comes back from the map lookup will be null. This can occur in error recovery
+                // situations.  If it is null, we fall back to the outer binder.
 
-            using (_nodeMapLock.DisposableRead())
-            {
-                nodes = GuardedGetBoundNodesFromMap(innerLambda);
-            }
+                using (_nodeMapLock.DisposableRead())
+                {
+                    nodes = GuardedGetBoundNodesFromMap(innerLambda);
+                }
 
-            if (nodes.IsDefaultOrEmpty)
-            {
-                return GetEnclosingBinder(node, position);
+                if (nodes.IsDefaultOrEmpty)
+                {
+                    return GetEnclosingBinder(node, position);
+                }
             }
 
             BoundNode boundInnerLambda = GetLowerBoundNode(innerLambda);
@@ -1394,27 +1394,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         private static Binder GetQueryEnclosingBinder(int position, CSharpSyntaxNode startingNode, BoundQueryClause queryClause)
         {
-            for (BoundNode n = queryClause.Value; n != null;)
+            BoundExpression node = queryClause;
+
+            do
             {
-                switch (n.Kind)
+                switch (node.Kind)
                 {
                     case BoundKind.QueryClause:
-                        queryClause = (BoundQueryClause)n;
-                        n = queryClause.Value;
+                        queryClause = (BoundQueryClause)node;
+                        node = GetQueryClauseValue(queryClause);
                         continue;
                     case BoundKind.Call:
-                        var call = (BoundCall)n;
-                        foreach (var arg in call.Arguments)
-                        {
-                            if (arg.Syntax.FullSpan.Contains(position) ||
-                                (arg as BoundQueryClause)?.Value.Syntax.FullSpan.Contains(position) == true)
-                            {
-                                n = arg;
-                                break;
-                            }
-                        }
-
-                        if (n != call)
+                        var call = (BoundCall)node;
+                        node = GetContainingArgument(call.Arguments, position);
+                        if (node != null)
                         {
                             continue;
                         }
@@ -1428,35 +1421,86 @@ namespace Microsoft.CodeAnalysis.CSharp
                             receiver = ((BoundMethodGroup)receiver).ReceiverOpt;
                         }
 
-                        if (receiver?.Syntax.FullSpan.Contains(position) == true ||
-                            (receiver as BoundQueryClause)?.Value.Syntax.FullSpan.Contains(position) == true)
+                        if (receiver != null)
                         {
-                            n = receiver;
-                            continue;
+                            node = GetContainingExprOrQueryClause(receiver, position);
+                            if (node != null)
+                            {
+                                continue;
+                            }
                         }
 
                         // TODO: should we look for the "nearest" argument as a fallback?
-                        n = call.Arguments.LastOrDefault();
+                        node = call.Arguments.LastOrDefault();
                         continue;
                     case BoundKind.Conversion:
-                        n = ((BoundConversion)n).Operand;
+                        node = ((BoundConversion)node).Operand;
                         continue;
                     case BoundKind.UnboundLambda:
-                        var unbound = (UnboundLambda)n;
+                        var unbound = (UnboundLambda)node;
                         return GetEnclosingBinder(AdjustStartingNodeAccordingToNewRoot(startingNode, unbound.Syntax),
                                                   position, unbound.BindForErrorRecovery().Binder, unbound.Syntax);
                     case BoundKind.Lambda:
-                        var lambda = (BoundLambda)n;
+                        var lambda = (BoundLambda)node;
                         return GetEnclosingBinder(AdjustStartingNodeAccordingToNewRoot(startingNode, lambda.Body.Syntax),
                                                   position, lambda.Binder, lambda.Body.Syntax);
                     default:
                         goto done;
                 }
             }
+            while (node != null);
 
 done:
             return GetEnclosingBinder(AdjustStartingNodeAccordingToNewRoot(startingNode, queryClause.Syntax),
                                       position, queryClause.Binder, queryClause.Syntax);
+        }
+
+        // Return the argument containing the position. For query
+        // expressions, the span of an argument may include other
+        // arguments, so the argument with the smallest span is returned.
+        private static BoundExpression GetContainingArgument(ImmutableArray<BoundExpression> arguments, int position)
+        {
+            BoundExpression result = null;
+            TextSpan resultSpan = default(TextSpan);
+            foreach (var arg in arguments)
+            {
+                var expr = GetContainingExprOrQueryClause(arg, position);
+                if (expr != null)
+                {
+                    var span = expr.Syntax.FullSpan;
+                    if (result == null || resultSpan.Contains(span))
+                    {
+                        result = expr;
+                        resultSpan = span;
+                    }
+                }
+            }
+            return result;
+        }
+
+        // Returns the expr if the syntax span contains the position;
+        // returns the BoundQueryClause value if expr is a BoundQueryClause
+        // and the value contains the position; otherwise returns null.
+        private static BoundExpression GetContainingExprOrQueryClause(BoundExpression expr, int position)
+        {
+            if (expr.Kind == BoundKind.QueryClause)
+            {
+                var value = GetQueryClauseValue((BoundQueryClause)expr);
+                if (value.Syntax.FullSpan.Contains(position))
+                {
+                    return value;
+                }
+            }
+            if (expr.Syntax.FullSpan.Contains(position))
+            {
+                return expr;
+            }
+            return null;
+        }
+
+        private static BoundExpression GetQueryClauseValue(BoundQueryClause queryClause)
+        {
+            return queryClause.UnoptimizedForm ?? queryClause.Value;
         }
 
         private static SyntaxNode AdjustStartingNodeAccordingToNewRoot(SyntaxNode startingNode, SyntaxNode root)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -883,13 +883,14 @@ public class Cls
             Assert.Equal(LocalDeclarationKind.RegularVariable, ((LocalSymbol)symbol).DeclarationKind);
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)variableDeclaratorSyntax));
 
+            var other = model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single();
             if (isShadowed)
             {
-                Assert.NotEqual(symbol, model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single());
+                Assert.NotEqual(symbol, other);
             }
             else
             {
-                Assert.Same(symbol, model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single());
+                Assert.Same(symbol, other);
             }
 
             Assert.True(model.LookupNames(decl.SpanStart).Contains(decl.Identifier().ValueText));
@@ -11209,8 +11210,7 @@ public class X
                 switch (i)
                 {
                     case 12:
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyNotAnOutLocal(model, yRef[1]);
+                        VerifyNotAnOutLocal(model, yRef[1]);
                         break;
                     default:
                         VerifyNotAnOutLocal(model, yRef[1]);
@@ -11220,8 +11220,7 @@ public class X
 
             var y13Decl = GetOutVarDeclarations(tree, "y13").Single();
             var y13Ref = GetReference(tree, "y13");
-            // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-            //VerifyModelForOutVar(model, y13Decl, y13Ref);
+            VerifyModelForOutVar(model, y13Decl, y13Ref);
         }
 
         [Fact]
@@ -11343,8 +11342,7 @@ public class X
                         VerifyModelForOutVarDuplicateInSameScope(model, yDecl[1]);
                         break;
                     case 12:
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyModelForOutVar(model, yDecl[0], yRef[1]);
+                        VerifyModelForOutVar(model, yDecl[0], yRef[1]);
                         VerifyModelForOutVar(model, yDecl[1], yRef[0]);
                         break;
 
@@ -11357,7 +11355,6 @@ public class X
         }
 
         [Fact]
-        [WorkItem(10466, "https://github.com/dotnet/roslyn/issues/10466")]
         public void Scope_Query_07()
         {
             var source =
@@ -11411,9 +11408,10 @@ public class X
             var yRef = GetReferences(tree, id).ToArray();
             Assert.Equal(2, yDecl.Length);
             Assert.Equal(2, yRef.Length);
-            VerifyModelForOutVar(model, yDecl[0], yRef[1]);
-            // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-            //VerifyModelForOutVar(model, yDecl[1], yRef[0]);
+            // Since the name is declared twice in the same scope,
+            // both references are to the same declaration.
+            VerifyModelForOutVar(model, yDecl[0], yRef);
+            VerifyModelForOutVarDuplicateInSameScope(model, yDecl[1]);
         }
 
         [Fact]
@@ -11559,14 +11557,12 @@ public class X
                 switch (i)
                 {
                     case 4:
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyModelForOutVar(model, yDecl);
+                        VerifyModelForOutVar(model, yDecl);
                         VerifyNotAnOutLocal(model, yRef);
                         break;
                     case 5:
                         VerifyModelForOutVar(model, yDecl);
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyNotAnOutLocal(model, yRef);
+                        VerifyNotAnOutLocal(model, yRef);
                         break;
                     default:
                         VerifyModelForOutVar(model, yDecl);
@@ -11726,13 +11722,11 @@ public class X
                     case 4:
                     case 6:
                         VerifyModelForOutVar(model, yDecl, yRef[0]);
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyNotAnOutLocal(model, yRef[1]);
+                        VerifyNotAnOutLocal(model, yRef[1]);
                         break;
                     case 8:
                         VerifyModelForOutVar(model, yDecl, yRef[1]);
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyNotAnOutLocal(model, yRef[0]);
+                        VerifyNotAnOutLocal(model, yRef[0]);
                         break;
                     case 10:
                         VerifyModelForOutVar(model, yDecl, yRef[0]);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTestBase.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTestBase.cs
@@ -63,13 +63,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(LocalDeclarationKind.PatternVariable, ((LocalSymbol)symbol).DeclarationKind);
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)designation));
 
+            var other = model.LookupSymbols(designation.SpanStart, name: designation.Identifier.ValueText).Single();
             if (isShadowed)
             {
-                Assert.NotEqual(symbol, model.LookupSymbols(designation.SpanStart, name: designation.Identifier.ValueText).Single());
+                Assert.NotEqual(symbol, other);
             }
             else
             {
-                Assert.Same(symbol, model.LookupSymbols(designation.SpanStart, name: designation.Identifier.ValueText).Single());
+                Assert.Same(symbol, other);
             }
 
             Assert.True(model.LookupNames(designation.SpanStart).Contains(designation.Identifier.ValueText));
@@ -124,7 +125,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 Assert.NotEqual(LocalDeclarationKind.PatternVariable, ((LocalSymbol)symbol).DeclarationKind);
             }
 
-            Assert.Same(symbol, model.LookupSymbols(reference.SpanStart, name: reference.Identifier.ValueText).Single());
+            var other = model.LookupSymbols(reference.SpanStart, name: reference.Identifier.ValueText).Single();
+            Assert.Same(symbol, other);
             Assert.True(model.LookupNames(reference.SpanStart).Contains(reference.Identifier.ValueText));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
@@ -2178,8 +2178,7 @@ public class X
                     case 1:
                     case 3:
                     case 12:
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyNotAPatternLocal(model, yRef[1]);
+                        VerifyNotAPatternLocal(model, yRef[1]);
                         break;
                     default:
                         VerifyNotAPatternLocal(model, yRef[1]);
@@ -2295,8 +2294,7 @@ public class X
                         VerifyModelForDeclarationPatternDuplicateInSameScope(model, yDecl[1]);
                         break;
                     case 12:
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyModelForDeclarationPattern(model, yDecl[0], yRef[1]);
+                        VerifyModelForDeclarationPattern(model, yDecl[0], yRef[1]);
                         VerifyModelForDeclarationPattern(model, yDecl[1], yRef[0]);
                         break;
 
@@ -2309,7 +2307,6 @@ public class X
         }
 
         [Fact]
-        [WorkItem(10466, "https://github.com/dotnet/roslyn/issues/10466")]
         public void ScopeOfPatternVariables_Query_07()
         {
             var source =
@@ -2351,9 +2348,10 @@ public class X
             var yRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(name => name.Identifier.ValueText == id).ToArray();
             Assert.Equal(2, yDecl.Length);
             Assert.Equal(2, yRef.Length);
-            VerifyModelForDeclarationPattern(model, yDecl[0], yRef[1]);
-            // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-            //VerifyModelForDeclarationPattern(model, yDecl[1], yRef[0]);
+            // Since the name is declared twice in the same scope,
+            // both references are to the same declaration.
+            VerifyModelForDeclarationPattern(model, yDecl[0], yRef);
+            VerifyModelForDeclarationPatternDuplicateInSameScope(model, yDecl[1]);
         }
 
         [Fact]
@@ -2487,14 +2485,12 @@ public class X
                 switch (i)
                 {
                     case 4:
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyModelForDeclarationPattern(model, yDecl);
+                        VerifyModelForDeclarationPattern(model, yDecl);
                         VerifyNotAPatternLocal(model, yRef);
                         break;
                     case 5:
                         VerifyModelForDeclarationPattern(model, yDecl);
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyNotAPatternLocal(model, yRef);
+                        VerifyNotAPatternLocal(model, yRef);
                         break;
                     default:
                         VerifyModelForDeclarationPattern(model, yDecl);
@@ -2648,13 +2644,11 @@ public class X
                     case 4:
                     case 6:
                         VerifyModelForDeclarationPattern(model, yDecl, yRef[0]);
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyNotAPatternLocal(model, yRef[1]);
+                        VerifyNotAPatternLocal(model, yRef[1]);
                         break;
                     case 8:
                         VerifyModelForDeclarationPattern(model, yDecl, yRef[1]);
-                        // Should be uncommented once https://github.com/dotnet/roslyn/issues/10466 is fixed.
-                        //VerifyNotAPatternLocal(model, yRef[0]);
+                        VerifyNotAPatternLocal(model, yRef[0]);
                         break;
                     case 10:
                         VerifyModelForDeclarationPattern(model, yDecl, yRef[0]);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/MetadataTypeTests.cs
@@ -551,6 +551,7 @@ class Test : StaticModClass
             var module = comp.GetMember<NamedTypeSymbol>("A").ContainingModule;
             GetAllNamespaceNames(builder, module.GlobalNamespace);
             Assert.Equal(new[] { "<global namespace>", "", ".", "..N", ".N", "N", "N.M", "N.M." }, builder);
+            builder.Free();
         }
 
         private static void GetAllNamespaceNames(ArrayBuilder<string> builder, NamespaceSymbol @namespace)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/MetadataTypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/MetadataTypeTests.vb
@@ -1217,6 +1217,7 @@ End Class
             Dim [module] = comp.GetMember(Of NamedTypeSymbol)("A").ContainingModule
             GetAllNamespaceNames(builder, [module].GlobalNamespace)
             Assert.Equal({"Global", "", ".", "..N", ".N", "N", "N.M", "N.M."}, builder)
+            builder.Free()
         End Sub
 
         Private Shared Sub GetAllNamespaceNames(builder As ArrayBuilder(Of String), [namespace] As NamespaceSymbol)


### PR DESCRIPTION
**Customer scenario**

Intellisense may report incorrect symbols in scope in C# LINQ queries with `out` or pattern variables in the query, particularly if there are duplicate names in scope.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/10466

**Workarounds, if any**

Simplify the query by removing the `out` variables.

**Risk**

Low. The changes are in walking the bound query to determine which node to use for symbol lookup.

**Performance impact**

Low.

**Is this a regression from a previous update?**

Not a regression. Issue was caught with unit tests.