### PR TITLE
Semantic model should use the first non-empty token of statement to determine binder

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1172,6 +1172,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var fullSpan = this.Root.FullSpan;
             var position = node.SpanStart;
+            if (node is StatementSyntax)
+            {
+                // skip zero-width tokens to get the postion, but never get past the end of the node
+                int betterPosition = node.GetFirstToken(includeZeroWidth: false).SpanStart;
+                if (betterPosition < node.Span.End)
+                {
+                    position = betterPosition;
+                }
+            }
 
             if (fullSpan.IsEmpty)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -28825,6 +28825,30 @@ public static class S
         }
 
         [Fact]
+        [WorkItem(363727, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/363727")]
+        public void FindCorrectBinderOnEmbeddedStatementWithMissingIdentifier()
+        {
+            var source =
+    @"
+public class C
+{
+    static void M(string x)
+    {
+        if(true)
+            && int.TryParse(x, out int y)) id(iVal);
+        // Note that the embedded statement is parsed as a missing identifier, followed by && with many spaces attached as leading trivia
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, references: new[] { SystemCoreRef });
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var x = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(n => n.ToString() == "x").Single();
+            Assert.Equal("x", x.ToString());
+            Assert.Equal("System.String x", model.GetSymbolInfo(x).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
         public void DeclarationInLocalFunctionParameterDefault()
         {
             var text = @"


### PR DESCRIPTION
**Customer scenario**

While the user is editing, some bad code that includes some declaration expression will cause the semantic model to throw. This causes VS to crash.
In the following example, `GetSymbolInfo` on `x` triggers binding of the embedded statement, but that would have failed because the wrong binder was used.

```C#
if(true)
            && int.TryParse(x, out int y)) id(iVal);
```

**Bugs this fixes:** 

Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=363727

**Workarounds, if any**

Valid code would not cause this problem. Also, any variant of the code that doesn't cause a missing token to be parsed on the second line (for example, deleting `&&`).

**Risk**
The risk is low. The fix was kept tight to minimize risk. Only statements will get this adjustment and only empty tokens are skipped.

**Performance impact**
Low. The additional computation is negligible.

**Is this a regression from a previous update?**
No. This was already broken in RC.2 and I think all the way back in June.

**Root cause analysis:**
The wrong binder was picked because the embedded statement is parsed as a missing token (at the start of the second line), followed by `&&` (with the spaces attached as trivia). The various adjustments of the position for finding the binder would result in the closing paren of the first line to be selected. Now, the position of the `&&` is selected (the syntax with zero-width within a statement is ignored).

**How was the bug found?**
Watson crash.

@dotnet/roslyn-compiler for review.