### PR TITLE
Enforce DocumentationFile is a centrally controlled property

### DIFF
--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -29,14 +29,12 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <Optimize>false</Optimize>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42014</NoWarn>
     <CodeAnalysisRuleSet>..\BasicCodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42014</NoWarn>
     <CodeAnalysisRuleSet>..\BasicCodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
+++ b/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
@@ -46,12 +46,10 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AutomaticCompletion\AutomaticLineEnderCommandHandler.vb" />

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -39,12 +39,10 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <Optimize>false</Optimize>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.Features.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.Features.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures" />

--- a/src/Interactive/EditorFeatures/VisualBasic/BasicInteractiveEditorFeatures.vbproj
+++ b/src/Interactive/EditorFeatures/VisualBasic/BasicInteractiveEditorFeatures.vbproj
@@ -66,12 +66,10 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
-    <DocumentationFile>Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Interactive\FileSystem\ReferenceDirectiveCompletionProvider.vb" />

--- a/src/Samples/CSharp/ConvertToConditional/Impl/ConvertToConditionalCS.csproj
+++ b/src/Samples/CSharp/ConvertToConditional/Impl/ConvertToConditionalCS.csproj
@@ -44,7 +44,6 @@
     <RoslynProjectType>Vsix</RoslynProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DocumentationFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
   <PropertyGroup>

--- a/src/Samples/CSharp/CopyPasteWithUsing/CopyPasteWithUsing.csproj
+++ b/src/Samples/CSharp/CopyPasteWithUsing/CopyPasteWithUsing.csproj
@@ -48,7 +48,6 @@
     <RoslynProjectType>Vsix</RoslynProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DocumentationFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>

--- a/src/Samples/CSharp/FormatSolution/TestSolutionForCSharp/VisualBasicProject/VisualBasicProject.vbproj
+++ b/src/Samples/CSharp/FormatSolution/TestSolutionForCSharp/VisualBasicProject/VisualBasicProject.vbproj
@@ -19,7 +19,6 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>VisualBasicProject.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
     <RemoveIntegerChecks>true</RemoveIntegerChecks>
   </PropertyGroup>
@@ -29,7 +28,6 @@
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>VisualBasicProject.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedCS.csproj
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedCS.csproj
@@ -46,7 +46,6 @@
     <RoslynProjectType>Vsix</RoslynProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DocumentationFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>

--- a/src/Samples/CSharp/MakeConst/Impl/MakeConstCS.csproj
+++ b/src/Samples/CSharp/MakeConst/Impl/MakeConstCS.csproj
@@ -39,7 +39,6 @@
     <RoslynProjectType>Vsix</RoslynProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DocumentationFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
   <PropertyGroup>

--- a/src/Samples/CSharp/RefOutModifier/AddOrRemoveRefOutModifier.csproj
+++ b/src/Samples/CSharp/RefOutModifier/AddOrRemoveRefOutModifier.csproj
@@ -47,7 +47,6 @@
     <RoslynProjectType>Vsix</RoslynProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DocumentationFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "></PropertyGroup>
   <PropertyGroup>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/BasicAnalyzers.Test.vbproj
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Test/BasicAnalyzers.Test.vbproj
@@ -15,7 +15,6 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>BasicAnalyzers.UnitTests.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -23,7 +22,6 @@
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>BasicAnalyzers.UnitTests.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Samples/VisualBasic/ConsoleClassifier/ConsoleClassifierVB.vbproj
+++ b/src/Samples/VisualBasic/ConsoleClassifier/ConsoleClassifierVB.vbproj
@@ -52,7 +52,6 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>ConsoleClassifier.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
     <DefineConstants>$(DefineConstants),_MyType="Empty"</DefineConstants>
   </PropertyGroup>
@@ -62,7 +61,6 @@
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>ConsoleClassifier.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Samples/VisualBasic/FormatSolution/FormatSolutionVB.vbproj
+++ b/src/Samples/VisualBasic/FormatSolution/FormatSolutionVB.vbproj
@@ -49,7 +49,6 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>FormatSolution.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -58,7 +57,6 @@
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>FormatSolution.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Samples/VisualBasic/FormatSolution/TestSolutionForVB/VisualBasicProject/VisualBasicProject.vbproj
+++ b/src/Samples/VisualBasic/FormatSolution/TestSolutionForVB/VisualBasicProject/VisualBasicProject.vbproj
@@ -19,7 +19,6 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>VisualBasicProject.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
     <RemoveIntegerChecks>true</RemoveIntegerChecks>
   </PropertyGroup>
@@ -29,7 +28,6 @@
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>VisualBasicProject.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedVB.vbproj
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedVB.vbproj
@@ -39,7 +39,6 @@
     <RoslynProjectType>Vsix</RoslynProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DocumentationFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>

--- a/src/Samples/VisualBasic/TreeTransforms/TreeTransformsVB.vbproj
+++ b/src/Samples/VisualBasic/TreeTransforms/TreeTransformsVB.vbproj
@@ -29,7 +29,6 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
-    <DocumentationFile>TreeTransformsVB.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
@@ -37,7 +36,6 @@
     <DefineDebug>false</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
-    <DocumentationFile>TreeTransformsVB.xml</DocumentationFile>
     <NoWarn>$(NoWarn);42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Tools/BuildBoss/ProjectCheckerUtil.cs
+++ b/src/Tools/BuildBoss/ProjectCheckerUtil.cs
@@ -48,6 +48,7 @@ namespace BuildBoss
                 allGood &= CheckForProperty(textWriter, "RemoveIntegerChecks");
                 allGood &= CheckForProperty(textWriter, "Deterministic");
                 allGood &= CheckForProperty(textWriter, "HighEntropyVA");
+                allGood &= CheckForProperty(textWriter, "DocumentationFile");
                 
                 allGood &= CheckRoslynProjectType(textWriter);
                 allGood &= CheckProjectReferences(textWriter);


### PR DESCRIPTION
This property is controlled by our central build targets.  It shouldn't be used in indivdidual projects anymore as it can lead to bugs.  See the following PR from @KirillOsenkov for an example of how this leads to bugs

Not ask mode as it's an infrastructure change. 