### PR TITLE
Classifier and some semantic model for ref var

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -634,14 +634,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.RefType:
                     {
                         var firstToken = node.GetFirstToken();
-                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken);
+                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken.ToString());
                         return new BoundTypeExpression(node, null, CreateErrorType("ref"));
                     }
 
                 case SyntaxKind.RefExpression:
                     {
                         var firstToken = node.GetFirstToken();
-                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken);
+                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken.ToString());
                         return new BoundBadExpression(
                             node, LookupResultKind.Empty, ImmutableArray<Symbol>.Empty, ImmutableArray<BoundNode>.Empty,
                             CreateErrorType("ref"));

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -634,14 +634,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.RefType:
                     {
                         var firstToken = node.GetFirstToken();
-                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken.ToString());
+                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken.ValueText);
                         return new BoundTypeExpression(node, null, CreateErrorType("ref"));
                     }
 
                 case SyntaxKind.RefExpression:
                     {
                         var firstToken = node.GetFirstToken();
-                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken.ToString());
+                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken.ValueText);
                         return new BoundBadExpression(
                             node, LookupResultKind.Empty, ImmutableArray<Symbol>.Empty, ImmutableArray<BoundNode>.Empty,
                             CreateErrorType("ref"));

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -598,7 +598,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // or it might not; if it is not then we do not want to report an error. If it is, then
             // we want to treat the declaration as an explicitly typed declaration.
 
-            TypeSymbol declType = BindType(typeSyntax, diagnostics, out isVar, out alias);
+            RefKind refKind;
+            TypeSymbol declType = BindType(typeSyntax.SkipRef(out refKind), diagnostics, out isVar, out alias);
             Debug.Assert((object)declType != null || isVar);
 
             if (isVar)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindDeclarationStatementParts(LocalDeclarationStatementSyntax node, DiagnosticBag diagnostics)
         {
-            var typeSyntax = node.Declaration.Type;
+            var typeSyntax = node.Declaration.Type.SkipRef(out RefKind _);
             bool isConst = node.IsConst;
 
             bool isVar;
@@ -598,8 +598,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // or it might not; if it is not then we do not want to report an error. If it is, then
             // we want to treat the declaration as an explicitly typed declaration.
 
-            RefKind refKind;
-            TypeSymbol declType = BindType(typeSyntax.SkipRef(out refKind), diagnostics, out isVar, out alias);
+            TypeSymbol declType = BindType(typeSyntax, diagnostics, out isVar, out alias);
             Debug.Assert((object)declType != null || isVar);
 
             if (isVar)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -97,6 +97,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case SyntaxKind.OmittedTypeArgument:
                 case SyntaxKind.RefExpression:
+                case SyntaxKind.RefType:
+                case SyntaxKind.DeclarationExpression:
                     // These are just placeholders and are not separately meaningful.
                     return false;
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -98,7 +98,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.OmittedTypeArgument:
                 case SyntaxKind.RefExpression:
                 case SyntaxKind.RefType:
-                case SyntaxKind.DeclarationExpression:
                     // These are just placeholders and are not separately meaningful.
                     return false;
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1670,6 +1670,7 @@ done:
                         {
                             return GetBindableSyntaxNode(tmp);
                         }
+
                         break;
 
                     case SyntaxKind.AnonymousObjectMemberDeclarator:

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1670,7 +1670,6 @@ done:
                         {
                             return GetBindableSyntaxNode(tmp);
                         }
-
                         break;
 
                     case SyntaxKind.AnonymousObjectMemberDeclarator:
@@ -1743,6 +1742,7 @@ done:
                 {
                     case SyntaxKind.ParenthesizedExpression:
                     case SyntaxKind.RefExpression:
+                    case SyntaxKind.RefType:
                         var pp = parent.Parent;
                         if (pp == null) break;
                         parent = pp;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
@@ -1599,6 +1597,105 @@ class Program
                 //         ref int rl = ref (new int[1])[0];
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(6, 22)
                 );
+        }
+
+        [Fact]
+        public void RefVarSemanticModel()
+        {
+            var text = @"
+class Program
+{
+    static void M()
+    {
+        int i = 0;
+        ref var x = ref i;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(text);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var xDecl = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ElementAt(1);
+            Assert.Equal("System.Int32 x", model.GetDeclaredSymbol(xDecl).ToTestDisplayString());
+
+            var refVar = tree.GetRoot().DescendantNodes().OfType<RefTypeSyntax>().Single();
+            var type = refVar.Type;
+            Assert.Equal("System.Int32", model.GetTypeInfo(type).Type.ToTestDisplayString());
+            Assert.Equal("System.Int32", model.GetSymbolInfo(type).Symbol.ToTestDisplayString());
+            Assert.Null(model.GetAliasInfo(type));
+
+            Assert.Null(model.GetSymbolInfo(refVar).Symbol);
+            Assert.Null(model.GetTypeInfo(refVar).Type);
+        }
+
+        [Fact]
+        public void RefAliasVarSemanticModel()
+        {
+            var text = @"
+using var = C;
+class C
+{
+    static void M()
+    {
+        C i = null;
+        ref var x = ref i;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(text);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var xDecl = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ElementAt(1);
+            Assert.Equal("C x", model.GetDeclaredSymbol(xDecl).ToTestDisplayString());
+
+            var refVar = tree.GetRoot().DescendantNodes().OfType<RefTypeSyntax>().Single();
+            var type = refVar.Type;
+            Assert.Equal("C", model.GetTypeInfo(type).Type.ToTestDisplayString());
+            Assert.Equal("C", model.GetSymbolInfo(type).Symbol.ToTestDisplayString());
+            var alias = model.GetAliasInfo(type);
+            Assert.Equal(SymbolKind.NamedType, alias.Target.Kind);
+            Assert.Equal("C", alias.Target.ToDisplayString());
+
+            Assert.Null(model.GetSymbolInfo(refVar).Symbol);
+            Assert.Null(model.GetTypeInfo(refVar).Type);
+        }
+
+        [Fact]
+        public void RefIntSemanticModel()
+        {
+            var text = @"
+class Program
+{
+    static void M()
+    {
+        int i = 0;
+        ref System.Int32 x = ref i;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(text);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var xDecl = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().ElementAt(1);
+            Assert.Equal("System.Int32 x", model.GetDeclaredSymbol(xDecl).ToTestDisplayString());
+
+            var refInt = tree.GetRoot().DescendantNodes().OfType<RefTypeSyntax>().Single();
+            var type = refInt.Type;
+            Assert.Equal("System.Int32", model.GetTypeInfo(type).Type.ToTestDisplayString());
+            Assert.Equal("System.Int32", model.GetSymbolInfo(type).Symbol.ToTestDisplayString());
+            Assert.Null(model.GetAliasInfo(type));
+
+            Assert.Null(model.GetSymbolInfo(refInt).Symbol);
+            Assert.Null(model.GetTypeInfo(refInt).Type);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -62,6 +62,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task RefVar()
+        {
+            await TestInMethodAsync(
+                className: "Class",
+                methodName: "M",
+                code: @"int i = 0; ref var x = ref i;",
+                expected: Keyword("var"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task UsingAlias1()
         {
             await TestAsync(

--- a/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
@@ -179,6 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         private bool IsInVarContext(NameSyntax name)
         {
             return
+                name.CheckParent<RefTypeSyntax>(v => v.Type == name) ||
                 name.CheckParent<VariableDeclarationSyntax>(v => v.Type == name) ||
                 name.CheckParent<ForEachStatementSyntax>(f => f.Type == name) ||
                 name.CheckParent<DeclarationExpressionSyntax>(f => f.Type == name);


### PR DESCRIPTION
**Customer scenario**

Use the `ref` locals feature in VS. The color on the `var` keyword is wrong, and hovering over `var` doesn't reveal the inferred type.

**Bugs this fixes:** 
[VSO 168348](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=294604&triage=true)

**Workarounds, if any**
The feature remains usable, but the user cannot see the inferred type.

**Risk**
**Performance impact**
Low. This is a minor change to the classifier and semantic model.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
Seems like a test gap.

**How was the bug found?**
Customer reporting and ad-hoc testing