### PR TITLE
Correct an off-by-one error in the precedence for is-pattern parsing.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9143,6 +9143,9 @@ tryAgain:
             return false;
         }
 
+        /// <summary>
+        /// Parse a subexpression of the enclosing operator of the given precedence.
+        /// </summary>
         private ExpressionSyntax ParseSubExpression(Precedence precedence)
         {
             _recursionDepth++;
@@ -9369,7 +9372,7 @@ tryAgain:
 
         private ExpressionSyntax ParseIsExpression(ExpressionSyntax leftOperand, SyntaxToken opToken)
         {
-            var node = this.ParseTypeOrPattern();
+            var node = this.ParseTypeOrPatternForIsOperator();
             if (node is PatternSyntax)
             {
                 var result = _syntaxFactory.IsPatternExpression(leftOperand, opToken, (PatternSyntax)node);

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -7,13 +7,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
     internal partial class LanguageParser : SyntaxParser
     {
-        // Priority is the TypeSyntax. It might return TypeSyntax which might be a constant pattern such as enum 'Days.Sunday' 
-        // We handle such cases in the binder of is operator.
-        // It is used for parsing patterns in the is operators.
-        private CSharpSyntaxNode ParseTypeOrPattern()
+        /// <summary>
+        /// Parses the type, or pattern, right-hand operand of an is expression.
+        /// Priority is the TypeSyntax. It may return a TypeSyntax which turns out in binding to
+        /// be a constant pattern such as enum 'Days.Sunday'. We handle such cases in the binder of the is operator.
+        /// </summary>
+        private CSharpSyntaxNode ParseTypeOrPatternForIsOperator()
         {
             var tk = this.CurrentToken.Kind;
-            CSharpSyntaxNode node = null;
+            Precedence precedence = GetPrecedence(SyntaxKind.IsPatternExpression);
 
             switch (tk)
             {
@@ -39,67 +41,40 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     TypeSyntax type = this.ParseType(ParseTypeMode.AfterIsOrCase);
 
-                    tk = this.CurrentToken.ContextualKind;
-                    if (!type.IsMissing)
+                    if (!type.IsMissing && this.IsTrueIdentifier())
                     {
-                        if (this.IsTrueIdentifier())
-                        {
-                            var designation = ParseSimpleDesignation();
-                            node = _syntaxFactory.DeclarationPattern(type, designation);
-                        }
+                        var designation = ParseSimpleDesignation();
+                        return _syntaxFactory.DeclarationPattern(type, designation);
                     }
 
-                    if (node == null)
+                    tk = this.CurrentToken.ContextualKind;
+                    if ((!IsExpectedBinaryOperator(tk) || GetPrecedence(SyntaxFacts.GetBinaryExpression(tk)) <= precedence) &&
+                        // member selection is not formally a binary operator but has higher precedence than relational
+                        tk != SyntaxKind.DotToken) 
                     {
-                        Debug.Assert(Precedence.Shift == Precedence.Relational + 1);
-                        if ((IsExpectedBinaryOperator(tk) && GetPrecedence(SyntaxFacts.GetBinaryExpression(tk)) > Precedence.Relational) ||
-                            tk == SyntaxKind.DotToken) // member selection is not formally a binary operator but has higher precedence than relational
-                        {
-                            this.Reset(ref resetPoint);
-                            // We parse a shift-expression ONLY (nothing looser) - i.e. not a relational expression
-                            // So x is y < z should be parsed as (x is y) < z
-                            // But x is y << z should be parsed as x is (y << z)
-                            node = _syntaxFactory.ConstantPattern(this.ParseSubExpression(Precedence.Shift));
-                        }
-                        // it is a typical "is Type" operator
-                        else
-                        {
-                            // Note that we don't bother checking for primary expressions such as X[e], X(e), X++, and X--
-                            // as those are never semantically valid constant expressions for a pattern
-                            node = type;
-                        }
+                        // it is a typical "is Type" operator.
+                        // Note that we don't bother checking for primary expressions such as X[e], X(e), X++, and X--
+                        // as those are never semantically valid constant expressions for a pattern
+                        return type;
                     }
+
+                    this.Reset(ref resetPoint);
                 }
                 finally
                 {
                     this.Release(ref resetPoint);
                 }
             }
-            else
-            {
-                // In places where a pattern is supported, we do not support tuple types
-                // due to both syntactic and semantic ambiguities between tuple types and positional patterns.
 
-                // But it still might be a pattern such as (operand is 3) or (operand is nameof(x))
-                node = _syntaxFactory.ConstantPattern(this.ParseExpressionCore());
-            }
+            // We parse a shift-expression ONLY (nothing looser) - i.e. not a relational expression
+            // So x is y < z should be parsed as (x is y) < z
+            // But x is y << z should be parsed as x is (y << z)
+            Debug.Assert(Precedence.Shift == precedence + 1);
 
-            return node;
-        }
-
-        // This method is used when we always want a pattern as a result.
-        // For instance, it is used in parsing recursivepattern and propertypattern.
-        // SubPatterns in these (recursivepattern, propertypattern) must be a type of Pattern.
-        private PatternSyntax ParsePattern()
-        {
-            var node = this.ParseExpressionOrPattern(whenIsKeyword: false);
-            if (node is PatternSyntax)
-            {
-                return (PatternSyntax)node;
-            }
-
-            Debug.Assert(node is ExpressionSyntax);
-            return _syntaxFactory.ConstantPattern((ExpressionSyntax)node);
+            // In places where a pattern is supported, we do not support tuple types
+            // due to both syntactic and semantic ambiguities between tuple types and positional patterns.
+            // But it still might be a pattern such as (operand is 3) or (operand is nameof(x))
+            return _syntaxFactory.ConstantPattern(this.ParseSubExpressionCore(precedence));
         }
 
         //

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -56,6 +56,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             UsingNode(node);
         }
 
+        internal void UsingExpression(string text, params DiagnosticDescription[] expectedErrors)
+        {
+            var node = SyntaxFactory.ParseExpression(text);
+            // we validate the text roundtrips
+            Assert.Equal(text, node.ToFullString());
+            var actualErrors = node.GetDiagnostics();
+            actualErrors.Verify(expectedErrors);
+            UsingNode(node);
+        }
+
         /// <summary>
         /// Parses given string and initializes a depth-first preorder enumerator.
         /// </summary>

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -532,5 +532,379 @@ class C
             }
             EOF();
         }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence00()
+        {
+            UsingExpression("A is B << C");
+            N(SyntaxKind.IsPatternExpression);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.IsKeyword);
+                N(SyntaxKind.ConstantPattern);
+                {
+                    N(SyntaxKind.LeftShiftExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "B");
+                        }
+                        N(SyntaxKind.LessThanLessThanToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "C");
+                        }
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence01()
+        {
+            UsingExpression("A is 1 << 2");
+            N(SyntaxKind.IsPatternExpression);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "A");
+                }
+                N(SyntaxKind.IsKeyword);
+                N(SyntaxKind.ConstantPattern);
+                {
+                    N(SyntaxKind.LeftShiftExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "1");
+                        }
+                        N(SyntaxKind.LessThanLessThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "2");
+                        }
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence02()
+        {
+            UsingExpression("A is null < B");
+            N(SyntaxKind.LessThanExpression);
+            {
+                N(SyntaxKind.IsPatternExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                    }
+                    N(SyntaxKind.IsKeyword);
+                    N(SyntaxKind.ConstantPattern);
+                    {
+                        N(SyntaxKind.NullLiteralExpression);
+                        {
+                            N(SyntaxKind.NullKeyword);
+                        }
+                    }
+                }
+                N(SyntaxKind.LessThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "B");
+                }
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence02b()
+        {
+            UsingExpression("A is B < C");
+            N(SyntaxKind.LessThanExpression);
+            {
+                N(SyntaxKind.IsExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                    }
+                    N(SyntaxKind.IsKeyword);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "B");
+                    }
+                }
+                N(SyntaxKind.LessThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "C");
+                }
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence03()
+        {
+            UsingExpression("A is null == B");
+            N(SyntaxKind.EqualsExpression);
+            {
+                N(SyntaxKind.IsPatternExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                    }
+                    N(SyntaxKind.IsKeyword);
+                    N(SyntaxKind.ConstantPattern);
+                    {
+                        N(SyntaxKind.NullLiteralExpression);
+                        {
+                            N(SyntaxKind.NullKeyword);
+                        }
+                    }
+                }
+                N(SyntaxKind.EqualsEqualsToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "B");
+                }
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence04()
+        {
+            UsingExpression("A is null & B");
+            N(SyntaxKind.BitwiseAndExpression);
+            {
+                N(SyntaxKind.IsPatternExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                    }
+                    N(SyntaxKind.IsKeyword);
+                    N(SyntaxKind.ConstantPattern);
+                    {
+                        N(SyntaxKind.NullLiteralExpression);
+                        {
+                            N(SyntaxKind.NullKeyword);
+                        }
+                    }
+                }
+                N(SyntaxKind.AmpersandToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "B");
+                }
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence05()
+        {
+            UsingExpression("A is null && B");
+            N(SyntaxKind.LogicalAndExpression);
+            {
+                N(SyntaxKind.IsPatternExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                    }
+                    N(SyntaxKind.IsKeyword);
+                    N(SyntaxKind.ConstantPattern);
+                    {
+                        N(SyntaxKind.NullLiteralExpression);
+                        {
+                            N(SyntaxKind.NullKeyword);
+                        }
+                    }
+                }
+                N(SyntaxKind.AmpersandAmpersandToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "B");
+                }
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence05b()
+        {
+            UsingExpression("A is null || B");
+            N(SyntaxKind.LogicalOrExpression);
+            {
+                N(SyntaxKind.IsPatternExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                    }
+                    N(SyntaxKind.IsKeyword);
+                    N(SyntaxKind.ConstantPattern);
+                    {
+                        N(SyntaxKind.NullLiteralExpression);
+                        {
+                            N(SyntaxKind.NullKeyword);
+                        }
+                    }
+                }
+                N(SyntaxKind.BarBarToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "B");
+                }
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(15734, "https://github.com/dotnet/roslyn/issues/15734")]
+        public void PatternExpressionPrecedence06()
+        {
+            UsingStatement(@"switch (e) {
+case 1 << 2:
+case B << C:
+case null < B:
+case null == B:
+case null & B:
+case null && B:
+    break;
+}");
+            N(SyntaxKind.SwitchStatement);
+            {
+                N(SyntaxKind.SwitchKeyword);
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "e");
+                }
+                N(SyntaxKind.CloseParenToken);
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.SwitchSection);
+                {
+                    N(SyntaxKind.CaseSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.LeftShiftExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "1");
+                            }
+                            N(SyntaxKind.LessThanLessThanToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "2");
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CaseSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.LeftShiftExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "B");
+                            }
+                            N(SyntaxKind.LessThanLessThanToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "C");
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CaseSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.LessThanExpression);
+                        {
+                            N(SyntaxKind.NullLiteralExpression);
+                            {
+                                N(SyntaxKind.NullKeyword);
+                            }
+                            N(SyntaxKind.LessThanToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "B");
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CaseSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.EqualsExpression);
+                        {
+                            N(SyntaxKind.NullLiteralExpression);
+                            {
+                                N(SyntaxKind.NullKeyword);
+                            }
+                            N(SyntaxKind.EqualsEqualsToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "B");
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CaseSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.BitwiseAndExpression);
+                        {
+                            N(SyntaxKind.NullLiteralExpression);
+                            {
+                                N(SyntaxKind.NullKeyword);
+                            }
+                            N(SyntaxKind.AmpersandToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "B");
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.CaseSwitchLabel);
+                    {
+                        N(SyntaxKind.CaseKeyword);
+                        N(SyntaxKind.LogicalAndExpression);
+                        {
+                            N(SyntaxKind.NullLiteralExpression);
+                            {
+                                N(SyntaxKind.NullKeyword);
+                            }
+                            N(SyntaxKind.AmpersandAmpersandToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "B");
+                            }
+                        }
+                        N(SyntaxKind.ColonToken);
+                    }
+                    N(SyntaxKind.BreakStatement);
+                    {
+                        N(SyntaxKind.BreakKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            EOF();
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Use the new pattern-matching `is` operator in a more complex expression, such as `e1 is null || e2`

In that case the compiler gets the precedence wrong.

**Bugs this fixes:** 

Fixes #15734

**Workarounds, if any**

Add redundant parens when the compiler gets the precedence wrong (if you notice).

In some circumstances, the compiler will produce executable code with no error, but generate code that is incorrect because of the precedence. Because of that, this should be fixed sooner rather than later.

**Risk**

Low; fix is localized to the relevant parsing code.

**Performance impact**

None. We parse the same way as before, but with the correct precedence.

**Is this a regression from a previous update?**

No. This is an error in the implementation of a new feature.

**Root cause analysis:**

We had a test hole for this particular combination of features. This PR adds a number of precedence tests for the feature so that the bug cannot recur undetected.

**How was the bug found?**

Customer report.

@dotnet/roslyn-compiler Please review.