### PR TITLE
Add Razor shims to NuGet

### DIFF
--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -104,10 +104,12 @@ string[] RedistPackageNames = {
 };
 
 string[] NonRedistPackageNames = {
+    "Microsoft.CodeAnalysis.Remote.Razor.ServiceHub",
     "Microsoft.Net.Compilers",
     "Microsoft.Net.Compilers.netcore",
     "Microsoft.Net.CSharp.Interactive.netcore",
     "Microsoft.VisualStudio.IntegrationTest.Utilities",
+    "Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient",
 };
 
 string[] TestPackageNames = {
@@ -123,10 +125,12 @@ var PreReleaseOnlyPackages = new HashSet<string>
     "Microsoft.CodeAnalysis.VisualBasic.Scripting",
     "Microsoft.Net.Compilers.netcore",
     "Microsoft.Net.CSharp.Interactive.netcore",
+    "Microsoft.CodeAnalysis.Remote.Razor.ServiceHub",
     "Microsoft.CodeAnalysis.Remote.ServiceHub",
     "Microsoft.CodeAnalysis.Remote.Workspaces",
     "Microsoft.CodeAnalysis.Test.Resources.Proprietary",
     "Microsoft.VisualStudio.LanguageServices.Next",
+    "Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient",
 };
 
 // The assets for these packages are not produced when building on Unix
@@ -137,6 +141,7 @@ var PackagesNotBuiltOnCore = new HashSet<string>
      "Microsoft.CodeAnalysis.EditorFeatures",
      "Microsoft.CodeAnalysis.EditorFeatures.Text",
      "Microsoft.CodeAnalysis.Features",
+     "Microsoft.CodeAnalysis.Remote.Razor.ServiceHub",
      "Microsoft.CodeAnalysis.Remote.ServiceHub",
      "Microsoft.CodeAnalysis.Remote.Workspaces",
      "Microsoft.CodeAnalysis.VisualBasic.Features",
@@ -144,6 +149,7 @@ var PackagesNotBuiltOnCore = new HashSet<string>
      "Microsoft.Net.Compilers",
      "Microsoft.VisualStudio.LanguageServices",
      "Microsoft.VisualStudio.LanguageServices.Next",
+     "Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient",
      "Roslyn.VisualStudio.Test.Utilities",
 };
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.CodeAnalysis.Remote.Razor.ServiceHub</id>
+    <summary>
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process.
+    </summary>
+    <description>
+      A shared package used by the .NET Compiler Platform ("Roslyn") including support for coordinating analysis of projects and solutions using a separate server process. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+
+Supported Platforms:
+- .NET Framework 4.6
+    </description>
+    <dependencies>
+      <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="[$version$]" />
+    </dependencies>
+
+    <language>en-US</language>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <version>$version$</version>
+    <authors>$authors$</authors>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+  </metadata>
+  <files>
+    <file src="Dlls\RazorServiceHub\Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.dll" target="lib\net46" />
+    <file src="Dlls\RazorServiceHub\Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.xml" target="lib\net46" />
+    <file src="$thirdPartyNoticesPath$" target="" />
+  </files>
+</package>

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient</id>
+    <description>
+      .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
+
+Supported Platforms:
+- .NET Framework 4.6
+    </description>
+    <dependencies>
+      <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />
+    </dependencies>
+
+    <language>en-US</language>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <version>$version$</version>
+    <authors>$authors$</authors>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <releaseNotes>$releaseNotes$</releaseNotes>
+    <tags>$tags$</tags>
+  </metadata>
+  <files>
+    <file src="Dlls\RazorVisualStudio\Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.dll" target="lib\net46" />
+    <file src="Dlls\RazorVisualStudio\Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.xml" target="lib\net46" />
+    <file src="$thirdPartyNoticesPath$" target="" />
+  </files>
+</package>


### PR DESCRIPTION
We missed this part of the change when adding these projects to the repo. This change will cause the Razor shims to be nupkg'ed and published to myget.org

I took the description text verbatim from some related packages. 