### PR TITLE
Harden compiler against exceptions during stream dispose

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7070,6 +7070,101 @@ Copyright (C) Microsoft Corporation. All rights reserved.", output);
         }
 
         [Fact]
+        public void IOFailure_DisposeOutputFile()
+        {
+            var srcPath = MakeTrivialExe(Temp.CreateDirectory().Path);
+            var exePath = Path.Combine(Path.GetDirectoryName(srcPath), "test.exe");
+            var csc = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/preferreduilang:en", $"/out:{exePath}", srcPath });
+            csc.FileOpen = (file, mode, access, share) =>
+            {
+                if (file == exePath)
+                {
+                    return new TestStream(backingStream: new MemoryStream(),
+                        dispose: () => { throw new IOException("Fake IOException"); });
+                }
+
+                return File.Open(file, mode, access, share);
+            };
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            Assert.Equal(1, csc.Run(outWriter));
+            Assert.Equal($"error CS0016: Could not write to output file '{exePath}' -- 'Fake IOException'{Environment.NewLine}", outWriter.ToString());
+        }
+
+        [Fact]
+        public void IOFailure_DisposePdbFile()
+        {
+            var srcPath = MakeTrivialExe(Temp.CreateDirectory().Path);
+            var exePath = Path.Combine(Path.GetDirectoryName(srcPath), "test.exe");
+            var pdbPath = Path.ChangeExtension(exePath, "pdb");
+            var csc = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/preferreduilang:en", "/debug", $"/out:{exePath}", srcPath });
+            csc.FileOpen = (file, mode, access, share) =>
+            {
+                if (file == pdbPath)
+                {
+                    return new TestStream(backingStream: new MemoryStream(),
+                        dispose: () => { throw new IOException("Fake IOException"); });
+                }
+
+                return File.Open(file, mode, access, share);
+            };
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            Assert.Equal(1, csc.Run(outWriter));
+            Assert.Equal($"error CS0016: Could not write to output file '{pdbPath}' -- 'Fake IOException'{Environment.NewLine}", outWriter.ToString());
+        }
+
+        [Fact]
+        public void IOFailure_DisposeXmlFile()
+        {
+            var srcPath = MakeTrivialExe(Temp.CreateDirectory().Path);
+            var xmlPath = Path.Combine(Path.GetDirectoryName(srcPath), "test.xml");
+            var csc = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/preferreduilang:en", $"/doc:{xmlPath}", srcPath });
+            csc.FileOpen = (file, mode, access, share) =>
+            {
+                if (file == xmlPath)
+                {
+                    return new TestStream(backingStream: new MemoryStream(),
+                        dispose: () => { throw new IOException("Fake IOException"); });
+                }
+
+                return File.Open(file, mode, access, share);
+            };
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            Assert.Equal(1, csc.Run(outWriter));
+            Assert.Equal($"error CS0016: Could not write to output file '{xmlPath}' -- 'Fake IOException'{Environment.NewLine}", outWriter.ToString());
+        }
+
+        [Fact]
+        public void IOFailure_DisposeSourceLinkFile()
+        {
+            var srcPath = MakeTrivialExe(Temp.CreateDirectory().Path);
+            var sourceLinkPath = Path.Combine(Path.GetDirectoryName(srcPath), "test.json");
+            var csc = new MockCSharpCompiler(null, _baseDirectory, new[] { "/nologo", "/preferreduilang:en", "/debug:portable", $"/sourcelink:{sourceLinkPath}", srcPath });
+            csc.FileOpen = (file, mode, access, share) =>
+            {
+                if (file == sourceLinkPath)
+                {
+                    return new TestStream(backingStream: new MemoryStream(Encoding.UTF8.GetBytes(@"
+{
+  ""documents"": {
+     ""f:/build/*"" : ""https://raw.githubusercontent.com/my-org/my-project/1111111111111111111111111111111111111111/*""
+  }
+}
+")),
+                        dispose: () => { throw new IOException("Fake IOException"); });
+                }
+
+                return File.Open(file, mode, access, share);
+            };
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            Assert.Equal(1, csc.Run(outWriter));
+            Assert.Equal($"error CS0016: Could not write to output file '{sourceLinkPath}' -- 'Fake IOException'{Environment.NewLine}", outWriter.ToString());
+        }
+
+        [Fact]
         public void IOFailure_OpenOutputFile()
         {
             string sourcePath = MakeTrivialExe();
@@ -7151,9 +7246,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.", output);
             CleanupAllGeneratedFiles(sourcePath);
         }
 
-        private string MakeTrivialExe()
+        private string MakeTrivialExe(string directory = null)
         {
-            return Temp.CreateFile(prefix: "", extension: ".cs").WriteAllText(@"
+            return Temp.CreateFile(directory: directory, prefix: "", extension: ".cs").WriteAllText(@"
 class Program
 {
     public static void Main() { }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7088,7 +7088,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.", output);
 
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             Assert.Equal(1, csc.Run(outWriter));
-            Assert.Contains($"error CS2012: Cannot open '{exePath}' for writing", outWriter.ToString());
+            Assert.Contains($"error CS0016: Could not write to output file '{exePath}' -- 'Fake IOException'{Environment.NewLine}", outWriter.ToString());
         }
 
         [Fact]
@@ -7111,7 +7111,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.", output);
 
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             Assert.Equal(1, csc.Run(outWriter));
-            Assert.Contains($"error CS2012: Cannot open '{pdbPath}' for writing", outWriter.ToString());
+            Assert.Contains($"error CS0016: Could not write to output file '{pdbPath}' -- 'Fake IOException'{Environment.NewLine}", outWriter.ToString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7088,7 +7088,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.", output);
 
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             Assert.Equal(1, csc.Run(outWriter));
-            Assert.Equal($"error CS0016: Could not write to output file '{exePath}' -- 'Fake IOException'{Environment.NewLine}", outWriter.ToString());
+            Assert.Contains($"error CS2012: Cannot open '{exePath}' for writing", outWriter.ToString());
         }
 
         [Fact]
@@ -7111,7 +7111,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.", output);
 
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             Assert.Equal(1, csc.Run(outWriter));
-            Assert.Equal($"error CS0016: Could not write to output file '{pdbPath}' -- 'Fake IOException'{Environment.NewLine}", outWriter.ToString());
+            Assert.Contains($"error CS2012: Cannot open '{pdbPath}' for writing", outWriter.ToString());
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -31,6 +31,7 @@
     </Content>
     <Compile Include="DiagnosticAnalyzer\AnalyzerManager.AnalyzerExecutionContext.cs" />
     <Compile Include="InternalUtilities\CommandLineUtilities.cs" />
+    <Compile Include="InternalUtilities\NoThrowStream.cs" />
     <Compile Include="InternalUtilities\OrderedMultiDictionary.cs" />
     <Compile Include="Serialization\FixedObjectBinder.cs" />
     <Compile Include="Serialization\IObjectReadable.cs" />

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -31,7 +31,7 @@
     </Content>
     <Compile Include="DiagnosticAnalyzer\AnalyzerManager.AnalyzerExecutionContext.cs" />
     <Compile Include="InternalUtilities\CommandLineUtilities.cs" />
-    <Compile Include="InternalUtilities\NoThrowStream.cs" />
+    <Compile Include="InternalUtilities\NoThrowStreamDisposer.cs" />
     <Compile Include="InternalUtilities\OrderedMultiDictionary.cs" />
     <Compile Include="Serialization\FixedObjectBinder.cs" />
     <Compile Include="Serialization\IObjectReadable.cs" />

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
@@ -20,16 +20,16 @@ namespace Microsoft.CodeAnalysis
             private readonly CommonCompiler _compiler;
             private readonly string _filePath;
             private Stream _streamToDispose;
-            private readonly Action<Exception, string> _exceptionHandler;
+            private readonly DiagnosticBag _diagnostics;
 
             internal CompilerEmitStreamProvider(
                 CommonCompiler compiler,
                 string filePath,
-                Action<Exception, string> exceptionHandler)
+                DiagnosticBag diagnostics)
             {
                 _compiler = compiler;
                 _filePath = filePath;
-                _exceptionHandler = exceptionHandler;
+                _diagnostics = diagnostics;
             }
 
             public void Dispose()
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis
                 }
                 catch (Exception e)
                 {
-                    _exceptionHandler(e, _filePath);
+                    ReportOpenFileDiagnostic(_diagnostics, e);
                 }
             }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.CompilerEmitStreamProvider.cs
@@ -20,16 +20,28 @@ namespace Microsoft.CodeAnalysis
             private readonly CommonCompiler _compiler;
             private readonly string _filePath;
             private Stream _streamToDispose;
+            private readonly Action<Exception, string> _exceptionHandler;
 
-            internal CompilerEmitStreamProvider(CommonCompiler compiler, string filePath)
+            internal CompilerEmitStreamProvider(
+                CommonCompiler compiler,
+                string filePath,
+                Action<Exception, string> exceptionHandler)
             {
                 _compiler = compiler;
                 _filePath = filePath;
+                _exceptionHandler = exceptionHandler;
             }
 
             public void Dispose()
             {
-                _streamToDispose?.Dispose();
+                try
+                {
+                    _streamToDispose?.Dispose();
+                }
+                catch (Exception e)
+                {
+                    _exceptionHandler(e, _filePath);
+                }
             }
 
             public override Stream Stream => null;

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -736,17 +736,22 @@ namespace Microsoft.CodeAnalysis
                             var peStreamProvider = new CompilerEmitStreamProvider(this, finalPeFilePath);
                             var pdbStreamProviderOpt = emitPdbFile ? new CompilerEmitStreamProvider(this, finalPdbFilePath) : null;
 
-                            success = compilation.SerializeToPeStream(
-                                moduleBeingBuilt,
-                                peStreamProvider,
-                                pdbStreamProviderOpt,
-                                testSymWriterFactory: null,
-                                diagnostics: diagnosticBag,
-                                metadataOnly: emitOptions.EmitMetadataOnly,
-                                cancellationToken: cancellationToken);
-
-                            peStreamProvider.Close(diagnosticBag);
-                            pdbStreamProviderOpt?.Close(diagnosticBag);
+                            try
+                            {
+                                success = compilation.SerializeToPeStream(
+                                    moduleBeingBuilt,
+                                    peStreamProvider,
+                                    pdbStreamProviderOpt,
+                                    testSymWriterFactory: null,
+                                    diagnostics: diagnosticBag,
+                                    metadataOnly: emitOptions.EmitMetadataOnly,
+                                    cancellationToken: cancellationToken);
+                            }
+                            finally
+                            {
+                                peStreamProvider.Close(diagnosticBag);
+                                pdbStreamProviderOpt?.Close(diagnosticBag);
+                            }
 
                             if (success && touchedFilesLogger != null)
                             {

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -215,6 +216,18 @@ namespace Microsoft.CodeAnalysis
         public abstract int ERR_PeWritingFailure { get; }
         public abstract int ERR_ModuleEmitFailure { get; }
         public abstract int ERR_EncUpdateFailedMissingAttribute { get; }
+
+        /// <summary>
+        /// Takes an exception produced while writing to a file stream and produces a diagnostic.
+        /// </summary>
+        public void ReportStreamWriteException(Exception e, string filePath, TextWriter consoleOutput)
+        {
+            if (consoleOutput != null)
+            {
+                var diagnostic = new DiagnosticInfo(this, ERR_OutputWriteFailed, filePath, e.Message);
+                consoleOutput.WriteLine(diagnostic.ToString(consoleOutput.FormatProvider));
+            }
+        }
 
         public abstract void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute);
         public abstract void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName);

--- a/src/Compilers/Core/Portable/InternalUtilities/NoThrowStream.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NoThrowStream.cs
@@ -1,18 +1,38 @@
 ﻿
 using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace Roslyn.Utilities
 {
-    struct NoThrowStreamDisposer : IDisposable
+    internal class NoThrowStreamDisposer : IDisposable
     {
+        private bool? _failed; // Nullable to assert that this is only checked after dispose
+        private readonly string _filePath;
+        private readonly TextWriter _writer;
+        private readonly Action<Exception, string, TextWriter> _exceptionHandler;
+
         public Stream Stream { get; }
 
-        private readonly Action<Exception> _exceptionHandler;
+        public bool Failed
+        {
+            get
+            {
+                Debug.Assert(_failed != null);
+                return _failed.GetValueOrDefault();
+            }
+        }
         
-        public NoThrowStreamDisposer(Stream stream, Action<Exception> exceptionHandler)
+        public NoThrowStreamDisposer(
+            Stream stream,
+            string filePath,
+            TextWriter writer,
+            Action<Exception, string, TextWriter> exceptionHandler)
         {
             Stream = stream;
+            _failed = null;
+            _filePath = filePath;
+            _writer = writer;
             _exceptionHandler = exceptionHandler;
         }
 
@@ -21,10 +41,12 @@ namespace Roslyn.Utilities
             try
             {
                 Stream.Dispose();
+                _failed = false;
             }
             catch (Exception e)
             {
-                _exceptionHandler(e);
+                _exceptionHandler(e, _filePath, _writer);
+                _failed = true;
             }
         }
     }

--- a/src/Compilers/Core/Portable/InternalUtilities/NoThrowStream.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NoThrowStream.cs
@@ -1,0 +1,31 @@
+﻿
+using System;
+using System.IO;
+
+namespace Roslyn.Utilities
+{
+    struct NoThrowStreamDisposer : IDisposable
+    {
+        public Stream Stream { get; }
+
+        private readonly Action<Exception> _exceptionHandler;
+        
+        public NoThrowStreamDisposer(Stream stream, Action<Exception> exceptionHandler)
+        {
+            Stream = stream;
+            _exceptionHandler = exceptionHandler;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Stream.Dispose();
+            }
+            catch (Exception e)
+            {
+                _exceptionHandler(e);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/NoThrowStreamDisposer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NoThrowStreamDisposer.cs
@@ -7,6 +7,12 @@ using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
+    /// <summary>
+    /// Catches exceptions thrown during disposal of the underlying stream and
+    /// writes them to the given <see cref="TextWriter"/>. Check
+    /// <see cref="HasFailedToDispose" /> after disposal to see if any
+    /// exceptions were thrown during disposal.
+    /// </summary>
     internal class NoThrowStreamDisposer : IDisposable
     {
         private bool? _failed; // Nullable to assert that this is only checked after dispose

--- a/src/Compilers/Core/Portable/InternalUtilities/NoThrowStreamDisposer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/NoThrowStreamDisposer.cs
@@ -56,7 +56,10 @@ namespace Roslyn.Utilities
             try
             {
                 Stream.Dispose();
-                if (_failed == null) _failed = false;
+                if (_failed == null)
+                {
+                    _failed = false;
+                }
             }
             catch (Exception e)
             {

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -8035,7 +8035,7 @@ End Module
 
             Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
             Assert.Equal(1, csc.Run(outWriter))
-            Assert.Equal($"error BC2012: can't open '{exePath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
+            Assert.Equal($"vbc : error BC2012: can't open '{exePath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
         End Sub
 
         <Fact>
@@ -8054,7 +8054,7 @@ End Module
 
             Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
             Assert.Equal(1, csc.Run(outWriter))
-            Assert.Equal($"error BC2012: can't open '{pdbPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
+            Assert.Equal($"vbc : error BC2012: can't open '{pdbPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -8020,6 +8020,94 @@ End Module
             CleanupAllGeneratedFiles(sourceFile.Path)
         End Sub
 
+        <Fact>
+        Public Sub IOFailure_DisposeOutputFile()
+            Dim srcPath = MakeTrivialExe(Temp.CreateDirectory().Path)
+            Dim exePath = Path.Combine(Path.GetDirectoryName(srcPath), "test.exe")
+            Dim csc = New MockVisualBasicCompiler(_baseDirectory, {"/nologo", "/preferreduilang:en", $"/out:{exePath}", srcPath})
+            csc.FileOpen = Function(filePath, mode, access, share)
+                               If filePath = exePath Then
+                                   Return New TestStream(backingStream:=New MemoryStream(), dispose:=Sub() Throw New IOException("Fake IOException"))
+                               End If
+
+                               Return File.Open(filePath, mode, access, share)
+                           End Function
+
+            Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
+            Assert.Equal(1, csc.Run(outWriter))
+            Assert.Equal($"error BC2012: can't open '{exePath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
+        End Sub
+
+        <Fact>
+        Public Sub IOFailure_DisposePdbFile()
+            Dim srcPath = MakeTrivialExe(Temp.CreateDirectory().Path)
+            Dim exePath = Path.Combine(Path.GetDirectoryName(srcPath), "test.exe")
+            Dim pdbPath = Path.ChangeExtension(exePath, "pdb")
+            Dim csc = New MockVisualBasicCompiler(_baseDirectory, {"/nologo", "/preferreduilang:en", "/debug", $"/out:{exePath}", srcPath})
+            csc.FileOpen = Function(filePath, mode, access, share)
+                               If filePath = pdbPath Then
+                                   Return New TestStream(backingStream:=New MemoryStream(), dispose:=Sub() Throw New IOException("Fake IOException"))
+                               End If
+
+                               Return File.Open(filePath, mode, access, share)
+                           End Function
+
+            Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
+            Assert.Equal(1, csc.Run(outWriter))
+            Assert.Equal($"error BC2012: can't open '{pdbPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
+        End Sub
+
+        <Fact>
+        Public Sub IOFailure_DisposeXmlFile()
+            Dim srcPath = MakeTrivialExe(Temp.CreateDirectory().Path)
+            Dim xmlPath = Path.Combine(Path.GetDirectoryName(srcPath), "test.xml")
+            Dim csc = New MockVisualBasicCompiler(_baseDirectory, {"/nologo", "/preferreduilang:en", $"/doc:{xmlPath}", srcPath})
+            csc.FileOpen = Function(filePath, mode, access, share)
+                               If filePath = xmlPath Then
+                                   Return New TestStream(backingStream:=New MemoryStream(), dispose:=Sub() Throw New IOException("Fake IOException"))
+                               End If
+
+                               Return File.Open(filePath, mode, access, share)
+                           End Function
+
+            Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
+            Assert.Equal(1, csc.Run(outWriter))
+            Assert.Equal($"error BC2012: can't open '{xmlPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
+        End Sub
+
+        <Fact>
+        Public Sub IOFailure_DisposeSourceLinkFile()
+            Dim srcPath = MakeTrivialExe(Temp.CreateDirectory().Path)
+            Dim sourceLinkPath = Path.Combine(Path.GetDirectoryName(srcPath), "test.json")
+            Dim csc = New MockVisualBasicCompiler(_baseDirectory, {"/nologo", "/preferreduilang:en", "/debug:portable", $"/sourcelink:{sourceLinkPath}", srcPath})
+            csc.FileOpen = Function(filePath, mode, access, share)
+                               If filePath = sourceLinkPath Then
+                                   Return New TestStream(
+                                   backingStream:=New MemoryStream(Encoding.UTF8.GetBytes("
+{
+  ""documents"": {
+     ""f:/build/*"" : ""https://raw.githubusercontent.com/my-org/my-project/1111111111111111111111111111111111111111/*""
+  }
+}
+")),
+                                   dispose:=Sub() Throw New IOException("Fake IOException"))
+                               End If
+
+                               Return File.Open(filePath, mode, access, share)
+                           End Function
+
+            Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
+            Assert.Equal(1, csc.Run(outWriter))
+            Assert.Equal($"error BC2012: can't open '{sourceLinkPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
+        End Sub
+
+        Private Function MakeTrivialExe(Optional directory As String = Nothing) As String
+            Return Temp.CreateFile(directory:=directory, prefix:="", extension:=".vb").WriteAllText("
+Class Program
+    Public Shared Sub Main()
+    End Sub
+End Class").Path
+        End Function
     End Class
 
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>

--- a/src/Test/Utilities/Portable/Mocks/TestStream.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestStream.cs
@@ -7,65 +7,105 @@ namespace Roslyn.Test.Utilities
 {
     public class TestStream : Stream
     {
-        private readonly bool _canRead, _canSeek, _canWrite;
+        private readonly bool? _canRead, _canSeek, _canWrite;
         private readonly Func<byte[], int, int, int> _readFunc;
-        private readonly long _length;
+        private readonly long? _length;
         private readonly Func<long> _getPosition;
         private readonly Action<long> _setPosition;
+        private readonly Stream _backingStream;
+        private readonly Action _dispose;
 
         public TestStream(
-            bool canRead = false,
-            bool canSeek = false,
-            bool canWrite = false,
+            bool? canRead = null,
+            bool? canSeek = null,
+            bool? canWrite = null,
             Func<byte[], int, int, int> readFunc = null,
-            long length = 0,
+            long? length = null,
             Func<long> getPosition = null,
-            Action<long> setPosition = null)
+            Action<long> setPosition = null,
+            Stream backingStream = null,
+            Action dispose = null)
         {
             _canRead = canRead;
             _canSeek = canSeek;
             _canWrite = canWrite;
-            _readFunc = readFunc != null
-                ? readFunc
-                : (_1, _2, _3) => { throw new NotImplementedException(); };
+            _readFunc = readFunc;
             _length = length;
-            _getPosition = getPosition != null
-                ? getPosition
-                : () => { throw new NotImplementedException(); };
-            _setPosition = setPosition != null
-                ? setPosition
-                : (_1) => { throw new NotImplementedException(); };
+            _getPosition = getPosition;
+            _setPosition = setPosition;
+            _backingStream = backingStream;
+            _dispose = dispose;
         }
 
-        public override bool CanRead => _canRead;
+        public override bool CanRead => _canRead ?? _backingStream?.CanRead ?? false;
 
-        public override bool CanSeek => _canSeek;
+        public override bool CanSeek => _canSeek ?? _backingStream?.CanSeek ?? false;
 
-        public override bool CanWrite => _canWrite;
+        public override bool CanWrite => _canWrite ?? _backingStream?.CanWrite ?? false;
 
-        public override long Length => _length;
+        public override long Length => _length ?? _backingStream?.Length ?? 0;
 
         public override long Position
         {
             get
             {
                 if (!CanSeek) throw new NotSupportedException();
-                return _getPosition();
+                if (_getPosition != null)
+                {
+                    return _getPosition();
+                }
+                if (_backingStream != null)
+                {
+                    return _backingStream.Position;
+                }
+                throw new NotImplementedException();
             }
 
             set
             {
-                if (!CanSeek) throw new NotSupportedException();
-                _setPosition(value);
+                if (!CanSeek)
+                {
+                    throw new NotSupportedException();
+                }
+                if (_setPosition != null)
+                {
+                    _setPosition(value);
+                }
+                else if (_backingStream != null)
+                {
+                    _backingStream.Position = value;
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
             }
         }
 
         public override void Flush()
         {
-            throw new NotSupportedException();
+            if (_backingStream == null)
+            {
+                throw new NotSupportedException();
+            }
+            _backingStream.Flush();
         }
 
-        public override int Read(byte[] buffer, int offset, int count) => _readFunc(buffer, offset, count);
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_readFunc != null)
+            {
+                return _readFunc(buffer, offset, count);
+            }
+            else if (_backingStream != null)
+            {
+                return _backingStream.Read(buffer, offset, count);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
 
         public override long Seek(long offset, SeekOrigin origin)
         {
@@ -79,7 +119,11 @@ namespace Roslyn.Test.Utilities
 
         public override void SetLength(long value)
         {
-            throw new NotSupportedException();
+            if (_backingStream == null)
+            {
+                throw new NotSupportedException();
+            }
+            _backingStream.SetLength(value);
         }
 
         public override void Write(byte[] buffer, int offset, int count)
@@ -88,6 +132,19 @@ namespace Roslyn.Test.Utilities
             {
                 throw new NotSupportedException();
             }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_dispose != null)
+            {
+                _dispose();
+            }
+            else
+            {
+                _backingStream?.Dispose();
+            }
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

This is a high-hit Watson where exceptions during stream disposal are crashing compiler. This is relatively likely to happen since many stream implementations don't flush until Dispose is called.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=217719

**Workarounds, if any**

None.

**Risk**

This is a small wrapper introduced just for the core compile loop in Roslyn that catches exceptions during dispose. The underlying stream is still passed down to core compilation routines, so they should be unaffected by the change.

**Performance impact**

Low. RunCore should only ever be called once per compilation and the few extra try-catches and allocations are small compared to the cost of the entire compile.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Thorough testing around stream failure cases would have caught this sooner. The `TestStream` class has been augmented to assist with more testing in this area and a number of new tests addressing this scenario have been added for every stream used in RunCore.

**How was the bug found?**

Watson.