### PR TITLE
OOM for file mappings

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/Host/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedFiles.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedFiles.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Host
             private void ForceCompactingGC()
             {
                 // repeated GC.Collect / WaitForPendingFinalizers till memory freed delta is super small, ignore the return value
-                GC.GetTotalMemory(true);
+                GC.GetTotalMemory(forceFullCollection:true);
 
                 // compact the LOH
                 GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;

--- a/src/Workspaces/Core/Desktop/Workspace/Host/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedFiles.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/TemporaryStorage/TemporaryStorageServiceFactory.MemoryMappedFiles.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
+using System.Runtime;
 using System.Runtime.InteropServices;
 using Roslyn.Utilities;
 
@@ -61,6 +62,16 @@ namespace Microsoft.CodeAnalysis.Host
             public string Name => _name;
             public long Size => _size;
 
+            private void ForceCompactingGC()
+            {
+                // repeated GC.Collect / WaitForPendingFinalizers till memory freed delta is super small, ignore the return value
+                GC.GetTotalMemory(true);
+
+                // compact the LOH
+                GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+                GC.Collect();
+            }
+
             /// <summary>
             /// Caller is responsible for disposing the returned stream.
             /// multiple call of this will not increase VM.
@@ -72,7 +83,18 @@ namespace Microsoft.CodeAnalysis.Host
                 {
                     if (_streamCount == 0)
                     {
-                        _accessor = _memoryMappedFile.CreateViewAccessor(0, _size, MemoryMappedFileAccess.Read);
+                        try
+                        {
+                            _accessor = _memoryMappedFile.CreateViewAccessor(0, _size, MemoryMappedFileAccess.Read);
+                        }
+                        catch (IOException)
+                        {
+                            // CreateViewAccessor will use a native memory map - which can't trigger a GC.
+                            // In this case, we'd otherwise crash with OOM, so we don't care about creating a UI delay with a full forced compacting GC.
+                            // If it crashes the second try, it means we're legitimately out of resources.
+                            this.ForceCompactingGC();
+                            _accessor = _memoryMappedFile.CreateViewAccessor(0, _size, MemoryMappedFileAccess.Read);
+                        }
                     }
 
                     _streamCount++;


### PR DESCRIPTION
Release resources to allow native file mapping to succeed.

**Customer scenario**

Customers are reporting OOM crashes due to this problem both in Watson and VSFeedbac

**Bugs this fixes:** 

VSO 234770

**Workarounds, if any**

None known.

**Risk**

The fix catches the exception and retries after forcing a GC.

**Performance impact**

The cost of the GC is high, however it otherwise takes the process out so it's a good tradeoff.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
We try map native memory when the GC hasn't released any free memory and we're close to the process maximum.

**How was the bug found?**
Direct customer engagement. The customer emailed me the dump files after an in-email analysis of his scenario.
