### PR TITLE
Handle pointer type constraint by ignoring it

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -231,8 +231,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             break;
 
                         case TypeKind.Pointer:
-                            // Such a constraint can only be introduced by type substitution, in which case it is already reported elsewhere,
-                            // so we ignore this constraint.
+                            // Such a constraint can only be introduced by type substitution,
+                            // in which case it is already reported elsewhere, so we ignore this constraint.
                             continue;
 
                         case TypeKind.Submission:

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -230,6 +230,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             constraintDeducedBase = constraintType;
                             break;
 
+                        case TypeKind.Pointer:
+                            // Such a constraint can only be introduced by type substitution, in which case it is already reported elsewhere,
+                            // so we ignore this constraint.
+                            continue;
+
                         case TypeKind.Submission:
                         default:
                             throw ExceptionUtilities.UnexpectedValue(constraintType.TypeKind);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -6685,5 +6685,35 @@ partial class Class4
     Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "Class2").WithArguments("Class2").WithLocation(30, 36)
                 );
         }
+
+        [Fact]
+        [WorkItem(278264, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=278264")]
+        public void IntPointerConstraintIntroducedBySubstitution()
+        {
+            string source = @"
+class R1<T1>
+{
+    public virtual void f<T2>() where T2 : T1 { }
+}
+class R2 : R1<int*>
+{
+    public override void f<T2>() { }
+}
+class Program
+{
+    static void Main(string[] args)
+    {
+        R2 r = new R2();
+        r.f<int>();
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlib(source);
+            compilation.VerifyDiagnostics(
+                // (6,7): error CS0306: The type 'int*' may not be used as a type argument
+                // class R2 : R1<int *>
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "R2").WithArguments("int*").WithLocation(6, 7)
+                );
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

This code will result in compiler crash once you try to use `new R2().f<int>()`.
```C#
class R1<T1>
{
    public virtual void f<T2>() where T2 : T1 { }
}
class R2 : R1<int*>
{
    public override void f<T2>() { }
}
```

This is because the bound resolution on `T2` assumes that the constraints bounding `T2` cannot include pointer types. The solution is for the bound resolution to ignore this incorrect constraint (since an error must have been reported already for using a pointer type in a type argument, ie. on `R1<int*>`).

**Bugs this fixes:** 

Watson crash https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=278264

**Workarounds, if any**

Don't use pointer types as type arguments (`R1<int*>`).

**Risk**
**Performance impact**
Low. We're just continuing processing as normal, instead of throwing an exception.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
Test gap: the switch statement has an explicit list of cases it handles, and it was thought or assumed that pointer types could never reach it.

**How was the bug found?**
Watson crash