### PR TITLE
Remove call to SetProgress for performance reasons.

### DIFF
--- a/src/VisualStudio/Core/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
@@ -580,6 +580,12 @@ namespace Microsoft.VisualStudio.LanguageServices.FindReferences
 
             public override Task ReportProgressAsync(int current, int maximum)
             {
+                // https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=359162
+                // Right now VS actually responds to each SetProgess call by enqueueing a UI task
+                // to do the progress bar update.  This can made FindReferences feel extremely slow
+                // when thousands of SetProgress calls are made.  So, for now, we're removing
+                // the progress update until the FindRefs window fixes that perf issue.
+#if false
                 try
                 {
                     // The original FAR window exposed a SetProgress(double). Ensure that we 
@@ -589,6 +595,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindReferences
                 catch
                 {
                 }
+#endif
 
                 return SpecializedTasks.EmptyTask;
             }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -87,6 +87,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             PredefinedType predefinedType,
             CancellationToken cancellationToken)
         {
+            if (predefinedType == PredefinedType.None)
+            {
+                return SpecializedTasks.EmptyImmutableArray<Document>();
+            }
+
             return FindDocumentsAsync(project, documents, async (d, c) =>
             {
                 var info = await SyntaxTreeInfo.GetContextInfoAsync(d, c).ConfigureAwait(false);
@@ -94,7 +99,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             }, cancellationToken);
         }
 
-        protected async Task<ImmutableArray<Document>> FindDocumentsAsync(
+        protected Task<ImmutableArray<Document>> FindDocumentsAsync(
             Project project,
             IImmutableSet<Document> documents,
             PredefinedOperator op,
@@ -102,14 +107,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
         {
             if (op == PredefinedOperator.None)
             {
-                return ImmutableArray<Document>.Empty;
+                return SpecializedTasks.EmptyImmutableArray<Document>();
             }
 
-            return await FindDocumentsAsync(project, documents, async (d, c) =>
+            return FindDocumentsAsync(project, documents, async (d, c) =>
             {
                 var info = await SyntaxTreeInfo.GetContextInfoAsync(d, c).ConfigureAwait(false);
                 return info.ContainsPredefinedOperator(op);
-            }, cancellationToken).ConfigureAwait(false);
+            }, cancellationToken);
         }
 
         protected static bool IdentifiersMatch(ISyntaxFactsService syntaxFacts, string name, SyntaxToken token)


### PR DESCRIPTION
**Customer scenario**

Customer performance 'FindReferences'.  It is slower because of all the time taken just to update the progress bar on the editor side.

**Bugs this fixes:** 

This is not a fix, but a mitigation for https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=359162

When a real fix is checked in by the editor, we can remove this mitigation.

**Workarounds, if any**

None, any find-refs call is affected by this.

**Risk**

Very low.  All we're doing is not updating a progress bar.

**Performance impact**

Performance improves here by removing a slow codepath.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

We have no tests for our new Dev15 features because our testing infrastrucutre was unable to run VS2017 until literally today.

**How was the bug found?**

Many internal and external reports.