### PR TITLE
Disable the vs-integration tests from running with PRs by default.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -197,7 +197,7 @@ set TMP=%TEMP%
         }
       }
 
-      def triggerPhraseOnly = false
+      def triggerPhraseOnly = true
       def triggerPhraseExtra = ""
       Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-dev15-rc')
       Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')


### PR DESCRIPTION
FYI. @jaredpar, @jasonmalinowski, @dotnet/roslyn-infrastructure

I had re-enabled these yesterday. It seems that the trial license has expired since then.

We need to automate renewing the license in some manner before these can be enabled again. The issue in question is also impacting our internal integration tests.