### PR TITLE
Add Margin to GroupBoxes in AdvancedOptionPageCSharp

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -10,7 +10,7 @@
     mc:Ignorable="d" d:DesignHeight="500" d:DesignWidth="500">
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel>
+        <StackPanel Margin="0,0,3,0">
             <GroupBox x:Uid="UsingDirectivesGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Using_Directives}">
                 <StackPanel>

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -12,8 +12,7 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="0,0,3,0">
             <GroupBox x:Uid="UsingDirectivesGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Using_Directives}"
-                      Margin="0,0,3,0">
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Using_Directives}">
                 <StackPanel>
                     <CheckBox x:Name="PlaceSystemNamespaceFirst"
                               x:Uid="SortUsings_PlaceSystemFirst"
@@ -27,7 +26,7 @@
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="HighlightingGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Highlighting}" Margin="0,0,3,0">
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Highlighting}">
                 <StackPanel>
                     <CheckBox x:Name="EnableHighlightReferences"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_EnableHighlightReferences}" />
@@ -36,7 +35,7 @@
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="OutliningGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Outlining}" Margin="0,0,3,0">
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Outlining}">
                 <StackPanel>
                     <CheckBox x:Name="EnterOutliningMode"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_EnterOutliningMode}" />
@@ -53,7 +52,7 @@
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="BlockStructureGuidesGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Block_Structure_Guides}" Margin="0,0,3,0">
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Block_Structure_Guides}">
                 <StackPanel>
                     <CheckBox x:Name="Show_guides_for_declaration_level_constructs"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_Show_guides_for_declaration_level_constructs}" />
@@ -62,7 +61,7 @@
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="EditorHelpGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_EditorHelp}" Margin="0,0,3,0">
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_EditorHelp}">
                 <StackPanel>
                     <CheckBox x:Name="GenerateXmlDocCommentsForTripleSlash"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_GenerateXmlDocCommentsForTripleSlash}" />
@@ -77,7 +76,7 @@
                 </StackPanel>
             </GroupBox>
             <GroupBox x:Uid="ExtractMethodGroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_ExtractMethod}" Margin="0,0,3,0">
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_ExtractMethod}">
                 <StackPanel>
                     <CheckBox x:Name="DontPutOutOrRefOnStruct"
                               Content="{x:Static local:AdvancedOptionPageStrings.Option_DontPutOutOrRefOnStruct}" />
@@ -88,7 +87,7 @@
             </GroupBox>
 
             <GroupBox x:Uid="Implement_Interface_or_Abstract_Class_GroupBox"
-                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Implement_Interface_or_Abstract_Class}" Margin="0,0,3,0">
+                      Header="{x:Static local:AdvancedOptionPageStrings.Option_Implement_Interface_or_Abstract_Class}">
 
                 <StackPanel Margin="0, -5, 0, 5">
                     <Label Content="{x:Static local:AdvancedOptionPageStrings.Option_When_inserting_properties_events_and_methods_place_them}"/>

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageControl.xaml
@@ -10,6 +10,7 @@
     mc:Ignorable="d" d:DesignHeight="500" d:DesignWidth="500">
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <!-- We have a Margin here, to get some distance to the Scrollbar See: https://github.com/dotnet/roslyn/issues/14979-->
         <StackPanel Margin="0,0,3,0">
             <GroupBox x:Uid="UsingDirectivesGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Using_Directives}">

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -10,7 +10,7 @@
     mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300">
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel>
+        <StackPanel Margin="0,0,3,0">
 
             <GroupBox x:Uid="ImportDirectivesGroupBox"
                       Header="{x:Static local:AdvancedOptionPageStrings.Option_Import_Directives}">

--- a/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AdvancedOptionPageControl.xaml
@@ -10,6 +10,7 @@
     mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300">
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <!-- We have a Margin here, to get some distance to the Scrollbar See: https://github.com/dotnet/roslyn/issues/14979-->
         <StackPanel Margin="0,0,3,0">
 
             <GroupBox x:Uid="ImportDirectivesGroupBox"


### PR DESCRIPTION
**Customer scenario** Go to Tools\Options without resizing, and the group box is touching the border.
**Bugs this fixes:** #14979
**Workarounds:** Can resize Tools\Options.
**Risk:** Very low, just adding a Margin to the UI.
**Performance impact:** None
**Is this a regression from a previous update?** No
**Root cause analysis:** Rarely on a clean machine where Tools\Options hasn't been resized.
**How was the bug found?** Bug bash