### PR TITLE
Localize the "Severity" header on the Naming Styles page

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
@@ -182,7 +182,7 @@
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn 
                     x:Name="severity" 
-                    Header="Severity"
+                    Header="{x:Static style:NamingStyleOptionPageControl.SeverityHeader}"
                     Width="2.5*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
         public static string ReorderHeader => ServicesVSResources.Reorder;
         public static string SpecificationHeader => ServicesVSResources.Specification;
         public static string RequiredStyleHeader => ServicesVSResources.Required_Style;
+        public static string SeverityHeader => ServicesVSResources.Severity;
         public static string ExplanatoryText => ServicesVSResources.For_a_given_symbol_only_the_topmost_rule_with_a_matching_Specification_will_be_applied_Violation_of_that_rules_Required_Style_will_be_reported_at_the_chosen_Severity_level;
 
         private NamingStyleOptionPageViewModel _viewModel;


### PR DESCRIPTION
Fixes internal bug 297517

Ask Mode
======

**Customer scenario**: Users of non-English languages would see the English word "Severity" in the Naming Styles table header. This makes the column's purpose less obvious for them.

**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=297517&triage=true

**Workarounds, if any**: They could use a translator, or they could possibly infer the meaning of the column from the elements in it.

**Risk**: None. This change is at the very top of the stack, and nothing depends on it. It now matches how all of the other headers are localized.

**Performance impact**: Essentially none. There's one extra data binding where there was none before (a drop in the bucket), and it's done on a user action on a very cold path.

**Is this a regression from a previous update?**: No

**Root cause analysis:** This header element was simply missed when doing the work to localize all of our option page table headers. My fault, at commit: https://github.com/dpoeschl/roslyn/commit/d9d352aa4449151bcf1d01d1e0812631a55a0d9e

**How was the bug found?**: Directed testing