### PR TITLE
Updating Locate-VS.ps1 to use the copy in the tools directory, so the native-interop binaries are available at runtime.

### DIFF
--- a/build/scripts/locate-vs.ps1
+++ b/build/scripts/locate-vs.ps1
@@ -13,7 +13,7 @@ function Create-Directory([string[]] $path) {
 
 function Locate-LocateVsApi {
   $packagesPath = Locate-PackagesPath
-  $locateVsApi = Join-Path -path $packagesPath -ChildPath "RoslynTools.Microsoft.LocateVS\$locateVsApiVersion\lib\net46\LocateVS.dll"
+  $locateVsApi = Join-Path -path $packagesPath -ChildPath "RoslynTools.Microsoft.LocateVS\$locateVsApiVersion\tools\LocateVS.dll"
 
   if (!(Test-Path -path $locateVsApi)) {
     throw "The specified LocateVS API version ($locateVsApiVersion) could not be located."


### PR DESCRIPTION
FYI. @jaredpar, @drognanar, @jasonmalinowski, @dotnet/roslyn-infrastructure 