### PR TITLE
Unify error messages on extension methods omitted type arguments

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3448,6 +3448,10 @@ public class Class1
         var nonExistingMethod1 = ""string literal"".ExtensionMethodNotFound1<int>();
         var nonExistingMethod2 = ""string literal"".ExtensionMethodNotFound2<int, string>();
 
+        System.Func<object> delegateConversion0 = ""string literal"".ExtensionMethod0<>;
+        System.Func<object> delegateConversion1 = ""string literal"".ExtensionMethod1<>;
+        System.Func<object> delegateConversion2 = ""string literal"".ExtensionMethod2<>;
+
         var exactArgs0 = ""string literal"".ExtensionMethod0();
         var exactArgs1 = ""string literal"".ExtensionMethod1<int>();
         var exactArgs2 = ""string literal"".ExtensionMethod2<int, bool>();
@@ -3513,7 +3517,25 @@ public class Class1
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
                 // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
                 //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
-                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51));
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51),
+                // (32,51): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(32, 51),
+                // (32,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Func<object> delegateConversion0 = "string literal".ExtensionMethod0<>;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(32, 68),
+                // (33,51): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(33, 51),
+                // (33,51): error CS0407: '? FooExtensions.ExtensionMethod1<?>(object)' has the wrong return type
+                //         System.Func<object> delegateConversion1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_BadRetType, @"""string literal"".ExtensionMethod1<>").WithArguments("FooExtensions.ExtensionMethod1<?>(object)", "?").WithLocation(33, 51),
+                // (34,51): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(34, 51),
+                // (34,68): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Func<object> delegateConversion2 = "string literal".ExtensionMethod2<>;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(34, 68));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -3420,27 +3420,100 @@ class Program
 @"
 public static class FooExtensions
 {
-    public static T Foo<T>(this object obj) => default(T);
+    public static object ExtensionMethod0(this object obj) => default(object);
+    public static T ExtensionMethod1<T>(this object obj) => default(T);
+    public static T1 ExtensionMethod2<T1, T2>(this object obj) => default(T1);
 }
 
 public class Class1
 {
     public void Test()
     {
-        var defaultA = ""a"".Foo<>();
-        var defaultB = FooExtensions.Foo<>(""b"");
+        var omittedArg0 = ""string literal"".ExtensionMethod0<>();
+        var omittedArg1 = ""string literal"".ExtensionMethod1<>();
+        var omittedArg2 = ""string literal"".ExtensionMethod2<>();
+
+        var omittedArgFunc0 = ""string literal"".ExtensionMethod0<>;
+        var omittedArgFunc1 = ""string literal"".ExtensionMethod1<>;
+        var omittedArgFunc2 = ""string literal"".ExtensionMethod2<>;
+
+        var moreArgs0 = ""string literal"".ExtensionMethod0<int>();
+        var moreArgs1 = ""string literal"".ExtensionMethod1<int, bool>();
+        var moreArgs2 = ""string literal"".ExtensionMethod2<int, bool, string>();
+
+        var lessArgs1 = ""string literal"".ExtensionMethod1();
+        var lessArgs2 = ""string literal"".ExtensionMethod2<int>();
+
+        var nonExistingMethod0 = ""string literal"".ExtensionMethodNotFound0();
+        var nonExistingMethod1 = ""string literal"".ExtensionMethodNotFound1<int>();
+        var nonExistingMethod2 = ""string literal"".ExtensionMethodNotFound2<int, string>();
+
+        var exactArgs0 = ""string literal"".ExtensionMethod0();
+        var exactArgs1 = ""string literal"".ExtensionMethod1<int>();
+        var exactArgs2 = ""string literal"".ExtensionMethod2<int, bool>();
     }
 }
 ";
             var compilation = CreateCompilationWithMscorlibAndSystemCore(source);
 
             compilation.VerifyDiagnostics(
-                // (11,24): error CS0305: Using the generic method group 'Foo' requires 1 type arguments
-                //         var defaultA = "a".Foo<>();
-                Diagnostic(ErrorCode.ERR_BadArity, @"""a"".Foo<>").WithArguments("Foo", "method group", "1").WithLocation(11, 24),
-                // (12,24): error CS0305: Using the generic method group 'Foo' requires 1 type arguments
-                //         var defaultB = FooExtensions.Foo<>("b");
-                Diagnostic(ErrorCode.ERR_BadArity, "FooExtensions.Foo<>").WithArguments("Foo", "method group", "1").WithLocation(12, 24));
+                // (13,27): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(13, 27),
+                // (13,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var omittedArg0 = "string literal".ExtensionMethod0<>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(13, 44),
+                // (14,27): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                //         var omittedArg1 = "string literal".ExtensionMethod1<>();
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(14, 27),
+                // (15,27): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(15, 27),
+                // (15,44): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var omittedArg2 = "string literal".ExtensionMethod2<>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(15, 44),
+                // (17,31): error CS0305: Using the generic method group 'ExtensionMethod0' requires 1 type arguments
+                //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod0<>").WithArguments("ExtensionMethod0", "method group", "1").WithLocation(17, 31),
+                // (17,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var omittedArgFunc0 = "string literal".ExtensionMethod0<>;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<>").WithArguments("string", "ExtensionMethod0").WithLocation(17, 48),
+                // (18,31): error CS0305: Using the generic method group 'ExtensionMethod1' requires 1 type arguments
+                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod1<>").WithArguments("ExtensionMethod1", "method group", "1").WithLocation(18, 31),
+                // (18,13): error CS0815: Cannot assign method group to an implicitly-typed variable
+                //         var omittedArgFunc1 = "string literal".ExtensionMethod1<>;
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, @"omittedArgFunc1 = ""string literal"".ExtensionMethod1<>").WithArguments("method group").WithLocation(18, 13),
+                // (19,31): error CS0305: Using the generic method group 'ExtensionMethod2' requires 1 type arguments
+                //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                Diagnostic(ErrorCode.ERR_BadArity, @"""string literal"".ExtensionMethod2<>").WithArguments("ExtensionMethod2", "method group", "1").WithLocation(19, 31),
+                // (19,48): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var omittedArgFunc2 = "string literal".ExtensionMethod2<>;
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<>").WithArguments("string", "ExtensionMethod2").WithLocation(19, 48),
+                // (21,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod0' and no extension method 'ExtensionMethod0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs0 = "string literal".ExtensionMethod0<int>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod0<int>").WithArguments("string", "ExtensionMethod0").WithLocation(21, 42),
+                // (22,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod1' and no extension method 'ExtensionMethod1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs1 = "string literal".ExtensionMethod1<int, bool>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod1<int, bool>").WithArguments("string", "ExtensionMethod1").WithLocation(22, 42),
+                // (23,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var moreArgs2 = "string literal".ExtensionMethod2<int, bool, string>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int, bool, string>").WithArguments("string", "ExtensionMethod2").WithLocation(23, 42),
+                // (25,42): error CS0411: The type arguments for method 'FooExtensions.ExtensionMethod1<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
+                //         var lessArgs1 = "string literal".ExtensionMethod1();
+                Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "ExtensionMethod1").WithArguments("FooExtensions.ExtensionMethod1<T>(object)").WithLocation(25, 42),
+                // (26,42): error CS1061: 'string' does not contain a definition for 'ExtensionMethod2' and no extension method 'ExtensionMethod2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var lessArgs2 = "string literal".ExtensionMethod2<int>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethod2<int>").WithArguments("string", "ExtensionMethod2").WithLocation(26, 42),
+                // (28,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound0' and no extension method 'ExtensionMethodNotFound0' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var nonExistingMethod0 = "string literal".ExtensionMethodNotFound0();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound0").WithArguments("string", "ExtensionMethodNotFound0").WithLocation(28, 51),
+                // (29,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound1' and no extension method 'ExtensionMethodNotFound1' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var nonExistingMethod1 = "string literal".ExtensionMethodNotFound1<int>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound1<int>").WithArguments("string", "ExtensionMethodNotFound1").WithLocation(29, 51),
+                // (30,51): error CS1061: 'string' does not contain a definition for 'ExtensionMethodNotFound2' and no extension method 'ExtensionMethodNotFound2' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)
+                //         var nonExistingMethod2 = "string literal".ExtensionMethodNotFound2<int, string>();
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "ExtensionMethodNotFound2<int, string>").WithArguments("string", "ExtensionMethodNotFound2").WithLocation(30, 51));
         }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -25979,15 +25979,43 @@ Imports System.Runtime.CompilerServices
 
 Module FooExtensions
     <Extension()>
-    Public Function Foo(Of T)(ByVal obj As Object)
+    Public Function ExtensionMethod0(ByVal obj As Object)
+        Return GetType(Object)
+    End Function
+    <Extension()>
+    Public Function ExtensionMethod1(Of T)(ByVal obj As Object)
         Return GetType(T)
+    End Function
+    <Extension()>
+    Public Function ExtensionMethod2(Of T1, T2)(ByVal obj As Object)
+        Return GetType(T1)
     End Function
 End Module
 
 Module Module1
     Sub Main()
-        Dim typeA As Type = "a".Foo()
-        Dim typeB As Type = "b".Foo()()
+        Dim omittedArg0 As Type = "string literal".ExtensionMethod0(Of )()
+        Dim omittedArg1 As Type = "string literal".ExtensionMethod1(Of )()
+        Dim omittedArg2 As Type = "string literal".ExtensionMethod2(Of )()
+        
+        Dim omittedArgFunc0 As Func(Of Object) = "string literal".ExtensionMethod0(Of )
+        Dim omittedArgFunc1 As Func(Of Object) = "string literal".ExtensionMethod1(Of )
+        Dim omittedArgFunc2 As Func(Of Object) = "string literal".ExtensionMethod2(Of )
+
+        Dim moreArgs0 As Type = "string literal".ExtensionMethod0(Of Integer)()
+        Dim moreArgs1 As Type = "string literal".ExtensionMethod1(Of Integer, Boolean)()
+        Dim moreArgs2 As Type = "string literal".ExtensionMethod2(Of Integer, Boolean, String)()
+
+        Dim lessArgs1 As Type = "string literal".ExtensionMethod1()
+        Dim lessArgs2 As Type = "string literal".ExtensionMethod2(Of Integer)()
+
+        Dim nonExistingMethod0 As Type = "string literal".ExtensionMethodNotFound0()
+        Dim nonExistingMethod1 As Type = "string literal".ExtensionMethodNotFound1(Of Integer)()
+        Dim nonExistingMethod2 As Type = "string literal".ExtensionMethodNotFound2(Of Integer, String)()
+
+        Dim exactArgs0 As Type = "string literal".ExtensionMethod0()
+        Dim exactArgs1 As Type = "string literal".ExtensionMethod1(Of Integer)()
+        Dim exactArgs2 As Type = "string literal".ExtensionMethod2(Of Integer, Boolean)()
     End Sub
 End Module
         ]]></file>
@@ -25997,12 +26025,60 @@ End Module
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
-BC36589: Type parameter 'T' for extension method 'Public Function Foo(Of T)() As Object' defined in 'FooExtensions' cannot be inferred.
-        Dim typeA As Type = "a".Foo()
-                                ~~~
-BC36589: Type parameter 'T' for extension method 'Public Function Foo(Of T)() As Object' defined in 'FooExtensions' cannot be inferred.
-        Dim typeB As Type = "b".Foo()()
-                                ~~~
+BC36907: Extension method 'Public Function ExtensionMethod0() As Object' defined in 'FooExtensions' is not generic (or has no free type parameters) and so cannot have type arguments.
+        Dim omittedArg0 As Type = "string literal".ExtensionMethod0(Of )()
+                                                                   ~~~~~
+BC30182: Type expected.
+        Dim omittedArg0 As Type = "string literal".ExtensionMethod0(Of )()
+                                                                       ~
+BC30182: Type expected.
+        Dim omittedArg1 As Type = "string literal".ExtensionMethod1(Of )()
+                                                                       ~
+BC36590: Too few type arguments to extension method 'Public Function ExtensionMethod2(Of T1, T2)() As Object' defined in 'FooExtensions'.
+        Dim omittedArg2 As Type = "string literal".ExtensionMethod2(Of )()
+                                                                   ~~~~~
+BC30182: Type expected.
+        Dim omittedArg2 As Type = "string literal".ExtensionMethod2(Of )()
+                                                                       ~
+BC36907: Extension method 'Public Function ExtensionMethod0() As Object' defined in 'FooExtensions' is not generic (or has no free type parameters) and so cannot have type arguments.
+        Dim omittedArgFunc0 As Func(Of Object) = "string literal".ExtensionMethod0(Of )
+                                                                                  ~~~~~
+BC30182: Type expected.
+        Dim omittedArgFunc0 As Func(Of Object) = "string literal".ExtensionMethod0(Of )
+                                                                                      ~
+BC30182: Type expected.
+        Dim omittedArgFunc1 As Func(Of Object) = "string literal".ExtensionMethod1(Of )
+                                                                                      ~
+BC36590: Too few type arguments to extension method 'Public Function ExtensionMethod2(Of T1, T2)() As Object' defined in 'FooExtensions'.
+        Dim omittedArgFunc2 As Func(Of Object) = "string literal".ExtensionMethod2(Of )
+                                                                                  ~~~~~
+BC30182: Type expected.
+        Dim omittedArgFunc2 As Func(Of Object) = "string literal".ExtensionMethod2(Of )
+                                                                                      ~
+BC36907: Extension method 'Public Function ExtensionMethod0() As Object' defined in 'FooExtensions' is not generic (or has no free type parameters) and so cannot have type arguments.
+        Dim moreArgs0 As Type = "string literal".ExtensionMethod0(Of Integer)()
+                                                                 ~~~~~~~~~~~~
+BC36591: Too many type arguments to extension method 'Public Function ExtensionMethod1(Of T)() As Object' defined in 'FooExtensions'.
+        Dim moreArgs1 As Type = "string literal".ExtensionMethod1(Of Integer, Boolean)()
+                                                                 ~~~~~~~~~~~~~~~~~~~~~
+BC36591: Too many type arguments to extension method 'Public Function ExtensionMethod2(Of T1, T2)() As Object' defined in 'FooExtensions'.
+        Dim moreArgs2 As Type = "string literal".ExtensionMethod2(Of Integer, Boolean, String)()
+                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC36589: Type parameter 'T' for extension method 'Public Function ExtensionMethod1(Of T)() As Object' defined in 'FooExtensions' cannot be inferred.
+        Dim lessArgs1 As Type = "string literal".ExtensionMethod1()
+                                                 ~~~~~~~~~~~~~~~~
+BC36590: Too few type arguments to extension method 'Public Function ExtensionMethod2(Of T1, T2)() As Object' defined in 'FooExtensions'.
+        Dim lessArgs2 As Type = "string literal".ExtensionMethod2(Of Integer)()
+                                                                 ~~~~~~~~~~~~
+BC30456: 'ExtensionMethodNotFound0' is not a member of 'String'.
+        Dim nonExistingMethod0 As Type = "string literal".ExtensionMethodNotFound0()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30456: 'ExtensionMethodNotFound1' is not a member of 'String'.
+        Dim nonExistingMethod1 As Type = "string literal".ExtensionMethodNotFound1(Of Integer)()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30456: 'ExtensionMethodNotFound2' is not a member of 'String'.
+        Dim nonExistingMethod2 As Type = "string literal".ExtensionMethodNotFound2(Of Integer, String)()
+                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </expected>)
         End Sub
 


### PR DESCRIPTION
This PR reverts #15718, and proposes a better way to fix #13617 (as suggested by @AlekseyTs).

The original behavior was:
1. The check for omitted type arguments was a specialized check for a code path that happens just when looking up instance methods, but never on extension methods.
2. Lookup was based on arity/number of type arguments (**1 in case if they're omitted**).
3. In case of methods with one type argument, lookup would succeed, and compiler would crash later during checking symbols.
4. In case of methods with more type arguments, binding would fail because it won't be able to find methods with correct arity.

#15718 proposed a check for omitted type arguments, which our report `ErrorCode.ERR_BadArity` if any (during step #2 above). With further testing, this error was:
- Inconsistent since compiler reports `ErrorCode.ERR_NoSuchMemberOrExtension` with other arities.
- Duplicate errors will occur in case of arity > 1.

This PR adds more tests, and fixes the original method by checking for omitted type arguments during binding. This will:
1. No more duplicate errors (using `ErrorCode.ERR_BadArity` was a bad call).
2. Make error messages consistent with the rest of how Roslyn reports extension methods errors.