### PR TITLE
Fix294080 DPL in web

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
@@ -106,56 +107,63 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private async Task PopulateWorkspaceFromDeferredProjectInfoAsync(
             CancellationToken cancellationToken)
         {
-            // NOTE: We need to check cancellationToken after each await, in case the user has
-            // already closed the solution.
-            AssertIsForeground();
-
-            var componentModel = _serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
-            var workspaceProjectContextFactory = componentModel.GetService<IWorkspaceProjectContextFactory>();
-
-            var dte = _serviceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
-            var solutionConfig = (EnvDTE80.SolutionConfiguration2)dte.Solution.SolutionBuild.ActiveConfiguration;
-
-            OutputToOutputWindow($"Getting project information - start");
-            var start = DateTimeOffset.UtcNow;
-
-            var projectInfos = SpecializedCollections.EmptyReadOnlyDictionary<string, DeferredProjectInformation>();
-
-            // Note that `solutionConfig` may be null. For example: if the solution doesn't actually
-            // contain any projects.
-            if (solutionConfig != null)
+            try
             {
-                // Capture the context so that we come back on the UI thread, and do the actual project creation there.
-                var deferredProjectWorkspaceService = _workspaceServices.GetService<IDeferredProjectWorkspaceService>();
-                projectInfos = await deferredProjectWorkspaceService.GetDeferredProjectInfoForConfigurationAsync(
-                    $"{solutionConfig.Name}|{solutionConfig.PlatformName}",
-                    cancellationToken).ConfigureAwait(true);
-            }
+                // NOTE: We need to check cancellationToken after each await, in case the user has
+                // already closed the solution.
+                AssertIsForeground();
 
-            AssertIsForeground();
-            cancellationToken.ThrowIfCancellationRequested();
-            OutputToOutputWindow($"Getting project information - done (took {DateTimeOffset.UtcNow - start})");
+                var componentModel = _serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
+                var workspaceProjectContextFactory = componentModel.GetService<IWorkspaceProjectContextFactory>();
 
-            OutputToOutputWindow($"Creating projects - start");
-            start = DateTimeOffset.UtcNow;
-            var targetPathsToProjectPaths = BuildTargetPathMap(projectInfos);
-            var analyzerAssemblyLoader = _workspaceServices.GetRequiredService<IAnalyzerService>().GetLoader();
-            foreach (var projectFilename in projectInfos.Keys)
-            {
+                var dte = _serviceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
+                var solutionConfig = (EnvDTE80.SolutionConfiguration2)dte.Solution.SolutionBuild.ActiveConfiguration;
+
+                OutputToOutputWindow($"Getting project information - start");
+                var start = DateTimeOffset.UtcNow;
+
+                var projectInfos = SpecializedCollections.EmptyReadOnlyDictionary<string, DeferredProjectInformation>();
+
+                // Note that `solutionConfig` may be null. For example: if the solution doesn't actually
+                // contain any projects.
+                if (solutionConfig != null)
+                {
+                    // Capture the context so that we come back on the UI thread, and do the actual project creation there.
+                    var deferredProjectWorkspaceService = _workspaceServices.GetService<IDeferredProjectWorkspaceService>();
+                    projectInfos = await deferredProjectWorkspaceService.GetDeferredProjectInfoForConfigurationAsync(
+                        $"{solutionConfig.Name}|{solutionConfig.PlatformName}",
+                        cancellationToken).ConfigureAwait(true);
+                }
+
+                AssertIsForeground();
                 cancellationToken.ThrowIfCancellationRequested();
-                GetOrCreateProjectFromArgumentsAndReferences(
-                    workspaceProjectContextFactory,
-                    analyzerAssemblyLoader,
-                    projectFilename,
-                    projectInfos,
-                    targetPathsToProjectPaths);
-            }
-            OutputToOutputWindow($"Creating projects - done (took {DateTimeOffset.UtcNow - start})");
+                OutputToOutputWindow($"Getting project information - done (took {DateTimeOffset.UtcNow - start})");
 
-            OutputToOutputWindow($"Pushing to workspace - start");
-            start = DateTimeOffset.UtcNow;
-            FinishLoad();
-            OutputToOutputWindow($"Pushing to workspace - done (took {DateTimeOffset.UtcNow - start})");
+                OutputToOutputWindow($"Creating projects - start");
+                start = DateTimeOffset.UtcNow;
+                var targetPathsToProjectPaths = BuildTargetPathMap(projectInfos);
+                var analyzerAssemblyLoader = _workspaceServices.GetRequiredService<IAnalyzerService>().GetLoader();
+                foreach (var projectFilename in projectInfos.Keys)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    GetOrCreateProjectFromArgumentsAndReferences(
+                        workspaceProjectContextFactory,
+                        analyzerAssemblyLoader,
+                        projectFilename,
+                        projectInfos,
+                        targetPathsToProjectPaths);
+                }
+                OutputToOutputWindow($"Creating projects - done (took {DateTimeOffset.UtcNow - start})");
+
+                OutputToOutputWindow($"Pushing to workspace - start");
+                start = DateTimeOffset.UtcNow;
+                FinishLoad();
+                OutputToOutputWindow($"Pushing to workspace - done (took {DateTimeOffset.UtcNow - start})");
+            }
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            {
+                throw;
+            }
         }
 
         private static ImmutableDictionary<string, string> BuildTargetPathMap(IReadOnlyDictionary<string, DeferredProjectInformation> projectInfos)


### PR DESCRIPTION
**Customer scenario** The customer experiences a crash after enabling lightweight solution load and loading a solution containing web application projects, where some web pages are open in the .suo file.

**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/294080

**Workarounds, if any:** Don't use lightweight solution load.

**Risk:** Low - this codepath is specific to lightweight solution load.  Worst case is we would fail to hook up a P2P ref.

**Performance impact:** Low, but not zero - we now walk the documents of projects with matching paths to ensure none are web pages.

**Is this a regression from a previous update?** No - this bug has existed since support for lightweight solution load was added to Roslyn

**Root cause analysis:** Didn't realize that both pages and core projects have the same `projectFilepath`.  It's a race condition involving timing between the OnIdle request to create the project for the page and the async work to build the AnyCode index that gives the project info to Roslyn in lightweight solution load.

**How was the bug found?** Watson
