### PR TITLE
Skip calling IsCustomTaskType for void*

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1314,7 +1314,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static bool IsCustomTaskType(this NamedTypeSymbol type, out object builderArgument)
         {
             Debug.Assert((object)type != null);
-            Debug.Assert(type.SpecialType != SpecialType.System_Void);
 
             var arity = type.Arity;
             if (arity < 2)


### PR DESCRIPTION
**Customer scenario**

Assert failure in `DEBUG` build in overload resolution with overload containing `void*` parameter. No failure in `RELEASE` build.

**Bugs this fixes:** 

#15955 

**Workarounds, if any**

Compile with `RELEASE` build.

**Risk**

Low

**Performance impact**

None

**How was the bug found?**

Bug found adding tests for other areas.