### PR TITLE
Suggest to populate switch only on 'switch' keyword

### DIFF
--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests.cs
@@ -19,6 +19,36 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task OnlyOnFirstToken()
+        {
+            await TestMissingAsync(
+@"namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz,
+        Buzz,
+        FizzBuzz
+    }
+
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([||]e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                default:
+                    break;
+            }
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
         public async Task AllMembersAndDefaultExist()
         {
             await TestMissingAsync(
@@ -36,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -67,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -123,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -179,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -237,7 +267,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -293,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -349,7 +379,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 default:
                     break;
@@ -407,7 +437,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
             }
         }
@@ -459,7 +489,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
             }
         }
@@ -507,7 +537,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwi
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
             }
         }
@@ -556,7 +586,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = Append;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case CreateNew:
                     break;
@@ -591,7 +621,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = Append;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case CreateNew:
                     break;
@@ -626,7 +656,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = Append;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case CreateNew:
                     break;
@@ -686,7 +716,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = Append;
-            switch ([|e|])
+            [||]switch (e)
             {
             }
         }
@@ -742,7 +772,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -799,7 +829,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ([|e|])
+            [||]switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -850,7 +880,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = ""test"";
-            switch ([|e|])
+            [||]switch (e)
             {
                 case ""test1"":
                 case ""test1"":
@@ -878,7 +908,7 @@ class MyClass
     void Method()
     {
         var e = MyEnum.Fizz;
-        switch ([|e|])
+        [||]switch (e)
         {
             case (MyEnum)0:
             case (MyEnum)1:
@@ -927,7 +957,7 @@ class MyClass
     void Method()
     {
         var e = MyEnum.Fizz;
-        switch ([|e|])
+        [||]switch (e)
     }
 }
 ",

--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.cs
@@ -28,7 +28,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ({|FixAllInDocument:e|})
+            {|FixAllInDocument:|}switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -192,7 +192,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum.Fizz;
-            switch ({|FixAllInProject:e|})
+            {|FixAllInProject:|}switch (e)
             {
                 case MyEnum.Fizz:
                 case MyEnum.Buzz:
@@ -342,7 +342,7 @@ namespace ConsoleApplication1
         void Method()
         {
             var e = MyEnum1.Fizz;
-            switch ({|FixAllInSolution:e|})
+            {|FixAllInSolution:|}switch (e)
             {
                 case MyEnum1.Fizz:
                 case MyEnum1.Buzz:

--- a/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests.vb
@@ -14,6 +14,35 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Popula
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function OnlyOnFirstToken() As Task
+            Dim markup =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [||]e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
         Public Async Function AllMembersAndElseExist() As Task
             Dim markup =
 <File>
@@ -25,7 +54,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -54,7 +83,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -105,7 +134,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -154,7 +183,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -205,7 +234,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -254,7 +283,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz ' not legal.  VB does not allow fallthrough.
@@ -303,7 +332,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
         End Select
     End Sub
 End Class
@@ -349,7 +378,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = CreateNew
-        Select Case [|e|]
+        [||]Select Case e
             Case CreateNew
                 Exit Select
             Case Create
@@ -385,7 +414,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = CreateNew
-        Select Case [|e|]
+        [||]Select Case e
             Case Truncate
                 Exit Select
             Case Append
@@ -421,7 +450,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = CreateNew
-        Select Case [|e|]
+        [||]Select Case e
             Case CreateNew
                 Exit Select
             Case Create
@@ -482,7 +511,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = CreateNew
-        Select Case [|e|]
+        [||]Select Case e
             
         End Select
     End Sub
@@ -536,7 +565,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -586,7 +615,7 @@ Class Foo
     End Enum
     Sub Bar()
         Dim e = MyEnum.Fizz
-        Select Case [|e|]
+        [||]Select Case e
             Case MyEnum.Fizz
                 Exit Select
             Case MyEnum.Buzz
@@ -630,7 +659,7 @@ End Class
 Class Foo
     Sub Bar()
         Dim e = "Test"
-        Select Case [|e|]
+        [||]Select Case e
             Case "Fizz"
                 Exit Select
             Case "Test"

--- a/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.vb
@@ -17,7 +17,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum1.Fizz
-        Select Case {|FixAllInDocument:e|}
+        {|FixAllInDocument:|}Select Case e
             Case MyEnum1.Fizz
                 Exit Select
             Case MyEnum1.Buzz
@@ -182,7 +182,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum1.Fizz
-        Select Case {|FixAllInProject:e|}
+        {|FixAllInProject:|}Select Case e
             Case MyEnum1.Fizz
                 Exit Select
             Case MyEnum1.Buzz
@@ -329,7 +329,7 @@ End Enum
 Class Foo
     Sub Bar()
         Dim e = MyEnum1.Fizz
-        Select Case {|FixAllInSolution:e|}
+        {|FixAllInSolution:|}Select Case e
             Case MyEnum1.Fizz
                 Exit Select
             Case MyEnum1.Buzz

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
@@ -122,7 +122,8 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             var hasMissingCases = bool.Parse(diagnostic.Properties[PopulateSwitchHelpers.MissingCases]);
             var hasMissingDefaultCase = bool.Parse(diagnostic.Properties[PopulateSwitchHelpers.MissingDefaultCase]);
 
-            var switchNode = diagnostic.Location.FindNode(cancellationToken);
+            var switchLocation = diagnostic.AdditionalLocations[0];
+            var switchNode = switchLocation.FindNode(cancellationToken);
             var internalMethod = typeof(SemanticModel).GetTypeInfo().GetDeclaredMethod("GetOperationInternal");
             var switchStatement = (ISwitchStatement)internalMethod.Invoke(model, new object[] { switchNode, cancellationToken });
             var enumType = switchStatement.Value.Type;

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchDiagnosticAnalyzer.cs
@@ -51,15 +51,11 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
                     .Add(PopulateSwitchHelpers.MissingCases, missingCases.ToString())
                     .Add(PopulateSwitchHelpers.MissingDefaultCase, missingDefaultCase.ToString());
 
-                // Report diagnostic on 'switch' keyword
-                var reportLocation = switchBlock.GetFirstToken().GetLocation();
-                var switchLocation = switchBlock.GetLocation();
-
                 var diagnostic = Diagnostic.Create(
                     HiddenDescriptor,
-                    reportLocation,
+                    switchBlock.GetFirstToken().GetLocation(),
                     properties: properties,
-                    additionalLocations: new[] { switchLocation });
+                    additionalLocations: new[] { switchBlock.GetLocation() });
                 context.ReportDiagnostic(diagnostic);
             }
         }

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchDiagnosticAnalyzer.cs
@@ -51,8 +51,15 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
                     .Add(PopulateSwitchHelpers.MissingCases, missingCases.ToString())
                     .Add(PopulateSwitchHelpers.MissingDefaultCase, missingDefaultCase.ToString());
 
+                // Report diagnostic on 'switch' keyword
+                var reportLocation = switchBlock.GetFirstToken().GetLocation();
+                var switchLocation = switchBlock.GetLocation();
+
                 var diagnostic = Diagnostic.Create(
-                    HiddenDescriptor, switchBlock.GetLocation(), properties: properties);
+                    HiddenDescriptor,
+                    reportLocation,
+                    properties: properties,
+                    additionalLocations: new[] { switchLocation });
                 context.ReportDiagnostic(diagnostic);
             }
         }


### PR DESCRIPTION
"Populate switch" diagnostic is so distracting and noisy as it appears everywhere in a switch statement, and it probably interferes with other most likely irrelevant diagnostics. This PR changes that to be reported only on `switch` keyword.

/cc @CyrusNajmabadi 