### PR TITLE
Permit a throw expression in an expression-bodied ref-returning method.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3565,7 +3565,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if ((object)returnType != null)
             {
-                if ((refKind != RefKind.None) != (returnRefKind != RefKind.None))
+                if ((refKind != RefKind.None) != (returnRefKind != RefKind.None) && expression.Kind != BoundKind.ThrowExpression)
                 {
                     var errorCode = refKind != RefKind.None
                         ? ErrorCode.ERR_MustNotHaveRefReturn


### PR DESCRIPTION
**Customer scenario**

Use a throw expression as the expression body of a ref-returning local function.

**Bugs this fixes:** 

Fixes #16171

**Workarounds, if any**

Don't use an expression bodied method for this confluence of features.

**Risk**

Very low. The additional code is a simple test and targeted to the problematic scenario.

**Performance impact**

Tiny, if any, for the same reason.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

We did not test the confluence of three new features (expression-bodied methods, ref-returning functions, and throw expressions).

**How was the bug found?**

Customer reported.

@dotnet/roslyn-compiler May I please have a couple of reviews of this tiny bug fix?
