### PR TITLE
Include the non-special type names for special types in cref completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -443,5 +443,22 @@ class C
                 Assert.True(called);
             }
         }
+
+        [WorkItem(16060, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/16060")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task SpecialTypeNames()
+        {
+            var text = @"
+using System;
+/// <see cref=""$$""/>
+class C 
+{ 
+    public void foo(int x) { }
+}
+";
+
+            await VerifyItemExistsAsync(text, "uint");
+            await VerifyItemExistsAsync(text, "UInt32");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -42,7 +42,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
                     SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        public static readonly SymbolDisplayFormat SpecialTypeCrefFormat =
+        // When creating items for SpecialTypes (eg. `UInt32`), create an item
+        // that uses the intrinsic type keyword and an item that uses the
+        // name of the special type 
+        public static readonly SymbolDisplayFormat CrefFormatForSpecialTypes =
             new SymbolDisplayFormat(
                 globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
                 typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
@@ -278,10 +281,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             Workspace workspace, SemanticModel semanticModel, ISymbol symbol, SyntaxToken token, int position, StringBuilder builder, 
             ImmutableDictionary<string, string> options, out CompletionItem item)
         {
+            // If the type is a SpecialType, create an additional item using 
+            // its actual name (as opposed to intrinsic type keyword)
             var typeSymbol = symbol as ITypeSymbol;
             if (typeSymbol.IsSpecialType())
             {
-                item = CreateItem(workspace, semanticModel, symbol, token, position, builder, options, SpecialTypeCrefFormat);
+                item = CreateItem(workspace, semanticModel, symbol, token, position, builder, options, CrefFormatForSpecialTypes);
                 return true;
             }
 
@@ -292,6 +297,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         private CompletionItem CreateItem(
             Workspace workspace, SemanticModel semanticModel, ISymbol symbol, SyntaxToken token, int position, StringBuilder builder, ImmutableDictionary<string, string> options)
         {
+            // For every symbol, we create an item that uses the regular CrefFormat,
+            // which uses intrinsic type keywords
             return CreateItem(workspace, semanticModel, symbol, token, position, builder, options, CrefFormat);
         }
 


### PR DESCRIPTION
**Customer scenario**
The customer is trying to type an XML cref but `UInt32` and other special types that have an intrinsic type keyword do not appear in the list. They only appear in their keyword form. This is confusing to users who want to use the type name.

**Bugs this fixes:** 
#16060 

**Workarounds, if any**
None

**Risk**
Low

**Performance impact**
Low--no allocation/complexity changes.

**Is this a regression from a previous update?**
No
**Root cause analysis:**
Never tested to see if special types appeared in the list--a test has been added to ensure we don't regress this.

**How was the bug found?**
Customer feedback