### PR TITLE
Do not mark argument values as bad due to issues with names.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2374,8 +2374,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         hadError = true;
                     }
-
-                    boundArgumentExpression = ToBadExpression(boundArgumentExpression);
                 }
 
                 result.Names.Add(nameColonSyntax.Name);
@@ -2389,8 +2387,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Error(diagnostics, ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, argumentSyntax);
                     hadError = true;
                 }
-
-                boundArgumentExpression = ToBadExpression(boundArgumentExpression);
 
                 result.Names.Add(null);
             }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2135,7 +2135,12 @@ namespace System.ServiceModel
 }";
             CreateCompilationWithMscorlib(source).VerifyDiagnostics(
                 // (7,13): error CS1740: Named argument 'arg' cannot be specified multiple times
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13));
+                //             arg: null);
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13),
+                // (5,9): error CS1501: No overload for method 'M' takes 3 arguments
+                //         M("",
+                Diagnostic(ErrorCode.ERR_BadArgCount, "M").WithArguments("M", "3").WithLocation(5, 9)
+                );
         }
 
         [WorkItem(543820, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543820")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -174,7 +174,11 @@ class C : Middle
                 Diagnostic(ErrorCode.ERR_BadNamedArgument, "optParam3").WithArguments("Foo", "optParam3").WithLocation(37, 15),
                 // (39,30): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
                 //         c.Foo(optArg1: 3333, 11111);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "11111").WithLocation(39, 30));
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "11111").WithLocation(39, 30),
+                // (39,15): error CS1739: The best overload for 'Foo' does not have a parameter named 'optArg1'
+                //         c.Foo(optArg1: 3333, 11111);
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "optArg1").WithArguments("Foo", "optArg1").WithLocation(39, 15)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -18064,6 +18064,84 @@ public class Cls
             Assert.Equal("System.Int32", model.GetTypeInfo(yRef).Type.ToTestDisplayString());
         }
 
+        [Fact]
+        [WorkItem(15732, "https://github.com/dotnet/roslyn/issues/15732")]
+        public void LocalVariableTypeInferenceAndOutVar_06()
+        {
+            var text = @"
+public class Cls
+{
+    public static void Main()
+    {
+        Test1(x: 1, out var y);
+        System.Console.WriteLine(y);
+    }
+
+    static void Test1(int x, ref int y)
+    {
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(text,
+                                                            options: TestOptions.ReleaseExe,
+                                                            parseOptions: TestOptions.Regular);
+
+            compilation.VerifyDiagnostics(
+                // (6,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
+                //         Test1(x: 1, out var y);
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "out var y").WithLocation(6, 21),
+                // (6,25): error CS1620: Argument 2 must be passed with the 'ref' keyword
+                //         Test1(x: 1, out var y);
+                Diagnostic(ErrorCode.ERR_BadArgRef, "var y").WithArguments("2", "ref").WithLocation(6, 25)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yDecl = GetDeclaration(tree, "y");
+            VerifyModelForOutVar(model, yDecl, GetReferences(tree, "y").ToArray());
+        }
+
+        [Fact]
+        [WorkItem(15732, "https://github.com/dotnet/roslyn/issues/15732")]
+        public void LocalVariableTypeInferenceAndOutVar_07()
+        {
+            var text = @"
+public class Cls
+{
+    public static void Main()
+    {
+        int x = 0;
+        Test1(y: ref x, y: out var y);
+        System.Console.WriteLine(y);
+    }
+
+    static void Test1(int x, ref int y)
+    {
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(text,
+                                                            options: TestOptions.ReleaseExe,
+                                                            parseOptions: TestOptions.Regular);
+
+            compilation.VerifyDiagnostics(
+                // (7,25): error CS1740: Named argument 'y' cannot be specified multiple times
+                //         Test1(y: ref x, y: out var y);
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "y").WithArguments("y").WithLocation(7, 25),
+                // (7,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'x' of 'Cls.Test1(int, ref int)'
+                //         Test1(y: ref x, y: out var y);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test1").WithArguments("x", "Cls.Test1(int, ref int)").WithLocation(7, 9)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yDecl = GetDeclaration(tree, "y");
+            var yRef = GetReferences(tree, "y").ToArray();
+            Assert.Equal(3, yRef.Length);
+            Assert.Equal("System.Console.WriteLine(y)", yRef[2].Parent.Parent.Parent.ToString());
+            VerifyModelForOutVar(model, yDecl, yRef[2]);
+        }
+
         [Fact, WorkItem(13219, "https://github.com/dotnet/roslyn/issues/13219")]
         public void IndexingDynamic()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -15738,8 +15738,15 @@ public class C
     public static void Test(int age , string Name)
     { }
 }";
-            DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
-                new ErrorDescription[] { new ErrorDescription { Code = 1740, Line = 6, Column = 29 } });
+            var compilation = CSharpTestBase.CreateCompilationWithMscorlib(text);
+            compilation.VerifyDiagnostics(
+                // (6,29): error CS1740: Named argument 'Name' cannot be specified multiple times
+                //             Test(Name: "5", Name: "");
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 29),
+                // (6,13): error CS7036: There is no argument given that corresponds to the required formal parameter 'age' of 'C.Test(int, string)'
+                //             Test(Name: "5", Name: "");
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test").WithArguments("age", "C.Test(int, string)").WithLocation(6, 13)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
**Customer scenario**
- Customer uses an Out Var declaration without an argument name after a named argument.
- Customer uses a duplicate argument name for an Out Var declaration.

Both scenarios are error conditions, but compiler crashes instead of reporting appropriate diagnostics.

**Bugs this fixes:** 
Fixes #15732.

**Workarounds, if any**
Avoid getting into the error conditions.

**Risk**
Low.

**Performance impact**
Low perf impact because no extra allocations and no complexity changes.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
New feature. Added regression tests for the scenarios.

**How was the bug found?**
Dogfood.
