### PR TITLE
Make the naming styles dialogs properly modal

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
         {
             var viewModel = new ManageSymbolSpecificationsDialogViewModel(_viewModel.Specifications, _viewModel.CodeStyleItems.ToList(), _languageName, _notificationService);
             var dialog = new ManageNamingStylesInfoDialog(viewModel);
-            if (dialog.ShowDialog().Value == true)
+            if (dialog.ShowModal().Value == true)
             {
                 _viewModel.UpdateSpecificationList(viewModel);
             }
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
         {
             var viewModel = new ManageNamingStylesDialogViewModel(_viewModel.NamingStyles, _viewModel.CodeStyleItems.ToList(), _notificationService);
             var dialog = new ManageNamingStylesInfoDialog(viewModel);
-            if (dialog.ShowDialog().Value == true)
+            if (dialog.ShowModal().Value == true)
             {
                 _viewModel.UpdateStyleList(viewModel);
             }

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyles/ManageNamingStylesDialogViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyles/ManageNamingStylesDialogViewModel.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
             var viewModel = new NamingStyleViewModel(style, canBeDeleted: true, notificationService: _notificationService);
             var dialog = new NamingStyleDialog(viewModel);
 
-            if (dialog.ShowDialog().Value == true)
+            if (dialog.ShowModal().Value == true)
             {
                 Items.Add(viewModel);
             }
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
             var viewModel = new NamingStyleViewModel(style, context.CanBeDeleted, notificationService: _notificationService);
             var dialog = new NamingStyleDialog(viewModel);
 
-            if (dialog.ShowDialog().Value == true)
+            if (dialog.ShowModal().Value == true)
             {
                 context.ItemName = viewModel.ItemName;
                 context.RequiredPrefix = viewModel.RequiredPrefix;

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/ManageSymbolSpecificationsDialogViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/ManageSymbolSpecificationsDialogViewModel.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
         {
             var viewModel = new SymbolSpecificationViewModel(LanguageName, canBeDeleted: true, notificationService: _notificationService);
             var dialog = new SymbolSpecificationDialog(viewModel);
-            if (dialog.ShowDialog().Value == true)
+            if (dialog.ShowModal().Value == true)
             {
                 Items.Add(viewModel);
             }
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
             var symbolSpecification = ((SymbolSpecificationViewModel)item).GetSymbolSpecification();
             var viewModel = new SymbolSpecificationViewModel(LanguageName, symbolSpecification, symbolSpecificationViewModel.CanBeDeleted, _notificationService);
             var dialog = new SymbolSpecificationDialog(viewModel);
-            if (dialog.ShowDialog().Value == true)
+            if (dialog.ShowModal().Value == true)
             {
                 symbolSpecificationViewModel.ItemName = viewModel.ItemName;
                 symbolSpecificationViewModel.AccessibilityList = viewModel.AccessibilityList;


### PR DESCRIPTION
Fixes #16172
Fixes #15429
Related to internal bug 276905

We were incorrectly calling .ShowDialog() instead of .ShowModal(), and
.ShowModal() is the version that does the work of setting the dialog's
Owner based on the currently focused hwnd.

Ask Mode
======

**Customer scenario**: Opening any of the modal dialogs in the Naming Styles option page would show the dialog in a seemingly arbitrary location, unrelated to the position of VS or the Tools | Options window. This would also cause the dialog to get "lost" when the user focuses another application and then comes back to VS (via alt+tab at least) -- the dialog would be hidden and VS would *appear* hung because the Tools | Options page would appear unresponsive.

**Bugs this fixes:** #16172, #15429, invalidates [internal bug 276905](https://devdiv.visualstudio.com/DevDiv/_workitems?id=276905&_a=edit)

**Workarounds, if any**: For the alt+tab problem, users can Win+tab instead to find the dialog. For the window placement problem, it's really just an annoyance and the window can be moved to a better location (every time).

**Risk**: Extremely low. This just changes how the Naming Styles dialogs are shown to match how we show all other modal dialogs in Roslyn.

**Performance impact**: Essentially none. No additional allocations in Roslyn code, though the platform may do more work on this code path. However, this is an infrequent action that's based on user action, so any inefficiencies in the platform code should be irrelevant. Plus this now matches how dialogs are *supposed* to be shown, so this should be no more inefficient than properly showing any other modal dialog in VS.

**Is this a regression from a previous update?** This has been broken since the introduction of the Naming Styles UI.

**Root cause analysis:** We were just calling the wrong API (.ShowDialog() instead of .ShowModal()), but I thought it wasn't working correctly because the dialogs were being launched from Tools | Options, which turned out to be a red herring.

**How was the bug found?** Dogfooding and customer feedback.