### PR TITLE
Do not run Naming Styles on overrides, etc.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 new CSharpNamingStyleDiagnosticAnalyzer(),
                 new NamingStyleCodeFixProvider());
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestPascalCaseClass_CorrectName()
         {
             await TestMissingAsync(
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 options: ClassNamesArePascalCase);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestPascalCaseClass_NameGetsCapitalized()
         {
             await TestAsync(
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 options: ClassNamesArePascalCase);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestPascalCaseMethod_CorrectName()
         {
             await TestMissingAsync(
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 options: MethodNamesArePascalCase);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestPascalCaseMethod_NameGetsCapitalized()
         {
             await TestAsync(
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 options: MethodNamesArePascalCase);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestPascalCaseMethod_ConstructorsAreIgnored()
         {
             await TestMissingAsync(
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 options: MethodNamesArePascalCase);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestPascalCaseMethod_PropertyAccessorsAreIgnored()
         {
             await TestMissingAsync(
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 options: MethodNamesArePascalCase);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestPascalCaseMethod_IndexerNameIsIgnored()
         {
             await TestMissingAsync(
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
                 options: MethodNamesArePascalCase);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
         public async Task TestCamelCaseParameters()
         {
             await TestAsync(
@@ -131,6 +131,193 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
     }
 }",
                 options: ParameterNamesAreCamelCase);
+		}
+		
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_InInterfaceWithImplicitImplementation()
+        {
+            await TestAsync(
+@"interface I
+{
+    void [|m|]();
+}
+
+class C : I
+{
+    public void m() { }
+}",
+@"interface I
+{
+    void M();
+}
+
+class C : I
+{
+    public void M() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_InInterfaceWithExplicitImplementation()
+        {
+            await TestAsync(
+@"interface I
+{
+    void [|m|]();
+}
+
+class C : I
+{
+    void I.m() { }
+}",
+@"interface I
+{
+    void M();
+}
+
+class C : I
+{
+    void I.M() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_NotInImplicitInterfaceImplementation()
+        {
+            await TestMissingAsync(
+@"interface I
+{
+    void m();
+}
+
+class C : I
+{
+    public void [|m|]() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_NotInExplicitInterfaceImplementation()
+        {
+            await TestMissingAsync(
+@"interface I
+{
+    void m();
+}
+
+class C : I
+{
+    void I.[|m|]() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_InAbstractType()
+        {
+            await TestAsync(
+@"
+abstract class C
+{
+    public abstract void [|m|]();
+}
+
+class D : C
+{
+    public override void m() { }
+}",
+@"
+abstract class C
+{
+    public abstract void M();
+}
+
+class D : C
+{
+    public override void M() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_NotInAbstractMethodImplementation()
+        {
+            await TestMissingAsync(
+@"
+abstract class C
+{
+    public abstract void m();
+}
+
+class D : C
+{
+    public override void [|m|]() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseProperty_InInterface()
+        {
+            await TestAsync(
+@"
+interface I
+{
+    int [|p|] { get; set; }
+}
+
+class C : I
+{
+    public int p { get { return 1; } set { } }
+}",
+@"
+interface I
+{
+    int P { get; set; }
+}
+
+class C : I
+{
+    public int P { get { return 1; } set { } }
+}",
+                options: PropertyNamesArePascalCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseProperty_NotInImplicitInterfaceImplementation()
+        {
+            await TestMissingAsync(
+@"
+interface I
+{
+    int p { get; set; }
+}
+
+class C : I
+{
+    public int [|p|] { get { return 1; } set { } }
+}",
+                options: PropertyNamesArePascalCase);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_OverrideInternalMethod()
+        {
+            await TestMissingAsync(
+@"
+abstract class C
+{
+    internal abstract void m();
+}
+
+class D : C
+{
+    internal override void [|m|]() { }
+}",
+                options: MethodNamesArePascalCase);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests_OptionSets.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests_OptionSets.cs
@@ -21,6 +21,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
         private IDictionary<OptionKey, object> ParameterNamesAreCamelCase =>
             Options(new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp), ParameterNamesAreCamelCaseOption());
 
+		private IDictionary<OptionKey, object> PropertyNamesArePascalCase =>
+            Options(new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp), PropertyNamesArePascalCaseOption());
+
         private IDictionary<OptionKey, object> Options(OptionKey option, object value)
         {
             var options = new Dictionary<OptionKey, object>
@@ -103,6 +106,38 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyle
             var namingStyle = new NamingStyle(
                 Guid.NewGuid(),
                 capitalizationScheme: Capitalization.CamelCase,
+                name: "Name",
+                prefix: "",
+                suffix: "",
+                wordSeparator: "");
+
+            var namingRule = new SerializableNamingRule()
+            {
+                SymbolSpecificationID = symbolSpecification.ID,
+                NamingStyleID = namingStyle.ID,
+                EnforcementLevel = DiagnosticSeverity.Error
+            };
+			
+			var info = new NamingStylePreferences(
+                ImmutableArray.Create(symbolSpecification),
+                ImmutableArray.Create(namingStyle),
+                ImmutableArray.Create(namingRule));
+
+            return info;
+		}
+
+        private NamingStylePreferences PropertyNamesArePascalCaseOption()
+        {
+            var symbolSpecification = new SymbolSpecification(
+                null,
+                "Name",
+                ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(SymbolKind.Property)),
+                ImmutableArray<Accessibility>.Empty,
+                ImmutableArray<SymbolSpecification.ModifierKind>.Empty);
+
+            var namingStyle = new NamingStyle(
+                Guid.NewGuid(),
+                capitalizationScheme: Capitalization.PascalCase,
                 name: "Name",
                 prefix: "",
                 suffix: "",

--- a/src/Workspaces/Core/Portable/NamingStyles/NamingStyleRules.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/NamingStyleRules.cs
@@ -1,12 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 {
     internal class NamingStyleRules
     {
         public ImmutableArray<NamingRule> NamingRules { get; }
+
+        private readonly ImmutableArray<SymbolKind> _symbolKindsThatCanBeOverridden =
+            ImmutableArray.Create(
+                SymbolKind.Method,
+                SymbolKind.Property,
+                SymbolKind.Event);
 
         public NamingStyleRules(ImmutableArray<NamingRule> namingRules)
         {
@@ -34,6 +42,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
         private bool IsSymbolNameAnalyzable(ISymbol symbol)
         {
+            if (_symbolKindsThatCanBeOverridden.Contains(symbol.Kind) && DoesSymbolImplementAnotherSymbol(symbol))
+            {
+                return false;
+            }
+
             if (symbol.Kind == SymbolKind.Method)
             {
                 return ((IMethodSymbol)symbol).MethodKind == MethodKind.Ordinary;
@@ -45,6 +58,53 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             }
 
             return true;
+        }
+
+        private bool DoesSymbolImplementAnotherSymbol(ISymbol symbol)
+        {
+            if (symbol.IsStatic)
+            {
+                return false;
+            }
+
+            var containingType = symbol.ContainingType;
+            if (containingType.TypeKind != TypeKind.Class && containingType.TypeKind != TypeKind.Struct)
+            {
+                return false;
+            }
+
+            return symbol.IsOverride ||
+                symbol.ExplicitInterfaceImplementations().Any() ||
+                IsInterfaceImplementation(symbol);
+        }
+
+        /// <summary>
+        /// This does not handle the case where a method in a base type implicitly implements an
+        /// interface method on behalf of one of its derived types.
+        /// </summary>
+        private bool IsInterfaceImplementation(ISymbol symbol)
+        {
+            if (symbol.DeclaredAccessibility != Accessibility.Public)
+            {
+                return false;
+            }
+
+            var containingType = symbol.ContainingType;
+            var implementedInterfaces = containingType.AllInterfaces;
+
+            foreach (var implementedInterface in implementedInterfaces)
+            {
+                var implementedInterfaceMembersWithSameName = implementedInterface.GetMembers(symbol.Name);
+                foreach(var implementedInterfaceMember in implementedInterfaceMembersWithSameName)
+                {
+                    if (symbol.Equals(containingType.FindImplementationForInterfaceMember(implementedInterfaceMember)))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fixes #15345

Do not run Naming Styles on overrides or known explicit/implicit interface implementations.

Escrow Template
================

**Customer scenario**: Customers who enable Naming Rules for members currently see the rules enforced on overrides and interface implementations, which can be noisy. This is particularly bad when the name is not fixable (when the name being overridden is in metadata), or when we eventually enable closed file analysis for this analyzer.

**Bugs this fixes:**: #15345

**Workarounds, if any**: None

**Risk**: Low. This is at the top of the stack and should just cause Naming Styles to be enforced less places.

**Performance impact**: For every Method/Property/Event without the "override" keyword and without being an explicit implementation of something, we will now do the work of examining each member of all base types and implemented interfaces to see if the given Method/Property/Event implements that member.

**Is this a regression from a previous update?**: No

**Root cause analysis:** This case was missed during the original feature work. Unit tests have been added to prevent regressions.

**How was the bug found?**: Dogfooding