### PR TITLE
Add 'Microsoft.DiaSymReader.Native.*.dll' to the VisualStudioSetup VSIX

### DIFF
--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -237,6 +237,10 @@
     <NuGetPackageToIncludeInVsix Include="System.Xml.XmlDocument" />
     <NuGetPackageToIncludeInVsix Include="System.Xml.XPath.XDocument" />
   </ItemGroup>
+  <ItemGroup>
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.DiaSymReader.Native.amd64.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.DiaSymReader.Native.x86.dll" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup>


### PR DESCRIPTION
FYI. @KevinH-MS, @tmat, @jaredpar, @Pilchie, @ManishJayaswal, @jasonmalinowski, @dotnet/testimpact 

This is required for determinism to be supported in design-time builds. Live Unit Testing currently requires this (@KevinH-MS is probably the best person to delve into the finer details about the build system here, if required).