### PR TITLE
Add missed code style options to automation object

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -572,6 +572,48 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set { SetXmlOption(CodeStyleOptions.QualifyEventAccess, value); }
         }
 
+        public string Style_PreferThrowExpression
+        {
+            get { return GetXmlOption(CodeStyleOptions.PreferThrowExpression); }
+            set { SetXmlOption(CodeStyleOptions.PreferThrowExpression, value); }
+        }
+
+        public string Style_PreferObjectInitializer
+        {
+            get { return GetXmlOption(CodeStyleOptions.PreferObjectInitializer); }
+            set { SetXmlOption(CodeStyleOptions.PreferObjectInitializer, value); }
+        }
+
+        public string Style_PreferCollectionInitializer
+        {
+            get { return GetXmlOption(CodeStyleOptions.PreferCollectionInitializer); }
+            set { SetXmlOption(CodeStyleOptions.PreferCollectionInitializer, value); }
+        }
+
+        public string Style_PreferCoalesceExpression
+        {
+            get { return GetXmlOption(CodeStyleOptions.PreferCoalesceExpression); }
+            set { SetXmlOption(CodeStyleOptions.PreferCoalesceExpression, value); }
+        }
+
+        public string Style_PreferNullPropagation
+        {
+            get { return GetXmlOption(CodeStyleOptions.PreferNullPropagation); }
+            set { SetXmlOption(CodeStyleOptions.PreferNullPropagation, value); }
+        }
+
+        public string Style_PreferInlinedVariableDeclaration
+        {
+            get { return GetXmlOption(CodeStyleOptions.PreferInlinedVariableDeclaration); }
+            set { SetXmlOption(CodeStyleOptions.PreferInlinedVariableDeclaration, value); }
+        }
+
+        public string Style_PreferExplicitTupleNames
+        {
+            get { return GetXmlOption(CodeStyleOptions.PreferExplicitTupleNames); }
+            set { SetXmlOption(CodeStyleOptions.PreferExplicitTupleNames, value); }
+        }
+
         [Obsolete("Use Style_UseImplicitTypeWherePossible, Style_UseImplicitTypeWhereApparent or Style_UseImplicitTypeForIntrinsicTypes", error: true)]
         public int Style_UseVarWhenDeclaringLocals
         {
@@ -595,6 +637,66 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get { return GetXmlOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes); }
             set { SetXmlOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, value); }
+        }
+
+        public string Style_PreferConditionalDelegateCall
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferConditionalDelegateCall); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferConditionalDelegateCall, value); }
+        }
+
+        public string Style_PreferPatternMatchingOverAsWithNullCheck
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck, value); }
+        }
+
+        public string Style_PreferPatternMatchingOverIsWithCastCheck
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck, value); }
+        }
+
+        public string Style_PreferExpressionBodiedConstructors
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, value); }
+        }
+
+        public string Style_PreferExpressionBodiedMethods
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedMethods); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, value); }
+        }
+
+        public string Style_PreferExpressionBodiedOperators
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedOperators); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedOperators, value); }
+        }
+
+        public string Style_PreferExpressionBodiedProperties
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, value); }
+        }
+
+        public string Style_PreferExpressionBodiedIndexers
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedIndexers); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, value); }
+        }
+
+        public string Style_PreferExpressionBodiedAccessors
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, value); }
+        }
+
+        public string Style_PreferBraces
+        {
+            get { return GetXmlOption(CSharpCodeStyleOptions.PreferBraces); }
+            set { SetXmlOption(CSharpCodeStyleOptions.PreferBraces, value); }
         }
 
         public int Wrapping_IgnoreSpacesAroundBinaryOperators

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
@@ -197,6 +197,70 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
             End Set
         End Property
 
+
+        Public Property Style_PreferThrowExpression As String
+            Get
+                Return GetXmlOption(CodeStyleOptions.PreferThrowExpression)
+            End Get
+            Set(value As String)
+                SetXmlOption(CodeStyleOptions.PreferThrowExpression, value)
+            End Set
+        End Property
+
+        Public Property Style_PreferObjectInitializer As String
+            Get
+                Return GetXmlOption(CodeStyleOptions.PreferObjectInitializer)
+            End Get
+            Set(value As String)
+                SetXmlOption(CodeStyleOptions.PreferObjectInitializer, value)
+            End Set
+        End Property
+
+        Public Property Style_PreferCollectionInitializer As String
+            Get
+                Return GetXmlOption(CodeStyleOptions.PreferCollectionInitializer)
+            End Get
+            Set(value As String)
+                SetXmlOption(CodeStyleOptions.PreferCollectionInitializer, value)
+            End Set
+        End Property
+
+        Public Property Style_PreferCoalesceExpression As String
+            Get
+                Return GetXmlOption(CodeStyleOptions.PreferCoalesceExpression)
+            End Get
+            Set(value As String)
+                SetXmlOption(CodeStyleOptions.PreferCoalesceExpression, value)
+            End Set
+        End Property
+
+        Public Property Style_PreferNullPropagation As String
+            Get
+                Return GetXmlOption(CodeStyleOptions.PreferNullPropagation)
+            End Get
+            Set(value As String)
+                SetXmlOption(CodeStyleOptions.PreferNullPropagation, value)
+            End Set
+        End Property
+
+        Public Property Style_PreferInlinedVariableDeclaration As String
+            Get
+                Return GetXmlOption(CodeStyleOptions.PreferInlinedVariableDeclaration)
+            End Get
+            Set(value As String)
+                SetXmlOption(CodeStyleOptions.PreferInlinedVariableDeclaration, value)
+            End Set
+        End Property
+
+        Public Property Style_PreferExplicitTupleNames As String
+            Get
+                Return GetXmlOption(CodeStyleOptions.PreferExplicitTupleNames)
+            End Get
+            Set(value As String)
+                SetXmlOption(CodeStyleOptions.PreferExplicitTupleNames, value)
+            End Set
+        End Property
+
         Public Property Option_PlaceSystemNamespaceFirst As Boolean
             Get
                 Return GetBooleanOption(GenerationOptions.PlaceSystemNamespaceFirst)


### PR DESCRIPTION
**Customer scenario**

Customer is unable to import or export most codestyle settings

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/14810

**Workarounds, if any**

Manually reset the options on each machine, or log in and have them roam with other VS settings

**Risk**

Low, we are adding options to the automation object.  This fix is very self-contained

**Performance impact**

Low, export/import of settings is an explicit user actions that has its own dialog and must be initiated by the user, it is not part of any mainline scenario

**Is this a regression from a previous update?**

Users have always been able to import/export all of tools->options so this is an experience regression, though these options are new so you could say these options have not been shipped before so this is not a regression.

**Root cause analysis:**

The Automation object class is what is reflected over by VS to import/export settings.  As more codestyle settings were added this release we forgot to update the automation object.

**How was the bug found?**

reported by customer