### PR TITLE
changed WithXXX method to go through no validation code path

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -48,7 +48,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             DocumentationMode documentationMode = DocumentationMode.Parse,
             SourceCodeKind kind = SourceCodeKind.Regular,
             IEnumerable<string> preprocessorSymbols = null)
-            : this(languageVersion, documentationMode, kind, preprocessorSymbols.ToImmutableArrayOrEmpty())
+            : this(languageVersion, 
+                  documentationMode, 
+                  kind, 
+                  preprocessorSymbols.ToImmutableArrayOrEmpty(), 
+                  ImmutableDictionary<string, string>.Empty)
         {
             // We test the mapped value, LanguageVersion, rather than the parameter, languageVersion,
             // which has not had "Latest" mapped to the latest version yet.
@@ -100,18 +104,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // No validation
-        internal CSharpParseOptions(
+        private CSharpParseOptions(
             LanguageVersion languageVersion,
             DocumentationMode documentationMode,
             SourceCodeKind kind,
-            ImmutableArray<string> preprocessorSymbols)
+            ImmutableArray<string> preprocessorSymbols,
+            ImmutableDictionary<string, string> features)
             : base(kind, documentationMode)
         {
             Debug.Assert(!preprocessorSymbols.IsDefault);
             this.SpecifiedLanguageVersion = languageVersion;
             this.LanguageVersion = languageVersion.MapSpecifiedToEffectiveVersion();
             this.PreprocessorSymbols = preprocessorSymbols;
-            _features = ImmutableDictionary<string, string>.Empty;
+            _features = features;
         }
 
         public override string Language => LanguageNames.CSharp;


### PR DESCRIPTION
**Customer scenario**

VS crashes when one of C# source file contains invalid preprocessor symbol.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems?id=366189&projectId=0bdbc590-a062-4c3f-b0f6-9383f67865ee&src=alerts&src-action=cta&fullScreen=true&_a=edit

**Workarounds, if any**

make sure there is no invalid preprocessor symbol

**Risk**

I double checked all CSharpParseOption ctor bound to same thing except WithXXXX methods. so risk should be low

**Performance impact**

code change is not related to any hot code path.

**Is this a regression from a previous update?**

no

**Root cause analysis:**

CSharpParseOption sometimes validate preprocessor symbols and sometimes not. and one code path went to wrong path where it shouldn't validate preprocessor symbols. 

more detail here - https://github.com/dotnet/roslyn/issues/15797

**How was the bug found?**

dogfooding