### PR TITLE
Deconstruct should return void and disallow 1-deconstruction

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes.md
@@ -12,3 +12,6 @@ Each entry should include a short description of the break, followed by either a
    [#11256](https://github.com/dotnet/roslyn/pull/11256) for when it was discovered, and [#10463](https://github.com/dotnet/roslyn/issues/10463) for the original issue that led to this.
 3. Native compiler used to generate warnings (169, 414, 649) on unused/unassigned fields of abstract classes.
    Roslyn 1 (VS 2015) didn't produce these warnings. With [#14628](https://github.com/dotnet/roslyn/pull/14628) these warnings should be reported again.
+4. In preview and RC releases of VS 2017 and C#7.0, deconstruction was allowed with a Deconstruct method that returned something (non-void return type).
+   Starting in RC.3, the Deconstruct method is required to return void. This will allow for future versions of C# to attach special semantics to the return value.
+   See issue [#15634](https://github.com/dotnet/roslyn/issues/15634) and PR [#15922](https://github.com/dotnet/roslyn/pull/15922) for more details.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             boundRHS = FixTupleLiteral(checkedVariables, boundRHS, node, diagnostics);
 
-            if ((object)boundRHS.Type == null)
+            if ((object)boundRHS.Type == null || boundRHS.Type.IsErrorType())
             {
                 // we could still not infer a type for the RHS
                 FailRemainingInferences(checkedVariables, diagnostics);
@@ -550,6 +550,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     DiagnosticBag diagnostics, out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders)
         {
             var receiverSyntax = receiver.Syntax;
+            if (numCheckedVariables < 2)
+            {
+                Error(diagnostics, ErrorCode.ERR_DeconstructionNeedsTwoParts, receiverSyntax);
+                outPlaceholders = default(ImmutableArray<BoundDeconstructValuePlaceholder>);
+
+                return BadExpression(receiverSyntax, receiver);
+            }
 
             if (receiver.Type.IsDynamic())
             {
@@ -615,6 +622,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         return MissingDeconstruct(receiver, syntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
                     }
+                }
+
+                if (deconstructMethod.ReturnType.GetSpecialTypeSafe() != SpecialType.System_Void)
+                {
+                    return MissingDeconstruct(receiver, syntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
                 }
 
                 if (outVars.Any(v => (object)v.Placeholder == null))

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiverSyntax = receiver.Syntax;
             if (numCheckedVariables < 2)
             {
-                Error(diagnostics, ErrorCode.ERR_DeconstructionNeedsTwoParts, receiverSyntax);
+                Error(diagnostics, ErrorCode.ERR_DeconstructTooFewElements, receiverSyntax);
                 outPlaceholders = default(ImmutableArray<BoundDeconstructValuePlaceholder>);
 
                 return BadExpression(receiverSyntax, receiver);

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3113,15 +3113,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deconstructions are only allowed into two or more parts..
-        /// </summary>
-        internal static string ERR_DeconstructionNeedsTwoParts {
-            get {
-                return ResourceManager.GetString("ERR_DeconstructionNeedsTwoParts", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Deconstruction &apos;var (...)&apos; form disallows a specific type for &apos;var&apos;..
         /// </summary>
         internal static string ERR_DeconstructionVarFormDisallowsSpecificType {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3113,6 +3113,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deconstructions are only allowed into two or more parts..
+        /// </summary>
+        internal static string ERR_DeconstructionNeedsTwoParts {
+            get {
+                return ResourceManager.GetString("ERR_DeconstructionNeedsTwoParts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deconstruction &apos;var (...)&apos; form disallows a specific type for &apos;var&apos;..
         /// </summary>
         internal static string ERR_DeconstructionVarFormDisallowsSpecificType {
@@ -6047,7 +6056,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No Deconstruct instance or extension method was found for type &apos;{0}&apos;, with {1} out parameters..
+        ///   Looks up a localized string similar to No Deconstruct instance or extension method was found for type &apos;{0}&apos;, with {1} out parameters and a void return type..
         /// </summary>
         internal static string ERR_MissingDeconstruct {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4871,7 +4871,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>tuples</value>
   </data>
   <data name="ERR_MissingDeconstruct" xml:space="preserve">
-    <value>No Deconstruct instance or extension method was found for type '{0}', with {1} out parameters.</value>
+    <value>No Deconstruct instance or extension method was found for type '{0}', with {1} out parameters and a void return type.</value>
   </data>
   <data name="ERR_DeconstructRequiresExpression" xml:space="preserve">
     <value>Deconstruct assignment requires an expression with a type on the right-hand-side.</value>
@@ -4980,6 +4980,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_MixedDeconstructionUnsupported" xml:space="preserve">
     <value>A deconstruction cannot mix declarations and expressions on the left-hand-side.</value>
+  </data>
+  <data name="ERR_DeconstructionNeedsTwoParts" xml:space="preserve">
+    <value>Deconstructions are only allowed into two or more parts.</value>
   </data>
   <data name="ERR_DeclarationExpressionNotPermitted" xml:space="preserve">
     <value>A declaration is not allowed in this context.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4981,9 +4981,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_MixedDeconstructionUnsupported" xml:space="preserve">
     <value>A deconstruction cannot mix declarations and expressions on the left-hand-side.</value>
   </data>
-  <data name="ERR_DeconstructionNeedsTwoParts" xml:space="preserve">
-    <value>Deconstructions are only allowed into two or more parts.</value>
-  </data>
   <data name="ERR_DeclarationExpressionNotPermitted" xml:space="preserve">
     <value>A declaration is not allowed in this context.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1435,10 +1435,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DeclarationExpressionNotPermitted = 8185,
         ERR_MustDeclareForeachIteration = 8186,
         ERR_TupleElementNamesInDeconstruction = 8187,
-        ERR_DeconstructionNeedsTwoParts = 8188,
         #endregion stragglers for C# 7
 
-        // Available  = 8189-8195
+        // Available  = 8188-8195
 
         #region diagnostics for out var
         ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList = 8196,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1435,9 +1435,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DeclarationExpressionNotPermitted = 8185,
         ERR_MustDeclareForeachIteration = 8186,
         ERR_TupleElementNamesInDeconstruction = 8187,
+        ERR_DeconstructionNeedsTwoParts = 8188,
         #endregion stragglers for C# 7
 
-        // Available  = 8188-8195
+        // Available  = 8189-8195
 
         #region diagnostics for out var
         ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList = 8196,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5843,9 +5843,9 @@ class C
 ";
             var compilation = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             compilation.VerifyDiagnostics(
-                // (13,20): error CS8188: Deconstructions are only allowed into two or more parts.
+                // (13,20): error CS8134: Deconstruction must contain at least two variables.
                 //         var (p2) = p;
-                Diagnostic(ErrorCode.ERR_DeconstructionNeedsTwoParts, "p").WithLocation(13, 20),
+                Diagnostic(ErrorCode.ERR_DeconstructTooFewElements, "p").WithLocation(13, 20),
                 // (13,14): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'p2'.
                 //         var (p2) = p;
                 Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "p2").WithArguments("p2").WithLocation(13, 14)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -216,7 +216,8 @@ class C
         }
 
         [Fact]
-        public void DeconstructCanHaveReturnType()
+        [WorkItem(15634, "https://github.com/dotnet/roslyn/issues/15634")]
+        public void DeconstructMustReturnVoid()
         {
             string source = @"
 class C
@@ -225,9 +226,7 @@ class C
     {
         long x;
         string y;
-
         (x, y) = new C();
-        System.Console.WriteLine(x + "" "" + y);
     }
 
     public int Deconstruct(out int a, out string b)
@@ -238,9 +237,12 @@ class C
     }
 }
 ";
-
-            var comp = CompileAndVerify(source, expectedOutput: "1 hello", additionalRefs: s_valueTupleRefs);
-            comp.VerifyDiagnostics();
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (8,18): error CS8129: No Deconstruct instance or extension method was found for type 'C', with 2 out parameters and a void return type.
+                //         (x, y) = new C();
+                Diagnostic(ErrorCode.ERR_MissingDeconstruct, "new C()").WithArguments("C", "2").WithLocation(8, 18)
+                );
         }
 
         [Fact]
@@ -5817,6 +5819,82 @@ class C
 
             VerifyModelForDeconstructionLocal(model, x1, x1Ref);
             VerifyModelForDeconstructionLocal(model, x2, x2Ref);
+        }
+
+        [Fact]
+        [WorkItem(15893, "https://github.com/dotnet/roslyn/issues/15893")]
+        public void DeconstructionOfOnlyOneElement()
+        {
+            string source = @"
+class C
+{
+    public int a;
+    public void Deconstruct(out int b)
+    {
+        b = a;
+    }
+
+    static void Main()
+    {
+        var p = new C() { a = 10 };
+        var (p2) = p;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            compilation.VerifyDiagnostics(
+                // (13,20): error CS8188: Deconstructions are only allowed into two or more parts.
+                //         var (p2) = p;
+                Diagnostic(ErrorCode.ERR_DeconstructionNeedsTwoParts, "p").WithLocation(13, 20),
+                // (13,14): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'p2'.
+                //         var (p2) = p;
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "p2").WithArguments("p2").WithLocation(13, 14)
+                );
+        }
+
+        [Fact]
+        [WorkItem(14876, "https://github.com/dotnet/roslyn/issues/14876")]
+        public void TupleTypeInDeconstruction()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        (int x, (string, long) y) = M();
+        System.Console.Write($""{x} {y}"");
+    }
+
+    static (int, (string, long)) M()
+    {
+        return (5, (""Foo"", 34983490));
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "5 (Foo, 34983490)", additionalRefs: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(12468, "https://github.com/dotnet/roslyn/issues/12468")]
+        public void RefReturningVarInvocation()
+        {
+            string source = @"
+class C
+{
+    static int i;
+
+    static void Main()
+    {
+        int x = 0, y = 0;
+        (var(x, y)) = 42; // parsed as invocation
+        System.Console.Write(i);
+    }
+    static ref int var(int a, int b) { return ref i; }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "42", verify: false);
+            comp.VerifyDiagnostics();
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/15614")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -1968,8 +1968,7 @@ class C
 }
 ";
             var comp = CompileAndVerify(source, expectedOutput: "42");
-            comp.VerifyDiagnostics(
-                );
+            comp.VerifyDiagnostics();
         }
 
         [Fact]


### PR DESCRIPTION
**Customer scenario**

1. If the user defines a `Deconstruct` method with a return type, we previously let this method be used in a deconstruction. This should instead report an error, as we want to keep our options open for using this return value in future versions of the language.

2. If the user attempts a deconstruction into a single part (with `var (x) = ...;`), the compiler previously crashed, when it should have reported an error.

**Bugs this fixes:** 

Fixes #15634 (void return)
Fixes #15893 (1-deconstruction)
Closes #12468 (workaround for invoking ref-returning var method)
Closes #14876 (deconstruction with tuple type)

**Workarounds, if any**

The first issue is was not blocking the user, but should.
The second issue could be worked around by using a proper deconstruction into 2 or more parts.

**Risk**
**Performance impact**

Low. The fixes are very localized (added check and reporting error).

**Is this a regression from a previous update?**

No

**Root cause analysis:**

The desired behavior for the first issue was clarified by Neal.
The second issue was a test gap in new feature. It was reported by a user.