### PR TITLE
Move Roslyn dependencies from VSSetup to VSSetup.Dependencies

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26014.0
+VisualStudioVersion = 15.0.26109.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysisTest", "src\Compilers\Core\CodeAnalysisTest\CodeAnalysisTest.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -365,6 +365,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RazorServiceHub", "src\Workspaces\Remote\Razor\RazorServiceHub.csproj", "{B6FC05F2-0E49-4BE2-8030-ACBB82B7F431}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities.CoreClr", "src\Test\Utilities\CoreClr\TestUtilities.CoreClr.csproj", "{67CA3EEE-37F1-4EDF-BD9B-C11911748F37}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualStudioSetup.Dependencies", "src\VisualStudio\Setup.Dependencies\VisualStudioSetup.Dependencies.csproj", "{1688E1E5-D510-4E06-86F3-F8DB10B1393D}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -990,6 +992,10 @@ Global
 		{67CA3EEE-37F1-4EDF-BD9B-C11911748F37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{67CA3EEE-37F1-4EDF-BD9B-C11911748F37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{67CA3EEE-37F1-4EDF-BD9B-C11911748F37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1688E1E5-D510-4E06-86F3-F8DB10B1393D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1688E1E5-D510-4E06-86F3-F8DB10B1393D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1688E1E5-D510-4E06-86F3-F8DB10B1393D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1688E1E5-D510-4E06-86F3-F8DB10B1393D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1163,5 +1169,6 @@ Global
 		{0C0EEB55-4B6D-4F2B-B0BB-B9EB2BA9E980} = {8DBA5174-B0AA-4561-82B1-A46607697753}
 		{B6FC05F2-0E49-4BE2-8030-ACBB82B7F431} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{67CA3EEE-37F1-4EDF-BD9B-C11911748F37} = {CAD2965A-19AB-489F-BE2E-7649957F914A}
+		{1688E1E5-D510-4E06-86F3-F8DB10B1393D} = {8DBA5174-B0AA-4561-82B1-A46607697753}
 	EndGlobalSection
 EndGlobal

--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -76,6 +76,7 @@
     <SystemSecurityAccessControlVersion>4.3.0</SystemSecurityAccessControlVersion>
     <SystemSecurityCryptographyAlgorithmsVersion>4.3.0</SystemSecurityCryptographyAlgorithmsVersion>
     <SystemSecurityCryptographyEncodingVersion>4.3.0</SystemSecurityCryptographyEncodingVersion>
+    <SystemSecurityCryptographyPrimitivesVersion>4.3.0</SystemSecurityCryptographyPrimitivesVersion>
     <SystemSecurityCryptographyX509CertificatesVersion>4.3.0</SystemSecurityCryptographyX509CertificatesVersion>
     <SystemSecurityPrincipalWindowsVersion>4.3.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingVersion>4.3.0</SystemTextEncodingVersion>

--- a/src/VisualStudio/Setup.Dependencies/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup.Dependencies/AssemblyRedirects.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.VisualStudio.Setup;
+
+[assembly: ProvideDependencyBindingRedirection("Microsoft.DiaSymReader.dll")]
+[assembly: ProvideDependencyBindingRedirection("Microsoft.DiaSymReader.PortablePdb.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.Collections.Immutable.dll")]
+//[assembly: ProvideDependencyBindingRedirection("System.Collections.dll")] // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.Collections.Concurrent.dll")] // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.Diagnostics.Contracts.dll")] // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.Diagnostics.Tools.dll")] // no implementation assembly for net46
+[assembly: ProvideDependencyBindingRedirection("System.Diagnostics.FileVersionInfo.dll")]
+//[assembly: ProvideDependencyBindingRedirection("System.IO.dll")] // no implementation assembly for net46
+[assembly: ProvideDependencyBindingRedirection("System.IO.Compression.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.IO.FileSystem.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.IO.FileSystem.Primitives.dll")]
+//[assembly: ProvideDependencyBindingRedirection("System.Linq.Expressions.dll")] // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.Linq.Parallel.dll")] // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.ObjectModel.dll")] // no implementation assembly for net46
+[assembly: ProvideDependencyBindingRedirection("System.Reflection.Metadata.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.Runtime.InteropServices.RuntimeInformation.dll")]
+//[assembly: ProvideDependencyBindingRedirection("System.Runtime.Numerics.dll")] // no implementation assembly for net46
+[assembly: ProvideDependencyBindingRedirection("System.Security.Cryptography.Algorithms.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.Security.Cryptography.Encoding.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.Security.Cryptography.Primitives.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.Security.Cryptography.X509Certificates.dll")]
+//[assembly: ProvideDependencyBindingRedirection("System.Text.Encoding.dll")] // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.Text.Encoding.Extensions.dll")] // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.Text.RegularExpressions.dll")] // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.Threading.Tasks.Parallel.dll")] // no implementation assembly for net46
+[assembly: ProvideDependencyBindingRedirection("System.Text.Encoding.CodePages.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.ValueTuple.dll")]
+[assembly: ProvideDependencyBindingRedirection("System.Xml.ReaderWriter.dll")]
+//[assembly: ProvideDependencyBindingRedirection("System.Xml.XDocument.dll")]  // no implementation assembly for net46
+//[assembly: ProvideDependencyBindingRedirection("System.Xml.XmlDocument.dll")]  // no implementation assembly for net46
+[assembly: ProvideDependencyBindingRedirection("System.Xml.XPath.XDocument.dll")]

--- a/src/VisualStudio/Setup.Dependencies/ProvideDependencyBindingRedirection.cs
+++ b/src/VisualStudio/Setup.Dependencies/ProvideDependencyBindingRedirection.cs
@@ -11,11 +11,11 @@ namespace Roslyn.VisualStudio.Setup
     /// It's just a wrapper for <see cref="ProvideBindingRedirectionAttribute"/> that sets all the defaults rather than duplicating them.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-    internal sealed class ProvideRoslynBindingRedirectionAttribute : RegistrationAttribute
+    internal sealed class ProvideDependencyBindingRedirectionAttribute : RegistrationAttribute
     {
         private readonly ProvideBindingRedirectionAttribute _redirectionAttribute;
 
-        public ProvideRoslynBindingRedirectionAttribute(string fileName)
+        public ProvideDependencyBindingRedirectionAttribute(string fileName)
         {
             // ProvideBindingRedirectionAttribute is sealed, so we can't inherit from it to provide defaults.
             // Instead, we'll do more of an aggregation pattern here.

--- a/src/VisualStudio/Setup.Dependencies/ProvideRoslynBindingRedirection.cs
+++ b/src/VisualStudio/Setup.Dependencies/ProvideRoslynBindingRedirection.cs
@@ -27,10 +27,18 @@ namespace Roslyn.VisualStudio.Setup
             };
         }
 
-        public override void Register(RegistrationContext context) => 
+        public override void Register(RegistrationContext context)
+        {
             _redirectionAttribute.Register(context);
 
-        public override void Unregister(RegistrationContext context) => 
-            _redirectionAttribute.Unregister(context);
+            // Opt into overriding the devenv.exe.config binding redirect
+            using (var key = context.CreateKey($@"RuntimeConfiguration\dependentAssembly\bindingRedirection\{_redirectionAttribute.Guid.ToString("B").ToUpperInvariant()}"))
+            {
+                key.SetValue("isPkgDefOverrideEnabled", true);
+            }
+        }
+
+        public override void Unregister(RegistrationContext context)
+            => _redirectionAttribute.Unregister(context);
     }
 }

--- a/src/VisualStudio/Setup.Dependencies/VisualStudioSetup.Dependencies.csproj
+++ b/src/VisualStudio/Setup.Dependencies/VisualStudioSetup.Dependencies.csproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\build\Targets\Settings.props" />
+  <PropertyGroup>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{1688E1E5-D510-4E06-86F3-F8DB10B1393D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Roslyn.VisualStudio.Setup.Dependencies</RootNamespace>
+    <AssemblyName>Roslyn.VisualStudio.Setup.Dependencies</AssemblyName>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
+    <ImportVSSDKTargets>true</ImportVSSDKTargets>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <RoslynProjectType>Vsix</RoslynProjectType>
+    <IsProductComponent>true</IsProductComponent>
+    <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
+    <ExtensionInstallationFolder>Microsoft\ManagedLanguages\VBCSharp\Dependencies</ExtensionInstallationFolder>
+    <Ngen>true</Ngen>
+    <NgenArchitecture>All</NgenArchitecture>
+    <NgenPriority>3</NgenPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <!-- 
+    Roslyn dependencies that are installed by other VS components. 
+    This project deploys them to RoslynDev hive to enable F5 scenario, 
+    but the resulting VSIX not inserted into VS.
+    -->
+    <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader" />
+    <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader.PortablePdb" />
+    <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" />
+    <NuGetPackageToIncludeInVsix Include="System.Collections" />
+    <NuGetPackageToIncludeInVsix Include="System.Collections.Concurrent" />
+    <NugetPackageToIncludeInVsix Include="System.Diagnostics.Contracts" />
+    <NuGetPackageToIncludeInVsix Include="System.Diagnostics.Tools" />
+    <NuGetPackageToIncludeInVsix Include="System.Diagnostics.FileVersionInfo" />
+    <NuGetPackageToIncludeInVsix Include="System.IO" />
+    <NuGetPackageToIncludeInVsix Include="System.IO.Compression" />
+    <NuGetPackageToIncludeInVsix Include="System.IO.FileSystem" />
+    <NuGetPackageToIncludeInVsix Include="System.IO.FileSystem.Primitives" />
+    <NuGetPackageToIncludeInVsix Include="System.Linq.Expressions" />
+    <NuGetPackageToIncludeInVsix Include="System.Linq.Parallel" />
+    <NuGetPackageToIncludeInVsix Include="System.ObjectModel" />
+    <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
+    <NuGetPackageToIncludeInVsix Include="System.Runtime.InteropServices.RuntimeInformation" />
+    <NuGetPackageToIncludeInVsix Include="System.Runtime.Numerics" />
+    <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Algorithms" />
+    <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Encoding" />
+    <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Primitives" />
+    <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.X509Certificates" />
+    <NuGetPackageToIncludeInVsix Include="System.Text.Encoding" />
+    <NuGetPackageToIncludeInVsix Include="System.Text.Encoding.CodePages" />
+    <NuGetPackageToIncludeInVsix Include="System.Text.Encoding.Extensions" />
+    <NuGetPackageToIncludeInVsix Include="System.Text.RegularExpressions" />
+    <NuGetPackageToIncludeInVsix Include="System.Threading.Tasks.Parallel" />
+    <NuGetPackageToIncludeInVsix Include="System.ValueTuple" />
+    <NuGetPackageToIncludeInVsix Include="System.Xml.ReaderWriter" />
+    <NuGetPackageToIncludeInVsix Include="System.Xml.XDocument" />
+    <NuGetPackageToIncludeInVsix Include="System.Xml.XmlDocument" />
+    <NuGetPackageToIncludeInVsix Include="System.Xml.XPath.XDocument" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+    <None Include="source.extension.vsixmanifest">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyRedirects.cs" />
+    <Compile Include="ProvideDependencyBindingRedirection.cs" />
+  </ItemGroup>
+  <Import Project="..\..\..\build\Targets\Imports.targets" />
+</Project>

--- a/src/VisualStudio/Setup.Dependencies/project.json
+++ b/src/VisualStudio/Setup.Dependencies/project.json
@@ -1,0 +1,44 @@
+{
+  "dependencies": {
+    "Microsoft.VisualStudio.Shell.Framework": "15.0.26014-alpha",
+    "Microsoft.VisualStudio.Shell.15.0": "15.0.26014-alpha",
+    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader.PortablePdb": "1.2.0-rc3-61304-09",
+    "System.Collections.Immutable": "1.3.1",
+    "System.Collections": "4.3.0",
+    "System.Collections.Concurrent": "4.3.0",
+    "System.Diagnostics.Contracts": "4.3.0",
+    "System.Diagnostics.Tools": "4.3.0",
+    "System.Diagnostics.FileVersionInfo": "4.3.0",
+    "System.IO": "4.3.0",
+    "System.IO.Compression": "4.3.0",
+    "System.IO.FileSystem": "4.3.0",
+    "System.IO.FileSystem.Primitives": "4.3.0",
+    "System.Linq.Expressions": "4.3.0",
+    "System.Linq.Parallel": "4.3.0",
+    "System.ObjectModel": "4.3.0",
+    "System.Reflection.Metadata": "1.4.2",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+    "System.Runtime.Numerics": "4.3.0",
+    "System.Security.Cryptography.Algorithms": "4.3.0",
+    "System.Security.Cryptography.Encoding": "4.3.0",
+    "System.Security.Cryptography.Primitives": "4.3.0",
+    "System.Security.Cryptography.X509Certificates": "4.3.0",
+    "System.Text.Encoding": "4.3.0",
+    "System.Text.Encoding.CodePages": "4.3.0",
+    "System.Text.Encoding.Extensions": "4.3.0",
+    "System.Text.RegularExpressions": "4.3.0",
+    "System.Threading.Tasks.Parallel": "4.3.0",
+    "System.ValueTuple": "4.3.0",
+    "System.Xml.ReaderWriter": "4.3.0",
+    "System.Xml.XDocument": "4.3.0",
+    "System.Xml.XmlDocument": "4.3.0",
+    "System.Xml.XPath.XDocument": "4.3.0"
+  },
+  "frameworks": {
+    "net46": {}
+  },
+  "runtimes": {
+    "win7": {}
+  }
+}

--- a/src/VisualStudio/Setup.Dependencies/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.Dependencies/source.extension.vsixmanifest
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="7b9f8160-9d62-48cd-9674-b487b1e17c1f" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>Roslyn Dependencies</DisplayName>
+    <Description>Roslyn dependencies for developer deployment.</Description>
+    <PackageId>Microsoft.CodeAnalysis.VisualStudio.Setup.Dependencies</PackageId>
+  </Metadata>
+  <Installation Experimental="true">
+    <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
+    <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
+    <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+</PackageManifest>

--- a/src/VisualStudio/Setup.Next/VisualStudioSetup.Next.csproj
+++ b/src/VisualStudio/Setup.Next/VisualStudioSetup.Next.csproj
@@ -91,8 +91,6 @@
   <ItemGroup>
     <!-- Visual Studio ships with some, but not all, of the assemblies in Microsoft.Composition, but we need them all -->
     <NuGetPackageToIncludeInVsix Include="Microsoft.Composition" />
-    <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
-    <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -23,37 +23,9 @@ using Roslyn.VisualStudio.Setup;
 [assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServices.CSharp.dll")]
 [assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.LanguageServices.SolutionExplorer.dll")]
 
-[assembly: ProvideRoslynBindingRedirection("System.Reflection.Metadata.dll")]
-[assembly: ProvideRoslynBindingRedirection("System.Collections.Immutable.dll")]
-[assembly: ProvideRoslynBindingRedirection("System.ValueTuple.dll")]
 [assembly: ProvideRoslynBindingRedirection("Esent.Interop.dll")]
 [assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.Elfie.dll")]
-[assembly: ProvideRoslynBindingRedirection("Microsoft.DiaSymReader.dll")]
-[assembly: ProvideRoslynBindingRedirection("Microsoft.DiaSymReader.PortablePdb.dll")]
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Composition.Convention.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Composition.Hosting.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Composition.TypedParts.dll")]
-
-// [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.AppContext.dll")] - removed because project is not executable.
-// [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Console.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Diagnostics.FileVersionInfo.dll")]
-// [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Diagnostics.Process.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Compression.dll")]
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.dll")]
-// [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.DriveInfo.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.Primitives.dll")]
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Pipes.dll")] - removed because project has no dependency.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Runtime.InteropServices.RuntimeInformation.dll")] - removed because project has no dependency.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.AccessControl.dll")] - removed because project has no dependency.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Claims.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.Algorithms.dll")]
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.Encoding.dll")]
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.Primitives.dll")]
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.X509Certificates.dll")]
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Principal.Windows.dll")] - removed because project has no dependency.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Text.Encoding.CodePages.dll")] - removed because project has no dependency.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Threading.Thread.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Xml.XmlDocument.dll")]
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Xml.XPath.XDocument.dll")]
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Xml.ReaderWriter.dll")]

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -198,43 +198,18 @@
       <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>3</NgenPriority>
     </ProjectReference>
+    <ProjectReference Include="..\Setup.Dependencies\VisualStudioSetup.Dependencies.csproj">
+      <Project>{1688e1e5-d510-4e06-86f3-f8db10b1393d}</Project>
+      <Name>VisualStudioSetup.Dependencies</Name>
+      <IncludeOutputGroupsInVSIX></IncludeOutputGroupsInVSIX>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <NuGetPackageToIncludeInVsix Include="ManagedEsent" />
     <NuGetPackageToIncludeInVsix Include="Microsoft.CodeAnalysis.Elfie" />
-    <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader" />
-    <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader.PortablePdb" />
     <!-- Visual Studio ships with some, but not all, of the assemblies in Microsoft.Composition, but we need them all -->
     <NuGetPackageToIncludeInVsix Include="Microsoft.Composition" />
-    <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
-    <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" />
-    <NuGetPackageToIncludeInVsix Include="System.Collections" />
-    <NuGetPackageToIncludeInVsix Include="System.Collections.Concurrent" />
-    <NugetPackageToIncludeInVsix Include="System.Diagnostics.Contracts" />
-    <NuGetPackageToIncludeInVsix Include="System.Diagnostics.Tools" />
-    <NuGetPackageToIncludeInVsix Include="System.Diagnostics.FileVersionInfo" />
-    <NuGetPackageToIncludeInVsix Include="System.IO" />
-    <NuGetPackageToIncludeInVsix Include="System.IO.Compression" />
-    <NuGetPackageToIncludeInVsix Include="System.IO.FileSystem" />
-    <NuGetPackageToIncludeInVsix Include="System.IO.FileSystem.Primitives" />
-    <NuGetPackageToIncludeInVsix Include="System.Linq.Expressions" />
-    <NuGetPackageToIncludeInVsix Include="System.Linq.Parallel" />
-    <NuGetPackageToIncludeInVsix Include="System.ObjectModel" />
-    <NuGetPackageToIncludeInVsix Include="System.Runtime.Numerics" />
-    <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Algorithms" />
-    <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Encoding" />
-    <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Primitives" />
-    <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.X509Certificates" />
-    <NuGetPackageToIncludeInVsix Include="System.Text.Encoding" />
-    <NuGetPackageToIncludeInVsix Include="System.Text.Encoding.CodePages" />
-    <NuGetPackageToIncludeInVsix Include="System.Text.Encoding.Extensions" />
-    <NuGetPackageToIncludeInVsix Include="System.Text.RegularExpressions" />
-    <NuGetPackageToIncludeInVsix Include="System.Threading.Tasks.Parallel" />
-    <NuGetPackageToIncludeInVsix Include="System.ValueTuple" />
-    <NuGetPackageToIncludeInVsix Include="System.Xml.ReaderWriter" />
-    <NuGetPackageToIncludeInVsix Include="System.Xml.XDocument" />
-    <NuGetPackageToIncludeInVsix Include="System.Xml.XmlDocument" />
-    <NuGetPackageToIncludeInVsix Include="System.Xml.XPath.XDocument" />
   </ItemGroup>
   <ItemGroup>
     <VSIXSourceItem Include="$(OutputPath)Microsoft.DiaSymReader.Native.amd64.dll" />

--- a/src/VisualStudio/VisualStudioInteractiveComponents/AssemblyRedirects.cs
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/AssemblyRedirects.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Shell;
 using Roslyn.VisualStudio.Setup;
 
 [assembly: ProvideRoslynBindingRedirection("Microsoft.CodeAnalysis.Scripting.dll")]
@@ -18,25 +17,3 @@ using Roslyn.VisualStudio.Setup;
 // [assembly: ProvideRoslynBindingRedirection("Microsoft.VisualStudio.VisualBasic.Repl.dll")]
 
 [assembly: ProvideRoslynBindingRedirection("InteractiveHost.exe")]
-
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.AppContext.dll")] - removed because project is not executable.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Console.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Diagnostics.FileVersionInfo.dll")]
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Diagnostics.Process.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Compression.dll")]
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.dll")]
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.DriveInfo.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.Primitives.dll")]
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Pipes.dll")] - removed because project has no dependency.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Runtime.InteropServices.RuntimeInformation.dll")] - removed because project has no dependency.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.AccessControl.dll")] - removed because project has no dependency.
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Claims.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.Algorithms.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Security.Cryptography.Encoding.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Security.Cryptography.Primitives.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Security.Cryptography.X509Certificates.dll")]
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Principal.Windows.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Text.Encoding.CodePages.dll")]
-//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Threading.Thread.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Xml.XmlDocument.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Xml.XPath.XDocument.dll")]


### PR DESCRIPTION
**Customer scenario**

Fixes RPS regressions by eliminating duplicates of CoreFX and DiaSymReader assemblies.

Allows Roslyn developers to F5 VisualStudio Setup against builds of VS that have older versions of Roslyn dependencies than used by Roslyn repo. 

**Bugs this fixes:** 

VSO bug 305710.
https://github.com/dotnet/roslyn/issues/16455

**Workarounds, if any**

None.

**Risk**

Needs full setup validation.

**Performance impact**

Fixes regression.

**Is this a regression from a previous update?**

Yes. We regressed in RC3 relative to RC2.

**Root cause analysis:**

We used to include these dependencies in the main Roslyn VSIX that gets pulled in by VS Setup. That resulted in duplicate files in VS install dir and in turn ngen failures. This change moves these dependencies to a separate package that's not inserted in VS.

**How was the bug found?**

RPS test.