### PR TITLE
Classifier and some semantic model for ref var

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1671,6 +1671,11 @@ done:
                             return GetBindableSyntaxNode(tmp);
                         }
 
+                        if (node.Kind() == SyntaxKind.IdentifierName && parent.Kind() == SyntaxKind.RefType)
+                        {
+                            return GetBindableSyntaxNode(parent);
+                        }
+
                         break;
 
                     case SyntaxKind.AnonymousObjectMemberDeclarator:
@@ -1743,6 +1748,7 @@ done:
                 {
                     case SyntaxKind.ParenthesizedExpression:
                     case SyntaxKind.RefExpression:
+                    case SyntaxKind.RefType:
                         var pp = parent.Parent;
                         if (pp == null) break;
                         parent = pp;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -21708,5 +21708,124 @@ class C
             var tupleType = model.GetTypeInfo(tuple);
             Assert.Equal("(System.Int32 Alice, ?)", tupleType.Type.ToTestDisplayString());
         }
+
+        [Fact]
+        [WorkItem(168348, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=168348")]
+        void Test()
+        {
+            string source = @"
+using System;
+
+public class List<T>
+{
+    const int defaultCapacity = 4;
+    T[] items;
+    int count;
+    public List(int capacity = defaultCapacity)
+    {
+        items = new T[capacity];
+    }
+    public int Count
+    {
+        get { return count; }
+    }
+    public int Capacity
+    {
+        get
+        {
+            return items.Length;
+        }
+        set
+        {
+            if (value < count) value = count;
+            if (value != items.Length)
+            {
+                T[] newItems = new T[value];
+                Array.Copy( items, 0, newItems, 0, count );
+                items = newItems;
+            }
+        }
+    }
+
+    public T this[int index]
+    {
+        get
+        {
+            return items[index];
+        }
+        set
+        {
+            items[index] = value;
+            OnChanged( );
+        }
+    }
+
+    public void Add(T item)
+    {
+        if (count == Capacity) Capacity = count * 2;
+        items[count] = item;
+        count++;
+        OnChanged( );
+    }
+    protected virtual void OnChanged()
+    {
+        if (Changed != null) Changed( this, EventArgs.Empty );
+    }
+    public override bool Equals(object other)
+    {
+        return Equals( this, other as List<T> );
+    }
+    static bool Equals(List<T> a, List<T> b)
+    {
+        if (a == null) return b == null;
+        if (b == null || a.count != b.count) return false;
+        for (int i = 0; i < a.count; i++)
+        {
+            if (!object.Equals( a.items[i], b.items[i] ))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public event EventHandler Changed;
+
+    public static bool operator ==(List<T> a, List<T> b)
+    {
+        return Equals( a, b );
+    }
+    public static bool operator !=(List<T> a, List<T> b)
+    {
+        return !Equals( a, b );
+    }
+}
+
+class Test
+{
+    static void Main()
+    {
+        List<int> a = new List<int>( );
+        a.Add( 1 );
+        a.Add( 2 );
+        List<int> b = new List<int>( );
+        b.Add( 1 );
+        b.Add( 2 );
+        Console.WriteLine( a == b ); // Outputs True
+        b.Add(3);
+        Console.WriteLine(a == b); // Outputs False
+    }
+} ";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (4,14): warning CS0659: 'List<T>' overrides Object.Equals(object o) but does not override Object.GetHashCode()
+                // public class List<T>
+                Diagnostic(ErrorCode.WRN_EqualsWithoutGetHashCode, "List").WithArguments("List<T>").WithLocation(4, 14),
+                // (4,14): warning CS0661: 'List<T>' defines operator == or operator != but does not override Object.GetHashCode()
+                // public class List<T>
+                Diagnostic(ErrorCode.WRN_EqualityOpWithoutGetHashCode, "List").WithArguments("List<T>").WithLocation(4, 14)
+                );
+            CompileAndVerify(comp, expectedOutput: "");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -62,6 +62,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task RefVar()
+        {
+            await TestInMethodAsync(
+                className: "Class",
+                methodName: "M",
+                code: @"int i = 0; ref var x = ref i;",
+                expected: Keyword("var"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task UsingAlias1()
         {
             await TestAsync(

--- a/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
@@ -179,6 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         private bool IsInVarContext(NameSyntax name)
         {
             return
+                name.CheckParent<RefTypeSyntax>(v => v.Type == name) ||
                 name.CheckParent<VariableDeclarationSyntax>(v => v.Type == name) ||
                 name.CheckParent<ForEachStatementSyntax>(f => f.Type == name) ||
                 name.CheckParent<DeclarationExpressionSyntax>(f => f.Type == name);


### PR DESCRIPTION
**Customer scenario**

Use the `ref` locals feature in VS. The color on the `var` keyword is wrong, and hovering over `var` doesn't reveal the inferred type.

**Bugs this fixes:** 
[VSO 168348](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=294604&triage=true)

**Workarounds, if any**
The feature remains usable, but the user cannot see the inferred type.

**Risk**
**Performance impact**
Low. This is a minor change to the classifier and semantic model.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
Seems like a test gap.

**How was the bug found?**
Customer reporting and ad-hoc testing