### PR TITLE
Updating the Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec to include Roslyn.Services.Test.Utilities

### DIFF
--- a/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
@@ -19,5 +19,6 @@
   </metadata>
   <files>
     <file src="Dlls\VisualStudioIntegrationTestUtilities\Microsoft.VisualStudio.IntegrationTest.Utilities.dll" target="lib\net46" />
+    <file src="Dlls\ServicesTestUtilities\Roslyn.Services.Test.Utilities.dll" target="lib\net46" />
   </files>
 </package>


### PR DESCRIPTION
FYI. @dotnet/roslyn-infrastructure, @dotnet/testimpact, @jasonmalinowski, @ManishJayaswal 

This is required for the Open Integration Test framework to be consumed by other repositories (such as Live Unit Testing).