### PR TITLE
Avoid possible null reference exception

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/Suppression/ExportSuppressionFixProviderAttribute.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/ExportSuppressionFixProviderAttribute.cs
@@ -27,13 +27,18 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             params string[] languages)
             : base(typeof(ISuppressionFixProvider))
         {
+            if (languages == null)
+            {
+                throw new ArgumentNullException(nameof(languages));
+            }
+            
             if (languages.Length == 0)
             {
-                throw new ArgumentException("languages");
+                throw new ArgumentException(nameof(languages));
             }
-
+            
+            this.Languages = languages;
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
-            this.Languages = languages ?? throw new ArgumentNullException(nameof(languages));
         }
     }
 }


### PR DESCRIPTION
This is probably introduced in a fix all operation, however, I think that is already fixed in #15023.

/cc @CyrusNajmabadi 