### PR TITLE
Lexer should not lose characters when too making bad tokens encountered

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -415,6 +415,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             char character;
             char surrogateCharacter = SlidingTextWindow.InvalidCharacter;
             bool isEscaped = false;
+            int startingPosition = TextWindow.Position;
 
             // Start scanning the token
             character = TextWindow.PeekChar();
@@ -877,10 +878,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     if (_badTokenCount++ > 200)
                     {
                         // If we get too many characters that we cannot make sense of, absorb the rest of the input.
-                        int position = TextWindow.Position - 1;
                         int end = TextWindow.Text.Length;
-                        int width = end - position;
-                        info.Text = TextWindow.Text.ToString(new TextSpan(position, width));
+                        int width = end - startingPosition;
+                        info.Text = TextWindow.Text.ToString(new TextSpan(startingPosition, width));
                         TextWindow.Reset(end);
                     }
                     else

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -4,6 +4,9 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Test.Utilities.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
@@ -126,6 +129,24 @@ class A
                 //     [Obsolete(2l)]
                 Diagnostic(ErrorCode.WRN_LowercaseEllSuffix, "l").WithLocation(4, 16)
                 );
+        }
+
+        [Fact]
+        [WorkItem(217398, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217398")]
+        public void LexerTooManyBadTokens()
+        {
+            var source = new StringBuilder();
+            for (int i = 0; i <= 200; i++)
+            {
+                source.Append(@"\u003C");
+            }
+            source.Append(@"\u003E\u003E\u003E\u003E");
+
+            var parsedTree = ParseWithRoundTripCheck(source.ToString());
+            IEnumerable<Diagnostic> actualErrors = parsedTree.GetDiagnostics();
+            Assert.Equal("202", actualErrors.Count().ToString());
+            Assert.Equal("(1,1201): error CS1056: Unexpected character '\\u003C'", actualErrors.ElementAt(200).ToString());
+            Assert.Equal("(1,1207): error CS1056: Unexpected character '\\u003E\\u003E\\u003E\\u003E'", actualErrors.ElementAt(201).ToString());
         }
 
         #region "Helpers"

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -149,6 +149,24 @@ class A
             Assert.Equal("(1,1207): error CS1056: Unexpected character '\\u003E\\u003E\\u003E\\u003E'", actualErrors.ElementAt(201).ToString());
         }
 
+        [Fact]
+        [WorkItem(217398, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217398")]
+        public void LexerTooManyBadTokens_LongUnicode()
+        {
+            var source = new StringBuilder();
+            for (int i = 0; i <= 200; i++)
+            {
+                source.Append(@"\U0000003C");
+            }
+            source.Append(@"\u003E\u003E\u003E\u003E");
+
+            var parsedTree = ParseWithRoundTripCheck(source.ToString());
+            IEnumerable<Diagnostic> actualErrors = parsedTree.GetDiagnostics();
+            Assert.Equal("202", actualErrors.Count().ToString());
+            Assert.Equal("(1,2001): error CS1056: Unexpected character '\\U0000003C'", actualErrors.ElementAt(200).ToString());
+            Assert.Equal("(1,2011): error CS1056: Unexpected character '\\u003E\\u003E\\u003E\\u003E'", actualErrors.ElementAt(201).ToString());
+        }
+
         #region "Helpers"
 
         public static void ParseAndValidate(string text, params DiagnosticDescription[] expectedErrors)


### PR DESCRIPTION
**Customer scenario**
Source files with too many (> 200) unicode characters in un-allowed positions don't round-trip properly through the compiler. This results in IDE crashes.

**Bugs this fixes:** 
Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217398

**Workarounds, if any**
Not really. Don't open such source files?

**Risk**

Low. The only affected code is when the lexer detects too many bad tokens.

**Performance impact**

None. Only one token is affected (it now contains a couple of additional characters that were previously getting dropped).

**Is this a regression from a previous update?**

No

**Root cause analysis:**

The code for dealing with too many bad tokens was added primarily to protect from binary files, but it can also get triggered by escaped unicode characters that aren't allowed in an identifier.

**How was the bug found?**

Watson crashes