### PR TITLE
Emit forwarded types in a deterministic order

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -557,7 +557,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 // (type, index of the parent exported type in builder, or -1 if the type is a top-level type)
                 var stack = ArrayBuilder<(NamedTypeSymbol type, int parentIndex)>.GetInstance();
 
-                foreach (NamedTypeSymbol forwardedType in wellKnownAttributeData.ForwardedTypes)
+                // Hashset enumeration is not guaranteed to be deterministic. Emitting in the order of fully qualified names.
+                var orderedForwardedTypes = wellKnownAttributeData.ForwardedTypes.OrderBy(t => t.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.QualifiedNameArityFormat));
+
+                foreach (NamedTypeSymbol forwardedType in orderedForwardedTypes)
                 {
                     NamedTypeSymbol originalDefinition = forwardedType.OriginalDefinition;
                     Debug.Assert((object)originalDefinition.ContainingType == null, "How did a nested type get forwarded?");

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -517,7 +517,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 ' (type, index of the parent exported type in builder, or -1 if the type is a top-level type)
                 Dim stack = ArrayBuilder(Of (type As NamedTypeSymbol, parentIndex As Integer)).GetInstance()
 
-                ' Hashset enumeration Is Not guaranteed to be deterministic. Emitting in the order of fully qualified names.
+                ' Hashset enumeration is not guaranteed to be deterministic. Emitting in the order of fully qualified names.
                 Dim orderedForwardedTypes = wellKnownAttributeData.ForwardedTypes.OrderBy(Function(t) t.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.QualifiedNameArityFormat))
 
                 For Each forwardedType As NamedTypeSymbol In orderedForwardedTypes

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -517,7 +517,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 ' (type, index of the parent exported type in builder, or -1 if the type is a top-level type)
                 Dim stack = ArrayBuilder(Of (type As NamedTypeSymbol, parentIndex As Integer)).GetInstance()
 
-                For Each forwardedType As NamedTypeSymbol In wellKnownAttributeData.ForwardedTypes
+                ' Hashset enumeration Is Not guaranteed to be deterministic. Emitting in the order of fully qualified names.
+                Dim orderedForwardedTypes = wellKnownAttributeData.ForwardedTypes.OrderBy(Function(t) t.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.QualifiedNameArityFormat))
+
+                For Each forwardedType As NamedTypeSymbol In orderedForwardedTypes
                     Dim originalDefinition As NamedTypeSymbol = forwardedType.OriginalDefinition
                     Debug.Assert(originalDefinition.ContainingType Is Nothing, "How did a nested type get forwarded?")
 

--- a/src/Test/Utilities/Portable/Metadata/MetadataValidation.cs
+++ b/src/Test/Utilities/Portable/Metadata/MetadataValidation.cs
@@ -132,5 +132,17 @@ namespace Roslyn.Test.Utilities
                 yield return (ns.Length == 0) ? name : (ns + "." + name);
             }
         }
+
+        internal static IEnumerable<string> GetExportedTypesFullNames(MetadataReader metadataReader)
+        {
+            foreach (var typeDefHandle in metadataReader.ExportedTypes)
+            {
+                var typeDef = metadataReader.GetExportedType(typeDefHandle);
+                var ns = metadataReader.GetString(typeDef.Namespace);
+                var name = metadataReader.GetString(typeDef.Name);
+
+                yield return (ns.Length == 0) ? name : (ns + "." + name);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #11990 

**Customer and Scenario Info**
Who is impacted by this bug: customers trying to use the deterministic output feature of compilers
What is the customer scenario and impact of the bug: two identical builds might not produce the same bits.
What is the workaround: none.
How was the bug found: Manual code inspection.
If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed: No.
​What is a Customer Rea​dy description of change should we need to document this: builds are now one step closer to be 100% deterministic (see #372).

**Bug Fix Details**
Overview of the fix: Enumerating a hashset in an ordered way when emitting forwarded types in an assembly.
Which VS products, SKUs, or components need the fix: all SKUs shipping Roslyn compilers.
What branch does the fix go into: lab/ml.
What feature areas are impacted by the fix: Roslyn compilers.
What is the risk of the code change: none.
Does this change have impact on anything else (e.g. setup, perf, stress, ux, visual freeze, go live, breaking change, samples, etc): no.
How is this fix rolling forward in the next major release / sprintly train (e.g. Dev15): RTM.

**​Validation**
What testing/validation was done on the fix, and what were the results: manual testing an unit tests were included in the PR.
Which engineering partner teams have signed off on the fix: @dotnet/roslyn-compiler
Who code reviewed the fix: @AlekseyTs @cston 

**Additional information during Divisional Escrow Mode**
Which Engineering DIRECTOR is accountable for the code change and quality: @MattGertz
What are you doing to ensure that this bug does not happen again: not a regression.
Which part of the D15 Escrow Bar does this fall under?: RTM ASK MODE
