### PR TITLE
Foreach deconstruction should mark iteration variables as assigned.

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -875,7 +875,7 @@
     <!-- This is so the binding API can find produce semantic info if the type is "var". -->
     <!-- If there is a deconstruction, there will be no iteration variable (but we'll still have a type for it). -->
     <Field Name="IterationVariableType" Type="BoundTypeExpression"/>
-    <Field Name="IterationVariableOpt" Type="LocalSymbol" Null="allow"/>
+    <Field Name="IterationVariables" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
     <!-- If this node does not have errors, then this is the foreach expression wrapped
          in a conversion to the collection type used by the foreach loop.  The conversion
          is here so that the binding API can return the correct ConvertedType in semantic 

--- a/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
@@ -262,7 +262,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundForEachStatement : IForEachLoopStatement
     {
-        ILocalSymbol IForEachLoopStatement.IterationVariable => this.IterationVariableOpt;
+        ILocalSymbol IForEachLoopStatement.IterationVariable => this.DeconstructionOpt == null?
+                                                                        this.IterationVariables.FirstOrDefault():
+                                                                        null;
 
         IOperation IForEachLoopStatement.Collection => this.Expression;
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1222,16 +1222,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     AssignImpl(((BoundRangeVariable)node).Value, value, refKind, written, read);
                     break;
 
-                case BoundKind.ForEachStatement:
-                    {
-                        var iterationVariable = ((BoundForEachStatement)node).IterationVariableOpt;
-                        Debug.Assert((object)iterationVariable != null);
-                        int slot = GetOrCreateSlot(iterationVariable);
-                        if (slot > 0) SetSlotState(slot, written);
-                        if (written) NoteWrite(iterationVariable, value, read);
-                        break;
-                    }
-
                 case BoundKind.BadExpression:
                     {
                         // Sometimes a bad node is not so bad that we cannot analyze it at all.
@@ -1582,6 +1572,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
+        public override BoundNode VisitForEachStatement(BoundForEachStatement node)
+        {
+            // NOTE: iteration variables are not declared or assigned
+            //       before the collection expression is evaluated 
+            var result = base.VisitForEachStatement(node);
+
+            // NOTE: do not report unused iteration variables. They are always considered used.
+            return result;
+        }
+
         public override BoundNode VisitDoStatement(BoundDoStatement node)
         {
             DeclareVariables(node.Locals);
@@ -1595,12 +1595,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             DeclareVariables(node.Locals);
             var result = base.VisitWhileStatement(node);
             ReportUnusedVariables(node.Locals);
-            return result;
-        }
-
-        public override BoundNode VisitForEachStatement(BoundForEachStatement node)
-        {
-            var result = base.VisitForEachStatement(node);
             return result;
         }
 
@@ -2186,14 +2180,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        public override void VisitForEachIterationVariable(BoundForEachStatement node)
+        public override void VisitForEachIterationVariables(BoundForEachStatement node)
         {
-            var local = node.IterationVariableOpt;
-            if ((object)local != null)
+            // declare and assign all iteration variables
+            foreach (var iterationVariable in node.IterationVariables)
             {
-                GetOrCreateSlot(local);
-                Assign(node, value: null);
-                // TODO: node needed? NoteRead(local); // Never warn about unused foreach variables.
+                Debug.Assert((object)iterationVariable != null);
+                int slot = GetOrCreateSlot(iterationVariable);
+                if (slot > 0) SetSlotAssigned(slot);
+                NoteWrite(iterationVariable, null, read: true);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1577,8 +1577,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // NOTE: iteration variables are not declared or assigned
             //       before the collection expression is evaluated 
             var result = base.VisitForEachStatement(node);
-
-            // NOTE: do not report unused iteration variables. They are always considered used.
             return result;
         }
 
@@ -2188,6 +2186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert((object)iterationVariable != null);
                 int slot = GetOrCreateSlot(iterationVariable);
                 if (slot > 0) SetSlotAssigned(slot);
+                // NOTE: do not report unused iteration variables. They are always considered used.
                 NoteWrite(iterationVariable, null, read: true);
             }
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
@@ -147,11 +147,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return local?.DeclarationKind == LocalDeclarationKind.CatchVariable ? local : null;
                         }
 
-                    case BoundKind.ForEachStatement:
-                        {
-                            return ((BoundForEachStatement)node).IterationVariableOpt;
-                        }
-
                     case BoundKind.RangeVariable:
                         {
                             return ((BoundRangeVariable)node).RangeVariableSymbol;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2118,7 +2118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VisitRvalue(node.Expression);
             var breakState = this.State.Clone();
             LoopHead(node);
-            VisitForEachIterationVariable(node);
+            VisitForEachIterationVariables(node);
             VisitStatement(node.Body);
             ResolveContinues(node.ContinueLabel);
             LoopTail(node);
@@ -2126,7 +2126,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public virtual void VisitForEachIterationVariable(BoundForEachStatement node)
+        public virtual void VisitForEachIterationVariables(BoundForEachStatement node)
         {
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ReadWriteWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ReadWriteWalker.cs
@@ -213,16 +213,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return VisitLambda(node.BindForErrorRecovery());
         }
 
-        public override void VisitForEachIterationVariable(BoundForEachStatement node)
-        {
-            var local = node.IterationVariableOpt;
-            if ((object)local != null)
-            {
-                GetOrCreateSlot(local);
-                Assign(node, value: null);
-            }
-        }
-
         public override BoundNode VisitRangeVariable(BoundRangeVariable node)
         {
             // Compute the "underlying symbol" for a read of the range variable

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -122,16 +122,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitLocalFunctionStatement(node);
         }
 
-        public override void VisitForEachIterationVariable(BoundForEachStatement node)
+        public override void VisitForEachIterationVariables(BoundForEachStatement node)
         {
             if (IsInside)
             {
-                if (node.IterationVariableOpt != null)
-                {
-                    _variablesDeclared.Add(node.IterationVariableOpt);
-                }
+                var deconstructionAssignment = node.DeconstructionOpt?.DeconstructionAssignment;
 
-                node.DeconstructionOpt?.DeconstructionAssignment.Left.VisitAllElements((x, self) => self.Visit(x), this);
+                if (deconstructionAssignment == null)
+                {
+                    // regular, not deconstructing, foreach declares exactly one iteration variable
+                    _variablesDeclared.Add(node.IterationVariables.Single());
+                }
+                else
+                {
+                    // deconstruction foreach declares multiple variables
+                   deconstructionAssignment.Left.VisitAllElements((x, self) => self.Visit(x), this);
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -518,19 +518,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return iterationVarDecl;
         }
 
-        private static ImmutableArray<LocalSymbol> GetLocalSymbols(BoundTupleExpression left)
-        {
-            var builder = ArrayBuilder<LocalSymbol>.GetInstance();
-            left.VisitAllElements((variable, b) =>
-                {
-                    if (variable.Kind == BoundKind.Local)
-                    {
-                        b.Add(((BoundLocal)variable).LocalSymbol);
-                    }
-                }, builder);
-            return builder.ToImmutableAndFree();
-        }
-
         private static BoundBlock CreateBlockDeclaringIterationVariables(
             ImmutableArray<LocalSymbol> iterationVariables,
             BoundStatement iteratorVariableInitialization,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6151,5 +6151,46 @@ class Program
             compilation.VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: "10");
         }
+
+        [Fact]
+        [WorkItem(16106, "https://github.com/dotnet/roslyn/issues/16106")]
+        public void DefAssignmentsStruct001()
+        {
+            string source = @"
+
+        using System.Collections.Generic;
+
+        public class MyClass
+        {
+            public static void Main()
+            {
+                ((int, int), string)[] arr = new((int, int), string)[1];
+
+                Test5(arr);
+            }
+
+            public static void Test4(IEnumerable<(KeyValuePair<int, int>, string)> en)
+            {
+                foreach ((KeyValuePair<int, int> kv, string s) in en)
+                {
+                    var a = kv.Key; // false error CS0170: Use of possibly unassigned field
+                }
+            }
+
+            public static void Test5(IEnumerable<((int, int), string)> en)
+            {
+                foreach (((int, int k) t, string s) in en)
+                {
+                    var a = t.k; // false error CS0170: Use of possibly unassigned field
+                    System.Console.WriteLine(a);
+                }
+            }
+        }";
+
+            var compilation = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "0");
+        }
+
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6158,34 +6158,34 @@ class Program
         {
             string source = @"
 
-        using System.Collections.Generic;
+using System.Collections.Generic;
 
-        public class MyClass
+public class MyClass
+{
+    public static void Main()
+    {
+        ((int, int), string)[] arr = new((int, int), string)[1];
+
+        Test5(arr);
+    }
+
+    public static void Test4(IEnumerable<(KeyValuePair<int, int>, string)> en)
+    {
+        foreach ((KeyValuePair<int, int> kv, string s) in en)
         {
-            public static void Main()
-            {
-                ((int, int), string)[] arr = new((int, int), string)[1];
+            var a = kv.Key; // false error CS0170: Use of possibly unassigned field
+        }
+    }
 
-                Test5(arr);
-            }
-
-            public static void Test4(IEnumerable<(KeyValuePair<int, int>, string)> en)
-            {
-                foreach ((KeyValuePair<int, int> kv, string s) in en)
-                {
-                    var a = kv.Key; // false error CS0170: Use of possibly unassigned field
-                }
-            }
-
-            public static void Test5(IEnumerable<((int, int), string)> en)
-            {
-                foreach (((int, int k) t, string s) in en)
-                {
-                    var a = t.k; // false error CS0170: Use of possibly unassigned field
-                    System.Console.WriteLine(a);
-                }
-            }
-        }";
+    public static void Test5(IEnumerable<((int, int), string)> en)
+    {
+        foreach (((int, int k) t, string s) in en)
+        {
+            var a = t.k; // false error CS0170: Use of possibly unassigned field
+            System.Console.WriteLine(a);
+        }
+    }
+}";
 
             var compilation = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ForEachTests.cs
@@ -1204,7 +1204,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Int32 x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Int32 x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal(SpecialType.System_Collections_IEnumerable, boundNode.Expression.Type.SpecialType);
             Assert.Equal(SymbolKind.ArrayType, ((BoundConversion)boundNode.Expression).Operand.Type.Kind);
         }
@@ -1236,7 +1236,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Char c", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Char c", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal(SpecialType.System_String, boundNode.Expression.Type.SpecialType);
             Assert.Equal(SpecialType.System_String, ((BoundConversion)boundNode.Expression).Operand.Type.SpecialType);
         }
@@ -1279,7 +1279,7 @@ class Enumerator
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.ImplicitNumeric, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Int64 x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Int64 x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal("Enumerable", boundNode.Expression.Type.ToTestDisplayString());
             Assert.Equal("Enumerable", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -1322,7 +1322,7 @@ struct Enumerator
             Assert.Equal(ConversionKind.Boxing, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.ImplicitNumeric, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Int64 x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Int64 x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal("Enumerable", boundNode.Expression.Type.ToTestDisplayString());
             Assert.Equal("Enumerable", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -1354,7 +1354,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Unboxing, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Int64 x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Int64 x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal("System.Collections.IEnumerable", boundNode.Expression.Type.ToTestDisplayString());
             Assert.Equal("System.Collections.IEnumerable", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -1393,7 +1393,7 @@ class Enumerable : System.Collections.Generic.IEnumerable<int>
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.ImplicitNumeric, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Int64 x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Int64 x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal("System.Collections.Generic.IEnumerable<System.Int32>", boundNode.Expression.Type.ToTestDisplayString());
             Assert.Equal("Enumerable", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -1434,7 +1434,7 @@ class Enumerable : System.Collections.Generic.IEnumerable<Enumerable.Hidden>
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Object x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Object x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal(SpecialType.System_Collections_IEnumerable, boundNode.Expression.Type.SpecialType);
             Assert.Equal("Enumerable", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -1472,7 +1472,7 @@ class Enumerable : System.Collections.IEnumerable
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Unboxing, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Int64 x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Int64 x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal(SpecialType.System_Collections_IEnumerable, boundNode.Expression.Type.SpecialType);
             Assert.Equal("Enumerable", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -1504,7 +1504,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal(SpecialType.System_Int32, boundNode.IterationVariableOpt.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int32, boundNode.IterationVariables.Single().Type.SpecialType);
         }
 
         [Fact]
@@ -1534,7 +1534,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal(SpecialType.System_Char, boundNode.IterationVariableOpt.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Char, boundNode.IterationVariables.Single().Type.SpecialType);
         }
 
         [Fact]
@@ -1563,7 +1563,7 @@ class Enumerator
             var boundNode = GetBoundForEachStatement(text);
             Assert.NotNull(boundNode.EnumeratorInfoOpt);
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal(SpecialType.System_Int32, boundNode.IterationVariableOpt.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Int32, boundNode.IterationVariables.Single().Type.SpecialType);
         }
 
         [Fact]
@@ -1587,7 +1587,7 @@ class Enumerable : System.Collections.IEnumerable
             var boundNode = GetBoundForEachStatement(text);
             Assert.NotNull(boundNode.EnumeratorInfoOpt);
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal(SpecialType.System_Object, boundNode.IterationVariableOpt.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Object, boundNode.IterationVariables.Single().Type.SpecialType);
         }
 
         [Fact]
@@ -1619,7 +1619,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal("C.var", boundNode.IterationVariableOpt.Type.ToTestDisplayString());
+            Assert.Equal("C.var", boundNode.IterationVariables.Single().Type.ToTestDisplayString());
         }
 
         [Fact]
@@ -1649,7 +1649,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.ExplicitDynamic, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Int32 x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Int32 x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal(SpecialType.System_Collections_IEnumerable, boundNode.Expression.Type.SpecialType);
             Assert.Equal(TypeKind.Dynamic, ((BoundConversion)boundNode.Expression).Operand.Type.TypeKind);
         }
@@ -1681,7 +1681,7 @@ class C
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind); //NB: differs from explicit case
-            Assert.Equal("dynamic x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("dynamic x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal(SpecialType.System_Collections_IEnumerable, boundNode.Expression.Type.SpecialType);
             Assert.Equal(SymbolKind.DynamicType, ((BoundConversion)boundNode.Expression).Operand.Type.Kind);
         }
@@ -1721,7 +1721,7 @@ public class Enumerable<T>
             Assert.Equal(ConversionKind.Boxing, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Object x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Object x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal("Enumerable<T>", boundNode.Expression.Type.ToTestDisplayString());
             Assert.Equal("Enumerable<T>", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -1804,7 +1804,7 @@ interface MyEnumerator
             Assert.Equal(ConversionKind.Boxing, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Object x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Object x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal("Enumerable<T>", boundNode.Expression.Type.ToTestDisplayString());
             Assert.Equal("Enumerable<T>", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -1850,7 +1850,7 @@ struct Enumerator
             Assert.Equal(ConversionKind.Boxing, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.ImplicitNumeric, boundNode.ElementConversion.Kind);
-            Assert.Equal("System.Int64 x", boundNode.IterationVariableOpt.ToTestDisplayString());
+            Assert.Equal("System.Int64 x", boundNode.IterationVariables.Single().ToTestDisplayString());
             Assert.Equal("Enumerable", boundNode.Expression.Type.ToTestDisplayString());
             Assert.Equal("Enumerable", ((BoundConversion)boundNode.Expression).Operand.Type.ToTestDisplayString());
         }
@@ -3004,7 +3004,7 @@ namespace System.Collections
             Assert.Equal(ConversionKind.ImplicitReference, info.EnumeratorConversion.Kind);
 
             Assert.Equal(ConversionKind.Identity, boundNode.ElementConversion.Kind);
-            Assert.Equal(SpecialType.System_Char, boundNode.IterationVariableOpt.Type.SpecialType);
+            Assert.Equal(SpecialType.System_Char, boundNode.IterationVariables.Single().Type.SpecialType);
         }
 
 


### PR DESCRIPTION
Fixes:#16106

**Customer scenario**

When deconstruction is used in a context of foreach, the deconstructed variables are not marked as assigned. As a result, if a deconstruction variable is a struct (KeyValuePair, etc...). Dotting off the variable in the loop body would result in a false definite assignment error.

**Bugs this fixes:** 

#16106

No workarounds other than not using the given language construct when structs are involved.
The bug would block a sizeable fraction of user scenarios for the feature.

**Risk**

The change is specific to the deconstruction foreach. 
It basically just marks the iteration variables introduced by deconstruction all definitely assigned at the beginning of the loop body

**Performance impact**

Low.

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

The bug is at intersection of "foreach" and "deconstruction" features. It also requires that deconstruction targets are structs. 
We seem to have missed this combination in testing.

**How was the bug found?**

Customer report.