### PR TITLE
Account for the fact that ```Not <null of Boolean?>``` is not true.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.ControlFlowAnalysis.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.ControlFlowAnalysis.vb
@@ -248,7 +248,7 @@ End Class</text>
             End Function
 
             <WorkItem(540154, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540154")>
-            <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/15223"), Trait(Traits.Feature, Traits.Features.ExtractMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)>
             Public Async Function BugFix6313_1() As Task
                 Dim code = <text>Imports System
 
@@ -424,7 +424,7 @@ End Class</text>
             End Function
 
             <WorkItem(540154, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540154"), WorkItem(541484, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541484")>
-            <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/15223"), Trait(Traits.Feature, Traits.Features.ExtractMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)>
             Public Async Function BugFix6313_6() As Task
                 Dim code = <text>Imports System
 

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.SelectionValidator.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.SelectionValidator.vb
@@ -512,7 +512,7 @@ End Class</text>
                 Await TestSelectionAsync(code)
             End Function
 
-            <Fact(Skip:= "https://github.com/dotnet/roslyn/issues/15223"), Trait(Traits.Feature, Traits.Features.ExtractMethod)>
+            <Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)>
             Public Async Function TestSelectReturnButNotAllCodePathsContainAReturn() As Task
                 Dim code = <text>Imports System
 Class A

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicSelectionValidator.vb
@@ -593,8 +593,8 @@ result.ReadOutside().Any(Function(s) s Is local) Then
                 Return False
             End If
 
-            Dim match = (TryCast(container, MethodBlockBaseSyntax)?.EndBlockStatement.EndKeyword = nextToken) OrElse
-                        (TryCast(container, MultiLineLambdaExpressionSyntax)?.EndSubOrFunctionStatement.EndKeyword = nextToken)
+            Dim match = (TryCast(container, MethodBlockBaseSyntax)?.EndBlockStatement.EndKeyword = nextToken).GetValueOrDefault() OrElse
+                        (TryCast(container, MultiLineLambdaExpressionSyntax)?.EndSubOrFunctionStatement.EndKeyword = nextToken).GetValueOrDefault()
 
             If Not match Then
                 Return False


### PR DESCRIPTION
**Customer scenario**
Extract method feature fails to properly validate selection for the extraction.

**Bugs this fixes:** 
Fixes #15223.

**Workarounds, if any**
None

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
Yes

**Root cause analysis:**
It was caught by existing unit-tests, but slipped through CI verification when it was having some issues.

**How was the bug found?**
Existing unit-tests failed.

@dotnet/roslyn-ide Please review.