### PR TITLE
Load codepages earlier

### DIFF
--- a/src/Compilers/Shared/CoreClrBuildClient.cs
+++ b/src/Compilers/Shared/CoreClrBuildClient.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         internal static int Run(IEnumerable<string> arguments, RequestLanguage language, CompileFunc compileFunc)
         {
             // Register encodings for console
+            // https://github.com/dotnet/roslyn/issues/10785 
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
             // Should be using BuildClient.GetCommandLineArgs(arguments) here.  But the native invoke

--- a/src/Compilers/Shared/CoreClrBuildClient.cs
+++ b/src/Compilers/Shared/CoreClrBuildClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {
@@ -25,6 +26,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         internal static int Run(IEnumerable<string> arguments, RequestLanguage language, CompileFunc compileFunc)
         {
+            // Register encodings for console
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
             // Should be using BuildClient.GetCommandLineArgs(arguments) here.  But the native invoke
             // ends up giving us both CoreRun and the exe file.  Need to find a good way to remove the host
             // as well as the EXE argument.

--- a/src/Compilers/Shared/CoreClrBuildClient.cs
+++ b/src/Compilers/Shared/CoreClrBuildClient.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {


### PR DESCRIPTION

**Customer scenario**

.NET CLI and other hosts of the CoreCLR version of csc cannot currently use encodings
not available on CoreCLR by default to print to the console. This change allows standard
encodings to be used as long as they're installed on the machine.


**Bugs this fixes:** 

Fixes #10785

**Workarounds, if any**

None.

**Risk**

Very small, well understood change to load encodings earlier (we are in fact
already loading these encodings, just too late to be used by the Console).

**Performance impact**

None -- we already run this code later.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

We run a very limited set of tests on CoreCLR at the moment.

**How was the bug found?**

Customer reported.