### PR TITLE
Only apply one edit when rolling back buffer before commit

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -156,12 +156,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 for (var i = versions.Count - 1; i >= 0; i--)
                 {
                     var version = versions[i];
+                    foreach (var change in version.Changes)
                     {
-                        foreach (var change in version.Changes)
-                        {
-                            textEdit.Replace(change.NewSpan, change.OldText);
-                        }
-
+                        textEdit.Replace(change.NewSpan, change.OldText);
                     }
                 }
                 textEdit.Apply();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -150,20 +150,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             // Get all the versions from the initial text snapshot (before we passed the
             // commit character down) to the current snapshot we're at.
             var versions = GetVersions(initialTextSnapshot, this.SubjectBuffer.CurrentSnapshot).ToList();
-
-            // Un-apply the edits. 
-            for (var i = versions.Count - 1; i >= 0; i--)
+            using (var textEdit = this.SubjectBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, editTag: null))
             {
-                var version = versions[i];
-                using (var textEdit = this.SubjectBuffer.CreateEdit(EditOptions.None, reiteratedVersionNumber: null, editTag: null))
+                // Un-apply the edits. 
+                for (var i = versions.Count - 1; i >= 0; i--)
                 {
-                    foreach (var change in version.Changes)
+                    var version = versions[i];
                     {
-                        textEdit.Replace(change.NewSpan, change.OldText);
-                    }
+                        foreach (var change in version.Changes)
+                        {
+                            textEdit.Replace(change.NewSpan, change.OldText);
+                        }
 
-                    textEdit.Apply();
+                    }
                 }
+                textEdit.Apply();
             }
         }
 


### PR DESCRIPTION
In https://devdiv.visualstudio.com/DevDiv/_workitems?id=242397&_a=edit we spend additional time in WpfTextView reacting to subjectbuffer changes while rolling back the text buffer to prepare to insert a completion item. We currently apply an edit for each snapshot version between the trigger and current snapshots. We can instead apply all the buffer diffs in one edit, which may reduce time in WpfTextView.OnVisualBufferChanged.

This is all under one undo transaction (http://source.roslyn.io/#Microsoft.CodeAnalysis.EditorFeatures/Implementation/Intellisense/Completion/Controller_Commit.cs,55) so the undo behavior should stay the same.

Tag @dotnet/roslyn-ide @dotnet/roslyn-perf for review

```
Name
 microsoft.codeanalysis.editorfeatures!Controller.RollbackToBeforeTypeChar
+ microsoft.visualstudio.platform.vseditor.ni!Microsoft.VisualStudio.Text.Implementation.BaseBuffer+TextBufferEdit.Apply()
|+ microsoft.visualstudio.platform.vseditor.ni!BufferGroup.FinishEdit
||+ microsoft.visualstudio.platform.vseditor.ni!Microsoft.VisualStudio.Text.Implementation.BaseBuffer+TextContentChangedEventRaiser.RaiseEvent(Microsoft.VisualStudio.Text.Implementation.BaseBuffer, Boolean)
|||+ microsoft.visualstudio.platform.vseditor.ni!BaseBuffer.RawRaiseEvent
||| + microsoft.visualstudio.platform.vseditor.ni!Microsoft.VisualStudio.Text.Utilities.GuardedOperations.RaiseEvent[System.__Canon](System.Object, System.EventHandler`1, System.__Canon)
|||  + microsoft.visualstudio.platform.vseditor.ni!WpfTextView.OnVisualBufferChanged
```