### PR TITLE
Disallow attributes in local function definitions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -487,7 +487,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            localSymbol.GetDeclarationDiangostics(diagnostics);
+            localSymbol.GetDeclarationDiagnostics(diagnostics);
 
             return new BoundLocalFunctionStatement(node, localSymbol, block, hasErrors);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -487,7 +487,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            localSymbol.GrabDiagnostics(diagnostics);
+            localSymbol.GetDeclarationDiangostics(diagnostics);
 
             return new BoundLocalFunctionStatement(node, localSymbol, block, hasErrors);
         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -719,6 +719,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attributes are not allowed on local function parameters or type parameters.
+        /// </summary>
+        internal static string ERR_AttributesInLocalFuncDecl {
+            get {
+                return ResourceManager.GetString("ERR_AttributesInLocalFuncDecl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Attributes are not valid in this context..
         /// </summary>
         internal static string ERR_AttributesNotAllowed {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5002,4 +5002,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_BadAssemblyName" xml:space="preserve">
     <value>Invalid assembly name: {0}</value>
   </data>
+  <data name="ERR_AttributesInLocalFuncDecl" xml:space="preserve">
+    <value>Attributes are not allowed on local function parameters or type parameters</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1452,6 +1452,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExpressionVariableInQueryClause = 8201,
         ERR_PublicSignNetModule = 8202,
         ERR_BadAssemblyName = 8203,
+        ERR_AttributesInLocalFuncDecl = 8204
         #endregion more stragglers for C# 7
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal Binder ScopeBinder { get; }
 
-        internal void GetDeclarationDiangostics(DiagnosticBag addTo)
+        internal void GetDeclarationDiagnostics(DiagnosticBag addTo)
         {
             // Force attribute binding for diagnostics
             foreach (var typeParam in _typeParameters)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -157,6 +157,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var diagnostics = DiagnosticBag.GetInstance();
             SyntaxToken arglistToken;
+
+            foreach (var param in _syntax.ParameterList.Parameters)
+            {
+                foreach (var attrList in param.AttributeLists)
+                {
+                    diagnostics.Add(ErrorCode.ERR_AttributesInLocalFuncDecl, attrList.Location);
+                }
+            }
+
             var parameters = ParameterHelpers.MakeParameters(
                 _binder,
                 this,
@@ -348,6 +357,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var location = identifier.GetLocation();
                 var name = identifier.ValueText;
 
+                foreach (var attr in parameter.AttributeLists)
+                {
+                    diagnostics.Add(ErrorCode.ERR_AttributesInLocalFuncDecl, attr.Location);
+                }
+
                 foreach (var @param in result)
                 {
                     if (name == @param.Name)
@@ -370,6 +384,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         ordinal,
                         ImmutableArray.Create(location),
                         ImmutableArray.Create(parameter.GetReference()));
+
+                // Force attribute binding for diagnostics
+                typeParameter.GetAttributesBag(diagnostics);
 
                 result.Add(typeParameter);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -166,10 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             foreach (var param in _syntax.ParameterList.Parameters)
             {
-                foreach (var attrList in param.AttributeLists)
-                {
-                    diagnostics.Add(ErrorCode.ERR_AttributesInLocalFuncDecl, attrList.Location);
-                }
+                ReportAnyAttributes(diagnostics, param.AttributeLists);
             }
 
             var parameters = ParameterHelpers.MakeParameters(
@@ -188,6 +185,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             var value = new ParametersAndDiagnostics(parameters, isVararg, diagnostics.ToReadOnlyAndFree());
             Interlocked.CompareExchange(ref _lazyParametersAndDiagnostics, value, null);
+        }
+
+        private static void ReportAnyAttributes(DiagnosticBag diagnostics, SyntaxList<AttributeListSyntax> attributes)
+        {
+            foreach (var attrList in attributes)
+            {
+                diagnostics.Add(ErrorCode.ERR_AttributesInLocalFuncDecl, attrList.Location);
+            }
         }
 
         public override TypeSymbol ReturnType
@@ -364,10 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var location = identifier.GetLocation();
                 var name = identifier.ValueText;
 
-                foreach (var attr in parameter.AttributeLists)
-                {
-                    diagnostics.Add(ErrorCode.ERR_AttributesInLocalFuncDecl, attr.Location);
-                }
+                ReportAnyAttributes(diagnostics, parameter.AttributeLists);
 
                 foreach (var @param in result)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -524,17 +524,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Hash.Combine(ContainingSymbol, Ordinal);
         }
 
-        /// <summary>
-        /// Returns a bag of applied custom attributes and data decoded from well-known attributes. Returns null if there are no attributes applied on the symbol.
-        /// </summary>
-        /// <remarks>
-        /// Forces binding and decoding of attributes.
-        /// </remarks>
-        internal virtual CustomAttributesBag<CSharpAttributeData> GetAttributesBag()
-        {
-            return null;
-        }
-
         #region ITypeParameterTypeSymbol Members
 
         TypeParameterKind ITypeParameterSymbol.TypeParameterKind

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -579,25 +579,6 @@ NamedOptional();
             VerifyOutputInMain(source, "3 2", "System");
         }
 
-        [Fact]
-        public void CallerMemberName()
-        {
-            var source = @"
-void CallerMemberName([CallerMemberName] string s = null)
-{
-    Console.Write(s);
-}
-void LocalFuncName()
-{
-    CallerMemberName();
-}
-LocalFuncName();
-Console.Write(' ');
-CallerMemberName();
-";
-            VerifyOutputInMain(source, "Main Main", "System", "System.Runtime.CompilerServices");
-        }
-
 
         [Fact]
         [CompilerTrait(CompilerFeature.Dynamic)]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -86,6 +86,7 @@ class C
                              .GetMember<NamedTypeSymbol>("CLSCompliantAttribute"),
                 attrs[2].AttributeClass);
             Assert.True(attrs[3].AttributeClass.IsErrorType());
+            comp.DeclarationDiagnostics.Verify();
         }
 
         [Fact]
@@ -141,6 +142,7 @@ class C
                              .GetMember<NamespaceSymbol>("System")
                              .GetMember<NamedTypeSymbol>("CLSCompliantAttribute"),
                 attrs[0].AttributeClass);
+            comp.DeclarationDiagnostics.Verify();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -105,6 +105,26 @@ class C
         void Local<[A]T, [CLSCompliant]U>() { }
     }
 }");
+            comp.VerifyDiagnostics(
+                // (7,21): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                //         void Local<[A]T, [CLSCompliant]U>() { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(7, 21),
+                // (7,21): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                //         void Local<[A]T, [CLSCompliant]U>() { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(7, 21),
+                // (7,27): error CS7036: There is no argument given that corresponds to the required formal parameter 'isCompliant' of 'CLSCompliantAttribute.CLSCompliantAttribute(bool)'
+                //         void Local<[A]T, [CLSCompliant]U>() { }
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "CLSCompliant").WithArguments("isCompliant", "System.CLSCompliantAttribute.CLSCompliantAttribute(bool)").WithLocation(7, 27),
+                // (7,20): error CS8204: Attributes are not allowed on local function parameters or type parameters
+                //         void Local<[A]T, [CLSCompliant]U>() { }
+                Diagnostic(ErrorCode.ERR_AttributesInLocalFuncDecl, "[A]").WithLocation(7, 20),
+                // (7,26): error CS8204: Attributes are not allowed on local function parameters or type parameters
+                //         void Local<[A]T, [CLSCompliant]U>() { }
+                Diagnostic(ErrorCode.ERR_AttributesInLocalFuncDecl, "[CLSCompliant]").WithLocation(7, 26),
+                // (7,14): warning CS0168: The variable 'Local' is declared but never used
+                //         void Local<[A]T, [CLSCompliant]U>() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local").WithArguments("Local").WithLocation(7, 14));
+
             var tree = comp.SyntaxTrees[0];
             var root = tree.GetRoot();
 
@@ -138,6 +158,7 @@ class C
 
             Assert.Null(model.GetDeclaredSymbol(clsCompliant));
 
+            // This should be null because there is no CLSCompliant ctor with no args
             var clsCompliantSymbolInfo = model.GetSymbolInfo(clsCompliant);
             Assert.Null(clsCompliantSymbolInfo.Symbol);
             Assert.Equal(clsCompliantSymbol.GetMember<MethodSymbol>(".ctor"),
@@ -165,6 +186,26 @@ class C
         void Local([A]int x, [CLSCompliant]int y) { }
     }
 }");
+            comp.VerifyDiagnostics(
+                // (7,20): error CS8204: Attributes are not allowed on local function parameters or type parameters
+                //         void Local([A]int x, [CLSCompliant]int y) { }
+                Diagnostic(ErrorCode.ERR_AttributesInLocalFuncDecl, "[A]").WithLocation(7, 20),
+                // (7,30): error CS8204: Attributes are not allowed on local function parameters or type parameters
+                //         void Local([A]int x, [CLSCompliant]int y) { }
+                Diagnostic(ErrorCode.ERR_AttributesInLocalFuncDecl, "[CLSCompliant]").WithLocation(7, 30),
+                // (7,21): error CS0246: The type or namespace name 'AAttribute' could not be found (are you missing a using directive or an assembly reference?)
+                //         void Local([A]int x, [CLSCompliant]int y) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("AAttribute").WithLocation(7, 21),
+                // (7,21): error CS0246: The type or namespace name 'A' could not be found (are you missing a using directive or an assembly reference?)
+                //         void Local([A]int x, [CLSCompliant]int y) { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "A").WithArguments("A").WithLocation(7, 21),
+                // (7,31): error CS7036: There is no argument given that corresponds to the required formal parameter 'isCompliant' of 'CLSCompliantAttribute.CLSCompliantAttribute(bool)'
+                //         void Local([A]int x, [CLSCompliant]int y) { }
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "CLSCompliant").WithArguments("isCompliant", "System.CLSCompliantAttribute.CLSCompliantAttribute(bool)").WithLocation(7, 31),
+                // (7,14): warning CS0168: The variable 'Local' is declared but never used
+                //         void Local([A]int x, [CLSCompliant]int y) { }
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local").WithArguments("Local").WithLocation(7, 14));
+
             var tree = comp.SyntaxTrees[0];
             var root = tree.GetRoot();
 
@@ -198,6 +239,7 @@ class C
 
             Assert.Null(model.GetDeclaredSymbol(clsCompliant));
 
+            // This should be null because there is no CLSCompliant ctor with no args
             var clsCompliantSymbolInfo = model.GetSymbolInfo(clsCompliant);
             Assert.Null(clsCompliantSymbolInfo.Symbol);
             Assert.Equal(clsCompliantSymbol.GetMember<MethodSymbol>(".ctor"),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -44,6 +44,7 @@ class C
     }
 }");
             var comp = CreateCompilationWithMscorlib(tree);
+            comp.DeclarationDiagnostics.Verify();
             comp.VerifyDiagnostics(
                 // (7,20): error CS8204: Attributes are not allowed on local function parameters or type parameters
                 //         void Local<[A, B, CLSCompliant, D]T>() { }
@@ -69,6 +70,7 @@ class C
                 // (7,27): error CS7036: There is no argument given that corresponds to the required formal parameter 'isCompliant' of 'CLSCompliantAttribute.CLSCompliantAttribute(bool)'
                 //         void Local<[A, B, CLSCompliant, D]T>() { }
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "CLSCompliant").WithArguments("isCompliant", "System.CLSCompliantAttribute.CLSCompliantAttribute(bool)").WithLocation(7, 27));
+
 
             var localDecl = tree.FindNodeOrTokenByKind(SyntaxKind.LocalFunctionStatement);
             var model = comp.GetSemanticModel(tree);
@@ -100,6 +102,7 @@ class C
     }
 }");
             var comp = CreateCompilationWithMscorlib(tree);
+            comp.DeclarationDiagnostics.Verify();
             comp.VerifyDiagnostics(
                 // (7,20): error CS8204: Attributes are not allowed on local function parameters or type parameters
                 //         void Local([A, B]int x, [CLSCompliant]string s = "") { }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     [CompilerTrait(CompilerFeature.LocalFunctions)]
     public class LocalFunctionTests : LocalFunctionsTestBase
     {
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/16652")]
         public void FetchLocalFunctionSymbolThroughLocal()
         {
             var tree = SyntaxFactory.ParseSyntaxTree(@"


### PR DESCRIPTION
**Scenario**

Mentioning an attribute on a type parameter which doesn't exist, e.g.

```csharp
class C
{
    public void M()
    {
        void Local< [A] T >() {}
    }
}
```
causes the compiler to crash. This also revealed a design hole: attributes
are currently allowed on type parameters and parameters, but not on
the local function itself or its return type.

After the fix attributes will not be permitted on type parameters or parameters of
local functions. This matches the existing behavior for the return type
and symbol itself, neither of which allow attributes to be applied to
them. Also, the compiler no longer crashes in these scenarios and correctly binds the attributes, even if they are invalid.

**Bugs this fixes:** 

Fixes #14640

**Workarounds, if any**

None.

**Risk**

We are disabling specific behavior and the error messages are tested, so this change should be focused narrowly to the problem and not affect anything outside of attributes on parameters/type parameters.

**Performance impact**

None -- the work was being done, but the diagnostics were being discarded.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

New feature.

**How was the bug found?**

Customer reported.