### PR TITLE
Spacing between this and open-paren in tuple extension method

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -196,8 +196,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // extension method on tuple type
             // M(this (
             if (currentToken.Kind() == SyntaxKind.OpenParenToken &&
-                previousToken.Kind() == SyntaxKind.ThisKeyword &&
-                previousToken.Parent?.Kind() == SyntaxKind.Parameter)
+                previousToken.Kind() == SyntaxKind.ThisKeyword)
             {
                 return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -193,6 +193,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
 
+            // extension method on tuple type
+            // M(this (
+            if (currentToken.Kind() == SyntaxKind.OpenParenToken &&
+                previousToken.Kind() == SyntaxKind.ThisKeyword &&
+                previousToken.Parent?.Kind() == SyntaxKind.Parameter)
+            {
+                return CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+            }
+
             // some * "(" cases
             if (currentToken.Kind() == SyntaxKind.OpenParenToken)
             {

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4465,6 +4465,22 @@ var(x,y)=(1,2);
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task SpacingInTupleExtension()
+        {
+            var code = @"static class Class5
+{
+    static void Extension(this(int, string) self) { }
+}";
+            var expectedCode = @"static class Class5
+{
+    static void Extension(this (int, string) self) { }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task SpacingInNestedDeconstruction()
         {
             var code = @"class Class5{


### PR DESCRIPTION
**Customer scenario**
Type an extension method on a tuple type (`static void Extension(this (int, string) self)`) and format document. The space before the tuple's open-paren is removed.

**Bugs this fixes:** 
https://github.com/dotnet/roslyn/issues/15570

**Workarounds, if any**
This is annoying but not breaking.

**Risk**
**Performance impact**
Low. Added a specific case to the space formatting rule.

**Is this a regression from a previous update?**
No.

**How was the bug found?**
Reported by customer.

@CyrusNajmabadi and @dotnet/roslyn-ide for review.