### PR TITLE
Fix crash in outlining when indexing out of an incomplete multiline comment.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/CompilationUnitStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/CompilationUnitStructureTests.cs
@@ -144,5 +144,15 @@ $${|hint:using|} {|textspan:|}";
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        [WorkItem(16186, "https://github.com/dotnet/roslyn/issues/16186")]
+        public async Task TestInvalidComment()
+        {
+            const string code = @"$${|span:/*/|}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("span", "/* / ...", autoCollapse: true));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
         public const string Ellipsis = "...";
         public const string MultiLineCommentSuffix = "*/";
         public const int MaxXmlDocCommentBannerLength = 120;
+        private static readonly char[] s_newLineCharacters = new char[] { '\r', '\n' };
 
         private static int GetCollapsibleStart(SyntaxToken firstToken)
         {
@@ -113,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             }
             else if (comment.IsMultiLineComment())
             {
-                var lineBreakStart = comment.ToString().IndexOfAny(new char[] { '\r', '\n' });
+                var lineBreakStart = comment.ToString().IndexOfAny(s_newLineCharacters);
 
                 var text = comment.ToString();
                 if (lineBreakStart >= 0)
@@ -122,7 +123,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 }
                 else
                 {
-                    text = text.EndsWith(MultiLineCommentSuffix) ? text.Substring(0, text.Length - MultiLineCommentSuffix.Length) : text;
+                    text = text.Length >= "/**/".Length && text.EndsWith(MultiLineCommentSuffix) 
+                        ? text.Substring(0, text.Length - MultiLineCommentSuffix.Length)
+                        : text;
                 }
 
                 return CreateCommentBannerTextWithPrefix(text, "/*");


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/16186