### PR TITLE
Don't crash the NamingStyle code fixer on error symbols

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/NamingStyle/AbstractNamingStyleCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/NamingStyle/AbstractNamingStyleCodeFixProvider.cs
@@ -36,6 +36,15 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
             var model = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
             var symbol = model.GetDeclaredSymbol(node, context.CancellationToken);
 
+            // The symbol can be null in certain error code cases. For example, trying to get the
+            // declared symbol on a field declared as "const readonly int i" (which gets turned 
+            // into a FieldDeclaration of "readonly int i") will give a null result. See
+            // https://github.com/dotnet/roslyn/issues/15788 for a full repro case.
+            if (symbol == null)
+            {
+                return;
+            }
+
             var fixedNames = style.MakeCompliant(symbol.Name);
             foreach (var fixedName in fixedNames)
             {


### PR DESCRIPTION
Fixes #15788

Escrow Template (TODO)
================

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address in Escrow.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:** 

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)