### PR TITLE
Don't crash perf.runner if a test crashes

### DIFF
--- a/src/Test/Perf/Runner/Program.cs
+++ b/src/Test/Perf/Runner/Program.cs
@@ -232,7 +232,6 @@ namespace Runner
                 catch (Exception)
                 {
                     traceManager.Stop();
-                    throw;
                 }
                 finally
                 {


### PR DESCRIPTION
cc @dotnet/roslyn-perf 