### PR TITLE
Add missing facade to the compiler insertion

### DIFF
--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -879,6 +879,7 @@ Public Class BuildDevDivInsertionFiles
         add("Vsix\CompilerExtension\System.Security.Principal.Windows.dll")
         add("Vsix\CompilerExtension\System.Text.Encoding.CodePages.dll")
         add("Vsix\CompilerExtension\System.Threading.Thread.dll")
+        add("Vsix\CompilerExtension\System.Xml.ReaderWriter.dll")
         add("Vsix\CompilerExtension\System.Xml.XmlDocument.dll")
         add("Vsix\CompilerExtension\System.Xml.XPath.dll")
         add("Vsix\CompilerExtension\System.Xml.XPath.XDocument.dll")

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -121,7 +121,7 @@ Public Class BuildDevDivInsertionFiles
         "System.Text.Encoding.CodePages.dll",
         "System.Threading.Thread.dll",
         "System.ValueTuple.dll",
-        "System.Xml.ReaderWriter.dll"
+        "System.Xml.ReaderWriter.dll",
         "System.Xml.XmlDocument.dll",
         "System.Xml.XPath.dll",
         "System.Xml.XPath.XDocument.dll",

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -121,6 +121,7 @@ Public Class BuildDevDivInsertionFiles
         "System.Text.Encoding.CodePages.dll",
         "System.Threading.Thread.dll",
         "System.ValueTuple.dll",
+        "System.Xml.ReaderWriter.dll"
         "System.Xml.XmlDocument.dll",
         "System.Xml.XPath.dll",
         "System.Xml.XPath.XDocument.dll",


### PR DESCRIPTION
The list of insertion files was missing System.Xml.ReaderWriter.dll, which breaks the toolset package and also results in an incomplete VS insertion.

This should fix the build break that was caused by missing this facade (from the update from netcore 1.0 references to 1.1).