### PR TITLE
Underscore should report an error if used as discard with langver < 7

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1240,7 +1240,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             CSharpSyntaxNode containingDeconstruction = node.GetContainingDeconstruction();
-            return containingDeconstruction != null || IsOutVarDiscardIdentifier(node);
+            bool isDiscard = containingDeconstruction != null || IsOutVarDiscardIdentifier(node);
+            if (isDiscard)
+            {
+                CheckFeatureAvailability(node.Location, MessageID.IDS_FeatureTuples, diagnostics);
+            }
+
+            return isDiscard;
         }
 
         private static bool IsOutVarDiscardIdentifier(SimpleNameSyntax node)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5151,6 +5151,79 @@ class C
         }
 
         [Fact]
+        public void VariousDiscardsInCSharp6()
+        {
+            var source =
+@"
+class C
+{
+    static void M(out int x)
+    {
+        (_, var _, int _) = (1, 2, 3);
+        var (_, _) = (1, 2);
+        bool b = 3 is int _;
+        switch (3)
+        {
+            case _: // not a discard
+                break;
+        }
+        switch (3)
+        {
+            case int _:
+                break;
+        }
+        M(out var _);
+        M(out int _);
+        M(out _);
+        x = 2;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular6, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (6,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //         (_, var _, int _) = (1, 2, 3);
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(_, var _, int _)").WithArguments("tuples", "7").WithLocation(6, 9),
+                // (6,29): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //         (_, var _, int _) = (1, 2, 3);
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(1, 2, 3)").WithArguments("tuples", "7").WithLocation(6, 29),
+                // (7,13): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //         var (_, _) = (1, 2);
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(_, _)").WithArguments("tuples", "7").WithLocation(7, 13),
+                // (7,22): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //         var (_, _) = (1, 2);
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(1, 2)").WithArguments("tuples", "7").WithLocation(7, 22),
+                // (8,18): error CS8059: Feature 'pattern matching' is not available in C# 6.  Please use language version 7 or greater.
+                //         bool b = 3 is int _;
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "3 is int _").WithArguments("pattern matching", "7").WithLocation(8, 18),
+                // (16,13): error CS8059: Feature 'pattern matching' is not available in C# 6.  Please use language version 7 or greater.
+                //             case int _:
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "case int _:").WithArguments("pattern matching", "7").WithLocation(16, 13),
+                // (19,19): error CS8059: Feature 'out variable declaration' is not available in C# 6.  Please use language version 7 or greater.
+                //         M(out var _);
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "_").WithArguments("out variable declaration", "7").WithLocation(19, 19),
+                // (20,19): error CS8059: Feature 'out variable declaration' is not available in C# 6.  Please use language version 7 or greater.
+                //         M(out int _);
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "_").WithArguments("out variable declaration", "7").WithLocation(20, 19),
+                // (6,10): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //         (_, var _, int _) = (1, 2, 3);
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "_").WithArguments("tuples", "7").WithLocation(6, 10),
+                // (11,18): error CS0103: The name '_' does not exist in the current context
+                //             case _: // not a discard
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(11, 18),
+                // (21,15): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //         M(out _);
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "_").WithArguments("tuples", "7").WithLocation(21, 15),
+                // (12,17): warning CS0162: Unreachable code detected
+                //                 break;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(12, 17),
+                // (17,17): warning CS0162: Unreachable code detected
+                //                 break;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(17, 17)
+                );
+        }
+
+        [Fact]
         public void SingleDiscardInAsyncAssignment()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5124,6 +5124,33 @@ class C
         }
 
         [Fact]
+        public void SingleDiscardInAssignmentInCSharp6()
+        {
+            var source =
+@"
+class C
+{
+    static void Error()
+    {
+        _ = 1;
+    }
+    static void Ok()
+    {
+        int _;
+        _ = 1;
+        System.Console.Write(_);
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular6);
+            comp.VerifyDiagnostics(
+                // (6,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //         _ = M();
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "_").WithArguments("tuples", "7").WithLocation(6, 9)
+                );
+        }
+
+        [Fact]
         public void SingleDiscardInAsyncAssignment()
         {
             var source =


### PR DESCRIPTION
**Customer scenario**
Set the language version for your project to C# 6 or older, then use the underscore identifier in a way that C# 7 now allows, such as `_ = 1;`. 
This should not be allowed, but the error is missing.

**Bugs this fixes:** 
Fixes https://github.com/dotnet/roslyn/issues/15959

**Workarounds, if any**
The user is not blocked (but should).

**Risk**
**Performance impact**
None. Only reporting an additional diagnostic.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
Most discard scenarios involve new syntax, which is subject to feature availability check. But this one scenario involves a semantic change, which allows old syntax.

**How was the bug found?**
In the shower.