### PR TITLE
made to reanalyze generated file whenever primary buffer is changed.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguage.cs
@@ -2,14 +2,17 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 {
@@ -18,6 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         where TLanguageService : AbstractLanguageService<TPackage, TLanguageService>
     {
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
+        private readonly IDiagnosticAnalyzerService _diagnosticAnalyzerService;
         private readonly TLanguageService _languageService;
 
         protected readonly Workspace Workspace;
@@ -46,7 +50,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             _languageService = languageService;
 
             this.Workspace = componentModel.GetService<VisualStudioWorkspace>();
+
             _editorAdaptersFactoryService = componentModel.GetService<IVsEditorAdaptersFactoryService>();
+            _diagnosticAnalyzerService = componentModel.GetService<IDiagnosticAnalyzerService>();
+
             // Get the ITextBuffer for the secondary buffer
             Marshal.ThrowExceptionForHR(bufferCoordinator.GetSecondaryBuffer(out var secondaryTextLines));
             var secondaryVsTextBuffer = (IVsTextBuffer)secondaryTextLines;
@@ -64,11 +71,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
             // TODO: Can contained documents be linked or shared?
             this.Project.AddDocument(this.ContainedDocument, isCurrentContext: true, hookupHandlers: true);
+            this.DataBuffer.Changed += OnDataBufferChanged;
         }
 
         private void OnDisconnect()
         {
+            this.DataBuffer.Changed -= OnDataBufferChanged;
             this.Project.RemoveDocument(this.ContainedDocument);
+        }
+
+        private void OnDataBufferChanged(object sender, TextContentChangedEventArgs e)
+        {
+            // we don't actually care what has changed in primary buffer. we just want to re-analyze secondary buffer
+            // when primary buffer has changed to update diagnostic positions.
+            _diagnosticAnalyzerService.Reanalyze(this.Workspace, documentIds: SpecializedCollections.SingletonEnumerable(this.ContainedDocument.Id));
         }
 
         public override void Dispose()


### PR DESCRIPTION
**Customer scenario**

when customer edits cshtml file that is not related to script, diagnostics reported on the script section don't get updated (such as positions)

**Bugs this fixes:** 

fix https://github.com/dotnet/roslyn/issues/15278

**Workarounds, if any**

update script sections

**Risk**

Risk should be low. all re-analyze requests are aggregated. and re-analyze is already supported scenario.

**Performance impact**

We now will reanalyze generated file more than before since we will consider any change on cshtml file as modification on the generated files. but all go to existing solution crawler engine, so all edits will be delayed, aggregated and etc.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

I dont believe we ever supported this scenario or razor might have updated generated file more often previously.

**How was the bug found?**

dogfooding.