### PR TITLE
make sure we initialize TelemetryHelper from UI threads before we usi…

### DIFF
--- a/src/VisualStudio/Core/Def/Telemetry/RoslynTelemetrySetup.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/RoslynTelemetrySetup.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.ComponentModel.Composition;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.Internal.VisualStudio.Shell;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.LanguageServices;
-using Microsoft.VisualStudio.LanguageServices.Setup;
 
 namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 {
@@ -17,6 +14,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
         {
             var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
             var optionService = componentModel.GetService<IGlobalOptionService>();
+
+            // Fetch the session synchronously on the UI thread; if this doesn't happen before we try using this on
+            // the background thread then we will experience hangs like we see in this bug:
+            // https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=190808 or
+            // https://devdiv.visualstudio.com/DevDiv/_workitems?id=296981&_a=edit
+            var unused1 = TelemetryHelper.TelemetryService;
+            var unused2 = TelemetryHelper.DefaultTelemetrySession;
 
             var telemetryService = serviceProvider.GetService(typeof(SVsTelemetryService)) as IVsTelemetryService;
             Logger.SetLogger(

--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryActivityLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryActivityLogger.cs
@@ -30,11 +30,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
         {
             _service = service;
             _pendingActivities = new ConcurrentDictionary<int, TelemetryActivity>(concurrencyLevel: 2, capacity: 10);
-
-            // Fetch the session synchronously on the UI thread; if this doesn't happen before we try using this on
-            // the background thread then we will experience hangs like we see in this bug:
-            // https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=190808
-            var unused = TelemetryHelper.DefaultTelemetrySession;
         }
 
         public bool IsEnabled(FunctionId functionId)


### PR DESCRIPTION
…ng it in any way

**Customer scenario**

VS sometimes fail to launch.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=296981&_a=edit

* this doesn't completely fix the bug, but part of it.

**Workarounds, if any**

re-open the VS.

**Risk**

I dont think it will make things worse than what we have now. 

**Performance impact**

this should not make anything in normal scenario do things differently. only make VS not to get into bad situation.

**Is this a regression from a previous update?**

no

**Root cause analysis:**

null exception is thrown when TelemetryService is first used in background thread. made sure those services are initialized in foreground before used in background thread.

**How was the bug found?**

testing.