### PR TITLE
Fixing the build version to be 'correct' for 'official' builds where no build number was specified.

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -24,11 +24,11 @@
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
     <Error Condition="'$(BuildNumber)' == '' AND '$(OfficialBuild)' == 'true'">A build number must be specified for a signed build.</Error>
 
-    <!-- When a build number is not specified, then we should default back to '00065535.0', which is a build number in the
+    <!-- When a build number is not specified, then we should default back to '00074335.0' (65535 + 8800), which is a build number in the
          same format as provided by MicroBuild v2, but greater than any that MicroBuild v2 will produce, and is still compatible
          with the Win32 file version limitations. This is required so that builds done locally, where '$(OfficialBuild)' == 'true',
          can still be deployed to VS and override the version that is globally installed. -->
-    <BuildNumber Condition="'$(BuildNumber)' == ''">00065535.0</BuildNumber>
+    <BuildNumber Condition="'$(BuildNumber)' == ''">00074335.0</BuildNumber>
     <!-- When a build number is specified, it needs to be in the format of 'x.y'-->
     <Error Condition="$(BuildNumber.Split('.').Length) != 2">BuildNumber should have two parts (in the form of 'x.y')</Error>
 


### PR DESCRIPTION
FYI. @jasonmalinowski, @dotnet/roslyn-infrastructure 