### PR TITLE
Visit all local function return types during lowering

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -890,12 +890,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node.Method.MethodKind == MethodKind.LocalFunction)
             {
-                var rewrittenArguments = this.VisitList(node.Arguments);
-
                 var withArguments = node.Update(
                     node.ReceiverOpt,
                     node.Method,
-                    rewrittenArguments,
+                    this.VisitList(node.Arguments),
                     node.ArgumentNamesOpt,
                     node.ArgumentRefKindsOpt,
                     node.IsDelegateCall,
@@ -903,7 +901,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     node.InvokedAsExtensionMethod,
                     node.ArgsToParamsOpt,
                     node.ResultKind,
-                    node.Type);
+                    this.VisitType(node.Type));
 
                 return PartiallyLowerLocalFunctionReference(withArguments);
             }
@@ -1147,7 +1145,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (node.MethodOpt?.MethodKind == MethodKind.LocalFunction)
             {
-                return PartiallyLowerLocalFunctionReference(node);
+                var rewritten = node.Update(
+                    node.Argument,
+                    node.MethodOpt,
+                    node.IsExtensionMethod,
+                    this.VisitType(node.Type));
+
+                return PartiallyLowerLocalFunctionReference(rewritten);
             }
             return base.VisitDelegateCreationExpression(node);
         }
@@ -1177,7 +1181,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (conversion.ConversionKind == ConversionKind.MethodGroup &&
                 conversion.SymbolOpt?.MethodKind == MethodKind.LocalFunction)
             {
-                return PartiallyLowerLocalFunctionReference(conversion);
+                var rewritten = conversion.Update(
+                    conversion.Operand,
+                    conversion.Conversion,
+                    conversion.IsBaseConversion,
+                    conversion.Checked,
+                    conversion.ExplicitCastInCode,
+                    conversion.ConstantValueOpt,
+                    this.VisitType(conversion.Type));
+
+                return PartiallyLowerLocalFunctionReference(rewritten);
             }
             return base.VisitConversion(conversion);
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -3315,6 +3315,170 @@ class Program
             VerifyOutput(src, "DECBADECBADECBADECBADECBA");
         }
 
+        [Fact]
+        [WorkItem(15751, "https://github.com/dotnet/roslyn/issues/15751")]
+        public void RecursiveGenericLocalFunction6()
+        {
+            var src = @"
+using System;
+class C<T1>
+{
+    T1 t1;
+
+    public C(T1 t1)
+    {
+        this.t1 = t1;
+    }
+
+    public void M<T2>(T2 t2)
+    {
+        void L1<T3>(T3 t3)
+        {
+            void L2<T4>(T4 t4)
+            {
+                void L3<U>(U u, int count)
+                {
+                    if (count > 0)
+                    {
+                        Console.Write(t1);
+                        Console.Write(t2);
+                        Console.Write(t3);
+                        Console.Write(t4);
+                        Console.Write(u);
+                        var a = new Action<U, int>(L3);
+                        a(u, count - 1);
+                    }
+                }
+                var b = new Action<string, int>(L3);
+                b(""A"", 5);
+            }
+            var c = new Action<string>(L2);
+            c(""B"");
+        }
+        var d = new Action<string>(L1);
+        d(""C"");
+    }
+
+}
+
+class Program
+{
+    public static void Main()
+    {
+        var c = new C<string>(""D"");
+        c.M(""E"");
+    }
+}";
+            VerifyOutput(src, "DECBADECBADECBADECBADECBA");
+        }
+
+        [Fact]
+        [WorkItem(15751, "https://github.com/dotnet/roslyn/issues/15751")]
+        public void RecursiveGenericLocalFunction7()
+        {
+            var src = @"
+using System;
+class C<T1>
+{
+    T1 t1;
+
+    public C(T1 t1)
+    {
+        this.t1 = t1;
+    }
+
+    public void M<T2>(T2 t2)
+    {
+        void L1<T3>(T3 t3)
+        {
+            void L2<T4>(T4 t4)
+            {
+                void L3<U>(U u, int count)
+                {
+                    if (count > 0)
+                    {
+                        Console.Write(t1);
+                        Console.Write(t2);
+                        Console.Write(t3);
+                        Console.Write(t4);
+                        Console.Write(u);
+                        var a = (Action<U, int>)(L3);
+                        a(u, count - 1);
+                    }
+                }
+                var b = (Action<string, int>)(L3);
+                b(""A"", 5);
+            }
+            var c = (Action<string>)(L2);
+            c(""B"");
+        }
+        var d = (Action<string>)(L1);
+        d(""C"");
+    }
+
+}
+
+class Program
+{
+    public static void Main()
+    {
+        var c = new C<string>(""D"");
+        c.M(""E"");
+    }
+}";
+            VerifyOutput(src, "DECBADECBADECBADECBADECBA");
+        }
+
+        [Fact]
+        [WorkItem(16038, "https://github.com/dotnet/roslyn/issues/16038")]
+        public void RecursiveGenericLocalFunction8()
+        {
+            var src = @"
+using System;
+class C<T0>
+{
+    T0 t0;
+
+    public C(T0 t0)
+    {
+        this.t0 = t0;
+    }
+
+    public void M<T1>(T1 t1)
+    {
+        (T0, T1, T2) L1<T2>(T2 t2)
+        {
+            (T0, T1, T2, T3) L2<T3>(T3 t3, int count)
+            {
+                if (count > 0)
+                {
+                    Console.Write(t0);
+                    Console.Write(t1);
+                    Console.Write(t2);
+                    Console.Write(t3);
+                    return L2(t3, count - 1);
+                }
+                return (t0, t1, t2, t3);
+            }
+            var (t4, t5, t6, t7) = L2(""A"", 5);
+            return (t4, t5, t6);
+        }
+        L1(""B"");
+    }
+}
+
+class Program
+{
+    public static void Main()
+    {
+        var c = new C<string>(""C"");
+        c.M(""D"");
+    }
+}";
+            CompileAndVerify(src, expectedOutput: "CDBACDBACDBACDBACDBA",
+                additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef });
+        }
+
         internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options)
         {
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: options);


### PR DESCRIPTION
**Customer scenario**

Write a recursive local function that captures a generic type from a parent scope.

**Bugs this fixes:** 

Fixes #16038 

**Workarounds, if any**

Pass the generic parameter as a generic parameter, rather than capturing it.

**Risk**

This only affects lowering of local function references.

**Performance impact**

Low. Generic substitution is a cheap, common operation in the compiler.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

@AlekseyTs noted an inconsistency in a previous PR.

**How was the bug found?**

Code review.