### PR TITLE
Updating the Workspaces.Common nuspec to explicitly partition the des…

### DIFF
--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -23,11 +23,6 @@
         <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
         <dependency id="Microsoft.CodeAnalysis.Elfie" version="$MicrosoftCodeAnalysisElfieVersion$" />
         <dependency id="Microsoft.Composition" version="$MicrosoftCompositionVersion$" />
-        <dependency id="System.Diagnostics.Contracts" version="$SystemDiagnosticsContractsVersion$" />
-        <dependency id="System.Linq.Parallel" version="$SystemLinqParallelVersion$" />
-        <dependency id="System.ObjectModel" version="$SystemObjectModelVersion$" />
-        <dependency id="System.Text.RegularExpressions" version="$SystemTextRegularExpressionsVersion$" />
-        <dependency id="System.Threading.Tasks.Parallel" version="$SystemThreadingTasksParallelVersion$" />
       </group>
     </dependencies>
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -9,15 +9,26 @@
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
     </description>
     <dependencies>
-      <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
-      <dependency id="Microsoft.Composition" version="$MicrosoftCompositionVersion$" />
-      <dependency id="System.Diagnostics.Contracts" version="$SystemDiagnosticsContractsVersion$" />
-      <dependency id="System.Linq.Parallel" version="$SystemLinqParallelVersion$" />
-      <dependency id="System.ObjectModel" version="$SystemObjectModelVersion$" />
-      <dependency id="System.Text.RegularExpressions" version="$SystemTextRegularExpressionsVersion$" />
-      <dependency id="System.Threading.Tasks.Parallel" version="$SystemThreadingTasksParallelVersion$" />
-      <dependency id="ManagedEsent" version="$ManagedEsentVersion$" />
-      <dependency id="Microsoft.CodeAnalysis.Elfie" version="$MicrosoftCodeAnalysisElfieVersion$" />
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
+        <dependency id="Microsoft.Composition" version="$MicrosoftCompositionVersion$" />
+        <dependency id="System.Diagnostics.Contracts" version="$SystemDiagnosticsContractsVersion$" />
+        <dependency id="System.Linq.Parallel" version="$SystemLinqParallelVersion$" />
+        <dependency id="System.ObjectModel" version="$SystemObjectModelVersion$" />
+        <dependency id="System.Text.RegularExpressions" version="$SystemTextRegularExpressionsVersion$" />
+        <dependency id="System.Threading.Tasks.Parallel" version="$SystemThreadingTasksParallelVersion$" />
+      </group>
+      <group targetFramework="net46">
+        <dependency id="ManagedEsent" version="$ManagedEsentVersion$" />
+        <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
+        <dependency id="Microsoft.CodeAnalysis.Elfie" version="$MicrosoftCodeAnalysisElfieVersion$" />
+        <dependency id="Microsoft.Composition" version="$MicrosoftCompositionVersion$" />
+        <dependency id="System.Diagnostics.Contracts" version="$SystemDiagnosticsContractsVersion$" />
+        <dependency id="System.Linq.Parallel" version="$SystemLinqParallelVersion$" />
+        <dependency id="System.ObjectModel" version="$SystemObjectModelVersion$" />
+        <dependency id="System.Text.RegularExpressions" version="$SystemTextRegularExpressionsVersion$" />
+        <dependency id="System.Threading.Tasks.Parallel" version="$SystemThreadingTasksParallelVersion$" />
+      </group>
     </dependencies>
 
     <language>en-US</language>


### PR DESCRIPTION
FYI. @jasonmalinowski, @Pilchie, @CyrusNajmabadi 

This was broken with https://github.com/dotnet/roslyn/commit/d1fdcadb23c34e359103eebb42d4323588232148 and https://github.com/dotnet/roslyn/commit/fa2952353a7bf9c340245b64fa42dc1a26eafd87#diff-8f75e0d47483ad1e5e656136a7fe45c2 when `ManagedEsent` and `Microsoft.CodeAnalysis.Elfie` were added to the nuspec as dependencies.

They should have only been added to the list of desktop dependencies.