### PR TITLE
Do not allow a throw expression in an expression tree.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4193,6 +4193,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An expression tree may not contain a throw-expression..
+        /// </summary>
+        internal static string ERR_ExpressionTreeContainsThrowExpression {
+            get {
+                return ResourceManager.GetString("ERR_ExpressionTreeContainsThrowExpression", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An expression tree may not contain a tuple conversion..
         /// </summary>
         internal static string ERR_ExpressionTreeContainsTupleConversion {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4993,4 +4993,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_PossibleBadNegCast" xml:space="preserve">
     <value>To cast a negative value, you must enclose the value in parentheses.</value>
   </data>
+  <data name="ERR_ExpressionTreeContainsThrowExpression" xml:space="preserve">
+    <value>An expression tree may not contain a throw-expression.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1435,9 +1435,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DeclarationExpressionNotPermitted = 8185,
         ERR_MustDeclareForeachIteration = 8186,
         ERR_TupleElementNamesInDeconstruction = 8187,
+        ERR_ExpressionTreeContainsThrowExpression = 8188,
         #endregion stragglers for C# 7
 
-        // Available  = 8188-8195
+        // Available  = 8189-8195
 
         #region diagnostics for out var
         ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList = 8196,

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -682,5 +682,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return base.VisitTupleLiteral(node);
         }
+
+        public override BoundNode VisitThrowExpression(BoundThrowExpression node)
+        {
+            if (_inExpressionLambda)
+            {
+                Error(ErrorCode.ERR_ExpressionTreeContainsThrowExpression, node);
+            }
+
+            return base.VisitThrowExpression(node);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -23275,5 +23275,44 @@ class Program
                 //     static object M(object obj, object value)
                 Diagnostic(ErrorCode.ERR_ReturnExpected, "M").WithArguments("Program.M(object, object)").WithLocation(4, 19));
         }
+
+        [Fact]
+        public void ThrowInExpressionTree()
+        {
+            var text = @"
+using System;
+using System.Linq.Expressions;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        static bool b = true;
+        static object o = string.Empty;
+        static void Main(string[] args)
+        {
+            Expression<Func<object>> e1 = () => o ?? throw null;
+            Expression<Func<object>> e2 = () => b ? throw null : o;
+            Expression<Func<object>> e3 = () => b ? o : throw null;
+            Expression<Func<object>> e4 = () => throw null;
+        }
+    }
+}
+";
+            CreateCompilationWithMscorlibAndSystemCore(text).VerifyDiagnostics(
+                // (13,54): error CS8188: An expression tree may not contain a throw-expression.
+                //             Expression<Func<object>> e1 = () => o ?? throw null;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsThrowExpression, "throw null").WithLocation(13, 54),
+                // (14,53): error CS8188: An expression tree may not contain a throw-expression.
+                //             Expression<Func<object>> e2 = () => b ? throw null : o;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsThrowExpression, "throw null").WithLocation(14, 53),
+                // (15,57): error CS8188: An expression tree may not contain a throw-expression.
+                //             Expression<Func<object>> e3 = () => b ? o : throw null;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsThrowExpression, "throw null").WithLocation(15, 57),
+                // (16,49): error CS8188: An expression tree may not contain a throw-expression.
+                //             Expression<Func<object>> e4 = () => throw null;
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsThrowExpression, "throw null").WithLocation(16, 49)
+                );
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Throw expressions were added in C# 7. While they are useful and easy to use,
they are not supported in expression trees. When they are used that way, the
compiler simply crashes.

**Bugs this fixes:** 

Fixes #16122

**Workarounds, if any**

Don't make that mistake.

**Risk**

Very small. The compiler change involves the simple addition of code to diagnose the situation.

**Performance impact**

None expected, as the changed code only affects a new language construct, and is a trivial test.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Missing test for intersection of existing (expression tree) feature with new (throw expression) feature.

**How was the bug found?**

Customer reported.

@dotnet/roslyn-compiler Please review this tiny bug fix.
