### PR TITLE
Prototype for "default": semantic model, constant value and more tests

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -887,6 +887,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.NullLiteral:
                     return sourceConstantValue;
 
+                case ConversionKind.DefaultLiteral:
+                    Debug.Assert(sourceConstantValue.IsDefaultLiteral);
+                    return destination.GetDefaultValue();
+
                 case ConversionKind.ImplicitConstant:
                     return FoldConstantNumericConversion(syntax, sourceConstantValue, destination, diagnostics);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return BindDefaultExpression((DefaultExpressionSyntax)node, diagnostics);
 
                 case SyntaxKind.DefaultLiteral:
-                    return new BoundDefaultOperator((DefaultLiteralSyntax)node, ConstantValue.DefaultLiteral, type: null);
+                    return BindDefaultLiteral((DefaultLiteralSyntax)node);
 
                 case SyntaxKind.TypeOfExpression:
                     return BindTypeOf((TypeOfExpressionSyntax)node, diagnostics);
@@ -654,6 +654,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(false, "Unexpected SyntaxKind " + node.Kind());
                     return BadExpression(node);
             }
+        }
+
+        private static BoundExpression BindDefaultLiteral(DefaultLiteralSyntax node)
+        {
+            return new BoundDefaultLiteral(node, ConstantValue.DefaultLiteral, type: null);
         }
 
         private BoundExpression BindTupleExpression(TupleExpressionSyntax node, DiagnosticBag diagnostics)
@@ -970,7 +975,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression BindDefaultExpression(DefaultExpressionSyntax node, DiagnosticBag diagnostics)
         {
             TypeSymbol type = this.BindType(node.Type, diagnostics);
-            return new BoundDefaultOperator(node, type);
+            return new BoundDefaultLiteral(node, type);
         }
 
         /// <summary>
@@ -5008,7 +5013,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static void WarnOnAccessOfOffDefault(SyntaxNode node, BoundExpression boundLeft, DiagnosticBag diagnostics)
         {
-            if (boundLeft != null && boundLeft.Kind == BoundKind.DefaultOperator && boundLeft.ConstantValue == ConstantValue.Null)
+            if (boundLeft != null && boundLeft.Kind == BoundKind.DefaultLiteral && boundLeft.ConstantValue == ConstantValue.Null)
             {
                 Error(diagnostics, ErrorCode.WRN_DotOnDefault, node, boundLeft.Type);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return BindDefaultExpression((DefaultExpressionSyntax)node, diagnostics);
 
                 case SyntaxKind.DefaultLiteral:
-                    return new BoundDefaultOperator((DefaultLiteralSyntax)node);
+                    return new BoundDefaultOperator((DefaultLiteralSyntax)node, ConstantValue.DefaultLiteral, type: null);
 
                 case SyntaxKind.TypeOfExpression:
                     return BindTypeOf((TypeOfExpressionSyntax)node, diagnostics);
@@ -1729,8 +1729,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 diagnostics.Add(ErrorCode.ERR_ValueCantBeNull, syntax.Location, targetType);
                 return;
             }
-
-            // PROTOTYPE(default) SHould handle default literal here?
 
             if (conversion.ResultKind == LookupResultKind.OverloadResolutionFailure)
             {
@@ -4834,7 +4832,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BadExpression(node, boundLeft);
             }
 
-            // PROTOTYPE(default) unify with case above
             // No member accesses on default
             if (boundLeft.IsLiteralDefault())
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -401,6 +401,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // error CS1978: Cannot use an expression of type '__arglist' as an argument to a dynamically dispatched operation
                         Error(diagnostics, ErrorCode.ERR_BadDynamicMethodArg, arg.Syntax, "__arglist");
                     }
+                    else if (arg.IsLiteralDefault())
+                    {
+                        Error(diagnostics, ErrorCode.ERR_BadDynamicMethodArgDefault, arg.Syntax);
+                        hasErrors = true;
+                    }
                     else
                     {
                         // Lambdas,anonymous methods and method groups are the typeless expressions that

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2628,6 +2628,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
+            if (operand.ConstantValue == ConstantValue.DefaultLiteral)
+            {
+                Error(diagnostics, ErrorCode.ERR_DefaultNotValid, node, targetType);
+                return new BoundIsOperator(node, operand, typeExpression, Conversion.NoConversion, resultType, hasErrors: true);
+            }
+
             if (operand.ConstantValue == ConstantValue.Null ||
                 operand.Kind == BoundKind.MethodGroup ||
                 operand.Type.SpecialType == SpecialType.System_Void)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3019,8 +3019,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundAsOperator(node, operand, typeExpression, Conversion.NullLiteral, resultType);
             }
 
-            // PROTOTYPE(default) Something needed here for "as" operator
-
             if (operand.Kind == BoundKind.MethodGroup)
             {
                 Error(diagnostics, ErrorCode.ERR_NoExplicitBuiltinConv, node, MessageID.IDS_MethodGroup.Localize(), targetType);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -713,7 +713,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (ultimateReceiver.IsLiteralDefault())
                 {
-                    diagnostics.Add(ErrorCode.ERR_NullNotValid, node.Location);
+                    diagnostics.Add(ErrorCode.ERR_DefaultNotValid, node.Location);
                 }
                 else if (ultimateReceiver.Kind == BoundKind.Lambda || ultimateReceiver.Kind == BoundKind.UnboundLambda)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -711,6 +711,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     diagnostics.Add(ErrorCode.ERR_NullNotValid, node.Location);
                 }
+                else if (ultimateReceiver.IsLiteralDefault())
+                {
+                    diagnostics.Add(ErrorCode.ERR_NullNotValid, node.Location);
+                }
                 else if (ultimateReceiver.Kind == BoundKind.Lambda || ultimateReceiver.Kind == BoundKind.UnboundLambda)
                 {
                     // Could not find an implementation of the query pattern for source type '{0}'.  '{1}' not found.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3176,7 +3176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var interactiveInitializerMethod = this.ContainingMemberOrLambda as SynthesizedInteractiveInitializerMethod;
                 if (interactiveInitializerMethod != null)
                 {
-                    arg = new BoundDefaultOperator(interactiveInitializerMethod.GetNonNullSyntaxNode(), interactiveInitializerMethod.ResultType);
+                    arg = new BoundDefaultLiteral(interactiveInitializerMethod.GetNonNullSyntaxNode(), interactiveInitializerMethod.ResultType);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1026,8 +1026,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 initializerOpt = GenerateConversionForAssignment(declType, initializerOpt, diagnostics);
                 if (!initializerOpt.HasAnyErrors)
                 {
-                    Debug.Assert(initializerOpt.Kind == BoundKind.Conversion && ((BoundConversion)initializerOpt).Operand.IsLiteralNull(),
+                    Debug.Assert(initializerOpt.Kind == BoundKind.Conversion &&
+                        (((BoundConversion)initializerOpt).Operand.IsLiteralNull() ||
+                            ((BoundConversion)initializerOpt).Operand.IsLiteralDefault()),
                         "All other typeless expressions should have conversion errors");
+
                     // CONSIDER: this is a very confusing error message, but it's what Dev10 reports.
                     Error(diagnostics, ErrorCode.ERR_FixedNotNeeded, initializerSyntax);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -394,12 +394,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Spec seems to refer to null literals, but Dev10 reports anything known to be null.
                     diagnostics.Add(ErrorCode.ERR_NullNotValid, _syntax.Expression.Location);
+                    return false;
                 }
                 else if (collectionExpr.ConstantValue.IsDefaultLiteral)
                 {
                     diagnostics.Add(ErrorCode.ERR_DefaultNotValid, _syntax.Expression.Location);
+                    return false;
                 }
-                return false;
             }
 
             if ((object)collectionExprType == null) // There's no way to enumerate something without a type.

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -388,12 +388,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             TypeSymbol collectionExprType = collectionExpr.Type;
 
-            if (collectionExpr.ConstantValue != null && collectionExpr.ConstantValue.IsNull)
+            if (collectionExpr.ConstantValue != null)
             {
-                // Spec seems to refer to null literals, but Dev10 reports anything known to be null.
-                Debug.Assert(collectionExpr.ConstantValue.IsNull); // only constant value with no type
-                diagnostics.Add(ErrorCode.ERR_NullNotValid, _syntax.Expression.Location);
-
+                if (collectionExpr.ConstantValue.IsNull)
+                {
+                    // Spec seems to refer to null literals, but Dev10 reports anything known to be null.
+                    diagnostics.Add(ErrorCode.ERR_NullNotValid, _syntax.Expression.Location);
+                }
+                else if (collectionExpr.ConstantValue.IsDefaultLiteral)
+                {
+                    diagnostics.Add(ErrorCode.ERR_DefaultNotValid, _syntax.Expression.Location);
+                }
                 return false;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -815,8 +815,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     break;
 
-                case BoundKind.DefaultOperator:
-                    var defaultExpression = (BoundDefaultOperator)sourceExpression;
+                case BoundKind.DefaultLiteral:
+                    var defaultExpression = (BoundDefaultLiteral)sourceExpression;
                     if ((object)defaultExpression.Type == null)
                     {
                         return Conversion.DefaultLiteral;
@@ -975,7 +975,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var constantValue = source.ConstantValue;
 
-            if (constantValue == null || constantValue.IsDefaultLiteral)
+            if (constantValue == null || (object)source.Type == null)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -975,7 +975,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var constantValue = source.ConstantValue;
 
-            if (constantValue == null)
+            if (constantValue == null || constantValue.IsDefaultLiteral)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -444,7 +444,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundDefaultOperator
+    internal partial class BoundDefaultLiteral
     {
         public override ConstantValue ConstantValue
         {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public static bool IsLiteralDefault(this BoundExpression node)
         {
-            return node.Kind == BoundKind.DefaultOperator && (object)node.Type == null;
+            return node.Kind == BoundKind.DefaultLiteral && (object)node.Type == null;
         }
 
         // returns true when expression has no side-effects and produces
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         //       after some folding/propagation/algebraic transformations.
         public static bool IsDefaultValue(this BoundExpression node)
         {
-            if (node.Kind == BoundKind.DefaultOperator)
+            if (node.Kind == BoundKind.DefaultLiteral)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -551,7 +551,7 @@
     <Field Name="GetFieldFromHandle" Type="MethodSymbol" Null="allow"/>
   </Node>
 
-  <Node Name="BoundDefaultOperator" Base="BoundExpression">
+  <Node Name="BoundDefaultLiteral" Base="BoundExpression">
     <!-- Type is null in the case of a default literal, and non-null in the case of a fully-spelled out default operator. -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="allow"/>
     <Field Name="ConstantValueOpt" Type="ConstantValue" Null="allow"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundTreeVisitors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundTreeVisitors.cs
@@ -48,8 +48,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitArrayAccess(node as BoundArrayAccess, arg);
                 case BoundKind.TypeOfOperator:
                     return VisitTypeOfOperator(node as BoundTypeOfOperator, arg);
-                case BoundKind.DefaultOperator:
-                    return VisitDefaultOperator(node as BoundDefaultOperator, arg);
+                case BoundKind.DefaultLiteral:
+                    return VisitDefaultLiteral(node as BoundDefaultLiteral, arg);
                 case BoundKind.IsOperator:
                     return VisitIsOperator(node as BoundIsOperator, arg);
                 case BoundKind.AsOperator:

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -523,14 +523,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundDefaultOperator
+    internal partial class BoundDefaultLiteral
     {
-        public BoundDefaultOperator(SyntaxNode syntax, TypeSymbol type, bool hasErrors = false)
+        public BoundDefaultLiteral(SyntaxNode syntax, TypeSymbol type, bool hasErrors = false)
             : this(syntax, type.GetDefaultValue(), type, hasErrors)
         {
         }
 
-        public BoundDefaultOperator(SyntaxNode syntax)
+        public BoundDefaultLiteral(SyntaxNode syntax)
           : this(syntax, constantValueOpt: null, type: null, hasErrors: false)
         {
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundDefaultOperator : IDefaultValueExpression
+    internal partial class BoundDefaultLiteral : IDefaultValueExpression
     {
         protected override OperationKind ExpressionKind => OperationKind.DefaultValueExpression;
 

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundDefaultOperator
+    internal partial class BoundDefaultLiteral
     {
         public override object Display
         {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3167,6 +3167,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use of default is not valid in this context.
+        /// </summary>
+        internal static string ERR_DefaultNotValid {
+            get {
+                return ResourceManager.GetString("ERR_DefaultNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Argument of type &apos;{0}&apos; is not applicable for the DefaultParameterValue attribute.
         /// </summary>
         internal static string ERR_DefaultValueBadValueType {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1340,6 +1340,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot use a type-inferred default operator as an argument to a dynamically dispatched operation..
+        /// </summary>
+        internal static string ERR_BadDynamicMethodArgDefault {
+            get {
+                return ResourceManager.GetString("ERR_BadDynamicMethodArgDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot use a lambda expression as an argument to a dynamically dispatched operation without first casting it to a delegate or expression tree type..
         /// </summary>
         internal static string ERR_BadDynamicMethodArgLambda {
@@ -4076,7 +4085,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An expression tree lambda may not contain a coalescing operator with a null literal left-hand side.
+        ///   Looks up a localized string similar to An expression tree lambda may not contain a coalescing operator with a null or default literal left-hand side.
         /// </summary>
         internal static string ERR_ExpressionTreeContainsBadCoalesce {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2169,7 +2169,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>Cannot use local variable '{0}' before it is declared. The declaration of the local variable hides the field '{1}'.</value>
   </data>
   <data name="ERR_ExpressionTreeContainsBadCoalesce" xml:space="preserve">
-    <value>An expression tree lambda may not contain a coalescing operator with a null literal left-hand side</value>
+    <value>An expression tree lambda may not contain a coalescing operator with a null or default literal left-hand side</value>
   </data>
   <data name="ERR_IdentifierExpected" xml:space="preserve">
     <value>Identifier expected</value>
@@ -4955,5 +4955,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_ExpressionVariableInConstructorOrFieldInitializer" xml:space="preserve">
     <value>Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.</value>
+  </data>
+  <data name="ERR_BadDynamicMethodArgDefault" xml:space="preserve">
+    <value>Cannot use a type-inferred default operator as an argument to a dynamically dispatched operation.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -837,6 +837,9 @@
   <data name="ERR_NullNotValid" xml:space="preserve">
     <value>Use of null is not valid in this context</value>
   </data>
+  <data name="ERR_DefaultNotValid" xml:space="preserve">
+    <value>Use of default is not valid in this context</value>
+  </data>
   <data name="ERR_UseDefViolationThis" xml:space="preserve">
     <value>The 'this' object cannot be used before all of its fields are assigned to</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -191,8 +191,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitAsExpression((BoundAsOperator)expression, used);
                     break;
 
-                case BoundKind.DefaultOperator:
-                    EmitDefaultExpression((BoundDefaultOperator)expression, used);
+                case BoundKind.DefaultLiteral:
+                    EmitDefaultExpression((BoundDefaultLiteral)expression, used);
                     break;
 
                 case BoundKind.TypeOfOperator:
@@ -2617,7 +2617,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
         }
 
-        private void EmitDefaultExpression(BoundDefaultOperator expression, bool used)
+        private void EmitDefaultExpression(BoundDefaultLiteral expression, bool used)
         {
             Debug.Assert(expression.Type.SpecialType == SpecialType.System_Decimal ||
                 expression.Type.GetDefaultValue() == null, "constant should be set on this expression");

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1405,7 +1405,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             if (node.OperatorKind.IsChecked() && node.OperatorKind.Operator() == UnaryOperatorKind.UnaryMinus)
             {
                 var origStack = StackDepth();
-                PushEvalStack(new BoundDefaultOperator(node.Syntax, node.Operand.Type), ExprContext.Value);
+                PushEvalStack(new BoundDefaultLiteral(node.Syntax, node.Operand.Type), ExprContext.Value);
                 BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
                 return node.Update(node.OperatorKind, operand, node.ConstantValueOpt, node.MethodOpt, node.ResultKind, node.Type);
             }

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1173,7 +1173,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     new BoundAssignmentOperator(
                     syntax,
                     new BoundThisReference(syntax, containingType),
-                    new BoundDefaultOperator(syntax, containingType),
+                    new BoundDefaultLiteral(syntax, containingType),
                     RefKind.None,
                     containingType));
         }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1435,5 +1435,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_OutVarDeconstructionIsNotSupported = 8199,
         ERR_ExpressionVariableInConstructorOrFieldInitializer = 8200,
         #endregion diagnostics for out var
+
+        ERR_BadDynamicMethodArgDefault = 9000,
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1437,5 +1437,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         #endregion diagnostics for out var
 
         ERR_BadDynamicMethodArgDefault = 9000,
+        ERR_DefaultNotValid = 9001,
     }
 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -585,7 +585,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         return WriteConsideredUse(null, boundConversion.Operand);
                     }
-                case BoundKind.DefaultOperator:
+                case BoundKind.DefaultLiteral:
                     return false;
                 case BoundKind.ObjectCreationExpression:
                     var init = (BoundObjectCreationExpression)value;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     Debug.Assert(submissionResultType.SpecialType != SpecialType.System_Void);
 
-                    var trailingExpression = new BoundDefaultOperator(method.GetNonNullSyntaxNode(), submissionResultType);
+                    var trailingExpression = new BoundDefaultLiteral(method.GetNonNullSyntaxNode(), submissionResultType);
                     var newStatements = block.Statements.Add(new BoundReturnStatement(trailingExpression.Syntax, RefKind.None, trailingExpression));
                     block = new BoundBlock(block.Syntax, ImmutableArray<LocalSymbol>.Empty, newStatements) { WasCompilerGenerated = true };
 #if DEBUG

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2449,7 +2449,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public override BoundNode VisitDefaultOperator(BoundDefaultOperator node)
+        public override BoundNode VisitDefaultLiteral(BoundDefaultLiteral node)
         {
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -588,7 +588,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitNullCoalescingOperator(BoundNullCoalescingOperator node)
         {
-            if (_inExpressionLambda && node.LeftOperand.IsLiteralNull())
+            if (_inExpressionLambda && (node.LeftOperand.IsLiteralNull() || node.LeftOperand.IsLiteralDefault()))
             {
                 Error(ErrorCode.ERR_ExpressionTreeContainsBadCoalesce, node.LeftOperand);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/Extensions.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Extensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // "default(int?)" never has a value.
-            if (expr.Kind == BoundKind.DefaultOperator)
+            if (expr.Kind == BoundKind.DefaultLiteral)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.UnaryOperator:
                     return VisitUnaryOperator((BoundUnaryOperator)node);
 
-                case BoundKind.DefaultOperator:
+                case BoundKind.DefaultLiteral:
                 case BoundKind.HostObjectMemberReference:
                 case BoundKind.Literal:
                 case BoundKind.Local:

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -535,7 +535,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (frame.Constructor == null)
             {
                 Debug.Assert(frame.TypeKind == TypeKind.Struct);
-                newFrame = new BoundDefaultOperator(syntax: syntax, type: frameType);
+                newFrame = new BoundDefaultLiteral(syntax: syntax, type: frameType);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AsOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AsOperator.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (constantValue != null)
                 {
                     Debug.Assert(constantValue.IsNull);
-                    BoundExpression result = rewrittenType.IsNullableType() ? new BoundDefaultOperator(syntax, rewrittenType) : MakeLiteral(syntax, constantValue, rewrittenType);
+                    BoundExpression result = rewrittenType.IsNullableType() ? new BoundDefaultLiteral(syntax, rewrittenType) : MakeLiteral(syntax, constantValue, rewrittenType);
 
                     if (rewrittenOperand.ConstantValue != null)
                     {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -1158,7 +1158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (leftAlwaysNull && rightAlwaysNull)
             {
                 // default(R?)
-                return new BoundDefaultOperator(syntax, null, type);
+                return new BoundDefaultLiteral(syntax, null, type);
             }
 
             // Optimization #2: If both sides are non-null then we can again eliminate the lifting entirely.
@@ -1230,14 +1230,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (sideEffect.ConstantValue != null)
             {
-                return new BoundDefaultOperator(syntax, null, type);
+                return new BoundDefaultLiteral(syntax, null, type);
             }
 
             return new BoundSequence(
                 syntax: syntax,
                 locals: ImmutableArray<LocalSymbol>.Empty,
                 sideEffects: ImmutableArray.Create<BoundExpression>(sideEffect),
-                value: new BoundDefaultOperator(syntax, null, type),
+                value: new BoundDefaultLiteral(syntax, null, type),
                 type: type);
         }
 
@@ -1302,7 +1302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression consequence = MakeLiftedBinaryOperatorConsequence(syntax, kind, callX_GetValueOrDefault, callY_GetValueOrDefault, type, method);
 
             // default(R?)
-            BoundExpression alternative = new BoundDefaultOperator(syntax, null, type);
+            BoundExpression alternative = new BoundDefaultLiteral(syntax, null, type);
 
             // tempX.HasValue & tempY.HasValue ? 
             //          new R?(tempX.GetValueOrDefault() OP tempY.GetValueOrDefault()) : 
@@ -1478,7 +1478,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             NamedTypeSymbol nullableBoolType = nullableType.Construct(boolType);
             if (value == null)
             {
-                return new BoundDefaultOperator(syntax, null, nullableBoolType);
+                return new BoundDefaultLiteral(syntax, null, nullableBoolType);
             }
             return new BoundObjectCreationExpression(
                 syntax,
@@ -1520,7 +1520,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression alwaysNull = leftAlwaysNull ? left : right;
             BoundExpression notAlwaysNull = leftAlwaysNull ? right : left;
             BoundExpression neverNull = NullableAlwaysHasValue(notAlwaysNull);
-            BoundExpression nullBool = new BoundDefaultOperator(syntax, null, alwaysNull.Type);
+            BoundExpression nullBool = new BoundDefaultLiteral(syntax, null, alwaysNull.Type);
 
             if (neverNull != null)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -990,14 +990,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // The argument to M([Optional] int x) becomes default(int)
-                    defaultValue = new BoundDefaultOperator(syntax, parameterType);
+                    defaultValue = new BoundDefaultLiteral(syntax, parameterType);
                 }
             }
             else if (defaultConstantValue.IsNull && parameterType.IsValueType)
             {
                 // We have something like M(int? x = null) or M(S x = default(S)),
                 // so replace the argument with default(int?).
-                defaultValue = new BoundDefaultOperator(syntax, parameterType);
+                defaultValue = new BoundDefaultLiteral(syntax, parameterType);
             }
             else if (parameterType.IsNullableType())
             {
@@ -1053,20 +1053,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (parameter.IsMarshalAsObject)
             {
                 // default(object)
-                defaultValue = new BoundDefaultOperator(syntax, parameter.Type);
+                defaultValue = new BoundDefaultLiteral(syntax, parameter.Type);
             }
             else if (parameter.IsIUnknownConstant)
             {
                 // new UnknownWrapper(default(object))
                 var methodSymbol = (MethodSymbol)_compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_InteropServices_UnknownWrapper__ctor);
-                var argument = new BoundDefaultOperator(syntax, parameter.Type);
+                var argument = new BoundDefaultLiteral(syntax, parameter.Type);
                 defaultValue = new BoundObjectCreationExpression(syntax, methodSymbol, argument);
             }
             else if (parameter.IsIDispatchConstant)
             {
                 // new DispatchWrapper(default(object))
                 var methodSymbol = (MethodSymbol)_compilation.GetWellKnownTypeMember(WellKnownMember.System_Runtime_InteropServices_DispatchWrapper__ctor);
-                var argument = new BoundDefaultOperator(syntax, parameter.Type);
+                var argument = new BoundDefaultLiteral(syntax, parameter.Type);
                 defaultValue = new BoundObjectCreationExpression(syntax, methodSymbol, argument);
             }
             else

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (NullableNeverHasValue(rewrittenOperand))
                         {
-                            return new BoundDefaultOperator(syntax, rewrittenType);
+                            return new BoundDefaultLiteral(syntax, rewrittenType);
                         }
 
                         BoundExpression nullableValue = NullableAlwaysHasValue(rewrittenOperand);
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.DefaultLiteral:
                     if (!_inExpressionLambda || !explicitCastInCode)
                     {
-                        return new BoundDefaultOperator(syntax, rewrittenType);
+                        return new BoundDefaultLiteral(syntax, rewrittenType);
                     }
 
                     break;
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ExplicitReference:
                     if (rewrittenOperand.IsDefaultValue() && (!_inExpressionLambda || !explicitCastInCode))
                     {
-                        return new BoundDefaultOperator(syntax, rewrittenType);
+                        return new BoundDefaultLiteral(syntax, rewrittenType);
                     }
 
                     break;
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ExplicitNumeric:
                     if (rewrittenOperand.IsDefaultValue() && (!_inExpressionLambda || !explicitCastInCode))
                     {
-                        return new BoundDefaultOperator(syntax, rewrittenType);
+                        return new BoundDefaultLiteral(syntax, rewrittenType);
                     }
 
                     if (rewrittenType.SpecialType == SpecialType.System_Decimal || rewrittenOperand.Type.SpecialType == SpecialType.System_Decimal)
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         rewrittenOperand.IsDefaultValue() &&
                         (!_inExpressionLambda || !explicitCastInCode))
                     {
-                        return new BoundDefaultOperator(syntax, rewrittenType);
+                        return new BoundDefaultLiteral(syntax, rewrittenType);
                     }
 
                     if (rewrittenType.SpecialType == SpecialType.System_Decimal)
@@ -660,7 +660,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // default(int?) never has a value.
-            if (expression.Kind == BoundKind.DefaultOperator)
+            if (expression.Kind == BoundKind.DefaultLiteral)
             {
                 return true;
             }
@@ -827,7 +827,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     conversion.UnderlyingConversions[0],
                     type.GetNullableUnderlyingType(),
                     @checked));
-            BoundExpression alternative = new BoundDefaultOperator(syntax, null, type);
+            BoundExpression alternative = new BoundDefaultLiteral(syntax, null, type);
             BoundExpression conditionalExpression = RewriteConditionalOperator(
                 syntax: syntax,
                 rewrittenCondition: condition,
@@ -855,7 +855,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (NullableNeverHasValue(operand))
             {
-                return new BoundDefaultOperator(syntax, type);
+                return new BoundDefaultLiteral(syntax, type);
             }
 
             // If the converted expression is known to never be null then we can return 
@@ -884,7 +884,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (NullableNeverHasValue(operand))
             {
-                return new BoundDefaultOperator(syntax, null, type);
+                return new BoundDefaultLiteral(syntax, null, type);
             }
 
             // Second, a trickier optimization. If the conversion is "(T?)(new S?(x))" then
@@ -1060,7 +1060,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression consequence = MakeLiftedUserDefinedConversionConsequence(userDefinedCall, rewrittenType);
 
             // default(R?)
-            BoundExpression alternative = new BoundDefaultOperator(syntax, rewrittenType);
+            BoundExpression alternative = new BoundDefaultLiteral(syntax, rewrittenType);
 
             // temp.HasValue ? new R?(op_Whatever(temp.GetValueOrDefault())) : default(R?)
             BoundExpression conditionalExpression = RewriteConditionalOperator(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ObjectCreationExpression.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // replace "new S()" with a default struct ctor with "default(S)"
             if (node.Constructor.IsDefaultValueTypeConstructor())
             {
-                rewrittenObjectCreation = new BoundDefaultOperator(rewrittenObjectCreation.Syntax, rewrittenObjectCreation.Type);
+                rewrittenObjectCreation = new BoundDefaultLiteral(rewrittenObjectCreation.Syntax, rewrittenObjectCreation.Type);
             }
 
             if (!temps.IsDefaultOrEmpty)
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!this.TryGetWellKnownTypeMember(syntax, WellKnownMember.System_Activator__CreateInstance_T, out method))
             {
-                return new BoundDefaultOperator(syntax, null, type: typeParameter, hasErrors: true);
+                return new BoundDefaultLiteral(syntax, null, type: typeParameter, hasErrors: true);
             }
 
             Debug.Assert((object)method != null);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression consequence = GetLiftedUnaryOperatorConsequence(kind, syntax, method, type, call_GetValueOrDefault);
 
             // default(R?)
-            BoundExpression alternative = new BoundDefaultOperator(syntax, null, type);
+            BoundExpression alternative = new BoundDefaultLiteral(syntax, null, type);
 
             // temp.HasValue ? 
             //          new R?(OP(temp.GetValueOrDefault())) : 
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (NullableNeverHasValue(loweredOperand))
             {
-                return new BoundDefaultOperator(syntax, null, type);
+                return new BoundDefaultLiteral(syntax, null, type);
             }
 
             // Second, another simple optimization. If we know that the operand is never null
@@ -636,7 +636,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression consequence = new BoundObjectCreationExpression(syntax, ctor, userDefinedCall);
 
             // default(S?)
-            BoundExpression alternative = new BoundDefaultOperator(syntax, null, type);
+            BoundExpression alternative = new BoundDefaultLiteral(syntax, null, type);
 
             // temp.HasValue ? 
             //          new S?(op_Increment(temp.GetValueOrDefault())) : 
@@ -802,7 +802,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // new decimal?(op_Inc(x.GetValueOrDefault()))
             BoundExpression consequence = new BoundObjectCreationExpression(syntax, ctor, methodCall);
             // default(decimal?)
-            BoundExpression alternative = new BoundDefaultOperator(syntax, null, operand.Type);
+            BoundExpression alternative = new BoundDefaultLiteral(syntax, null, operand.Type);
 
             // x.HasValue ? new decimal?(op_Inc(x.GetValueOrDefault())) : default(decimal?)
             return RewriteConditionalOperator(syntax, condition, consequence, alternative, ConstantValue.NotAvailable, operand.Type);

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -522,7 +522,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.ThisReference:
                 case BoundKind.BaseReference:
-                case BoundKind.DefaultOperator:
+                case BoundKind.DefaultLiteral:
                     return expr;
 
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1163,7 +1163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal BoundExpression Default(TypeSymbol type)
         {
-            return new BoundDefaultOperator(Syntax, type) { WasCompilerGenerated = true };
+            return new BoundDefaultLiteral(Syntax, type) { WasCompilerGenerated = true };
         }
 
         internal BoundStatement Try(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Also when valuetype S has a parameterless constructor, 
             // new S() is clearly not a constant expression and should produce an error
             return (expression.ConstantValue != null) ||
-                   (expression.Kind == BoundKind.DefaultOperator) ||
+                   (expression.Kind == BoundKind.DefaultLiteral) ||
                    (expression.Kind == BoundKind.ObjectCreationExpression &&
                        IsValidDefaultValue((BoundObjectCreationExpression)expression));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -348,6 +348,22 @@ class C
         }
 
         [Fact]
+        public void ArrayConstruction()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        var t = new object[default];
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Tuple()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -609,9 +609,9 @@ class C
 ";
             var compilation = CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.ExperimentalParseOptions);
             compilation.VerifyDiagnostics(
-                // (5,35): error CS0186: Use of null is not valid in this context
+                // (5,35): error CS9001: Use of default is not valid in this context
                 //         var q = from x in default select x;
-                Diagnostic(ErrorCode.ERR_NullNotValid, "select x").WithLocation(5, 35)
+                Diagnostic(ErrorCode.ERR_DefaultNotValid, "select x").WithLocation(5, 35)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
@@ -80,16 +82,13 @@ class C<T> where T : class
         dynamic x3 = default;
         ITest x5 = default;
         T x6 = default;
+        System.Console.Write($""{x1} {x2} {x3} {x5} {x6}"");
     }
 }
 interface ITest { }
 ";
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions);
-            comp.VerifyDiagnostics(
-                // (7,14): warning CS0219: The variable 'x2' is assigned but its value is never used
-                //         int? x2 = default;
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x2").WithArguments("x2").WithLocation(7, 14)
-                );
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -258,7 +257,15 @@ class C
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "0");
-            // PROTOTYPE(default) Verify semantic model
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+            var def = nodes.OfType<DefaultLiteralSyntax>().Single();
+            Assert.Null(model.GetTypeInfo(def).Type);
+            Assert.Equal("System.Int32", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
+            Assert.Null(model.GetSymbolInfo(def).Symbol);
         }
 
         [Fact]
@@ -336,6 +343,16 @@ class C
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
             CompileAndVerify(comp, expectedOutput: "0 2");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+            var def = nodes.OfType<DefaultLiteralSyntax>().Single();
+            Assert.Null(model.GetTypeInfo(def).Type);
+            Assert.Null(model.GetSymbolInfo(def).Symbol);
+            Assert.Null(model.GetSymbolInfo(def).Symbol);
+            Assert.Null(model.GetDeclaredSymbol(def));
         }
 
         [Fact]
@@ -370,7 +387,7 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        [Fact(Skip = "PROTOTYPE(default)")]
+        [Fact]
         public void ConstAndProperty()
         {
             string source = @"
@@ -380,17 +397,16 @@ class C
     static int P { get { return default; } }
     static void Main()
     {
-        System.Console.Write($""{x} {P}"");
+        System.Console.Write($""{x}-{P}"");
     }
 }
 ";
-            // PROTOTYPE(default) There is a problem with treating default literal as constant (should the constant value in the literal or in the conversion, or somewhere else?)
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "0 0");
+            CompileAndVerify(comp, expectedOutput: "0-0");
         }
 
-        [Fact(Skip = "PROTOTYPE(default)")]
+        [Fact]
         public void DynamicInvocation()
         {
             string source = @"
@@ -405,8 +421,259 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions);
+            comp.VerifyDiagnostics(
+                // (7,14): error CS9000: Cannot use a type-inferred default operator as an argument to a dynamically dispatched operation.
+                //         d.M2(default);
+                Diagnostic(ErrorCode.ERR_BadDynamicMethodArgDefault, "default").WithLocation(7, 14)
+                );
+        }
+
+        [Fact]
+        public void DefaultEqualsDefault()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write($""{default == default} {default != default}"");
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,33): error CS0034: Operator '==' is ambiguous on operands of type 'default' and 'default'
+                //         System.Console.Write($"{default == default} {default != default}");
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default == default").WithArguments("==", "default", "default").WithLocation(6, 33),
+                // (6,54): error CS0034: Operator '!=' is ambiguous on operands of type 'default' and 'default'
+                //         System.Console.Write($"{default == default} {default != default}");
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default != default").WithArguments("!=", "default", "default").WithLocation(6, 54)
+                );
+        }
+
+        [Fact]
+        public void NormalInitializerType_Default()
+        {
+            var text = @"
+class Program
+{
+    unsafe static void Main()
+    {
+        fixed (int* p = default)
+        {
+        }
+    }
+}
+";
+            // Confusing, but matches Dev10.
+            CreateCompilationWithMscorlib(text, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.ExperimentalParseOptions)
+                .VerifyDiagnostics(
+                // (6,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
+                //         fixed (int* p = default)
+                Diagnostic(ErrorCode.ERR_FixedNotNeeded, "default").WithLocation(6, 25)
+                );
+        }
+
+        [Fact]
+        public void TestErrorDefaultLiteralCollection()
+        {
+            var text = @"
+class C
+{
+    static void Main()
+    {
+        foreach (int x in default) { }
+        foreach (int x in null) { }
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,27): error CS0446: Foreach cannot operate on a 'default'. Did you intend to invoke the 'default'?
+                //         foreach (int x in default) { }
+                Diagnostic(ErrorCode.ERR_AnonMethGrpInForEach, "default").WithArguments("default").WithLocation(6, 27),
+                // (7,27): error CS0186: Use of null is not valid in this context
+                //         foreach (int x in null) { }
+                Diagnostic(ErrorCode.ERR_NullNotValid, "null").WithLocation(7, 27)
+                );
+        }
+
+        [Fact]
+        public void QueryOnDefault()
+        {
+            string source =
+@"static class C
+{
+    static void Main()
+    {
+        var q = from x in default select x;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.ExperimentalParseOptions);
+            compilation.VerifyDiagnostics(
+                // (5,35): error CS0186: Use of null is not valid in this context
+                //         var q = from x in default select x;
+                Diagnostic(ErrorCode.ERR_NullNotValid, "select x").WithLocation(5, 35)
+                );
+        }
+
+        [Fact]
+        public void DefaultInConditionalExpression()
+        {
+            string source =
+@"static class C
+{
+    static void Main()
+    {
+        var x = default ? 4 : 5;
+        System.Console.Write(x);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: "5");
+        }
+
+        [Fact]
+        public void AlwaysNonNull()
+        {
+            string source =
+@"static class C
+{
+    static void Main()
+    {
+        System.Console.Write((int?)1 == default);
+        System.Console.Write(default == (int?)1);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.ExperimentalParseOptions);
+            compilation.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ThrowDefault()
+        {
+            var text = @"
+class C
+{
+    static void Main()
+    {
+        throw default;
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,15): error CS0155: The type caught or thrown must be derived from System.Exception
+                //         throw default;
+                Diagnostic(ErrorCode.ERR_BadExceptionType, "default").WithLocation(6, 15)
+                );
+        }
+
+        [Fact]
+        public void DefaultInAsOperator()
+        {
+            var text = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write(default as long);
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics(
+                // (6,30): error CS0077: The as operator must be used with a reference type or nullable type ('long' is a non-nullable value type)
+                //         System.Console.Write(default as long);
+                Diagnostic(ErrorCode.ERR_AsMustHaveReferenceType, "default as long").WithArguments("long").WithLocation(6, 30)
+                );
+        }
+
+        [Fact]
+        public void CS0403ERR_TypeVarCanBeDefault()
+        {
+            var source =
+@"interface I { }
+class A { }
+class B<T1, T2, T3, T4, T5, T6, T7>
+    where T2 : class
+    where T3 : struct
+    where T4 : new()
+    where T5 : I
+    where T6 : A
+    where T7 : T1
+{
+    static void M()
+    {
+        T1 t1 = default;
+        T2 t2 = default;
+        T3 t3 = default;
+        T4 t4 = default;
+        T5 t5 = default;
+        T6 t6 = default;
+        T7 t7 = default;
+        System.Console.Write($""{t1} {t2} {t3} {t4} {t5} {t6} {t7}"");
+    }
+    static T1 F1() { return default; }
+    static T2 F2() { return default; }
+    static T3 F3() { return default; }
+    static T4 F4() { return default; }
+    static T5 F5() { return default; }
+    static T6 F6() { return default; }
+    static T7 F7() { return default; }
+}";
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions);
             comp.VerifyDiagnostics();
-            // PROTOTYPE(default) Crash
+        }
+
+        [Fact]
+        public void ExprTreeConvertedNullOnLHS()
+        {
+            var text =
+@"using System;
+using System.Linq.Expressions;
+
+class Program
+{
+    Expression<Func<object>> testExpr = () => default ?? ""hello"";
+}";
+
+            var comp = CreateCompilationWithMscorlibAndSystemCore(text, parseOptions: TestOptions.ExperimentalParseOptions);
+            comp.VerifyDiagnostics(
+                // (6,47): error CS0845: An expression tree lambda may not contain a coalescing operator with a null or default literal left-hand side
+                //     Expression<Func<object>> testExpr = () => default ?? "hello";
+                Diagnostic(ErrorCode.ERR_ExpressionTreeContainsBadCoalesce, "default").WithLocation(6, 47)
+                );
+        }
+
+        [Fact]
+        public void NullableAndDefault()
+        {
+            var text =
+@"class Program
+{
+    static void Main()
+    {
+        int? x = default;
+        System.Console.Write(x.HasValue);
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlibAndSystemCore(text, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "False");
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var def = tree.GetCompilationUnitRoot().DescendantNodes().OfType<DefaultLiteralSyntax>().Single();
+            Assert.Null(model.GetTypeInfo(def).Type);
+            Assert.Equal("System.Int32?", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
+            Assert.Null(model.GetSymbolInfo(def).Symbol);
         }
 
         [Fact]
@@ -450,7 +717,7 @@ class C
             CompileAndVerify(comp, expectedOutput: "0");
         }
 
-        [Fact(Skip = "PROTOTYPE(default)")]
+        [Fact]
         public void Switch()
         {
             string source = @"
@@ -458,14 +725,16 @@ class C
 {
     static void Main()
     {
-        int x = 1;
+        M(0);
+    }
+    static void M(int x)
+    {
         switch (x)
         {
-            case default: // PROTOTYPE(default) default is not recognized as constant
-            default:
+            case default:
+                System.Console.Write(""default"");
                 break;
-            case 1:
-                System.Console.Write(""1"");
+            default:
                 break;
         }
     }
@@ -474,7 +743,7 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "1");
+            CompileAndVerify(comp, expectedOutput: "default");
         }
 
         [Fact]
@@ -597,7 +866,21 @@ class C
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
             CompileAndVerify(comp, expectedOutput: "0");
-            // PROTOTYPE(default) Verify semantic model. What is the type of default?
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+            var def = nodes.OfType<DefaultLiteralSyntax>().Single();
+            Assert.Null(model.GetTypeInfo(def).Type);
+            Assert.Null(model.GetSymbolInfo(def).Symbol);
+            Assert.Null(model.GetSymbolInfo(def).Symbol);
+            Assert.Null(model.GetDeclaredSymbol(def));
+
+            var conversion = nodes.OfType<CastExpressionSyntax>().Single();
+            var conversionTypeInfo = model.GetTypeInfo(conversion);
+            Assert.Equal("System.Int16", conversionTypeInfo.Type.ToTestDisplayString());
+            Assert.Equal("System.Int32", conversionTypeInfo.ConvertedType.ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -251,7 +251,8 @@ class C
     {
         const T x = default(T);
         const T y = (T)default;
-        System.Console.Write($""{x} {y}"");
+        const object z = (T)default;
+        System.Console.Write($""{x} {y} {z}"");
     }
 }
 ";
@@ -262,7 +263,10 @@ class C
                 Diagnostic(ErrorCode.ERR_BadConstType, "T").WithArguments("T").WithLocation(6, 15),
                 // (7,15): error CS0283: The type 'T' cannot be declared const
                 //         const T y = (T)default;
-                Diagnostic(ErrorCode.ERR_BadConstType, "T").WithArguments("T").WithLocation(7, 15)
+                Diagnostic(ErrorCode.ERR_BadConstType, "T").WithArguments("T").WithLocation(7, 15),
+                // (8,26): error CS0134: 'z' is of type 'object'. A const field of a reference type other than string can only be initialized with null.
+                //         const object z = (T)default;
+                Diagnostic(ErrorCode.ERR_NotNullConstRefField, "(T)default").WithArguments("z", "object").WithLocation(8, 26)
                 );
         }
 
@@ -277,18 +281,22 @@ class C
     {
         const S x = default(S);
         const S y = (S)default;
-        System.Console.Write($""{x} {y}"");
+        const object z = (S)default;
+        System.Console.Write($""{x} {y} {z}"");
     }
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions);
             comp.VerifyDiagnostics(
-                // (7,15): error CS0283: The type 'S' cannot be declared const
+                 // (7,15): error CS0283: The type 'S' cannot be declared const
                 //         const S x = default(S);
                 Diagnostic(ErrorCode.ERR_BadConstType, "S").WithArguments("S").WithLocation(7, 15),
                 // (8,15): error CS0283: The type 'S' cannot be declared const
                 //         const S y = (S)default;
-                Diagnostic(ErrorCode.ERR_BadConstType, "S").WithArguments("S").WithLocation(8, 15)
+                Diagnostic(ErrorCode.ERR_BadConstType, "S").WithArguments("S").WithLocation(8, 15),
+                // (9,26): error CS0134: 'z' is of type 'object'. A const field of a reference type other than string can only be initialized with null.
+                //         const object z = (S)default;
+                Diagnostic(ErrorCode.ERR_NotNullConstRefField, "(S)default").WithArguments("z", "object").WithLocation(9, 26)
                 );
         }
 
@@ -425,10 +433,15 @@ class C
         public void YieldReturn()
         {
             string source = @"
+using System.Collections;
 using System.Collections.Generic;
 class C
 {
     static IEnumerable<int> M()
+    {
+        yield return default;
+    }
+    static IEnumerable M2()
     {
         yield return default;
     }
@@ -682,7 +695,7 @@ class C
         }
 
         [Fact]
-        public void CS0403ERR_TypeVarCanBeDefault()
+        public void TypeVarCanBeDefault()
         {
             var source =
 @"interface I { }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -1853,7 +1853,7 @@ No, FieldAccess 'new S().i' is not a non-moveable variable
 No, ObjectCreationExpression 'new S()' is not a non-moveable variable
 No, Conversion 'default(S).i' is not a non-moveable variable
 No, FieldAccess 'default(S).i' is not a non-moveable variable
-No, DefaultOperator 'default(S)' is not a non-moveable variable
+No, DefaultLiteral 'default(S)' is not a non-moveable variable
 No, Conversion 'MakeS().i' is not a non-moveable variable
 No, FieldAccess 'MakeS().i' is not a non-moveable variable
 No, Call 'MakeS()' is not a non-moveable variable

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -27,6 +27,7 @@ namespace Microsoft.CodeAnalysis
         String,
         Decimal,
         DateTime,
+        DefaultLiteral,
     }
 
     internal abstract partial class ConstantValue : IEquatable<ConstantValue>
@@ -79,6 +80,7 @@ namespace Microsoft.CodeAnalysis
 
         public static ConstantValue Bad { get { return ConstantValueBad.Instance; } }
         public static ConstantValue Null { get { return ConstantValueNull.Instance; } }
+        public static ConstantValue DefaultLiteral { get { return ConstantValueDefault.DefaultLiteralConstant; } }
         public static ConstantValue Nothing { get { return Null; } }
         // Null, Nothing and Unset are all ConstantValueNull. Null and Nothing are equivalent and represent the null and
         // nothing constants in C# and VB.  Unset indicates an uninitialized ConstantValue.
@@ -652,6 +654,14 @@ namespace Microsoft.CodeAnalysis
             get
             {
                 return ReferenceEquals(this, Null);
+            }
+        }
+
+        public bool IsDefaultLiteral
+        {
+            get
+            {
+                return ReferenceEquals(this, DefaultLiteral);
             }
         }
 

--- a/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
+++ b/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
@@ -269,6 +269,7 @@ namespace Microsoft.CodeAnalysis
             public static readonly ConstantValueDefault Decimal = new ConstantValueDecimalZero();
             public static readonly ConstantValueDefault DateTime = new ConstantValueDefault(ConstantValueTypeDiscriminator.DateTime);
             public static readonly ConstantValueDefault Boolean = new ConstantValueDefault(ConstantValueTypeDiscriminator.Boolean);
+            public static readonly ConstantValueDefault DefaultLiteralConstant = new ConstantValueDefault(ConstantValueTypeDiscriminator.DefaultLiteral);
 
             protected ConstantValueDefault(ConstantValueTypeDiscriminator discriminator)
                 : base(discriminator)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             if (!hasCustomTypeInfoPayload)
             {
-                return new BoundDefaultOperator(syntax, guidConstructor.ContainingType);
+                return new BoundDefaultLiteral(syntax, guidConstructor.ContainingType);
             }
 
             var value = ConstantValue.Create(DynamicFlagsCustomTypeInfo.PayloadTypeId.ToString());

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -3462,7 +3462,7 @@ class C
                 string error;
                 var testData = new CompilationTestData();
                 context.CompileExpression("F(() => null ?? new object())", out error, testData);
-                Assert.Equal(error, "error CS0845: An expression tree lambda may not contain a coalescing operator with a null literal left-hand side");
+                Assert.Equal(error, "error CS0845: An expression tree lambda may not contain a coalescing operator with a null or default literal left-hand side");
             });
         }
 


### PR DESCRIPTION
Continuing prototyping for https://github.com/dotnet/roslyn/issues/13602

- Adding some tests for semantic model
- Allow target-typed literal to be seen as a constant
- Adding tests corresponding to scenarios where `null` gets special treatment (`throw null`, `null == null`, `null as Some Type`, ...)

As a refresher, the first part of this prototype work was in PR https://github.com/dotnet/roslyn/pull/13603

CC @dotnet/roslyn-compiler for review. This is for features/default branch. No rush.
