### PR TITLE
Add EditorConfig settings for source formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -68,3 +68,11 @@ csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true


### PR DESCRIPTION
**Customer scenario**

Working on Roslyn source if you use different source formatting options for your own projects

**Workarounds, if any** Don't use the formatter, or make a separate VS profile.

+ @Pilchie @kuhlenh @jmarolf to think about option names