### PR TITLE
Ensure the 'Add' name actually matches before accepting any invocation expression.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -648,5 +648,42 @@ class C
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
+        [WorkItem(16158, "https://github.com/dotnet/roslyn/issues/16158")]
+        public async Task TestIncorrectAddName()
+        {
+            await TestAsync(
+@"using System.Collections.Generic;
+
+public class Foo
+{
+    public static void Bar()
+    {
+        string item = null;
+        var items = new List<string>();
+
+        var values = new [||]List<string>(); // Collection initialization can be simplified
+        values.Add(item);
+        values.AddRange(items);
+    }
+}",
+@"using System.Collections.Generic;
+
+public class Foo
+{
+    public static void Bar()
+    {
+        string item = null;
+        var items = new List<string>();
+
+        var values = new List<string>
+        {
+            item
+        }; // Collection initialization can be simplified
+        values.AddRange(items);
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/UseCollectionInitializer/ObjectCreationExpressionAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/ObjectCreationExpressionAnalyzer.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 return false;
             }
 
-            _syntaxFacts.GetPartsOfMemberAccessExpression(memberAccess, out instance, out var memberName);
+            _syntaxFacts.GetPartsOfMemberAccessExpression(memberAccess, out var localInstance, out var memberName);
             _syntaxFacts.GetNameAndArityOfSimpleName(memberName, out var name, out var arity);
 
             if (arity != 0 || !name.Equals(nameof(IList.Add)))
@@ -194,6 +194,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 return false;
             }
 
+            instance = localInstance;
             return true;
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/16158