### PR TITLE
Run Naming Rules on parameters

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/EditorConfigNamingStyleParserTests.cs
@@ -185,6 +185,41 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
         }
 
         [Fact]
+        public static void TestParametersAreCamelCaseRule()
+        {
+            var dictionary = new Dictionary<string, object>()
+            {
+                ["dotnet_naming_rule.parameters_are_camel_case.severity"] = "suggestion",
+                ["dotnet_naming_rule.parameters_are_camel_case.symbols"] = "parameters",
+                ["dotnet_naming_rule.parameters_are_camel_case.style"] = "camel_case_style",
+                ["dotnet_naming_symbols.parameters.applicable_kinds"] = "parameter",
+                ["dotnet_naming_style.camel_case_style.capitalization"] = "camel_case",
+            };
+
+            var result = ParseDictionary(dictionary);
+            Assert.Single(result.NamingRules);
+            var namingRule = result.NamingRules.Single();
+            Assert.Single(result.NamingStyles);
+            var namingStyle = result.NamingStyles.Single();
+            Assert.Single(result.SymbolSpecifications);
+
+            var symbolSpec = result.SymbolSpecifications.Single();
+            Assert.Equal(namingStyle.ID, namingRule.NamingStyleID);
+            Assert.Equal(symbolSpec.ID, namingRule.SymbolSpecificationID);
+            Assert.Equal(DiagnosticSeverity.Info, namingRule.EnforcementLevel);
+
+            Assert.Equal("parameters", symbolSpec.Name);
+            var expectedApplicableSymbolKindList = new[] { new SymbolKindOrTypeKind(SymbolKind.Parameter) };
+            AssertEx.SetEqual(expectedApplicableSymbolKindList, symbolSpec.ApplicableSymbolKindList);
+
+            Assert.Equal("camel_case_style", namingStyle.Name);
+            Assert.Equal("", namingStyle.Prefix);
+            Assert.Equal("", namingStyle.Suffix);
+            Assert.Equal("", namingStyle.WordSeparator);
+            Assert.Equal(Capitalization.CamelCase, namingStyle.CapitalizationScheme);
+        }
+
+        [Fact]
         public static void TestNoRulesAreReturned()
         {
             var dictionary = new Dictionary<string, object>()

--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests.cs
@@ -113,5 +113,24 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
 }",
                 options: MethodNamesArePascalCase);
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestCamelCaseParameters()
+        {
+            await TestAsync(
+@"class C
+{
+    public void M(int [|X|])
+    {
+    }
+}",
+@"class C
+{
+    public void M(int x)
+    {
+    }
+}",
+                options: ParameterNamesAreCamelCase);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests_OptionSets.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests_OptionSets.cs
@@ -18,6 +18,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
         private IDictionary<OptionKey, object> MethodNamesArePascalCase =>
             Options(new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp), MethodNamesArePascalCaseOption());
 
+        private IDictionary<OptionKey, object> ParameterNamesAreCamelCase =>
+            Options(new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp), ParameterNamesAreCamelCaseOption());
+
         private IDictionary<OptionKey, object> Options(OptionKey option, object value)
         {
             var options = new Dictionary<OptionKey, object>
@@ -80,6 +83,38 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 NamingStyleID = namingStyle.ID,
                 EnforcementLevel = DiagnosticSeverity.Error
             };
+            var info = new NamingStylePreferences(
+                ImmutableArray.Create(symbolSpecification),
+                ImmutableArray.Create(namingStyle),
+                ImmutableArray.Create(namingRule));
+
+            return info;
+        }
+
+        private NamingStylePreferences ParameterNamesAreCamelCaseOption()
+        {
+            var symbolSpecification = new SymbolSpecification(
+                null,
+                "Name",
+                ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(SymbolKind.Parameter)),
+                ImmutableArray<Accessibility>.Empty,
+                ImmutableArray<SymbolSpecification.ModifierKind>.Empty);
+
+            var namingStyle = new NamingStyle(
+                Guid.NewGuid(),
+                capitalizationScheme: Capitalization.CamelCase,
+                name: "Name",
+                prefix: "",
+                suffix: "",
+                wordSeparator: "");
+
+            var namingRule = new SerializableNamingRule()
+            {
+                SymbolSpecificationID = symbolSpecification.ID,
+                NamingStyleID = namingStyle.ID,
+                EnforcementLevel = DiagnosticSeverity.Error
+            };
+
             var info = new NamingStylePreferences(
                 ImmutableArray.Create(symbolSpecification),
                 ImmutableArray.Create(namingStyle),

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyleDiagnosticAnalyzerBase.cs
@@ -33,7 +33,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             SymbolKind.Method,
             SymbolKind.NamedType,
             SymbolKind.Namespace,
-            SymbolKind.Property);
+            SymbolKind.Property,
+            SymbolKind.Parameter);
 
         public bool OpenFileOnly(Workspace workspace) => true;
 

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationViewModel.cs
@@ -52,6 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
                     new SymbolKindViewModel(SymbolKind.Field, "field", specification),
                     new SymbolKindViewModel(SymbolKind.Event, "event", specification),
                     new SymbolKindViewModel(TypeKind.Delegate, "delegate", specification),
+                    new SymbolKindViewModel(SymbolKind.Parameter, "parameter", specification)
                 };
 
                 AccessibilityList = new List<AccessibilityViewModel>
@@ -86,6 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
                     new SymbolKindViewModel(SymbolKind.Field, "Field", specification),
                     new SymbolKindViewModel(SymbolKind.Event, "Event", specification),
                     new SymbolKindViewModel(TypeKind.Delegate, "Delegate", specification),
+                    new SymbolKindViewModel(SymbolKind.Parameter, "Parameter", specification)
                 };
 
                 AccessibilityList = new List<AccessibilityViewModel>

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_SymbolSpec.cs
@@ -70,7 +70,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
         private static readonly SymbolKindOrTypeKind _field = new SymbolKindOrTypeKind(SymbolKind.Field);
         private static readonly SymbolKindOrTypeKind _event = new SymbolKindOrTypeKind(SymbolKind.Event);
         private static readonly SymbolKindOrTypeKind _delegate = new SymbolKindOrTypeKind(TypeKind.Delegate);
-        private static readonly ImmutableArray<SymbolKindOrTypeKind> _all = ImmutableArray.Create(_class, _struct, _interface, _enum, _property, _method, _field, _event, _delegate);
+        private static readonly SymbolKindOrTypeKind _parameter = new SymbolKindOrTypeKind(SymbolKind.Parameter);
+        private static readonly ImmutableArray<SymbolKindOrTypeKind> _all = ImmutableArray.Create(_class, _struct, _interface, _enum, _property, _method, _field, _event, _delegate, _parameter);
         private static ImmutableArray<SymbolKindOrTypeKind> ParseSymbolKindList(string symbolSpecApplicableKinds)
         {
             if (symbolSpecApplicableKinds == null)
@@ -114,6 +115,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                         break;
                     case "delegate":
                         builder.Add(_delegate);
+                        break;
+                    case "parameter":
+                        builder.Add(_parameter);
                         break;
                     default:
                         break;

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
@@ -29,7 +29,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                 new SymbolKindOrTypeKind(SymbolKind.Property),
                 new SymbolKindOrTypeKind(SymbolKind.Method),
                 new SymbolKindOrTypeKind(SymbolKind.Field),
-                new SymbolKindOrTypeKind(SymbolKind.Event)),
+                new SymbolKindOrTypeKind(SymbolKind.Event),
+                new SymbolKindOrTypeKind(SymbolKind.Parameter)),
             accessibilityList: ImmutableArray.Create(
                 Accessibility.Public,
                 Accessibility.Internal,


### PR DESCRIPTION
Fixes #13249

Ask Mode
======

**Customer scenario**: Customers cannot create naming rules that target parameters.

**Bugs this fixes:** #13249

**Workarounds, if any**: None

**Risk**: Low. However, this utilizes a new feature of RegisterSymbolAction that allows it to work on parameters (#13931), and this new feature has not been used much to this point.

**Performance impact**: Low, but non-zero. The naming style analyzer will now process *more* symbols (all parameters), and processing a symbol does require some allocations, though @CyrusNajmabadi did a pass to decrease the number of allocations per analyzed symbol in #15972.

**Is this a regression from a previous update?**: No

**Root cause analysis:** `RegisterSymbolAction` did not support parameters until #13931, so we could not support parameters when this feature was first checked in. 

**How was the bug found?** It was just a known missing piece of Naming Styles. Not reported by anyone as far as I can tell.