### PR TITLE
Check for assembly resolution errors in bootstrap build

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -353,7 +353,7 @@
              Condition="!Exists('$(ToolsetCompilerPropsFilePath)')" />
   </Target>
 
-  <Target Name="CheckBootstrapState" Condition="'$(BootstrapBuildPath)' != ''" BeforeTargets="CoreCompile">
+  <Target Name="CheckBootstrapState" Condition="'$(BootstrapBuildPath)' != ''" AfterTargets="CoreCompile">
     <ValidateBootstrap BootstrapPath="$(BootstrapBuildPath)" />
   </Target>
 

--- a/src/Compilers/Core/MSBuildTask/AssemblyResolution.cs
+++ b/src/Compilers/Core/MSBuildTask/AssemblyResolution.cs
@@ -58,6 +58,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             }
 
+#if DEBUG || BOOTSTRAP
+            ValidateBootstrap.AddFailedLoad(name);
+#endif
+
             return false;
         }
 

--- a/src/Compilers/Core/MSBuildTask/AssemblyResolution.cs
+++ b/src/Compilers/Core/MSBuildTask/AssemblyResolution.cs
@@ -54,6 +54,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     return TryRedirect(name, s_b03f5f7f11d50a3a, 4, 0, 2, 0);
 
                 case "System.Diagnostics.StackTrace":
+                case "System.Security.AccessControl":
                     return TryRedirect(name, s_b03f5f7f11d50a3a, 4, 0, 3, 0);
 
             }

--- a/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
+++ b/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
@@ -92,9 +92,16 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
         internal static void AddFailedLoad(AssemblyName name)
         {
-            if (Path.GetExtension(name.Name) != ".resources")
+            switch (name.Name)
             {
-                s_failedLoadSet.TryAdd(name, 0);
+                case "System":
+                case "System.Core":
+                case "Microsoft.Build.Tasks.CodeAnalysis.resources":
+                    // These are failures are expected by design.
+                    break;
+                default:
+                    s_failedLoadSet.TryAdd(name, 0);
+                    break;
             }
         }
     }

--- a/src/Compilers/Core/MSBuildTask/project.json
+++ b/src/Compilers/Core/MSBuildTask/project.json
@@ -7,6 +7,7 @@
         "Microsoft.Win32.Primitives": "4.3.0",
         "System.AppContext": "4.3.0",
         "System.Console": "4.3.0",
+        "System.Collections.Concurrent": "4.3.0",
         "System.Diagnostics.Process": "4.3.0",
         "System.Diagnostics.Tools": "4.3.0",
         "System.IO.FileSystem": "4.3.0",


### PR DESCRIPTION
**Customer Scenario**

The compiler server is broken since our move to Net Core 1.1.  This change addresses the problem in two ways:

- Add the infrastructure to detect the assembly resolution errors at bootstrap time.  An initial push was made to validate this does cause all PRs to fail.  
- Fix the actual resolution issue with System.Security.AccessControl

**Why wasn't it discovered earlier?**

There is no infrastructure to catch this failure.  The MSBuild task itself is resilient to unexpected errors in the server code path and correctly fell back to command line compiles.  