### PR TITLE
Append editorconfig namingstyle options to the top of the workspace o…

### DIFF
--- a/src/EditorFeatures/Next/Options/EditorConfigDocumentOptionsProvider.DocumentOptions.cs
+++ b/src/EditorFeatures/Next/Options/EditorConfigDocumentOptionsProvider.DocumentOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.Options
                 _errorLogger = errorLogger;
             }
 
-            public bool TryGetDocumentOption(Document document, OptionKey option, out object value)
+            public bool TryGetDocumentOption(Document document, OptionKey option, OptionSet underlyingOptions, out object value)
             {
                 var editorConfigPersistence = option.Option.StorageLocations.OfType<EditorConfigStorageLocation>().SingleOrDefault();
                 if (editorConfigPersistence == null)
@@ -32,7 +32,8 @@ namespace Microsoft.CodeAnalysis.Editor.Options
                 var allRawConventions = _codingConventionSnapshot.AllRawConventions;
                 try
                 {
-                    return editorConfigPersistence.TryParseReadonlyDictionary(allRawConventions, option.Option.Type, out value);
+                    var underlyingOption = underlyingOptions.GetOption(option);
+                    return editorConfigPersistence.TryGetOption(underlyingOption, allRawConventions, option.Option.Type, out value);
                 }
                 catch (Exception ex)
                 {

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/NamingStylePreferencesExtensions.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/NamingStylePreferencesExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
+{
+    internal static class NamingStylePreferencesExtensions
+    {
+        public static NamingStylePreferences AppendNamingStylePreferencesToFront(this NamingStylePreferences original, NamingStylePreferences newPreferences)
+        {
+            var symbolSpecifications = original.SymbolSpecifications.InsertRange(0, newPreferences.SymbolSpecifications);
+            var namingStyles = original.NamingStyles.InsertRange(0, newPreferences.NamingStyles);
+            var namingRules = original.NamingRules.InsertRange(0, newPreferences.NamingRules);
+            return new NamingStylePreferences(symbolSpecifications, namingStyles, namingRules);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/NamingStylePreferencesExtensions.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/NamingStylePreferencesExtensions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 {
     internal static class NamingStylePreferencesExtensions
     {
-        public static NamingStylePreferences AppendNamingStylePreferencesToFront(this NamingStylePreferences original, NamingStylePreferences newPreferences)
+        public static NamingStylePreferences PrependNamingStylePreferences(this NamingStylePreferences original, NamingStylePreferences newPreferences)
         {
             var symbolSpecifications = original.SymbolSpecifications.InsertRange(0, newPreferences.SymbolSpecifications);
             var namingStyles = original.NamingStyles.InsertRange(0, newPreferences.NamingStyles);

--- a/src/Workspaces/Core/Portable/Options/IDocumentOptions.cs
+++ b/src/Workspaces/Core/Portable/Options/IDocumentOptions.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.Options
     /// </summary>
     interface IDocumentOptions
     {
-        bool TryGetDocumentOption(Document document, OptionKey option, out object value);
+        bool TryGetDocumentOption(Document document, OptionKey option, OptionSet underlyingOptions, out object value);
     }
 }

--- a/src/Workspaces/Core/Portable/Options/OptionServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionServiceFactory.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Options
 
                     foreach (var documentOptionSource in _documentOptions)
                     {
-                        if (documentOptionSource.TryGetDocumentOption(_document, optionKey, out value))
+                        if (documentOptionSource.TryGetDocumentOption(_document, optionKey, _underlyingOptions, out value))
                         {
                             // Cache and return
                             lock (_gate)

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -383,6 +383,7 @@
     <Compile Include="FindSymbols\SyntaxTree\SyntaxTreeIndex.cs" />
     <Compile Include="FindSymbols\SyntaxTree\SyntaxTreeIndex.DeclarationInfo.cs" />
     <Compile Include="FindSymbols\SyntaxTree\SyntaxTreeIndex.IdentifierInfo.cs" />
+    <Compile Include="NamingStyles\Serialization\NamingStylePreferencesExtensions.cs" />
     <Compile Include="PatternMatching\PatternMatch.cs" />
     <Compile Include="PatternMatching\PatternMatcher.cs" />
     <Compile Include="PatternMatching\PatternMatcher.Segment.cs" />

--- a/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
+++ b/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
@@ -2,20 +2,78 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.NamingStyles;
 using Microsoft.CodeAnalysis.Options;
 using Xunit;
+using static Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.EditorConfigNamingStyleParser;
 
 namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
 {
     public class EditorConfigStorageLocationTests
     {
         [Fact]
-        public static void TestEmptyDictionaryReturnFalse()
+        public static void TestEmptyDictionaryReturnNoNamingStylePreferencesObjectReturnsFalse()
         {
             var editorConfigStorageLocation = new EditorConfigStorageLocation();
-            var result = editorConfigStorageLocation.TryParseReadonlyDictionary(new Dictionary<string, object>(), typeof(NamingStylePreferences), out var @object);
+            var result = editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(NamingStylePreferences), out var @object);
             Assert.False(result, "Expected TryParseReadonlyDictionary to return 'false' for empty dictionary");
+        }
+
+        [Fact]
+        public static void TestEmptyDictionaryDefaultNamingStylePreferencesObjectReturnsFalse()
+        {
+            var editorConfigStorageLocation = new EditorConfigStorageLocation();
+            var existingNamingStylePreferences = new NamingStylePreferences(
+                ImmutableArray.Create<SymbolSpecification>(),
+                ImmutableArray.Create<NamingStyle>(),
+                ImmutableArray.Create<SerializableNamingRule>());
+
+            var result = editorConfigStorageLocation.TryGetOption(
+                existingNamingStylePreferences,
+                new Dictionary<string, object>(),
+                typeof(NamingStylePreferences),
+                out var @object);
+
+            Assert.False(result, "Expected TryParseReadonlyDictionary to return 'false' for empty dictionary");
+        }
+
+        [Fact]
+        public static void TestNonEmptyDictionaryReturnsTrue()
+        {
+            var initialDictionary = new Dictionary<string, object>()
+            {
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity"] = "warning",
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.symbols"] = "method_and_property_symbols",
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.style"] = "pascal_case_style",
+                ["dotnet_naming_symbols.method_and_property_symbols.applicable_kinds"] = "method,property",
+                ["dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities"] = "*",
+                ["dotnet_naming_style.pascal_case_style.capitalization"] = "pascal_case"
+            };
+            var existingNamingStylePreferences = ParseDictionary(initialDictionary);
+
+            var editorConfigStorageLocation = new EditorConfigStorageLocation();
+            var newDictionary = new Dictionary<string, object>()
+            {
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity"] = "error",
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.symbols"] = "method_and_property_symbols",
+                ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.style"] = "pascal_case_style",
+                ["dotnet_naming_symbols.method_and_property_symbols.applicable_kinds"] = "method,property",
+                ["dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities"] = "*",
+                ["dotnet_naming_style.pascal_case_style.capitalization"] = "pascal_case"
+            };
+
+            var result = editorConfigStorageLocation.TryGetOption(
+                existingNamingStylePreferences,
+                newDictionary,
+                typeof(NamingStylePreferences),
+                out var combinedNamingStyles);
+
+            Assert.True(result, "Expected non-empty dictionary to return true");
+            var isNamingStylePreferencesObject = combinedNamingStyles is NamingStylePreferences;
+            Assert.True(isNamingStylePreferencesObject, $"Expected returned object to be of type '{nameof(NamingStylePreferences)}'");
+            Assert.Equal(DiagnosticSeverity.Error, ((NamingStylePreferences)combinedNamingStyles).Rules.NamingRules[0].EnforcementLevel);
         }
 
         [Fact]
@@ -24,7 +82,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
             var editorConfigStorageLocation = new EditorConfigStorageLocation();
             Assert.Throws<NotSupportedException>(() =>
             {
-                editorConfigStorageLocation.TryParseReadonlyDictionary(new Dictionary<string, object>(), typeof(object), out var @object);
+                editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(object), out var @object);
             });
         }
     }

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -68,10 +68,10 @@
   <ItemGroup>
     <Compile Include="CodeStyle\EditorConfigCodeStyleParserTests.cs" />
     <Compile Include="DependentTypeFinderTests.cs" />
-    <Compile Include="EditorConfigStorageLocation\EditorConfigStorageLocationTests.cs" />
     <Compile Include="Differencing\LongestCommonSubsequenceTests.cs" />
     <Compile Include="Editting\SyntaxEditorTests.cs" />
     <Compile Include="Execution\Extensions.cs" />
+    <Compile Include="EditorConfigStorageLocation\EditorConfigStorageLocationTests.cs" />
     <Compile Include="Execution\SnapshotSerializationTestBase.cs" />
     <Compile Include="Execution\SnapshotSerializationTests.cs" />
     <Compile Include="ExtensionOrdererTests.cs" />


### PR DESCRIPTION
Previously if we encountered an editorconfig file it would override naming styles the user had set in Visual Studio.  With this change the editorconfig styles are appended on top of the Visual Studio styles ensuring that editorconfig will always override Visual Studio if the styles conflict, but allowing naming styles specified in Visual Studio to still be used if there is no conflict