### PR TITLE
Semantic model APIs on declaration expressions and discards

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             Error(diagnostics, ErrorCode.ERR_DeconstructionVarFormDisallowsSpecificType, component.Designation);
                         }
 
-                        return BindDeconstructionVariables(declType, component.Designation, diagnostics);
+                        return BindDeconstructionVariables(declType, component.Designation, declaration, diagnostics);
                     }
                 case SyntaxKind.TupleExpression:
                     {
@@ -770,6 +770,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private DeconstructionVariable BindDeconstructionVariables(
             TypeSymbol declType,
             VariableDesignationSyntax node,
+            CSharpSyntaxNode syntax,
             DiagnosticBag diagnostics)
         {
             switch (node.Kind())
@@ -790,9 +791,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var builder = ArrayBuilder<DeconstructionVariable>.GetInstance();
                         foreach (var n in tuple.Variables)
                         {
-                            builder.Add(BindDeconstructionVariables(declType, n, diagnostics));
+                            builder.Add(BindDeconstructionVariables(declType, n, tuple, diagnostics));
                         }
-                        return new DeconstructionVariable(builder, node);
+                        return new DeconstructionVariable(builder, syntax);
                     }
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.Kind());

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -556,7 +556,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var type = TupleTypeSymbol.Create(syntax.Location,
                 elementsBuilder.ToImmutableAndFree(), locationsBuilder.ToImmutableAndFree(),
-                elementNames: default(ImmutableArray<string>), compilation: this.Compilation);
+                elementNames: default(ImmutableArray<string>), compilation: this.Compilation, shouldCheckConstraints: false);
 
             return new BoundTupleLiteral(syntax: syntax, argumentNamesOpt: default(ImmutableArray<string>),
                 arguments: argBuilder.ToImmutableAndFree(), type: type);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -717,13 +717,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             AliasSymbol alias;
             TypeSymbol declType = BindVariableType(node.Designation, diagnostics, node.Type, ref isConst, out isVar, out alias);
             Error(diagnostics, ErrorCode.ERR_DeclarationExpressionNotPermitted, node);
-            return BindDeclarationVariables(declType, node.Designation, diagnostics);
+            return BindDeclarationVariables(declType, node.Designation, node, diagnostics);
         }
 
         /// <summary>
         /// Bind a declaration variable where it isn't permitted. The caller is expected to produce a diagnostic.
         /// </summary>
-        private BoundExpression BindDeclarationVariables(TypeSymbol declType, VariableDesignationSyntax node, DiagnosticBag diagnostics)
+        private BoundExpression BindDeclarationVariables(TypeSymbol declType, VariableDesignationSyntax node, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             declType = declType ?? CreateErrorType("var");
             switch (node.Kind())
@@ -731,7 +731,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.SingleVariableDesignation:
                     {
                         var single = (SingleVariableDesignationSyntax)node;
-                        var result = BindDeconstructionVariable(declType, single, diagnostics);
+                        var result = BindDeconstructionVariable(declType, single, syntax, diagnostics);
                         return result;
                     }
                 case SyntaxKind.DiscardDesignation:
@@ -745,7 +745,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var builder = ArrayBuilder<BoundExpression>.GetInstance(tuple.Variables.Count);
                         foreach (var n in tuple.Variables)
                         {
-                            builder.Add(BindDeclarationVariables(declType, n, diagnostics));
+                            builder.Add(BindDeclarationVariables(declType, n, n, diagnostics));
                         }
                         var subExpressions = builder.ToImmutableAndFree();
 
@@ -2173,7 +2173,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         TypeSymbol declType = BindVariableType(designation, diagnostics, typeSyntax, ref isConst, out isVar, out alias);
                         Debug.Assert(isVar == ((object)declType == null));
 
-                        return new BoundDiscardExpression((DiscardDesignationSyntax)designation, declType);
+                        return new BoundDiscardExpression(declarationExpression, declType);
                     }
                 case SyntaxKind.SingleVariableDesignation:
                     return BindOutVariableDeclarationArgument(declarationExpression, diagnostics);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
+                Debug.Assert((object)this.Type != null);
                 return new DiscardSymbol(this.Type);
             }
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDiscardExpression.cs
@@ -21,5 +21,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             return this.Update(binder.CreateErrorType("var"));
         }
+
+        public override Symbol ExpressionSymbol
+        {
+            get
+            {
+                return new DiscardSymbol(this.Type);
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -629,6 +630,45 @@ namespace Microsoft.CodeAnalysis.CSharp
         bool System.IEquatable<BoundTypeOrValueData>.Equals(BoundTypeOrValueData b)
         {
             return b == this;
+        }
+    }
+
+    internal partial class BoundTupleExpression
+    {
+        /// <summary>
+        /// Applies action to all the nested elements of this tuple.
+        /// </summary>
+        internal void VisitAllElements(Action<BoundExpression> action)
+        {
+            foreach (var argument in this.Arguments)
+            {
+                if (argument.Kind == BoundKind.TupleLiteral)
+                {
+                    ((BoundTupleExpression)argument).VisitAllElements(action);
+                }
+                else
+                {
+                    action(argument);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies action to all the nested elements of this tuple.
+        /// </summary>
+        internal void VisitAllElements<T>(Action<BoundExpression, T> action, T args)
+        {
+            foreach (var argument in this.Arguments)
+            {
+                if (argument.Kind == BoundKind.TupleLiteral)
+                {
+                    ((BoundTupleExpression)argument).VisitAllElements(action, args);
+                }
+                else
+                {
+                    action(argument, args);
+                }
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -638,24 +638,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Applies action to all the nested elements of this tuple.
         /// </summary>
-        internal void VisitAllElements(Action<BoundExpression> action)
-        {
-            foreach (var argument in this.Arguments)
-            {
-                if (argument.Kind == BoundKind.TupleLiteral)
-                {
-                    ((BoundTupleExpression)argument).VisitAllElements(action);
-                }
-                else
-                {
-                    action(argument);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Applies action to all the nested elements of this tuple.
-        /// </summary>
         internal void VisitAllElements<T>(Action<BoundExpression, T> action, T args)
         {
             foreach (var argument in this.Arguments)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -392,9 +392,7 @@
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
 
-    <!-- Various assignable expressions, in a flat structure (no nesting) -->
-    <Field Name="LeftVariables" Type="ImmutableArray&lt;BoundExpression&gt;" Null="disallow"/>
-
+    <Field Name="Left" Type="BoundTupleExpression"/>
     <Field Name="Right" Type="BoundExpression"/>
 
     <Field Name="DeconstructSteps" Type="ImmutableArray&lt;BoundDeconstructionDeconstructStep&gt;" Null="disallow" SkipInVisitor="true" />

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -882,7 +882,7 @@
          info.  It will be stripped off in the rewriter if it is redundant or causes extra
          boxing.  If this node has errors, then the conversion may not be present.-->
     <Field Name="Expression" Type="BoundExpression"/>
-    <Field Name="DeconstructionOpt" Type="BoundForEachDeconstructStep" Null="allow" SkipInVisitor="true"/>
+    <Field Name="DeconstructionOpt" Type="BoundForEachDeconstructStep" Null="allow"/>
     <Field Name="Body" Type="BoundStatement"/>
   
     <Field Name="Checked" Type="Boolean"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression SetInferredType(TypeSymbol type, Binder binderOpt, DiagnosticBag diagnostics)
         {
             Debug.Assert(binderOpt != null || (object)type != null);
-            Debug.Assert(this.Syntax.Kind() == SyntaxKind.SingleVariableDesignation);
+            Debug.Assert(this.Syntax.Kind() == SyntaxKind.SingleVariableDesignation || this.Syntax.Kind() == SyntaxKind.DeclarationExpression);
 
             bool inferenceFailed = ((object)type == null);
 

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
@@ -12,7 +12,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression SetInferredType(TypeSymbol type, Binder binderOpt, DiagnosticBag diagnostics)
         {
             Debug.Assert(binderOpt != null || (object)type != null);
-            Debug.Assert(this.Syntax.Kind() == SyntaxKind.SingleVariableDesignation || this.Syntax.Kind() == SyntaxKind.DeclarationExpression);
+
+            Debug.Assert(this.Syntax.Kind() == SyntaxKind.SingleVariableDesignation ||
+                (this.Syntax.Kind() == SyntaxKind.DeclarationExpression &&
+                ((DeclarationExpressionSyntax)this.Syntax).Designation.Kind() == SyntaxKind.SingleVariableDesignation));
 
             bool inferenceFailed = ((object)type == null);
 
@@ -55,7 +58,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void ReportInferenceFailure(DiagnosticBag diagnostics)
         {
-            var designation = (SingleVariableDesignationSyntax)this.Syntax;
+            SingleVariableDesignationSyntax designation;
+            switch (this.Syntax.Kind())
+            {
+                case SyntaxKind.SingleVariableDesignation:
+                    designation = (SingleVariableDesignationSyntax)this.Syntax;
+                    break;
+                case SyntaxKind.DeclarationExpression:
+                    designation = (SingleVariableDesignationSyntax)((DeclarationExpressionSyntax)this.Syntax).Designation;
+                    break;
+                default:
+                    throw ExceptionUtilities.Unreachable;
+            }
+
             Binder.Error(
                 diagnostics, ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, designation.Identifier,
                 designation.Identifier.ValueText);

--- a/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ReportInferenceFailure(inferenceDiagnostics);
                     }
 
-                    fieldSymbol.SetType(type, inferenceDiagnostics);
+                    type = fieldSymbol.SetType(type, inferenceDiagnostics);
                     inferenceDiagnostics.Free();
 
                     return new BoundFieldAccess(this.Syntax,

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -117,8 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         (node is ExpressionSyntax && (isSpeculative || allowNamedArgumentName || !SyntaxFacts.IsNamedArgumentName(node))) ||
                         (node is ConstructorInitializerSyntax) ||
                         (node is AttributeSyntax) ||
-                        (node is CrefSyntax) ||
-                        (node is DeclarationExpressionSyntax);
+                        (node is CrefSyntax);
             }
         }
 
@@ -536,6 +535,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 var symbol = GetDeclaredSymbol((SingleVariableDesignationSyntax)declaration.Designation, cancellationToken);
+                if ((object)symbol == null)
+                {
+                    return SymbolInfo.None;
+                }
                 return new SymbolInfo(symbol);
             }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -510,8 +510,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             CheckSyntaxNode(expression);
 
-            DeclarationExpressionSyntax parent;
-
             if (!CanGetSemanticInfo(expression, allowNamedArgumentName: true))
             {
                 return SymbolInfo.None;
@@ -521,7 +519,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Named arguments handled in special way.
                 return this.GetNamedArgumentSymbolInfo((IdentifierNameSyntax)expression, cancellationToken);
             }
-            else if (SyntaxFacts.IsDeclarationExpressionType(expression, out parent))
+            else if (SyntaxFacts.IsDeclarationExpressionType(expression, out DeclarationExpressionSyntax parent))
             {
                 if (parent.Designation.Kind() != SyntaxKind.SingleVariableDesignation)
                 {
@@ -529,6 +527,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 return TypeFromVariable((SingleVariableDesignationSyntax)parent.Designation, cancellationToken);
+            }
+            else if (expression is DeclarationExpressionSyntax declaration)
+            {
+                if (declaration.Designation.Kind() != SyntaxKind.SingleVariableDesignation)
+                {
+                    return SymbolInfo.None;
+                }
+
+                var symbol = GetDeclaredSymbol((SingleVariableDesignationSyntax)declaration.Designation, cancellationToken);
+                return new SymbolInfo(symbol);
             }
 
             return this.GetSymbolInfoWorker(expression, SymbolInfoOptions.DefaultOptions, cancellationToken);

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -97,7 +97,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case SyntaxKind.OmittedTypeArgument:
                 case SyntaxKind.RefExpression:
-                case SyntaxKind.DeclarationExpression:
                     // These are just placeholders and are not separately meaningful.
                     return false;
 
@@ -118,7 +117,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         (node is ExpressionSyntax && (isSpeculative || allowNamedArgumentName || !SyntaxFacts.IsNamedArgumentName(node))) ||
                         (node is ConstructorInitializerSyntax) ||
                         (node is AttributeSyntax) ||
-                        (node is CrefSyntax);
+                        (node is CrefSyntax) ||
+                        (node is DeclarationExpressionSyntax);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -255,30 +255,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw ExceptionUtilities.Unreachable;
             }
 
-            public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
-            {
-                Visit(node.Left);
-                Visit(node.Right);
-                // don't map the deconstruction, conversion or assignment steps
-                return null;
-            }
-
-            public override BoundNode VisitForEachStatement(BoundForEachStatement node)
-            {
-                if ((object)node.DeconstructionOpt == null)
-                {
-                    this.Visit(node.IterationVariableType);
-                }
-                else
-                {
-                    this.Visit(node.DeconstructionOpt.DeconstructionAssignment.Left);
-                }
-
-                this.Visit(node.Expression);
-                this.Visit(node.Body);
-                return null;
-            }
-
             protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
             {
-                VisitList(node.LeftVariables);
+                Visit(node.Left);
                 Visit(node.Right);
                 // don't map the deconstruction, conversion or assignment steps
                 return null;

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -263,6 +263,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
+            public override BoundNode VisitForEachStatement(BoundForEachStatement node)
+            {
+                if ((object)node.DeconstructionOpt == null)
+                {
+                    this.Visit(node.IterationVariableType);
+                }
+                else
+                {
+                    this.Visit(node.DeconstructionOpt.DeconstructionAssignment.Left);
+                }
+
+                this.Visit(node.Expression);
+                this.Visit(node.Body);
+                return null;
+            }
+
             protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1676,18 +1676,6 @@ done:
                     case SyntaxKind.AnonymousObjectMemberDeclarator:
                         return GetBindableSyntaxNode(parent);
 
-                    case SyntaxKind.DeclarationExpression:
-                    case SyntaxKind.TupleExpression:
-                        var assignment = ((ExpressionSyntax)node).GetContainingDeconstruction() as AssignmentExpressionSyntax;
-                        if (assignment != null)
-                        {
-                            return assignment;
-                        }
-                        else
-                        {
-                            goto default;
-                        }
-
                     case SyntaxKind.VariableDeclarator: // declarators are mapped in SyntaxBinder
 
                         // When a local variable declaration contains a single declarator, the bound node

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1865,7 +1865,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
         {
             base.VisitDeconstructionAssignmentOperator(node);
-            node.Left.VisitAllElements(x => this.Assign(x, value: null, refKind: RefKind.None));
+            node.Left.VisitAllElements((x, self) => self.Assign(x, value: null, refKind: RefKind.None), this);
 
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1865,11 +1865,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
         {
             base.VisitDeconstructionAssignmentOperator(node);
-
-            foreach (BoundExpression variable in node.LeftVariables)
-            {
-                Assign(variable, value: null, refKind: RefKind.None);
-            }
+            node.Left.VisitAllElements(x => this.Assign(x, value: null, refKind: RefKind.None));
 
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1664,11 +1664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
         {
-            foreach (BoundExpression variable in node.LeftVariables)
-            {
-                VisitLvalue(variable);
-            }
-
+            node.Left.VisitAllElements(x => this.VisitLvalue(x));
             VisitRvalue(node.Right);
 
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1664,7 +1664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
         {
-            node.Left.VisitAllElements(x => this.VisitLvalue(x));
+            node.Left.VisitAllElements((x, self) => self.VisitLvalue(x), this);
             VisitRvalue(node.Right);
 
             return null;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _variablesDeclared.Add(node.IterationVariableOpt);
                 }
 
-                node.DeconstructionOpt?.DeconstructionAssignment?.Left?.VisitAllElements(x => Visit(x));
+                node.DeconstructionOpt?.DeconstructionAssignment?.Left?.VisitAllElements(x => this.Visit(x));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -131,13 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _variablesDeclared.Add(node.IterationVariableOpt);
                 }
 
-                var leftVariables =
-                    (node.DeconstructionOpt?.DeconstructionAssignment?.LeftVariables)
-                    .GetValueOrDefault().NullToEmpty();
-                foreach (var variable in leftVariables)
-                {
-                    Visit(variable);
-                }
+                node.DeconstructionOpt?.DeconstructionAssignment?.Left?.VisitAllElements(x => Visit(x));
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _variablesDeclared.Add(node.IterationVariableOpt);
                 }
 
-                node.DeconstructionOpt?.DeconstructionAssignment?.Left?.VisitAllElements((x, self) => self.Visit(x), this);
+                node.DeconstructionOpt?.DeconstructionAssignment.Left.VisitAllElements((x, self) => self.Visit(x), this);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _variablesDeclared.Add(node.IterationVariableOpt);
                 }
 
-                node.DeconstructionOpt?.DeconstructionAssignment?.Left?.VisitAllElements(x => this.Visit(x));
+                node.DeconstructionOpt?.DeconstructionAssignment?.Left?.VisitAllElements((x, self) => self.Visit(x), this);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var placeholders = ArrayBuilder<BoundValuePlaceholderBase>.GetInstance();
 
             // evaluate left-hand-side side-effects
-            ImmutableArray<BoundExpression> lhsTargets = GetAssignmentTargetsAndSideEffects(node.LeftVariables, temps, stores);
+            ImmutableArray<BoundExpression> lhsTargets = GetAssignmentTargetsAndSideEffects(node.Left, temps, stores);
 
             // get or make right-hand-side values
             BoundExpression loweredRight = VisitExpression(node.Right);
@@ -152,21 +152,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Adds the side effects to stores and returns temporaries (as a flat list) to access them.
         /// </summary>
-        private ImmutableArray<BoundExpression> GetAssignmentTargetsAndSideEffects(ImmutableArray<BoundExpression> variables, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
+        private ImmutableArray<BoundExpression> GetAssignmentTargetsAndSideEffects(BoundTupleExpression variables, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
         {
-            var assignmentTargets = ArrayBuilder<BoundExpression>.GetInstance(variables.Length);
+            var assignmentTargets = ArrayBuilder<BoundExpression>.GetInstance();
 
-            foreach (var variable in variables)
-            {
-                if (variable.Kind == BoundKind.DiscardExpression)
+            variables.VisitAllElements(
+                (variable, args) =>
                 {
-                    assignmentTargets.Add(variable);
-                }
-                else
-                {
-                    assignmentTargets.Add(TransformCompoundAssignmentLHS(variable, stores, temps, isDynamicAssignment: variable.Type.IsDynamic()));
-                }
-            }
+                    if (variable.Kind == BoundKind.DiscardExpression)
+                    {
+                        assignmentTargets.Add(variable);
+                    }
+                    else
+                    {
+                        assignmentTargets.Add(this.TransformCompoundAssignmentLHS(variable, args.stores, args.temps, isDynamicAssignment: variable.Type.IsDynamic()));
+                    }
+                },
+                (temps: temps, stores: stores)
+            );
 
             return assignmentTargets.ToImmutableAndFree();
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -165,10 +165,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        args.targets.Add(this.TransformCompoundAssignmentLHS(variable, args.stores, args.temps, isDynamicAssignment: variable.Type.IsDynamic()));
+                        args.targets.Add(args.self.TransformCompoundAssignmentLHS(variable, args.stores, args.temps, isDynamicAssignment: variable.Type.IsDynamic()));
                     }
                 },
-                (temps: temps, stores: stores, targets: assignmentTargets)
+                (temps: temps, stores: stores, targets: assignmentTargets, self: this)
             );
 
             return assignmentTargets.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -161,14 +161,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (variable.Kind == BoundKind.DiscardExpression)
                     {
-                        assignmentTargets.Add(variable);
+                        args.targets.Add(variable);
                     }
                     else
                     {
-                        assignmentTargets.Add(this.TransformCompoundAssignmentLHS(variable, args.stores, args.temps, isDynamicAssignment: variable.Type.IsDynamic()));
+                        args.targets.Add(this.TransformCompoundAssignmentLHS(variable, args.stores, args.temps, isDynamicAssignment: variable.Type.IsDynamic()));
                     }
                 },
-                (temps: temps, stores: stores)
+                (temps: temps, stores: stores, targets: assignmentTargets)
             );
 
             return assignmentTargets.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private ImmutableArray<BoundExpression> GetAssignmentTargetsAndSideEffects(BoundTupleExpression variables, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
         {
-            var assignmentTargets = ArrayBuilder<BoundExpression>.GetInstance();
+            var assignmentTargets = ArrayBuilder<BoundExpression>.GetInstance(variables.Arguments.Length);
 
             variables.VisitAllElements(
                 (variable, args) =>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -532,7 +532,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (variable.Kind == BoundKind.Local)
                     {
-                        builder.Add(((BoundLocal)variable).LocalSymbol);
+                        b.Add(((BoundLocal)variable).LocalSymbol);
                     }
                 }, builder);
             return builder.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -519,22 +519,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 iterationVarDecl = new BoundExpressionStatement(assignment.Syntax, loweredAssignment);
                 RemovePlaceholderReplacement(deconstruction.TargetPlaceholder);
 
-                iterationVariables = GetLocalSymbols(assignment.LeftVariables);
+                iterationVariables = GetLocalSymbols(assignment.Left);
             }
 
             return iterationVarDecl;
         }
 
-        private static ImmutableArray<LocalSymbol> GetLocalSymbols(ImmutableArray<BoundExpression> leftVariables)
+        private static ImmutableArray<LocalSymbol> GetLocalSymbols(BoundTupleExpression left)
         {
             var builder = ArrayBuilder<LocalSymbol>.GetInstance();
-            foreach (var variable in leftVariables)
-            {
-                if (variable.Kind == BoundKind.Local)
+            left.VisitAllElements((variable, b) =>
                 {
-                    builder.Add(((BoundLocal)variable).LocalSymbol);
-                }
-            }
+                    if (variable.Kind == BoundKind.Local)
+                    {
+                        builder.Add(((BoundLocal)variable).LocalSymbol);
+                    }
+                }, builder);
             return builder.ToImmutableAndFree();
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8599,6 +8599,10 @@ tryAgain:
             {
                 var openParen = this.EatToken(SyntaxKind.OpenParenToken);
                 var listOfDesignations = _pool.AllocateSeparated<VariableDesignationSyntax>();
+
+                listOfDesignations.Add(ParseDesignation());
+                listOfDesignations.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
+
                 while (true)
                 {
                     listOfDesignations.Add(ParseDesignation());
@@ -8611,6 +8615,7 @@ tryAgain:
                         break;
                     }
                 }
+
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
                 result = _syntaxFactory.ParenthesizedVariableDesignation(openParen, listOfDesignations, closeParen);
                 _pool.Free(listOfDesignations);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/GlobalExpressionVariable.cs
@@ -104,8 +104,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Can add some diagnostics into <paramref name="diagnostics"/>. 
+        /// Returns the type that it actually locks onto (it's possible that it had already locked onto ErrorType).
         /// </summary>
-        private void SetType(CSharpCompilation compilation, DiagnosticBag diagnostics, TypeSymbol type)
+        private TypeSymbol SetType(CSharpCompilation compilation, DiagnosticBag diagnostics, TypeSymbol type)
         {
             TypeSymbol originalType = _lazyType;
 
@@ -123,14 +124,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 compilation.DeclarationDiagnostics.AddRange(diagnostics);
                 state.NotePartComplete(CompletionPart.Type);
             }
+            return _lazyType;
         }
 
         /// <summary>
-        /// Can add some diagnostics into <paramref name="diagnostics"/>. 
+        /// Can add some diagnostics into <paramref name="diagnostics"/>.
+        /// Returns the type that it actually locks onto (it's possible that it had already locked onto ErrorType).
         /// </summary>
-        internal void SetType(TypeSymbol type, DiagnosticBag diagnostics)
+        internal TypeSymbol SetType(TypeSymbol type, DiagnosticBag diagnostics)
         {
-            SetType(DeclaringCompilation, diagnostics, type);
+            return SetType(DeclaringCompilation, diagnostics, type);
         }
 
         protected virtual void InferFieldType(ConsList<FieldSymbol> fieldsBeingBound, Binder binder)

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             NamedTypeSymbol underlyingType = GetTupleUnderlyingType(elementTypes, syntax, compilation, diagnostics);
 
-            if (((SourceModuleSymbol)compilation.SourceModule).AnyReferencedAssembliesAreLinked)
+            if (((SourceModuleSymbol)compilation.SourceModule).AnyReferencedAssembliesAreLinked && diagnostics != null)
             {
                 // Complain about unembeddable types from linked assemblies.
                 Emit.NoPia.EmbeddedTypesManager.IsValidEmbeddableType(underlyingType, syntax, diagnostics);

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             NamedTypeSymbol underlyingType = GetTupleUnderlyingType(elementTypes, syntax, compilation, diagnostics);
 
-            if (((SourceModuleSymbol)compilation.SourceModule).AnyReferencedAssembliesAreLinked && diagnostics != null)
+            if (diagnostics != null && ((SourceModuleSymbol)compilation.SourceModule).AnyReferencedAssembliesAreLinked)
             {
                 // Complain about unembeddable types from linked assemblies.
                 Emit.NoPia.EmbeddedTypesManager.IsValidEmbeddableType(underlyingType, syntax, diagnostics);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5637,11 +5637,11 @@ class C
             var discard1 = GetDiscardDesignations(tree).First();
             Assert.Null(model.GetDeclaredSymbol(discard1));
             Assert.True(model.GetSymbolInfo(discard1).IsEmpty);
-            Assert.Null(model.GetTypeInfo(discard1).Type); // TODO REVIEW This seems wrong
+            Assert.Null(model.GetTypeInfo(discard1).Type);
             var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
             Assert.Equal("var _", declaration1.ToString());
             Assert.Equal("System.Int64", model.GetTypeInfo(declaration1).Type.ToTestDisplayString());
-            Assert.Null(model.GetSymbolInfo(declaration1).Symbol); // TODO REVIEW This seems wrong
+            Assert.Null(model.GetSymbolInfo(declaration1).Symbol);
 
             var discard2 = GetDiscardDesignations(tree).ElementAt(1);
             Assert.Null(model.GetDeclaredSymbol(discard2));

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1202,18 +1202,18 @@ class C
                 // (7,22): error CS0306: The type 'ArgIterator' may not be used as a type argument
                 //         (int x, var (err1, y)) = (0, new C());
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "err1").WithArguments("System.ArgIterator").WithLocation(7, 22),
-                // (8,22): error CS0306: The type 'ArgIterator' may not be used as a type argument
+                // (8,10): error CS0306: The type 'ArgIterator' may not be used as a type argument
                 //         (ArgIterator err2, var err3) = M2();
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "err2").WithArguments("System.ArgIterator").WithLocation(8, 22),
-                // (8,32): error CS0306: The type 'ArgIterator' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "ArgIterator err2").WithArguments("System.ArgIterator").WithLocation(8, 10),
+                // (8,28): error CS0306: The type 'ArgIterator' may not be used as a type argument
                 //         (ArgIterator err2, var err3) = M2();
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "err3").WithArguments("System.ArgIterator").WithLocation(8, 32),
-                // (9,31): error CS0306: The type 'ArgIterator' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "var err3").WithArguments("System.ArgIterator").WithLocation(8, 28),
+                // (9,19): error CS0306: The type 'ArgIterator' may not be used as a type argument
                 //         foreach ((ArgIterator err4, var err5) in new[] { M2() })
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "err4").WithArguments("System.ArgIterator").WithLocation(9, 31),
-                // (9,41): error CS0306: The type 'ArgIterator' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "ArgIterator err4").WithArguments("System.ArgIterator").WithLocation(9, 19),
+                // (9,37): error CS0306: The type 'ArgIterator' may not be used as a type argument
                 //         foreach ((ArgIterator err4, var err5) in new[] { M2() })
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "err5").WithArguments("System.ArgIterator").WithLocation(9, 41),
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "var err5").WithArguments("System.ArgIterator").WithLocation(9, 37),
                 // (16,17): error CS0306: The type 'ArgIterator' may not be used as a type argument
                 //         return (default(ArgIterator), default(ArgIterator));
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "default(ArgIterator)").WithArguments("System.ArgIterator").WithLocation(16, 17),
@@ -1262,18 +1262,18 @@ unsafe class C
                 // (6,22): error CS0306: The type 'int*' may not be used as a type argument
                 //         (int x, var (err1, y)) = (0, new C());
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "err1").WithArguments("int*").WithLocation(6, 22),
-                // (7,14): error CS0306: The type 'int*' may not be used as a type argument
+                // (7,10): error CS0306: The type 'int*' may not be used as a type argument
                 //         (var err2, var err3) = M2();
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "err2").WithArguments("int*").WithLocation(7, 14),
-                // (7,24): error CS0306: The type 'int*' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "var err2").WithArguments("int*").WithLocation(7, 10),
+                // (7,20): error CS0306: The type 'int*' may not be used as a type argument
                 //         (var err2, var err3) = M2();
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "err3").WithArguments("int*").WithLocation(7, 24),
-                // (8,23): error CS0306: The type 'int*' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "var err3").WithArguments("int*").WithLocation(7, 20),
+                // (8,19): error CS0306: The type 'int*' may not be used as a type argument
                 //         foreach ((var err4, var err5) in new[] { M2() })
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "err4").WithArguments("int*").WithLocation(8, 23),
-                // (8,33): error CS0306: The type 'int*' may not be used as a type argument
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "var err4").WithArguments("int*").WithLocation(8, 19),
+                // (8,29): error CS0306: The type 'int*' may not be used as a type argument
                 //         foreach ((var err4, var err5) in new[] { M2() })
-                Diagnostic(ErrorCode.ERR_BadTypeArgument, "err5").WithArguments("int*").WithLocation(8, 33),
+                Diagnostic(ErrorCode.ERR_BadTypeArgument, "var err5").WithArguments("int*").WithLocation(8, 29),
                 // (15,17): error CS0306: The type 'int*' may not be used as a type argument
                 //         return (default(int*), default(int*));
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "default(int*)").WithArguments("int*").WithLocation(15, 17),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -13665,12 +13665,12 @@ class C
                 // (6,18): error CS0150: A constant value is expected
                 //         if (o is (int a, int b)) { }
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "(int a, int b)").WithLocation(6, 18),
-                // (6,23): error CS0165: Use of unassigned local variable 'a'
+                // (6,19): error CS0165: Use of unassigned local variable 'a'
                 //         if (o is (int a, int b)) { }
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "a").WithArguments("a").WithLocation(6, 23),
-                // (6,30): error CS0165: Use of unassigned local variable 'b'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "int a").WithArguments("a").WithLocation(6, 19),
+                // (6,26): error CS0165: Use of unassigned local variable 'b'
                 //         if (o is (int a, int b)) { }
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "b").WithArguments("b").WithLocation(6, 30)
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "int b").WithArguments("b").WithLocation(6, 26)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -2526,7 +2526,15 @@ class Program
                 var si = model.GetSymbolInfo(node);
                 var symbol = si.Symbol;
                 if (symbol == null) continue;
-                Assert.NotEqual(SymbolKind.Local, symbol.Kind);
+
+                if (node is DeclarationExpressionSyntax)
+                {
+                    Assert.Equal(SymbolKind.Local, symbol.Kind);
+                }
+                else
+                {
+                    Assert.NotEqual(SymbolKind.Local, symbol.Kind);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -1585,10 +1585,10 @@ class Program
                 // (6,9): error CS0119: 'Program' is a type, which is not valid in the given context
                 //         Program operator +(Program left, Program right)
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "Program").WithArguments("Program", "type").WithLocation(6, 9),
-                // (6,28): error CS8184: A declaration is not allowed in this context.
+                // (6,28): error CS8185: A declaration is not allowed in this context.
                 //         Program operator +(Program left, Program right)
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "Program left").WithLocation(6, 28),
-                // (6,42): error CS8184: A declaration is not allowed in this context.
+                // (6,42): error CS8185: A declaration is not allowed in this context.
                 //         Program operator +(Program left, Program right)
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "Program right").WithLocation(6, 42),
                 // (6,27): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
@@ -1600,12 +1600,12 @@ class Program
                 // (8,13): error CS0127: Since 'Program.Main(string[])' returns void, a return keyword must not be followed by an object expression
                 //             return left;
                 Diagnostic(ErrorCode.ERR_RetNoObjectRequired, "return").WithArguments("Program.Main(string[])").WithLocation(8, 13),
-                // (6,36): error CS0165: Use of unassigned local variable 'left'
+                // (6,28): error CS0165: Use of unassigned local variable 'left'
                 //         Program operator +(Program left, Program right)
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "left").WithArguments("left").WithLocation(6, 36),
-                // (6,50): error CS0165: Use of unassigned local variable 'right'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "Program left").WithArguments("left").WithLocation(6, 28),
+                // (6,42): error CS0165: Use of unassigned local variable 'right'
                 //         Program operator +(Program left, Program right)
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "right").WithArguments("right").WithLocation(6, 50)
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "Program right").WithArguments("right").WithLocation(6, 42)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -27360,7 +27360,7 @@ class H
                 var x1Ref = GetReferences(tree, "x1").ToArray();
                 Assert.Equal(2, x1Ref.Length);
                 AssertContainedInDeclaratorArguments(x1Decl);
-                VerifyModelForOutField(model, x1Decl, x1Ref); // TODO FIX problem with verifying type (which is inferred to int). No member model returned.
+                VerifyModelForOutField(model, x1Decl, x1Ref);
             }
 
             {
@@ -28403,18 +28403,23 @@ public class C
             var discard1 = GetDiscardDesignations(tree).ElementAt(0);
             Assert.Null(model.GetDeclaredSymbol(discard1));
             Assert.Null(model.GetTypeInfo(discard1).Type);
+            Assert.Null(model.GetSymbolInfo(discard1).Symbol);
             var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
             Assert.Equal("int _", declaration1.ToString());
             Assert.Equal("System.Int32", model.GetTypeInfo(declaration1).Type.ToTestDisplayString());
+            Assert.Null(model.GetSymbolInfo(declaration1).Symbol);
 
             var discard2 = GetDiscardDesignations(tree).ElementAt(1);
             Assert.Null(model.GetDeclaredSymbol(discard2));
             Assert.Null(model.GetTypeInfo(discard2).Type);
+            Assert.Null(model.GetSymbolInfo(discard2).Symbol);
             var declaration2 = (DeclarationExpressionSyntax)discard2.Parent;
             Assert.Equal("var _", declaration2.ToString());
             Assert.Equal("System.Int32", model.GetTypeInfo(declaration2).Type.ToTestDisplayString());
+            Assert.Null(model.GetSymbolInfo(declaration2).Symbol);
 
             var discard3 = GetDiscardIdentifiers(tree).First();
+            Assert.Null(model.GetDeclaredSymbol(discard3));
             var discard3Symbol = (IDiscardSymbol)model.GetSymbolInfo(discard3).Symbol;
             Assert.Equal("System.Int32", discard3Symbol.Type.ToTestDisplayString());
             Assert.Equal("System.Int32", model.GetTypeInfo(discard3).Type.ToTestDisplayString());
@@ -28482,17 +28487,22 @@ public class C
 
             var discard1 = GetDiscardDesignations(tree).ElementAt(0);
             Assert.Null(model.GetDeclaredSymbol(discard1));
+            Assert.Equal(null, model.GetSymbolInfo(discard1).Symbol);
             var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
             Assert.Equal("int _", declaration1.ToString());
             Assert.Equal("System.Int32", model.GetTypeInfo(declaration1).Type.ToTestDisplayString());
+            Assert.Equal(null, model.GetSymbolInfo(declaration1).Symbol);
 
             var discard2 = GetDiscardDesignations(tree).ElementAt(1);
             Assert.Null(model.GetDeclaredSymbol(discard2));
+            Assert.Equal(null, model.GetSymbolInfo(discard2).Symbol);
             var declaration2 = (DeclarationExpressionSyntax)discard2.Parent;
             Assert.Equal("var _", declaration2.ToString());
             Assert.Equal("System.Int32", model.GetTypeInfo(declaration2).Type.ToTestDisplayString());
+            Assert.Equal(null, model.GetSymbolInfo(declaration2).Symbol);
 
             var discard3 = GetDiscardIdentifiers(tree).First();
+            Assert.Equal("System.Int32", model.GetTypeInfo(discard3).Type.ToTestDisplayString());
             var discard3Symbol = (IDiscardSymbol)model.GetSymbolInfo(discard3).Symbol;
             Assert.Equal("System.Int32", discard3Symbol.Type.ToTestDisplayString());
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -929,20 +929,14 @@ public class Cls
         private static void AssertInfoForDeclarationExpressionSyntax(SemanticModel model, DeclarationExpressionSyntax decl, Symbol expectedSymbol = null, TypeSymbol expectedType = null)
         {
             var symbolInfo = model.GetSymbolInfo(decl);
-            if (expectedSymbol != null)
-            {
-                Assert.Equal(expectedSymbol, symbolInfo.Symbol);
-            }
+            Assert.Equal(expectedSymbol, symbolInfo.Symbol);
             Assert.Empty(symbolInfo.CandidateSymbols);
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(symbolInfo, ((CSharpSemanticModel)model).GetSymbolInfo(decl));
 
             var typeInfo = model.GetTypeInfo(decl);
-            if (expectedType != null)
-            {
-                Assert.Equal(expectedType, typeInfo.Type);
-                Assert.Equal(expectedType, typeInfo.ConvertedType);
-            }
+            Assert.Equal(expectedType, typeInfo.Type);
+            Assert.Equal(expectedType, typeInfo.ConvertedType);
             Assert.Equal(typeInfo, ((CSharpSemanticModel)model).GetTypeInfo(decl));
 
             var conversion = model.ClassifyConversion(decl, model.Compilation.ObjectType, false);
@@ -11970,20 +11964,20 @@ public class X
             // this program cannot be run. However, once we allow that (https://github.com/dotnet/roslyn/issues/15619)
             // the program wil be capable of being run. In that case the following (commented code) would test for the expected output.
 
-//            CompileAndVerify(compilation, expectedOutput:
-//@"1
-//3
-//5
-//2
-//4
-//6
-//7
-//8
-//10
-//9
-//11
-//12
-//");
+            //            CompileAndVerify(compilation, expectedOutput:
+            //@"1
+            //3
+            //5
+            //2
+            //4
+            //6
+            //7
+            //8
+            //10
+            //9
+            //11
+            //12
+            //");
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -28394,19 +28394,22 @@ public class C
 
             var discard1 = GetDiscardDesignations(tree).ElementAt(0);
             Assert.Null(model.GetDeclaredSymbol(discard1));
+            Assert.Null(model.GetTypeInfo(discard1).Type);
             var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
             Assert.Equal("int _", declaration1.ToString());
-            //Assert.Equal("", model.GetTypeInfo(declaration1).Type.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/15450
+            Assert.Equal("System.Int32", model.GetTypeInfo(declaration1).Type.ToTestDisplayString());
 
             var discard2 = GetDiscardDesignations(tree).ElementAt(1);
             Assert.Null(model.GetDeclaredSymbol(discard2));
+            Assert.Null(model.GetTypeInfo(discard2).Type);
             var declaration2 = (DeclarationExpressionSyntax)discard2.Parent;
             Assert.Equal("var _", declaration2.ToString());
-            //Assert.Equal("", model.GetTypeInfo(declaration2).Type.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/15450
+            Assert.Equal("System.Int32", model.GetTypeInfo(declaration2).Type.ToTestDisplayString());
 
             var discard3 = GetDiscardIdentifiers(tree).First();
-            var symbol = (IDiscardSymbol)model.GetSymbolInfo(discard3).Symbol; // returns null  https://github.com/dotnet/roslyn/issues/15450
-            //Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
+            var discard3Symbol = (IDiscardSymbol)model.GetSymbolInfo(discard3).Symbol;
+            Assert.Equal("System.Int32", discard3Symbol.Type.ToTestDisplayString());
+            Assert.Equal("System.Int32", model.GetTypeInfo(discard3).Type.ToTestDisplayString());
 
             comp.VerifyIL("C.Main()", @"
 {
@@ -28473,17 +28476,17 @@ public class C
             Assert.Null(model.GetDeclaredSymbol(discard1));
             var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
             Assert.Equal("int _", declaration1.ToString());
-            //Assert.Equal("System.Int32", model.GetTypeInfo(declaration1).Type.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/15450
+            Assert.Equal("System.Int32", model.GetTypeInfo(declaration1).Type.ToTestDisplayString());
 
             var discard2 = GetDiscardDesignations(tree).ElementAt(1);
             Assert.Null(model.GetDeclaredSymbol(discard2));
             var declaration2 = (DeclarationExpressionSyntax)discard2.Parent;
             Assert.Equal("var _", declaration2.ToString());
-            //Assert.Equal("System.Int32", model.GetTypeInfo(declaration2).Type.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/15450
+            Assert.Equal("System.Int32", model.GetTypeInfo(declaration2).Type.ToTestDisplayString());
 
             var discard3 = GetDiscardIdentifiers(tree).First();
-            var symbol = (IDiscardSymbol)model.GetSymbolInfo(discard3).Symbol; // returns null  https://github.com/dotnet/roslyn/issues/15450
-            //Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
+            var discard3Symbol = (IDiscardSymbol)model.GetSymbolInfo(discard3).Symbol;
+            Assert.Equal("System.Int32", discard3Symbol.Type.ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -175,10 +175,10 @@ public class Cls
             var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular);
 
             compilation.VerifyDiagnostics(
-                // (6,20): error CS8184: A declaration is not allowed in this context.
+                // (6,20): error CS8185: A declaration is not allowed in this context.
                 //         Test1(out (int x1, long x2));
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int x1").WithLocation(6, 20),
-                // (6,28): error CS8184: A declaration is not allowed in this context.
+                // (6,28): error CS8185: A declaration is not allowed in this context.
                 //         Test1(out (int x1, long x2));
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "long x2").WithLocation(6, 28),
                 // (6,19): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
@@ -187,12 +187,12 @@ public class Cls
                 // (6,19): error CS1510: A ref or out value must be an assignable variable
                 //         Test1(out (int x1, long x2));
                 Diagnostic(ErrorCode.ERR_RefLvalueExpected, "(int x1, long x2)").WithLocation(6, 19),
-                // (6,24): error CS0165: Use of unassigned local variable 'x1'
+                // (6,20): error CS0165: Use of unassigned local variable 'x1'
                 //         Test1(out (int x1, long x2));
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(6, 24),
-                // (6,33): error CS0165: Use of unassigned local variable 'x2'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "int x1").WithArguments("x1").WithLocation(6, 20),
+                // (6,28): error CS0165: Use of unassigned local variable 'x2'
                 //         Test1(out (int x1, long x2));
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x2").WithArguments("x2").WithLocation(6, 33)
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "long x2").WithArguments("x2").WithLocation(6, 28)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -232,13 +232,13 @@ public class Cls
             var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular);
 
             compilation.VerifyDiagnostics(
-                // (6,20): error CS8184: A declaration is not allowed in this context.
+                // (6,20): error CS8185: A declaration is not allowed in this context.
                 //         Test1(out (int x1, (long x2, byte x3)));
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int x1").WithLocation(6, 20),
-                // (6,29): error CS8184: A declaration is not allowed in this context.
+                // (6,29): error CS8185: A declaration is not allowed in this context.
                 //         Test1(out (int x1, (long x2, byte x3)));
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "long x2").WithLocation(6, 29),
-                // (6,38): error CS8184: A declaration is not allowed in this context.
+                // (6,38): error CS8185: A declaration is not allowed in this context.
                 //         Test1(out (int x1, (long x2, byte x3)));
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "byte x3").WithLocation(6, 38),
                 // (6,28): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
@@ -250,15 +250,15 @@ public class Cls
                 // (6,19): error CS1510: A ref or out value must be an assignable variable
                 //         Test1(out (int x1, (long x2, byte x3)));
                 Diagnostic(ErrorCode.ERR_RefLvalueExpected, "(int x1, (long x2, byte x3))").WithLocation(6, 19),
-                // (6,24): error CS0165: Use of unassigned local variable 'x1'
+                // (6,20): error CS0165: Use of unassigned local variable 'x1'
                 //         Test1(out (int x1, (long x2, byte x3)));
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(6, 24),
-                // (6,34): error CS0165: Use of unassigned local variable 'x2'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "int x1").WithArguments("x1").WithLocation(6, 20),
+                // (6,29): error CS0165: Use of unassigned local variable 'x2'
                 //         Test1(out (int x1, (long x2, byte x3)));
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x2").WithArguments("x2").WithLocation(6, 34),
-                // (6,43): error CS0165: Use of unassigned local variable 'x3'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "long x2").WithArguments("x2").WithLocation(6, 29),
+                // (6,38): error CS0165: Use of unassigned local variable 'x3'
                 //         Test1(out (int x1, (long x2, byte x3)));
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x3").WithArguments("x3").WithLocation(6, 43)
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "byte x3").WithArguments("x3").WithLocation(6, 38)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -853,17 +853,17 @@ public class Cls
 
         private static void VerifyModelForOutVarWithoutDataFlow(SemanticModel model, DeclarationExpressionSyntax decl, params IdentifierNameSyntax[] references)
         {
-            VerifyModelForOutVar(model, decl, false, true, false, false, references);
+            VerifyModelForOutVar(model, decl, isDelegateCreation: false, isExecutableCode: true, isShadowed: false, verifyDataFlow: false, references: references);
         }
 
         private static void VerifyModelForOutVar(SemanticModel model, DeclarationExpressionSyntax decl, params IdentifierNameSyntax[] references)
         {
-            VerifyModelForOutVar(model, decl, false, true, false, true, references);
+            VerifyModelForOutVar(model, decl, isDelegateCreation: false, isExecutableCode: true, isShadowed: false, verifyDataFlow: true, references: references);
         }
 
         private static void VerifyModelForOutVarInNotExecutableCode(SemanticModel model, DeclarationExpressionSyntax decl, params IdentifierNameSyntax[] references)
         {
-            VerifyModelForOutVar(model, decl, false, false, false, true, references);
+            VerifyModelForOutVar(model, decl, isDelegateCreation: false, isExecutableCode: false, isShadowed: false, verifyDataFlow: true, references: references);
         }
 
         private static void VerifyModelForOutVar(
@@ -926,17 +926,23 @@ public class Cls
             }
         }
 
-        private static void AssertInfoForDeclarationExpressionSyntax(SemanticModel model, DeclarationExpressionSyntax decl)
+        private static void AssertInfoForDeclarationExpressionSyntax(SemanticModel model, DeclarationExpressionSyntax decl, bool expectSymbol = true, bool expectType = true)
         {
             var symbolInfo = model.GetSymbolInfo(decl);
-            Assert.Null(symbolInfo.Symbol);
+            if (expectSymbol)
+            {
+                Assert.NotNull(symbolInfo.Symbol);
+            }
             Assert.Empty(symbolInfo.CandidateSymbols);
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(symbolInfo, ((CSharpSemanticModel)model).GetSymbolInfo(decl));
 
             var typeInfo = model.GetTypeInfo(decl);
-            Assert.Null(typeInfo.Type);
-            Assert.Null(typeInfo.ConvertedType);
+            if (expectType)
+            {
+                Assert.NotNull(typeInfo.Type);
+                Assert.NotNull(typeInfo.ConvertedType);
+            }
             Assert.Equal(typeInfo, ((CSharpSemanticModel)model).GetTypeInfo(decl));
 
             var conversion = model.ClassifyConversion(decl, model.Compilation.ObjectType, false);
@@ -13139,7 +13145,7 @@ public class X
             Assert.Equal(2, x14Decl.Length);
             Assert.Equal(4, x14Ref.Length);
             VerifyModelForOutVar(model, x14Decl[0], x14Ref);
-            VerifyModelForOutVar(model, x14Decl[1], false, true, true);
+            VerifyModelForOutVar(model, x14Decl[1], isDelegateCreation: false, isExecutableCode: true, isShadowed: true);
 
             var x15Decl = GetOutVarDeclarations(tree, "x15").ToArray();
             var x15Ref = GetReferences(tree, "x15").ToArray();
@@ -13898,7 +13904,7 @@ public class X
             VerifyNotAnOutLocal(model, x14Ref[1]);
             VerifyNotAnOutLocal(model, x14Ref[2]);
             VerifyNotAnOutLocal(model, x14Ref[3]);
-            VerifyModelForOutVar(model, x14Decl, false, true, true);
+            VerifyModelForOutVar(model, x14Decl, isDelegateCreation: false, isExecutableCode: true, isShadowed: true);
 
             var x16Decl = GetOutVarDeclarations(tree, "x16").Single();
             var x16Ref = GetReferences(tree, "x16").ToArray();
@@ -17324,7 +17330,7 @@ public class Cls
 
             var x1Decl = GetOutVarDeclaration(tree, "x1");
             var x1Ref = GetReference(tree, "x1");
-            VerifyModelForOutVar(model, x1Decl, true, true, false, true, x1Ref);
+            VerifyModelForOutVar(model, x1Decl, isDelegateCreation: true, isExecutableCode: true, isShadowed: false, verifyDataFlow: true, references: x1Ref);
 
             Assert.Null(model.GetAliasInfo(x1Decl.Type));
             Assert.Equal("var x1", model.GetDeclaredSymbol(GetVariableDesignation(x1Decl)).ToTestDisplayString());
@@ -17953,12 +17959,12 @@ public class Cls
                 // (7,25): error CS8197: Cannot infer the type of implicitly-typed out variable 'x1'.
                 //         Test2(x[out var x1]);
                 Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedOutVariable, "x1").WithArguments("x1").WithLocation(7, 25),
-                // (9,25): error CS1615: Argument 1 may not be passed with the 'out' keyword
+                // (9,21): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //         Test2(x[out var _]);
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(9, 25),
-                // (9,25): error CS8183: Cannot infer the type of implicitly-typed discard.
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "var _").WithArguments("1", "out").WithLocation(9, 21),
+                // (9,21): error CS8183: Cannot infer the type of implicitly-typed discard.
                 //         Test2(x[out var _]);
-                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "_").WithLocation(9, 25)
+                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "var _").WithLocation(9, 21)
                 );
         }
 
@@ -18439,9 +18445,9 @@ public class Cls
             // the C# dynamic binder does not support ref or out indexers, so we don't run this
             var comp = CreateCompilationWithMscorlib(text, options: TestOptions.DebugDll, references: new[] { SystemCoreRef, CSharpRef });
             comp.VerifyDiagnostics(
-                // (7,27): error CS8183: Cannot infer the type of implicitly-typed discard.
+                // (7,23): error CS8183: Cannot infer the type of implicitly-typed discard.
                 //         var x = d[out var _];
-                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "_").WithLocation(7, 27)
+                Diagnostic(ErrorCode.ERR_DiscardTypeInferenceFailed, "var _").WithLocation(7, 23)
                 );
         }
 
@@ -18877,9 +18883,9 @@ public class Cls
                 // (9,18): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //             [out var x1] = 3,
                 Diagnostic(ErrorCode.ERR_BadArgExtraRef, "var x1").WithArguments("1", "out").WithLocation(9, 18),
-                // (10,22): error CS1615: Argument 1 may not be passed with the 'out' keyword
+                // (10,18): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //             [out var _] = 4,
-                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(10, 22),
+                Diagnostic(ErrorCode.ERR_BadArgExtraRef, "var _").WithArguments("1", "out").WithLocation(10, 18),
                 // (11,18): error CS1615: Argument 1 may not be passed with the 'out' keyword
                 //             [out _] = 5
                 Diagnostic(ErrorCode.ERR_BadArgExtraRef, "_").WithArguments("1", "out").WithLocation(11, 18),
@@ -20914,7 +20920,7 @@ public class X
             Assert.False(model.LookupNames(decl.SpanStart).Contains(identifierText));
             Assert.Null(model.GetSymbolInfo(decl.Type).Symbol);
 
-            AssertInfoForDeclarationExpressionSyntax(model, decl);
+            AssertInfoForDeclarationExpressionSyntax(model, decl, expectSymbol: false, expectType: false);
 
             VerifyModelNotSupported(model, references);
         }
@@ -23433,7 +23439,7 @@ class H
 
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
-            CompileAndVerify(compilation, expectedOutput:@"1").VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: @"1").VerifyDiagnostics();
 
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
@@ -27354,7 +27360,7 @@ class H
                 var x1Ref = GetReferences(tree, "x1").ToArray();
                 Assert.Equal(2, x1Ref.Length);
                 AssertContainedInDeclaratorArguments(x1Decl);
-                VerifyModelForOutField(model, x1Decl, x1Ref);
+                VerifyModelForOutField(model, x1Decl, x1Ref); // TODO FIX problem with verifying type (which is inferred to int). No member model returned.
             }
 
             {
@@ -28175,7 +28181,9 @@ class Program
             var inFieldDeclaratorArgumentlist = declarator != null && declarator.Parent.Parent.Kind() != SyntaxKind.LocalDeclarationStatement &&
                                            (declarator.ArgumentList?.Contains(decl)).GetValueOrDefault();
 
-            AssertInfoForDeclarationExpressionSyntax(model, decl);
+            // We're not able to get type information at such location (out var argument in global code) at this point
+            // Seee https://github.com/dotnet/roslyn/issues/13569
+            AssertInfoForDeclarationExpressionSyntax(model, decl, expectType: false);
 
             foreach (var reference in references)
             {
@@ -28665,9 +28673,9 @@ public class C
                 // (9,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.M(out object)' and 'C.M(out int)'
                 //         M(out _);
                 Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C.M(out object)", "C.M(out int)").WithLocation(9, 9),
-                // (10,20): error CS1503: Argument 1: cannot convert from 'out byte' to 'out object'
+                // (10,15): error CS1503: Argument 1: cannot convert from 'out byte' to 'out object'
                 //         M(out byte _);
-                Diagnostic(ErrorCode.ERR_BadArgType, "_").WithArguments("1", "out byte", "out object").WithLocation(10, 20)
+                Diagnostic(ErrorCode.ERR_BadArgType, "byte _").WithArguments("1", "out byte", "out object").WithLocation(10, 15)
                 );
         }
 
@@ -28694,9 +28702,9 @@ public static class S
                 // (7,18): error CS1503: Argument 2: cannot convert from 'out A' to 'out B'
                 //         a.M2(out A x);
                 Diagnostic(ErrorCode.ERR_BadArgType, "A x").WithArguments("2", "out A", "out B").WithLocation(7, 18),
-                // (8,20): error CS1503: Argument 2: cannot convert from 'out A' to 'out B'
+                // (8,18): error CS1503: Argument 2: cannot convert from 'out A' to 'out B'
                 //         a.M2(out A _);
-                Diagnostic(ErrorCode.ERR_BadArgType, "_").WithArguments("2", "out A", "out B").WithLocation(8, 20)
+                Diagnostic(ErrorCode.ERR_BadArgType, "A _").WithArguments("2", "out A", "out B").WithLocation(8, 18)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -28487,24 +28487,24 @@ public class C
 
             var discard1 = GetDiscardDesignations(tree).ElementAt(0);
             Assert.Null(model.GetDeclaredSymbol(discard1));
-            Assert.Equal(null, model.GetSymbolInfo(discard1).Symbol);
+            Assert.Null(model.GetSymbolInfo(discard1).Symbol);
             var declaration1 = (DeclarationExpressionSyntax)discard1.Parent;
             Assert.Equal("int _", declaration1.ToString());
             Assert.Equal("System.Int32", model.GetTypeInfo(declaration1).Type.ToTestDisplayString());
-            Assert.Equal(null, model.GetSymbolInfo(declaration1).Symbol);
+            Assert.Null(model.GetSymbolInfo(declaration1).Symbol);
 
             var discard2 = GetDiscardDesignations(tree).ElementAt(1);
             Assert.Null(model.GetDeclaredSymbol(discard2));
-            Assert.Equal(null, model.GetSymbolInfo(discard2).Symbol);
+            Assert.Null(model.GetSymbolInfo(discard2).Symbol);
             var declaration2 = (DeclarationExpressionSyntax)discard2.Parent;
             Assert.Equal("var _", declaration2.ToString());
             Assert.Equal("System.Int32", model.GetTypeInfo(declaration2).Type.ToTestDisplayString());
-            Assert.Equal(null, model.GetSymbolInfo(declaration2).Symbol);
+            Assert.Null(model.GetSymbolInfo(declaration2).Symbol);
 
             var discard3 = GetDiscardIdentifiers(tree).First();
             Assert.Equal("System.Int32", model.GetTypeInfo(discard3).Type.ToTestDisplayString());
             var discard3Symbol = (IDiscardSymbol)model.GetSymbolInfo(discard3).Symbol;
-            Assert.Equal("System.Int32", discard3Symbol.Type.ToTestDisplayString());
+            Assert.Equal("int _", discard3Symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -910,7 +910,7 @@ public class Cls
                 Assert.Equal(local.Type, model.GetSymbolInfo(typeSyntax).Symbol);
             }
 
-            AssertInfoForDeclarationExpressionSyntax(model, decl);
+            AssertInfoForDeclarationExpressionSyntax(model, decl, expectedSymbol: local, expectedType: local.Type);
 
             foreach (var reference in references)
             {
@@ -926,22 +926,22 @@ public class Cls
             }
         }
 
-        private static void AssertInfoForDeclarationExpressionSyntax(SemanticModel model, DeclarationExpressionSyntax decl, bool expectSymbol = true, bool expectType = true)
+        private static void AssertInfoForDeclarationExpressionSyntax(SemanticModel model, DeclarationExpressionSyntax decl, Symbol expectedSymbol = null, TypeSymbol expectedType = null)
         {
             var symbolInfo = model.GetSymbolInfo(decl);
-            if (expectSymbol)
+            if (expectedSymbol != null)
             {
-                Assert.NotNull(symbolInfo.Symbol);
+                Assert.Equal(expectedSymbol, symbolInfo.Symbol);
             }
             Assert.Empty(symbolInfo.CandidateSymbols);
             Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
             Assert.Equal(symbolInfo, ((CSharpSemanticModel)model).GetSymbolInfo(decl));
 
             var typeInfo = model.GetTypeInfo(decl);
-            if (expectType)
+            if (expectedType != null)
             {
-                Assert.NotNull(typeInfo.Type);
-                Assert.NotNull(typeInfo.ConvertedType);
+                Assert.Equal(expectedType, typeInfo.Type);
+                Assert.Equal(expectedType, typeInfo.ConvertedType);
             }
             Assert.Equal(typeInfo, ((CSharpSemanticModel)model).GetTypeInfo(decl));
 
@@ -20920,7 +20920,7 @@ public class X
             Assert.False(model.LookupNames(decl.SpanStart).Contains(identifierText));
             Assert.Null(model.GetSymbolInfo(decl.Type).Symbol);
 
-            AssertInfoForDeclarationExpressionSyntax(model, decl, expectSymbol: false, expectType: false);
+            AssertInfoForDeclarationExpressionSyntax(model, decl, expectedSymbol: null, expectedType: null);
 
             VerifyModelNotSupported(model, references);
         }
@@ -28183,7 +28183,7 @@ class Program
 
             // We're not able to get type information at such location (out var argument in global code) at this point
             // Seee https://github.com/dotnet/roslyn/issues/13569
-            AssertInfoForDeclarationExpressionSyntax(model, decl, expectType: false);
+            AssertInfoForDeclarationExpressionSyntax(model, decl, expectedSymbol: local, expectedType: inFieldDeclaratorArgumentlist ? null : local.Type);
 
             foreach (var reference in references)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4010,7 +4010,7 @@ public class C
                 Write(""case int _, "");
                 break;
         }
-        switch (3)
+        switch (3L)
         {
             case var _:
                 Write(""case var _"");
@@ -4029,25 +4029,29 @@ public class C
             Assert.Null(model.GetDeclaredSymbol(discard1));
             var declaration1 = (DeclarationPatternSyntax)discard1.Parent;
             Assert.Equal("int _", declaration1.ToString());
-            //Assert.Equal("", model.GetTypeInfo(declaration1).Type.ToTestDisplayString()); //  https://github.com/dotnet/roslyn/issues/15450
+            Assert.Null(model.GetTypeInfo(declaration1).Type);
+            Assert.Equal("System.Int32", model.GetTypeInfo(declaration1.Type).Type.ToTestDisplayString());
 
             var discard2 = GetDiscardDesignations(tree).Skip(1).First();
             Assert.Null(model.GetDeclaredSymbol(discard2));
             var declaration2 = (DeclarationPatternSyntax)discard2.Parent;
             Assert.Equal("var _", declaration2.ToString());
-            //Assert.Equal("", model.GetTypeInfo(declaration2).Type.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/15450
+            Assert.Null(model.GetTypeInfo(declaration2).Type);
+            Assert.Equal("System.Int32", model.GetTypeInfo(declaration2.Type).Type.ToTestDisplayString());
 
             var discard3 = GetDiscardDesignations(tree).Skip(2).First();
             Assert.Null(model.GetDeclaredSymbol(discard3));
             var declaration3 = (DeclarationPatternSyntax)discard3.Parent;
             Assert.Equal("int _", declaration3.ToString());
-            //Assert.Equal("", model.GetTypeInfo(declaration3).Type.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/15450
+            Assert.Null(model.GetTypeInfo(declaration3).Type);
+            Assert.Equal("System.Int32", model.GetTypeInfo(declaration3.Type).Type.ToTestDisplayString());
 
             var discard4 = GetDiscardDesignations(tree).Skip(3).First();
             Assert.Null(model.GetDeclaredSymbol(discard4));
             var declaration4 = (DeclarationPatternSyntax)discard4.Parent;
             Assert.Equal("var _", declaration4.ToString());
-            //Assert.Equal("", model.GetTypeInfo(declaration4).Type.ToTestDisplayString()); // https://github.com/dotnet/roslyn/issues/15450
+            Assert.Null(model.GetTypeInfo(declaration4).Type);
+            Assert.Equal("System.Int64", model.GetTypeInfo(declaration4.Type).Type.ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4034,10 +4034,12 @@ public class C
 
             var discard2 = GetDiscardDesignations(tree).Skip(1).First();
             Assert.Null(model.GetDeclaredSymbol(discard2));
+            Assert.Null(model.GetSymbolInfo(discard2).Symbol);
             var declaration2 = (DeclarationPatternSyntax)discard2.Parent;
             Assert.Equal("var _", declaration2.ToString());
             Assert.Null(model.GetTypeInfo(declaration2).Type);
             Assert.Equal("System.Int32", model.GetTypeInfo(declaration2.Type).Type.ToTestDisplayString());
+            Assert.Null(model.GetSymbolInfo(declaration2).Symbol);
 
             var discard3 = GetDiscardDesignations(tree).Skip(2).First();
             Assert.Null(model.GetDeclaredSymbol(discard3));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -1585,10 +1585,10 @@ class Program
                 // (21,18): error CS0150: A constant value is expected
                 //             case (int, int):
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "(int, int)").WithLocation(21, 18),
-                // (22,19): error CS8184: A declaration is not allowed in this context.
+                // (22,19): error CS8185: A declaration is not allowed in this context.
                 //             case (int x, int y):
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int x").WithLocation(22, 19),
-                // (22,26): error CS8184: A declaration is not allowed in this context.
+                // (22,26): error CS8185: A declaration is not allowed in this context.
                 //             case (int x, int y):
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int y").WithLocation(22, 26),
                 // (22,18): error CS0150: A constant value is expected
@@ -1597,10 +1597,10 @@ class Program
                 // (23,18): error CS0150: A constant value is expected
                 //             case (int, int) z:
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "(int, int)").WithLocation(23, 18),
-                // (24,19): error CS8184: A declaration is not allowed in this context.
+                // (24,19): error CS8185: A declaration is not allowed in this context.
                 //             case (int a, int b) c:
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int a").WithLocation(24, 19),
-                // (24,26): error CS8184: A declaration is not allowed in this context.
+                // (24,26): error CS8185: A declaration is not allowed in this context.
                 //             case (int a, int b) c:
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int b").WithLocation(24, 26),
                 // (24,18): error CS0150: A constant value is expected
@@ -1630,10 +1630,10 @@ class Program
                 // (43,22): error CS0150: A constant value is expected
                 //             if (o is (int, int)) {}
                 Diagnostic(ErrorCode.ERR_ConstantExpected, "(int, int)").WithLocation(43, 22),
-                // (44,23): error CS8184: A declaration is not allowed in this context.
+                // (44,23): error CS8185: A declaration is not allowed in this context.
                 //             if (o is (int x, int y)) {}
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int x").WithLocation(44, 23),
-                // (44,30): error CS8184: A declaration is not allowed in this context.
+                // (44,30): error CS8185: A declaration is not allowed in this context.
                 //             if (o is (int x, int y)) {}
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int y").WithLocation(44, 30),
                 // (44,22): error CS0150: A constant value is expected
@@ -1645,10 +1645,10 @@ class Program
                 // (45,33): error CS0103: The name 'z' does not exist in the current context
                 //             if (o is (int, int) z)) {}
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z").WithArguments("z").WithLocation(45, 33),
-                // (46,23): error CS8184: A declaration is not allowed in this context.
+                // (46,23): error CS8185: A declaration is not allowed in this context.
                 //             if (o is (int a, int b) c) {}
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int a").WithLocation(46, 23),
-                // (46,30): error CS8184: A declaration is not allowed in this context.
+                // (46,30): error CS8185: A declaration is not allowed in this context.
                 //             if (o is (int a, int b) c) {}
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "int b").WithLocation(46, 30),
                 // (46,22): error CS0150: A constant value is expected
@@ -1663,10 +1663,10 @@ class Program
                 // (49,37): error CS0119: 'int' is a type, which is not valid in the given context
                 //             if (o is (System.Int32, System.Int32)) {}
                 Diagnostic(ErrorCode.ERR_BadSKunknown, "System.Int32").WithArguments("int", "type").WithLocation(49, 37),
-                // (50,23): error CS8184: A declaration is not allowed in this context.
+                // (50,23): error CS8185: A declaration is not allowed in this context.
                 //             if (o is (System.Int32 x, System.Int32 y)) {}
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "System.Int32 x").WithLocation(50, 23),
-                // (50,39): error CS8184: A declaration is not allowed in this context.
+                // (50,39): error CS8185: A declaration is not allowed in this context.
                 //             if (o is (System.Int32 x, System.Int32 y)) {}
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "System.Int32 y").WithLocation(50, 39),
                 // (50,22): error CS0150: A constant value is expected
@@ -1681,10 +1681,10 @@ class Program
                 // (51,51): error CS0103: The name 'z' does not exist in the current context
                 //             if (o is (System.Int32, System.Int32) z)) {}
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z").WithArguments("z").WithLocation(51, 51),
-                // (52,23): error CS8184: A declaration is not allowed in this context.
+                // (52,23): error CS8185: A declaration is not allowed in this context.
                 //             if (o is (System.Int32 a, System.Int32 b) c) {}
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "System.Int32 a").WithLocation(52, 23),
-                // (52,39): error CS8184: A declaration is not allowed in this context.
+                // (52,39): error CS8185: A declaration is not allowed in this context.
                 //             if (o is (System.Int32 a, System.Int32 b) c) {}
                 Diagnostic(ErrorCode.ERR_DeclarationExpressionNotPermitted, "System.Int32 b").WithLocation(52, 39),
                 // (52,22): error CS0150: A constant value is expected
@@ -1720,30 +1720,30 @@ class Program
                 // (39,47): warning CS0164: This label has not been referenced
                 //             case (System.Int64, System.Int64) d:
                 Diagnostic(ErrorCode.WRN_UnreferencedLabel, "d").WithLocation(39, 47),
-                // (44,27): error CS0165: Use of unassigned local variable 'x'
+                // (44,23): error CS0165: Use of unassigned local variable 'x'
                 //             if (o is (int x, int y)) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(44, 27),
-                // (44,34): error CS0165: Use of unassigned local variable 'y'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "int x").WithArguments("x").WithLocation(44, 23),
+                // (44,30): error CS0165: Use of unassigned local variable 'y'
                 //             if (o is (int x, int y)) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(44, 34),
-                // (46,27): error CS0165: Use of unassigned local variable 'a'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "int y").WithArguments("y").WithLocation(44, 30),
+                // (46,23): error CS0165: Use of unassigned local variable 'a'
                 //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "a").WithArguments("a").WithLocation(46, 27),
-                // (46,34): error CS0165: Use of unassigned local variable 'b'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "int a").WithArguments("a").WithLocation(46, 23),
+                // (46,30): error CS0165: Use of unassigned local variable 'b'
                 //             if (o is (int a, int b) c) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "b").WithArguments("b").WithLocation(46, 34),
-                // (50,36): error CS0165: Use of unassigned local variable 'x'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "int b").WithArguments("b").WithLocation(46, 30),
+                // (50,23): error CS0165: Use of unassigned local variable 'x'
                 //             if (o is (System.Int32 x, System.Int32 y)) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(50, 36),
-                // (50,52): error CS0165: Use of unassigned local variable 'y'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "System.Int32 x").WithArguments("x").WithLocation(50, 23),
+                // (50,39): error CS0165: Use of unassigned local variable 'y'
                 //             if (o is (System.Int32 x, System.Int32 y)) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(50, 52),
-                // (52,36): error CS0165: Use of unassigned local variable 'a'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "System.Int32 y").WithArguments("y").WithLocation(50, 39),
+                // (52,23): error CS0165: Use of unassigned local variable 'a'
                 //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "a").WithArguments("a").WithLocation(52, 36),
-                // (52,52): error CS0165: Use of unassigned local variable 'b'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "System.Int32 a").WithArguments("a").WithLocation(52, 23),
+                // (52,39): error CS0165: Use of unassigned local variable 'b'
                 //             if (o is (System.Int32 a, System.Int32 b) c) {}
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "b").WithArguments("b").WithLocation(52, 52)
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "System.Int32 b").WithArguments("b").WithLocation(52, 39)
                 );
         }
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -350,7 +350,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Dim tupleUnderlyingType As NamedTypeSymbol = TupleTypeSymbol.GetTupleUnderlyingType(elementTypes, syntax, compilation, diagnostics)
-            If DirectCast(compilation.SourceModule, SourceModuleSymbol).AnyReferencedAssembliesAreLinked Then
+            If diagnostics IsNot Nothing AndAlso DirectCast(compilation.SourceModule, SourceModuleSymbol).AnyReferencedAssembliesAreLinked Then
                 ' Complain about unembeddable types from linked assemblies.
                 Emit.NoPia.EmbeddedTypesManager.IsValidEmbeddableType(tupleUnderlyingType, syntax, diagnostics)
             End If


### PR DESCRIPTION
**Customer scenario**

Update semantic model APIs for declaration and discard expressions.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/15450

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

No. Previously the semantic model would return no information for declaration expressions and discards. Now it does.

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

Tracked work item.