### PR TITLE
Combine duplicate methods

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
+++ b/src/Compilers/Server/VBCSCompiler/NamedPipeClientConnection.cs
@@ -175,30 +175,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         ///
         /// This will return true if the pipe was disconnected.
         /// </summary>
-        protected override async Task CreateMonitorDisconnectTask(CancellationToken cancellationToken)
+        protected override Task CreateMonitorDisconnectTask(CancellationToken cancellationToken)
         {
-            var buffer = Array.Empty<byte>();
-
-            while (!cancellationToken.IsCancellationRequested && _pipeStream.IsConnected)
-            {
-                // Wait a second before trying again
-                await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
-
-                try
-                {
-                    CompilerServerLogger.Log($"Pipe {LoggingIdentifier}: Before poking pipe.");
-                    await _pipeStream.ReadAsync(buffer, 0, 0, cancellationToken).ConfigureAwait(false);
-                    CompilerServerLogger.Log($"Pipe {LoggingIdentifier}: After poking pipe.");
-                }
-                catch (Exception e)
-                {
-                    // It is okay for this call to fail.  Errors will be reflected in the 
-                    // IsConnected property which will be read on the next iteration of the 
-                    // loop
-                    var msg = string.Format($"Pipe {LoggingIdentifier}: Error poking pipe.");
-                    CompilerServerLogger.LogException(e, msg);
-                }
-            }
+            return BuildServerConnection.CreateMonitorDisconnectTask(_pipeStream, LoggingIdentifier, cancellationToken);
         }
 
         protected override void ValidateBuildRequest(BuildRequest request)

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 Log("Begin reading response");
 
                 var responseTask = BuildResponse.ReadAsync(pipeStream, serverCts.Token);
-                var monitorTask = CreateMonitorDisconnectTask(pipeStream, serverCts.Token);
+                var monitorTask = CreateMonitorDisconnectTask(pipeStream, "client", serverCts.Token);
                 await Task.WhenAny(responseTask, monitorTask).ConfigureAwait(false);
 
                 Log("End reading response");
@@ -263,17 +263,13 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// The IsConnected property on named pipes does not detect when the client has disconnected
         /// if we don't attempt any new I/O after the client disconnects. We start an async I/O here
         /// which serves to check the pipe for disconnection.
-        ///
-        /// This will return true if the pipe was disconnected.
         /// </summary>
-        private static async Task CreateMonitorDisconnectTask(
-            NamedPipeClientStream pipeStream,
-            CancellationToken cancellationToken)
+        internal static async Task CreateMonitorDisconnectTask(
+            PipeStream pipeStream,
+            string identifier = null,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Ignore this warning because the desktop projects don't target 4.6 yet
-#pragma warning disable CA1825 // Avoid zero-length array allocations.
-            var buffer = new byte[0];
-#pragma warning restore CA1825 // Avoid zero-length array allocations.
+            var buffer = Array.Empty<byte>();
 
             while (!cancellationToken.IsCancellationRequested && pipeStream.IsConnected)
             {
@@ -282,17 +278,18 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
                 try
                 {
-                    Log("Before poking pipe.");
+                    Log($"Before poking pipe {identifier}.");
                     await pipeStream.ReadAsync(buffer, 0, 0, cancellationToken).ConfigureAwait(false);
-                    Log("After poking pipe.");
+                    Log($"After poking pipe {identifier}.");
                 }
-                // Ignore cancellation
-                catch (OperationCanceledException) { }
+                catch (OperationCanceledException)
+                {
+                }
                 catch (Exception e)
                 {
                     // It is okay for this call to fail.  Errors will be reflected in the
                     // IsConnected property which will be read on the next iteration of the
-                    LogException(e, "Error poking pipe");
+                    LogException(e, $"Error poking pipe {identifier}.");
                 }
             }
         }


### PR DESCRIPTION
.**Customer scenario**

Customer reports an error involving compiler server and sends logs.  There were two versions of the CreateMonitorDisconnect task: client and server.  This code is the same and having it in two places was making it difficult to track down a customer investigation.  Merging into a single location to make the intent clearer. 

**Workarounds, if any**

Look harder at the log files 

**Risk**

Very low.  It's the same code, with the same comments.  It's now just a single method. 

**How was the bug found?**

Working with a customer on a compiler server issue. 