### PR TITLE
Add csc and vbc to PATH

### DIFF
--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -60,3 +60,6 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XmlDocument.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XPath.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Xml.XPath.XDocument.dll vs.file.ngenArchitecture=all
+
+folder InstallDir:\Common7\Tools\vsdevcmd\ext
+    file source=$(OutputPath)\Insertion\roslyn.bat

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.vsmanproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.vsmanproj
@@ -14,7 +14,12 @@
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.props" />
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.targets" />
 
+  <ItemGroup>
+    <RoslynVsixFileToCopy Include="..\..\MSBuildScripts\roslyn.bat" />
+  </ItemGroup>
+
   <Target Name="BeforeBuild"> 
+    <Copy SourceFiles="@(RoslynVsixFileToCopy)" DestinationFolder="$(OutputPath)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" />
     <MSBuild Projects="Microsoft.CodeAnalysis.Compilers.swixproj" Targets="Build" /> 
   </Target>
 

--- a/src/Setup/MSBuildScripts/roslyn.bat
+++ b/src/Setup/MSBuildScripts/roslyn.bat
@@ -1,0 +1,49 @@
+
+set __VSCMD_script_err_count=0
+if "%VSCMD_TEST%" NEQ "" goto :test
+if "%VSCMD_ARG_CLEAN_ENV%" NEQ "" goto :clean_env
+
+@REM ------------------------------------------------------------------------
+:start
+
+set PATH="%VSINSTALLDIR%MSBuild\15.0\bin\Roslyn;%PATH%"
+
+goto :end
+
+@REM ------------------------------------------------------------------------
+:test
+
+setlocal
+
+@REM Test whether csc.exe is now on PATH
+where csc.exe > nul 2>&1
+if "%ERRORLEVEL%" NEQ "0" (
+    @echo [ERROR:%~nx0] 'where csc.exe' failed
+    set /A __VSCMD_script_err_count=__VSCMD_script_err_count+1
+)
+
+
+@REM exports the value of _vscmd_script_err_count from the 'setlocal' region
+endlocal & set __VSCMD_script_err_count=%__VSCMD_script_err_count%
+
+goto :end
+
+@REM ------------------------------------------------------------------------
+:clean_env
+
+@REM Since this script only adds to PATH, the vsdevcmd.bat core infrastructure
+@REM will handle clean-up of PATH.
+
+goto :end
+
+@REM ------------------------------------------------------------------------
+:end
+
+@REM return value other than 0 if tests failed.
+if "%__VSCMD_script_err_count%" NEQ "0" (
+   set __VSCMD_script_err_count=
+   exit /B 1
+)
+
+set __VSCMD_script_err_count=
+exit /B 0

--- a/src/Setup/MSBuildScripts/roslyn.bat
+++ b/src/Setup/MSBuildScripts/roslyn.bat
@@ -6,7 +6,7 @@ if "%VSCMD_ARG_CLEAN_ENV%" NEQ "" goto :clean_env
 @REM ------------------------------------------------------------------------
 :start
 
-set PATH="%VSINSTALLDIR%MSBuild\15.0\bin\Roslyn;%PATH%"
+set "PATH=%VSINSTALLDIR%MSBuild\15.0\bin\Roslyn;%PATH%"
 
 goto :end
 


### PR DESCRIPTION
This PR adds a script to VS installation that adds roslyn MSBuild folder to path, which includes roslyn compilers.
Fixes #16037