### PR TITLE
make sure we don't block UI thread while initializing workspace host

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -31,10 +31,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 _workspace = workspace;
                 _client = client;
                 _currentSolutionId = workspace.CurrentSolution.Id;
+            }
 
+            public Task InitializeAsync()
+            {
                 // Ensure that we populate the remote service with the initial state of
                 // the workspace's solution.
-                RegisterPrimarySolutionAsync().Wait();
+                return RegisterPrimarySolutionAsync();
             }
 
             public void OnAfterWorkingFolderChange()


### PR DESCRIPTION
**Customer scenario**

VS UI being blocking while Roslyn package is first initialized.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems?id=365626&projectId=0bdbc590-a062-4c3f-b0f6-9383f67865ee&src=alerts&src-action=cta&fullScreen=true&_a=edit

**Workarounds, if any**

no workaround

**Risk**

I don't see any obvious risk due to this change. 

**Performance impact**

it should make perf better by doing blocking work in background and do cheap and quick work only on UI thread.

**Is this a regression from a previous update?**

Yes. introduced while fixing functional bug.

**Root cause analysis:**

the very first call to service hub service requires some time to initialize service hub and we did that on UI thread. the call didn't need to be on UI thread, it just happen to do that on UI thread due to recent change. 

**How was the bug found?**
Perf Test from Xaml team.