### PR TITLE
Fix XML doc name for BasicInteractiveEditorFeatures

### DIFF
--- a/src/Interactive/EditorFeatures/VisualBasic/BasicInteractiveEditorFeatures.vbproj
+++ b/src/Interactive/EditorFeatures/VisualBasic/BasicInteractiveEditorFeatures.vbproj
@@ -66,12 +66,12 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.xml</DocumentationFile>
+    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.xml</DocumentationFile>
+    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Interactive\FileSystem\ReferenceDirectiveCompletionProvider.vb" />


### PR DESCRIPTION
I found that the XML doc file for Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures.dll was called Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.xml, which clashed with the other XML file if you dump all output into the same directory.