### PR TITLE
make sure RegisterWorkspace is called from foreground thread

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -180,11 +180,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _workspaceHosts.Add(new WorkspaceHostState(this, host));
         }
 
-        public Task RegisterWorkspaceHostFromForegroundThreadAsync(IVisualStudioWorkspaceHost host)
-        {
-            return InvokeBelowInputPriority(() => RegisterWorkspaceHost(host));
-        }
-
         public void StartSendingEventsToWorkspaceHost(IVisualStudioWorkspaceHost host)
         {
             AssertIsForeground();

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using Microsoft.CodeAnalysis;
@@ -67,7 +68,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private readonly Dictionary<ProjectId, AbstractProject> _projectMap;
         private readonly Dictionary<string, ProjectId> _projectPathToIdMap;
-#endregion
+        #endregion
 
         /// <summary>
         /// Provided to not break CodeLens which has a dependency on this API until there is a
@@ -177,6 +178,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             _workspaceHosts.Add(new WorkspaceHostState(this, host));
+        }
+
+        public Task RegisterWorkspaceHostFromForegroundThreadAsync(IVisualStudioWorkspaceHost host)
+        {
+            return InvokeBelowInputPriority(() => RegisterWorkspaceHost(host));
         }
 
         public void StartSendingEventsToWorkspaceHost(IVisualStudioWorkspaceHost host)

--- a/src/VisualStudio/Core/Next/Remote/RemoteHostClientFactory.cs
+++ b/src/VisualStudio/Core/Next/Remote/RemoteHostClientFactory.cs
@@ -16,18 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     {
         public async Task<RemoteHostClient> CreateAsync(Workspace workspace, CancellationToken cancellationToken)
         {
-            try
-            {
-                // this is the point where we can create different kind of remote host client in future (cloud or etc)
-                return await ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken).ConfigureAwait(false);
-            }
-            catch
-            {
-                // currently there is so many moving parts that cause, in some branch/drop,
-                // service hub not to work. in such places (ex, Jenkins), rather than crashing VS
-                // right away, let VS run without service hub enabled.
-                return null;
-            }
+            // this is the point where we can create different kind of remote host client in future (cloud or etc)
+            return await ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -46,23 +46,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                 // Create a workspace host to hear about workspace changes.  We'll 
                 // remote those changes over to the remote side when they happen.
-                RegisterWorkspaceHost(workspace, instance);
+                await RegisterWorkspaceHostAsync(workspace, instance).ConfigureAwait(false);
 
                 // return instance
                 return instance;
             }
         }
 
-        private static void RegisterWorkspaceHost(Workspace workspace, RemoteHostClient client)
+        private static Task RegisterWorkspaceHostAsync(Workspace workspace, RemoteHostClient client)
         {
             var vsWorkspace = workspace as VisualStudioWorkspaceImpl;
             if (vsWorkspace == null)
             {
-                return;
+                return Task.CompletedTask;
             }
 
-            vsWorkspace.ProjectTracker.RegisterWorkspaceHost(
-                new WorkspaceHost(vsWorkspace, client));
+            return vsWorkspace.ProjectTracker.RegisterWorkspaceHostFromForegroundThreadAsync(new WorkspaceHost(vsWorkspace, client));
         }
 
         private ServiceHubRemoteHostClient(

--- a/src/VisualStudio/RemoteHostClientMock/Remote/RemoteHostClientFactory.cs
+++ b/src/VisualStudio/RemoteHostClientMock/Remote/RemoteHostClientFactory.cs
@@ -16,20 +16,13 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow.Remote
     {
         public async Task<RemoteHostClient> CreateAsync(Workspace workspace, CancellationToken cancellationToken)
         {
-            try
+            // this is the point where we can create different kind of remote host client in future (cloud or etc)
+            if (workspace.Options.GetOption(RemoteHostClientFactoryOptions.RemoteHost_InProc))
             {
-                // this is the point where we can create different kind of remote host client in future (cloud or etc)
-                if (workspace.Options.GetOption(RemoteHostClientFactoryOptions.RemoteHost_InProc))
-                {
-                    return await InProcRemoteHostClient.CreateAsync(workspace, runCacheCleanup: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
+                return await InProcRemoteHostClient.CreateAsync(workspace, runCacheCleanup: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
 
-                return await ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken).ConfigureAwait(false);
-            }
-            catch
-            {
-                return null;
-            }
+            return await ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/SpecializedTasks.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpecializedTasks.cs
@@ -11,7 +11,7 @@ namespace Roslyn.Utilities
     {
         public static readonly Task<bool> True = Task.FromResult<bool>(true);
         public static readonly Task<bool> False = Task.FromResult<bool>(false);
-        public static readonly Task EmptyTask = Empty<object>.Default;
+        public static readonly Task EmptyTask = Task.CompletedTask;
 
         public static Task<T> Default<T>()
         {


### PR DESCRIPTION
addresses https://github.com/dotnet/roslyn/issues/16065

it is part of @dotnet/roslyn-ide addressing roslyn race and threading issue to make sure we can detect bugs on those area early.

..

turns out this broke OOP completely. initializing OOP failed at start up. exception got swallowed due to try/catch I added for jenkins where service hub didn't supported yet.