### PR TITLE
Make ScanType() and ParseType() agree not to accept pointer types in deconstruction

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6179,7 +6179,12 @@ tryAgain:
 
         private ScanTypeFlags ScanType(out SyntaxToken lastTokenOfType)
         {
-            ScanTypeFlags result = this.ScanNonArrayType(out lastTokenOfType);
+            return ScanType(ParseTypeMode.Normal, out lastTokenOfType);
+        }
+
+        private ScanTypeFlags ScanType(ParseTypeMode mode, out SyntaxToken lastTokenOfType)
+        {
+            ScanTypeFlags result = this.ScanNonArrayType(mode, out lastTokenOfType);
 
             if (result == ScanTypeFlags.NotType)
             {
@@ -6236,10 +6241,10 @@ tryAgain:
         private ScanTypeFlags ScanNonArrayType()
         {
             SyntaxToken lastTokenOfType;
-            return ScanNonArrayType(out lastTokenOfType);
+            return ScanNonArrayType(ParseTypeMode.Normal, out lastTokenOfType);
         }
 
-        private ScanTypeFlags ScanNonArrayType(out SyntaxToken lastTokenOfType)
+        private ScanTypeFlags ScanNonArrayType(ParseTypeMode mode, out SyntaxToken lastTokenOfType)
         {
             ScanTypeFlags result;
 
@@ -6311,17 +6316,27 @@ tryAgain:
             }
 
             // Now check for pointer type(s)
-            while (this.CurrentToken.Kind == SyntaxKind.AsteriskToken)
+            switch (mode)
             {
-                lastTokenOfType = this.EatToken();
-                if (result == ScanTypeFlags.GenericTypeOrExpression || result == ScanTypeFlags.NonGenericTypeOrExpression)
-                {
-                    result = ScanTypeFlags.PointerOrMultiplication;
-                }
-                else if (result == ScanTypeFlags.GenericTypeOrMethod)
-                {
-                    result = ScanTypeFlags.MustBeType;
-                }
+                case ParseTypeMode.FirstElementOfPossibleTupleLiteral:
+                case ParseTypeMode.AfterTupleComma:
+                    // We are parsing the type for a declaration expression in a tuple, which does
+                    // not permit pointer types. In that context a `*` is parsed as a multiplication.
+                    break;
+                default:
+                    while (this.CurrentToken.Kind == SyntaxKind.AsteriskToken)
+                    {
+                        lastTokenOfType = this.EatToken();
+                        if (result == ScanTypeFlags.GenericTypeOrExpression || result == ScanTypeFlags.NonGenericTypeOrExpression)
+                        {
+                            result = ScanTypeFlags.PointerOrMultiplication;
+                        }
+                        else if (result == ScanTypeFlags.GenericTypeOrMethod)
+                        {
+                            result = ScanTypeFlags.MustBeType;
+                        }
+                    }
+                    break;
             }
 
             return result;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -152,18 +152,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             {
                 bool typeIsVar = IsVarType();
                 SyntaxToken lastTokenOfType;
-                switch (ScanType(out lastTokenOfType))
+                if (ScanType(mode, out lastTokenOfType) == ScanTypeFlags.NotType)
                 {
-                    case ScanTypeFlags.PointerOrMultiplication:
-                        if (mode == ParseTypeMode.FirstElementOfPossibleTupleLiteral || mode == ParseTypeMode.AfterTupleComma)
-                        {
-                            // Tuples cannot contain pointer types because pointers may not be generic type arguments.
-                            return false;
-                        }
-                        break;
-
-                    case ScanTypeFlags.NotType:
-                        return false;
+                    return false;
                 }
 
                 // check for a designation

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -2601,5 +2601,125 @@ class C
                 Diagnostic(ErrorCode.ERR_TypeVarNotFound, "var").WithLocation(6, 15)
             );
         }
+
+        [Fact, WorkItem(15934, "https://github.com/dotnet/roslyn/issues/15934")]
+        public void PointerTypeInDeconstruction()
+        {
+            string source = @"
+unsafe class C
+{
+    static void Main(C c)
+    {
+        (int* x1, int y1) = c;
+        (var* x2, int y2) = c;
+        (int*[] x3, int y3) = c;
+        (var*[] x4, int y4) = c;
+    }
+    public void Deconstruct(out dynamic x, out dynamic y)
+    {
+        x = y = null;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlibAndSystemCore(source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                options: TestOptions.UnsafeDebugDll);
+
+            // The precise diagnostics here are not important, and may be sensitive to parser
+            // adjustments. This is a test that we don't crash. The errors here are likely to
+            // change as we adjust the parser and semantic analysis of error cases.
+            comp.VerifyDiagnostics(
+                // (6,10): error CS1525: Invalid expression term 'int'
+                //         (int* x1, int y1) = c;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(6, 10),
+                // (8,10): error CS1525: Invalid expression term 'int'
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(8, 10),
+                // (8,14): error CS1525: Invalid expression term '['
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "[").WithArguments("[").WithLocation(8, 14),
+                // (8,15): error CS0443: Syntax error; value expected
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_ValueExpected, "]").WithLocation(8, 15),
+                // (8,17): error CS1026: ) expected
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "x3").WithLocation(8, 17),
+                // (8,17): error CS1002: ; expected
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "x3").WithLocation(8, 17),
+                // (8,19): error CS1002: ; expected
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ",").WithLocation(8, 19),
+                // (8,19): error CS1513: } expected
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ",").WithLocation(8, 19),
+                // (8,27): error CS1002: ; expected
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(8, 27),
+                // (8,27): error CS1513: } expected
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(8, 27),
+                // (8,29): error CS1525: Invalid expression term '='
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(8, 29),
+                // (9,14): error CS1525: Invalid expression term '['
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "[").WithArguments("[").WithLocation(9, 14),
+                // (9,15): error CS0443: Syntax error; value expected
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_ValueExpected, "]").WithLocation(9, 15),
+                // (9,17): error CS1026: ) expected
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "x4").WithLocation(9, 17),
+                // (9,17): error CS1002: ; expected
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "x4").WithLocation(9, 17),
+                // (9,19): error CS1002: ; expected
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ",").WithLocation(9, 19),
+                // (9,19): error CS1513: } expected
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ",").WithLocation(9, 19),
+                // (9,27): error CS1002: ; expected
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(9, 27),
+                // (9,27): error CS1513: } expected
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(9, 27),
+                // (9,29): error CS1525: Invalid expression term '='
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(9, 29),
+                // (6,15): error CS0103: The name 'x1' does not exist in the current context
+                //         (int* x1, int y1) = c;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(6, 15),
+                // (6,9): error CS8184: A deconstruction cannot mix declarations and expressions on the left-hand-side.
+                //         (int* x1, int y1) = c;
+                Diagnostic(ErrorCode.ERR_MixedDeconstructionUnsupported, "(int* x1, int y1)").WithLocation(6, 9),
+                // (7,10): error CS0103: The name 'var' does not exist in the current context
+                //         (var* x2, int y2) = c;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "var").WithArguments("var").WithLocation(7, 10),
+                // (7,15): error CS0103: The name 'x2' does not exist in the current context
+                //         (var* x2, int y2) = c;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x2").WithArguments("x2").WithLocation(7, 15),
+                // (7,9): error CS8184: A deconstruction cannot mix declarations and expressions on the left-hand-side.
+                //         (var* x2, int y2) = c;
+                Diagnostic(ErrorCode.ERR_MixedDeconstructionUnsupported, "(var* x2, int y2)").WithLocation(7, 9),
+                // (8,17): error CS0103: The name 'x3' does not exist in the current context
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x3").WithArguments("x3").WithLocation(8, 17),
+                // (9,10): error CS0103: The name 'var' does not exist in the current context
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "var").WithArguments("var").WithLocation(9, 10),
+                // (9,17): error CS0103: The name 'x4' does not exist in the current context
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x4").WithArguments("x4").WithLocation(9, 17),
+                // (8,25): warning CS0168: The variable 'y3' is declared but never used
+                //         (int*[] x3, int y3) = c;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "y3").WithArguments("y3").WithLocation(8, 25),
+                // (9,25): warning CS0168: The variable 'y4' is declared but never used
+                //         (var*[] x4, int y4) = c;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "y4").WithArguments("y4").WithLocation(9, 25)
+                );
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Crash in deconstruction that attempts to use a pointer type.

**Bugs this fixes:** 

Fixes #15934

**Workarounds, if any**

Don't make that mistake.

**Risk**

Low. This changes an area of the compiler that recently underwent a complete overhaul. The changes here are relatively small and correct an error introduced at that time.

**Performance impact**

Low. The parser logic changes without any significant algorithmic changes.

**Is this a regression from a previous update?**

The previous update was not know to crash in this scenario, however, the scenario underwent a significant spec revision. The affected scenario is now an assignment expression, not a deconstruction declaration. So it is a bug in relatively recent code.

**Root cause analysis:**

We didn't have tests for this combination of features.

**How was the bug found?**

Customer reported.
