### PR TITLE
Fix newline formatting for local funcs

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -266,8 +266,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             var currentTokenParentParent = currentToken.Parent.Parent;
 
-            // * { - in the member declaration context
-            if (currentToken.Kind() == SyntaxKind.OpenBraceToken && currentTokenParentParent != null && currentTokenParentParent is MemberDeclarationSyntax)
+            // * { - in the member declaration or local function context
+            if (currentToken.Kind() == SyntaxKind.OpenBraceToken && currentTokenParentParent != null &&
+                (currentTokenParentParent is MemberDeclarationSyntax || currentTokenParentParent.IsKind(SyntaxKind.LocalFunctionStatement)))
             {
                 var option = currentTokenParentParent is BasePropertyDeclarationSyntax
                     ? CSharpFormattingOptions.NewLinesForBracesInProperties

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4465,6 +4465,61 @@ var(x,y)=(1,2);
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task LocalFunctionWithNewLinesForBraces()
+        {
+            var code = @"class C
+{
+    void M1()
+    {
+        void M2()     {
+            throw null;
+                }
+    }
+}";
+            var expectedCode = @"class C
+{
+    void M1()
+    {
+        void M2()
+        {
+            throw null;
+        }
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task LocalFunctionWithoutNewLinesForBraces()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>();
+            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInTypes, false);
+            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInMethods, false);
+
+            var code =
+@"class C {
+    void M1()    {
+        void M2()     {
+            throw null;
+        }
+    }
+}";
+            var expectedCode =
+@"class C {
+    void M1() {
+        void M2() {
+            throw null;
+        }
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code, changedOptionSet: changingOptions);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task SpacingInTupleExtension()
         {
             var code = @"static class Class5


### PR DESCRIPTION
**Customer scenario**

User types a local function with their preferred newline formatting, such as:
```C#
void M() {
    throw null;
}
```
Even if they disable the VS option to insert newlines for braces in functions, auto-formatting will turn it into:
```C#
void M()
{
    throw null;
}
```

**Bugs this fixes:** 
https://github.com/dotnet/roslyn/issues/14119

**Workarounds, if any**
Don't invoke auto-formatting.

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)