### PR TITLE
fixed 2 bugs reported on primary workspace

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -59,6 +59,22 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
+        public async Task TestUnknownProject()
+        {
+            var workspace = new AdhocWorkspace(TestHostServices.CreateHostServices());
+            var solution = workspace.CurrentSolution.AddProject("unknown", "unknown", NoCompilationConstants.LanguageName).Solution;
+
+            var client = (InProcRemoteHostClient)(await InProcRemoteHostClient.CreateAsync(workspace, runCacheCleanup: false, cancellationToken: CancellationToken.None));
+
+            await UpdatePrimaryWorkspace(client, solution);
+            VerifyAssetStorage(client, solution);
+
+            Assert.Equal(
+                await solution.State.GetChecksumAsync(CancellationToken.None),
+                await PrimaryWorkspace.Workspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public async Task TestRemoteHostSynchronizeIncrementalUpdate()
         {
             using (var workspace = await TestWorkspace.CreateCSharpAsync(Array.Empty<string>(), metadataReferences: null))

--- a/src/VisualStudio/Core/Test.Next/TestUtils.cs
+++ b/src/VisualStudio/Core/Test.Next/TestUtils.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Serialization;
 using Xunit;
 
@@ -44,7 +45,11 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         private static void AppendAssetMap(Project project, Dictionary<Checksum, object> map)
         {
             ProjectStateChecksums projectChecksums;
-            Assert.True(project.State.TryGetStateChecksums(out projectChecksums));
+            if (!project.State.TryGetStateChecksums(out projectChecksums))
+            {
+                Assert.False(RemoteSupportedLanguages.Support(project.Language));
+                return;
+            }
 
             projectChecksums.Find(project.State, Flatten(projectChecksums), map, CancellationToken.None);
 

--- a/src/VisualStudio/Core/Test.Next/TestUtils.cs
+++ b/src/VisualStudio/Core/Test.Next/TestUtils.cs
@@ -47,7 +47,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             ProjectStateChecksums projectChecksums;
             if (!project.State.TryGetStateChecksums(out projectChecksums))
             {
-                Assert.False(RemoteSupportedLanguages.Support(project.Language));
+                Assert.False(RemoteSupportedLanguages.IsSupported(project.Language));
                 return;
             }
 

--- a/src/Workspaces/Core/Portable/Remote/RemoteSupportedLanguages.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteSupportedLanguages.cs
@@ -4,7 +4,7 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal static class RemoteSupportedLanguages
     {
-        public static bool Support(this string language)
+        public static bool IsSupported(this string language)
         {
             return language == LanguageNames.CSharp ||
                    language == LanguageNames.VisualBasic;

--- a/src/Workspaces/Core/Portable/Remote/RemoteSupportedLanguages.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteSupportedLanguages.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Remote
+{
+    internal static class RemoteSupportedLanguages
+    {
+        public static bool Support(this string language)
+        {
+            return language == LanguageNames.CSharp ||
+                   language == LanguageNames.VisualBasic;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState_Checksum.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis
             {
                 // get states by id order to have deterministic checksum
                 var projectChecksumTasks = ProjectIds.Select(id => ProjectStates[id])
-                                                     .Where(s => RemoteSupportedLanguages.Support(s.Language))
+                                                     .Where(s => RemoteSupportedLanguages.IsSupported(s.Language))
                                                      .Select(s => s.GetChecksumAsync(cancellationToken));
 
                 var serializer = new Serializer(_solutionServices.Workspace);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                 // check unsupported projects
                 if (!projectState.TryGetStateChecksums(out var projectStateChecksums))
                 {
-                    Contract.ThrowIfTrue(RemoteSupportedLanguages.Support(projectState.Language));
+                    Contract.ThrowIfTrue(RemoteSupportedLanguages.IsSupported(projectState.Language));
                     continue;
                 }
 

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -384,6 +384,7 @@
     <Compile Include="PatternMatching\PatternMatcher.TextChunk.cs" />
     <Compile Include="PatternMatching\PatternMatches.cs" />
     <Compile Include="PatternMatching\PatternMatchKind.cs" />
+    <Compile Include="Remote\RemoteSupportedLanguages.cs" />
     <Compile Include="Shared\Extensions\SolutionExtensions.cs" />
     <Compile Include="SymbolKey\SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs" />
     <Compile Include="Tags\WellKnownTags.cs" />

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -415,7 +415,7 @@ namespace Microsoft.CodeAnalysis.Remote
             var projectSnapshot = await _assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, _cancellationToken).ConfigureAwait(false);
 
             var projectInfo = await _assetService.GetAssetAsync<ProjectInfo.ProjectAttributes>(projectSnapshot.Info, _cancellationToken).ConfigureAwait(false);
-            if (!RemoteSupportedLanguages.Support(projectInfo.Language))
+            if (!RemoteSupportedLanguages.IsSupported(projectInfo.Language))
             {
                 // only add project our workspace supports. 
                 // workspace doesn't allow creating project with unknown languages

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -207,9 +207,9 @@ namespace Microsoft.CodeAnalysis.Remote
             var newProjectInfo = await _assetService.GetAssetAsync<ProjectInfo.ProjectAttributes>(infoChecksum, _cancellationToken).ConfigureAwait(false);
 
             // there is no API to change these once project is created
-            Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.Id != newProjectInfo.Id);
-            Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.Language != newProjectInfo.Language);
-            Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.IsSubmission != newProjectInfo.IsSubmission);
+            Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.Id == newProjectInfo.Id);
+            Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.Language == newProjectInfo.Language);
+            Contract.ThrowIfFalse(project.State.ProjectInfo.Attributes.IsSubmission == newProjectInfo.IsSubmission);
 
             if (project.State.ProjectInfo.Attributes.Name != newProjectInfo.Name)
             {
@@ -321,10 +321,10 @@ namespace Microsoft.CodeAnalysis.Remote
             var newDocumentInfo = await _assetService.GetAssetAsync<DocumentInfo.DocumentAttributes>(infoChecksum, _cancellationToken).ConfigureAwait(false);
 
             // there is no api to change these once document is created
-            Contract.ThrowIfFalse(document.State.Info.Attributes.Id != newDocumentInfo.Id);
-            Contract.ThrowIfFalse(document.State.Info.Attributes.Name != newDocumentInfo.Name);
-            Contract.ThrowIfFalse(document.State.Info.Attributes.FilePath != newDocumentInfo.FilePath);
-            Contract.ThrowIfFalse(document.State.Info.Attributes.IsGenerated != newDocumentInfo.IsGenerated);
+            Contract.ThrowIfFalse(document.State.Info.Attributes.Id == newDocumentInfo.Id);
+            Contract.ThrowIfFalse(document.State.Info.Attributes.Name == newDocumentInfo.Name);
+            Contract.ThrowIfFalse(document.State.Info.Attributes.FilePath == newDocumentInfo.FilePath);
+            Contract.ThrowIfFalse(document.State.Info.Attributes.IsGenerated == newDocumentInfo.IsGenerated);
 
             if (document.State.Info.Attributes.Folders != newDocumentInfo.Folders)
             {
@@ -415,12 +415,14 @@ namespace Microsoft.CodeAnalysis.Remote
             var projectSnapshot = await _assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, _cancellationToken).ConfigureAwait(false);
 
             var projectInfo = await _assetService.GetAssetAsync<ProjectInfo.ProjectAttributes>(projectSnapshot.Info, _cancellationToken).ConfigureAwait(false);
-            if (!_baseSolution.Workspace.Services.IsSupported(projectInfo.Language))
+            if (!RemoteSupportedLanguages.Support(projectInfo.Language))
             {
                 // only add project our workspace supports. 
                 // workspace doesn't allow creating project with unknown languages
                 return null;
             }
+
+            Contract.ThrowIfFalse(_baseSolution.Workspace.Services.IsSupported(projectInfo.Language));
 
             var compilationOptions = await _assetService.GetAssetAsync<CompilationOptions>(projectSnapshot.CompilationOptions, _cancellationToken).ConfigureAwait(false);
             var parseOptions = await _assetService.GetAssetAsync<ParseOptions>(projectSnapshot.ParseOptions, _cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
1. filter out projects that is not supported in remote host when calculating checksum (open xaml designer)
2. wrong validation on contract (rename project)

both of them is crashing issue.

unit test added

...

this is a bug fix for this PR - https://github.com/dotnet/roslyn/pull/15212