### PR TITLE
Tuple type always parses a minimum of two elements

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -475,8 +475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (typesArray.Length < 2)
             {
-                elementNames?.Free();
-                return new ExtendedErrorTypeSymbol(this.Compilation.Assembly.GlobalNamespace, LookupResultKind.NotCreatable, diagnostics.Add(ErrorCode.ERR_TupleTooFewElements, syntax.Location));
+                throw ExceptionUtilities.Unreachable;
             }
 
             return TupleTypeSymbol.Create(syntax.Location,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (typesArray.Length < 2)
             {
-                throw ExceptionUtilities.Unreachable;
+                throw ExceptionUtilities.UnexpectedValue(typesArray.Length);
             }
 
             return TupleTypeSymbol.Create(syntax.Location,

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6693,12 +6693,13 @@ tryAgain:
                     }
                 }
 
-                if (list.Count < 1)
-                {
-                    list.Add(_syntaxFactory.TupleElement(this.CreateMissingIdentifierName(), identifier: null));
-                }
                 if (list.Count < 2)
                 {
+                    if (list.Count < 1)
+                    {
+                        list.Add(_syntaxFactory.TupleElement(this.CreateMissingIdentifierName(), identifier: null));
+                    }
+
                     list.AddSeparator(SyntaxFactory.MissingToken(SyntaxKind.CommaToken));
                     var missingElement = _syntaxFactory.TupleElement(this.CreateMissingIdentifierName(), identifier: null);
                     list.Add(this.AddError(missingElement, ErrorCode.ERR_TupleTooFewElements));

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -10380,13 +10380,15 @@ tryAgain:
                     list.Add(arg);
                 }
 
-                var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                var result = _syntaxFactory.TupleExpression(openParen, list, closeParen);
-
                 if (list.Count < 2)
                 {
-                    result = this.AddError(result, ErrorCode.ERR_TupleTooFewElements);
+                    list.AddSeparator(SyntaxFactory.MissingToken(SyntaxKind.CommaToken));
+                    var missingExpression = this.AddError(this.CreateMissingIdentifierName(), ErrorCode.ERR_TupleTooFewElements);
+                    list.Add(_syntaxFactory.Argument(nameColon: null, refOrOutKeyword: default(SyntaxToken), expression: missingExpression));
                 }
+
+                var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
+                var result = _syntaxFactory.TupleExpression(openParen, list, closeParen);
 
                 result = CheckFeatureAvailability(result, MessageID.IDS_FeatureTuples);
                 return result;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6701,8 +6701,8 @@ tryAgain:
                     }
 
                     list.AddSeparator(SyntaxFactory.MissingToken(SyntaxKind.CommaToken));
-                    var missingElement = _syntaxFactory.TupleElement(this.CreateMissingIdentifierName(), identifier: null);
-                    list.Add(this.AddError(missingElement, ErrorCode.ERR_TupleTooFewElements));
+                    var missing = this.AddError(this.CreateMissingIdentifierName(), ErrorCode.ERR_TupleTooFewElements);
+                    list.Add(_syntaxFactory.TupleElement(missing, identifier: null));
                 }
 
                 var close = this.EatToken(SyntaxKind.CloseParenToken);
@@ -10384,8 +10384,8 @@ tryAgain:
                 if (list.Count < 2)
                 {
                     list.AddSeparator(SyntaxFactory.MissingToken(SyntaxKind.CommaToken));
-                    var missingExpression = this.AddError(this.CreateMissingIdentifierName(), ErrorCode.ERR_TupleTooFewElements);
-                    list.Add(_syntaxFactory.Argument(nameColon: null, refOrOutKeyword: default(SyntaxToken), expression: missingExpression));
+                    var missing = this.AddError(this.CreateMissingIdentifierName(), ErrorCode.ERR_TupleTooFewElements);
+                    list.Add(_syntaxFactory.Argument(nameColon: null, refOrOutKeyword: default(SyntaxToken), expression: missing));
                 }
 
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6693,13 +6693,19 @@ tryAgain:
                     }
                 }
 
-                var close = this.EatToken(SyntaxKind.CloseParenToken);
-                var result = _syntaxFactory.TupleType(open, list, close);
-
+                if (list.Count < 1)
+                {
+                    list.Add(_syntaxFactory.TupleElement(this.CreateMissingIdentifierName(), identifier: null));
+                }
                 if (list.Count < 2)
                 {
-                    result = this.AddError(result, ErrorCode.ERR_TupleTooFewElements);
+                    list.AddSeparator(SyntaxFactory.MissingToken(SyntaxKind.CommaToken));
+                    var missingElement = _syntaxFactory.TupleElement(this.CreateMissingIdentifierName(), identifier: null);
+                    list.Add(this.AddError(missingElement, ErrorCode.ERR_TupleTooFewElements));
                 }
+
+                var close = this.EatToken(SyntaxKind.CloseParenToken);
+                var result = _syntaxFactory.TupleType(open, list, close);
 
                 result = CheckFeatureAvailability(result, MessageID.IDS_FeatureTuples);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3774,12 +3774,12 @@ class C
                 // (4,16): error CS1519: Invalid token '=' in class, struct, or interface member declaration
                 //     var (x, y) = (1, 2);
                 Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(4, 16),
-                // (4,18): error CS8124: Tuple must contain at least two elements.
-                //     var (x, y) = (1, 2);
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(").WithLocation(4, 18),
                 // (4,19): error CS1031: Type expected
                 //     var (x, y) = (1, 2);
                 Diagnostic(ErrorCode.ERR_TypeExpected, "1").WithLocation(4, 19),
+                // (4,19): error CS8124: Tuple must contain at least two elements.
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "1").WithLocation(4, 19),
                 // (4,19): error CS1026: ) expected
                 //     var (x, y) = (1, 2);
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, "1").WithLocation(4, 19),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -3602,9 +3602,9 @@ namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B 
                 // (2,19): error CS1001: Identifier expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "(").WithLocation(2, 19),
-                // (2,20): error CS8124: Tuple must contain at least two elements.
+                // (2,71): error CS8124: Tuple must contain at least two elements.
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(System.Linq.Expressions.Expression<System.Func<B>>)").WithLocation(2, 20),
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(2, 71),
                 // (2,76): error CS1026: ) expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, "=>").WithLocation(2, 76),
@@ -3626,9 +3626,9 @@ namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B 
                 // (2,93): error CS1002: ; expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(2, 93),
-                // (2,93): error CS8124: Tuple must contain at least two elements.
+                // (2,94): error CS8124: Tuple must contain at least two elements.
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(2, 93),
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(2, 94),
                 // (2,95): error CS1022: Type or namespace definition, or end-of-file expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_EOFExpected, "{").WithLocation(2, 95),
@@ -3652,9 +3652,9 @@ namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B 
                 // (2,19): error CS1001: Identifier expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "(").WithLocation(2, 19),
-                // (2,20): error CS8124: Tuple must contain at least two elements.
+                // (2,20): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(System.Linq.Expressions.Expression<System.Func<B>>)").WithLocation(2, 20),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(System.Linq.Expressions.Expression<System.Func<B>>)").WithArguments("tuples", "7").WithLocation(2, 20),
                 // (2,76): error CS1026: ) expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, "=>").WithLocation(2, 76),
@@ -3676,12 +3676,12 @@ namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B 
                 // (2,93): error CS1002: ; expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(2, 93),
-                // (2,93): error CS8124: Tuple must contain at least two elements.
-                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(2, 93),
                 // (2,93): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(2, 93),
+                // (2,94): error CS8124: Tuple must contain at least two elements.
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(2, 94),
                 // (2,95): error CS1022: Type or namespace definition, or end-of-file expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_EOFExpected, "{").WithLocation(2, 95),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -20951,5 +20951,23 @@ class C
             var xSymbol = (model.GetDeclaredSymbol(x) as LocalSymbol)?.Type;
             Assert.Equal("(System.Int32 a, System.Int32 b)", xSymbol.ToTestDisplayString());
         }
+
+        [Fact]
+        [WorkItem(14841, "https://github.com/dotnet/roslyn/issues/14841")]
+        public void TupleWithOneElement()
+        {
+            var source = @"
+class C
+{
+    void M(int x, (int a) y) { }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (4,25): error CS8124: Tuple must contain at least two elements.
+                //     void M(int x, (int a) y) { }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 25)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -20953,21 +20953,63 @@ class C
         }
 
         [Fact]
-        [WorkItem(14841, "https://github.com/dotnet/roslyn/issues/14841")]
-        public void TupleWithOneElement()
+        [WorkItem(14091, "https://github.com/dotnet/roslyn/issues/14091")]
+        public void TupleTypeWithTooFewElements()
         {
             var source = @"
 class C
 {
-    void M(int x, (int a) y) { }
+    void M(int x, () y, (int a) z) { }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (4,20): error CS8124: Tuple must contain at least two elements.
+                //     void M(int x, () y, (int a) z) { }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 20),
+                // (4,31): error CS8124: Tuple must contain at least two elements.
+                //     void M(int x, () y, (int a) z) { }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 31)
+                );
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var y = tree.GetRoot().DescendantNodes().OfType<TupleTypeSyntax>().ElementAt(0);
+            Assert.Equal("()", y.ToString());
+            var yType = model.GetTypeInfo(y);
+            Assert.Equal("(?, ?)", yType.Type.ToTestDisplayString());
+
+            var z = tree.GetRoot().DescendantNodes().OfType<TupleTypeSyntax>().ElementAt(1);
+            Assert.Equal("(int a)", z.ToString());
+            var zType = model.GetTypeInfo(z);
+            Assert.Equal("(System.Int32 a, ?)", zType.Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        [WorkItem(14091, "https://github.com/dotnet/roslyn/issues/14091")]
+        public void TupleExpressionWithTooFewElements()
+        {
+            var source = @"
+class C
+{
+    object x = (Alice: 1);
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
                 // (4,25): error CS8124: Tuple must contain at least two elements.
-                //     void M(int x, (int a) y) { }
+                //     object x = (Alice: 1);
                 Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 25)
                 );
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var tuple = tree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>().ElementAt(0);
+            Assert.Equal("(Alice: 1)", tuple.ToString());
+            var tupleType = model.GetTypeInfo(tuple);
+            Assert.Equal("(System.Int32 Alice, ?)", tupleType.Type.ToTestDisplayString());
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -497,15 +497,15 @@ namespace A.B {
                 // (1,19): error CS1002: ; expected
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(1, 19),
-                // (1,19): error CS8124: Tuple must contain at least two elements.
-                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(*#$@^%*&); class D : Alias(*#$@^%*&).C {}").WithLocation(1, 19),
                 // (1,20): error CS1031: Type expected
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_TypeExpected, "*").WithLocation(1, 20),
                 // (1,21): error CS1040: Preprocessor directives must appear as the first non-whitespace character on a line
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_BadDirectivePlacement, "#").WithLocation(1, 21),
+                // (1,61): error CS8124: Tuple must contain at least two elements.
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "").WithLocation(1, 61),
                 // (1,61): error CS1026: ) expected
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(1, 61),
@@ -565,9 +565,6 @@ namespace A.B {
                 // (1,19): error CS1002: ; expected
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(1, 19),
-                // (1,19): error CS8124: Tuple must contain at least two elements.
-                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(*#$@^%*&); class D : Alias(*#$@^%*&).C {}").WithLocation(1, 19),
                 // (1,19): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(*#$@^%*&); class D : Alias(*#$@^%*&).C {}").WithArguments("tuples", "7").WithLocation(1, 19),
@@ -577,6 +574,9 @@ namespace A.B {
                 // (1,21): error CS1040: Preprocessor directives must appear as the first non-whitespace character on a line
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_BadDirectivePlacement, "#").WithLocation(1, 21),
+                // (1,61): error CS8124: Tuple must contain at least two elements.
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "").WithLocation(1, 61),
                 // (1,61): error CS1026: ) expected
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(1, 61),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
@@ -292,9 +292,9 @@ class A
                 // (5,37): error CS1002: ; expected
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "const").WithLocation(5, 37),
-                // (5,43): error CS8124: Tuple must contain at least two elements.
+                // (5,44): error CS8124: Tuple must contain at least two elements.
                 //     protected virtual void Finalize const () { }
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 43),
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(5, 44),
                 // (5,46): error CS1001: Identifier expected
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(5, 46),
@@ -316,9 +316,12 @@ class A
                 // (5,46): error CS0102: The type 'A' already contains a definition for ''
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "").WithArguments("A", "").WithLocation(5, 46),
-                // (5,43): error CS8124: Tuple must contain at least two elements.
+                // (5,37): error CS0283: The type '(?, ?)' cannot be declared const
                 //     protected virtual void Finalize const () { }
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 43),
+                Diagnostic(ErrorCode.ERR_BadConstType, "const").WithArguments("(?, ?)").WithLocation(5, 37),
+                // (5,43): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //     protected virtual void Finalize const () { }
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "()").WithArguments("System.ValueTuple`2").WithLocation(5, 43),
                 // (5,23): error CS0670: Field cannot have void type
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_FieldCantHaveVoidType, "void").WithLocation(5, 23),
@@ -357,12 +360,12 @@ class A
                 // (5,37): error CS1002: ; expected
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "const").WithLocation(5, 37),
-                // (5,43): error CS8124: Tuple must contain at least two elements.
-                //     protected virtual void Finalize const () { }
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 43),
                 // (5,43): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(5, 43),
+                // (5,44): error CS8124: Tuple must contain at least two elements.
+                //     protected virtual void Finalize const () { }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(5, 44),
                 // (5,46): error CS1001: Identifier expected
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(5, 46),
@@ -384,9 +387,12 @@ class A
                 // (5,46): error CS0102: The type 'A' already contains a definition for ''
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "").WithArguments("A", "").WithLocation(5, 46),
-                // (5,43): error CS8124: Tuple must contain at least two elements.
+                // (5,37): error CS0283: The type '(?, ?)' cannot be declared const
                 //     protected virtual void Finalize const () { }
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 43),
+                Diagnostic(ErrorCode.ERR_BadConstType, "const").WithArguments("(?, ?)").WithLocation(5, 37),
+                // (5,43): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //     protected virtual void Finalize const () { }
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "()").WithArguments("System.ValueTuple`2").WithLocation(5, 43),
                 // (5,23): error CS0670: Field cannot have void type
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_FieldCantHaveVoidType, "void").WithLocation(5, 23),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -1059,21 +1059,21 @@ class C
                 // (5,15): error CS1003: Syntax error, ',' expected
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments(",", "(").WithLocation(5, 15),
-                // (5,15): error CS8124: Tuple must contain at least two elements.
+                // (5,16): error CS8124: Tuple must contain at least two elements.
                 //     int F<int>() { }  // CS0081
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 15),
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(5, 16),
                 // (5,18): error CS1001: Identifier expected
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(5, 18),
                 // (5,18): error CS1026: ) expected
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, "{").WithLocation(5, 18),
-                // (5,15): error CS8124: Tuple must contain at least two elements.
+                // (5,15): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //     int F<int>() { }  // CS0081
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 15),
-                // (5,9): error CS0161: 'C.F<>(int, ?)': not all code paths return a value
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "()").WithArguments("System.ValueTuple`2").WithLocation(5, 15),
+                // (5,9): error CS0161: 'C.F<>(int, (?, ?))': not all code paths return a value
                 //     int F<int>() { }  // CS0081
-                Diagnostic(ErrorCode.ERR_ReturnExpected, "F").WithArguments("NS.C.F<>(int, ?)").WithLocation(5, 9)
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "F").WithArguments("NS.C.F<>(int, (?, ?))").WithLocation(5, 9)
     );
         }
 
@@ -1110,24 +1110,24 @@ class C
                 // (5,15): error CS1003: Syntax error, ',' expected
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments(",", "(").WithLocation(5, 15),
-                // (5,15): error CS8124: Tuple must contain at least two elements.
-                //     int F<int>() { }  // CS0081
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 15),
                 // (5,15): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(5, 15),
+                // (5,16): error CS8124: Tuple must contain at least two elements.
+                //     int F<int>() { }  // CS0081
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(5, 16),
                 // (5,18): error CS1001: Identifier expected
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(5, 18),
                 // (5,18): error CS1026: ) expected
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_CloseParenExpected, "{").WithLocation(5, 18),
-                // (5,15): error CS8124: Tuple must contain at least two elements.
+                // (5,15): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //     int F<int>() { }  // CS0081
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 15),
-                // (5,9): error CS0161: 'C.F<>(int, ?)': not all code paths return a value
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "()").WithArguments("System.ValueTuple`2").WithLocation(5, 15),
+                // (5,9): error CS0161: 'C.F<>(int, (?, ?))': not all code paths return a value
                 //     int F<int>() { }  // CS0081
-                Diagnostic(ErrorCode.ERR_ReturnExpected, "F").WithArguments("NS.C.F<>(int, ?)").WithLocation(5, 9)
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "F").WithArguments("NS.C.F<>(int, (?, ?))").WithLocation(5, 9)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Text;
-using Xunit;
 using Roslyn.Test.Utilities;
+using System;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class AsyncParsingTests : ParsingTests
     {
+        public AsyncParsingTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             return SyntaxFactory.ParseSyntaxTree(text, options: (options ?? TestOptions.Regular).WithLanguageVersion(LanguageVersion.CSharp5));

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AwaitParsingTests.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class AwaitParsingTests : ParsingTests
     {
+        public AwaitParsingTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             return SyntaxFactory.ParseSyntaxTree(text);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/CrefParsingTests.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Test.Utilities;
 using System;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class CrefParsingTests : ParsingTests
     {
+        public CrefParsingTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             throw new NotSupportedException();

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationExpressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationExpressionTests.cs
@@ -2,12 +2,15 @@
 
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
 {
     [CompilerTrait(CompilerFeature.Tuples)]
     public class DeclarationExpressionTests : ParsingTests
     {
+        public DeclarationExpressionTests(ITestOutputHelper output) : base(output) { }
+
         [Fact]
         public void NullaboutOutDeclaration()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -8,11 +8,14 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class DeclarationParsingTests : ParsingTests
     {
+        public DeclarationParsingTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             return SyntaxFactory.ParseSyntaxTree(text, options);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTests.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Xunit;
 using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
 {
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
     [CompilerTrait(CompilerFeature.Tuples)]
     public class DeconstructionTests : ParsingTests
     {
+        public DeconstructionTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             return SyntaxFactory.ParseSyntaxTree(text, options: options);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -1,17 +1,18 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Test.Utilities;
-using Xunit;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class ExpressionParsingTexts : ParsingTests
     {
+        public ExpressionParsingTexts(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             return SyntaxFactory.ParseSyntaxTree(text, options: options);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class LambdaParameterParsingTests : ParsingTests
     {
+        public LambdaParameterParsingTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             return SyntaxFactory.ParseSyntaxTree(text, options: options);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -6,12 +6,15 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     [CompilerTrait(CompilerFeature.LocalFunctions)]
     public class LocalFunctionParsingTests : ParsingTests
     {
+        public LocalFunctionParsingTests(ITestOutputHelper output) : base(output) { }
+
         [Fact]
         [WorkItem(13480, "https://github.com/dotnet/roslyn/issues/13480")]
         public void IncompleteLocalFunc()

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/NameAttributeValueParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/NameAttributeValueParsingTests.cs
@@ -7,11 +7,14 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.Compilers.CSharp.UnitTests
 {
     public class NameAttributeValueParsingTests : ParsingTests
     {
+        public NameAttributeValueParsingTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             throw new NotSupportedException();

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2064,9 +2064,9 @@ namespace x
                 // (9,21): error CS8181: 'new' cannot be used with tuple type. Use a tuple literal expression instead.
                 //             e = new ();     // CS1031, too few tuple elements
                 Diagnostic(ErrorCode.ERR_NewWithTupleTypeSyntax, "()").WithLocation(9, 21),
-                // (9,21): error CS8124: Tuple must contain at least two elements.
+                // (9,22): error CS8124: Tuple must contain at least two elements.
                 //             e = new ();     // CS1031, too few tuple elements
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(9, 21),
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(9, 22),
                 // (9,23): error CS1526: A new expression requires (), [], or {} after type
                 //             e = new ();     // CS1031, too few tuple elements
                 Diagnostic(ErrorCode.ERR_BadNewExpr, ";").WithLocation(9, 23)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -6,11 +6,14 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class ParserErrorMessageTests : ParsingTests
     {
+        public ParserErrorMessageTests(ITestOutputHelper output) : base(output) { }
+
         #region "Targeted Error Tests - please arrange tests in the order of error code"
 
         [WorkItem(536666, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536666")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2115,12 +2115,12 @@ namespace x
                 // (9,21): error CS8181: 'new' cannot be used with tuple type. Use a tuple literal expression instead.
                 //             e = new ();     // CS1031, not a type
                 Diagnostic(ErrorCode.ERR_NewWithTupleTypeSyntax, "()").WithLocation(9, 21),
-                // (9,21): error CS8124: Tuple must contain at least two elements.
-                //             e = new ();     // CS1031, not a type
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(9, 21),
                 // (9,21): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //             e = new ();     // CS1031, not a type
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(9, 21),
+                // (9,22): error CS8124: Tuple must contain at least two elements.
+                //             e = new ();     // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(9, 22),
                 // (9,23): error CS1526: A new expression requires (), [], or {} after type
                 //             e = new ();     // CS1031, not a type
                 Diagnostic(ErrorCode.ERR_BadNewExpr, ";").WithLocation(9, 23)
@@ -2194,9 +2194,9 @@ class A
                 // (4,32): error CS1041: Identifier expected; 'operator' is a keyword
                 //     public static int explicit operator ()
                 Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "operator").WithArguments("", "operator").WithLocation(4, 32),
-                // (4,41): error CS8124: Tuple must contain at least two elements.
+                // (4,42): error CS8124: Tuple must contain at least two elements.
                 //     public static int explicit operator ()
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(4, 41),
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 42),
                 // (4,43): error CS1001: Identifier expected
                 //     public static int explicit operator ()
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(4, 43),
@@ -2252,12 +2252,12 @@ class A
                 // (4,32): error CS1041: Identifier expected; 'operator' is a keyword
                 //     public static int explicit operator ()
                 Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "operator").WithArguments("", "operator").WithLocation(4, 32),
-                // (4,41): error CS8124: Tuple must contain at least two elements.
-                //     public static int explicit operator ()
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(4, 41),
                 // (4,41): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //     public static int explicit operator ()
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(4, 41),
+                // (4,42): error CS8124: Tuple must contain at least two elements.
+                //     public static int explicit operator ()
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 42),
                 // (4,43): error CS1001: Identifier expected
                 //     public static int explicit operator ()
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(4, 43),
@@ -3598,9 +3598,9 @@ public class MainClass
                 // (3,32): error CS1041: Identifier expected; 'operator' is a keyword
                 //     public static int implicit operator (foo f) { return 6; }    // Error
                 Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "operator").WithArguments("", "operator").WithLocation(3, 32),
-                // (3,41): error CS8124: Tuple must contain at least two elements.
+                // (3,47): error CS8124: Tuple must contain at least two elements.
                 //     public static int implicit operator (foo f) { return 6; }    // Error
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(foo f)").WithLocation(3, 41),
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(3, 47),
                 // (3,49): error CS1001: Identifier expected
                 //     public static int implicit operator (foo f) { return 6; }    // Error
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(3, 49),
@@ -3652,12 +3652,12 @@ public class MainClass
                 // (3,32): error CS1041: Identifier expected; 'operator' is a keyword
                 //     public static int implicit operator (foo f) { return 6; }    // Error
                 Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "operator").WithArguments("", "operator").WithLocation(3, 32),
-                // (3,41): error CS8124: Tuple must contain at least two elements.
-                //     public static int implicit operator (foo f) { return 6; }    // Error
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(foo f)").WithLocation(3, 41),
                 // (3,41): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //     public static int implicit operator (foo f) { return 6; }    // Error
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(foo f)").WithArguments("tuples", "7").WithLocation(3, 41),
+                // (3,47): error CS8124: Tuple must contain at least two elements.
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(3, 47),
                 // (3,49): error CS1001: Identifier expected
                 //     public static int implicit operator (foo f) { return 6; }    // Error
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(3, 49),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -1,18 +1,25 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Xunit;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public abstract class ParsingTests : CSharpTestBase
     {
         private IEnumerator<SyntaxNodeOrToken> _treeEnumerator;
+        private readonly ITestOutputHelper _output;
+
+        public ParsingTests(ITestOutputHelper output)
+        {
+            this._output = output;
+        }
 
         public static void ParseAndValidate(string text, params DiagnosticDescription[] expectedErrors)
         {
@@ -144,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.False(_treeEnumerator.MoveNext());
         }
 
-        private static IEnumerable<SyntaxNodeOrToken> EnumerateNodes(CSharpSyntaxNode node)
+        private IEnumerable<SyntaxNodeOrToken> EnumerateNodes(CSharpSyntaxNode node)
         {
             Print(node);
             yield return node;
@@ -182,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Conditional("PARSING_TESTS_DUMP")]
-        private static void Print(SyntaxNodeOrToken node)
+        private void Print(SyntaxNodeOrToken node)
         {
             switch (node.Kind())
             {
@@ -192,30 +199,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     {
                         goto default;
                     }
-                    Debug.WriteLine(@"N(SyntaxKind.{0}, ""{1}"");", node.Kind(), node.ToString());
+                    _output.WriteLine(@"N(SyntaxKind.{0}, ""{1}"");", node.Kind(), node.ToString());
                     break;
                 default:
-                    Debug.WriteLine("{0}(SyntaxKind.{1});", node.IsMissing ? "M" : "N", node.Kind());
+                    _output.WriteLine("{0}(SyntaxKind.{1});", node.IsMissing ? "M" : "N", node.Kind());
                     break;
             }
         }
 
         [Conditional("PARSING_TESTS_DUMP")]
-        private static void Open()
+        private void Open()
         {
-            Debug.WriteLine("{");
+            _output.WriteLine("{");
         }
 
         [Conditional("PARSING_TESTS_DUMP")]
-        private static void Close()
+        private void Close()
         {
-            Debug.WriteLine("}");
+            _output.WriteLine("}");
         }
 
         [Conditional("PARSING_TESTS_DUMP")]
-        private static void Done()
+        private void Done()
         {
-            Debug.WriteLine("EOF();");
+            _output.WriteLine("EOF();");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -4,12 +4,17 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     [CompilerTrait(CompilerFeature.Patterns)]
     public class PatternParsingTexts : ParsingTests
     {
+        public PatternParsingTexts(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void CasePatternVersusFeatureFlag()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
@@ -6,11 +6,14 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class ScriptParsingTests : ParsingTests
     {
+        public ScriptParsingTests(ITestOutputHelper output) : base(output) { }
+
         #region Helpers
 
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SeparatedSyntaxListParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SeparatedSyntaxListParsingTests.cs
@@ -5,11 +5,16 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class SeparatedSyntaxListParsingTests : ParsingTests
     {
+        public SeparatedSyntaxListParsingTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             return SyntaxFactory.ParseSyntaxTree(text, options: options);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SeparatedSyntaxListParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SeparatedSyntaxListParsingTests.cs
@@ -247,6 +247,21 @@ class M<,> { }
                         N(SyntaxKind.TupleType);
                         {
                             N(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.TupleElement);
+                            {
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
+                                }
+                            }
+                            M(SyntaxKind.CommaToken);
+                            M(SyntaxKind.TupleElement);
+                            {
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
+                                }
+                            }
                             N(SyntaxKind.CloseParenToken);
                         }
                     }
@@ -277,6 +292,21 @@ class M<,> { }
                         N(SyntaxKind.TupleType);
                         {
                             N(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.TupleElement);
+                            {
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
+                                }
+                            }
+                            M(SyntaxKind.CommaToken);
+                            M(SyntaxKind.TupleElement);
+                            {
+                                M(SyntaxKind.IdentifierName);
+                                {
+                                    M(SyntaxKind.IdentifierToken);
+                                }
+                            }
                             N(SyntaxKind.CloseParenToken);
                         }
                     }
@@ -439,7 +469,7 @@ class M<,> { }
                                             {
                                                 N(SyntaxKind.NumericLiteralExpression);
                                                 {
-                                                    N(SyntaxKind.NumericLiteralToken);
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
                                                 }
                                             }
                                             N(SyntaxKind.CommaToken);
@@ -447,7 +477,7 @@ class M<,> { }
                                             {
                                                 N(SyntaxKind.NumericLiteralExpression);
                                                 {
-                                                    N(SyntaxKind.NumericLiteralToken);
+                                                    N(SyntaxKind.NumericLiteralToken, "1");
                                                 }
                                             }
                                             N(SyntaxKind.CloseParenToken);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ValueTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ValueTupleTests.cs
@@ -5,16 +5,19 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
 {
     public class ValueTupleTests : ParsingTests
     {
+        public ValueTupleTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             return SyntaxFactory.ParseSyntaxTree(text, options: options);
         }
-        
+
         [Fact]
         public void SimpleTuple()
         {
@@ -481,6 +484,215 @@ class C
                             N(SyntaxKind.OpenBraceToken);
                             N(SyntaxKind.CloseBraceToken);
                         }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TupleTypeWithTooFewElements()
+        {
+            var tree = UsingTree(@"
+class C
+{
+    void M(int x, () y, (int a) z) { }
+}", options: TestOptions.Regular);
+
+            tree.GetDiagnostics().Verify(
+                // (4,20): error CS8124: Tuple must contain at least two elements.
+                //     void M(int x, () y, (int a) z) { }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 20),
+                // (4,31): error CS8124: Tuple must contain at least two elements.
+                //     void M(int x, () y, (int a) z) { }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 31)
+                );
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "M");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.Parameter);
+                            {
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                                N(SyntaxKind.IdentifierToken, "x");
+                            }
+                            N(SyntaxKind.CommaToken);
+                            N(SyntaxKind.Parameter);
+                            {
+                                N(SyntaxKind.TupleType);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    M(SyntaxKind.TupleElement);
+                                    {
+                                        M(SyntaxKind.IdentifierName);
+                                        {
+                                            M(SyntaxKind.IdentifierToken);
+                                        }
+                                    }
+                                    M(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.TupleElement);
+                                    {
+                                        M(SyntaxKind.IdentifierName);
+                                        {
+                                            M(SyntaxKind.IdentifierToken);
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.IdentifierToken, "y");
+                            }
+                            N(SyntaxKind.CommaToken);
+                            N(SyntaxKind.Parameter);
+                            {
+                                N(SyntaxKind.TupleType);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.TupleElement);
+                                    {
+                                        N(SyntaxKind.PredefinedType);
+                                        {
+                                            N(SyntaxKind.IntKeyword);
+                                        }
+                                        N(SyntaxKind.IdentifierToken, "a");
+                                    }
+                                    M(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.TupleElement);
+                                    {
+                                        M(SyntaxKind.IdentifierName);
+                                        {
+                                            M(SyntaxKind.IdentifierToken);
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.IdentifierToken, "z");
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TupleExpressionWithTooFewElements()
+        {
+            var tree = UsingTree(@"
+class C
+{
+    object x = ((Alice: 1), ());
+}", options: TestOptions.Regular);
+
+            tree.GetDiagnostics().Verify(
+                // (4,26): error CS8124: Tuple must contain at least two elements.
+                //     object x = ((Alice: 1), ());
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 26),
+                // (4,30): error CS1525: Invalid expression term ')'
+                //     object x = ((Alice: 1), ());
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(4, 30)
+                );
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "C");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.FieldDeclaration);
+                    {
+                        N(SyntaxKind.VariableDeclaration);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.ObjectKeyword);
+                            }
+                            N(SyntaxKind.VariableDeclarator);
+                            {
+                                N(SyntaxKind.IdentifierToken, "x");
+                                N(SyntaxKind.EqualsValueClause);
+                                {
+                                    N(SyntaxKind.EqualsToken);
+                                    N(SyntaxKind.TupleExpression);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.TupleExpression);
+                                            {
+                                                N(SyntaxKind.OpenParenToken);
+                                                N(SyntaxKind.Argument);
+                                                {
+                                                    N(SyntaxKind.NameColon);
+                                                    {
+                                                        N(SyntaxKind.IdentifierName);
+                                                        {
+                                                            N(SyntaxKind.IdentifierToken, "Alice");
+                                                        }
+                                                        N(SyntaxKind.ColonToken);
+                                                    }
+                                                    N(SyntaxKind.NumericLiteralExpression);
+                                                    {
+                                                        N(SyntaxKind.NumericLiteralToken, "1");
+                                                    }
+                                                }
+                                                M(SyntaxKind.CommaToken);
+                                                M(SyntaxKind.Argument);
+                                                {
+                                                    M(SyntaxKind.IdentifierName);
+                                                    {
+                                                        M(SyntaxKind.IdentifierToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.CloseParenToken);
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.ParenthesizedExpression);
+                                            {
+                                                N(SyntaxKind.OpenParenToken);
+                                                M(SyntaxKind.IdentifierName);
+                                                {
+                                                    M(SyntaxKind.IdentifierToken);
+                                                }
+                                                N(SyntaxKind.CloseParenToken);
+                                            }
+                                        }
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                }
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
                     }
                     N(SyntaxKind.CloseBraceToken);
                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ValueTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ValueTupleTests.cs
@@ -712,12 +712,12 @@ class Program
 }
 ";
             ParseAndValidate(test,
-                // (4,16): error CS8124: Tuple must contain at least two elements.
-                //     object a = (x: 3l);
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(x: 3l)").WithLocation(4, 16),
                 // (4,21): warning CS0078: The 'l' suffix is easily confused with the digit '1' -- use 'L' for clarity
                 //     object a = (x: 3l);
-                Diagnostic(ErrorCode.WRN_LowercaseEllSuffix, "l").WithLocation(4, 21)
+                Diagnostic(ErrorCode.WRN_LowercaseEllSuffix, "l").WithLocation(4, 21),
+                // (4,22): error CS8124: Tuple must contain at least two elements.
+                //     object a = (x: 3l);
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(4, 22)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/VerbatimCrefParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/VerbatimCrefParsingTests.cs
@@ -6,11 +6,14 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class VerbatimCrefParsingTests : ParsingTests
     {
+        public VerbatimCrefParsingTests(ITestOutputHelper output) : base(output) { }
+
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
             throw new NotSupportedException();

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -757,7 +757,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim locationsArray As ImmutableArray(Of Location) = locations.ToImmutableAndFree()
 
                 If typesArray.Length < 2 Then
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(typesArray.Length)
                 End If
 
                 Return TupleTypeSymbol.Create(syntax.GetLocation,

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -757,9 +757,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim locationsArray As ImmutableArray(Of Location) = locations.ToImmutableAndFree()
 
                 If typesArray.Length < 2 Then
-                    elementNames?.Free()
-                    diagnostics.Add(ERRID.ERR_TupleTooFewElements, syntax.GetLocation)
-                    Return ErrorTypeSymbol.UnknownResultType
+                    Throw ExceptionUtilities.Unreachable
                 End If
 
                 Return TupleTypeSymbol.Create(syntax.GetLocation,

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -1291,6 +1291,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Dim closeParen As PunctuationSyntax = Nothing
             TryEatNewLineAndGetToken(SyntaxKind.CloseParenToken, closeParen, createIfMissing:=True)
 
+            If argumentBuilder.Count < 2 Then
+                argumentBuilder.AddSeparator(InternalSyntaxFactory.MissingToken(SyntaxKind.CommaToken))
+
+                Dim missingExpression = SyntaxFactory.SimpleArgument(nameColonEquals:=Nothing, expression:=SyntaxFactory.IdentifierName(InternalSyntaxFactory.MissingIdentifier()))
+                missingExpression = ReportSyntaxError(missingExpression, ERRID.ERR_TupleTooFewElements)
+                argumentBuilder.Add(missingExpression)
+            End If
+
             Dim arguments = argumentBuilder.ToList
             _pool.Free(argumentBuilder)
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -1294,9 +1294,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             If argumentBuilder.Count < 2 Then
                 argumentBuilder.AddSeparator(InternalSyntaxFactory.MissingToken(SyntaxKind.CommaToken))
 
-                Dim missingExpression = SyntaxFactory.SimpleArgument(nameColonEquals:=Nothing, expression:=SyntaxFactory.IdentifierName(InternalSyntaxFactory.MissingIdentifier()))
-                missingExpression = ReportSyntaxError(missingExpression, ERRID.ERR_TupleTooFewElements)
-                argumentBuilder.Add(missingExpression)
+                Dim missing = SyntaxFactory.IdentifierName(InternalSyntaxFactory.MissingIdentifier())
+                missing = ReportSyntaxError(missing, ERRID.ERR_TupleTooFewElements)
+                argumentBuilder.Add(SyntaxFactory.SimpleArgument(nameColonEquals:=Nothing, expression:=missing))
             End If
 
             Dim arguments = argumentBuilder.ToList

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -3020,11 +3020,12 @@ checkNullable:
             End If
 
             If elementBuilder.Count < 2 Then
+                Debug.Assert(elementBuilder.Count > 0)
                 elementBuilder.AddSeparator(InternalSyntaxFactory.MissingToken(SyntaxKind.CommaToken))
 
-                Dim missingElement = _syntaxFactory.TypedTupleElement(SyntaxFactory.IdentifierName(InternalSyntaxFactory.MissingIdentifier()))
-                missingElement = ReportSyntaxError(missingElement, ERRID.ERR_TupleTooFewElements)
-                elementBuilder.Add(missingElement)
+                Dim missing = SyntaxFactory.IdentifierName(InternalSyntaxFactory.MissingIdentifier())
+                missing = ReportSyntaxError(missing, ERRID.ERR_TupleTooFewElements)
+                elementBuilder.Add(_syntaxFactory.TypedTupleElement(missing))
             End If
 
             Dim tupleElements = elementBuilder.ToList

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -3019,6 +3019,14 @@ checkNullable:
                 closeParen = closeParen.AddLeadingSyntax(unexpected)
             End If
 
+            If elementBuilder.Count < 2 Then
+                elementBuilder.AddSeparator(InternalSyntaxFactory.MissingToken(SyntaxKind.CommaToken))
+
+                Dim missingElement = _syntaxFactory.TypedTupleElement(SyntaxFactory.IdentifierName(InternalSyntaxFactory.MissingIdentifier()))
+                missingElement = ReportSyntaxError(missingElement, ERRID.ERR_TupleTooFewElements)
+                elementBuilder.Add(missingElement)
+            End If
+
             Dim tupleElements = elementBuilder.ToList
             _pool.Free(elementBuilder)
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Parenthesized.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Parenthesized.vb
@@ -111,11 +111,11 @@ End Module
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
-    BC30112: 'System' is a namespace and cannot be used as an expression.
+BC30112: 'System' is a namespace and cannot be used as an expression.
     System.Console.WriteLine((System).String.Equals("", ""))
                               ~~~~~~
 BC30203: Identifier expected.
@@ -138,10 +138,13 @@ BC30451: 'C2' is not declared. It may be inaccessible due to its protection leve
                                  ~~
 BC37259: Tuple must contain at least two elements.
     System.Console.WriteLine(GetType((System.String)))
-                                     ~~~~~~~~~~~~~~~
+                                                   ~
+BC30456: 'C2' is not a member of 'Type'.
+    System.Console.WriteLine(GetType((C1).C2)))
+                             ~~~~~~~~~~~~~~~
 BC37259: Tuple must contain at least two elements.
     System.Console.WriteLine(GetType((C1).C2)))
-                                     ~~~~
+                                        ~
 BC30198: ')' expected.
     System.Console.WriteLine(GetType((C1).C2)))
                                          ~

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -380,16 +380,25 @@ ToString]]>.Value)
 
     <Fact>
     Public Sub ParseTuple4()
-        Dim expr = ParseExpression("(A:=1)", expectsErrors:=False)
+        Dim expr = ParseExpression("(A:=1)", expectsErrors:=True)
         Assert.Equal(SyntaxKind.TupleExpression, expr.Kind)
+        Assert.Equal(SyntaxKind.SimpleArgument, expr.ChildNodesAndTokens()(1).Kind())
+        Assert.Equal(SyntaxKind.NameColonEquals, expr.ChildNodesAndTokens()(1).ChildNodesAndTokens()(0).Kind())
+        Dim missingComma = expr.ChildNodesAndTokens()(2)
+        Assert.Equal(SyntaxKind.CommaToken, missingComma.Kind())
+        Assert.Equal(True, missingComma.IsMissing)
+        Dim missingArg = expr.ChildNodesAndTokens()(3)
+        Assert.Equal(SyntaxKind.SimpleArgument, missingArg.Kind())
+        Assert.Equal(True, missingArg.IsMissing)
+
         expr = ParseExpression("(A:=, C).C", expectsErrors:=True)
         Assert.Equal(SyntaxKind.TupleExpression, expr.ChildNodesAndTokens()(0).Kind())
         Assert.Equal(SyntaxKind.SimpleArgument, expr.ChildNodesAndTokens()(0).ChildNodesAndTokens()(1).Kind())
         Assert.Equal(SyntaxKind.NameColonEquals, expr.ChildNodesAndTokens()(0).ChildNodesAndTokens()(1).ChildNodesAndTokens()(0).Kind())
 
-        Dim missingArg = expr.ChildNodesAndTokens()(0).ChildNodesAndTokens()(1).ChildNodesAndTokens()(1)
-        Assert.Equal(SyntaxKind.IdentifierName, missingArg.Kind)
-        Assert.Equal(True, missingArg.IsMissing)
+        Dim missingArg2 = expr.ChildNodesAndTokens()(0).ChildNodesAndTokens()(1).ChildNodesAndTokens()(1)
+        Assert.Equal(SyntaxKind.IdentifierName, missingArg2.Kind)
+        Assert.Equal(True, missingArg2.IsMissing)
     End Sub
 
     <Fact>


### PR DESCRIPTION
**Customer scenario**
When typing an incomplete tuple type (with one element), such as `void M(int x, (int a) y)`, two identical errors are reported (one from parsing and one from binding).
This fix ensures that parsing always produces at least two tuple elements (missing ones if necessary) and removes the error from binding stage.

**Bugs this fixes:** 
https://github.com/dotnet/roslyn/issues/14091

**Workarounds, if any**
Type a proper tuple type.

**Risk**
**Performance impact**
Low. This is a very localized change to parsing and binding tuple types.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
The tests that we had for this situation didn't reach binding stage, so we didn't notice the duplication of errors.

**How was the bug found?**
Dogfooding.