### PR TITLE
Unify error messages for omitted type arguments in extension method calls

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5263,7 +5263,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (searchExtensionMethodsIfNecessary)
                 {
-                    var boundMethodGroup = new BoundMethodGroup(
+                    return new BoundMethodGroup(
                         node,
                         typeArguments,
                         boundLeft,
@@ -5271,13 +5271,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         lookupResult.Symbols.All(s => s.Kind == SymbolKind.Method) ? lookupResult.Symbols.SelectAsArray(s_toMethodSymbolFunc) : ImmutableArray<MethodSymbol>.Empty,
                         lookupResult,
                         flags);
-
-                    if (!boundMethodGroup.HasErrors && boundMethodGroup.ResultKind == LookupResultKind.Empty && typeArgumentsSyntax.Any(SyntaxKind.OmittedTypeArgument))
-                    {
-                        Error(diagnostics, ErrorCode.ERR_BadArity, node, rightName, MessageID.IDS_MethodGroup.Localize(), typeArgumentsSyntax.Count);
-                    }
-
-                    return boundMethodGroup;
                 }
 
                 this.BindMemberAccessReportError(node, right, rightName, boundLeft, lookupResult.Error, diagnostics);
@@ -5697,9 +5690,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeSymbol> typeArguments,
             DiagnosticBag diagnostics)
         {
+            bool nodeHasOmittedTypeArgs = false;
+
+            if (node.Kind() == SyntaxKind.SimpleMemberAccessExpression)
+            {
+                var memberAccessSyntax = (MemberAccessExpressionSyntax)node;
+                if (memberAccessSyntax.Name.Kind() == SyntaxKind.GenericName)
+                {
+                    var genericNameSyntax = (GenericNameSyntax)memberAccessSyntax.Name;
+                    if (genericNameSyntax.TypeArgumentList.Arguments.Any(SyntaxKind.OmittedTypeArgument))
+                    {
+                        nodeHasOmittedTypeArgs = true;
+                    }
+                }
+            }
+
             int arity;
             LookupOptions options;
-            if (typeArguments.IsDefault)
+
+            if (typeArguments.IsDefault || nodeHasOmittedTypeArgs)
             {
                 arity = 0;
                 options = LookupOptions.AllMethodsOnArityZero;
@@ -5708,6 +5717,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 arity = typeArguments.Length;
                 options = LookupOptions.Default;
+            }
+
+            if (nodeHasOmittedTypeArgs)
+            {
+                options |= LookupOptions.TryMatchOmittedTypeArgs;
             }
 
             var lookupResult = LookupResult.GetInstance();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -379,6 +379,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var methods = ArrayBuilder<MethodSymbol>.GetInstance();
             var binder = scope.Binder;
+
             binder.GetCandidateExtensionMethods(scope.SearchUsingsNotNamespace, methods, name, arity, options, this);
 
             foreach (var method in methods)
@@ -1438,7 +1439,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case SymbolKind.Method:
-                    if (arity != 0 || (options & LookupOptions.AllMethodsOnArityZero) == 0)
+                    if (arity != 0 || (options & LookupOptions.AllMethodsOnArityZero) == 0 || (options & LookupOptions.TryMatchOmittedTypeArgs) != 0)
                     {
                         MethodSymbol method = (MethodSymbol)symbol;
                         if (method.Arity != arity)
@@ -1451,7 +1452,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             else
                             {
                                 // Using the generic {1} '{0}' requires {2} type arguments
-                                diagInfo = diagnose ? new CSDiagnosticInfo(ErrorCode.ERR_BadArity, method, MessageID.IDS_SK_METHOD.Localize(), method.Arity) : null;
+                                diagInfo = diagnose ? new CSDiagnosticInfo(ErrorCode.ERR_BadArity, method, MessageID.IDS_MethodGroup.Localize(), method.Arity) : null;
                             }
                             return true;
                         }

--- a/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LookupOptions.cs
@@ -96,6 +96,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Do not consider symbols that are method type parameters.
         /// </summary>
         MustNotBeMethodTypeParameter = 1 << 14,
+
+        /// <summary>
+        /// Lookup symbols that can match omitted type arguments
+        /// </summary>
+        TryMatchOmittedTypeArgs = 1 << 15,
     }
 
     internal static class LookupOptionExtensions

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -482,12 +482,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // First deal with eliminating generic-arity mismatches.
 
             // SPEC: If F is generic and M includes a type argument list, F is a candidate when:
-            // SPEC: * F has the same number of method type parameters as were supplied in the type argument list, and
-            //
-            // This is specifying an impossible condition; the member lookup algorithm has already filtered
-            // out methods from the method group that have the wrong generic arity.
+            // SPEC: * F has the same number of method type parameters as were supplied in the type argument list
 
-            Debug.Assert(typeArguments.Count == 0 || typeArguments.Count == member.GetMemberArity());
+            // filter out methods from the method group that have the wrong generic arity.
+            if (typeArguments.Count != 0 && typeArguments.Count != member.GetMemberArity())
+            {
+                return;
+            }
 
             // Second, we need to determine if the method is applicable in its normal form or its expanded form.
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -119,18 +119,18 @@ class C<T, U> { }
     }
 }";
             CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                // (9,9): error CS0305: Using the generic method 'C.M1<T>()' requires 1 type arguments
-                Diagnostic(ErrorCode.ERR_BadArity, "M1<object, object>").WithArguments("C.M1<T>()", "method", "1").WithLocation(9, 9),
-                // (10,11): error CS0305: Using the generic method 'C.M1<T>()' requires 1 type arguments
-                Diagnostic(ErrorCode.ERR_BadArity, "M1<object, object>").WithArguments("C.M1<T>()", "method", "1").WithLocation(10, 11),
+                // (9,9): error CS0305: Using the generic method group 'C.M1<T>()' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_BadArity, "M1<object, object>").WithArguments("C.M1<T>()", "method group", "1").WithLocation(9, 9),
+                // (10,11): error CS0305: Using the generic method group 'C.M1<T>()' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_BadArity, "M1<object, object>").WithArguments("C.M1<T>()", "method group", "1").WithLocation(10, 11),
                 // (11,9): error CS0308: The non-generic method 'C.M2()' cannot be used with type arguments
                 Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M2<int>").WithArguments("C.M2()", "method").WithLocation(11, 9),
                 // (12,11): error CS0308: The non-generic method 'C.M2()' cannot be used with type arguments
                 Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M2<int>").WithArguments("C.M2()", "method").WithLocation(12, 11),
-                // (13,9): error CS0305: Using the generic method 'C.M3<T>()' requires 1 type arguments
-                Diagnostic(ErrorCode.ERR_BadArity, "M3<object, object>").WithArguments("C.M3<T>()", "method", "1").WithLocation(13, 9),
-                // (14,14): error CS0305: Using the generic method 'C.M3<T>()' requires 1 type arguments
-                Diagnostic(ErrorCode.ERR_BadArity, "M3<object, object>").WithArguments("C.M3<T>()", "method", "1").WithLocation(14, 14),
+                // (13,9): error CS0305: Using the generic method group 'C.M3<T>()' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_BadArity, "M3<object, object>").WithArguments("C.M3<T>()", "method group", "1").WithLocation(13, 9),
+                // (14,14): error CS0305: Using the generic method group 'C.M3<T>()' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_BadArity, "M3<object, object>").WithArguments("C.M3<T>()", "method group", "1").WithLocation(14, 14),
                 // (15,9): error CS0308: The non-generic method 'C.M4()' cannot be used with type arguments
                 Diagnostic(ErrorCode.ERR_HasNoTypeVars, "M4<int>").WithArguments("C.M4()", "method").WithLocation(15, 9),
                 // (16,14): error CS0308: The non-generic method 'C.M4()' cannot be used with type arguments
@@ -3414,33 +3414,124 @@ class Program
         }
 
         [Fact, WorkItem(13617, "https://github.com/dotnet/roslyn/issues/13617")]
-        public void MissingTypeArgumentInGenericExtensionMethod()
+        public void MissingTypeArgumentInGenericExtensionMethods_Arity()
         {
             var source =
 @"
 public static class FooExtensions
 {
-    public static T Foo<T>(this object obj) => default(T);
+    public static object ExtensionMethod0(this object obj) => default(object);
+    public static T ExtensionMethod1<T>(this object obj) => default(T);
+    public static T1 ExtensionMethod2<T1, T2>(this object obj) => default(T1);
 }
 
 public class Class1
 {
     public void Test()
     {
-        var defaultA = ""a"".Foo<>();
-        var defaultB = FooExtensions.Foo<>(""b"");
+        var omittedArg0 = ""string literal"".ExtensionMethod0<>();
+        var omittedArg1 = ""string literal"".ExtensionMethod1<>();
+        var omittedArg2 = ""string literal"".ExtensionMethod2<>();
+
+        var moreArgs0 = ""string literal"".ExtensionMethod0<int>();
+        var moreArgs1 = ""string literal"".ExtensionMethod1<int, bool>();
+        var moreArgs2 = ""string literal"".ExtensionMethod2<int, bool, string>();
+
+        var lessArgs1 = ""string literal"".ExtenionMethod1();
+        var lessArgs2 = ""string literal"".ExtenionMethod2<int>();
+
+        var exactArgs0 = ""string literal"".ExtensionMethod0();
+        var exactArgs1 = ""string literal"".ExtensionMethod1<int>();
+        var exactArgs2 = ""string literal"".ExtensionMethod2<int, bool>();
     }
 }
 ";
             var compilation = CreateCompilationWithMscorlibAndSystemCore(source);
 
             compilation.VerifyDiagnostics(
-                // (11,24): error CS0305: Using the generic method group 'Foo' requires 1 type arguments
-                //         var defaultA = "a".Foo<>();
-                Diagnostic(ErrorCode.ERR_BadArity, @"""a"".Foo<>").WithArguments("Foo", "method group", "1").WithLocation(11, 24),
-                // (12,24): error CS0305: Using the generic method group 'Foo' requires 1 type arguments
-                //         var defaultB = FooExtensions.Foo<>("b");
-                Diagnostic(ErrorCode.ERR_BadArity, "FooExtensions.Foo<>").WithArguments("Foo", "method group", "1").WithLocation(12, 24));
+                // (13,44): error CS1501: No overload for method 'ExtensionMethod0' takes 0 arguments
+                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                Diagnostic(ErrorCode.ERR_BadArgCount, "ExtensionMethod0<>").WithArguments("ExtensionMethod0", "0").WithLocation(13, 44),
+                // (14,44): error CS0305: Using the generic method group 'FooExtensions.ExtensionMethod1<T>(object)' requires 1 type arguments
+                //         var omittedArg1 = "string literal".ExtensionMethod1<>();
+                Diagnostic(ErrorCode.ERR_BadArity, "ExtensionMethod1<>").WithArguments("FooExtensions.ExtensionMethod1<T>(object)", "method group", "1").WithLocation(14, 44),
+                // (15,44): error CS0305: Using the generic method group 'FooExtensions.ExtensionMethod2<T1, T2>(object)' requires 2 type arguments
+                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                Diagnostic(ErrorCode.ERR_BadArity, "ExtensionMethod2<>").WithArguments("FooExtensions.ExtensionMethod2<T1, T2>(object)", "method group", "2").WithLocation(15, 44),
+                // (17,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 42),
+                // (18,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(18, 42),
+                // (19,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 42),
+                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtenionMethod1' and no extension method 'ExtenionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var lessArgs1 = "string literal".ExtenionMethod1();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtenionMethod1").WithArguments("string", "ExtenionMethod1").WithLocation(21, 42),
+                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtenionMethod2' and no extension method 'ExtenionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var lessArgs2 = "string literal".ExtenionMethod2<int>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtenionMethod2<int>").WithArguments("string", "ExtenionMethod2").WithLocation(22, 42));
+        }
+
+        [Fact, WorkItem(13617, "https://github.com/dotnet/roslyn/issues/13617")]
+        public void MissingTypeArgumentInGenericInstanceMethods_Arity()
+        {
+            var source =
+@"
+public class Class1
+{
+    public object InstanceMethod0() => default(object);
+    public T InstanceMethod1<T>() => default(T);
+    public T1 InstanceMethod2<T1, T2>() => default(T1);
+
+    public void Test()
+    {
+        var omittedArg0 = InstanceMethod0<>();
+        var omittedArg1 = InstanceMethod1<>();
+        var omittedArg2 = InstanceMethod2<>();
+
+        var moreArgs0 = InstanceMethod0<int>();
+        var moreArgs1 = InstanceMethod1<int, bool>();
+        var moreArgs2 = InstanceMethod2<int, bool, string>();
+
+        var lessArgs1 = InstanceMethod1();
+        var lessArgs2 = InstanceMethod2<int>();
+
+        var exactArgs0 = InstanceMethod0();
+        var exactArgs1 = InstanceMethod1<int>();
+        var exactArgs2 = InstanceMethod2<int, bool>();
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source);
+
+            compilation.VerifyDiagnostics(
+                // (10,27): error CS0308: The non-generic method 'Class1.InstanceMethod0()' cannot be used with type arguments
+                //         var omittedArg0 = InstanceMethod0<>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "InstanceMethod0<>").WithArguments("Class1.InstanceMethod0()", "method").WithLocation(10, 27),
+                // (11,27): error CS0305: Using the generic method group 'InstanceMethod1' requires 1 type arguments
+                //         var omittedArg1 = InstanceMethod1<>();
+                Diagnostic(ErrorCode.ERR_BadArity, "InstanceMethod1<>").WithArguments("InstanceMethod1", "method group", "1").WithLocation(11, 27),
+                // (12,27): error CS0305: Using the generic method group 'Class1.InstanceMethod2<T1, T2>()' requires 2 type arguments
+                //         var omittedArg2 = InstanceMethod2<>();
+                Diagnostic(ErrorCode.ERR_BadArity, "InstanceMethod2<>").WithArguments("Class1.InstanceMethod2<T1, T2>()", "method group", "2").WithLocation(12, 27),
+                // (14,25): error CS0308: The non-generic method 'Class1.InstanceMethod0()' cannot be used with type arguments
+                //         var moreArgs0 = InstanceMethod0<int>();
+                Diagnostic(ErrorCode.ERR_HasNoTypeVars, "InstanceMethod0<int>").WithArguments("Class1.InstanceMethod0()", "method").WithLocation(14, 25),
+                // (15,25): error CS0305: Using the generic method group 'Class1.InstanceMethod1<T>()' requires 1 type arguments
+                //         var moreArgs1 = InstanceMethod1<int, bool>();
+                Diagnostic(ErrorCode.ERR_BadArity, "InstanceMethod1<int, bool>").WithArguments("Class1.InstanceMethod1<T>()", "method group", "1").WithLocation(15, 25),
+                // (16,25): error CS0305: Using the generic method group 'Class1.InstanceMethod2<T1, T2>()' requires 2 type arguments
+                //         var moreArgs2 = InstanceMethod2<int, bool, string>();
+                Diagnostic(ErrorCode.ERR_BadArity, "InstanceMethod2<int, bool, string>").WithArguments("Class1.InstanceMethod2<T1, T2>()", "method group", "2").WithLocation(16, 25),
+                // (18,25): error CS0411: The type arguments for method 'Class1.InstanceMethod1<T>()' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         var lessArgs1 = InstanceMethod1();
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "InstanceMethod1").WithArguments("Class1.InstanceMethod1<T>()").WithLocation(18, 25),
+                // (19,25): error CS0305: Using the generic method group 'Class1.InstanceMethod2<T1, T2>()' requires 2 type arguments
+                //         var lessArgs2 = InstanceMethod2<int>();
+                Diagnostic(ErrorCode.ERR_BadArity, "InstanceMethod2<int>").WithArguments("Class1.InstanceMethod2<T1, T2>()", "method group", "2").WithLocation(19, 25));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MethodTypeInferenceTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MethodTypeInferenceTests.cs
@@ -623,9 +623,9 @@ class Program
 }
 ";
             CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                // (6,17): error CS0305: Using the generic method 'Program.Foo<T, U>(T, U)' requires 2 type arguments
+                // (6,17): error CS0305: Using the generic method group 'Program.Foo<T, U>(T, U)' requires 2 type arguments
                 //         var s = Foo<>(123, 345);
-                Diagnostic(ErrorCode.ERR_BadArity, "Foo<>").WithArguments("Program.Foo<T, U>(T, U)", "method", "2"));
+                Diagnostic(ErrorCode.ERR_BadArity, "Foo<>").WithArguments("Program.Foo<T, U>(T, U)", "method group", "2"));
         }
 
         [WorkItem(541887, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541887")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticAnalyzerTests.cs
@@ -469,9 +469,9 @@ class C
                 // (118,11): error CS0411: The type arguments for method 'P.Generic<T>()' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         p.Generic();
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "Generic").WithArguments("P.Generic<T>()").WithLocation(118, 11),
-                // (122,11): error CS0305: Using the generic method 'P.Generic<T>()' requires 1 type arguments
+                // (122,11): error CS0305: Using the generic method group 'P.Generic<T>()' requires 1 type arguments
                 //         p.Generic<int, int>();
-                Diagnostic(ErrorCode.ERR_BadArity, "Generic<int, int>").WithArguments("P.Generic<T>()", "method", "1").WithLocation(122, 11),
+                Diagnostic(ErrorCode.ERR_BadArity, "Generic<int, int>").WithArguments("P.Generic<T>()", "method group", "1").WithLocation(122, 11),
                 // (125,11): error CS0308: The non-generic method 'P.NotGeneric()' cannot be used with type arguments
                 //         p.NotGeneric<int, int>();
                 Diagnostic(ErrorCode.ERR_HasNoTypeVars, "NotGeneric<int, int>").WithArguments("P.NotGeneric()", "method").WithLocation(125, 11),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -9200,8 +9200,8 @@ public class NormalType
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (7,17): error CS1031: Type expected
                 Diagnostic(ErrorCode.ERR_TypeExpected, ">"),
-                // (7,9): error CS0305: Using the generic method 'NormalType.M1<T1>(T1, T1)' requires 1 type arguments
-                Diagnostic(ErrorCode.ERR_BadArity, "M1<int, >").WithArguments("NormalType.M1<T1>(T1, T1)", "method", "1"));
+                // (7,9): error CS0305: Using the generic method group 'NormalType.M1<T1>(T1, T1)' requires 1 type arguments
+                Diagnostic(ErrorCode.ERR_BadArity, "M1<int, >").WithArguments("NormalType.M1<T1>(T1, T1)", "method group", "1"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -681,9 +681,9 @@ namespace N4
                 // (13,17): error CS0411: The type arguments for method 'N1.N2.C.M4<T>(T, int)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //                 this.M4(null, 2); // MethodResolutionKind.TypeInferenceFailed
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "M4").WithArguments("N1.N2.C.M4<T>(T, int)").WithLocation(13, 22),
-                // (14,22): error CS0305: Using the generic method 'N1.N2.C.M5<T>(T, int)' requires 1 type arguments
+                // (14,22): error CS0305: Using the generic method group 'N1.N2.C.M5<T>(T, int)' requires 1 type arguments
                 //                 this.M5<string, string>(null, 2); // Bad arity
-                Diagnostic(ErrorCode.ERR_BadArity, "M5<string, string>").WithArguments("N1.N2.C.M5<T>(T, int)", "method", "1").WithLocation(14, 22),
+                Diagnostic(ErrorCode.ERR_BadArity, "M5<string, string>").WithArguments("N1.N2.C.M5<T>(T, int)", "method group", "1").WithLocation(14, 22),
                 // (15,17): error CS0121: The call is ambiguous between the following methods or properties: 'N1.N2.C.M6(object, string)' and 'N1.N2.C.M6(string, object)'
                 //                 this.M6(null, null); // Ambiguous
                 Diagnostic(ErrorCode.ERR_AmbigCall, "M6").WithArguments("N1.N2.C.M6(object, string)", "N1.N2.C.M6(string, object)").WithLocation(15, 22),
@@ -1897,9 +1897,9 @@ static class S
                 // (7,16): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
                 //         this.E<A>(null);
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(7, 16),
-                // (8,14): error CS0305: Using the generic method 'C.E<T>()' requires 1 type arguments
+                // (8,14): error CS0305: Using the generic method group 'C.E<T>()' requires 1 type arguments
                 //         this.E<int, int>(1);
-                Diagnostic(ErrorCode.ERR_BadArity, "E<int, int>").WithArguments("C.E<T>()", "method", "1").WithLocation(8, 14)
+                Diagnostic(ErrorCode.ERR_BadArity, "E<int, int>").WithArguments("C.E<T>()", "method group", "1").WithLocation(8, 14)
                 );
         }
 


### PR DESCRIPTION
This PR reverts #15718, and proposes a better way to fix #13617 (as suggested by @AlekseyTs).