### PR TITLE
Foreach deconstruction should mark iteration variables as assigned.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -2199,6 +2199,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Assign(node, value: null);
                 // TODO: node needed? NoteRead(local); // Never warn about unused foreach variables.
             }
+
+            var deconstruction = node.DeconstructionOpt;
+            if (deconstruction != null)
+            {
+                VisitDeconstructionAssignmentOperator(deconstruction.DeconstructionAssignment);
+            }
+
         }
 
         public override BoundNode VisitObjectInitializerMember(BoundObjectInitializerMember node)


### PR DESCRIPTION
Fixes:#16106

**Customer scenario**

When deconstruction is used in a context of foreach, the deconstructed variables are not marked as assigned. As a result, if a deconstruction variable is a struct (KeyValuePair, etc...). Dotting off the variable in the loop body would result in a false definite assignment error.

**Bugs this fixes:** 

#16106

No workarounds other than not using the given language construct when structs are involved.
The bug would block a sizeable fraction of user scenarios for the feature.

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

Low.

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

The bug is at intersection of "foreach" and "deconstruction" features. It also requires that deconstruction targets are structs. 
We seem to have missed this combination in testing.

**How was the bug found?**

Customer report.