### PR TITLE
Handling null in is pattern when type is missing

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -131,6 +131,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             out bool wasExpression,
             bool wasSwitchCase)
         {
+            Debug.Assert((object)operandType != null);
+
             var expression = BindValue(patternExpression, diagnostics, BindValueKind.RValue);
             ConstantValue constantValueOpt = null;
             var convertedExpression = ConvertPatternExpression(operandType, patternExpression, expression, ref constantValueOpt, diagnostics);


### PR DESCRIPTION
**Customer scenario**
Type `if (null is ID) { }` and VS crashes.

**Bugs this fixes:** 
Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=336030

**Workarounds, if any**
Only type correct and complete code when using `is` operator.

**Risk**
**Performance impact**
Low. Just adding an error and falling back to an error type instead of null type.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
The binding for the `is` operator (in `BindIsOperator`) will try to bind a constant pattern, when the right part doesn't look like a valid type. But that code path expects a non-null operand type.

**How was the bug found?**
Reported by customer.

@dotnet/roslyn-compiler for review for RTM.

I did a very localized fix (because RTM) and looked at other ways of reaching `BindConstantPattern` with a null `operandType`, but the other paths I tried seem safe. Let me know if you have other ideas.