### PR TITLE
Remove leading trivia from a type when moving to a new file.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         {
             var code =
 @"[|clas|]s Class1 { }
-class Class2 { }";
+ class Class2 { }";
             var codeAfterMove = @"class Class2 { }";
 
             var expectedDocumentName = "Class1.cs";
@@ -783,6 +783,44 @@ partial class Outer {
 }";
 
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
+        }
+
+        [WorkItem(16283, "https://github.com/dotnet/roslyn/issues/16283")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task TestLeadingTrivia1()
+        {
+            var code =
+@"
+class Outer
+{
+    class Inner1
+    {
+    }
+
+    [|class|] Inner2
+    {
+    }
+}";
+            var codeAfterMove = @"
+partial class Outer
+{
+    class Inner1
+    {
+    }
+}";
+
+            var expectedDocumentName = "Inner2.cs";
+            var destinationDocumentText = @"
+partial class Outer
+{
+    class Inner2
+    {
+    }
+}";
+
+            await TestMoveTypeToNewFileAsync(
+                code, codeAfterMove, expectedDocumentName, destinationDocumentText,
+                compareTokens: false);
         }
     }
 }

--- a/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructStatementVisitor_IfStatement.vb
+++ b/src/EditorFeatures/VisualBasic/EndConstructGeneration/EndConstructStatementVisitor_IfStatement.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
 
                 ' Add the new whitespace on the start of the statement
                 If statement.Kind <> SyntaxKind.EmptyStatement OrElse statement.HasTrailingTrivia Then
-                    Dim leadingTrivia = indentedWhitespaceTrivia.Concat(triviaLeftForNextStatement.Concat(statement.GetLeadingTrivia()).WithoutLeadingWhitespace())
+                    Dim leadingTrivia = indentedWhitespaceTrivia.Concat(triviaLeftForNextStatement.Concat(statement.GetLeadingTrivia()).WithoutLeadingWhitespaceOrEndOfLine())
                     statement = statement.WithLeadingTrivia(leadingTrivia)
                 End If
 

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.RemoveUnnecessaryImports;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -227,6 +228,30 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                         documentEditor.RemoveAllComments(node);
                     }
                 }
+
+                documentEditor.ReplaceNode(State.TypeNode,
+                    (currentNode, generator) =>
+                    {
+                        var currentTypeNode = (TTypeDeclarationSyntax)currentNode;
+
+                        // Trim leading whitespace from the type so we don't have excessive
+                        // leading blank lines.
+                        return RemoveLeadingWhitespace(currentTypeNode);
+                    });
+            }
+
+            private TTypeDeclarationSyntax RemoveLeadingWhitespace(
+                TTypeDeclarationSyntax currentTypeNode)
+            {
+                var syntaxFacts = State.SemanticDocument.Document.GetLanguageService<ISyntaxFactsService>();
+                var leadingTrivia = currentTypeNode.GetLeadingTrivia();
+                var afterWhitespace = leadingTrivia.SkipWhile(
+                    t => syntaxFacts.IsWhitespaceTrivia(t) || syntaxFacts.IsEndOfLineTrivia(t));
+
+                var withoutLeadingWhitespace = currentTypeNode.WithLeadingTrivia(afterWhitespace);
+                return withoutLeadingWhitespace.ReplaceToken(
+                    withoutLeadingWhitespace.GetFirstToken(),
+                    withoutLeadingWhitespace.GetFirstToken().WithAdditionalAnnotations(Formatter.Annotation));
             }
         }
     }

--- a/src/Features/VisualBasic/Portable/RemoveUnnecessaryImports/AbstractVisualBasicRemoveUnnecessaryImportsService.Rewriter.vb
+++ b/src/Features/VisualBasic/Portable/RemoveUnnecessaryImports/AbstractVisualBasicRemoveUnnecessaryImportsService.Rewriter.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnnecessaryImports
                         oldImports(i) = Nothing
 
                         Dim leadingTrivia = oldImport.GetLeadingTrivia()
-                        If leadingTrivia.Any(Function(t) Not t.IsWhitespace()) Then
+                        If leadingTrivia.Any(Function(t) Not t.IsWhitespaceOrEndOfLine()) Then
                             ' This import had trivia we want to preserve. If we're the last import,
                             ' then copy this trivia out so that our caller can place it on the next token.
                             ' If there is any import following us, then place it on that.

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.vb
@@ -2187,7 +2187,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 If trivia.Kind = SyntaxKind.CommentTrivia Then
                     firstCommentFound = True
                     commentList.Add(trivia)
-                ElseIf Not firstCommentFound AndAlso trivia.IsWhitespace() Then
+                ElseIf Not firstCommentFound AndAlso trivia.IsWhitespaceOrEndOfLine() Then
                     Continue For
                 ElseIf firstCommentFound AndAlso trivia.Kind = SyntaxKind.EndOfLineTrivia AndAlso nextTrivia.Kind = SyntaxKind.CommentTrivia Then
                     Continue For

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTriviaExtensions.cs
@@ -171,9 +171,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsWhitespaceOrEndOfLine(this SyntaxTrivia trivia)
-        {
-            return IsWhitespace(trivia) || trivia.Kind() == SyntaxKind.EndOfLineTrivia;
-        }
+            => IsWhitespace(trivia) || IsEndOfLine(trivia);
+
+        public static bool IsEndOfLine(this SyntaxTrivia trivia)
+            => trivia.Kind() == SyntaxKind.EndOfLineTrivia;
 
         public static bool IsWhitespace(this SyntaxTrivia trivia)
             => trivia.Kind() == SyntaxKind.WhitespaceTrivia;

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1808,6 +1808,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public SyntaxNode GetOperandOfPrefixUnaryExpression(SyntaxNode node)
             => ((PrefixUnaryExpressionSyntax)node).Operand;
 
+        public bool IsWhitespaceTrivia(SyntaxTrivia trivia)
+            => trivia.IsWhitespace();
+
+        public bool IsEndOfLineTrivia(SyntaxTrivia trivia)
+            => trivia.IsEndOfLine();
+
         private class AddFirstMissingCloseBaceRewriter: CSharpSyntaxRewriter
         {
             private readonly SyntaxNode _contextNode; 

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -118,6 +118,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
         bool IsSkippedTokensTrivia(SyntaxNode node);
 
+        bool IsWhitespaceTrivia(SyntaxTrivia trivia);
+        bool IsEndOfLineTrivia(SyntaxTrivia trivia);
+
         SyntaxNode GetExpressionOfConditionalAccessExpression(SyntaxNode node);
 
         SyntaxNode GetExpressionOfElementAccessExpression(SyntaxNode node);

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
@@ -234,7 +234,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                 ' If previousToken has trailing WhitespaceTrivia, strip off the trailing WhitespaceTrivia from the lastToken.
                 Dim lastTrailingTrivia = lastToken.TrailingTrivia
                 If prevTrailingTrivia.Any(SyntaxKind.WhitespaceTrivia) Then
-                    lastTrailingTrivia = lastTrailingTrivia.WithoutLeadingWhitespace()
+                    lastTrailingTrivia = lastTrailingTrivia.WithoutLeadingWhitespaceOrEndOfLine()
                 End If
 
                 ' get the trivia and attach it to the last token

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTriviaExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTriviaExtensions.vb
@@ -17,10 +17,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                    trivia.Kind = kind3
         End Function
 
-        <Extension()>
+        <Extension>
+        Public Function IsWhitespaceOrEndOfLine(trivia As SyntaxTrivia) As Boolean
+            Return trivia.IsWhitespace() OrElse trivia.IsEndOfLine()
+        End Function
+
+        <Extension>
         Public Function IsWhitespace(trivia As SyntaxTrivia) As Boolean
-            Return trivia.Kind = SyntaxKind.WhitespaceTrivia OrElse
-                   trivia.Kind = SyntaxKind.EndOfLineTrivia
+            Return trivia.Kind = SyntaxKind.WhitespaceTrivia
+        End Function
+
+        <Extension>
+        Public Function IsEndOfLine(trivia As SyntaxTrivia) As Boolean
+            Return trivia.Kind = SyntaxKind.EndOfLineTrivia
         End Function
 
         <Extension>

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTriviaListExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTriviaListExtensions.vb
@@ -17,8 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         <Extension()>
-        Public Function WithoutLeadingWhitespace(list As IEnumerable(Of SyntaxTrivia)) As SyntaxTriviaList
-            Return list.SkipWhile(Function(t) t.IsWhitespace()).ToSyntaxTriviaList()
+        Public Function WithoutLeadingWhitespaceOrEndOfLine(list As IEnumerable(Of SyntaxTrivia)) As SyntaxTriviaList
+            Return list.SkipWhile(Function(t) t.IsWhitespaceOrEndOfLine()).ToSyntaxTriviaList()
         End Function
     End Module
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
@@ -343,7 +343,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             ' see whether first non whitespace trivia after previous member is comment or not
             Dim list = token1.TrailingTrivia.Concat(token2.LeadingTrivia)
 
-            Dim firstNonWhitespaceTrivia = list.FirstOrDefault(Function(t) Not t.IsWhitespace())
+            Dim firstNonWhitespaceTrivia = list.FirstOrDefault(Function(t) Not t.IsWhitespaceOrEndOfLine())
             If firstNonWhitespaceTrivia.IsKind(SyntaxKind.CommentTrivia, SyntaxKind.DocumentationCommentTrivia) Then
                 Dim totalLines = GetNumberOfLines(list)
                 Dim blankLines = GetNumberOfLines(list.TakeWhile(Function(t) t <> firstNonWhitespaceTrivia))

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1621,5 +1621,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             expression = memberAccess.Expression
             name = memberAccess.Name
         End Sub
+
+        Public Function IsWhitespaceTrivia(trivia As SyntaxTrivia) As Boolean Implements ISyntaxFactsService.IsWhitespaceTrivia
+            Return trivia.IsWhitespace()
+        End Function
+
+        Public Function IsEndOfLineTrivia(trivia As SyntaxTrivia) As Boolean Implements ISyntaxFactsService.IsEndOfLineTrivia
+            Return trivia.IsEndOfLine()
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/16283