### PR TITLE
Properly handle lack of editorconfig file for naming styles

### DIFF
--- a/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
+++ b/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Options;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
+{
+    public class EditorConfigStorageLocationTests
+    {
+        [Fact]
+        public static void TestEmptyDictionaryReturnFalse()
+        {
+            var editorConfigStorageLocation = new EditorConfigStorageLocation();
+            var result = editorConfigStorageLocation.TryParseReadonlyDictionary(new Dictionary<string, object>(), typeof(NamingStylePreferences), out var @object);
+            Assert.False(result, "Expected TryParseReadonlyDictionary to return 'false' for empty dictionary");
+        }
+
+        [Fact]
+        public static void TestObjectTypeThrowsNotSupportedException()
+        {
+            var editorConfigStorageLocation = new EditorConfigStorageLocation();
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                editorConfigStorageLocation.TryParseReadonlyDictionary(new Dictionary<string, object>(), typeof(object), out var @object);
+            });
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="CodeStyle\EditorConfigCodeStyleParserTests.cs" />
     <Compile Include="DependentTypeFinderTests.cs" />
+    <Compile Include="EditorConfigStorageLocation\EditorConfigStorageLocationTests.cs" />
     <Compile Include="Editting\SyntaxEditorTests.cs" />
     <Compile Include="Execution\Extensions.cs" />
     <Compile Include="Execution\SnapshotSerializationTestBase.cs" />


### PR DESCRIPTION
**Customer scenario**

If the user does not have an editofconfig they cannot use the naming styles feature.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16408

**Workarounds, if any**

none, the user can only set options from editorconfig

**Risk**
Low, we are returning false where we used to return true

**Performance impact**
None, we are returning false where we used to return true

**Is this a regression from a previous update?**
Yes, this worked in RC1

**Root cause analysis:**
When the editorconfig parser was called with no editorconfig file present it was given an empty dictionary, which it succeeded in parsing as an empty set of options, leading our per document option service to believe that it should return these options over the default workspace.  Passing an empty dictionary now causes the editorconfig service to return false, indicating to the options service that it should use the workspace options instead. This was regressed in one of the refactorings to the initial PR to support naming styles in editorconfig.  We now have a unit test for this case.

**How was the bug found?**
ad hoc testing by @dpoeschl 