### PR TITLE
Report an error about an invalid assembly name rather than throwing an exception.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -559,11 +559,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (ModuleName != null)
             {
-                Exception e = MetadataHelpers.CheckAssemblyOrModuleName(ModuleName, nameof(ModuleName));
-                if (e != null)
-                {
-                    builder.Add(Diagnostic.Create(MessageProvider.Instance, (int)ErrorCode.ERR_BadCompilationOption, e.Message));
-                }
+                MetadataHelpers.CheckAssemblyOrModuleName(ModuleName, MessageProvider.Instance, (int)ErrorCode.ERR_BadModuleName, builder);
             }
 
             if (!OutputKind.IsValid())

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -881,6 +881,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid assembly name: {0}.
+        /// </summary>
+        internal static string ERR_BadAssemblyName {
+            get {
+                return ResourceManager.GetString("ERR_BadAssemblyName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Async methods cannot have ref or out parameters.
         /// </summary>
         internal static string ERR_BadAsyncArgType {
@@ -1219,15 +1228,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_BadCompatMode {
             get {
                 return ResourceManager.GetString("ERR_BadCompatMode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0}.
-        /// </summary>
-        internal static string ERR_BadCompilationOption {
-            get {
-                return ResourceManager.GetString("ERR_BadCompilationOption", resourceCulture);
             }
         }
         
@@ -1642,6 +1642,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_BadModifiersOnNamespace {
             get {
                 return ResourceManager.GetString("ERR_BadModifiersOnNamespace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid module name: {0}.
+        /// </summary>
+        internal static string ERR_BadModuleName {
+            get {
+                return ResourceManager.GetString("ERR_BadModuleName", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4077,8 +4077,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_NetModuleNameMismatch" xml:space="preserve">
     <value>Module name '{0}' stored in '{1}' must match its filename.</value>
   </data>
-  <data name="ERR_BadCompilationOption" xml:space="preserve">
-    <value>{0}</value>
+  <data name="ERR_BadModuleName" xml:space="preserve">
+    <value>Invalid module name: {0}</value>
   </data>
   <data name="ERR_BadCompilationOptionValue" xml:space="preserve">
     <value>Invalid '{0}' value: '{1}'.</value>
@@ -4998,5 +4998,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_ExpressionTreeContainsThrowExpression" xml:space="preserve">
     <value>An expression tree may not contain a throw-expression.</value>
+  </data>
+  <data name="ERR_BadAssemblyName" xml:space="preserve">
+    <value>Invalid assembly name: {0}</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -243,7 +243,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(options != null);
             Debug.Assert(!isSubmission || options.ReferencesSupersedeLowerVersions);
-            CheckAssemblyName(assemblyName);
 
             var validatedReferences = ValidateReferences<CSharpCompilationReference>(references);
 
@@ -400,8 +399,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public new CSharpCompilation WithAssemblyName(string assemblyName)
         {
-            CheckAssemblyName(assemblyName);
-
             // Can't reuse references since the source assembly name changed and the referenced symbols might 
             // have internals-visible-to relationship with this compilation or they might had a circular reference 
             // to this compilation.
@@ -1944,6 +1941,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (stage == CompilationStage.Declare || stage > CompilationStage.Declare && includeEarlierStages)
             {
+                CheckAssemblyName(builder);
                 builder.AddRange(Options.Errors);
 
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1224,7 +1224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_WinRtEventPassedByRef = 7084,
         ERR_ByRefReturnUnsupported = 7085,
         ERR_NetModuleNameMismatch = 7086,
-        ERR_BadCompilationOption = 7087,
+        ERR_BadModuleName = 7087,
         ERR_BadCompilationOptionValue = 7088,
         ERR_BadAppConfigPath = 7089,
         WRN_AssemblyAttributeFromModuleIsOverridden = 7090,
@@ -1451,6 +1451,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExpressionVariableInConstructorOrFieldInitializer = 8200,
         ERR_ExpressionVariableInQueryClause = 8201,
         ERR_PublicSignNetModule = 8202,
+        ERR_BadAssemblyName = 8203,
         #endregion more stragglers for C# 7
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -259,5 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var node = (AttributeSyntax)attributeSyntax;
             diagnostics.Add(ErrorCode.ERR_AttributeParameterRequired2, node.Name.Location, parameterName1, parameterName2);
         }
+
+        public override int ERR_BadAssemblyName => (int)ErrorCode.ERR_BadAssemblyName;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReferenceManager.cs
@@ -361,7 +361,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         out modules,
                         resolutionDiagnostics);
 
-                    var assemblyBeingBuiltData = new AssemblyDataForAssemblyBeingBuilt(new AssemblyIdentity(name: SimpleAssemblyName), referencedAssemblies, modules);
+                    var assemblyBeingBuiltData = new AssemblyDataForAssemblyBeingBuilt(new AssemblyIdentity(name: SimpleAssemblyName, noThrow:true), referencedAssemblies, modules);
                     var explicitAssemblyData = referencedAssemblies.Insert(0, assemblyBeingBuiltData);
 
                     // Let's bind all the references and resolve missing one (if resolver is available)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<PEModule> netModules)
         {
             Debug.Assert(compilation != null);
-            Debug.Assert(!String.IsNullOrWhiteSpace(assemblySimpleName));
+            Debug.Assert(assemblySimpleName != null);
             Debug.Assert(!String.IsNullOrWhiteSpace(moduleName));
             Debug.Assert(!netModules.IsDefault);
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1796,7 +1796,7 @@ public sealed class ContentType
             var result = compilation.Emit(new MemoryStream(), options: new EmitOptions(outputNameOverride: "x\0x"));
             result.Diagnostics.Verify(
                 // error CS2041: Invalid output name: Name contains invalid characters.
-                Diagnostic(ErrorCode.ERR_InvalidOutputName).WithArguments(CodeAnalysisResources.NameContainsInvalidCharacter));
+                Diagnostic(ErrorCode.ERR_InvalidOutputName).WithArguments(CodeAnalysisResources.NameContainsInvalidCharacter).WithLocation(1, 1));
 
             Assert.False(result.Success);
         }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CSharpCompilationOptionsTests.cs
@@ -248,38 +248,33 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             // ModuleName
             Assert.Equal(null, TestOptions.ReleaseDll.WithModuleName(null).ModuleName);
             TestOptions.ReleaseDll.WithModuleName("").VerifyErrors(
-    // error CS7087: Name cannot be empty.
-    // Parameter name: ModuleName
-    Diagnostic(ErrorCode.ERR_BadCompilationOption).WithArguments(new ArgumentException(CodeAnalysisResources.NameCannotBeEmpty, "ModuleName").Message));
+                // error CS7087: Invalid module name: Name cannot be empty.
+                Diagnostic(ErrorCode.ERR_BadModuleName).WithArguments("Name cannot be empty.").WithLocation(1, 1)
+                );
 
             TestOptions.ReleaseDll.WithModuleName("a\0a").VerifyErrors(
-    // error CS7087: Name contains invalid characters.
-    // Parameter name: ModuleName
-    Diagnostic(ErrorCode.ERR_BadCompilationOption).WithArguments(new ArgumentException(CodeAnalysisResources.NameContainsInvalidCharacter, "ModuleName").Message)
+                // error CS7087: Invalid module name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadModuleName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
                 );
 
             TestOptions.ReleaseDll.WithModuleName("a\uD800b").VerifyErrors(
-    // error CS7087: Name contains invalid characters.
-    // Parameter name: ModuleName
-    Diagnostic(ErrorCode.ERR_BadCompilationOption).WithArguments(new ArgumentException(CodeAnalysisResources.NameContainsInvalidCharacter, "ModuleName").Message)
+                // error CS7087: Invalid module name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadModuleName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
                 );
 
             TestOptions.ReleaseDll.WithModuleName("a\\b").VerifyErrors(
-    // error CS7087: Name contains invalid characters.
-    // Parameter name: ModuleName
-    Diagnostic(ErrorCode.ERR_BadCompilationOption).WithArguments(new ArgumentException(CodeAnalysisResources.NameContainsInvalidCharacter, "ModuleName").Message)
+                // error CS7087: Invalid module name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadModuleName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
                 );
 
             TestOptions.ReleaseDll.WithModuleName("a/b").VerifyErrors(
-    // error CS7087: Name contains invalid characters.
-    // Parameter name: ModuleName
-    Diagnostic(ErrorCode.ERR_BadCompilationOption).WithArguments(new ArgumentException(CodeAnalysisResources.NameContainsInvalidCharacter, "ModuleName").Message)
+                // error CS7087: Invalid module name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadModuleName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
                 );
 
             TestOptions.ReleaseDll.WithModuleName("a:b").VerifyErrors(
-    // error CS7087: Name contains invalid characters.
-    // Parameter name: ModuleName
-    Diagnostic(ErrorCode.ERR_BadCompilationOption).WithArguments(new ArgumentException(CodeAnalysisResources.NameContainsInvalidCharacter, "ModuleName").Message)
+                // error CS7087: Invalid module name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadModuleName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -44,29 +44,68 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
+        [WorkItem(233669, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=233669")]
         public void CompilationName()
         {
             // report an error, rather then silently ignoring the directory
             // (see cli partition II 22.30) 
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@"C:/foo/Test.exe"));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@"C:\foo\Test.exe"));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@"\foo/Test.exe"));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@"C:Test.exe"));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@"Te\0st.exe"));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@"   \t  "));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@"\uD800"));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@""));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@" a"));
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create(@"\u2000a")); // U+20700 is whitespace
-            Assert.Throws<ArgumentException>(() => CSharpCompilation.Create("..\\..\\RelativePath"));
+            CSharpCompilation.Create(@"C:/foo/Test.exe").VerifyEmitDiagnostics(
+                // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
+                Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1),
+                // error CS8203: Invalid assembly name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name contains invalid characters.").WithLocation(1, 1),
+                // error CS5001: Program does not contain a static 'Main' method suitable for an entry point
+                Diagnostic(ErrorCode.ERR_NoEntryPoint).WithLocation(1, 1)
+                );
+            CSharpCompilation.Create(@"C:\foo\Test.exe").GetDeclarationDiagnostics().Verify(
+                // error CS8203: Invalid assembly name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
+                );
+            var compilationOptions = TestOptions.DebugDll.WithWarningLevel(0);
+            CSharpCompilation.Create(@"\foo/Test.exe", options: compilationOptions).VerifyEmitDiagnostics(
+                // error CS8203: Invalid assembly name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
+                );
+            CSharpCompilation.Create(@"C:Test.exe", options: compilationOptions).VerifyEmitDiagnostics(
+                // error CS8203: Invalid assembly name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
+                );
+            CSharpCompilation.Create(@"Te\0st.exe", options: compilationOptions).VerifyEmitDiagnostics(
+                // error CS8203: Invalid assembly name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
+                );
+            CSharpCompilation.Create(@"   \t  ", options: compilationOptions).VerifyEmitDiagnostics(
+                // error CS8203: Invalid assembly name: Name cannot start with whitespace.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name cannot start with whitespace.").WithLocation(1, 1)
+                );
+            CSharpCompilation.Create(@"\uD800", options: compilationOptions).VerifyEmitDiagnostics(
+                // error CS8203: Invalid assembly name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
+                );
+            CSharpCompilation.Create(@"", options: compilationOptions).VerifyEmitDiagnostics(
+                // error CS8203: Invalid assembly name: Name cannot be empty.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name cannot be empty.").WithLocation(1, 1)
+                );
+            CSharpCompilation.Create(@" a", options: compilationOptions).VerifyEmitDiagnostics(
+                // error CS8203: Invalid assembly name: Name cannot start with whitespace.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name cannot start with whitespace.").WithLocation(1, 1)
+                );
+            CSharpCompilation.Create(@"\u2000a", options: compilationOptions).VerifyEmitDiagnostics( // U+20700 is whitespace
+                // error CS8203: Invalid assembly name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
+                );
+            CSharpCompilation.Create("..\\..\\RelativePath", options: compilationOptions).VerifyEmitDiagnostics(
+                // error CS8203: Invalid assembly name: Name contains invalid characters.
+                Diagnostic(ErrorCode.ERR_BadAssemblyName).WithArguments("Name contains invalid characters.").WithLocation(1, 1)
+                );
 
             // other characters than directory and volume separators are ok:
-            CSharpCompilation.Create(@";,*?<>#!@&");
-            CSharpCompilation.Create("foo");
-            CSharpCompilation.Create(".foo");
-            CSharpCompilation.Create("foo "); // can end with whitespace
-            CSharpCompilation.Create("....");
-            CSharpCompilation.Create(null);
+            CSharpCompilation.Create(@";,*?<>#!@&", options: compilationOptions).VerifyEmitDiagnostics();
+            CSharpCompilation.Create("foo", options: compilationOptions).VerifyEmitDiagnostics();
+            CSharpCompilation.Create(".foo", options: compilationOptions).VerifyEmitDiagnostics();
+            CSharpCompilation.Create("foo ", options: compilationOptions).VerifyEmitDiagnostics(); // can end with whitespace
+            CSharpCompilation.Create("....", options: compilationOptions).VerifyEmitDiagnostics();
+            CSharpCompilation.Create(null, options: compilationOptions).VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -241,13 +280,13 @@ namespace A.B {
 
             result.Diagnostics.Verify(
                 // error CS2042: Invalid debug information format: -1
-                Diagnostic(ErrorCode.ERR_InvalidDebugInformationFormat).WithArguments("-1"),
+                Diagnostic(ErrorCode.ERR_InvalidDebugInformationFormat).WithArguments("-1").WithLocation(1, 1),
                 // error CS2041: Invalid output name: Name cannot start with whitespace.
-                Diagnostic(ErrorCode.ERR_InvalidOutputName).WithArguments(CodeAnalysisResources.NameCannotStartWithWhitespace),
+                Diagnostic(ErrorCode.ERR_InvalidOutputName).WithArguments(CodeAnalysisResources.NameCannotStartWithWhitespace).WithLocation(1, 1),
                 // error CS2024: Invalid file section alignment '513'
-                Diagnostic(ErrorCode.ERR_InvalidFileAlignment).WithArguments("513"),
+                Diagnostic(ErrorCode.ERR_InvalidFileAlignment).WithArguments("513").WithLocation(1, 1),
                 // error CS1773: Invalid version 1000000.-1000000 for /subsystemversion. The version must be 6.02 or greater for ARM or AppContainerExe, and 4.00 or greater otherwise
-                Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("1000000.-1000000"));
+                Diagnostic(ErrorCode.ERR_InvalidSubsystemVersion).WithArguments("1000000.-1000000").WithLocation(1, 1));
 
             Assert.False(result.Success);
         }
@@ -1520,7 +1559,7 @@ class A
 ";
             // equivalent of csc with no /moduleassemblyname specified:
             var compilation = CSharpCompilation.Create(assemblyName: null, options: TestOptions.ReleaseModule, syntaxTrees: new[] { Parse(source) }, references: new[] { MscorlibRef });
-            compilation.VerifyDiagnostics();
+            compilation.VerifyEmitDiagnostics();
 
             Assert.Null(compilation.AssemblyName);
             Assert.Equal("?", compilation.Assembly.Name);
@@ -1528,7 +1567,7 @@ class A
 
             // no name is allowed for assembly as well, although it isn't useful:
             compilation = CSharpCompilation.Create(assemblyName: null, options: TestOptions.ReleaseDll, syntaxTrees: new[] { Parse(source) }, references: new[] { MscorlibRef });
-            compilation.VerifyDiagnostics();
+            compilation.VerifyEmitDiagnostics();
 
             Assert.Null(compilation.AssemblyName);
             Assert.Equal("?", compilation.Assembly.Name);

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/AssemblyIdentityTests.cs
@@ -247,7 +247,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void MetadataConstructor()
         {
-            var id = new AssemblyIdentity("Foo", new Version(1, 2, 3, 4), "en-US", RoPublicKey1, hasPublicKey: true, isRetargetable: true, contentType: AssemblyContentType.Default, noThrow: true);
+            var id = new AssemblyIdentity(/*noThrow:*/true, "Foo", new Version(1, 2, 3, 4), "en-US", RoPublicKey1, 
+                hasPublicKey: true, isRetargetable: true, contentType: AssemblyContentType.Default);
             Assert.Equal("Foo", id.Name);
             Assert.Equal(new Version(1, 2, 3, 4), id.Version);
             Assert.Equal(AssemblyNameFlags.PublicKey | AssemblyNameFlags.Retargetable, id.Flags);
@@ -259,7 +260,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(AssemblyContentType.Default, id.ContentType);
 
             // invalid content type:
-            id = new AssemblyIdentity("Foo", new Version(1, 2, 3, 4), null, ImmutableArray<byte>.Empty, hasPublicKey: false, isRetargetable: false, contentType: (AssemblyContentType)2, noThrow: true);
+            id = new AssemblyIdentity(/*noThrow:*/true, "Foo", new Version(1, 2, 3, 4), null, ImmutableArray<byte>.Empty, 
+                hasPublicKey: false, isRetargetable: false, contentType: (AssemblyContentType)2);
             Assert.Equal(AssemblyNameFlags.None, id.Flags);
             Assert.Equal("", id.CultureName);
             Assert.Equal(false, id.HasPublicKey);
@@ -268,7 +270,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(AssemblyContentType.Default, id.ContentType);
 
             // default Retargetable=No if content type is WinRT
-            id = new AssemblyIdentity("Foo", new Version(1, 2, 3, 4), null, ImmutableArray<byte>.Empty, hasPublicKey: false, isRetargetable: true, contentType: AssemblyContentType.WindowsRuntime, noThrow: true);
+            id = new AssemblyIdentity(/*noThrow:*/true, "Foo", new Version(1, 2, 3, 4), null, ImmutableArray<byte>.Empty, 
+                hasPublicKey: false, isRetargetable: true, contentType: AssemblyContentType.WindowsRuntime);
             Assert.Equal("Foo", id.Name);
             Assert.Equal(new Version(1, 2, 3, 4), id.Version);
             Assert.Equal(AssemblyNameFlags.None, id.Flags);
@@ -280,13 +283,16 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // invalid culture:
             // The native compiler doesn't enforce that the culture be anything in particular. 
             // AssemblyIdentity should preserve user input even if it is of dubious utility.
-            id = new AssemblyIdentity("Foo", new Version(1, 2, 3, 4), "blah,", ImmutableArray<byte>.Empty, hasPublicKey: false, isRetargetable: false, contentType: AssemblyContentType.Default, noThrow: true);
+            id = new AssemblyIdentity(/*noThrow:*/true, "Foo", new Version(1, 2, 3, 4), "blah,", ImmutableArray<byte>.Empty, 
+                hasPublicKey: false, isRetargetable: false, contentType: AssemblyContentType.Default);
             Assert.Equal("blah,", id.CultureName);
 
-            id = new AssemblyIdentity("Foo", new Version(1, 2, 3, 4), "*", ImmutableArray<byte>.Empty, hasPublicKey: false, isRetargetable: false, contentType: AssemblyContentType.Default, noThrow: true);
+            id = new AssemblyIdentity(/*noThrow:*/true, "Foo", new Version(1, 2, 3, 4), "*", ImmutableArray<byte>.Empty, 
+                hasPublicKey: false, isRetargetable: false, contentType: AssemblyContentType.Default);
             Assert.Equal("*", id.CultureName);
 
-            id = new AssemblyIdentity("Foo", new Version(1, 2, 3, 4), "neutral", ImmutableArray<byte>.Empty, hasPublicKey: false, isRetargetable: false, contentType: AssemblyContentType.Default, noThrow: true);
+            id = new AssemblyIdentity(/*noThrow:*/true, "Foo", new Version(1, 2, 3, 4), "neutral", ImmutableArray<byte>.Empty, 
+                hasPublicKey: false, isRetargetable: false, contentType: AssemblyContentType.Default);
             Assert.Equal("", id.CultureName);
         }
 

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -929,6 +929,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Name cannot be null..
+        /// </summary>
+        internal static string NameCannotBeNull {
+            get {
+                return ResourceManager.GetString("NameCannotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name cannot start with whitespace..
         /// </summary>
         internal static string NameCannotStartWithWhitespace {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -279,6 +279,9 @@
   <data name="FileSizeExceedsMaximumAllowed" xml:space="preserve">
     <value>File size exceeds maximum allowed size of a valid metadata file.</value>
   </data>
+  <data name="NameCannotBeNull" xml:space="preserve">
+    <value>Name cannot be null.</value>
+  </data>
   <data name="NameCannotBeEmpty" xml:space="preserve">
     <value>Name cannot be empty.</value>
   </data>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -219,15 +219,14 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         public string AssemblyName { get; }
 
-        internal static void CheckAssemblyName(string assemblyName)
+        internal void CheckAssemblyName(DiagnosticBag diagnostics)
         {
             // We could only allow name == null if OutputKind is Module. 
-            // However we couldn't check such condition here since one wouldn't be able to call WithName(...).WithOptions(...).
-            // It does no harm that we allow name == null for assemblies as well, so we don't enforce it.
+            // However, it does no harm that we allow name == null for assemblies as well, so we don't enforce it.
 
-            if (assemblyName != null)
+            if (this.AssemblyName != null)
             {
-                MetadataHelpers.ValidateAssemblyOrModuleName(assemblyName, "assemblyName");
+                MetadataHelpers.CheckAssemblyOrModuleName(this.AssemblyName, MessageProvider, MessageProvider.ERR_BadAssemblyName, diagnostics);
             }
         }
 

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -225,5 +225,7 @@ namespace Microsoft.CodeAnalysis
 
         public abstract void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName);
         public abstract void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2);
+
+        public abstract int ERR_BadAssemblyName { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/EmitOptions.cs
+++ b/src/Compilers/Core/Portable/Emit/EmitOptions.cs
@@ -236,11 +236,7 @@ namespace Microsoft.CodeAnalysis.Emit
 
             if (OutputNameOverride != null)
             {
-                Exception error = MetadataHelpers.CheckAssemblyOrModuleName(OutputNameOverride, argumentName: null);
-                if (error != null)
-                {
-                    diagnostics.Add(messageProvider.CreateDiagnostic(messageProvider.ERR_InvalidOutputName, Location.None, error.Message));
-                }
+                MetadataHelpers.CheckAssemblyOrModuleName(OutputNameOverride, messageProvider, messageProvider.ERR_InvalidOutputName, diagnostics);
             }
 
             if (FileAlignment != 0 && !IsValidFileAlignment(FileAlignment))

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentity.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyIdentity.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis
             ImmutableArray<byte> publicKeyOrToken,
             bool hasPublicKey)
         {
-            Debug.Assert(IsValidName(name));
+            Debug.Assert(name != null);
             Debug.Assert(IsValid(version));
             Debug.Assert(IsValidCultureName(cultureName));
             Debug.Assert((hasPublicKey && MetadataHelpers.IsValidPublicKey(publicKeyOrToken)) || (!hasPublicKey && (publicKeyOrToken.IsDefaultOrEmpty || publicKeyOrToken.Length == PublicKeyTokenSize)));
@@ -171,16 +171,16 @@ namespace Microsoft.CodeAnalysis
 
         // constructor used by metadata reader:
         internal AssemblyIdentity(
+            bool noThrow,
             string name,
-            Version version,
-            string cultureName,
-            ImmutableArray<byte> publicKeyOrToken,
-            bool hasPublicKey,
-            bool isRetargetable,
-            AssemblyContentType contentType,
-            bool noThrow)
+            Version version = null,
+            string cultureName = null,
+            ImmutableArray<byte> publicKeyOrToken = default(ImmutableArray<byte>),
+            bool hasPublicKey = false,
+            bool isRetargetable = false,
+            AssemblyContentType contentType = AssemblyContentType.Default)
         {
-            Debug.Assert(!string.IsNullOrEmpty(name));
+            Debug.Assert(name != null);
             Debug.Assert((hasPublicKey && MetadataHelpers.IsValidPublicKey(publicKeyOrToken)) || (!hasPublicKey && (publicKeyOrToken.IsDefaultOrEmpty || publicKeyOrToken.Length == PublicKeyTokenSize)));
             Debug.Assert(noThrow);
 

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -366,8 +366,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 options = New VisualBasicCompilationOptions(OutputKind.ConsoleApplication)
             End If
 
-            CheckAssemblyName(assemblyName)
-
             Dim validatedReferences = ValidateReferences(Of VisualBasicCompilationReference)(references)
 
             Dim c As VisualBasicCompilation = Nothing
@@ -535,8 +533,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Creates a new compilation with the specified name.
         ''' </summary>
         Public Shadows Function WithAssemblyName(assemblyName As String) As VisualBasicCompilation
-            CheckAssemblyName(assemblyName)
-
             ' Can't reuse references since the source assembly name changed and the referenced symbols might 
             ' have internals-visible-to relationship with this compilation or they might had a circular reference 
             ' to this compilation.
@@ -1942,6 +1938,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' Add declaration errors
             If (stage = CompilationStage.Declare OrElse stage > CompilationStage.Declare AndAlso includeEarlierStages) Then
+                CheckAssemblyName(builder)
                 builder.AddRange(Options.Errors)
                 builder.AddRange(GetBoundReferenceManager().Diagnostics)
                 builder.AddRange(SourceAssembly.GetAllDeclarationErrors(cancellationToken))

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1627,7 +1627,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_PartialMethodParamArrayMismatch2 = 37204
 
         ERR_NetModuleNameMismatch = 37205
-        ERR_BadCompilationOption = 37206
+        ERR_BadModuleName = 37206
         ERR_CmdOptionConflictsSource = 37207
         ' unused 37208   
         ERR_InvalidSignaturePublicKey = 37209
@@ -1722,6 +1722,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_NewWithTupleTypeSyntax = 37280
         ERR_PredefinedValueTupleTypeMustBeStruct = 37281
         ERR_PublicSignNetModule = 37282
+        ERR_BadAssemblyName = 37283
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -525,6 +525,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return ERRID.ERR_EncUpdateFailedMissingAttribute
             End Get
         End Property
+
+        Public Overrides ReadOnly Property ERR_BadAssemblyName As Integer
+            Get
+                Return ERRID.ERR_BadAssemblyName
+            End Get
+        End Property
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ReferenceManager.vb
@@ -309,7 +309,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         modules,
                         resolutionDiagnostics)
 
-                    Dim assemblyBeingBuiltData As New AssemblyDataForAssemblyBeingBuilt(New AssemblyIdentity(name:=SimpleAssemblyName), referencedAssemblies, modules)
+                    Dim assemblyBeingBuiltData As New AssemblyDataForAssemblyBeingBuilt(New AssemblyIdentity(name:=SimpleAssemblyName, noThrow:=True), referencedAssemblies, modules)
                     Dim explicitAssemblyData = referencedAssemblies.Insert(0, assemblyBeingBuiltData)
 
                     ' Let's bind all the references and resolve missing one (if resolver is available)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -75,7 +75,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                        netModules As ImmutableArray(Of PEModule))
 
             Debug.Assert(compilation IsNot Nothing)
-            Debug.Assert(Not String.IsNullOrWhiteSpace(assemblySimpleName))
+            Debug.Assert(assemblySimpleName IsNot Nothing)
             Debug.Assert(Not String.IsNullOrWhiteSpace(moduleName))
             Debug.Assert(Not netModules.IsDefault)
 

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -748,6 +748,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Invalid assembly name: {0}.
+        '''</summary>
+        Friend ReadOnly Property ERR_BadAssemblyName() As String
+            Get
+                Return ResourceManager.GetString("ERR_BadAssemblyName", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Async methods cannot have ByRef parameters..
         '''</summary>
         Friend ReadOnly Property ERR_BadAsyncByRefParam() As String
@@ -969,15 +978,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property ERR_BadCodepage() As String
             Get
                 Return ResourceManager.GetString("ERR_BadCodepage", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
-        '''  Looks up a localized string similar to {0}.
-        '''</summary>
-        Friend ReadOnly Property ERR_BadCompilationOption() As String
-            Get
-                Return ResourceManager.GetString("ERR_BadCompilationOption", resourceCulture)
             End Get
         End Property
         
@@ -1329,6 +1329,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property ERR_BadModuleFlags1() As String
             Get
                 Return ResourceManager.GetString("ERR_BadModuleFlags1", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Invalid module name: {0}.
+        '''</summary>
+        Friend ReadOnly Property ERR_BadModuleName() As String
+            Get
+                Return ResourceManager.GetString("ERR_BadModuleName", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -4844,8 +4844,8 @@
   <data name="ERR_NetModuleNameMismatch" xml:space="preserve">
     <value>Module name '{0}' stored in '{1}' must match its filename.</value>
   </data>
-  <data name="ERR_BadCompilationOption" xml:space="preserve">
-    <value>{0}</value>
+  <data name="ERR_BadModuleName" xml:space="preserve">
+    <value>Invalid module name: {0}</value>
   </data>
   <data name="WRN_AssemblyAttributeFromModuleIsOverridden" xml:space="preserve">
     <value>Attribute '{0}' from module '{1}' will be ignored in favor of the instance appearing in source.</value>
@@ -5457,5 +5457,8 @@
   </data>
   <data name="ERR_DocFileGen" xml:space="preserve">
     <value>Error writing to XML documentation file: {0}</value>
+  </data>
+  <data name="ERR_BadAssemblyName" xml:space="preserve">
+    <value>Invalid assembly name: {0}</value>
   </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -911,10 +911,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If ModuleName IsNot Nothing Then
-                Dim e As Exception = MetadataHelpers.CheckAssemblyOrModuleName(ModuleName, NameOf(ModuleName))
-                If e IsNot Nothing Then
-                    builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_BadCompilationOption, e.Message))
-                End If
+                MetadataHelpers.CheckAssemblyOrModuleName(ModuleName, MessageProvider.Instance, ERRID.ERR_BadModuleName, builder)
             End If
 
             If Not OutputKind.IsValid() Then

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -43,28 +43,60 @@ BC37257: Option 'CryptoKeyFile' must be an absolute path.
 
         <WorkItem(538778, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538778")>
         <WorkItem(537623, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537623")>
+        <WorkItem(233669, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=233669")>
         <Fact>
         Public Sub CompilationName()
             ' report an error, rather then silently ignoring the directory
             ' (see cli partition II 22.30) 
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create("C:/foo/Test.exe"))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create("C:\foo\Test.exe"))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create("\foo/Test.exe"))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create("C:Test.exe"))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create("Te" & ChrW(0) & "st.exe"))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create("  " & vbTab & "  "))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create(ChrW(&HD800)))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create(""))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create(" a"))
-            Assert.Throws(Of ArgumentException)(Function() VisualBasicCompilation.Create("\u2000a")) ' // U+2000 is whitespace
+            VisualBasicCompilation.Create("C:/foo/Test.exe").AssertTheseEmitDiagnostics(
+                <expected>
+BC30420: 'Sub Main' was not found in 'C:/foo/Test.exe'.
+BC37283: Invalid assembly name: Name contains invalid characters.
+                </expected>)
+            VisualBasicCompilation.Create("C:\foo\Test.exe", options:=TestOptions.ReleaseDll).AssertTheseDeclarationDiagnostics(
+                <expected>
+BC37283: Invalid assembly name: Name contains invalid characters.
+                </expected>)
+            VisualBasicCompilation.Create("\foo/Test.exe", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics(
+                <expected>
+BC37283: Invalid assembly name: Name contains invalid characters.
+                </expected>)
+            VisualBasicCompilation.Create("C:Test.exe", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics(
+                <expected>
+BC37283: Invalid assembly name: Name contains invalid characters.
+                </expected>)
+            VisualBasicCompilation.Create("Te" & ChrW(0) & "st.exe", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics(
+                <expected>
+BC37283: Invalid assembly name: Name contains invalid characters.
+                </expected>)
+            VisualBasicCompilation.Create("  " & vbTab & "  ", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics(
+                <expected>
+BC37283: Invalid assembly name: Name cannot start with whitespace.
+                </expected>)
+            VisualBasicCompilation.Create(ChrW(&HD800), options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics(
+                <expected>
+BC37283: Invalid assembly name: Name contains invalid characters.
+                </expected>)
+            VisualBasicCompilation.Create("", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics(
+                <expected>
+BC37283: Invalid assembly name: Name cannot be empty.
+                </expected>)
+            VisualBasicCompilation.Create(" a", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics(
+                <expected>
+BC37283: Invalid assembly name: Name cannot start with whitespace.
+                </expected>)
+            VisualBasicCompilation.Create("\u2000a", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics( ' // U+2000 is whitespace
+                <expected>
+BC37283: Invalid assembly name: Name contains invalid characters.
+                </expected>)
 
             ' other characters than directory separators are ok:
-            VisualBasicCompilation.Create(";,*?<>#!@&")
-            VisualBasicCompilation.Create("foo")
-            VisualBasicCompilation.Create(".foo")
-            VisualBasicCompilation.Create("foo ") ' can end with whitespace
-            VisualBasicCompilation.Create("....")
-            VisualBasicCompilation.Create(Nothing)
+            VisualBasicCompilation.Create(";,*?<>#!@&", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics()
+            VisualBasicCompilation.Create("foo", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics()
+            VisualBasicCompilation.Create(".foo", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics()
+            VisualBasicCompilation.Create("foo ", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics() ' can end with whitespace
+            VisualBasicCompilation.Create("....", options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics()
+            VisualBasicCompilation.Create(Nothing, options:=TestOptions.ReleaseDll).AssertTheseEmitDiagnostics()
         End Sub
 
         <Fact>
@@ -1491,14 +1523,14 @@ End Class
 
             ' equivalent of vbc with no /moduleassemblyname specified:
             Dim c = VisualBasicCompilation.Create(assemblyName:=Nothing, options:=TestOptions.ReleaseModule, syntaxTrees:={Parse(source)}, references:={MscorlibRef})
-            c.VerifyDiagnostics()
+            c.VerifyEmitDiagnostics()
             Assert.Null(c.AssemblyName)
             Assert.Equal("?", c.Assembly.Name)
             Assert.Equal("?", c.Assembly.Identity.Name)
 
             ' no name is allowed for assembly as well, although it isn't useful:
             c = VisualBasicCompilation.Create(assemblyName:=Nothing, options:=TestOptions.ReleaseModule, syntaxTrees:={Parse(source)}, references:={MscorlibRef})
-            c.VerifyDiagnostics()
+            c.VerifyEmitDiagnostics()
             Assert.Null(c.AssemblyName)
             Assert.Equal("?", c.Assembly.Name)
             Assert.Equal("?", c.Assembly.Identity.Name)

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
@@ -126,6 +126,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             TestProperty(Function(old, value) old.WithStrongNameProvider(value), Function(opt) opt.StrongNameProvider, New DesktopStrongNameProvider())
         End Sub
 
+        <Fact>
         Public Sub WithXxx()
             AssertTheseDiagnostics(New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithScriptClassName(Nothing).Errors,
 <expected>
@@ -176,12 +177,12 @@ BC2014: the value '<%= Int32.MinValue %>' is invalid for option 'OutputKind'
 
             AssertTheseDiagnostics(New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptimizationLevel(CType(Int32.MaxValue, OptimizationLevel)).Errors,
 <expected>
-BC2014: the value '<%= Int32.MaxValue %>' is invalid for option 'DebugInformationKind'
+BC2014: the value '<%= Int32.MaxValue %>' is invalid for option 'OptimizationLevel'
 </expected>)
 
             AssertTheseDiagnostics(New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptimizationLevel(CType(Int32.MinValue, OptimizationLevel)).Errors,
 <expected>
-BC2014: the value '<%= Int32.MinValue %>' is invalid for option 'DebugInformationKind'
+BC2014: the value '<%= Int32.MinValue %>' is invalid for option 'OptimizationLevel'
 </expected>)
 
             AssertTheseDiagnostics(New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionStrict(CType(3, OptionStrict)).Errors,
@@ -202,38 +203,32 @@ BC2014: the value '<%= Int32.MinValue %>' is invalid for option 'Platform'
             Assert.Equal(Nothing, TestOptions.ReleaseDll.WithModuleName("foo").WithModuleName(Nothing).ModuleName)
             AssertTheseDiagnostics(TestOptions.ReleaseDll.WithModuleName("").Errors,
 <expected>
-BC37206: Name cannot be empty.
-Parameter name: ModuleName
+BC37206: Invalid module name: Name cannot be empty.
 </expected>)
 
             AssertTheseDiagnostics(TestOptions.ReleaseDll.WithModuleName("a\0a").Errors,
 <expected>
-BC37206: Name contains invalid characters.
-Parameter name: ModuleName
+BC37206: Invalid module name: Name contains invalid characters.
 </expected>)
 
             AssertTheseDiagnostics(TestOptions.ReleaseDll.WithModuleName("a\uD800b").Errors,
 <expected>
-BC37206: Name contains invalid characters.
-Parameter name: ModuleName
+BC37206: Invalid module name: Name contains invalid characters.
 </expected>)
 
             AssertTheseDiagnostics(TestOptions.ReleaseDll.WithModuleName("a\\b").Errors,
 <expected>
-BC37206: Name contains invalid characters.
-Parameter name: ModuleName
+BC37206: Invalid module name: Name contains invalid characters.
 </expected>)
 
             AssertTheseDiagnostics(TestOptions.ReleaseDll.WithModuleName("a/b").Errors,
 <expected>
-BC37206: Name contains invalid characters.
-Parameter name: ModuleName
+BC37206: Invalid module name: Name contains invalid characters.
 </expected>)
 
             AssertTheseDiagnostics(TestOptions.ReleaseDll.WithModuleName("a:b").Errors,
 <expected>
-BC37206: Name contains invalid characters.
-Parameter name: ModuleName
+BC37206: Invalid module name: Name contains invalid characters.
 </expected>)
         End Sub
 

--- a/src/Test/Utilities/Portable/Mocks/TestMessageProvider.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestMessageProvider.cs
@@ -417,5 +417,13 @@ namespace Roslyn.Test.Utilities
                 throw new NotImplementedException();
             }
         }
+
+        public override int ERR_BadAssemblyName
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**
Compilation.Create API throws an exception for an invalid assembly name given as an input. It is preferred to report the problem as diagnostics.

**Bugs this fixes:** 
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=233669.

**Workarounds, if any**
No

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
Have unit-tests.

**How was the bug found?**
Watson.