### PR TITLE
Updating the open vs-integration tests to run by default.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -197,7 +197,7 @@ set TMP=%TEMP%
         }
       }
 
-      def triggerPhraseOnly = true
+      def triggerPhraseOnly = false
       def triggerPhraseExtra = ""
       Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-dev15-rc')
       Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')


### PR DESCRIPTION
FYI. @jasonmalinowski, @jaredpar, @dotnet/roslyn-infrastructure 

We are on the latest Dev15 RC bits in Jenkins and that should have resolved the deployment issues we were seeing with the VSIX.