### PR TITLE
add missing codebase to VS for System.Xml.ReaderWriter.dll

### DIFF
--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -56,3 +56,4 @@ using Roslyn.VisualStudio.Setup;
 //[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Threading.Thread.dll")] - removed because project has no dependency.
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Xml.XmlDocument.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Xml.XPath.XDocument.dll")]
+[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Xml.ReaderWriter.dll")]


### PR DESCRIPTION
many vsi tests are failing due to missing xml documents. this should fix the issue.