### PR TITLE
Type nested in generic type cannot be task-like

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1317,7 +1317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(type.SpecialType != SpecialType.System_Void);
 
             var arity = type.Arity;
-            if (arity < 2)
+            if (arity < 2 && ((object)type.ContainingType == null || !type.ContainingType.IsGenericType))
             {
                 // Find the AsyncBuilder attribute.
                 foreach (var attr in type.GetAttributes())


### PR DESCRIPTION
**Customer scenario**

The user makes a task-like type, but it is nested in a generic type. The compilation fails to emit module, but no diagnostic related to this type or the async code is reported.

For example:
```C#
public class TypeParametersProvider<T>
{
    [AsyncMethodBuilder(typeof(AsyncValueTaskMethodBuilder))]
    public struct ValueTask
    {
    }
}
```

**Bugs this fixes:** 
Fixes https://github.com/dotnet/roslyn/issues/16493

**Workarounds, if any**
Avoid such bad code.

**Risk**
**Performance impact**
Low. Additional check on containing type in method that checks task-like types.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
New feature.

**How was the bug found?**
Reported by customer.

@cston @dotnet/roslyn-compiler for review.