### PR TITLE
Ensure that CPS property setters also invoke the code within ExecuteF…

### DIFF
--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             }
             set
             {
-                UpdateProjectDisplayName(value);
+                ExecuteForegroundAction(() => UpdateProjectDisplayName(value));
             }
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             }
             set
             {
-                UpdateProjectFilePath(value);
+                ExecuteForegroundAction(() => UpdateProjectFilePath(value));
             }
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             }
             set
             {
-                SetIntellisenseBuildResultAndNotifyWorkspaceHosts(value);
+                ExecuteForegroundAction(() => SetIntellisenseBuildResultAndNotifyWorkspaceHosts(value));
             }
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             }
             set
             {
-                NormalizeAndSetBinOutputPathAndRelatedData(value);
+                ExecuteForegroundAction(() => NormalizeAndSetBinOutputPathAndRelatedData(value));
             }
         }
 


### PR DESCRIPTION
…oregroundAction

This fixes the foreground asserts from CPS property setters.

**Customer scenario**

VS crash/in-deterministic behavior when creating dotnet core projects

**Bugs this fixes:** 
 
Fixes https://github.com/dotnet/roslyn-project-system/issues/1000.

**Workarounds, if any**

None.

**Risk**

None

**Performance impact**

Low or none

**Is this a regression from a previous update?**

Regression from dotnet/roslyn#15852

**Root cause analysis:**

We need to enable dotnet core VSI tests to catch such issues.

**How was the bug found?**

Manual/ad-hoc testing