### PR TITLE
Additional usage of NameOf and String Interpolation in Parser.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Parser/ParseConditional.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseConditional.vb
@@ -135,7 +135,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseIfDirective(hashToken As PunctuationSyntax, elseKeyword As KeywordSyntax) As IfDirectiveTriviaSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.IfKeyword OrElse CurrentToken.Kind = SyntaxKind.ElseIfKeyword)
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(SyntaxKind.IfKeyword, SyntaxKind.ElseIfKeyword))
 
             Dim ifKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -251,8 +251,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseRegionDirective(hashToken As PunctuationSyntax) As RegionDirectiveTriviaSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.IdentifierToken AndAlso DirectCast(CurrentToken, IdentifierTokenSyntax).PossibleKeywordKind = SyntaxKind.RegionKeyword,
-                         NameOf(ParseRegionDirective) & " called with wrong token.")
+            Debug.Assert(CurrentToken.IsKindAndKeywordKind(SyntaxKind.IdentifierToken, SyntaxKind.RegionKeyword),
+                         $"{NameOf(ParseRegionDirective)} called with wrong token.")
 
             Dim identifier = DirectCast(CurrentToken, IdentifierTokenSyntax)
             GetNextToken()
@@ -265,8 +265,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseExternalSourceDirective(hashToken As PunctuationSyntax) As ExternalSourceDirectiveTriviaSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.IdentifierToken AndAlso DirectCast(CurrentToken, IdentifierTokenSyntax).PossibleKeywordKind = SyntaxKind.ExternalSourceKeyword,
-                         NameOf(ParseExternalSourceDirective) & " called with wrong token")
+            Debug.Assert(CurrentToken.IsKindAndKeywordKind(SyntaxKind.IdentifierToken, SyntaxKind.ExternalSourceKeyword),
+                         $"{NameOf(ParseExternalSourceDirective)} called with wrong token")
 
             Dim identifier = DirectCast(CurrentToken, IdentifierTokenSyntax)
             Dim externalSourceKeyword = _scanner.MakeKeyword(identifier)
@@ -312,8 +312,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseExternalChecksumDirective(hashToken As PunctuationSyntax) As ExternalChecksumDirectiveTriviaSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.IdentifierToken AndAlso DirectCast(CurrentToken, IdentifierTokenSyntax).PossibleKeywordKind = SyntaxKind.ExternalChecksumKeyword,
-                          NameOf(ParseExternalChecksumDirective) & " called with wrong token")
+            Debug.Assert(CurrentToken.IsKindAndKeywordKind(SyntaxKind.IdentifierToken, SyntaxKind.ExternalChecksumKeyword),
+                          $"{NameOf(ParseExternalChecksumDirective)} called with wrong token")
 
             Dim identifier = DirectCast(CurrentToken, IdentifierTokenSyntax)
             Dim externalChecksumKeyword = _scanner.MakeKeyword(identifier)
@@ -379,14 +379,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         End Function
 
+
+
         Private Function ParseWarningDirective(hashToken As PunctuationSyntax) As DirectiveTriviaSyntax
             Debug.Assert(CurrentToken.Kind = SyntaxKind.IdentifierToken,
-                         NameOf(ParseWarningDirective) & " called with token that is not an " & NameOf(SyntaxKind.IdentifierToken))
+                         $"{NameOf(ParseWarningDirective)} called with token that is not an { NameOf(SyntaxKind.IdentifierToken)}")
+
             Dim identifier = DirectCast(CurrentToken, IdentifierTokenSyntax)
 
-            Debug.Assert((identifier.PossibleKeywordKind = SyntaxKind.EnableKeyword) OrElse
-                         (identifier.PossibleKeywordKind = SyntaxKind.DisableKeyword),
-                         NameOf(ParseWarningDirective) & " called with token that is neither " & NameOf(SyntaxKind.EnableKeyword) & " nor " & NameOf(SyntaxKind.DisableKeyword))
+            Debug.Assert(identifier.PossibleKeywordKind.IsAnyOf(SyntaxKind.EnableKeyword, SyntaxKind.DisableKeyword),
+                         $"{NameOf(ParseWarningDirective)} called with token that is neither {NameOf(SyntaxKind.EnableKeyword)} nor {NameOf(SyntaxKind.DisableKeyword)}")
+
             Dim enableOrDisableKeyword = _scanner.MakeKeyword(identifier)
 
             GetNextToken()
@@ -444,8 +447,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseReferenceDirective(hashToken As PunctuationSyntax) As DirectiveTriviaSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.IdentifierToken AndAlso DirectCast(CurrentToken, IdentifierTokenSyntax).PossibleKeywordKind = SyntaxKind.ReferenceKeyword,
-                         NameOf(ParseReferenceDirective) & " called with wrong token.")
+            Debug.Assert(CurrentToken.IsKindAndKeywordKind(SyntaxKind.IdentifierToken, SyntaxKind.ReferenceKeyword),
+                         $"{NameOf(ParseReferenceDirective)} called with wrong token.")
 
             Dim identifier = DirectCast(CurrentToken, IdentifierTokenSyntax)
             GetNextToken()

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -1003,7 +1003,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ) As ExpressionSyntax
             Debug.Assert(CurrentToken.Kind = SyntaxKind.DotToken OrElse
                   CurrentToken.Kind = SyntaxKind.ExclamationToken,
-                  "Must be on either a '.' or '!' when entering parseQualifiedExpr()")
+                  $"Must be on either a '.' or '!' when entering {NameOf(ParseQualifiedExpr)}()")
 
             Dim DotOrBangToken As PunctuationSyntax = DirectCast(CurrentToken, PunctuationSyntax)
 
@@ -1639,7 +1639,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Debug.Assert(CurrentToken.Kind = SyntaxKind.FunctionKeyword OrElse
                          CurrentToken.Kind = SyntaxKind.SubKeyword,
-                         "ParseFunctionLambda called on wrong token.")
+                         $"{NameOf(ParseFunctionOrSubLambdaHeader)} called on wrong token.")
             ' The current token is on the function or delegate's name
 
             Dim methodKeyword = DirectCast(CurrentToken, KeywordSyntax)

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseInterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseInterpolatedString.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
     Friend Partial Class Parser
 
         Private Function ParseInterpolatedStringExpression() As InterpolatedStringExpressionSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.DollarSignDoubleQuoteToken, "ParseInterpolatedStringExpression called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.DollarSignDoubleQuoteToken, $"{NameOf(ParseInterpolatedStringExpression)} called on the wrong token.")
 
             ResetCurrentToken(ScannerState.InterpolatedStringPunctuation)
 
@@ -96,7 +96,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseInterpolatedStringInterpolation() As InterpolationSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.OpenBraceToken, "ParseInterpolatedStringEmbeddedExpression called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.OpenBraceToken, $"{NameOf(ParseInterpolatedStringInterpolation)} called on the wrong token.")
 
             Dim colonToken As PunctuationSyntax = Nothing
             Dim excessText As String = Nothing

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Statement* .Parser::ParseContinueStatement( [ _In_ Token* StmtStart ] [ _Inout_ bool& ErrorInConstruct ] )
 
         Private Function ParseContinueStatement() As ContinueStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ContinueKeyword, "ParseContinueStatement called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ContinueKeyword, $"{NameOf(ParseContinueStatement)} called on wrong token")
 
             Dim continueKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -91,7 +91,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseExitStatement() As StatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ExitKeyword, "ParseExitStatement called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ExitKeyword, $"{NameOf(ParseExitStatement)} called on wrong token")
 
             Dim exitKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -238,7 +238,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseCaseStatement() As CaseStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.CaseKeyword, "ParseCaseStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.CaseKeyword, $"{NameOf(ParseCaseStatement)} called on wrong token.")
 
             Dim caseKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -368,7 +368,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseSelectStatement() As SelectStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.SelectKeyword, "ParseSelectStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.SelectKeyword, $"{NameOf(ParseSelectStatement)} called on wrong token.")
 
             Dim selectKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -404,7 +404,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         'davidsch - Renamed ParseIfStatement from ParseIfConstruct
         Private Function ParseIfStatement() As IfStatementSyntax
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.IfKeyword, "ParseIfConstruct called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.IfKeyword, $"{NameOf(ParseIfStatement)} called on wrong token.")
 
             Dim ifKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -426,7 +426,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseElseStatement() As ElseStatementSyntax
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ElseKeyword, "ParseIfConstruct called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ElseKeyword, $"{NameOf(ParseElseStatement)} called on wrong token.")
 
             Dim elseKeyword = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -439,7 +439,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function ParseElseIfStatement() As StatementSyntax
 
             Debug.Assert(CurrentToken.Kind = SyntaxKind.ElseIfKeyword OrElse (CurrentToken.Kind = SyntaxKind.ElseKeyword AndAlso PeekToken(1).Kind = SyntaxKind.IfKeyword),
-                         "ParseIfConstruct called on wrong token.")
+                         $"{NameOf(ParseElseIfStatement)} called on wrong token.")
 
             Dim elseIfKeyword As KeywordSyntax = Nothing
 
@@ -483,9 +483,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseAnachronisticStatement() As StatementSyntax
             ' Assume CurrentToken is on ENDIF, WEND
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.EndIfKeyword OrElse
-                             CurrentToken.Kind = SyntaxKind.GosubKeyword OrElse
-                             CurrentToken.Kind = SyntaxKind.WendKeyword, "ParseAnachronisticEndIfStatement called on wrong token")
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(SyntaxKind.EndIfKeyword, SyntaxKind.GosubKeyword, SyntaxKind.WendKeyword), $"{NameOf(ParseAnachronisticStatement)} called on wrong token")
 
             Dim keyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -522,7 +520,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function ParseDoStatement() As DoStatementSyntax
 
             ' Assume CurrentToken is on Do
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.DoKeyword, "ParseDoStatement called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.DoKeyword, $"{NameOf(ParseDoStatement)} called on wrong token")
 
             Dim doKeyword = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -549,7 +547,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseLoopStatement() As LoopStatementSyntax
             ' Assume CurrentToken is on Loop
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.LoopKeyword, "ParseDoStatement called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.LoopKeyword, $"{NameOf(ParseLoopStatement)} called on wrong token")
 
             Dim loopKeyword = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -575,7 +573,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseForStatement() As StatementSyntax
             ' Assume CurrentToken is on For
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ForKeyword, "ParseForStatement called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ForKeyword, $"{NameOf(ParseForStatement)} called on wrong token")
 
             Dim forKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -704,7 +702,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseNextStatement() As NextStatementSyntax
             ' Assume CurrentToken is on Next
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.NextKeyword, "ParseNextStatement called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.NextKeyword, $"{NameOf(ParseNextStatement)} called on wrong token")
 
             Dim nextKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -988,7 +986,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseOnErrorResumeNext(onKeyword As KeywordSyntax, errorKeyword As KeywordSyntax) As OnErrorResumeNextStatementSyntax
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ResumeKeyword, "ParseOnErrorResumeNext called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ResumeKeyword, $"{NameOf(ParseOnErrorResumeNext)} called on wrong token.")
 
             Dim resumeKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             Dim nextKeyword As KeywordSyntax = Nothing
@@ -1003,7 +1001,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseOnErrorGoto(onKeyword As KeywordSyntax, errorKeyword As KeywordSyntax) As OnErrorGoToStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.GoToKeyword, "ParseOnErrorGoto called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.GoToKeyword, $"{NameOf(ParseOnErrorGoto)} called on wrong token.")
 
             Dim gotoKeyword = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -1050,7 +1048,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' .Parser::ParseResumeStatement( [ _Inout_ bool& ErrorInConstruct ] )
 
         Private Function ParseResumeStatement() As ResumeStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ResumeKeyword, "ParseResumeStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ResumeKeyword, $"{NameOf(ParseResumeStatement)} called on wrong token.")
 
             Dim resumeKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             Dim optionalLabel As SyntaxToken = Nothing
@@ -1198,7 +1196,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' .Parser::ParseCallStatement( [ _Inout_ bool& ErrorInConstruct ] )
 
         Private Function ParseCallStatement() As CallStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.CallKeyword, "ParseCallStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.CallKeyword, $"{NameOf(ParseCallStatement)} called on wrong token.")
 
             Dim callKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -1265,7 +1263,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseRedimStatement() As StatementSyntax '[ReDim]
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ReDimKeyword, "ParseRedimStatement must start with Redim.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ReDimKeyword, $"{NameOf(ParseRedimStatement)} must start with Redim.")
             Dim reDimKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
 
@@ -1375,9 +1373,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         'TODO - Rename ParseKeywordExpression and share with other statements that follow this pattern
         ' i.e. Throw, others?
         Private Function ParseExpressionBlockStatement() As StatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.WhileKeyword OrElse
-                             CurrentToken.Kind = SyntaxKind.WithKeyword OrElse
-                             CurrentToken.Kind = SyntaxKind.SyncLockKeyword, "ParseExpressionBlockStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(SyntaxKind.WhileKeyword, SyntaxKind.WithKeyword, SyntaxKind.SyncLockKeyword),
+                         $"{NameOf(ParseExpressionBlockStatement)} called on wrong token.")
 
             Dim keyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -1409,7 +1406,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         'TODO - rename ParseObsoleteAssignment
         Private Function ParseAssignmentStatement() As StatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.LetKeyword OrElse CurrentToken.Kind = SyntaxKind.SetKeyword, "Assignment statement parsing is lost.")
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(SyntaxKind.LetKeyword, SyntaxKind.SetKeyword), "Assignment statement parsing is lost.")
             ' Let and set are now illegal
 
             If CurrentToken.Kind = SyntaxKind.SetKeyword AndAlso
@@ -1433,7 +1430,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 11909 - 11909
         ' .Parser::ParseTry( )
         Private Function ParseTry() As TryStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.TryKeyword, "ParseTry called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.TryKeyword, $"{NameOf(ParseTry)} called on wrong token")
 
             Dim tryKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -1448,7 +1445,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' .Parser::ParseCatch( [ _Inout_ bool& ErrorInConstruct ] )
 
         Private Function ParseCatch() As CatchStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.CatchKeyword, "ParseCatch called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.CatchKeyword, $"{NameOf(ParseCatch)} called on wrong token.")
 
             Dim catchKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -1497,7 +1494,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' .Parser::ParseFinally( [ _Inout_ bool& ErrorInConstruct ] )
 
         Private Function ParseFinally() As FinallyStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.FinallyKeyword, "ParseFinally called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.FinallyKeyword, $"{NameOf(ParseFinally)} called on wrong token.")
 
             Dim finallyKeyword = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -1508,7 +1505,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseThrowStatement() As ThrowStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ThrowKeyword, "ParseThrowStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ThrowKeyword, $"{NameOf(ParseThrowStatement)} called on wrong token.")
 
             Dim throwKeyword = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -1568,8 +1565,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseLabel() As LabelStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.IdentifierToken OrElse CurrentToken.Kind = SyntaxKind.IntegerLiteralToken)
-
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(SyntaxKind.IdentifierToken, SyntaxKind.IntegerLiteralToken))
             Dim labelName = ParseLabelReference()
 
             If labelName.Kind = SyntaxKind.IntegerLiteralToken AndAlso CurrentToken.Kind <> SyntaxKind.ColonToken Then
@@ -1719,7 +1715,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseReturnStatement() As ReturnStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ReturnKeyword, "ParseReturnStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ReturnKeyword, $"{NameOf(ParseReturnStatement)} called on wrong token.")
 
             Dim returnKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -1770,7 +1766,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' TryStatement
         ' FinallyStatement
         Private Function ParseStopOrEndStatement() As StopOrEndStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.StopKeyword OrElse CurrentToken.Kind = SyntaxKind.EndKeyword, "ParseStopOrEndStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(SyntaxKind.StopKeyword, SyntaxKind.EndKeyword), $"{NameOf(ParseStopOrEndStatement)} called on wrong token.")
 
             Dim stopOrEndKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -1783,7 +1779,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseUsingStatement() As UsingStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.UsingKeyword, "ParseUsingStatement called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.UsingKeyword, $"{NameOf(ParseUsingStatement} called on wrong token")
 
             Dim usingKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()
@@ -1818,7 +1814,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             Debug.Assert(CurrentToken.Kind = SyntaxKind.IdentifierToken AndAlso
                          DirectCast(CurrentToken, IdentifierTokenSyntax).ContextualKind = SyntaxKind.AwaitKeyword,
-                         "ParseAwaitStatement called on wrong token.")
+                         $"{NameOf(ParseAwaitStatement)} called on wrong token.")
 
             Dim expression = ParseAwaitExpression()
 

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseStatement.vb
@@ -1779,7 +1779,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseUsingStatement() As UsingStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.UsingKeyword, $"{NameOf(ParseUsingStatement} called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.UsingKeyword, $"{NameOf(ParseUsingStatement)} called on wrong token")
 
             Dim usingKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken()

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseXml.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseXml.vb
@@ -17,12 +17,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 13261 - 13261
         ' Expression* .Parser::ParseXmlExpression( [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseXmlExpression() As XmlNodeSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanToken OrElse
-                 CurrentToken.Kind = SyntaxKind.LessThanGreaterThanToken OrElse
-                 CurrentToken.Kind = SyntaxKind.LessThanSlashToken OrElse
-                 CurrentToken.Kind = SyntaxKind.BeginCDataToken OrElse
-                 CurrentToken.Kind = SyntaxKind.LessThanExclamationMinusMinusToken OrElse
-                 CurrentToken.Kind = SyntaxKind.LessThanQuestionToken, "ParseXmlMarkup called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(SyntaxKind.LessThanToken,
+                                                   SyntaxKind.LessThanGreaterThanToken,
+                                                   SyntaxKind.LessThanSlashToken,
+                                                   SyntaxKind.BeginCDataToken,
+                                                   SyntaxKind.LessThanExclamationMinusMinusToken,
+                                                   SyntaxKind.LessThanQuestionToken), $"{NameOf(ParseXmlExpression)} called on the wrong token.")
 
             ' The < token must be reset because a VB scanned < might following trivia attached to it.
             ResetCurrentToken(ScannerState.Content)
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 13370 - 13370
         ' Expression* .Parser::ParseXmlDocument( [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseXmlDocument() As XmlNodeSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanQuestionToken, "ParseXmlDocument called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanQuestionToken, $"{NameOf(ParseXmlDocument)} called on wrong token")
             Dim whitespaceChecker As New XmlWhitespaceChecker()
 
             Dim nextToken = PeekNextToken(ScannerState.Element)
@@ -100,7 +100,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Private Function ParseXmlDeclaration() As XmlDeclarationSyntax
             Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanQuestionToken AndAlso
                               PeekNextToken(ScannerState.Element).Kind = SyntaxKind.XmlNameToken AndAlso
-                              DirectCast(PeekNextToken(ScannerState.Element), XmlNameTokenSyntax).PossibleKeywordKind = SyntaxKind.XmlKeyword, "ParseXmlDecl called on the wrong token.")
+                              DirectCast(PeekNextToken(ScannerState.Element), XmlNameTokenSyntax).PossibleKeywordKind = SyntaxKind.XmlKeyword,
+                         $"{NameOf(ParseXmlDeclaration)} called on the wrong token.")
 
             Dim beginPrologue = DirectCast(CurrentToken, PunctuationSyntax)
             GetNextToken(ScannerState.Element)
@@ -252,13 +253,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 13813 - 13813
         ' Expression* .Parser::ParseXmlAttribute( [ bool AllowNameAsExpression ] [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseXmlDeclarationOption() As XmlDeclarationOptionSyntax
-            Debug.Assert(IsToken(CurrentToken,
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(
                                  SyntaxKind.XmlNameToken,
                                  SyntaxKind.LessThanPercentEqualsToken,
                                  SyntaxKind.EqualsToken,
                                  SyntaxKind.SingleQuoteToken,
                                  SyntaxKind.DoubleQuoteToken),
-                             "ParseXmlPrologueOption called on wrong token.")
+                             $"{NameOf(ParseXmlDeclarationOption)} called on wrong token.")
 
             Dim result As XmlDeclarationOptionSyntax = Nothing
             Dim name As XmlNameTokenSyntax = Nothing
@@ -362,7 +363,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         Private Function ParseXmlDocType(enclosingState As ScannerState) As GreenNode
             Debug.Assert(CurrentToken.Kind = SyntaxKind.BadToken AndAlso
-                         DirectCast(CurrentToken, BadTokenSyntax).SubKind = SyntaxSubKind.BeginDocTypeToken, "ParseDTD called on wrong token.")
+                         DirectCast(CurrentToken, BadTokenSyntax).SubKind = SyntaxSubKind.BeginDocTypeToken, $"{NameOf(ParseXmlDocType)} called on wrong token.")
 
 
             Dim builder = SyntaxListBuilder(Of GreenNode).Create()
@@ -505,7 +506,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 13624 - 13624
         ' XmlElementExpression* .Parser::ParseXmlElement( [ _In_opt_ ParseTree::XmlElementExpression* Parent ] [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseXmlElementStartTag(enclosingState As ScannerState) As XmlNodeSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanToken, "ParseXmlElement call on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanToken, $"{NameOf(ParseXmlElementStartTag)} call on wrong token.")
 
             Dim lessThan As PunctuationSyntax = DirectCast(CurrentToken, PunctuationSyntax)
             GetNextToken(ScannerState.Element)
@@ -571,7 +572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 13624 - 13624
         ' XmlElementExpression* .Parser::ParseXmlElement( [ _In_opt_ ParseTree::XmlElementExpression* Parent ] [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseXmlElement(enclosingState As ScannerState) As XmlNodeSyntax
-            Debug.Assert(IsToken(CurrentToken,
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(
                                  SyntaxKind.LessThanToken,
                                  SyntaxKind.LessThanGreaterThanToken,
                                  SyntaxKind.LessThanSlashToken,
@@ -581,7 +582,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                                  SyntaxKind.LessThanPercentEqualsToken,
                                  SyntaxKind.XmlTextLiteralToken,
                                  SyntaxKind.BadToken),
-                             "ParseXmlElement call on wrong token.")
+                             $"{NameOf(ParseXmlElement)} call on wrong token.")
 
             Dim xml As XmlNodeSyntax = Nothing
             Dim contexts As New List(Of XmlContext)
@@ -953,13 +954,13 @@ LessThanSlashTokenCase:
         ' Lines: 13813 - 13813
         ' Expression* .Parser::ParseXmlAttribute( [ bool AllowNameAsExpression ] [ _Inout_ bool& ErrorInConstruct ] )
         Friend Function ParseXmlAttribute(requireLeadingWhitespace As Boolean, AllowNameAsExpression As Boolean, xmlElementName As XmlNodeSyntax) As XmlNodeSyntax
-            Debug.Assert(IsToken(CurrentToken,
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(
                                  SyntaxKind.XmlNameToken,
                                  SyntaxKind.LessThanPercentEqualsToken,
                                  SyntaxKind.EqualsToken,
                                  SyntaxKind.SingleQuoteToken,
                                  SyntaxKind.DoubleQuoteToken),
-                             "ParseXmlAttribute called on wrong token.")
+                             $"{NameOf(ParseXmlAttribute)} called on wrong token.")
 
             Dim Result As XmlNodeSyntax = Nothing
 
@@ -1723,7 +1724,7 @@ lFailed:
         ' Lines: 14004 - 14004
         ' ExpressionList* .Parser::ParseXmlContent( [ _Inout_ ParseTree::XmlElementExpression* Parent ] [ _Inout_ bool& ErrorInConstruct ] )
         Friend Function ParseXmlContent(state As ScannerState) As CodeAnalysis.Syntax.InternalSyntax.SyntaxList(Of XmlNodeSyntax)
-            Debug.Assert(IsToken(CurrentToken,
+            Debug.Assert(CurrentToken.Kind.IsAnyOf(
                                  SyntaxKind.XmlTextLiteralToken,
                                  SyntaxKind.DocumentationCommentLineBreakToken,
                                  SyntaxKind.XmlEntityLiteralToken,
@@ -1737,7 +1738,7 @@ lFailed:
                                  SyntaxKind.EndOfFileToken,
                                  SyntaxKind.EndOfXmlToken,
                                  SyntaxKind.BadToken),
-                             "ParseXmlContent called on wrong token.")
+                             $"{NameOf(ParseXmlContent)} called on wrong token.")
 
             Dim Content = Me._pool.Allocate(Of XmlNodeSyntax)()
             Dim whitespaceChecker As New XmlWhitespaceChecker()
@@ -1885,7 +1886,7 @@ TryResync:
         ' Lines: 14119 - 14119
         ' Expression* .Parser::ParseXmlCData( [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseXmlCData(nextState As ScannerState) As XmlCDataSectionSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.BeginCDataToken, "ParseXmlCData called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.BeginCDataToken, $"{NameOf(ParseXmlCData)} called on the wrong token.")
 
             Dim beginCData = DirectCast(CurrentToken, PunctuationSyntax)
 
@@ -1911,7 +1912,7 @@ TryResync:
         ' Lines: 14134 - 14134
         ' Expression* .Parser::ParseXmlComment( [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseXmlComment(nextState As ScannerState) As XmlNodeSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanExclamationMinusMinusToken, "ParseXmlComment called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanExclamationMinusMinusToken, $"{NameOf(ParseXmlComment)} called on wrong token.")
 
             Dim beginComment As PunctuationSyntax = DirectCast(CurrentToken, PunctuationSyntax)
             GetNextToken(ScannerState.Comment)
@@ -2002,7 +2003,7 @@ TryResync:
         ' Lines: 14379 - 14379
         ' Expression* .Parser::ParseXmlEmbedded( [ bool AllowEmbedded ] [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseXmlEmbedded(enclosingState As ScannerState) As XmlEmbeddedExpressionSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanPercentEqualsToken, "ParseXmlEmbedded called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanPercentEqualsToken, $"{NameOf(ParseXmlEmbedded)} called on wrong token")
 
             Dim beginXmlEmbedded As PunctuationSyntax = DirectCast(CurrentToken, PunctuationSyntax)
             GetNextToken(enclosingState)

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -6136,7 +6136,7 @@ checkNullable:
             If token.Kind = SyntaxKind.IdentifierToken Then
                 Return Scanner.IsContextualKeyword(token, kinds)
             Else
-                Return IsToken(token, kinds)
+                Return kinds.Contains(token.Kind)
             End If
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -1453,7 +1453,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                   Optional attributes As CoreInternalSyntax.SyntaxList(Of AttributeListSyntax) = Nothing,
                   Optional modifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax) = Nothing
         ) As EnumStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.EnumKeyword, "ParseEnumStatement called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.EnumKeyword, $"{NameOf(ParseEnumStatement)} called on the wrong token.")
 
             Dim enumKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             Dim optionalUnderlyingType As AsClauseSyntax = Nothing
@@ -1677,7 +1677,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseNamespaceStatement(attributes As CoreInternalSyntax.SyntaxList(Of AttributeListSyntax), Specifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax)) As NamespaceStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.NamespaceKeyword, "ParseNamespaceStatement called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.NamespaceKeyword, $"{NameOf(ParseNamespaceStatement)} called on the wrong token.")
 
             Dim namespaceKeyword As KeywordSyntax = ReportModifiersOnStatementError(ERRID.ERR_SpecifiersInvalidOnInheritsImplOpt, attributes, Specifiers, DirectCast(CurrentToken, KeywordSyntax))
 
@@ -1715,7 +1715,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         End Function
 
         Private Function ParseEndStatement() As StatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.EndKeyword, "ParseEndStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.EndKeyword, $"{NameOf(ParseEndStatement)} called on wrong token.")
 
             ' Dev10#708061
             ' "End" is a keyword which takes an optional next argument. Things get confusing with "End Select"...
@@ -1752,7 +1752,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' Lines: 5054 - 5054
         ' .Parser::ParseGroupEndStatement( [ _Inout_ bool& ErrorInConstruct ] )
         Private Function ParseGroupEndStatement() As StatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.EndKeyword, "ParseGroupEndStatement called on wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.EndKeyword, $"{NameOf(ParseGroupEndStatement)} called on wrong token.")
 
             Dim endKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             Dim nextToken = PeekToken(1)
@@ -2475,7 +2475,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ''' <returns>ObjectMemberInitializer</returns>
         Private Function ParseObjectInitializerList(Optional anonymousTypeInitializer As Boolean = False, Optional anonymousTypesAllowedHere As Boolean = True) As ObjectMemberInitializerSyntax
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.WithKeyword, "ParseObjectInitializerList called with wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.WithKeyword, $"{NameOf(ParseObjectInitializerList)} called with wrong token")
 
             ' Handle the "With" clause in the following syntax:
             '  Dim x as new Customer With {.Id = 1, .Name = "A"}
@@ -3723,7 +3723,7 @@ checkNullable:
 
             Debug.Assert(kind = SyntaxKind.SubStatement OrElse
                          kind = SyntaxKind.SubNewStatement OrElse
-                         kind = SyntaxKind.DelegateSubStatement, "Wrong kind passed to ParseSubOrDelegateStatement")
+                         kind = SyntaxKind.DelegateSubStatement, $"Wrong kind passed to {NameOf(ParseSubOrDelegateStatement)}")
 
             'The current token is on the Sub or Delegate's name
 
@@ -3863,7 +3863,7 @@ checkNullable:
 
             Debug.Assert(
                 kind = SyntaxKind.FunctionStatement OrElse
-                kind = SyntaxKind.DelegateFunctionStatement, "Wrong kind passed to ParseFunctionOrDelegateStatement")
+                kind = SyntaxKind.DelegateFunctionStatement, $"Wrong kind passed to {NameOf(ParseFunctionOrDelegateStatement)}")
 
             'TODO - davidsch Can ParseFunctionOrDelegateDeclaration and
             'ParseSubOrDelegateDeclaration share more code? They are nearly the same.
@@ -4140,7 +4140,7 @@ checkNullable:
             modifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax)
         ) As PropertyStatementSyntax
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.PropertyKeyword, "ParsePropertyDefinition called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.PropertyKeyword, $"{NameOf(ParsePropertyDefinition)} called on the wrong token.")
 
             Dim propertyKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
             GetNextToken() ' get off PROPERTY
@@ -4254,7 +4254,7 @@ checkNullable:
             modifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax)
         ) As DelegateStatementSyntax
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.DelegateKeyword, "ParseDelegateStatement called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.DelegateKeyword, $"{NameOf(ParseDelegateStatement)} called on the wrong token.")
 
             Dim delegateKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -4749,7 +4749,7 @@ checkNullable:
         ' ImportsStatement* .Parser::ParseImportsStatement( [ _Inout_ bool& ErrorInConstruct ] )
 
         Private Function ParseImportsStatement(Attributes As CoreInternalSyntax.SyntaxList(Of AttributeListSyntax), Specifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax)) As ImportsStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.ImportsKeyword, "called on wrong token")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.ImportsKeyword, $"{NameOf(ParseImportsStatement)} called on wrong token")
 
             Dim importsKeyword As KeywordSyntax = ReportModifiersOnStatementError(Attributes, Specifiers, DirectCast(CurrentToken, KeywordSyntax))
             Dim importsClauses = Me._pool.AllocateSeparated(Of ImportsClauseSyntax)()
@@ -4906,7 +4906,7 @@ checkNullable:
         Private Function ParseInheritsImplementsStatement(Attributes As CoreInternalSyntax.SyntaxList(Of AttributeListSyntax), Specifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax)) As InheritsOrImplementsStatementSyntax
 
             Debug.Assert(CurrentToken.Kind = SyntaxKind.InheritsKeyword OrElse CurrentToken.Kind = SyntaxKind.ImplementsKeyword,
-                "ParseInheritsImplementsStatement called on the wrong token.")
+                $"{NameOf(ParseInheritsImplementsStatement)} called on the wrong token.")
 
             Dim keyword As KeywordSyntax = ReportModifiersOnStatementError(Attributes, Specifiers, DirectCast(CurrentToken, KeywordSyntax))
             Dim typeNames = Me._pool.AllocateSeparated(Of TypeSyntax)()
@@ -5072,7 +5072,7 @@ checkNullable:
         ' ForeignMethodDeclarationStatement* .Parser::ParseProcDeclareStatement( [ ParseTree::AttributeSpecifierList* Attributes ] [ ParseTree::SpecifierList* Specifiers ] [ _In_ Token* Start ] [ _Inout_ bool& ErrorInConstruct ] )
 
         Private Function ParseProcDeclareStatement(attributes As CoreInternalSyntax.SyntaxList(Of AttributeListSyntax), modifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax)) As DeclareStatementSyntax
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.DeclareKeyword, "ParseProcDeclareStatement called on wrong token. Must be at a Declare.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.DeclareKeyword, $"{NameOf(ParseProcDeclareStatement)} called on wrong token. Must be at a Declare.")
 
             ' Dev10_667800 we are parsing a method declaration and will need to let the scanner know that we
             ' are so the scanner can correctly identify attributes vs. xml while scanning the declaration.
@@ -5277,7 +5277,7 @@ checkNullable:
                 modifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax)
         ) As StatementSyntax
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.IdentifierToken AndAlso DirectCast(CurrentToken, IdentifierTokenSyntax).PossibleKeywordKind = SyntaxKind.CustomKeyword, "ParseCustomEventDefinition called on the wrong token.")
+            Debug.Assert(CurrentToken.IsKindAndKeywordKind(SyntaxKind.IdentifierToken, SyntaxKind.CustomKeyword), $"{NameOf(ParseCustomEventDefinition)} called on the wrong token.")
 
             ' This enables better error reporting for invalid uses of CUSTOM as a specifier.
             '
@@ -5384,7 +5384,7 @@ checkNullable:
                 modifiers As CoreInternalSyntax.SyntaxList(Of KeywordSyntax)
             ) As EventStatementSyntax
 
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.EventKeyword, "ParseEventDefinition called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.EventKeyword, $"{NameOf(ParseEventDefinition)} called on the wrong token.")
 
             Dim eventKeyword As KeywordSyntax = DirectCast(CurrentToken, KeywordSyntax)
 
@@ -5505,7 +5505,7 @@ checkNullable:
 
         ' TODO: this function is so complex (n^2 loop?) it times out in CC verifier.
         Private Function ParseAttributeLists(allowFileLevelAttributes As Boolean) As CoreInternalSyntax.SyntaxList(Of AttributeListSyntax)
-            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanToken, "ParseAttributeSpecifier called on the wrong token.")
+            Debug.Assert(CurrentToken.Kind = SyntaxKind.LessThanToken, $"{NameOf(ParseAttributeLists)} called on the wrong token.")
 
             Dim attributeBlocks = _pool.Allocate(Of AttributeListSyntax)()
             Dim attributes = _pool.AllocateSeparated(Of AttributeSyntax)()
@@ -6138,10 +6138,6 @@ checkNullable:
             Else
                 Return IsToken(token, kinds)
             End If
-        End Function
-
-        Private Shared Function IsToken(token As SyntaxToken, ParamArray kinds As SyntaxKind()) As Boolean
-            Return kinds.Contains(token.Kind)
         End Function
 
         Friend Function ConsumeUnexpectedTokens(Of TNode As VisualBasicSyntaxNode)(node As TNode) As TNode

--- a/src/Compilers/VisualBasic/Portable/Parser/ParserExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParserExtensions.vb
@@ -62,6 +62,76 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             Return False
         End Function
 
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1)
+        End Function
+
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind, k2 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1) OrElse (value = k2)
+        End Function
+
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind, k2 As SyntaxKind, k3 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1) OrElse (value = k2) OrElse (value = k3)
+        End Function
+
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind, k2 As SyntaxKind, k3 As SyntaxKind,
+                                                     k4 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1) OrElse (value = k2) OrElse (value = k3) OrElse
+                   (value = k4)
+        End Function
+
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind, k2 As SyntaxKind, k3 As SyntaxKind,
+                                                     k4 As SyntaxKind, k5 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1) OrElse (value = k2) OrElse (value = k3) OrElse
+                   (value = k4) OrElse (value = k5)
+        End Function
+
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind, k2 As SyntaxKind, k3 As SyntaxKind,
+                                                     k4 As SyntaxKind, k5 As SyntaxKind, k6 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1) OrElse (value = k2) OrElse (value = k3) OrElse
+                   (value = k4) OrElse (value = k5) OrElse (value = k6)
+        End Function
+
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind, k2 As SyntaxKind, k3 As SyntaxKind,
+                                                     k4 As SyntaxKind, k5 As SyntaxKind, k6 As SyntaxKind, k7 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1) OrElse (value = k2) OrElse (value = k3) OrElse
+                   (value = k4) OrElse (value = k5) OrElse (value = k6) OrElse (value = k7)
+        End Function
+
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind, k2 As SyntaxKind, k3 As SyntaxKind,
+                                                     k4 As SyntaxKind, k5 As SyntaxKind, k6 As SyntaxKind, k7 As SyntaxKind,
+                                                     k8 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1) OrElse (value = k2) OrElse (value = k3) OrElse
+                   (value = k4) OrElse (value = k5) OrElse (value = k6) OrElse (value = k7) OrElse
+                   (value = k8)
+        End Function
+
+        <Extension>
+        Friend Function IsAnyOf(value As SyntaxKind, k0 As SyntaxKind, k1 As SyntaxKind, k2 As SyntaxKind, k3 As SyntaxKind,
+                                                     k4 As SyntaxKind, k5 As SyntaxKind, k6 As SyntaxKind, k7 As SyntaxKind,
+                                                     k8 As SyntaxKind, k9 As SyntaxKind, k10 As SyntaxKind, k11 As SyntaxKind,
+                                                     k12 As SyntaxKind) As Boolean
+            Return (value = k0) OrElse (value = k1) OrElse (value = k2) OrElse (value = k3) OrElse
+                   (value = k4) OrElse (value = k5) OrElse (value = k6) OrElse (value = k7) OrElse
+                   (value = k8) OrElse (value = k9) OrElse (value = k10) OrElse (value = k11) OrElse
+                   (value = k12)
+        End Function
+
+        <Extension>
+        Friend Function IsKindAndKeywordKind(CurrentToken As SyntaxToken, OfKind As SyntaxKind, KeywordKind As SyntaxKind) As Boolean
+            Return (CurrentToken.Kind = OfKind) AndAlso
+                   DirectCast(CurrentToken, IdentifierTokenSyntax).PossibleKeywordKind = KeywordKind
+
+        End Function
+
     End Module
 End Namespace
 


### PR DESCRIPTION
Some additional use cases for String Interpolation and NameOf.  Refactor out a common pattern into its own function (extension method). Remove now unused private function.
