### PR TITLE
made venus span mapper to deal with typescript better

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioVenusSpanMappingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioVenusSpanMappingService.cs
@@ -67,19 +67,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
         private TextLineCollection GetTextLines(DocumentId currentDocumentId, Location location)
         {
+            // normal case - all C# and VB should hit this
             if (location.SourceTree != null)
             {
-                // normal case - all C# and VB should hit this
                 return location.SourceTree.GetText().Lines;
             }
 
+            // special case for typescript and etc that don't use our compilations.
             var filePath = location.GetLineSpan().Path;
             if (filePath != null)
             {
-                // special case for typescript and etc that don't use our compilations.
+                // as a sanity check, make sure given location is on the current document
+                // we do the check down the stack for C# and VB using SyntaxTree in location
+                // but for typescript and other, we don't have the tree, so adding this as
+                // sanity check. later we could convert this to Contract to crash VS and
+                // know about the issue.
                 var documentIds = _workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath);
-
-                // make sure we are dealing with right document
                 if (documentIds.Contains(currentDocumentId))
                 {
                     // text most likely already read in


### PR DESCRIPTION
**Customer scenario**

when TS has an error in venus file at the edge of script section which requires adjustment of error span, VS might crash.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/363717

**Workarounds, if any**

no workaround

**Risk**

we now might not show errors if we can't recover but we will no longer crash VS. so I would say risk is low.

**Performance impact**

I don't see anything that could impact perf bad.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

the venus mapper assumed it can always get text from syntax tree. but now new comers like typescript, xaml that use roslyn framework for their IDE don't have syntax tree so the assumption is no longer valid.

**How was the bug found?**

watson report