### PR TITLE
Ignore missing directory in ShadowCopyAnalyzerAssemblyLoader.DeleteLeftoverDirectories

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CommandLine;
+using Roslyn.Test.Utilities;
 using System;
-using System.Collections;
 using System.Collections.Specialized;
+using System.IO;
 using System.IO.Pipes;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -14,6 +14,20 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
     public class VBCSCompilerServerTests
     {
+        public class StartupTests : VBCSCompilerServerTests
+        {
+            [Fact]
+            [WorkItem(217709, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/217709")]
+            public async Task ShadowCopyAnalyzerAssemblyLoaderMissingDirectory()
+            {
+                var baseDirectory = Path.Combine(Path.GetTempPath(), TestBase.GetUniqueName());
+                var loader = new ShadowCopyAnalyzerAssemblyLoader(baseDirectory);
+                var task = loader.DeleteLeftoverDirectoriesTask;
+                await task;
+                Assert.False(task.IsFaulted);
+            }
+        }
+
         public class ShutdownTests : VBCSCompilerServerTests
         {
             private static Task<int> RunShutdownAsync(string pipeName, bool waitForProcess = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Shared/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading;
@@ -17,6 +18,8 @@ namespace Microsoft.CodeAnalysis
         /// for scavenge operations.
         /// </summary>
         private readonly string _baseDirectory;
+
+        internal readonly Task DeleteLeftoverDirectoriesTask;
 
         /// <summary>
         /// The directory where this instance of <see cref="ShadowCopyAnalyzerAssemblyLoader"/>
@@ -41,12 +44,22 @@ namespace Microsoft.CodeAnalysis
                 _baseDirectory = Path.Combine(Path.GetTempPath(), "CodeAnalysis", "AnalyzerShadowCopies");
             }
 
-            Task.Run((Action)DeleteLeftoverDirectories);
+            DeleteLeftoverDirectoriesTask = Task.Run((Action)DeleteLeftoverDirectories);
         }
 
         private void DeleteLeftoverDirectories()
         {
-            foreach (var subDirectory in Directory.EnumerateDirectories(_baseDirectory))
+            IEnumerable<string> subDirectories;
+            try
+            {
+                subDirectories = Directory.EnumerateDirectories(_baseDirectory);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return;
+            }
+
+            foreach (var subDirectory in subDirectories)
             {
                 string name = Path.GetFileName(subDirectory).ToLowerInvariant();
                 Mutex mutex = null;


### PR DESCRIPTION
**Customer scenario**

Race condition accessing analyzer shadow copy directory from compiler server on first run, resulting in crash of compiler server.

**Bugs this fixes:** 

217709

**Workarounds, if any**

Re-start compiler server.

**Risk**

Low

**Performance impact**

None

**Root cause analysis:**

Found from crash report. Unit test added.