### PR TITLE
make sure we empty out information in solution/project/documentInfo w…

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -73,7 +73,10 @@ namespace Microsoft.CodeAnalysis
                 language,
                 services);
 
-            // remove any initial loader so we don't keep source alive
+            // ownership of TextLoader information has moved to document state. clear out textloader the info is
+            // holding on. otherwise, these information will be held onto unnecesarily by documentInfo even after
+            // the info has changed by DocumentState.
+            // we hold onto the info so that we don't need to duplicate all information info already has in the state
             info = info.WithTextLoader(null);
 
             return new DocumentState(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -59,13 +59,18 @@ namespace Microsoft.CodeAnalysis
             _branchId = branchId;
             _workspaceVersion = workspaceVersion;
             _solutionServices = solutionServices;
-            _solutionInfo = solutionInfo;
             _projectIds = projectIds.ToImmutableReadOnlyListOrEmpty();
             _projectIdToProjectStateMap = idToProjectStateMap;
             _projectIdToTrackerMap = projectIdToTrackerMap;
             _linkedFilesMap = linkedFilesMap;
             _dependencyGraph = dependencyGraph;
             _lazyLatestProjectVersion = lazyLatestProjectVersion;
+
+            // ownership of information on project has moved to solution state. clear out projectInfo the state is
+            // holding on. otherwise, these information will be held onto unnecesarily by solutionInfo even after
+            // the info has changed by ProjectState.
+            // we hold onto the info so that we don't need to duplicate all information info already has in the state
+            _solutionInfo = solutionInfo.WithProjects(ImmutableArray<ProjectInfo>.Empty);
 
             // when solution state is changed, we re-calcuate its checksum
             _lazyChecksums = new AsyncLazy<SolutionStateChecksums>(ComputeChecksumsAsync, cacheResult: true);
@@ -407,8 +412,7 @@ namespace Microsoft.CodeAnalysis
         private SolutionState AddProject(ProjectId projectId, ProjectState projectState)
         {
             // changed project list so, increment version.
-            var newSolutionInfo = _solutionInfo.WithVersion(this.Version.GetNewerVersion())
-                                               .WithProjects(_solutionInfo.Projects.Concat(projectState.ProjectInfo));
+            var newSolutionInfo = _solutionInfo.WithVersion(this.Version.GetNewerVersion());
 
             var newProjectIds = _projectIds.ToImmutableArray().Add(projectId);
             var newStateMap = _projectIdToProjectStateMap.Add(projectId, projectState);
@@ -502,8 +506,7 @@ namespace Microsoft.CodeAnalysis
             CheckContainsProject(projectId);
 
             // changed project list so, increment version.
-            var newSolutionInfo = _solutionInfo.WithVersion(this.Version.GetNewerVersion())
-                                               .WithProjects(_solutionInfo.Projects.Where(s => s.Id != projectId));
+            var newSolutionInfo = _solutionInfo.WithVersion(this.Version.GetNewerVersion());
 
             var newProjectIds = _projectIds.ToImmutableArray().Remove(projectId);
             var newStateMap = _projectIdToProjectStateMap.Remove(projectId);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -86,7 +86,10 @@ namespace Microsoft.CodeAnalysis
                 ? CreateRecoverableText(info.TextLoader, info.Id, services, reportInvalidDataException: false)
                 : CreateStrongText(TextAndVersion.Create(SourceText.From(string.Empty, Encoding.UTF8), VersionStamp.Default, info.FilePath));
 
-            // remove any initial loader so we don't keep source alive
+            // ownership of TextLoader information has moved to document state. clear out textloader the info is
+            // holding on. otherwise, these information will be held onto unnecesarily by documentInfo even after
+            // the info has changed by DocumentState.
+            // we hold onto the info so that we don't need to duplicate all information info already has in the state
             info = info.WithTextLoader(null);
 
             return new TextDocumentState(


### PR DESCRIPTION
…hose ownership is moved to Solution/Project/DocumentState

otherwise, we will keep holding on staled data longer than necessary.

this change makes OOP to consume 300MB less in roslyn size solution.

**Customer scenario**

users open a solution in VS. and memory consumption in roslyn out of proc goes down. this is pure performance optimization. with Roslyn solution, this reduce memory consumption up to 300MB after initial solution population time.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16570

**Workarounds, if any**

there is no workaround. this is a perf optimization.

**Risk**

I don't see a risk. it basically letting go staled data.

**Performance impact**

it reduces amount of memory held onto by OOP. the initial memory required to set up OOP process is same. but after that, around 3 mins later, memory consumption is down 300+MB compared to previous bits.

here are comparison of memory consumption with fix and no fix.
![image](https://cloud.githubusercontent.com/assets/1333179/22046023/d41a5b8c-dcd2-11e6-9530-7d12ef0ee223.png)

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Initial textloader wasn't get cleared after it is saved to temporary storage. causing process to hold onto all initial text loader given to workspace. it wasn't big deal for VS which uses FileLoader (holding onto path to a file) but it was quite a bit of memory for OOP since it uses TextLoader which hold onto actual content not file path.

**How was the bug found?**

while investigating some performance issue.
