### PR TITLE
Handle Color Color constant pattern

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -984,7 +984,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundExpression BindQualifiedName(QualifiedNameSyntax node, DiagnosticBag diagnostics)
         {
-            return BindMemberAccessWithBoundLeft(node, this.BindExpression(node.Left, diagnostics), node.Right, node.DotToken, invoked: false, indexed: false, diagnostics: diagnostics);
+            return BindMemberAccessWithBoundLeft(node, this.BindLeftOfPotentialColorColorMemberAccess(node.Left, diagnostics), node.Right, node.DotToken, invoked: false, indexed: false, diagnostics: diagnostics);
         }
 
         private BoundExpression BindParenthesizedExpression(ExpressionSyntax innerExpression, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4324,20 +4324,29 @@ public class Program
         {
             var source =
 @"
-class Foo {
-  public Color Color { get; }
+public class Program
+{
+    public static Color Color { get; }
 
-  public void M(object o) {
-    if (o is Color.Constant) { }
-  }
+    public static void M(object o)
+    {
+        System.Console.WriteLine(o is Color.Constant);
+    }
+
+    public static void Main()
+    {
+        M(Color.Constant);
+    }
 }
 
-class Color {
-  public const string Constant = ""abc"";
+public class Color
+{
+    public const string Constant = ""abc"";
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics();
+            var comp = CompileAndVerify(compilation, expectedOutput: "True");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4318,5 +4318,26 @@ public class Program
             compilation.VerifyDiagnostics();
             var comp = CompileAndVerify(compilation, expectedOutput: "True");
         }
+
+        [Fact]
+        public void ColorColorConstantPattern()
+        {
+            var source =
+@"
+class Foo {
+  public Color Color { get; }
+
+  public void M(object o) {
+    if (o is Color.Constant) { }
+  }
+}
+
+class Color {
+  public const string Constant = ""abc"";
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Pattern-matching using a constant pattern that is subject to the C# language Color-Color rule doesn't work correctly, reported an error instead of binding.

**Bugs this fixes:** 

Fixes #16517

**Workarounds, if any**

Avoid Color-Color scenarios for constant patterns.

**Risk**

Low; this simply changes the binding of the left-hand-side to use a helper for the Color-Color situation.

**Performance impact**

Low; A trivial amount of new code using an existing helper addresses the problem.

**Is this a regression from a previous update?**

No; this is a bug in a new feature.

**Root cause analysis:**

Insufficient test coverage. Lack of dedicated testing team. Failure to follow through on our engineering test plan to pair a developer to "break" each feature under development.

**How was the bug found?**

Customer reported. The fix is provided by the reporter.

@dotnet/roslyn-compiler Please review.
