### PR TITLE
Fix ability to run portable tests with TDD, F5, etc ... 

### DIFF
--- a/build/Defaults/Portable/app.config
+++ b/build/Defaults/Portable/app.config
@@ -22,6 +22,10 @@
         <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.TraceSource" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
       </dependentAssembly>

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -21,10 +21,22 @@
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'UnitTestPortable' or '$(RoslynProjectType)' == 'UnitTestDesktop'">
+      <!-- Portable DLLs don't have a supported mechanism for deploying their dependencies
+           as a part of a normal build.  This breaks developer workflows like F5, TDD, and 
+           standard unit testing.
+
+           For developer convenience we use an unsupported way of deploying dependencies.  This
+           includes NuGet and standard references.  This is not done on official builds because
+           it's not a supported mechanism hence we don't rely on it for official validation.
+           
+           This bug tracks getting an official solution out of MSBuild.  
+
+           https://github.com/Microsoft/msbuild/issues/1499 -->
       <PropertyGroup>
-        <_CopyReferences>false</_CopyReferences>
-        <_CopyProjectReferences>false</_CopyProjectReferences>
+        <_CopyReferences>$(DeveloperBuild></_CopyReferences>
+        <_CopyProjectReferences>$(DeveloperBuild></_CopyProjectReferences>
         <_IsAnyUnitTest>true</_IsAnyUnitTest>
+        <_IsAnyPortableUnitTest>true</_IsAnyPortableUnitTest>
         <CopyNuGetImplementations>false</CopyNuGetImplementations>
         <OutDir>$(OutDir)Dlls\$(MSBuildProjectName)\</OutDir>
       </PropertyGroup>
@@ -341,6 +353,7 @@
        ==================================================================================== -->
 
   <PropertyGroup>
+    <PrepareResourcesDependsOn>DeployPortableOnDeveloperBuild;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
     <TargetFrameworkMonikerAssemblyAttributesPath>$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)</TargetFrameworkMonikerAssemblyAttributesPath>
     <PostCompileBinaryModificationSentinelFile>$(IntermediateOutputPath)$(TargetFileName).pcbm</PostCompileBinaryModificationSentinelFile>
     <OptimizationDataFolderPath>$(NuGetPackageRoot)\RoslynDependencies.OptimizationData\2.0.0-rc-61101-16\content\OptimizationData</OptimizationDataFolderPath>
@@ -409,6 +422,27 @@
       </Exec>
       <Message Text="$(IbcMergeOutput)" />
 
+  </Target>
+
+  <!-- This is part of our developer convenience work to allow easy testing of our portable 
+       unit test projects.  It's a similar mechanism to CopyNuGetImplementations but is 
+       both unsupported and somewhat special cased to our build setup.
+
+       This bug tracks getting an official solution out of MSBuild.  
+
+       https://github.com/Microsoft/msbuild/issues/1499 -->
+  <Target Name="DeployPortableOnDeveloperBuild" 
+          Condition="'$(_IsAnyPortableUnitTest)' == 'true' and '$(DeveloperBuild)' == 'true' and '$(OS)' == 'Windows_NT'">
+    <ResolveNuGetPackageAssets 
+       IncludeFrameworkReferences="true"
+       NuGetPackagesDirectory="$(NuGetPackageRoot)"
+       RuntimeIdentifier="win7"
+       ProjectLanguage="$(ProjectLanguage)"
+       ProjectLockFile="$(MSBuildThisFileDirectory)..\..\src\Test\DeployDesktopTestRuntime\project.lock.json"
+       TargetMonikers=".NETFramework,Version=v4.6">
+
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="ReferenceCopyLocalPaths" />
+    </ResolveNuGetPackageAssets>
   </Target>
 
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -3,6 +3,11 @@
   <Import Project="Versions.props"/>
 
   <PropertyGroup>
+    <JenkinsBuild>false</JenkinsBuild>
+    <JenkinsBuild Condition="'$(JENKINS_HOME)' != ''">true</JenkinsBuild>
+    <DeveloperBuild>false</DeveloperBuild>
+    <DeveloperBuild Condition="'$(OfficialBuild)' != 'true' and '$(JenkinsBuild)' != 'true'">true</DeveloperBuild>
+
     <ProjectDir>$(MSBuildThisFileDirectory)..\..\</ProjectDir>
     <NuGetToolPath>$(ProjectDir)nuget.exe</NuGetToolPath>
     <ToolsetPackagesDir>$(ProjectDir)build\ToolsetPackages\</ToolsetPackagesDir>

--- a/src/Test/Utilities/Portable/TestUtilities.csproj
+++ b/src/Test/Utilities/Portable/TestUtilities.csproj
@@ -45,16 +45,20 @@
     <PlatformTarget>ARM</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Any CPU' ">
-    <PlatformTarget></PlatformTarget>
+    <PlatformTarget>
+    </PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Any CPU' ">
-    <PlatformTarget></PlatformTarget>
+    <PlatformTarget>
+    </PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <PlatformTarget></PlatformTarget>
+    <PlatformTarget>
+    </PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <PlatformTarget></PlatformTarget>
+    <PlatformTarget>
+    </PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleToTest Include="Roslyn.Test.Utilities.Desktop" />
@@ -114,6 +118,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>TestResource.resx</DependentUpon>
     </Compile>
+    <Compile Include="ThrowingTraceListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="TestResource.resx">

--- a/src/Test/Utilities/Portable/ThrowingTraceListener.cs
+++ b/src/Test/Utilities/Portable/ThrowingTraceListener.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
     //    <trace>
     //      <listeners>
     //        <remove name="Default" />
-    //        <add name="ThrowingTraceListener" type="Microsoft.CodeAnalysis.ThrowingTraceListener, Roslyn.Test.Utilities.Desktop" />
+    //        <add name="ThrowingTraceListener" type="Microsoft.CodeAnalysis.ThrowingTraceListener, Roslyn.Test.Utilities" />
     //      </listeners>
     //    </trace>
     //  </system.diagnostics>


### PR DESCRIPTION
Infrastructure change:

Summary: after this change devs can use TDD / F5 on our syntax tests again 

Longer:

At this moment there is no supported way of building a portable DLL and deploying
current OS dependencies (say windows) as a default.  As a result these DLLs are
not full deployed post build (not runnable) and this breaks any number of
tools developers use to be productive: F5, TDD, WPF xunit runner.

Roslyn works around this for official builds by using deployment projects.  This
is a project per supported delpoyment (Desktop, CoreCLR) which consists of a
dummy EXE and referenes all of our portable DLLs.  Hence they DLLs as they exist
in that output directory are fully deployed.

This makes it possible to do official testing with confidence but doesn't developers
who want a more rapid feedback experience.

This change makes it possible to do direct testing again by adding an ad-hoc deployment
mechanism.  This uses the same code as the official deployments but is still ad-hoc
so it won't be used for official builds: just developer builds.

Here is the bug on MSBuild tracking the real bug and fix

Microsoft/msbuild#1499