### PR TITLE
Upgrade Linux use of portable targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(TOOLSET_PATH): $(BINARIES_PATH)/dotnet-cli
 	pushd $(TOOLSET_SRC_PATH) ; \
 	$(BINARIES_PATH)/dotnet-cli/dotnet restore && \
 	$(BINARIES_PATH)/dotnet-cli/dotnet publish -o $(TOOLSET_PATH) && \
-	sed -i -e 's/Microsoft.CSharp.Targets/Microsoft.CSharp.targets/g' $(TOOLSET_PATH)/Extensions/Microsoft/Portable/v5.0/Microsoft.Portable.CSharp.targets
+	sed -i -e 's/Microsoft.CSharp.Targets/Microsoft.CSharp.targets/g' $(TOOLSET_PATH)/Microsoft/Portable/v5.0/Microsoft.Portable.CSharp.targets
 # https://github.com/dotnet/roslyn/issues/9641
 
 $(BINARIES_PATH)/dotnet-cli:

--- a/build/MSBuildToolset/project.json
+++ b/build/MSBuildToolset/project.json
@@ -16,7 +16,7 @@
     "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-rc2-61102-09",
     "Microsoft.NETCore.TestHost": "1.1.0",
     "Microsoft.NETCore.App": "1.1.0",
-    "Microsoft.Portable.Targets": "0.1.1-dev",
+    "Microsoft.Portable.Targets": "0.1.2-dev",
     "Newtonsoft.Json": "8.0.3",
     "NuGet.CommandLine.XPlat": "3.5.0-beta2-1484"
   },
@@ -30,6 +30,7 @@
   },
   "runtimes": {
     "ubuntu.14.04-x64": {},
+    "ubuntu.16.04-x64": {},
     "osx.10.11-x64": {},
     "osx.10.12-x64": {}
   }

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -90,12 +90,6 @@
   </Choose>
 
   <Choose>
-    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' AND '$(OS)' != 'Windows_NT'">
-      <PropertyGroup>
-        <!-- https://github.com/Microsoft/msbuild/issues/1533 -->
-        <MSBuildTargetsFilePath>$(MSBuildExtensionsPath32)\Extensions\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.$(MSBuildTargetsLanguageName).targets</MSBuildTargetsFilePath>
-      </PropertyGroup>
-    </When>
     <When Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable'">
       <PropertyGroup>
         <MSBuildTargetsFilePath>$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.$(MSBuildTargetsLanguageName).targets</MSBuildTargetsFilePath>


### PR DESCRIPTION
Infrastructure change

MSBuild team fixed the issue we were seeing in the portable targets and
now we can remove the work around we added for it.

https://github.com/Microsoft/msbuild/issues/1533
