### PR TITLE
Change option version

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -518,13 +518,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set { SetBooleanOption(CSharpFormattingOptions.SpaceWithinSquareBrackets, value); }
         }
 
-        public string Style_PreferIntrinsicPredefinedTypeKeywordInDeclaration
+        public string Style_PreferIntrinsicPredefinedTypeKeywordInDeclaration_CodeStyle
         {
             get { return GetXmlOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration); }
             set { SetXmlOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, value); }
         }
 
-        public string Style_PreferIntrinsicPredefinedTypeKeywordInMemberAccess
+        public string Style_PreferIntrinsicPredefinedTypeKeywordInMemberAccess_CodeStyle
         {
             get { return GetXmlOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess); }
             set { SetXmlOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, value); }

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
@@ -143,7 +143,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             End Set
         End Property
 
-        Public Property Style_PreferIntrinsicPredefinedTypeKeywordInDeclaration As String
+        Public Property Style_PreferIntrinsicPredefinedTypeKeywordInDeclaration_CodeStyle As String
             Get
                 Return GetXmlOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration)
             End Get
@@ -152,7 +152,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             End Set
         End Property
 
-        Public Property Style_PreferIntrinsicPredefinedTypeKeywordInMemberAccess As String
+        Public Property Style_PreferIntrinsicPredefinedTypeKeywordInMemberAccess_CodeStyle As String
             Get
                 Return GetXmlOption(CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess)
             End Get

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         public static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIntrinsicPredefinedTypeKeywordInDeclaration = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInDeclaration), defaultValue: TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[]{
                 new EditorConfigStorageLocation("dotnet_style_predefined_type_for_locals_parameters_members"),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInDeclaration")});
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInDeclaration.CodeStyle")});
 
         /// <summary>
         /// This option says if we should prefer keyword for Intrinsic Predefined Types in Member Access Expression
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         public static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIntrinsicPredefinedTypeKeywordInMemberAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInMemberAccess), defaultValue: TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[]{
                 new EditorConfigStorageLocation("dotnet_style_predefined_type_for_member_access"),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInMemberAccess")});
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInMemberAccess.CodeStyle")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferThrowExpression = new PerLanguageOption<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions),


### PR DESCRIPTION


**Customer scenario**

Customer changes setting on a VS 2017 Machine and then their settings on their VS 2015 machine stop syncing and they receive an error message 
Customer changes setting on a VS 2015 Machine and then their settings on their VS 2017 machine stop syncing and they receive an error message 

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/13556
https://github.com/dotnet/roslyn/issues/15076
[#273302](https://devdiv.visualstudio.com/DevDiv/_workitems?id=273302)

**Workarounds, if any**

Do not roam any settings between VS 2015 or VS 2017.  If you roam settings on VS 2015 do not roam them on VS 2017.

**Risk**
Low, we are changing a key name.

**Performance impact**

None, we are changing a key name.

**Is this a regression from a previous update?**
Yes, you could previously roam settings between versions

**Root cause analysis:**

in Dev14 these options were persisted as booleans. They are now persisted as xml in Dev15.  The fix is to not have the persistence keys overlap, ensuring Dev14 will not try to deserialize Dev15 options and vice versa

**How was the bug found?**

Customer reported and found via ad-hoc testing

@Pilchie @jasonmalinowski @dotnet/roslyn-ide 