### PR TITLE
Moving the LibGit2Sharp.NativeBinaries reference back to 1.0.129

### DIFF
--- a/src/Tools/Github/GitMergeBot/project.json
+++ b/src/Tools/Github/GitMergeBot/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "LibGit2Sharp": "0.22.0",
-    "LibGit2Sharp.NativeBinaries": "1.0.160",
     "Mono.Options": "4.4.0",
     "Newtonsoft.Json": "9.0.1",
     "Octokit": "0.23.0",


### PR DESCRIPTION
FYI. @jaredpar, @jasonmalinowski, @dotnet/roslyn-infrastructure 


The LibGit2Sharp and LibGit2Sharp.NativeBinaries references are very closely tied together. LibGit2Sharp v0.22 needs to reference LibGit2Sharp.NativeBinaries v1.0.129 so that the native binary copied to the output folder has a name of `git2-785d8c4.dll`, rather than `git2-baa87df.dll`