### PR TITLE
Make Local Functions follow brace newline option for methods

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -808,11 +808,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Place open brace on new line for methods.
+        ///   Looks up a localized string similar to Place open brace on new line for methods and local functions.
         /// </summary>
-        internal static string Place_open_brace_on_new_line_for_methods {
+        internal static string Place_open_brace_on_new_line_for_methods_local_functions {
             get {
-                return ResourceManager.GetString("Place_open_brace_on_new_line_for_methods", resourceCulture);
+                return ResourceManager.GetString("Place_open_brace_on_new_line_for_methods_local_functions", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -189,8 +189,8 @@
   <data name="Place_open_brace_on_new_line_for_lambda_expression" xml:space="preserve">
     <value>Place open brace on new line for lambda expression</value>
   </data>
-  <data name="Place_open_brace_on_new_line_for_methods" xml:space="preserve">
-    <value>Place open brace on new line for methods</value>
+  <data name="Place_open_brace_on_new_line_for_methods_local_functions" xml:space="preserve">
+    <value>Place open brace on new line for methods and local functions</value>
   </data>
   <data name="Place_open_brace_on_new_line_for_object_collection_and_array_initializers" xml:space="preserve">
     <value>Place open brace on new line for object, collection and array initializers</value>

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/NewLinesViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/NewLinesViewModel.cs
@@ -21,13 +21,13 @@ class C {
         private static string s_methodPreview = @"class c {
 //[
     void Foo(){
-        int bar = 42;
+        Console.WriteLine();
 
         int LocalFunction(int x) {
             return 2 * x;
         }
 
-        var baz = 9.75;
+        Console.ReadLine();
     }
 //]
 }";

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/NewLinesViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/NewLinesViewModel.cs
@@ -21,6 +21,13 @@ class C {
         private static string s_methodPreview = @"class c {
 //[
     void Foo(){
+        int bar = 42;
+
+        int LocalFunction(int x) {
+            return 2 * x;
+        }
+
+        var baz = 9.75;
     }
 //]
 }";
@@ -192,7 +199,7 @@ class B {
         {
             Items.Add(new HeaderItemViewModel() { Header = CSharpVSResources.New_line_options_for_braces });
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.NewLinesForBracesInTypes, CSharpVSResources.Place_open_brace_on_new_line_for_types, s_previewText, this, options));
-            Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.NewLinesForBracesInMethods, CSharpVSResources.Place_open_brace_on_new_line_for_methods, s_methodPreview, this, options));
+            Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.NewLinesForBracesInMethods, CSharpVSResources.Place_open_brace_on_new_line_for_methods_local_functions, s_methodPreview, this, options));
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.NewLinesForBracesInProperties, CSharpVSResources.Place_open_brace_on_new_line_for_properties_indexers_and_events, s_propertyPreview, this, options));
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.NewLinesForBracesInAccessors, CSharpVSResources.Place_open_brace_on_new_line_for_property_indexer_and_event_accessors, s_propertyPreview, this, options));
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods, CSharpVSResources.Place_open_brace_on_new_line_for_anonymous_methods, s_anonymousMethodPreview, this, options));

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -116,6 +116,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
+            // * { - in the anonymous Method context
+            if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentTokenParentParent != null && currentTokenParentParent.IsKind(SyntaxKind.LocalFunctionStatement))
+            {
+                if (!optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
+                {
+                    operation = CreateAdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);
+                }
+            }
+
             // * { - in the Lambda context
             if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentTokenParentParent != null &&
                (currentTokenParentParent.IsKind(SyntaxKind.SimpleLambdaExpression) || currentTokenParentParent.IsKind(SyntaxKind.ParenthesizedLambdaExpression)))
@@ -300,6 +309,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentToken.Kind() == SyntaxKind.OpenBraceToken && currentTokenParentParent != null && currentTokenParentParent.Kind() == SyntaxKind.AnonymousMethodExpression)
             {
                 if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods))
+                {
+                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLinesIfOnSingleLine);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            // * { - in the local function context
+            if (currentToken.Kind() == SyntaxKind.OpenBraceToken && currentTokenParentParent != null && currentTokenParentParent.Kind() == SyntaxKind.LocalFunctionStatement)
+            {
+                if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
                 {
                     return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLinesIfOnSingleLine);
                 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
-            // * { - in the anonymous Method context
+            // * { - in the local function context
             if (currentToken.IsKind(SyntaxKind.OpenBraceToken) && currentTokenParentParent != null && currentTokenParentParent.IsKind(SyntaxKind.LocalFunctionStatement))
             {
                 if (!optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 if (optionSet.GetOption(CSharpFormattingOptions.NewLinesForBracesInMethods))
                 {
-                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLinesIfOnSingleLine);
+                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
                 }
                 else
                 {

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -1446,6 +1446,10 @@ class foo{int x = 0;}", false, changingOptions);
         {
         };
 
+        async void LocalFunction()
+        {
+        }
+
         try
         {
         }
@@ -1504,6 +1508,9 @@ else
 var obj1 = new foo         
             {
                             };
+
+        async void LocalFunction() {
+        }
 
            try
         {
@@ -1569,6 +1576,9 @@ public class foo : System.Object
         var obj1 = new foo {
         };
 
+        async void LocalFunction() {
+        }
+
         try {
         }
         catch (Exception e) {
@@ -1616,6 +1626,10 @@ else
 var obj1 = new foo         
             {
                             };
+
+        async void LocalFunction() 
+            {
+    }
 
            try
         {


### PR DESCRIPTION

**Customer scenario**

Make local functions follow customer newline options


User types a local function with their preferred newline formatting, such as:
```C#
void M() {
    throw null;
}
```
Even if they disable the VS option to insert newlines for braces in functions, auto-formatting will turn it into:
```C#
void M()
{
    throw null;
}
```

**Bugs this fixes:** 
Fixes #14119

**Workarounds, if any**
Have an inconsistent codebase, or don't use the auto-formatter on files with local functions.

**Risk** 
Low. Additional case in formatting rules, specific to local functions.

**Performance impact**
Low; simple new codepath with one allocations in non-hot path.

**Is this a regression from a previous update?** 
No

**Root cause analysis:** 
New feature

**How was the bug found?** 
Ad-hoc testing