### PR TITLE
Fix race condition writing assembly attribute file

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -341,6 +341,7 @@
        ==================================================================================== -->
 
   <PropertyGroup>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)</TargetFrameworkMonikerAssemblyAttributesPath>
     <PostCompileBinaryModificationSentinelFile>$(IntermediateOutputPath)$(TargetFileName).pcbm</PostCompileBinaryModificationSentinelFile>
     <OptimizationDataFolderPath>$(NuGetPackageRoot)\RoslynDependencies.OptimizationData\2.0.0-rc-61101-16\content\OptimizationData</OptimizationDataFolderPath>
     <OptimizationDataFile>$([System.IO.Path]::GetFullPath('$(OptimizationDataFolderPath)\$(TargetName).pgo'))</OptimizationDataFile>


### PR DESCRIPTION
Infrastructure change: not ask mode applicable 

MSBuild generates the TargetFrameworkAttribute file to the same path on
disk for equivalent combinations of TargetFrameworkIdentifier and
TargetProfile.  This means if two projects in a solution have equivalent
identifiers, their builds will race to write the same file to disk.

This is safe by virtue that the content of the file is the same in both
cases.  Hence it doesn't really matter who wins the race, both projects
see the same output.

This is frustrating though because even though it's safe, MSBuild still
isssue a warning when it happens.  This breaks our desire to have
warning free builds.

To fix this we will instead generate the file to the Obj\ProjectName
directory.  This means every project gets their own indepnedent copy of
the file, eliminating the race.

closes #10116