### PR TITLE
Disallow expression variables in query clauses.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4229,6 +4229,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Out variable and pattern variable declarations are not allowed within a query clause..
+        /// </summary>
+        internal static string ERR_ExpressionVariableInQueryClause {
+            get {
+                return ResourceManager.GetString("ERR_ExpressionVariableInQueryClause", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot define a new extension method because the compiler required type &apos;{0}&apos; cannot be found. Are you missing a reference to System.Core.dll?.
         /// </summary>
         internal static string ERR_ExtensionAttrNotFound {
@@ -10413,7 +10422,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;throw&gt;.
+        ///   Looks up a localized string similar to &lt;throw expression&gt;.
         /// </summary>
         internal static string IDS_ThrowExpression {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4969,6 +4969,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ExpressionVariableInConstructorOrFieldInitializer" xml:space="preserve">
     <value>Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.</value>
   </data>
+  <data name="ERR_ExpressionVariableInQueryClause" xml:space="preserve">
+    <value>Out variable and pattern variable declarations are not allowed within a query clause.</value>
+  </data>
   <data name="ERR_SemiOrLBraceOrArrowExpected" xml:space="preserve">
     <value>{ or ; or =&gt; expected</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1443,8 +1443,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList = 8196,
         ERR_TypeInferenceFailedForImplicitlyTypedOutVariable = 8197,
         ERR_ExpressionTreeContainsOutVariable = 8198,
+        #endregion diagnostics for out var
+
+        #region more stragglers for C# 7
         ERR_VarInvocationLvalueReserved = 8199,
         ERR_ExpressionVariableInConstructorOrFieldInitializer = 8200,
-        #endregion diagnostics for out var
+        ERR_ExpressionVariableInQueryClause = 8201,
+        #endregion more stragglers for C# 7
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -655,7 +655,7 @@ class C
         <forward declaringType=""C"" methodName=""M"" />
       </customDebugInfo>
       <sequencePoints>
-        <entry offset=""0x0"" startLine=""10"" startColumn=""17"" endLine=""10"" endColumn=""30"" />
+        <entry offset=""0x0"" startLine=""10"" startColumn=""25"" endLine=""10"" endColumn=""30"" />
       </sequencePoints>
     </method>
     <method containingType=""C+&lt;&gt;c"" name=""&lt;M&gt;b__0_1"" parameterNames=""&lt;&gt;h__TransparentIdentifier0"">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -10683,12 +10683,18 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
+                // (23,63): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { TakeOutParam(x1, out var z2) ? z2 : 0, z2, y2}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z2").WithLocation(23, 63),
                 // (25,26): error CS0103: The name 'z2' does not exist in the current context
                 //                          z2;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(25, 26),
                 // (27,15): error CS0103: The name 'z2' does not exist in the current context
                 //         Dummy(z2); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(27, 15),
+                // (33,53): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x2 = TakeOutParam(x1, out var z3) && z3 > 0 && y3 < 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z3").WithLocation(33, 53),
                 // (35,32): error CS0103: The name 'z3' does not exist in the current context
                 //                                z3};
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z3").WithArguments("z3").WithLocation(35, 32),
@@ -10698,9 +10704,15 @@ public class X
                 // (45,35): error CS0103: The name 'v4' does not exist in the current context
                 //                                   v4 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(45, 35),
+                // (44,72): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                             on x1 + y4 + z4 + (TakeOutParam(3, out var u4) ? u4 : 0) + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u4").WithLocation(44, 72),
                 // (47,35): error CS1938: The name 'u4' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
                 //                                   u4 
                 Diagnostic(ErrorCode.ERR_QueryInnerKey, "u4").WithArguments("u4").WithLocation(47, 35),
+                // (46,79): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                                equals x2 + y4 + z4 + (TakeOutParam(4, out var v4) ? v4 : 0) +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v4").WithLocation(46, 79),
                 // (49,32): error CS0103: The name 'u4' does not exist in the current context
                 //                                u4, v4 };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(49, 32),
@@ -10716,9 +10728,15 @@ public class X
                 // (61,35): error CS0103: The name 'v5' does not exist in the current context
                 //                                   v5 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(61, 35),
+                // (60,72): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                             on x1 + y5 + z5 + (TakeOutParam(3, out var u5) ? u5 : 0) + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u5").WithLocation(60, 72),
                 // (63,35): error CS1938: The name 'u5' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
                 //                                   u5 
                 Diagnostic(ErrorCode.ERR_QueryInnerKey, "u5").WithArguments("u5").WithLocation(63, 35),
+                // (62,79): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                                equals x2 + y5 + z5 + (TakeOutParam(4, out var v5) ? v5 : 0) +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v5").WithLocation(62, 79),
                 // (66,32): error CS0103: The name 'u5' does not exist in the current context
                 //                                u5, v5 };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(66, 32),
@@ -10731,6 +10749,9 @@ public class X
                 // (70,15): error CS0103: The name 'v5' does not exist in the current context
                 //         Dummy(v5); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(70, 15),
+                // (76,59): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where x > y6 && TakeOutParam(1, out var z6) && z6 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z6").WithLocation(76, 59),
                 // (78,26): error CS0103: The name 'z6' does not exist in the current context
                 //                          z6;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z6").WithArguments("z6").WithLocation(78, 26),
@@ -10740,15 +10761,21 @@ public class X
                 // (87,27): error CS0103: The name 'u7' does not exist in the current context
                 //                           u7,
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(87, 27),
+                // (86,61): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby x > y7 && TakeOutParam(1, out var z7) && z7 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z7").WithLocation(86, 61),
                 // (89,27): error CS0103: The name 'z7' does not exist in the current context
                 //                           z7   
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(89, 27),
-                // (91,31): error CS0103: The name 'u7' does not exist in the current context
-                //                          z7 + u7;
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(91, 31),
+                // (88,61): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           x > y7 && TakeOutParam(1, out var u7) && u7 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u7").WithLocation(88, 61),
                 // (91,26): error CS0103: The name 'z7' does not exist in the current context
                 //                          z7 + u7;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(91, 26),
+                // (91,31): error CS0103: The name 'u7' does not exist in the current context
+                //                          z7 + u7;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(91, 31),
                 // (93,15): error CS0103: The name 'z7' does not exist in the current context
                 //         Dummy(z7); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(93, 15),
@@ -10758,15 +10785,24 @@ public class X
                 // (88,68): error CS0165: Use of unassigned local variable 'u7'
                 //                           x > y7 && TakeOutParam(1, out var u7) && u7 == 
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "u7").WithArguments("u7").WithLocation(88, 68),
+                // (100,60): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select x > y8 && TakeOutParam(1, out var z8) && z8 == 1;
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z8").WithLocation(100, 60),
                 // (102,15): error CS0103: The name 'z8' does not exist in the current context
                 //         Dummy(z8); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z8").WithArguments("z8").WithLocation(102, 15),
                 // (112,25): error CS0103: The name 'z9' does not exist in the current context
                 //                         z9;   
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z9").WithArguments("z9").WithLocation(112, 25),
+                // (111,59): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                         x > y9 && TakeOutParam(1, out var u9) && u9 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u9").WithLocation(111, 59),
                 // (109,25): error CS0103: The name 'u9' does not exist in the current context
                 //                         u9
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u9").WithArguments("u9").WithLocation(109, 25),
+                // (108,59): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group x > y9 && TakeOutParam(1, out var z9) && z9 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z9").WithLocation(108, 59),
                 // (114,15): error CS0103: The name 'z9' does not exist in the current context
                 //         Dummy(z9); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z9").WithArguments("z9").WithLocation(114, 15),
@@ -11006,9 +11042,15 @@ public class X
                 // (18,35): error CS0103: The name 'v4' does not exist in the current context
                 //                                   v4 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(18, 35),
+                // (17,72): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                             on x1 + y4 + z4 + (TakeOutParam(3, out var u4) ? u4 : 0) + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u4").WithLocation(17, 72),
                 // (20,35): error CS1938: The name 'u4' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
                 //                                   u4 
                 Diagnostic(ErrorCode.ERR_QueryInnerKey, "u4").WithArguments("u4").WithLocation(20, 35),
+                // (19,79): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                                equals x2 + y4 + z4 + (TakeOutParam(4, out var v4) ? v4 : 0) +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v4").WithLocation(19, 79),
                 // (22,32): error CS0103: The name 'u4' does not exist in the current context
                 //                                u4, v4 };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(22, 32),
@@ -11024,9 +11066,15 @@ public class X
                 // (35,35): error CS0103: The name 'v5' does not exist in the current context
                 //                                   v5 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(35, 35),
+                // (34,72): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                             on x1 + y5 + z5 + (TakeOutParam(3, out var u5) ? u5 : 0) + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u5").WithLocation(34, 72),
                 // (37,35): error CS1938: The name 'u5' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
                 //                                   u5 
                 Diagnostic(ErrorCode.ERR_QueryInnerKey, "u5").WithArguments("u5").WithLocation(37, 35),
+                // (36,80): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                                equals x2 + y5 + z5 + (TakeOutParam(4 , out var v5) ? v5 : 0) +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v5").WithLocation(36, 80),
                 // (40,32): error CS0103: The name 'u5' does not exist in the current context
                 //                                u5, v5 };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(40, 32),
@@ -11145,42 +11193,75 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (16,62): error CS0128: A local variable named 'y1' is already defined in this scope
+                // (16,62): error CS0128: A local variable or function named 'y1' is already defined in this scope
                 //         var res = from x1 in new[] { TakeOutParam(1, out var y1) ? y1 : 0}
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y1").WithArguments("y1").WithLocation(16, 62),
                 // (17,62): error CS0136: A local or parameter named 'y2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   from x2 in new[] { TakeOutParam(2, out var y2) ? y2 : 0}
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y2").WithArguments("y2").WithLocation(17, 62),
-                // (18,62): error CS0128: A local variable named 'y3' is already defined in this scope
+                // (17,62): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { TakeOutParam(2, out var y2) ? y2 : 0}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y2").WithLocation(17, 62),
+                // (18,62): error CS0128: A local variable or function named 'y3' is already defined in this scope
                 //                   join x3 in new[] { TakeOutParam(3, out var y3) ? y3 : 0}
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y3").WithArguments("y3").WithLocation(18, 62),
                 // (19,51): error CS0136: A local or parameter named 'y4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                        on TakeOutParam(4, out var y4) ? y4 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y4").WithArguments("y4").WithLocation(19, 51),
+                // (19,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        on TakeOutParam(4, out var y4) ? y4 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y4").WithLocation(19, 51),
                 // (20,58): error CS0136: A local or parameter named 'y5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                           equals TakeOutParam(5, out var y5) ? y5 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y5").WithArguments("y5").WithLocation(20, 58),
+                // (20,58): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           equals TakeOutParam(5, out var y5) ? y5 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y5").WithLocation(20, 58),
                 // (21,49): error CS0136: A local or parameter named 'y6' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   where TakeOutParam(6, out var y6) && y6 == 1
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y6").WithArguments("y6").WithLocation(21, 49),
+                // (21,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where TakeOutParam(6, out var y6) && y6 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y6").WithLocation(21, 49),
                 // (22,51): error CS0136: A local or parameter named 'y7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   orderby TakeOutParam(7, out var y7) && y7 > 0, 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y7").WithArguments("y7").WithLocation(22, 51),
+                // (22,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby TakeOutParam(7, out var y7) && y7 > 0, 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y7").WithLocation(22, 51),
                 // (23,51): error CS0136: A local or parameter named 'y8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                           TakeOutParam(8, out var y8) && y8 > 0 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y8").WithArguments("y8").WithLocation(23, 51),
+                // (23,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           TakeOutParam(8, out var y8) && y8 > 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y8").WithLocation(23, 51),
                 // (25,47): error CS0136: A local or parameter named 'y10' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   by TakeOutParam(10, out var y10) && y10 > 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y10").WithArguments("y10").WithLocation(25, 47),
+                // (25,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   by TakeOutParam(10, out var y10) && y10 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y10").WithLocation(25, 47),
                 // (24,49): error CS0136: A local or parameter named 'y9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   group TakeOutParam(9, out var y9) && y9 > 0 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y9").WithArguments("y9").WithLocation(24, 49),
+                // (24,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group TakeOutParam(9, out var y9) && y9 > 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y9").WithLocation(24, 49),
                 // (27,54): error CS0136: A local or parameter named 'y11' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   let x11 = TakeOutParam(11, out var y11) && y11 > 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y11").WithArguments("y11").WithLocation(27, 54),
+                // (27,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x11 = TakeOutParam(11, out var y11) && y11 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y11").WithLocation(27, 54),
                 // (28,51): error CS0136: A local or parameter named 'y12' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   select TakeOutParam(12, out var y12) && y12 > 0
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y12").WithArguments("y12").WithLocation(28, 51)
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y12").WithArguments("y12").WithLocation(28, 51),
+                // (28,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select TakeOutParam(12, out var y12) && y12 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y12").WithLocation(28, 51),
+                // (30,115): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select y1 + y2 + y3 + y4 + y5 + y6 + y7 + y8 + y9 + y10 + y11 + y12 + (TakeOutParam(13, out var y13) ? y13 : 0);
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y13").WithLocation(30, 115)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -11285,42 +11366,72 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (26,62): error CS0128: A local variable named 'y1' is already defined in this scope
+                // (26,62): error CS0128: A local variable or function named 'y1' is already defined in this scope
                 //                   from x1 in new[] { TakeOutParam(1, out var y1) ? y1 : 0}
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y1").WithArguments("y1").WithLocation(26, 62),
                 // (27,62): error CS0136: A local or parameter named 'y2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   from x2 in new[] { TakeOutParam(2, out var y2) ? y2 : 0}
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y2").WithArguments("y2").WithLocation(27, 62),
-                // (28,62): error CS0128: A local variable named 'y3' is already defined in this scope
+                // (27,62): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { TakeOutParam(2, out var y2) ? y2 : 0}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y2").WithLocation(27, 62),
+                // (28,62): error CS0128: A local variable or function named 'y3' is already defined in this scope
                 //                   join x3 in new[] { TakeOutParam(3, out var y3) ? y3 : 0}
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y3").WithArguments("y3").WithLocation(28, 62),
                 // (29,51): error CS0136: A local or parameter named 'y4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                        on TakeOutParam(4, out var y4) ? y4 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y4").WithArguments("y4").WithLocation(29, 51),
+                // (29,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        on TakeOutParam(4, out var y4) ? y4 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y4").WithLocation(29, 51),
                 // (30,58): error CS0136: A local or parameter named 'y5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                           equals TakeOutParam(5, out var y5) ? y5 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y5").WithArguments("y5").WithLocation(30, 58),
+                // (30,58): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           equals TakeOutParam(5, out var y5) ? y5 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y5").WithLocation(30, 58),
                 // (31,49): error CS0136: A local or parameter named 'y6' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   where TakeOutParam(6, out var y6) && y6 == 1
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y6").WithArguments("y6").WithLocation(31, 49),
+                // (31,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where TakeOutParam(6, out var y6) && y6 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y6").WithLocation(31, 49),
                 // (32,51): error CS0136: A local or parameter named 'y7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   orderby TakeOutParam(7, out var y7) && y7 > 0, 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y7").WithArguments("y7").WithLocation(32, 51),
+                // (32,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby TakeOutParam(7, out var y7) && y7 > 0, 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y7").WithLocation(32, 51),
                 // (33,51): error CS0136: A local or parameter named 'y8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                           TakeOutParam(8, out var y8) && y8 > 0 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y8").WithArguments("y8").WithLocation(33, 51),
+                // (33,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           TakeOutParam(8, out var y8) && y8 > 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y8").WithLocation(33, 51),
                 // (35,47): error CS0136: A local or parameter named 'y10' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   by TakeOutParam(10, out var y10) && y10 > 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y10").WithArguments("y10").WithLocation(35, 47),
+                // (35,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   by TakeOutParam(10, out var y10) && y10 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y10").WithLocation(35, 47),
                 // (34,49): error CS0136: A local or parameter named 'y9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   group TakeOutParam(9, out var y9) && y9 > 0 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y9").WithArguments("y9").WithLocation(34, 49),
+                // (34,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group TakeOutParam(9, out var y9) && y9 > 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y9").WithLocation(34, 49),
                 // (37,54): error CS0136: A local or parameter named 'y11' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   let x11 = TakeOutParam(11, out var y11) && y11 > 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y11").WithArguments("y11").WithLocation(37, 54),
+                // (37,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x11 = TakeOutParam(11, out var y11) && y11 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y11").WithLocation(37, 54),
                 // (38,51): error CS0136: A local or parameter named 'y12' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   select TakeOutParam(12, out var y12) && y12 > 0
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y12").WithArguments("y12").WithLocation(38, 51)
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y12").WithArguments("y12").WithLocation(38, 51),
+                // (38,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select TakeOutParam(12, out var y12) && y12 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y12").WithLocation(38, 51)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -11675,36 +11786,66 @@ public class X
 
             // error CS0412 is misleading and reported due to preexisting bug https://github.com/dotnet/roslyn/issues/12052
             compilation.VerifyDiagnostics(
-                // (15,59): error CS0412: 'y1': a parameter or local variable cannot have the same name as a method type parameter
+                // (15,59): error CS0412: 'y1': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   from x2 in new[] { TakeOutParam(out var y1) ? y1 : 1 }
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y1").WithArguments("y1").WithLocation(15, 59),
-                // (23,48): error CS0412: 'y2': a parameter or local variable cannot have the same name as a method type parameter
+                // (15,59): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { TakeOutParam(out var y1) ? y1 : 1 }
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y1").WithLocation(15, 59),
+                // (23,48): error CS0412: 'y2': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                        on TakeOutParam(out var y2) ? y2 : 0 
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y2").WithArguments("y2").WithLocation(23, 48),
-                // (33,52): error CS0412: 'y3': a parameter or local variable cannot have the same name as a method type parameter
+                // (23,48): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        on TakeOutParam(out var y2) ? y2 : 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y2").WithLocation(23, 48),
+                // (33,52): error CS0412: 'y3': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                        equals TakeOutParam(out var y3) ? y3 : 0
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y3").WithArguments("y3").WithLocation(33, 52),
-                // (40,46): error CS0412: 'y4': a parameter or local variable cannot have the same name as a method type parameter
+                // (33,52): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        equals TakeOutParam(out var y3) ? y3 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y3").WithLocation(33, 52),
+                // (40,46): error CS0412: 'y4': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   where TakeOutParam(out var y4) && y4 == 1
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y4").WithArguments("y4").WithLocation(40, 46),
-                // (47,48): error CS0412: 'y5': a parameter or local variable cannot have the same name as a method type parameter
+                // (40,46): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where TakeOutParam(out var y4) && y4 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y4").WithLocation(40, 46),
+                // (47,48): error CS0412: 'y5': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   orderby TakeOutParam(out var y5) && y5 > 1, 
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y5").WithArguments("y5").WithLocation(47, 48),
-                // (56,48): error CS0412: 'y6': a parameter or local variable cannot have the same name as a method type parameter
+                // (47,48): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby TakeOutParam(out var y5) && y5 > 1, 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y5").WithLocation(47, 48),
+                // (56,48): error CS0412: 'y6': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                           TakeOutParam(out var y6) && y6 > 1 
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y6").WithArguments("y6").WithLocation(56, 48),
-                // (63,46): error CS0412: 'y7': a parameter or local variable cannot have the same name as a method type parameter
+                // (56,48): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           TakeOutParam(out var y6) && y6 > 1 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y6").WithLocation(56, 48),
+                // (63,46): error CS0412: 'y7': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   group TakeOutParam(out var y7) && y7 == 3 
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y7").WithArguments("y7").WithLocation(63, 46),
-                // (71,43): error CS0412: 'y8': a parameter or local variable cannot have the same name as a method type parameter
+                // (63,46): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group TakeOutParam(out var y7) && y7 == 3 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y7").WithLocation(63, 46),
+                // (71,43): error CS0412: 'y8': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   by TakeOutParam(out var y8) && y8 == 3;
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y8").WithArguments("y8").WithLocation(71, 43),
-                // (77,49): error CS0412: 'y9': a parameter or local variable cannot have the same name as a method type parameter
+                // (71,43): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   by TakeOutParam(out var y8) && y8 == 3;
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y8").WithLocation(71, 43),
+                // (77,49): error CS0412: 'y9': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   let x4 = TakeOutParam(out var y9) && y9 > 0
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y9").WithArguments("y9").WithLocation(77, 49),
-                // (84,47): error CS0412: 'y10': a parameter or local variable cannot have the same name as a method type parameter
+                // (77,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x4 = TakeOutParam(out var y9) && y9 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y9").WithLocation(77, 49),
+                // (84,47): error CS0412: 'y10': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   select TakeOutParam(out var y10) && y10 > 0;
-                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y10").WithArguments("y10").WithLocation(84, 47)
+                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y10").WithArguments("y10").WithLocation(84, 47),
+                // (84,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select TakeOutParam(out var y10) && y10 > 0;
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y10").WithLocation(84, 47)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -11786,20 +11927,52 @@ public class X
 }
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
-            CompileAndVerify(compilation, expectedOutput:
-@"1
-3
-5
-2
-4
-6
-7
-8
-10
-9
-11
-12
-");
+            compilation.VerifyDiagnostics(
+                // (14,62): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { TakeOutParam(2, out var y2) && Print(y2) ? 1 : 0}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y2").WithLocation(14, 62),
+                // (16,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        on TakeOutParam(4, out var y4) && Print(y4) ? 1 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y4").WithLocation(16, 51),
+                // (17,58): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           equals TakeOutParam(5, out var y5) && Print(y5) ? 1 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y5").WithLocation(17, 58),
+                // (18,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where TakeOutParam(6, out var y6) && Print(y6)
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y6").WithLocation(18, 49),
+                // (19,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby TakeOutParam(7, out var y7) && Print(y7), 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y7").WithLocation(19, 51),
+                // (20,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           TakeOutParam(8, out var y8) && Print(y8) 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y8").WithLocation(20, 51),
+                // (22,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   by TakeOutParam(10, out var y10) && Print(y10)
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y10").WithLocation(22, 47),
+                // (21,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group TakeOutParam(9, out var y9) && Print(y9) 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y9").WithLocation(21, 49),
+                // (24,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x11 = TakeOutParam(11, out var y11) && Print(y11)
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y11").WithLocation(24, 54),
+                // (25,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select TakeOutParam(12, out var y12) && Print(y12);
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y12").WithLocation(25, 51)
+                );
+//            CompileAndVerify(compilation, expectedOutput:
+//@"1
+//3
+//5
+//2
+//4
+//6
+//7
+//8
+//10
+//9
+//11
+//12
+//");
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -11959,6 +11959,11 @@ public class X
                 //                   select TakeOutParam(12, out var y12) && Print(y12);
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y12").WithLocation(25, 51)
                 );
+
+            // Because expression variables are not permitted in query clauses (https://github.com/dotnet/roslyn/issues/15910)
+            // this program cannot be run. However, once we allow that (https://github.com/dotnet/roslyn/issues/15619)
+            // the program wil be capable of being run. In that case the following (commented code) would test for the expected output.
+
 //            CompileAndVerify(compilation, expectedOutput:
 //@"1
 //3

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -869,6 +869,11 @@ public class X
                 //                   select 12 is var y12 && Print(y12);
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y12").WithLocation(25, 36)
                 );
+
+            // Because expression variables are not permitted in query clauses (https://github.com/dotnet/roslyn/issues/15910)
+            // this program cannot be run. However, once we allow that (https://github.com/dotnet/roslyn/issues/15619)
+            // the program wil be capable of being run. In that case the following (commented code) would test for the expected output.
+
 //            CompileAndVerify(compilation, expectedOutput:
 //@"1
 //3

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -837,20 +837,52 @@ public class X
 }
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
-            CompileAndVerify(compilation, expectedOutput:
-@"1
-3
-5
-2
-4
-6
-7
-8
-10
-9
-11
-12
-");
+            compilation.VerifyDiagnostics(
+                // (14,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { 2 is var y2 && Print(y2) ? 1 : 0}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y2").WithLocation(14, 47),
+                // (16,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        on 4 is var y4 && Print(y4) ? 1 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y4").WithLocation(16, 36),
+                // (17,43): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           equals 5 is var y5 && Print(y5) ? 1 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y5").WithLocation(17, 43),
+                // (18,34): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where 6 is var y6 && Print(y6)
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y6").WithLocation(18, 34),
+                // (19,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby 7 is var y7 && Print(y7), 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y7").WithLocation(19, 36),
+                // (20,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           8 is var y8 && Print(y8) 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y8").WithLocation(20, 36),
+                // (22,32): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   by 10 is var y10 && Print(y10)
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y10").WithLocation(22, 32),
+                // (21,34): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group 9 is var y9 && Print(y9) 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y9").WithLocation(21, 34),
+                // (24,39): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x11 = 11 is var y11 && Print(y11)
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y11").WithLocation(24, 39),
+                // (25,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select 12 is var y12 && Print(y12);
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y12").WithLocation(25, 36)
+                );
+//            CompileAndVerify(compilation, expectedOutput:
+//@"1
+//3
+//5
+//2
+//4
+//6
+//7
+//8
+//10
+//9
+//11
+//12
+//");
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
@@ -1661,105 +1661,141 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (25,26): error CS0103: The name 'z2' does not exist in the current context
-    //                          z2;
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(25, 26),
-    // (27,15): error CS0103: The name 'z2' does not exist in the current context
-    //         Dummy(z2); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(27, 15),
-    // (35,32): error CS0103: The name 'z3' does not exist in the current context
-    //                                z3};
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z3").WithArguments("z3").WithLocation(35, 32),
-    // (37,15): error CS0103: The name 'z3' does not exist in the current context
-    //         Dummy(z3); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z3").WithArguments("z3").WithLocation(37, 15),
-    // (45,35): error CS0103: The name 'v4' does not exist in the current context
-    //                                   v4 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(45, 35),
-    // (47,35): error CS1938: The name 'u4' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
-    //                                   u4 
-    Diagnostic(ErrorCode.ERR_QueryInnerKey, "u4").WithArguments("u4").WithLocation(47, 35),
-    // (49,32): error CS0103: The name 'u4' does not exist in the current context
-    //                                u4, v4 };
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(49, 32),
-    // (49,36): error CS0103: The name 'v4' does not exist in the current context
-    //                                u4, v4 };
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(49, 36),
-    // (52,15): error CS0103: The name 'u4' does not exist in the current context
-    //         Dummy(u4); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(52, 15),
-    // (53,15): error CS0103: The name 'v4' does not exist in the current context
-    //         Dummy(v4); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(53, 15),
-    // (61,35): error CS0103: The name 'v5' does not exist in the current context
-    //                                   v5 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(61, 35),
-    // (63,35): error CS1938: The name 'u5' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
-    //                                   u5 
-    Diagnostic(ErrorCode.ERR_QueryInnerKey, "u5").WithArguments("u5").WithLocation(63, 35),
-    // (66,32): error CS0103: The name 'u5' does not exist in the current context
-    //                                u5, v5 };
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(66, 32),
-    // (66,36): error CS0103: The name 'v5' does not exist in the current context
-    //                                u5, v5 };
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(66, 36),
-    // (69,15): error CS0103: The name 'u5' does not exist in the current context
-    //         Dummy(u5); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(69, 15),
-    // (70,15): error CS0103: The name 'v5' does not exist in the current context
-    //         Dummy(v5); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(70, 15),
-    // (78,26): error CS0103: The name 'z6' does not exist in the current context
-    //                          z6;
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z6").WithArguments("z6").WithLocation(78, 26),
-    // (80,15): error CS0103: The name 'z6' does not exist in the current context
-    //         Dummy(z6); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z6").WithArguments("z6").WithLocation(80, 15),
-    // (87,27): error CS0103: The name 'u7' does not exist in the current context
-    //                           u7,
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(87, 27),
-    // (89,27): error CS0103: The name 'z7' does not exist in the current context
-    //                           z7   
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(89, 27),
-    // (91,31): error CS0103: The name 'u7' does not exist in the current context
-    //                          z7 + u7;
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(91, 31),
-    // (91,26): error CS0103: The name 'z7' does not exist in the current context
-    //                          z7 + u7;
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(91, 26),
-    // (93,15): error CS0103: The name 'z7' does not exist in the current context
-    //         Dummy(z7); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(93, 15),
-    // (94,15): error CS0103: The name 'u7' does not exist in the current context
-    //         Dummy(u7); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(94, 15),
-    // (88,52): error CS0165: Use of unassigned local variable 'u7'
-    //                           x > y7 && 1 is var u7 && u7 == 
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "u7").WithArguments("u7").WithLocation(88, 52),
-    // (102,15): error CS0103: The name 'z8' does not exist in the current context
-    //         Dummy(z8); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z8").WithArguments("z8").WithLocation(102, 15),
-    // (112,25): error CS0103: The name 'z9' does not exist in the current context
-    //                         z9;   
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z9").WithArguments("z9").WithLocation(112, 25),
-    // (109,25): error CS0103: The name 'u9' does not exist in the current context
-    //                         u9
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u9").WithArguments("u9").WithLocation(109, 25),
-    // (114,15): error CS0103: The name 'z9' does not exist in the current context
-    //         Dummy(z9); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z9").WithArguments("z9").WithLocation(114, 15),
-    // (115,15): error CS0103: The name 'u9' does not exist in the current context
-    //         Dummy(u9); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u9").WithArguments("u9").WithLocation(115, 15),
-    // (108,50): error CS0165: Use of unassigned local variable 'z9'
-    //                   group x > y9 && 1 is var z9 && z9 == 
-    Diagnostic(ErrorCode.ERR_UseDefViolation, "z9").WithArguments("z9").WithLocation(108, 50),
-    // (121,24): error CS1931: The range variable 'y10' conflicts with a previous declaration of 'y10'
-    //                   from y10 in new[] { 1 }
-    Diagnostic(ErrorCode.ERR_QueryRangeVariableOverrides, "y10").WithArguments("y10").WithLocation(121, 24),
-    // (128,23): error CS1931: The range variable 'y11' conflicts with a previous declaration of 'y11'
-    //                   let y11 = x1 + 1
-    Diagnostic(ErrorCode.ERR_QueryRangeVariableOverrides, "y11").WithArguments("y11").WithLocation(128, 23)
+                // (23,48): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { x1 is var z2 ? z2 : 0, z2, y2}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z2").WithLocation(23, 48),
+                // (25,26): error CS0103: The name 'z2' does not exist in the current context
+                //                          z2;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(25, 26),
+                // (27,15): error CS0103: The name 'z2' does not exist in the current context
+                //         Dummy(z2); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(27, 15),
+                // (33,38): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x2 = x1 is var z3 && z3 > 0 && y3 < 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z3").WithLocation(33, 38),
+                // (35,32): error CS0103: The name 'z3' does not exist in the current context
+                //                                z3};
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z3").WithArguments("z3").WithLocation(35, 32),
+                // (37,15): error CS0103: The name 'z3' does not exist in the current context
+                //         Dummy(z3); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z3").WithArguments("z3").WithLocation(37, 15),
+                // (45,35): error CS0103: The name 'v4' does not exist in the current context
+                //                                   v4 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(45, 35),
+                // (44,56): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                             on x1 + y4 + z4 + 3 is var u4 ? u4 : 0 + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u4").WithLocation(44, 56),
+                // (47,35): error CS1938: The name 'u4' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                                   u4 
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "u4").WithArguments("u4").WithLocation(47, 35),
+                // (46,63): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                                equals x2 + y4 + z4 + 4 is var v4 ? v4 : 0 +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v4").WithLocation(46, 63),
+                // (49,32): error CS0103: The name 'u4' does not exist in the current context
+                //                                u4, v4 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(49, 32),
+                // (49,36): error CS0103: The name 'v4' does not exist in the current context
+                //                                u4, v4 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(49, 36),
+                // (52,15): error CS0103: The name 'u4' does not exist in the current context
+                //         Dummy(u4); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(52, 15),
+                // (53,15): error CS0103: The name 'v4' does not exist in the current context
+                //         Dummy(v4); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(53, 15),
+                // (61,35): error CS0103: The name 'v5' does not exist in the current context
+                //                                   v5 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(61, 35),
+                // (60,56): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                             on x1 + y5 + z5 + 3 is var u5 ? u5 : 0 + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u5").WithLocation(60, 56),
+                // (63,35): error CS1938: The name 'u5' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                                   u5 
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "u5").WithArguments("u5").WithLocation(63, 35),
+                // (62,63): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                                equals x2 + y5 + z5 + 4 is var v5 ? v5 : 0 +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v5").WithLocation(62, 63),
+                // (66,32): error CS0103: The name 'u5' does not exist in the current context
+                //                                u5, v5 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(66, 32),
+                // (66,36): error CS0103: The name 'v5' does not exist in the current context
+                //                                u5, v5 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(66, 36),
+                // (69,15): error CS0103: The name 'u5' does not exist in the current context
+                //         Dummy(u5); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(69, 15),
+                // (70,15): error CS0103: The name 'v5' does not exist in the current context
+                //         Dummy(v5); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(70, 15),
+                // (76,44): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where x > y6 && 1 is var z6 && z6 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z6").WithLocation(76, 44),
+                // (78,26): error CS0103: The name 'z6' does not exist in the current context
+                //                          z6;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z6").WithArguments("z6").WithLocation(78, 26),
+                // (80,15): error CS0103: The name 'z6' does not exist in the current context
+                //         Dummy(z6); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z6").WithArguments("z6").WithLocation(80, 15),
+                // (87,27): error CS0103: The name 'u7' does not exist in the current context
+                //                           u7,
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(87, 27),
+                // (86,46): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby x > y7 && 1 is var z7 && z7 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z7").WithLocation(86, 46),
+                // (89,27): error CS0103: The name 'z7' does not exist in the current context
+                //                           z7   
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(89, 27),
+                // (88,46): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           x > y7 && 1 is var u7 && u7 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u7").WithLocation(88, 46),
+                // (91,26): error CS0103: The name 'z7' does not exist in the current context
+                //                          z7 + u7;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(91, 26),
+                // (91,31): error CS0103: The name 'u7' does not exist in the current context
+                //                          z7 + u7;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(91, 31),
+                // (93,15): error CS0103: The name 'z7' does not exist in the current context
+                //         Dummy(z7); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(93, 15),
+                // (94,15): error CS0103: The name 'u7' does not exist in the current context
+                //         Dummy(u7); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(94, 15),
+                // (88,52): error CS0165: Use of unassigned local variable 'u7'
+                //                           x > y7 && 1 is var u7 && u7 == 
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "u7").WithArguments("u7").WithLocation(88, 52),
+                // (100,45): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select x > y8 && 1 is var z8 && z8 == 1;
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z8").WithLocation(100, 45),
+                // (102,15): error CS0103: The name 'z8' does not exist in the current context
+                //         Dummy(z8); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z8").WithArguments("z8").WithLocation(102, 15),
+                // (112,25): error CS0103: The name 'z9' does not exist in the current context
+                //                         z9;   
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z9").WithArguments("z9").WithLocation(112, 25),
+                // (111,44): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                         x > y9 && 1 is var u9 && u9 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u9").WithLocation(111, 44),
+                // (109,25): error CS0103: The name 'u9' does not exist in the current context
+                //                         u9
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u9").WithArguments("u9").WithLocation(109, 25),
+                // (108,44): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group x > y9 && 1 is var z9 && z9 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z9").WithLocation(108, 44),
+                // (114,15): error CS0103: The name 'z9' does not exist in the current context
+                //         Dummy(z9); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z9").WithArguments("z9").WithLocation(114, 15),
+                // (115,15): error CS0103: The name 'u9' does not exist in the current context
+                //         Dummy(u9); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u9").WithArguments("u9").WithLocation(115, 15),
+                // (108,50): error CS0165: Use of unassigned local variable 'z9'
+                //                   group x > y9 && 1 is var z9 && z9 == 
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z9").WithArguments("z9").WithLocation(108, 50),
+                // (121,24): error CS1931: The range variable 'y10' conflicts with a previous declaration of 'y10'
+                //                   from y10 in new[] { 1 }
+                Diagnostic(ErrorCode.ERR_QueryRangeVariableOverrides, "y10").WithArguments("y10").WithLocation(121, 24),
+                // (128,23): error CS1931: The range variable 'y11' conflicts with a previous declaration of 'y11'
+                //                   let y11 = x1 + 1
+                Diagnostic(ErrorCode.ERR_QueryRangeVariableOverrides, "y11").WithArguments("y11").WithLocation(128, 23)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -1975,42 +2011,54 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (18,35): error CS0103: The name 'v4' does not exist in the current context
-    //                                   v4 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(18, 35),
-    // (20,35): error CS1938: The name 'u4' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
-    //                                   u4 
-    Diagnostic(ErrorCode.ERR_QueryInnerKey, "u4").WithArguments("u4").WithLocation(20, 35),
-    // (22,32): error CS0103: The name 'u4' does not exist in the current context
-    //                                u4, v4 };
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(22, 32),
-    // (22,36): error CS0103: The name 'v4' does not exist in the current context
-    //                                u4, v4 };
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(22, 36),
-    // (25,15): error CS0103: The name 'u4' does not exist in the current context
-    //         Dummy(u4); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(25, 15),
-    // (26,15): error CS0103: The name 'v4' does not exist in the current context
-    //         Dummy(v4); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(26, 15),
-    // (35,35): error CS0103: The name 'v5' does not exist in the current context
-    //                                   v5 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(35, 35),
-    // (37,35): error CS1938: The name 'u5' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
-    //                                   u5 
-    Diagnostic(ErrorCode.ERR_QueryInnerKey, "u5").WithArguments("u5").WithLocation(37, 35),
-    // (40,32): error CS0103: The name 'u5' does not exist in the current context
-    //                                u5, v5 };
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(40, 32),
-    // (40,36): error CS0103: The name 'v5' does not exist in the current context
-    //                                u5, v5 };
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(40, 36),
-    // (43,15): error CS0103: The name 'u5' does not exist in the current context
-    //         Dummy(u5); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(43, 15),
-    // (44,15): error CS0103: The name 'v5' does not exist in the current context
-    //         Dummy(v5); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(44, 15)
+                // (18,35): error CS0103: The name 'v4' does not exist in the current context
+                //                                   v4 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(18, 35),
+                // (17,56): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                             on x1 + y4 + z4 + 3 is var u4 ? u4 : 0 + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u4").WithLocation(17, 56),
+                // (20,35): error CS1938: The name 'u4' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                                   u4 
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "u4").WithArguments("u4").WithLocation(20, 35),
+                // (19,63): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                                equals x2 + y4 + z4 + 4 is var v4 ? v4 : 0 +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v4").WithLocation(19, 63),
+                // (22,32): error CS0103: The name 'u4' does not exist in the current context
+                //                                u4, v4 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(22, 32),
+                // (22,36): error CS0103: The name 'v4' does not exist in the current context
+                //                                u4, v4 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(22, 36),
+                // (25,15): error CS0103: The name 'u4' does not exist in the current context
+                //         Dummy(u4); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(25, 15),
+                // (26,15): error CS0103: The name 'v4' does not exist in the current context
+                //         Dummy(v4); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(26, 15),
+                // (35,35): error CS0103: The name 'v5' does not exist in the current context
+                //                                   v5 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(35, 35),
+                // (34,56): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                             on x1 + y5 + z5 + 3 is var u5 ? u5 : 0 + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u5").WithLocation(34, 56),
+                // (37,35): error CS1938: The name 'u5' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                                   u5 
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "u5").WithArguments("u5").WithLocation(37, 35),
+                // (36,63): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                                equals x2 + y5 + z5 + 4 is var v5 ? v5 : 0 +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v5").WithLocation(36, 63),
+                // (40,32): error CS0103: The name 'u5' does not exist in the current context
+                //                                u5, v5 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(40, 32),
+                // (40,36): error CS0103: The name 'v5' does not exist in the current context
+                //                                u5, v5 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(40, 36),
+                // (43,15): error CS0103: The name 'u5' does not exist in the current context
+                //         Dummy(u5); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(43, 15),
+                // (44,15): error CS0103: The name 'v5' does not exist in the current context
+                //         Dummy(v5); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(44, 15)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -2111,42 +2159,72 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-                // (16,47): error CS0128: A local variable named 'y1' is already defined in this scope
+                // (16,47): error CS0128: A local variable or function named 'y1' is already defined in this scope
                 //         var res = from x1 in new[] { 1 is var y1 ? y1 : 0}
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y1").WithArguments("y1").WithLocation(16, 47),
                 // (17,47): error CS0136: A local or parameter named 'y2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   from x2 in new[] { 2 is var y2 ? y2 : 0}
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y2").WithArguments("y2").WithLocation(17, 47),
-                // (18,47): error CS0128: A local variable named 'y3' is already defined in this scope
+                // (17,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { 2 is var y2 ? y2 : 0}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y2").WithLocation(17, 47),
+                // (18,47): error CS0128: A local variable or function named 'y3' is already defined in this scope
                 //                   join x3 in new[] { 3 is var y3 ? y3 : 0}
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y3").WithArguments("y3").WithLocation(18, 47),
                 // (19,36): error CS0136: A local or parameter named 'y4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                        on 4 is var y4 ? y4 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y4").WithArguments("y4").WithLocation(19, 36),
+                // (19,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        on 4 is var y4 ? y4 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y4").WithLocation(19, 36),
                 // (20,43): error CS0136: A local or parameter named 'y5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                           equals 5 is var y5 ? y5 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y5").WithArguments("y5").WithLocation(20, 43),
+                // (20,43): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           equals 5 is var y5 ? y5 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y5").WithLocation(20, 43),
                 // (21,34): error CS0136: A local or parameter named 'y6' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   where 6 is var y6 && y6 == 1
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y6").WithArguments("y6").WithLocation(21, 34),
+                // (21,34): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where 6 is var y6 && y6 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y6").WithLocation(21, 34),
                 // (22,36): error CS0136: A local or parameter named 'y7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   orderby 7 is var y7 && y7 > 0, 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y7").WithArguments("y7").WithLocation(22, 36),
+                // (22,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby 7 is var y7 && y7 > 0, 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y7").WithLocation(22, 36),
                 // (23,36): error CS0136: A local or parameter named 'y8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                           8 is var y8 && y8 > 0 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y8").WithArguments("y8").WithLocation(23, 36),
+                // (23,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           8 is var y8 && y8 > 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y8").WithLocation(23, 36),
                 // (25,32): error CS0136: A local or parameter named 'y10' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   by 10 is var y10 && y10 > 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y10").WithArguments("y10").WithLocation(25, 32),
+                // (25,32): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   by 10 is var y10 && y10 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y10").WithLocation(25, 32),
                 // (24,34): error CS0136: A local or parameter named 'y9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   group 9 is var y9 && y9 > 0 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y9").WithArguments("y9").WithLocation(24, 34),
+                // (24,34): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group 9 is var y9 && y9 > 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y9").WithLocation(24, 34),
                 // (27,39): error CS0136: A local or parameter named 'y11' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   let x11 = 11 is var y11 && y11 > 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y11").WithArguments("y11").WithLocation(27, 39),
+                // (27,39): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x11 = 11 is var y11 && y11 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y11").WithLocation(27, 39),
                 // (28,36): error CS0136: A local or parameter named 'y12' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   select 12 is var y12 && y12 > 0
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y12").WithArguments("y12").WithLocation(28, 36)
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y12").WithArguments("y12").WithLocation(28, 36),
+                // (28,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select 12 is var y12 && y12 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y12").WithLocation(28, 36)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -2237,42 +2315,72 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-                // (26,47): error CS0128: A local variable named 'y1' is already defined in this scope
+                // (26,47): error CS0128: A local variable or function named 'y1' is already defined in this scope
                 //                   from x1 in new[] { 1 is var y1 ? y1 : 0}
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y1").WithArguments("y1").WithLocation(26, 47),
                 // (27,47): error CS0136: A local or parameter named 'y2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   from x2 in new[] { 2 is var y2 ? y2 : 0}
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y2").WithArguments("y2").WithLocation(27, 47),
-                // (28,47): error CS0128: A local variable named 'y3' is already defined in this scope
+                // (27,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { 2 is var y2 ? y2 : 0}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y2").WithLocation(27, 47),
+                // (28,47): error CS0128: A local variable or function named 'y3' is already defined in this scope
                 //                   join x3 in new[] { 3 is var y3 ? y3 : 0}
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y3").WithArguments("y3").WithLocation(28, 47),
                 // (29,36): error CS0136: A local or parameter named 'y4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                        on 4 is var y4 ? y4 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y4").WithArguments("y4").WithLocation(29, 36),
+                // (29,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        on 4 is var y4 ? y4 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y4").WithLocation(29, 36),
                 // (30,43): error CS0136: A local or parameter named 'y5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                           equals 5 is var y5 ? y5 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y5").WithArguments("y5").WithLocation(30, 43),
+                // (30,43): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           equals 5 is var y5 ? y5 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y5").WithLocation(30, 43),
                 // (31,34): error CS0136: A local or parameter named 'y6' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   where 6 is var y6 && y6 == 1
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y6").WithArguments("y6").WithLocation(31, 34),
+                // (31,34): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where 6 is var y6 && y6 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y6").WithLocation(31, 34),
                 // (32,36): error CS0136: A local or parameter named 'y7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   orderby 7 is var y7 && y7 > 0, 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y7").WithArguments("y7").WithLocation(32, 36),
+                // (32,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby 7 is var y7 && y7 > 0, 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y7").WithLocation(32, 36),
                 // (33,36): error CS0136: A local or parameter named 'y8' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                           8 is var y8 && y8 > 0 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y8").WithArguments("y8").WithLocation(33, 36),
+                // (33,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           8 is var y8 && y8 > 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y8").WithLocation(33, 36),
                 // (35,32): error CS0136: A local or parameter named 'y10' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   by 10 is var y10 && y10 > 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y10").WithArguments("y10").WithLocation(35, 32),
+                // (35,32): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   by 10 is var y10 && y10 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y10").WithLocation(35, 32),
                 // (34,34): error CS0136: A local or parameter named 'y9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   group 9 is var y9 && y9 > 0 
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y9").WithArguments("y9").WithLocation(34, 34),
+                // (34,34): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group 9 is var y9 && y9 > 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y9").WithLocation(34, 34),
                 // (37,39): error CS0136: A local or parameter named 'y11' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   let x11 = 11 is var y11 && y11 > 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y11").WithArguments("y11").WithLocation(37, 39),
+                // (37,39): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x11 = 11 is var y11 && y11 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y11").WithLocation(37, 39),
                 // (38,36): error CS0136: A local or parameter named 'y12' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   select 12 is var y12 && y12 > 0
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y12").WithArguments("y12").WithLocation(38, 36)
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y12").WithArguments("y12").WithLocation(38, 36),
+                // (38,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select 12 is var y12 && y12 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y12").WithLocation(38, 36)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -2597,36 +2705,66 @@ public class X
 
             // error CS0412 is misleading and reported due to preexisting bug https://github.com/dotnet/roslyn/issues/12052
             compilation.VerifyDiagnostics(
-                // (15,47): error CS0412: 'y1': a parameter or local variable cannot have the same name as a method type parameter
+                // (15,47): error CS0412: 'y1': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   from x2 in new[] { 1 is var y1 ? y1 : 1 }
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y1").WithArguments("y1").WithLocation(15, 47),
-                // (23,36): error CS0412: 'y2': a parameter or local variable cannot have the same name as a method type parameter
+                // (15,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   from x2 in new[] { 1 is var y1 ? y1 : 1 }
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y1").WithLocation(15, 47),
+                // (23,36): error CS0412: 'y2': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                        on 2 is var y2 ? y2 : 0 
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y2").WithArguments("y2").WithLocation(23, 36),
-                // (33,40): error CS0412: 'y3': a parameter or local variable cannot have the same name as a method type parameter
+                // (23,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        on 2 is var y2 ? y2 : 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y2").WithLocation(23, 36),
+                // (33,40): error CS0412: 'y3': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                        equals 3 is var y3 ? y3 : 0
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y3").WithArguments("y3").WithLocation(33, 40),
-                // (40,34): error CS0412: 'y4': a parameter or local variable cannot have the same name as a method type parameter
+                // (33,40): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                        equals 3 is var y3 ? y3 : 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y3").WithLocation(33, 40),
+                // (40,34): error CS0412: 'y4': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   where 4 is var y4 && y4 == 1
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y4").WithArguments("y4").WithLocation(40, 34),
-                // (47,36): error CS0412: 'y5': a parameter or local variable cannot have the same name as a method type parameter
+                // (40,34): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   where 4 is var y4 && y4 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y4").WithLocation(40, 34),
+                // (47,36): error CS0412: 'y5': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   orderby 5 is var y5 && y5 > 1, 
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y5").WithArguments("y5").WithLocation(47, 36),
-                // (56,36): error CS0412: 'y6': a parameter or local variable cannot have the same name as a method type parameter
+                // (47,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   orderby 5 is var y5 && y5 > 1, 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y5").WithLocation(47, 36),
+                // (56,36): error CS0412: 'y6': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                           6 is var y6 && y6 > 1 
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y6").WithArguments("y6").WithLocation(56, 36),
-                // (63,34): error CS0412: 'y7': a parameter or local variable cannot have the same name as a method type parameter
+                // (56,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                           6 is var y6 && y6 > 1 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y6").WithLocation(56, 36),
+                // (63,34): error CS0412: 'y7': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   group 7 is var y7 && y7 == 3 
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y7").WithArguments("y7").WithLocation(63, 34),
-                // (71,31): error CS0412: 'y8': a parameter or local variable cannot have the same name as a method type parameter
+                // (63,34): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   group 7 is var y7 && y7 == 3 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y7").WithLocation(63, 34),
+                // (71,31): error CS0412: 'y8': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   by 8 is var y8 && y8 == 3;
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y8").WithArguments("y8").WithLocation(71, 31),
-                // (77,37): error CS0412: 'y9': a parameter or local variable cannot have the same name as a method type parameter
+                // (71,31): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   by 8 is var y8 && y8 == 3;
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y8").WithLocation(71, 31),
+                // (77,37): error CS0412: 'y9': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   let x4 = 9 is var y9 && y9 > 0
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y9").WithArguments("y9").WithLocation(77, 37),
-                // (84,36): error CS0412: 'y10': a parameter or local variable cannot have the same name as a method type parameter
+                // (77,37): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   let x4 = 9 is var y9 && y9 > 0
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y9").WithLocation(77, 37),
+                // (84,36): error CS0412: 'y10': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                   select 10 is var y10 && y10 > 0;
-                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y10").WithArguments("y10").WithLocation(84, 36)
+                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "y10").WithArguments("y10").WithLocation(84, 36),
+                // (84,36): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                   select 10 is var y10 && y10 > 0;
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "y10").WithLocation(84, 36)
                 );
 
             var tree = compilation.SyntaxTrees.Single();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -2241,5 +2241,143 @@ class Test
 
             CompileAndVerify(compilation, expectedOutput: "Select");
         }
+
+        [WorkItem(15910, "https://github.com/dotnet/roslyn/issues/15910")]
+        [Fact]
+        public void ExpressionVariablesInQueryClause_01()
+        {
+            var csSource = @"
+using System.Linq;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        var a = new[] { 1, 2, 3, 4 };
+        var za = from x in M(a, out var q1) select x; // ok
+        var zc = from x in a from y in M(a, out var z) select x; // error 1
+        var zd = from x in a from int y in M(a, out var z) select x; // error 2
+        var ze = from x in a from y in M(a, out var z) where true select x; // error 3
+        var zf = from x in a from int y in M(a, out var z) where true select x; // error 4
+        var zg = from x in a let y = M(a, out var z) select x; // error 5
+        var zh = from x in a where M(x, out var z) == 1 select x; // error 6
+        var zi = from x in a join y in M(a, out var q2) on x equals y select x; // ok
+        var zj = from x in a join y in a on M(x, out var z) equals y select x; // error 7
+        var zk = from x in a join y in a on x equals M(y, out var z) select x; // error 8
+        var zl = from x in a orderby M(x, out var z) select x; // error 9
+        var zm = from x in a orderby x, M(x, out var z) select x; // error 10
+        var zn = from x in a group M(x, out var z) by x; // error 11
+        var zo = from x in a group x by M(x, out var z); // error 12
+    }
+    public static T M<T>(T x, out T z) => z = x;
+}";
+            CreateCompilationWithMscorlibAndSystemCore(csSource).VerifyDiagnostics(
+                // (10,53): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zc = from x in a from y in M(a, out var z) select x; // error 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(10, 53),
+                // (11,57): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zd = from x in a from int y in M(a, out var z) select x; // error 2
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(11, 57),
+                // (12,53): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var ze = from x in a from y in M(a, out var z) where true select x; // error 3
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(12, 53),
+                // (13,57): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zf = from x in a from int y in M(a, out var z) where true select x; // error 4
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(13, 57),
+                // (14,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zg = from x in a let y = M(a, out var z) select x; // error 5
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(14, 51),
+                // (15,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zh = from x in a where M(x, out var z) == 1 select x; // error 6
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(15, 49),
+                // (17,58): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zj = from x in a join y in a on M(x, out var z) equals y select x; // error 7
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(17, 58),
+                // (18,67): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zk = from x in a join y in a on x equals M(y, out var z) select x; // error 8
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(18, 67),
+                // (19,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zl = from x in a orderby M(x, out var z) select x; // error 9
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(19, 51),
+                // (20,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zm = from x in a orderby x, M(x, out var z) select x; // error 10
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(20, 54),
+                // (21,49): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zn = from x in a group M(x, out var z) by x; // error 11
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(21, 49),
+                // (22,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zo = from x in a group x by M(x, out var z); // error 12
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(22, 54)
+                );
+        }
+
+        [WorkItem(15910, "https://github.com/dotnet/roslyn/issues/15910")]
+        [Fact]
+        public void ExpressionVariablesInQueryClause_02()
+        {
+            var csSource = @"
+using System.Linq;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        var a = new[] { 1, 2, 3, 4 };
+        var za = from x in M(a, a is var q1) select x; // ok
+        var zc = from x in a from y in M(a, a is var z) select x; // error 1
+        var zd = from x in a from int y in M(a, a is var z) select x; // error 2
+        var ze = from x in a from y in M(a, a is var z) where true select x; // error 3
+        var zf = from x in a from int y in M(a, a is var z) where true select x; // error 4
+        var zg = from x in a let y = M(a, a is var z) select x; // error 5
+        var zh = from x in a where M(x, x is var z) == 1 select x; // error 6
+        var zi = from x in a join y in M(a, a is var q2) on x equals y select x; // ok
+        var zj = from x in a join y in a on M(x, x is var z) equals y select x; // error 7
+        var zk = from x in a join y in a on x equals M(y, y is var z) select x; // error 8
+        var zl = from x in a orderby M(x, x is var z) select x; // error 9
+        var zm = from x in a orderby x, M(x, x is var z) select x; // error 10
+        var zn = from x in a group M(x, x is var z) by x; // error 11
+        var zo = from x in a group x by M(x, x is var z); // error 12
+    }
+    public static T M<T>(T x, bool b) => x;
+}";
+            CreateCompilationWithMscorlibAndSystemCore(csSource).VerifyDiagnostics(
+                // (10,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zc = from x in a from y in M(a, a is var z) select x; // error 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(10, 54),
+                // (11,58): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zd = from x in a from int y in M(a, a is var z) select x; // error 2
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(11, 58),
+                // (12,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var ze = from x in a from y in M(a, a is var z) where true select x; // error 3
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(12, 54),
+                // (13,58): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zf = from x in a from int y in M(a, a is var z) where true select x; // error 4
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(13, 58),
+                // (14,52): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zg = from x in a let y = M(a, a is var z) select x; // error 5
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(14, 52),
+                // (15,50): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zh = from x in a where M(x, x is var z) == 1 select x; // error 6
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(15, 50),
+                // (17,59): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zj = from x in a join y in a on M(x, x is var z) equals y select x; // error 7
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(17, 59),
+                // (18,68): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zk = from x in a join y in a on x equals M(y, y is var z) select x; // error 8
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(18, 68),
+                // (19,52): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zl = from x in a orderby M(x, x is var z) select x; // error 9
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(19, 52),
+                // (20,55): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zm = from x in a orderby x, M(x, x is var z) select x; // error 10
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(20, 55),
+                // (21,50): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zn = from x in a group M(x, x is var z) by x; // error 11
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(21, 50),
+                // (22,55): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zo = from x in a group x by M(x, x is var z); // error 12
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(22, 55)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -2379,5 +2379,91 @@ class Program
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(22, 55)
                 );
         }
+
+        [WorkItem(15910, "https://github.com/dotnet/roslyn/issues/15910")]
+        [Fact]
+        public void ExpressionVariablesInQueryClause_03()
+        {
+            var csSource = @"
+using System.Linq;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        var a = new[] { (1, 2), (3, 4) };
+        var za = from x in M(a, (int qa, int wa) = a[0]) select x; // scoping ok
+        var zc = from x in a from y in M(a, (int z, int w) = x) select x; // error 1
+        var zd = from x in a from int y in M(a, (int z, int w) = x) select x; // error 2
+        var ze = from x in a from y in M(a, (int z, int w) = x) where true select x; // error 3
+        var zf = from x in a from int y in M(a, (int z, int w) = x) where true select x; // error 4
+        var zg = from x in a let y = M(x, (int z, int w) = x) select x; // error 5
+        var zh = from x in a where M(x, (int z, int w) = x).Item1 == 1 select x; // error 6
+        var zi = from x in a join y in M(a, (int qi, int wi) = a[0]) on x equals y select x; // scoping ok
+        var zj = from x in a join y in a on M(x, (int z, int w) = x) equals y select x; // error 7
+        var zk = from x in a join y in a on x equals M(y, (int z, int w) = y) select x; // error 8
+        var zl = from x in a orderby M(x, (int z, int w) = x) select x; // error 9
+        var zm = from x in a orderby x, M(x, (int z, int w) = x) select x; // error 10
+        var zn = from x in a group M(x, (int z, int w) = x) by x; // error 11
+        var zo = from x in a group x by M(x, (int z, int w) = x); // error 12
+    }
+    public static T M<T>(T x, (int, int) z) => x;
+}
+namespace System
+{
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+}
+";
+            CreateCompilationWithMscorlibAndSystemCore(csSource)
+                .GetDiagnostics()
+                .Where(d => d.Code != (int)ErrorCode.ERR_DeclarationExpressionNotPermitted)
+                .Verify(
+                // (10,50): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zc = from x in a from y in M(a, (int z, int w) = x) select x; // error 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(10, 50),
+                // (11,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zd = from x in a from int y in M(a, (int z, int w) = x) select x; // error 2
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(11, 54),
+                // (12,50): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var ze = from x in a from y in M(a, (int z, int w) = x) where true select x; // error 3
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(12, 50),
+                // (13,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zf = from x in a from int y in M(a, (int z, int w) = x) where true select x; // error 4
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(13, 54),
+                // (14,48): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zg = from x in a let y = M(x, (int z, int w) = x) select x; // error 5
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(14, 48),
+                // (15,46): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zh = from x in a where M(x, (int z, int w) = x).Item1 == 1 select x; // error 6
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(15, 46),
+                // (17,55): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zj = from x in a join y in a on M(x, (int z, int w) = x) equals y select x; // error 7
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(17, 55),
+                // (18,64): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zk = from x in a join y in a on x equals M(y, (int z, int w) = y) select x; // error 8
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(18, 64),
+                // (19,48): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zl = from x in a orderby M(x, (int z, int w) = x) select x; // error 9
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(19, 48),
+                // (20,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zm = from x in a orderby x, M(x, (int z, int w) = x) select x; // error 10
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(20, 51),
+                // (21,46): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zn = from x in a group M(x, (int z, int w) = x) by x; // error 11
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(21, 46),
+                // (22,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //         var zo = from x in a group x by M(x, (int z, int w) = x); // error 12
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z").WithLocation(22, 51)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Xunit;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
@@ -1011,15 +1012,25 @@ class C
 {
     static void Main(string[] args)
     {
-        C c = new C();
-        var z1 =
-            from x in c
-            select ref x;
-        var z2 =
-            from x in c
-            from C y in ref c
-            select y;
+        var a = new[] { 1, 2, 3, 4 };
+        bool b = true;
+        int i = 0;
+        { var za = from x in a select ref x; } // error 1
+        { var zc = from x in a from y in ref a select x; } // error2
+        { var zd = from x in a from int y in ref a select x; } // error 3
+        { var ze = from x in a from y in ref a where true select x; } // error 4
+        { var zf = from x in a from int y in ref a where true select x; } // error 5
+        { var zg = from x in a let y = ref a select x; } // error 6
+        { var zh = from x in a where ref b select x; } // error 7
+        { var zi = from x in a join y in ref a on x equals y select x; } // error 8 (not lambda case)
+        { var zj = from x in a join y in a on ref i equals y select x; } // error 9
+        { var zk = from x in a join y in a on x equals ref i select x; } // error 10
+        { var zl = from x in a orderby ref i select x; } // error 11
+        { var zm = from x in a orderby x, ref i select x; } // error 12
+        { var zn = from x in a group ref i by x; } // error 13
+        { var zo = from x in a group x by ref i; } // error 14
     }
+    public static T M<T>(T x, out T z) => z = x;
 
     public C Select(RefFunc<C, C> c1) => this;
     public C SelectMany(RefFunc<C, C> c1, RefFunc<C, C, C> c2) => this;
@@ -1028,58 +1039,66 @@ class C
 public delegate ref TR RefFunc<T1, TR>(T1 t1);
 public delegate ref TR RefFunc<T1, T2, TR>(T1 t1, T2 t2);
 ";
-            CreateCompilationWithMscorlibAndSystemCore(text).VerifyDiagnostics(
-                // (9,20): error CS1525: Invalid expression term 'ref'
-                //             select ref x;
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(9, 20),
-                // (9,20): error CS1002: ; expected
-                //             select ref x;
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "ref").WithLocation(9, 20),
-                // (9,25): error CS1001: Identifier expected
-                //             select ref x;
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, ";").WithLocation(9, 25),
-                // (12,25): error CS1525: Invalid expression term 'ref'
-                //             from C y in ref c
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(12, 25),
-                // (12,25): error CS0742: A query body must end with a select clause or a group clause
-                //             from C y in ref c
-                Diagnostic(ErrorCode.ERR_ExpectedSelectOrGroup, "ref").WithLocation(12, 25),
-                // (12,25): error CS1002: ; expected
-                //             from C y in ref c
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "ref").WithLocation(12, 25),
-                // (13,20): error CS1002: ; expected
-                //             select y;
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "y").WithLocation(13, 20),
-                // (9,20): error CS8150: By-value returns may only be used in methods that return by value
-                //             select ref x;
-                Diagnostic(ErrorCode.ERR_MustHaveRefReturn, "").WithLocation(9, 20),
-                // (9,24): error CS0246: The type or namespace name 'x' could not be found (are you missing a using directive or an assembly reference?)
-                //             select ref x;
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "x").WithArguments("x").WithLocation(9, 24),
-                // (9,25): error CS8174: A declaration of a by-reference variable must have an initializer
-                //             select ref x;
-                Diagnostic(ErrorCode.ERR_ByReferenceVariableMustBeInitialized, "").WithLocation(9, 25),
-                // (12,25): error CS8150: By-value returns may only be used in methods that return by value
-                //             from C y in ref c
-                Diagnostic(ErrorCode.ERR_MustHaveRefReturn, "").WithLocation(12, 25),
-                // (12,25): error CS8150: By-value returns may only be used in methods that return by value
-                //             from C y in ref c
-                Diagnostic(ErrorCode.ERR_MustHaveRefReturn, "").WithLocation(12, 25),
-                // (12,29): error CS0118: 'c' is a variable but is used like a type
-                //             from C y in ref c
-                Diagnostic(ErrorCode.ERR_BadSKknown, "c").WithArguments("c", "variable", "type").WithLocation(12, 29),
-                // (13,13): error CS8174: A declaration of a by-reference variable must have an initializer
-                //             select y;
-                Diagnostic(ErrorCode.ERR_ByReferenceVariableMustBeInitialized, "select").WithLocation(13, 13),
-                // (13,20): error CS0103: The name 'y' does not exist in the current context
-                //             select y;
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "y").WithArguments("y").WithLocation(13, 20),
-                // (13,20): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
-                //             select y;
-                Diagnostic(ErrorCode.ERR_IllegalStatement, "y").WithLocation(13, 20),
-                // (13,13): warning CS0168: The variable 'select' is declared but never used
-                //             select y;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "select").WithArguments("select").WithLocation(13, 13)
+            CreateCompilationWithMscorlibAndSystemCore(text)
+                .GetDiagnostics()
+                // It turns out each of them is diagnosed with ErrorCode.ERR_InvalidExprTerm in the midst
+                // of a flurry of other syntax errors.
+                .Where(d => d.Code == (int)ErrorCode.ERR_InvalidExprTerm)
+                .Verify(
+                // (9,39): error CS1525: Invalid expression term 'ref'
+                //         { var za = from x in a select ref x; } // error 1
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(9, 39),
+                // (10,42): error CS1525: Invalid expression term 'ref'
+                //         { var zc = from x in a from y in ref a select x; } // error2
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(10, 42),
+                // (11,46): error CS1525: Invalid expression term 'ref'
+                //         { var zd = from x in a from int y in ref a select x; } // error 3
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(11, 46),
+                // (12,42): error CS1525: Invalid expression term 'ref'
+                //         { var ze = from x in a from y in ref a where true select x; } // error 4
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(12, 42),
+                // (13,46): error CS1525: Invalid expression term 'ref'
+                //         { var zf = from x in a from int y in ref a where true select x; } // error 5
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(13, 46),
+                // (14,40): error CS1525: Invalid expression term 'ref'
+                //         { var zg = from x in a let y = ref a select x; } // error 6
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(14, 40),
+                // (15,38): error CS1525: Invalid expression term 'ref'
+                //         { var zh = from x in a where ref b select x; } // error 7
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(15, 38),
+                // (16,42): error CS1525: Invalid expression term 'ref'
+                //         { var zi = from x in a join y in ref a on x equals y select x; } // error 8 (not lambda case)
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(16, 42),
+                // (16,42): error CS1525: Invalid expression term 'ref'
+                //         { var zi = from x in a join y in ref a on x equals y select x; } // error 8 (not lambda case)
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(16, 42),
+                // (16,42): error CS1525: Invalid expression term 'ref'
+                //         { var zi = from x in a join y in ref a on x equals y select x; } // error 8 (not lambda case)
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(16, 42),
+                // (17,47): error CS1525: Invalid expression term 'ref'
+                //         { var zj = from x in a join y in a on ref i equals y select x; } // error 9
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(17, 47),
+                // (17,47): error CS1525: Invalid expression term 'ref'
+                //         { var zj = from x in a join y in a on ref i equals y select x; } // error 9
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(17, 47),
+                // (18,56): error CS1525: Invalid expression term 'ref'
+                //         { var zk = from x in a join y in a on x equals ref i select x; } // error 10
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(18, 56),
+                // (19,40): error CS1525: Invalid expression term 'ref'
+                //         { var zl = from x in a orderby ref i select x; } // error 11
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(19, 40),
+                // (20,43): error CS1525: Invalid expression term 'ref'
+                //         { var zm = from x in a orderby x, ref i select x; } // error 12
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(20, 43),
+                // (21,38): error CS1525: Invalid expression term 'ref'
+                //         { var zn = from x in a group ref i by x; } // error 13
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(21, 38),
+                // (21,38): error CS1525: Invalid expression term 'ref'
+                //         { var zn = from x in a group ref i by x; } // error 13
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(21, 38),
+                // (22,43): error CS1525: Invalid expression term 'ref'
+                //         { var zo = from x in a group x by ref i; } // error 14
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(22, 43)
                 );
         }
     }


### PR DESCRIPTION
Fixes #15910
Also fixes a sequence point issue with the let expression. Specifically, the source range for the query lambda included more than the expression of the let, but included the entire query clause. It now includes only the expression, like other query clauses.

**Customer scenario**

Writing something like
```cs
from x in e
where x is int i
select i
```

The LDM is considering supporting something like this in the future, but if we don't block off declaring expression variables in query clauses today, the `i` in the `select` clause could bind to an enclosing field instead of the pattern variable. In that case adding the feature as the LDM would like to would be a breaking change. This change blocks off the use of expression variables in query clauses so we can make a more deliberate design of how we want them to be scoped.

**Bugs this fixes:** 

Fixes #15910

**Workarounds, if any**

This isn't a compiler bug, per se, so there is nothing to work around. We are preventing customer code from blocking our ability to extend the language in the future.

**Risk**

Low, since this is just the addition of a new error case in a new feature.

**Performance impact**

Low, as this is a small modification to existing code in the compiler; we just add a test for the error case now.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This was an oversight in the LDM design for the features, called to our attention by the community.

**How was the bug found?**

Community feedback.
