### PR TITLE
Fix FSA option not being persisted

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             else if (optionKey.Option.Type == typeof(bool?))
             {
                 // when nullable type is assigned to object, it can lose nullable type.
-                return (value is bool) || (value == null);
+                return (value is bool?) || (value is bool) || (value == null);
             }
             else if (value != null && optionKey.Option.Type != value.GetType())
             {

--- a/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
@@ -174,6 +174,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 value = longValue != 0;
                 return true;
             }
+            else if (optionKey.Option.Type == typeof(bool?))
+            {
+                // when nullable type is assigned to object, it can lose nullable type.
+                return (value is bool) || (value == null);
+            }
             else if (value != null && optionKey.Option.Type != value.GetType())
             {
                 // We got something back different than we expected, so fail to deserialize

--- a/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/RoamingVisualStudioProfileOptionPersister.cs
@@ -176,8 +176,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             }
             else if (optionKey.Option.Type == typeof(bool?))
             {
-                // when nullable type is assigned to object, it can lose nullable type.
-                return (value is bool?) || (value is bool) || (value == null);
+                // code uses object to hold onto any value which will use boxing on value types.
+                // see boxing on nullable types - https://msdn.microsoft.com/en-us/library/ms228597.aspx
+                return (value is bool) || (value == null);
             }
             else if (value != null && optionKey.Option.Type != value.GetType())
             {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
@@ -50,23 +50,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             _errorList.PropertyChanged += OnErrorListPropertyChanged;
             AddInitialTableSource(workspace.CurrentSolution, GetCurrentDataSource());
             SuppressionStateColumnDefinition.SetDefaultFilter(_errorList.TableControl);
-
-            if (ErrorListHasFullSolutionAnalysisButton())
-            {
-                SetupErrorListFullSolutionAnalysis(workspace);
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void SetupErrorListFullSolutionAnalysis(Workspace workspace)
-        {
-            var errorList2 = _errorList as IErrorList2;
-            if (errorList2 != null)
-            {
-                InitializeFullSolutionAnalysisState(workspace, errorList2);
-                errorList2.AnalysisToggleStateChanged += OnErrorListFullSolutionAnalysisToggled;
-                workspace.Services.GetService<IOptionService>().OptionChanged += OnOptionChanged;
-            }
         }
 
         private ITableDataSource GetCurrentDataSource()
@@ -152,54 +135,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             if (e.PropertyName == nameof(IErrorList.AreOtherErrorSourceEntriesShown))
             {
                 AddTableSourceIfNecessary(this.Workspace.CurrentSolution);
-            }
-        }
-
-        private void OnOptionChanged(object sender, OptionChangedEventArgs e)
-        {
-            Contract.ThrowIfFalse(_errorList is IErrorList2);
-
-            if (e.Option == RuntimeOptions.FullSolutionAnalysis || e.Option == ServiceFeatureOnOffOptions.ClosedFileDiagnostic)
-            {
-                var analysisDisabled = !(bool)e.Value;
-                if (analysisDisabled)
-                {
-                    ((IErrorList2)_errorList).AnalysisToggleState = false;
-                }
-            }
-        }
-
-        private void OnErrorListFullSolutionAnalysisToggled(object sender, AnalysisToggleStateChangedEventArgs e)
-        {
-            Workspace.Options = Workspace.Options
-                .WithChangedOption(RuntimeOptions.FullSolutionAnalysis, e.NewState)
-                .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.CSharp, e.NewState)
-                .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.VisualBasic, e.NewState)
-                .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, TypeScriptLanguageName, e.NewState);
-        }
-
-        private static void InitializeFullSolutionAnalysisState(Workspace workspace, IErrorList2 errorList2)
-        {
-            // Initialize the error list toggle state based on full solution analysis state for all supported languages.
-            var fullAnalysisState = workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis) &&
-                ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace.Options, LanguageNames.CSharp) &&
-                ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace.Options, LanguageNames.VisualBasic) &&
-                ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace.Options, TypeScriptLanguageName);
-            errorList2.AnalysisToggleState = fullAnalysisState;
-        }
-
-        internal static bool ErrorListHasFullSolutionAnalysisButton()
-        {
-            try
-            {
-                // Full solution analysis option has been moved to the error list from Dev14 Update3.
-                // Use reflection to check if the new interface "IErrorList2" exists in Microsoft.VisualStudio.Shell.XX.0.dll.
-                return typeof(ErrorHandler).Assembly.GetType("Microsoft.Internal.VisualStudio.Shell.IErrorList2") != null;
-            }
-            catch (Exception)
-            {
-                // Ignore exceptions.
-                return false;
             }
         }
     }

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -130,16 +130,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         protected void BindToFullSolutionAnalysisOption(CheckBox checkbox, string languageName)
         {
-            // Full solution analysis option has been moved to error list from Dev14 Update3.
-            // We only want to show the full solution analysis option in Tools Options, if we are running against prior VS bits.
-            if (VisualStudioDiagnosticListTable.ErrorListHasFullSolutionAnalysisButton())
-            {
-                checkbox.Visibility = Visibility.Collapsed;
-                return;
-            }
-
             checkbox.Visibility = Visibility.Visible;
-                        
+
             Binding binding = new Binding()
             {
                 Source = new FullSolutionAnalysisOptionBinding(OptionService, languageName),


### PR DESCRIPTION
**Customer scenario**

Full solution analysis option is not persisted between VS sessions.

**Bugs this fixes:** 

fix https://github.com/dotnet/roslyn/issues/16015

**Workarounds, if any**

no workaround.

**Risk**

risk is low

**Performance impact**

I don't believe this will impact perf in any way

**Is this a regression from a previous update?**

Yes. regressed when we moved to new option framework to support editor config

**Root cause analysis:**

missed one case for nullable type.

**How was the bug found?**

dogfooding from other team.