### PR TITLE
fixed multiple issues that caused checksum mismatch

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -48,7 +48,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             DocumentationMode documentationMode = DocumentationMode.Parse,
             SourceCodeKind kind = SourceCodeKind.Regular,
             IEnumerable<string> preprocessorSymbols = null)
-            : this(languageVersion, documentationMode, kind, preprocessorSymbols.ToImmutableArrayOrEmpty())
+            : this(languageVersion, 
+                  documentationMode, 
+                  kind, 
+                  preprocessorSymbols.ToImmutableArrayOrEmpty(), 
+                  ImmutableDictionary<string, string>.Empty)
         {
             // We test the mapped value, LanguageVersion, rather than the parameter, languageVersion,
             // which has not had "Latest" mapped to the latest version yet.
@@ -100,18 +104,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // No validation
-        internal CSharpParseOptions(
+        private CSharpParseOptions(
             LanguageVersion languageVersion,
             DocumentationMode documentationMode,
             SourceCodeKind kind,
-            ImmutableArray<string> preprocessorSymbols)
+            ImmutableArray<string> preprocessorSymbols,
+            ImmutableDictionary<string, string> features)
             : base(kind, documentationMode)
         {
             Debug.Assert(!preprocessorSymbols.IsDefault);
             this.SpecifiedLanguageVersion = languageVersion;
             this.LanguageVersion = languageVersion.MapSpecifiedToEffectiveVersion();
             this.PreprocessorSymbols = preprocessorSymbols;
-            _features = ImmutableDictionary<string, string>.Empty;
+            _features = features;
         }
 
         public override string Language => LanguageNames.CSharp;

--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -518,10 +518,13 @@ namespace Microsoft.CodeAnalysis.Execution
                 writer.WriteString(nameof(AnalyzerFileReference));
                 writer.WriteInt32((int)SerializationKinds.FilePath);
 
-                if (!checksum)
+                if (checksum)
                 {
                     // we don't write full path when creating checksum
-                    writer.WriteString(file.FullPath);
+                    // make sure we always normalize assemblyPath to lower case since it comes from Assembly.Location
+                    // unlike FullPath which comes from string
+                    writer.WriteString(assemblyPath.ToLowerInvariant());
+                    return;
                 }
 
                 // TODO: remove this kind of host specific knowledge from common layer.
@@ -531,6 +534,7 @@ namespace Microsoft.CodeAnalysis.Execution
                 // snapshot version for analyzer (since it is based on shadow copy)
                 // we can't send over bits and load analyer from memory (image) due to CLR not being able
                 // to find satellite dlls for analyzers.
+                writer.WriteString(file.FullPath);
                 writer.WriteString(assemblyPath);
                 return;
             }

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -138,6 +138,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var solution = CreateFullSolution();
 
+            var firstProjectChecksum = await solution.GetProject(solution.ProjectIds[0]).State.GetChecksumAsync(CancellationToken.None);
+            var secondProjectChecksum = await solution.GetProject(solution.ProjectIds[1]).State.GetChecksumAsync(CancellationToken.None);
+
             var snapshotService = (new SolutionSynchronizationServiceFactory()).CreateService(solution.Workspace.Services) as ISolutionSynchronizationService;
             using (var snapshot = await snapshotService.CreatePinnedRemotableDataScopeAsync(solution, CancellationToken.None).ConfigureAwait(false))
             {
@@ -151,8 +154,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 Assert.Equal(solutionObject.Projects.Count, 2);
 
                 var projects = solutionObject.Projects.ToProjectObjects(snapshotService);
-                VerifySnapshotInService(snapshotService, projects[0], 1, 1, 1, 1, 1);
-                VerifySnapshotInService(snapshotService, projects[1], 1, 0, 0, 0, 0);
+                VerifySnapshotInService(snapshotService, projects.Where(p => p.Checksum == firstProjectChecksum).First(), 1, 1, 1, 1, 1);
+                VerifySnapshotInService(snapshotService, projects.Where(p => p.Checksum == secondProjectChecksum).First(), 1, 0, 0, 0, 0);
             }
         }
 

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -453,7 +453,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 projectInfo.Id, projectInfo.Version, projectInfo.Name, projectInfo.AssemblyName,
                 projectInfo.Language, projectInfo.FilePath, projectInfo.OutputFilePath,
                 compilationOptions, parseOptions,
-                documents, p2p, metadata, analyzers, additionals, projectInfo.IsSubmission);
+                documents, p2p, metadata, analyzers, additionals, projectInfo.IsSubmission).WithHasAllInformation(projectInfo.HasAllInformation);
         }
 
         private async Task<List<T>> CreateCollectionAsync<T>(ChecksumCollection collections)


### PR DESCRIPTION
**Customer scenario**

VS crashes sometimes after solution load.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16401
https://github.com/dotnet/roslyn/issues/16396
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/366189

**Workarounds, if any**

use internal registry key to turn off OOP

**Risk**

it should make things better and not regress anything.

**Performance impact**

I dont see anything that could impact perf. most of code changes that are related to creating checksum changes rarely.

**Is this a regression from a previous update?**

Yes. new concept on how to create solution is introduced in RC3 to make perf better. less memory, incremental solution creation. share more caches and etc

**Root cause analysis:**

we get assembly path for analyzer reference (dll) from Assembly.Location which sometimes return different casing for same path. and that caused checksum to be different for same dll.

order of documentId/ProjectId collection being always same is not true between 2 processes. now, we explicitly order them.

when creating ProjectInfo, HasAllInformation was not added to the info.

CSharpParseOption sometimes validate preprocessor symbols and sometimes not. and one code path went to wrong path where it shouldn't validate preprocessor symbols.

**How was the bug found?**

dogfooding.