### PR TITLE
revert expected vssdk wizard version

### DIFF
--- a/src/Setup/Templates/CSRef.vstemplate
+++ b/src/Setup/Templates/CSRef.vstemplate
@@ -29,7 +29,7 @@
     </ProjectCollection>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKRootTemplateWizard</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/src/Setup/Templates/CSharp/CodeRefactoring/Ref/CSharpCodeRefactoring.vstemplate
+++ b/src/Setup/Templates/CSharp/CodeRefactoring/Ref/CSharpCodeRefactoring.vstemplate
@@ -23,7 +23,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKAnalyzerTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>

--- a/src/Setup/Templates/CSharp/CodeRefactoring/Vsix/Deployment.vstemplate
+++ b/src/Setup/Templates/CSharp/CodeRefactoring/Vsix/Deployment.vstemplate
@@ -18,7 +18,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKVsixTemplateWizardSecondProject</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
@@ -26,7 +26,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKAnalyzerTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>

--- a/src/Setup/Templates/CSharp/Diagnostic/Test/Test.vstemplate
+++ b/src/Setup/Templates/CSharp/Diagnostic/Test/Test.vstemplate
@@ -24,7 +24,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKTestTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>

--- a/src/Setup/Templates/CSharp/Diagnostic/Vsix/Deployment.vstemplate
+++ b/src/Setup/Templates/CSharp/Diagnostic/Vsix/Deployment.vstemplate
@@ -18,7 +18,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKVsixTemplateWizardThirdProject</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/src/Setup/Templates/CSharpDiagnostic.vstemplate
+++ b/src/Setup/Templates/CSharpDiagnostic.vstemplate
@@ -28,7 +28,7 @@
     </ProjectCollection>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKRootTemplateWizard</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/src/Setup/Templates/VBDiagnostic.vstemplate
+++ b/src/Setup/Templates/VBDiagnostic.vstemplate
@@ -29,7 +29,7 @@
     </ProjectCollection>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKRootTemplateWizard</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/src/Setup/Templates/VBRef.vstemplate
+++ b/src/Setup/Templates/VBRef.vstemplate
@@ -30,7 +30,7 @@
     </ProjectCollection>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKRootTemplateWizard</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/src/Setup/Templates/VisualBasic/CodeRefactoring/Ref/VBCodeRefactoring.vstemplate
+++ b/src/Setup/Templates/VisualBasic/CodeRefactoring/Ref/VBCodeRefactoring.vstemplate
@@ -21,7 +21,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKAnalyzerTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>

--- a/src/Setup/Templates/VisualBasic/CodeRefactoring/Vsix/Deployment.vstemplate
+++ b/src/Setup/Templates/VisualBasic/CodeRefactoring/Vsix/Deployment.vstemplate
@@ -21,7 +21,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKVsixTemplateWizardSecondProject</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
@@ -28,7 +28,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKAnalyzerTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Test/Test.vstemplate
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Test/Test.vstemplate
@@ -37,7 +37,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKTestTemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Vsix/Deployment.vstemplate
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Vsix/Deployment.vstemplate
@@ -21,7 +21,7 @@
     </Project>
   </TemplateContent>
   <WizardExtension>
-    <Assembly>Roslyn.Templates, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
+    <Assembly>Roslyn.Templates, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</Assembly>
     <FullClassName>RoslynSDKVsixTemplateWizardThirdProject</FullClassName>
   </WizardExtension>
 </VSTemplate>


### PR DESCRIPTION
This change does not ship with roslyn.  This is merely changes the version of the VSSDK wizard to match what the build now produces