### PR TITLE
Allow the C# compiler to run on Mono again

### DIFF
--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -44,6 +44,9 @@
     <Compile Include="..\Portable\InternalUtilities\IReadOnlySet.cs">
       <Link>IReadOnlySet.cs</Link>
     </Compile>
+    <Compile Include="..\Portable\InternalUtilities\PlatformInformation.cs">
+      <Link>PlatformInformation.cs</Link>
+    </Compile>
     <Compile Include="..\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>ReflectionUtilities.cs</Link>
     </Compile>

--- a/src/Compilers/Core/MSBuildTask/project.json
+++ b/src/Compilers/Core/MSBuildTask/project.json
@@ -15,7 +15,6 @@
     "System.IO.Pipes": "4.3.0",
     "System.Linq": "4.3.0",
     "System.Reflection": "4.3.0",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
     "System.Security.AccessControl": "4.3.0",
     "System.Security.Cryptography.Algorithms": "4.3.0",
     "System.Security.Principal.Windows": "4.3.0",

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -32,6 +32,7 @@
     <Compile Include="DiagnosticAnalyzer\AnalyzerManager.AnalyzerExecutionContext.cs" />
     <Compile Include="InternalUtilities\CommandLineUtilities.cs" />
     <Compile Include="InternalUtilities\OrderedMultiDictionary.cs" />
+    <Compile Include="InternalUtilities\PlatformInformation.cs" />
     <Compile Include="Serialization\FixedObjectBinder.cs" />
     <Compile Include="Serialization\IObjectReadable.cs" />
     <Compile Include="Serialization\IObjectWritable.cs" />

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Roslyn.Utilities
 {
@@ -14,12 +13,12 @@ namespace Roslyn.Utilities
     {
         // We consider '/' a directory separator on Unix like systems. 
         // On Windows both / and \ are equally accepted.
-        internal static readonly char DirectorySeparatorChar = IsUnixLikePlatform ? '/' : '\\';
+        internal static readonly char DirectorySeparatorChar = PlatformInformation.IsUnix ? '/' : '\\';
         internal static readonly char AltDirectorySeparatorChar = '/';
         internal static readonly string DirectorySeparatorStr = new string(DirectorySeparatorChar, 1);
         internal const char VolumeSeparatorChar = ':';
 
-        internal static bool IsUnixLikePlatform => !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        internal static bool IsUnixLikePlatform => PlatformInformation.IsUnix;
 
         internal static bool IsDirectorySeparator(char c)
         {

--- a/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.IO;
 
 namespace Roslyn.Utilities

--- a/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/PlatformInformation.cs
@@ -1,0 +1,15 @@
+using System.IO;
+
+namespace Roslyn.Utilities
+{
+    /// <summary>
+    /// This class provides simple properties for determining whether the current platform is Windows or Unix-based.
+    /// We intentionally do not use System.Runtime.InteropServices.RuntimeInformation.IsOSPlatfrom(...) because
+    /// it incorrectly reports 'true' for 'Windows' in desktop builds running on Unix-based platforms via Mono.
+    /// </summary>
+    internal static class PlatformInformation
+    {
+        public static bool IsWindows => Path.DirectorySeparatorChar == '\\';
+        public static bool IsUnix => Path.DirectorySeparatorChar == '/';
+    }
+}

--- a/src/Compilers/Core/Portable/project.json
+++ b/src/Compilers/Core/Portable/project.json
@@ -12,7 +12,6 @@
     "System.IO.FileSystem": "4.3.0",
     "System.IO.FileSystem.Primitives": "4.3.0",
     "System.Reflection.Metadata": "1.4.2",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
     "System.Runtime.Numerics": "4.3.0",
     "System.Security.Cryptography.Algorithms": "4.3.0",
     "System.Security.Cryptography.Encoding": "4.3.0",

--- a/src/Compilers/Extension/AssemblyRedirects.cs
+++ b/src/Compilers/Extension/AssemblyRedirects.cs
@@ -15,7 +15,6 @@ using Roslyn.VisualStudio.Setup;
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.DriveInfo.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.Primitives.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Pipes.dll")]
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Runtime.InteropServices.RuntimeInformation.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.AccessControl.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Claims.dll")]
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.Algorithms.dll")]

--- a/src/Compilers/Extension/CompilerExtension.csproj
+++ b/src/Compilers/Extension/CompilerExtension.csproj
@@ -65,7 +65,6 @@
     <NuGetPackageToIncludeInVsix Include="System.ObjectModel" />
     <NuGetPackageToIncludeInVsix Include="System.Reflection" />
     <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
-    <NuGetPackageToIncludeInVsix Include="System.Runtime.InteropServices.RuntimeInformation" />
     <NuGetPackageToIncludeInVsix Include="System.Runtime.Numerics" />
     <NuGetPackageToIncludeInVsix Include="System.Security.AccessControl" />
     <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Algorithms" />

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -4,18 +4,18 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.IO.Pipes;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.CommandLine.CompilerServerLogger;
 using static Microsoft.CodeAnalysis.CommandLine.NativeMethods;
-using System.Reflection;
-using System.Security.AccessControl;
-using System.Security.Cryptography;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
         /// Determines if the compiler server is supported in this environment.
         /// </summary>
         internal static bool IsCompilerServerSupported => 
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+            PlatformInformation.IsWindows &&
             GetRuntimeDirectoryOpt() != null &&
             GetPipeNameForPathOpt("") != null;
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
@@ -20,7 +20,6 @@
         <dependency id="System.IO.FileSystem"                               version="$SystemIOFileSystemVersion$"/>
         <dependency id="System.IO.FileSystem.DriveInfo"                     version="$SystemIOFileSystemDriveInfoVersion$"/>
         <dependency id="System.IO.Pipes"                                    version="$SystemIOPipesVersion$" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation"  version="$SystemRuntimeInteropServicesRuntimeInformationVersion$"/>
         <dependency id="System.Security.AccessControl"                      version="$SystemSecurityAccessControlVersion$" />
         <dependency id="System.Security.Cryptography.Algorithms"            version="$SystemSecurityCryptographyAlgorithmsVersion$"/>
         <dependency id="System.Security.Principal.Windows"                  version="$SystemSecurityPrincipalWindowsVersion$" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
@@ -32,7 +32,6 @@
         <dependency id="System.Runtime"                                version="$SystemRuntimeVersion$"/>
         <dependency id="System.Runtime.Extensions"                     version="$SystemRuntimeExtensionsVersion$"/>
         <dependency id="System.Runtime.InteropServices"                version="$SystemRuntimeInteropServicesVersion$"/>
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="$SystemRuntimeInteropServicesRuntimeInformationVersion$"/>
         <dependency id="System.Runtime.Numerics"                       version="$SystemRuntimeNumericsVersion$"/>
         <dependency id="System.Security.Cryptography.Algorithms"       version="$SystemSecurityCryptographyAlgorithmsVersion$"/>
         <dependency id="System.Security.Cryptography.Encoding"         version="$SystemSecurityCryptographyEncodingVersion$"/>

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -61,7 +61,6 @@ Supported Platforms:
     <file src="Exes\Toolset\System.IO.FileSystem.Primitives.dll" target="tools" />
     <file src="Exes\Toolset\System.IO.Pipes.dll" target="tools" />
     <file src="Exes\Toolset\System.Reflection.Metadata.dll" target="tools" />
-    <file src="Exes\Toolset\System.Runtime.InteropServices.RuntimeInformation.dll" target="tools" />
     <file src="Exes\Toolset\System.Security.AccessControl.dll" target="tools" />
     <file src="Exes\Toolset\System.Security.Claims.dll" target="tools" />
     <file src="Exes\Toolset\System.Security.Cryptography.Algorithms.dll" target="tools" />

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -110,7 +110,6 @@ Public Class BuildDevDivInsertionFiles
         "System.IO.FileSystem.DriveInfo.dll",
         "System.IO.FileSystem.Primitives.dll",
         "System.IO.Pipes.dll",
-        "System.Runtime.InteropServices.RuntimeInformation.dll",
         "System.Security.AccessControl.dll",
         "System.Security.Claims.dll",
         "System.Security.Cryptography.Algorithms.dll",
@@ -869,7 +868,6 @@ Public Class BuildDevDivInsertionFiles
         add("Vsix\CompilerExtension\System.IO.FileSystem.DriveInfo.dll")
         add("Vsix\CompilerExtension\System.IO.FileSystem.Primitives.dll")
         add("Vsix\CompilerExtension\System.IO.Pipes.dll")
-        add("Vsix\CompilerExtension\System.Runtime.InteropServices.RuntimeInformation.dll")
         add("Vsix\CompilerExtension\System.Security.AccessControl.dll")
         add("Vsix\CompilerExtension\System.Security.Claims.dll")
         add("Vsix\CompilerExtension\System.Security.Cryptography.Algorithms.dll")

--- a/src/Setup/DevDivPackages/Roslyn/project.json
+++ b/src/Setup/DevDivPackages/Roslyn/project.json
@@ -19,7 +19,6 @@
     "System.IO.FileSystem": "4.3.0",
     "System.IO.FileSystem.Primitives": "4.3.0",
     "System.IO.Pipes": "4.3.0",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
     "System.Runtime.Numerics": "4.3.0",
     "System.Security.AccessControl": "4.3.0",
     "System.Security.Cryptography.Algorithms": "4.3.0",

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -47,7 +47,6 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.DriveInfo.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.FileSystem.Primitives.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.IO.Pipes.dll vs.file.ngenArchitecture=all
-    file source=$(OutputPath)\Vsix\CompilerExtension\System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.AccessControl.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Claims.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Security.Cryptography.Algorithms.dll vs.file.ngenArchitecture=all

--- a/src/VisualStudio/Setup/AssemblyRedirects.cs
+++ b/src/VisualStudio/Setup/AssemblyRedirects.cs
@@ -44,7 +44,7 @@ using Roslyn.VisualStudio.Setup;
 // [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.DriveInfo.dll")] - removed because project has no dependency.
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.Primitives.dll")]
 //[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Pipes.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Runtime.InteropServices.RuntimeInformation.dll")]
+//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Runtime.InteropServices.RuntimeInformation.dll")] - removed because project has no dependency.
 //[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.AccessControl.dll")] - removed because project has no dependency.
 //[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Claims.dll")] - removed because project has no dependency.
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.Algorithms.dll")]

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -220,7 +220,6 @@
     <NuGetPackageToIncludeInVsix Include="System.Linq.Expressions" />
     <NuGetPackageToIncludeInVsix Include="System.Linq.Parallel" />
     <NuGetPackageToIncludeInVsix Include="System.ObjectModel" />
-    <NuGetPackageToIncludeInVsix Include="System.Runtime.InteropServices.RuntimeInformation" />
     <NuGetPackageToIncludeInVsix Include="System.Runtime.Numerics" />
     <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Algorithms" />
     <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Encoding" />

--- a/src/VisualStudio/VisualStudioInteractiveComponents/AssemblyRedirects.cs
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/AssemblyRedirects.cs
@@ -28,7 +28,7 @@ using Roslyn.VisualStudio.Setup;
 //[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.DriveInfo.dll")] - removed because project has no dependency.
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.FileSystem.Primitives.dll")]
 //[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.IO.Pipes.dll")] - removed because project has no dependency.
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Runtime.InteropServices.RuntimeInformation.dll")]
+//[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Runtime.InteropServices.RuntimeInformation.dll")] - removed because project has no dependency.
 //[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.AccessControl.dll")] - removed because project has no dependency.
 //[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Claims.dll")] - removed because project has no dependency.
 [assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\System.Security.Cryptography.Algorithms.dll")]

--- a/src/VisualStudio/VisualStudioInteractiveComponents/VisualStudioInteractiveComponents.csproj
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/VisualStudioInteractiveComponents.csproj
@@ -186,7 +186,6 @@
     <NuGetPackageToIncludeInVsix Include="System.Linq.Parallel" />
     <NuGetPackageToIncludeInVsix Include="System.ObjectModel" />
     <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
-    <NuGetPackageToIncludeInVsix Include="System.Runtime.InteropServices.RuntimeInformation" />
     <NuGetPackageToIncludeInVsix Include="System.Runtime.Numerics" />
     <NuGetPackageToIncludeInVsix Include="System.Security.AccessControl" />
     <NuGetPackageToIncludeInVsix Include="System.Security.Cryptography.Algorithms" />

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -114,6 +114,9 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs">
       <Link>InternalUtilities\ExceptionUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs">
+      <Link>InternalUtilities\PlatformInformation.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ReaderWriterLockSlimExtensions.cs">
       <Link>InternalUtilities\ReaderWriterLockSlimExtensions.cs</Link>
     </Compile>


### PR DESCRIPTION
**Customer scenario**
Anyone trying to compile code with csc.exe on Mono will encounter unexpected failures. For example, imagine a customer references the latest Microsoft.Net.Compilers package and tries to run the C# compiler on Mono like so:

```
$ mono csc.exe HelloWorld.cs
```

The C# compiler will fail with an error like so:

```
error CS2001: Source file '/Users/joebob/helloworld\HelloWorld.cs' could not be found.
```

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16487

**Workarounds, if any**

To workaround the issue, the user must manually delete `System.Runtime.InteropServices.RuntimeInformation.dll` from the folder where the `Microsoft.Net.Compilers` NuGet package is installed. This is a very non-obvious workaround that would require the user to debug the compiler itself and perform detailed analysis of it's dependencies. It is highly unlikely that a user would find this workaround on their own.

This has been present in our packages since the end of September, so it is not critical for RC3. However, it should be fixed before RTW.

**Risk**

This is low-risk in that it essentially reverts the check to determine whether the compiler is running on a Unix-based platform to match what it was doing for the same check a few months ago.

**Performance impact**

Very low perf impact. There are no allocations introduced and the check is simple literal comparison.

**Is this a regression from a previous update?**

Yes. This was regressed on 9/29/2016 when the C# compiler was made to target netstandard1.3.

**Root cause analysis:**

When the 9/29/2016 change was made, it was assumed that `System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(...)` would do the right thing on all platforms. However, that turned out to be incorrect for an app targeting the .NET Framework. On such an app, this API will always return 'true' for 'Windows' -- even if it's running on macOS/Linux via Mono. There is an issue tracking this at https://github.com/dotnet/corefx/issues/9012.

Unfortunately, we don't have Mono builds in our CI, so this was missed. We have plenty of tests to ensure that we won't regression desktop compiler builds on Windows or cross-platform .NET Core compiler builds. However, we don't have the machinery in place to ensure that we won't regress desktop compiler builds running on Mono.

**How was the bug found?**

Building the latest MSBuild xplat branch targeting Mono.