### PR TITLE
Make the General Code Style & Naming Style options pages accessible

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1187,6 +1187,24 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Move down.
+        /// </summary>
+        internal static string Move_down {
+            get {
+                return ResourceManager.GetString("Move_down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move up.
+        /// </summary>
+        internal static string Move_up {
+            get {
+                return ResourceManager.GetString("Move_up", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name:.
         /// </summary>
         internal static string Name_colon1 {
@@ -1676,6 +1694,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Remarks_colon {
             get {
                 return ResourceManager.GetString("Remarks_colon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove.
+        /// </summary>
+        internal static string Remove {
+            get {
+                return ResourceManager.GetString("Remove", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -858,4 +858,13 @@ Additional information: {1}</value>
   <data name="Get_help_for_0_from_Bing" xml:space="preserve">
     <value>Get help for '{0}' from Bing</value>
   </data>
+  <data name="Move_down" xml:space="preserve">
+    <value>Move down</value>
+  </data>
+  <data name="Move_up" xml:space="preserve">
+    <value>Move up</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Remove</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Impl/Options/ColumnToTabStopConverter.cs
+++ b/src/VisualStudio/Core/Impl/Options/ColumnToTabStopConverter.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Globalization;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.PlatformUI;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
+{
+    /// <summary>
+    /// DataGridTemplateColumns have custom controls that should be focused instead of the cell.
+    /// </summary>
+    internal class ColumnToTabStopConverter : ValueConverter<DataGridColumn, bool>
+    {
+        protected override bool Convert(DataGridColumn value, object parameter, CultureInfo culture)
+        {
+            // We use DataGridTemplateColumns in our options grids to contain controls (as opposed
+            // to plain text in DataGridTextColumns). We want the tab stop to be on the contained
+            // control and not the cell itself, so don't have DataGridTemplateColumns be tab stops.
+            return !(value is DataGridTemplateColumn);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -15,11 +15,17 @@
 
     <Grid>
         <Grid.Resources>
+            <options:ColumnToTabStopConverter x:Key="ColumnToTabStopConverter" />
             <Style x:Key="DataGridStyle" TargetType="DataGrid">
                 <Setter Property="CellStyle">
                     <Setter.Value>
                         <Style TargetType="DataGridCell">
                             <Setter Property="BorderThickness" Value="1" />
+                            <Setter Property="IsTabStop" 
+                                    Value="{Binding 
+                                        Path=Column, 
+                                        Converter={StaticResource ColumnToTabStopConverter},
+                                        RelativeSource={RelativeSource Self}}"/>
                         </Style>
                     </Setter.Value>
                 </Setter>
@@ -93,6 +99,7 @@
                             <Setter Property="VerticalAlignment" Value="Center"/>
                             <Setter Property="HorizontalAlignment" Value="Left" />
                             <Setter Property="TextWrapping" Value="Wrap" />
+                            <Setter Property="AutomationProperties.Name" Value="{Binding GroupName}" />
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
@@ -107,7 +114,13 @@
                                     DisplayMemberPath="Name"
                                     SelectedItem="{Binding SelectedPreference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                                     VerticalContentAlignment="Center"
-                                    HorizontalContentAlignment="Left"/>
+                                    HorizontalContentAlignment="Left">
+                                <ComboBox.ItemContainerStyle>
+                                    <Style TargetType="ComboBoxItem">
+                                        <Setter Property="AutomationProperties.Name" Value="{Binding Name}" />
+                                    </Style>
+                                </ComboBox.ItemContainerStyle>
+                            </ComboBox>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
@@ -142,6 +155,11 @@
                                         </Grid>
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
+                                <ComboBox.ItemContainerStyle>
+                                    <Style TargetType="ComboBoxItem">
+                                        <Setter Property="AutomationProperties.Name" Value="{Binding Name}" />
+                                    </Style>
+                                </ComboBox.ItemContainerStyle>
                             </ComboBox>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
@@ -23,6 +23,7 @@
                     <Setter.Value>
                         <Style TargetType="DataGridCell">
                             <Setter Property="BorderThickness" Value="1" />
+                            <Setter Property="IsTabStop" Value="False" />
                         </Style>
                     </Setter.Value>
                 </Setter>
@@ -158,7 +159,13 @@
                                 SelectedItem="{Binding SelectedSpecification, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                                 VerticalContentAlignment="Center"
                                 HorizontalContentAlignment="Left"
-                                ToolTip="{Binding Path=SelectedItem.Name, RelativeSource={RelativeSource Self}}"/>
+                                ToolTip="{Binding Path=SelectedItem.Name, RelativeSource={RelativeSource Self}}">
+                                <ComboBox.ItemContainerStyle>
+                                    <Style TargetType="ComboBoxItem">
+                                        <Setter Property="AutomationProperties.Name" Value="{Binding Name}" />
+                                    </Style>
+                                </ComboBox.ItemContainerStyle>
+                            </ComboBox>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
@@ -176,6 +183,11 @@
                                     VerticalContentAlignment="Center"
                                     HorizontalContentAlignment="Left"
                                     ToolTip="{Binding Path=SelectedItem.Name, RelativeSource={RelativeSource Self}}">
+                                <ComboBox.ItemContainerStyle>
+                                    <Style TargetType="ComboBoxItem">
+                                        <Setter Property="AutomationProperties.Name" Value="{Binding Name}" />
+                                    </Style>
+                                </ComboBox.ItemContainerStyle>
                             </ComboBox>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
@@ -211,6 +223,11 @@
                                         </Grid>
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
+                                <ComboBox.ItemContainerStyle>
+                                    <Style TargetType="ComboBoxItem">
+                                        <Setter Property="AutomationProperties.Name" Value="{Binding Name}" />
+                                    </Style>
+                                </ComboBox.ItemContainerStyle>
                             </ComboBox>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
@@ -219,14 +236,15 @@
                                         Width="30">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Button Click="RemoveButton_Click"  
+                            <Button Click="RemoveButton_Click"
                                     Height="16" 
                                     Width="16" 
                                     Margin="5, 0, 0, 0"
                                     VerticalContentAlignment="Center"
                                     HorizontalContentAlignment="Center"
                                     HorizontalAlignment="Center"
-                                    VerticalAlignment="Center">
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.Name="{Binding RemoveAutomationText}">
                                 <imaging:CrispImage Moniker="{x:Static imagecatalog:KnownMonikers.DeleteListItem}" />
                             </Button>
                         </DataTemplate>

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageViewModel.cs
@@ -275,6 +275,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
                 }
             }
 
+            public string MoveUpAutomationText => ServicesVSResources.Move_up;
+            public string MoveDownAutomationText => ServicesVSResources.Move_down;
+
+            public string RemoveAutomationText => ServicesVSResources.Remove;
+
             public bool IsComplete()
             {
                 return SelectedSpecification != null && SelectedStyle != null && SelectedNotificationPreference != null;

--- a/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
+++ b/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Options\AbstractCodeStyleOptionViewModel.cs" />
     <Compile Include="Options\BooleanCodeStyleOptionViewModel.cs" />
     <Compile Include="Options\CodeStylePreference.cs" />
+    <Compile Include="Options\ColumnToTabStopConverter.cs" />
     <Compile Include="Options\Converters\MarginConverter.cs" />
     <Compile Include="Options\SimpleCodeStyleOptionViewModel.cs" />
     <Compile Include="Options\AbstractCheckBoxViewModel.cs" />


### PR DESCRIPTION
Fixes #13579
Fixes #13099

Fixes for tabbing and Narrator.

Escrow Template
===========

**Customer scenario**: Sight-impaired users could not use the General Code Style & Naming Style option pages.

**Bugs this fixes:**  #13579, #13099

**Workarounds, if any**: None. I suppose the sight-impaired user could find a sighted person to explain what's going on, but that is unacceptable.

**Risk**: Very little. This change is at the very top of the stack, and it doesn't change any non-accessibility-related product functionality.

**Performance impact**: Essentially none. There will be at least one additional allocation every time the option pages are shown, but this is negligible, especially because it's on an infrequent user action. 

**Is this a regression from a previous update?**: No

**Root cause analysis:** This work was simply not done as part of the original feature work for either option page.

**How was the bug found?** Directed testing (thanks @rchande)