### PR TITLE
Have Narrator announce that an Inline Rename session has started

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -108,6 +108,7 @@
     <Compile Include="FindUsages\IFindUsagesContext.cs" />
     <Compile Include="FindUsages\IFindUsagesService.cs" />
     <Compile Include="FindUsages\SimpleFindUsagesContext.cs" />
+    <Compile Include="Implementation\InlineRename\Dashboard\DashboardAutomationPeer.cs" />
     <Compile Include="Implementation\Structure\BlockTagState.cs" />
     <Compile Include="Tags\ExportImageMonikerServiceAttribute.cs" />
     <Compile Include="Implementation\NavigateTo\AbstractNavigateToItemDisplay.cs" />

--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -189,6 +189,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An inline rename session is active.
+        /// </summary>
+        internal static string An_inline_rename_session_is_active {
+            get {
+                return ResourceManager.GetString("An_inline_rename_session_is_active", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Apply.
         /// </summary>
         internal static string Apply1 {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -754,4 +754,8 @@ Do you want to proceed?</value>
   <data name="_0_declarations" xml:space="preserve">
     <value>'{0}' declarations</value>
   </data>
+  <data name="An_inline_rename_session_is_active" xml:space="preserve">
+    <value>An inline rename session is active</value>
+    <comment>For screenreaders</comment>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.VisualStudio.Text.Editor;
@@ -62,9 +63,25 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 // Find UI doesn't exist in ETA.
             }
 
+            // Once the Dashboard is loaded, the visual tree is completely created and the 
+            // UIAutomation system has discovered and connected the AutomationPeer to the tree,
+            // allowing us to raise the AutomationFocusChanged event and have it process correctly.
+            // for us to set up the AutomationPeer
+            this.Loaded += Dashboard_Loaded;
+
             this.Focus();
             textView.Caret.IsHidden = false;
             ShouldReceiveKeyboardNavigation = false;
+        }
+
+        private void Dashboard_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Move automation focus to the Dashboard so that screenreaders will announce that the
+            // session has begun.
+            if (AutomationPeer.ListenerExists(AutomationEvents.AutomationFocusChanged))
+            {
+                UIElementAutomationPeer.CreatePeerForElement(this)?.RaiseAutomationEvent(AutomationEvents.AutomationFocusChanged);
+            }
         }
 
         private void ShowCaret()
@@ -178,6 +195,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new DashboardAutomationPeer(this);
+        }
+
         private void DisconnectFromPresentationSource()
         {
             if (_rootInputElement != null)
@@ -271,6 +293,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 ((UIElement)_findAdornmentLayer).LayoutUpdated -= FindAdornmentCanvas_LayoutUpdated;
             }
+
+            this.Loaded -= Dashboard_Loaded;
 
             _model.Dispose();
             PresentationSource.RemoveSourceChangedHandler(this, OnPresentationSourceChanged);

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardAutomationPeer.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardAutomationPeer.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
+{
+    /// <summary>
+    /// Custom AutomationPeer to announce that an Inline Rename session has begun.
+    /// </summary>
+    internal class DashboardAutomationPeer : UserControlAutomationPeer
+    {
+        public DashboardAutomationPeer(UserControl owner) : base(owner)
+        {
+        }
+
+        protected override bool HasKeyboardFocusCore()
+        {
+            return true;
+        }
+
+        protected override bool IsKeyboardFocusableCore()
+        {
+            return true;
+        }
+
+        protected override string GetNameCore()
+        {
+            return EditorFeaturesResources.An_inline_rename_session_is_active;
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Edit;
+        }
+    }
+}


### PR DESCRIPTION
Fixes part of #9960

Escrow Template
===========

**Customer scenario**: When a sight-impaired user invokes the Inline Rename command, they have no way of knowing that they've entered Inline Rename mode.

**Bugs this fixes:** This fixes part of #9960

**Workarounds, if any**: None really. The user could just *believe* that inline rename has started and proceed, but that's not really acceptable.

**Risk**: Low. This is at the top of the stack and only impacts accessibility.

**Performance impact**: Essentially none. We now explicitly make an AutomationPeer instead of using the built-in one. I'm not sure if that's an extra allocation or not, but it's only once per Inline Rename session anyway.

**Is this a regression from a previous update?** No

**Root cause analysis:** This was simply not done as part of the original feature work

**How was the bug found?** The Inline Rename Dashboard was known to have accessibility problems internally basically since it was introduced.