### PR TITLE
updating nuget packages

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -31,7 +31,7 @@
     <MicrosoftCodeAnalysisVisualBasicVersion>1.0.1</MicrosoftCodeAnalysisVisualBasicVersion>
     <MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>1.0.1</MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonVersion>1.0.1</MicrosoftCodeAnalysisWorkspacesCommonVersion>
-    <MicrosoftCompositionVersion>1.0.27</MicrosoftCompositionVersion>
+    <SystemCompositionVersion>1.0.31</SystemCompositionVersion>
     <MicrosoftCSharpVersion>4.3.0</MicrosoftCSharpVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
@@ -14,7 +14,7 @@ Supported Platforms:
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />
-      <dependency id="Microsoft.Composition" version="$MicrosoftCompositionVersion$" />
+      <dependency id="System.Composition" version="$SystemCompositionVersion$" />
     </dependencies>
 
     <language>en-US</language>

--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -11,7 +11,7 @@
     <dependencies>
       <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
-        <dependency id="Microsoft.Composition" version="$MicrosoftCompositionVersion$" />
+        <dependency id="System.Composition" version="$SystemCompositionVersion$" />
         <dependency id="System.Diagnostics.Contracts" version="$SystemDiagnosticsContractsVersion$" />
         <dependency id="System.Linq.Parallel" version="$SystemLinqParallelVersion$" />
         <dependency id="System.ObjectModel" version="$SystemObjectModelVersion$" />
@@ -21,7 +21,7 @@
       <group targetFramework="net46">
         <dependency id="ManagedEsent" version="$ManagedEsentVersion$" />
         <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
-        <dependency id="Microsoft.Composition" version="$MicrosoftCompositionVersion$" />
+        <dependency id="System.Composition" version="$SystemCompositionVersion$" />
       </group>
     </dependencies>
 

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/CSharpAnalyzers.csproj
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/CSharpAnalyzers.csproj
@@ -79,7 +79,7 @@
     <InternalsVisibleToTest Include="CSharpAnalyzers.Test" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Composition" Version="$(MicrosoftCompositionVersion)" />
+    <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
   </ItemGroup>
   <Target Name="AfterBuild">
     <GetAssemblyIdentity AssemblyFiles="$(OutDir)\CSharpAnalyzers.dll">

--- a/src/Samples/CSharp/ConsoleClassifier/ConsoleClassifierCS.csproj
+++ b/src/Samples/CSharp/ConsoleClassifier/ConsoleClassifierCS.csproj
@@ -52,8 +52,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/CSharp/ConvertToAutoProperty/ConvertToAutoPropertyCS.csproj
+++ b/src/Samples/CSharp/ConvertToAutoProperty/ConvertToAutoPropertyCS.csproj
@@ -66,8 +66,8 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/CSharp/ConvertToConditional/Impl/ConvertToConditionalCS.csproj
+++ b/src/Samples/CSharp/ConvertToConditional/Impl/ConvertToConditionalCS.csproj
@@ -67,8 +67,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/CSharp/CopyPasteWithUsing/CopyPasteWithUsing.csproj
+++ b/src/Samples/CSharp/CopyPasteWithUsing/CopyPasteWithUsing.csproj
@@ -72,8 +72,8 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0">
       <Version>$(MicrosoftVisualStudioShell150Version)</Version>

--- a/src/Samples/CSharp/FormatSolution/FormatSolutionCS.csproj
+++ b/src/Samples/CSharp/FormatSolution/FormatSolutionCS.csproj
@@ -45,8 +45,8 @@
       <Name>Microsoft.CodeAnalysis.VisualBasic.Workspaces</Name>
     </ProjectReference>
     <Reference Include="System" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedCS.csproj
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedCS.csproj
@@ -75,8 +75,8 @@
     <PackageReference Include="EnvDTE">
       <Version>$(EnvDTEVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/CSharp/MakeConst/Impl/MakeConstCS.csproj
+++ b/src/Samples/CSharp/MakeConst/Impl/MakeConstCS.csproj
@@ -63,8 +63,8 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/CSharp/RefOutModifier/AddOrRemoveRefOutModifier.csproj
+++ b/src/Samples/CSharp/RefOutModifier/AddOrRemoveRefOutModifier.csproj
@@ -82,8 +82,8 @@
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/ConvertToAutoPropertyVB.vbproj
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/ConvertToAutoPropertyVB.vbproj
@@ -55,8 +55,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedVB.vbproj
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/ImplementNotifyPropertyChangedVB.vbproj
@@ -65,8 +65,8 @@
     <PackageReference Include="EnvDTE">
       <Version>$(EnvDTEVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/VisualBasic/MakeConst/Impl/MakeConstVB.vbproj
+++ b/src/Samples/VisualBasic/MakeConst/Impl/MakeConstVB.vbproj
@@ -64,8 +64,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/VisualBasic/RemoveByVal/Impl/RemoveByValVB.vbproj
+++ b/src/Samples/VisualBasic/RemoveByVal/Impl/RemoveByValVB.vbproj
@@ -66,8 +66,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Samples/VisualBasic/TreeTransforms/TreeTransformsVB.vbproj
+++ b/src/Samples/VisualBasic/TreeTransforms/TreeTransformsVB.vbproj
@@ -44,8 +44,8 @@
     <Reference Include="System.Deployment" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
+    <PackageReference Include="System.Composition">
+      <Version>$(SystemCompositionVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Setup/BuildTasks/UpdateNuGetTemplateVersions.vb
+++ b/src/Setup/BuildTasks/UpdateNuGetTemplateVersions.vb
@@ -118,8 +118,8 @@ Public Class UpdateNuGetTemplateVersions
                 package.@version = "1.1.36"
             ElseIf package.@id = "System.Reflection.Metadata" Then
                 package.@version = "1.0.21"
-            ElseIf package.@id = "Microsoft.Composition" Then
-                package.@version = "1.0.27"
+            ElseIf package.@id = "System.Composition" Then
+                package.@version = "1.0.31"
             ElseIf package.@id = "Microsoft.CodeAnalysis.Analyzers" Then
                 package.@version = "1.1.0"
             Else

--- a/src/Setup/NuGet/PackageDependencies.dgml
+++ b/src/Setup/NuGet/PackageDependencies.dgml
@@ -14,7 +14,7 @@
     <Node Id="Microsoft.CodeAnalysis.VisualBasic"/>
     <Node Id="Microsoft.CodeAnalysis.VisualBasic.Workspaces"/>
     <Node Id="Microsoft.CodeAnalysis.Workspaces.Common"/>
-    <Node Id="Microsoft.Composition"/>
+    <Node Id="System.Composition"/>
     <Node Id="Microsoft.Net.Compilers"/>
     <Node Id="Microsoft.Net.RoslynDiagnostics"/>
     <Node Id="Microsoft.Net.ToolsetCompilers"/>
@@ -37,7 +37,7 @@
     <Link Source="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Target="Microsoft.CodeAnalysis.VisualBasic"/>
     <Link Source="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Target="Microsoft.CodeAnalysis.Workspaces.Common"/>
     <Link Source="Microsoft.CodeAnalysis.Workspaces.Common" Target="Microsoft.CodeAnalysis.Common"/>
-    <Link Source="Microsoft.CodeAnalysis.Workspaces.Common" Target="Microsoft.Composition"/>
+    <Link Source="Microsoft.CodeAnalysis.Workspaces.Common" Target="System.Composition"/>
     <Link Source="Microsoft.Net.RoslynDiagnostics" Target="Microsoft.Net.ToolsetCompilers"/>
     <Link Source="Microsoft.VisualStudio.LanguageServices" Target="Microsoft.CodeAnalysis.CodeActions"/>
   </Links>

--- a/src/Setup/Templates/CSharp/CodeRefactoring/Ref/CSharpCodeRefactoring.vstemplate
+++ b/src/Setup/Templates/CSharp/CodeRefactoring/Ref/CSharpCodeRefactoring.vstemplate
@@ -36,7 +36,7 @@
       <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" skipAssemblyReferences="false" />
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
-      <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
+      <package id="System.Composition" version="1.0.31" skipAssemblyReferences="false" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/Setup/Templates/CSharp/ConsoleApplication/CSharpConsoleApplication.vstemplate
+++ b/src/Setup/Templates/CSharp/ConsoleApplication/CSharpConsoleApplication.vstemplate
@@ -37,7 +37,7 @@
       <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" skipAssemblyReferences="false" />
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
-      <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
+      <package id="System.Composition" version="1.0.31" skipAssemblyReferences="false" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
@@ -38,7 +38,7 @@
       <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" skipAssemblyReferences="false" />
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
-      <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
+      <package id="System.Composition" version="1.0.31" skipAssemblyReferences="false" />
       <package id="NuGet.CommandLine" version="2.8.5" />
     </packages>
   </WizardData>

--- a/src/Setup/Templates/CSharp/Diagnostic/Test/Test.vstemplate
+++ b/src/Setup/Templates/CSharp/Diagnostic/Test/Test.vstemplate
@@ -37,7 +37,7 @@
       <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" skipAssemblyReferences="false" />
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
-      <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
+      <package id="System.Composition" version="1.0.31" skipAssemblyReferences="false" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/Setup/Templates/Templates.csproj
+++ b/src/Setup/Templates/Templates.csproj
@@ -239,9 +239,6 @@
     <PackageReference Include="EnvDTE">
       <Version>$(EnvDTEVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <Version>$(MicrosoftCodeAnalysisAnalyzersVersion)</Version>
     </PackageReference>
@@ -367,7 +364,7 @@
       <VSIXSourceItem Include="$(NuGetPackageRoot)\Microsoft.CodeAnalysis.VisualBasic.Workspaces\1.0.1\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.1.nupkg">
         <VSIXSubPath>Packages</VSIXSubPath>
       </VSIXSourceItem>
-      <VSIXSourceItem Include="$(NuGetPackageRoot)\Microsoft.Composition\1.0.27\Microsoft.Composition.1.0.27.nupkg">
+      <VSIXSourceItem Include="$(NuGetPackageRoot)\System.Composition\1.0.31\System.Composition.1.0.31.nupkg">
         <VSIXSubPath>Packages</VSIXSubPath>
       </VSIXSourceItem>
       <VSIXSourceItem Include="$(NuGetPackageRoot)\System.Collections.Immutable\1.1.36\System.Collections.Immutable.1.1.36.nupkg">

--- a/src/Setup/Templates/VisualBasic/CodeRefactoring/Ref/VBCodeRefactoring.vstemplate
+++ b/src/Setup/Templates/VisualBasic/CodeRefactoring/Ref/VBCodeRefactoring.vstemplate
@@ -34,7 +34,7 @@
       <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" skipAssemblyReferences="false" />
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
-      <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
+      <package id="System.Composition" version="1.0.31" skipAssemblyReferences="false" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/Setup/Templates/VisualBasic/ConsoleApplication/VBConsoleApplication.vstemplate
+++ b/src/Setup/Templates/VisualBasic/ConsoleApplication/VBConsoleApplication.vstemplate
@@ -40,7 +40,7 @@
       <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" skipAssemblyReferences="false"/>
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
-      <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
+      <package id="System.Composition" version="1.0.31" skipAssemblyReferences="false" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
@@ -40,7 +40,7 @@
       <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" skipAssemblyReferences="false" />
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
-      <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
+      <package id="System.Composition" version="1.0.31" skipAssemblyReferences="false" />
       <package id="NuGet.CommandLine" version="2.8.5" />
     </packages>
   </WizardData>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Test/Test.vstemplate
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Test/Test.vstemplate
@@ -50,7 +50,7 @@
       <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.1" skipAssemblyReferences="false" />
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
-      <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
+      <package id="System.Composition" version="1.0.31" skipAssemblyReferences="false" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.csproj
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/SyntaxVisualizerControl.csproj
@@ -28,9 +28,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <Version>$(MicrosoftCodeAnalysisAnalyzersVersion)</Version>
     </PackageReference>

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerDgmlHelper/SyntaxVisualizerDgmlHelper.vbproj
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerDgmlHelper/SyntaxVisualizerDgmlHelper.vbproj
@@ -20,9 +20,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <Version>$(MicrosoftCodeAnalysisAnalyzersVersion)</Version>
     </PackageReference>

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerExtension.csproj
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerExtension.csproj
@@ -58,9 +58,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
       <Version>$(MicrosoftCodeAnalysisWorkspacesCommonVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Composition">
-      <Version>$(MicrosoftCompositionVersion)</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility">
       <Version>$(MicrosoftVisualStudioCoreUtilityFixedVersion)</Version>
     </PackageReference>

--- a/src/VisualStudio/Setup.Next/VisualStudioSetup.Next.csproj
+++ b/src/VisualStudio/Setup.Next/VisualStudioSetup.Next.csproj
@@ -90,8 +90,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <!-- Visual Studio ships with some, but not all, of the assemblies in Microsoft.Composition, but we need them all -->
-    <NuGetPackageToIncludeInVsix Include="Microsoft.Composition" />
+    <!-- Visual Studio ships with some, but not all, of the assemblies in System.Composition, but we need them all -->
+    <NuGetPackageToIncludeInVsix Include="System.Composition" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -210,8 +210,8 @@
     <NuGetPackageToIncludeInVsix Include="ManagedEsent" />
     <NuGetPackageToIncludeInVsix Include="SQLitePCLRaw.bundle_green" />
     <NuGetPackageToIncludeInVsix Include="Microsoft.CodeAnalysis.Elfie" />
-    <!-- Visual Studio ships with some, but not all, of the assemblies in Microsoft.Composition, but we need them all -->
-    <NuGetPackageToIncludeInVsix Include="Microsoft.Composition" />
+    <!-- Visual Studio ships with some, but not all, of the assemblies in System.Composition, but we need them all -->
+    <NuGetPackageToIncludeInVsix Include="System.Composition" />
   </ItemGroup>
   <ItemGroup>
     <VSIXSourceItem Include="$(NuGetPackageRoot)\SQLitePCLRaw.bundle_green\1.1.2\lib\net45\SQLitePCLRaw.batteries_green.dll" />

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -1145,7 +1145,7 @@
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Composition" Version="$(MicrosoftCompositionVersion)" />
+    <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="$(SystemDiagnosticsContractsVersion)" />
     <PackageReference Include="System.Linq.Parallel" Version="$(SystemLinqParallelVersion)" />
     <PackageReference Include="System.ObjectModel" Version="$(SystemObjectModelVersion)" />


### PR DESCRIPTION
**Note:** This is a cross cutting change https://github.com/dotnet/roslyn-internal/pull/1469 will need to be merged after this for ETA tests to work

**Customer scenario**

Customer wants to target netstandard and reference roslyn nuget packages.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16040

**Workarounds, if any**

Add fallback profile in project.json for Profile7

**Risk**

There is some risk associated with this change. Binding redirects will need to be added on the VS side for version 1.0.31.0 as opposed 1.0.27.0.  Because of this a validation build will need to be done on the insertion that contains this change to verify that all the redirects in VS were  done correctly.

**Performance impact**

There is no performance impact as we are just changing how we are referencing our nuget packages.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

The Microsoft.CodeAnalysis.Workspaces.Common nuget package depends on the Microsoft.Composition nuget package today.  Since Microsoft.Composition does not target netstanard any roslyn nuget package that depends on Microsoft.CodeAnalysis.Workspaces.Common will be unable to target netstandard unless they create a fallback entry in their project.json file.

**How was the bug found?**

This issues was know for a while.  We were waiting for the System.Composition package to be made available publicly.