### PR TITLE
Set an appropriate title on the FindRefs window in response to new editor API changes.

### DIFF
--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; declarations.
+        /// </summary>
+        internal static string _0_declarations {
+            get {
+                return ResourceManager.GetString("_0_declarations", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; does not support the &apos;{1}&apos; operation. However, it may contain nested &apos;{2}&apos;s (see &apos;{2}.{3}&apos;) that support this operation..
         /// </summary>
         internal static string _0_does_not_support_the_1_operation_However_it_may_contain_nested_2_s_see_2_3_that_support_this_operation {
@@ -80,11 +89,29 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; implementations.
+        /// </summary>
+        internal static string _0_implementations {
+            get {
+                return ResourceManager.GetString("_0_implementations", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} - (Line {1}).
         /// </summary>
         internal static string _0_Line_1 {
             get {
                 return ResourceManager.GetString("_0_Line_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; references.
+        /// </summary>
+        internal static string _0_references {
+            get {
+                return ResourceManager.GetString("_0_references", resourceCulture);
             }
         }
         

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -745,4 +745,13 @@ Do you want to proceed?</value>
   <data name="Suggestion_ellipses" xml:space="preserve">
     <value>Suggestion ellipses (…)</value>
   </data>
+  <data name="_0_references" xml:space="preserve">
+    <value>'{0}' references</value>
+  </data>
+  <data name="_0_implementations" xml:space="preserve">
+    <value>'{0}' implementations</value>
+  </data>
+  <data name="_0_declarations" xml:space="preserve">
+    <value>'{0}' declarations</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/FindReferences/AbstractFindReferencesService.cs
+++ b/src/EditorFeatures/Core/FindReferences/AbstractFindReferencesService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
             var symbol = symbolAndProject?.symbol;
             var project = symbolAndProject?.project;
 
-            var displayName = GetDisplayName(symbol);
+            var displayName = FindUsagesHelpers.GetDisplayName(symbol);
 
             waitContext.Message = string.Format(
                 EditorFeaturesResources.Finding_references_of_0, displayName);
@@ -52,11 +52,6 @@ namespace Microsoft.CodeAnalysis.Editor.FindReferences
             var result = await SymbolFinder.FindReferencesAsync(symbol, project.Solution, cancellationToken).ConfigureAwait(false);
 
             return Tuple.Create(result, project.Solution);
-        }
-
-        public static string GetDisplayName(ISymbol symbol)
-        {
-            return symbol.IsConstructor() ? symbol.ContainingType.Name : symbol.Name;
         }
 
         public bool TryFindReferences(Document document, int position, IWaitContext waitContext)

--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.FindReferences;
-using Microsoft.CodeAnalysis.Editor.GoToImplementation;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.FindUsages;
 
@@ -32,8 +27,10 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
                 return;
             }
 
-            var project = tuple.Value.project;
+            context.SetSearchTitle(string.Format(EditorFeaturesResources._0_implementations,
+                FindUsagesHelpers.GetDisplayName(tuple.Value.symbol)));
 
+            var project = tuple.Value.project;
             foreach (var implementation in tuple.Value.implementations)
             {
                 var definitionItem = implementation.ToDefinitionItem(
@@ -79,8 +76,8 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
             var symbol = symbolAndProject?.symbol;
             var project = symbolAndProject?.project;
 
-            var displayName = AbstractFindReferencesService.GetDisplayName(symbol);
-            context.SetSearchLabel(displayName);
+            context.SetSearchTitle(string.Format(EditorFeaturesResources._0_references,
+                FindUsagesHelpers.GetDisplayName(symbol)));
 
             var progressAdapter = new ProgressAdapter(project.Solution, context);
 

--- a/src/EditorFeatures/Core/FindUsages/FindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesContext.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
         {
         }
 
-        public virtual void SetSearchLabel(string displayName)
+        public virtual void SetSearchTitle(string title)
         {
         }
 

--- a/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
+++ b/src/EditorFeatures/Core/FindUsages/FindUsagesHelpers.cs
@@ -14,6 +14,9 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
 {
     internal static class FindUsagesHelpers
     {
+        public static string GetDisplayName(ISymbol symbol)
+            => symbol.IsConstructor() ? symbol.ContainingType.Name : symbol.Name;
+
         /// <summary>
         /// Common helper for both the synchronous and streaming versions of FAR. 
         /// It returns the symbol we want to search for and the solution we should

--- a/src/EditorFeatures/Core/FindUsages/IFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/IFindUsagesContext.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// <summary>
         /// Set the title of the window that results are displayed in.
         /// </summary>
-        void SetSearchLabel(string displayName);
+        void SetSearchTitle(string title);
 
         Task OnDefinitionFoundAsync(DefinitionItem definition);
         Task OnReferenceFoundAsync(SourceReferenceItem reference);

--- a/src/EditorFeatures/Core/FindUsages/SimpleFindUsagesContext.cs
+++ b/src/EditorFeatures/Core/FindUsages/SimpleFindUsagesContext.cs
@@ -29,9 +29,13 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
         }
 
         public string Message { get; private set; }
+        public string SearchTitle { get; private set; }
 
         public override void ReportMessage(string message)
             => Message = message;
+
+        public override void SetSearchTitle(string title)
+            => SearchTitle = title;
 
         public ImmutableArray<DefinitionItem> GetDefinitions()
         {

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.Editor.FindReferences;
+using Microsoft.CodeAnalysis.Editor.FindUsages;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.FindUsages;
@@ -69,9 +71,11 @@ namespace Microsoft.CodeAnalysis.Editor.GoToDefinition
             definitions.Add(symbol.ToDefinitionItem(solution, includeHiddenLocations: true));
 
             var presenter = GetFindUsagesPresenter(streamingPresenters);
+            var title = string.Format(EditorFeaturesResources._0_declarations,
+                FindUsagesHelpers.GetDisplayName(symbol));
+
             return presenter.TryNavigateToOrPresentItemsAsync(
-                EditorFeaturesResources.Go_to_Definition,
-                definitions.ToImmutableAndFree(),
+                title, definitions.ToImmutableAndFree(),
                 alwaysShowDeclarations: true).WaitAndGetResult(cancellationToken);
         }
 

--- a/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToImplementation/GoToImplementationCommandHandler.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.GoToImplementation
             var definitionItems = goToImplContext.GetDefinitions();
 
             streamingPresenter.TryNavigateToOrPresentItemsAsync(
-                EditorFeaturesResources.Go_To_Implementation, definitionItems,
+                goToImplContext.SearchTitle, definitionItems,
                 alwaysShowDeclarations: true).Wait(cancellationToken);
         }
 

--- a/src/VisualStudio/Core/Next/FindReferences/StreamingFindUsagesPresenter.TableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/StreamingFindUsagesPresenter.TableDataSourceFindUsagesContext.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -197,12 +198,23 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
             #region FindUsagesContext overrides.
 
-            public override void SetSearchLabel(string displayName)
+            public override void SetSearchTitle(string title)
             {
-                var labelProperty = _findReferencesWindow.GetType().GetProperty("Label");
-                if (labelProperty != null)
+                try
                 {
-                    labelProperty.SetValue(_findReferencesWindow, displayName);
+                    // Editor renamed their property from Label to Title, and made it public.
+                    // However, we don't have access to that property yet until they publish
+                    // their next SDK.  In the meantime, use reflection to get at the right
+                    // property.
+                    var titleProperty = _findReferencesWindow.GetType().GetProperty(
+                        "Title", BindingFlags.Public | BindingFlags.Instance);
+                    if (titleProperty != null)
+                    {
+                        titleProperty.SetValue(_findReferencesWindow, title);
+                    }
+                }
+                catch (Exception)
+                {
                 }
             }
 


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems?fullScreen=true&id=291359&triage=true&_a=edit

Due to different internal customer requests, the editor has stopped labeling all 'Find all references' windows automatically.  This is because the window may be used for features like Go-To-Implementation or Go-To-Definition, so saying "Find all references" isn't accurate.  The hard-coded title was also problematic as you can now have many of these windows open, and you can't look at teh title easily to distinguish them.

We now call into the editor's API for setting the title with something reasonable.  We list the symbol name first, so the windows are easy to distinguish, and we state if they are references, implementations or declarations that we're showing.

