### PR TITLE
follow up to the fix for #15672

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -382,8 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // or if we have default(T) (to do box just once)
             var nullCheckOnCopy = LocalRewriter.CanChangeValueBetweenReads(receiver, localsMayBeAssignedOrCaptured: false) ||
                                    (receiverType.IsReferenceType && receiverType.TypeKind == TypeKind.TypeParameter) ||
-                                   (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol)) ||
-                                   (receiver.IsDefaultValue() && unconstrainedReceiver);
+                                   (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol));
 
             // ===== RECEIVER
             if (nullCheckOnCopy)
@@ -492,7 +491,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             {
                 Debug.Assert(receiverTemp == null);
                 receiverTemp = EmitReceiverRef(receiver, isAccessConstrained: unconstrainedReceiver);
-                Debug.Assert(receiverTemp == null);
+                Debug.Assert(receiverTemp == null || receiver.IsDefaultValue());
             }
 
             EmitExpression(expression.WhenNotNull, used);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenShortCircuitOperatorTests.cs
@@ -6924,37 +6924,29 @@ class Program
 
             verifier.VerifyIL("Test<T>.Run", @"
 {
-  // Code size       65 (0x41)
-  .maxstack  2
+  // Code size       48 (0x30)
+  .maxstack  1
   .locals init (T V_0,
-                T V_1,
-                string V_2)
+                string V_1)
   IL_0000:  nop
   IL_0001:  ldloca.s   V_0
   IL_0003:  initobj    ""T""
   IL_0009:  ldloc.0
-  IL_000a:  stloc.0
-  IL_000b:  ldloca.s   V_0
-  IL_000d:  ldloca.s   V_1
-  IL_000f:  initobj    ""T""
-  IL_0015:  ldloc.1
-  IL_0016:  box        ""T""
-  IL_001b:  brtrue.s   IL_0031
-  IL_001d:  ldobj      ""T""
-  IL_0022:  stloc.1
-  IL_0023:  ldloca.s   V_1
-  IL_0025:  ldloc.1
-  IL_0026:  box        ""T""
-  IL_002b:  brtrue.s   IL_0031
-  IL_002d:  pop
-  IL_002e:  ldnull
-  IL_002f:  br.s       IL_003c
-  IL_0031:  constrained. ""T""
-  IL_0037:  callvirt   ""string object.ToString()""
-  IL_003c:  stloc.2
-  IL_003d:  br.s       IL_003f
-  IL_003f:  ldloc.2
-  IL_0040:  ret
+  IL_000a:  box        ""T""
+  IL_000f:  brtrue.s   IL_0014
+  IL_0011:  ldnull
+  IL_0012:  br.s       IL_002b
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  initobj    ""T""
+  IL_001c:  ldloc.0
+  IL_001d:  stloc.0
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  constrained. ""T""
+  IL_0026:  callvirt   ""string object.ToString()""
+  IL_002b:  stloc.1
+  IL_002c:  br.s       IL_002e
+  IL_002e:  ldloc.1
+  IL_002f:  ret
 }");
         }
 
@@ -7051,37 +7043,29 @@ class Program
 
             verifier.VerifyIL("Test<T>.Run", @"
 {
-  // Code size       65 (0x41)
-  .maxstack  2
+  // Code size       48 (0x30)
+  .maxstack  1
   .locals init (T V_0,
-                T V_1,
-                string V_2)
+                string V_1)
   IL_0000:  nop
   IL_0001:  ldloca.s   V_0
   IL_0003:  initobj    ""T""
   IL_0009:  ldloc.0
-  IL_000a:  stloc.0
-  IL_000b:  ldloca.s   V_0
-  IL_000d:  ldloca.s   V_1
-  IL_000f:  initobj    ""T""
-  IL_0015:  ldloc.1
-  IL_0016:  box        ""T""
-  IL_001b:  brtrue.s   IL_0031
-  IL_001d:  ldobj      ""T""
-  IL_0022:  stloc.1
-  IL_0023:  ldloca.s   V_1
-  IL_0025:  ldloc.1
-  IL_0026:  box        ""T""
-  IL_002b:  brtrue.s   IL_0031
-  IL_002d:  pop
-  IL_002e:  ldnull
-  IL_002f:  br.s       IL_003c
-  IL_0031:  constrained. ""T""
-  IL_0037:  callvirt   ""string object.ToString()""
-  IL_003c:  stloc.2
-  IL_003d:  br.s       IL_003f
-  IL_003f:  ldloc.2
-  IL_0040:  ret
+  IL_000a:  box        ""T""
+  IL_000f:  brtrue.s   IL_0014
+  IL_0011:  ldnull
+  IL_0012:  br.s       IL_002b
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  initobj    ""T""
+  IL_001c:  ldloc.0
+  IL_001d:  stloc.0
+  IL_001e:  ldloca.s   V_0
+  IL_0020:  constrained. ""T""
+  IL_0026:  callvirt   ""string object.ToString()""
+  IL_002b:  stloc.1
+  IL_002c:  br.s       IL_002e
+  IL_002e:  ldloc.1
+  IL_002f:  ret
 }");
         }
 

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -366,7 +366,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
                 If Not nullCheckOnCopy Then
                     receiverTemp = EmitReceiverRef(receiver, isAccessConstrained:=Not receiverType.IsReferenceType, addressKind:=AddressKind.ReadOnly)
-                    Debug.Assert(receiverTemp Is Nothing)
+                    Debug.Assert(receiverTemp Is Nothing OrElse receiver.IsDefaultValue())
                 End If
 
                 EmitExpression(conditional.WhenNotNull, used)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return DirectCast(receiver, BoundLocal).LocalSymbol.IsByRef
 
                 Case Else
-                    Return True
+                    Return Not receiver.IsDefaultValue()
             End Select
         End Function
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -13620,5 +13620,50 @@ IL_000c:  ret
 }
 ]]>)
         End Sub
+
+        <Fact, WorkItem(15672, "https://github.com/dotnet/roslyn/pull/15672")>
+        Public Sub ConditionalAccessOffOfUnconstrainedDefault1()
+            Dim c = CompileAndVerify(
+                <compilation>
+                    <file name="ignoreNullableValue.vb">
+Module Module1
+    Public Sub Main()
+        Test(42)
+        Test("")
+    End Sub
+
+    Public Sub Test(of T)(arg as T)
+        System.Console.WriteLine(DirectCast(Nothing, T)?.ToString())
+    End Sub
+End Module
+                    </file>
+                </compilation>, options:=TestOptions.ReleaseExe,
+                expectedOutput:="0")
+
+            c.VerifyIL("Module1.Test",
+            <![CDATA[
+{
+  // Code size       48 (0x30)
+  .maxstack  1
+  .locals init (T V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  initobj    "T"
+  IL_0008:  ldloc.0
+  IL_0009:  box        "T"
+  IL_000e:  brtrue.s   IL_0013
+  IL_0010:  ldnull
+  IL_0011:  br.s       IL_002a
+  IL_0013:  ldloca.s   V_0
+  IL_0015:  initobj    "T"
+  IL_001b:  ldloc.0
+  IL_001c:  stloc.0
+  IL_001d:  ldloca.s   V_0
+  IL_001f:  constrained. "T"
+  IL_0025:  callvirt   "Function Object.ToString() As String"
+  IL_002a:  call       "Sub System.Console.WriteLine(String)"
+  IL_002f:  ret
+}
+]]>)
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Just a minor follow up to the fix for #15672

The "default(T)" does not need to be spilled into a temp when emitting "default(T)?.Foo()"

