### PR TITLE
Fix InlineDecl issues.

### DIFF
--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests_FixAllTests.cs
@@ -73,5 +73,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InlineDeclaration
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task FixAllInDocument3()
+        {
+
+            await TestAsync(
+@"class C
+{
+    void M()
+    {
+        // Now get final exe and args. CTtrl-F5 wraps exe in cmd prompt
+        string {|FixAllInDocument:finalExecutable|}, finalArguments;
+        GetExeAndArguments(useCmdShell, executable, arguments, out finalExecutable, out finalArguments);
+    }
+}",
+@"class C
+{
+    void M()
+    {
+        GetExeAndArguments(useCmdShell, executable, arguments, out string finalExecutable, out string finalArguments);
+    }
+}", compareTokens: false);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -49,7 +49,10 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             // of hte local.  This is necessary in some cases (for example, when the
             // type of the out-var-decl affects overload resolution or generic instantiation).
 
-            foreach (var diagnostic in diagnostics)
+            // Process diagnostics in the order they appear in the document.  That way if 
+            // we have multiple diagnostics for the same declaration (i.e. "var foo, bar") 
+            // and we want to inline all the declarators, we process them in declarator order.
+            foreach (var diagnostic in diagnostics.OrderBy(d => d.Location.SourceSpan.Start))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 await AddEditsAsync(

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -49,10 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             // of hte local.  This is necessary in some cases (for example, when the
             // type of the out-var-decl affects overload resolution or generic instantiation).
 
-            // Process diagnostics in the order they appear in the document.  That way if 
-            // we have multiple diagnostics for the same declaration (i.e. "var foo, bar") 
-            // and we want to inline all the declarators, we process them in declarator order.
-            foreach (var diagnostic in diagnostics.OrderBy(d => d.Location.SourceSpan.Start))
+            foreach (var diagnostic in diagnostics)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 await AddEditsAsync(

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -266,16 +266,20 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                 currentLocalDeclarator,
                 currentLocalDeclarator.WithInitializer(null));
 
+            var rootWithoutInitializerTree = root.SyntaxTree.WithRootAndOptions(
+                rootWithoutInitializer, root.SyntaxTree.Options);
+
             // Fork the compilation so we can do this analysis.
             var newCompilation = semanticModel.Compilation.ReplaceSyntaxTree(
-                root.SyntaxTree, rootWithoutInitializer.SyntaxTree);
-            var newSemanticModel = newCompilation.GetSemanticModel(rootWithoutInitializer.SyntaxTree);
+                root.SyntaxTree, rootWithoutInitializerTree);
+            var newSemanticModel = newCompilation.GetSemanticModel(rootWithoutInitializerTree);
 
             // NOTE: there is no current compiler API to determine if a variable is definitely
             // assigned or not.  So, for now, we just get diagnostics for this block and see if
             // we get any definite assigment errors where we have a reference to the symbol. If
             // so, then we don't offer the fix.
 
+            rootWithoutInitializer = (CompilationUnitSyntax)rootWithoutInitializerTree.GetRoot(cancellationToken);
             var currentBlock = rootWithoutInitializer.GetCurrentNode(enclosingBlock);
             var diagnostics = newSemanticModel.GetDiagnostics(currentBlock.Span, cancellationToken);
 

--- a/src/Workspaces/Core/Portable/CodeFixes/SyntaxEditorBasedCodeFixProvider.FixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/SyntaxEditorBasedCodeFixProvider.FixAllProvider.cs
@@ -62,7 +62,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             private Task<Document> FixDocumentAsync(
                 Document document, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
             {
-                var filteredDiagnostics = diagnostics.WhereAsArray(_codeFixProvider.IncludeDiagnosticDuringFixAll);
+                // Ensure that diagnostics for this document are always in document location
+                // order.  This provides a consistent and deterministic order for fixers
+                // that want to update a document.
+                var filteredDiagnostics = diagnostics.WhereAsArray(_codeFixProvider.IncludeDiagnosticDuringFixAll)
+                                                     .Sort((d1, d2) => d1.Location.SourceSpan.Start - d2.Location.SourceSpan.Start);
                 return _codeFixProvider.FixAllAsync(document, filteredDiagnostics, cancellationToken);
             }
         }


### PR DESCRIPTION
1. When we make a new syntax tree, ensure it has the right options set.
2. Ensure we process declarators in a consistent order.

Fixes https://github.com/dotnet/roslyn/issues/15992