### PR TITLE
Respect debugger suggestion mode settings

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_ComputeModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_ComputeModel.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
                     _text = _subjectBufferCaretPosition.Snapshot.AsText();
 
-                    _useSuggestionMode = session.Controller.SubjectBuffer.GetFeatureOnOffOption(Options.EditorCompletionOptions.UseSuggestionMode);
+                    _useSuggestionMode = options.GetOption(Options.EditorCompletionOptions.UseSuggestionMode);
 
                     _disconnectedBufferGraph = new DisconnectedBufferGraph(session.Controller.SubjectBuffer, session.Controller.TextView.TextBuffer);
                 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ToggleCompletionMode.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ToggleCompletionMode.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
@@ -23,8 +24,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         {
             if (Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
-                var newState = !workspace.Options.GetOption(EditorCompletionOptions.UseSuggestionMode);
-                workspace.Options = workspace.Options.WithChangedOption(EditorCompletionOptions.UseSuggestionMode, newState);
+                Option<bool> option;
+                if (_isDebugger)
+                {
+                    option = EditorCompletionOptions.UseSuggestionMode_Debugger;
+                }
+                else
+                {
+                    option = EditorCompletionOptions.UseSuggestionMode;
+                }
+
+                var newState = !workspace.Options.GetOption(option);
+                workspace.Options = workspace.Options.WithChangedOption(option, newState);
 
                 // If we don't have a computation in progress, then we don't have to do anything here.
                 if (this.sessionOpt == null)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ToggleCompletionMode.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ToggleCompletionMode.cs
@@ -24,15 +24,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         {
             if (Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out var workspace))
             {
-                Option<bool> option;
-                if (_isDebugger)
-                {
-                    option = EditorCompletionOptions.UseSuggestionMode_Debugger;
-                }
-                else
-                {
-                    option = EditorCompletionOptions.UseSuggestionMode;
-                }
+                Option<bool> option = _isDebugger
+                    ? EditorCompletionOptions.UseSuggestionMode_Debugger
+                    : EditorCompletionOptions.UseSuggestionMode;
 
                 var newState = !workspace.Options.GetOption(option);
                 workspace.Options = workspace.Options.WithChangedOption(option, newState);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/OptionSetExtensions.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/OptionSetExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
@@ -10,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
         public static OptionSet WithDebuggerCompletionOptions(this OptionSet options)
         {
             return options
-                .WithChangedOption(CompletionControllerOptions.AlwaysShowBuilder, true)
+                .WithChangedOption(EditorCompletionOptions.UseSuggestionMode, options.GetOption(EditorCompletionOptions.UseSuggestionMode_Debugger))
                 .WithChangedOption(CompletionControllerOptions.FilterOutOfScopeLocals, false)
                 .WithChangedOption(CompletionControllerOptions.ShowXmlDocCommentCompletion, false);
         }

--- a/src/EditorFeatures/Core/Options/CompletionOptions.cs
+++ b/src/EditorFeatures/Core/Options/CompletionOptions.cs
@@ -10,5 +10,10 @@ namespace Microsoft.CodeAnalysis.Editor.Options
 
         [ExportOption]
         public static readonly Option<bool> UseSuggestionMode = new Option<bool>(FeatureName, nameof(UseSuggestionMode), defaultValue: false);
+
+        // Default into suggestion mode in the watch/immediate windows but respect the
+        // user's preferences if they switch away from it.
+        [ExportOption]
+        public static readonly Option<bool> UseSuggestionMode_Debugger = new Option<bool>(FeatureName, nameof(UseSuggestionMode_Debugger), defaultValue: true);
     }
 }

--- a/src/EditorFeatures/Core/Options/CompletionOptions.cs
+++ b/src/EditorFeatures/Core/Options/CompletionOptions.cs
@@ -8,11 +8,13 @@ namespace Microsoft.CodeAnalysis.Editor.Options
     {
         public const string FeatureName = "EditorCompletion";
 
+        // Intentionally not persisted
         [ExportOption]
         public static readonly Option<bool> UseSuggestionMode = new Option<bool>(FeatureName, nameof(UseSuggestionMode), defaultValue: false);
 
         // Default into suggestion mode in the watch/immediate windows but respect the
         // user's preferences if they switch away from it.
+        // Intentionally not persisted
         [ExportOption]
         public static readonly Option<bool> UseSuggestionMode_Debugger = new Option<bool>(FeatureName, nameof(UseSuggestionMode_Debugger), defaultValue: true);
     }

--- a/src/EditorFeatures/TestUtilities/AbstractCommandHandlerTestState.cs
+++ b/src/EditorFeatures/TestUtilities/AbstractCommandHandlerTestState.cs
@@ -415,6 +415,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         {
             commandHandler(new SelectAllCommandArgs(TextView, SubjectBuffer), nextHandler);
         }
+
+        public void SendToggleCompletionMode(Action<ToggleCompletionModeCommandArgs, Action> commandHandler, Action nextHandler)
+        {
+            commandHandler(new ToggleCompletionModeCommandArgs(TextView, SubjectBuffer), nextHandler);
+        }
         #endregion
     }
 }

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenterSession.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestCompletionPresenterSession.vb
@@ -16,6 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public SelectedItem As CompletionItem
         Public IsSoftSelected As Boolean
         Public SuggestionModeItem As CompletionItem
+        Public SuggestionMode As Boolean
 
         Public Event Dismissed As EventHandler(Of EventArgs) Implements ICompletionPresenterSession.Dismissed
         Public Event ItemSelected As EventHandler(Of CompletionItemEventArgs) Implements ICompletionPresenterSession.ItemSelected
@@ -40,6 +41,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Me.SelectedItem = selectedItem
             Me.IsSoftSelected = isSoftSelected
             Me.SuggestionModeItem = suggestionModeItem
+            Me.SuggestionMode = suggestionMode
             Me._completionFilters = completionItemFilters
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
@@ -289,19 +289,6 @@ End Class
             Await VerifyBuilderAsync(markup)
         End Function
 
-        <WorkItem(1044441, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1044441")>
-        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function BuilderInDebugger() As Task
-            Dim markup = <a> 
-Class C1
-    Sub Foo()
-        Dim __o = $$
-    End Sub
-End Class
-</a>
-            Await VerifyBuilderAsync(markup, CompletionTrigger.Default, useDebuggerOptions:=True)
-        End Function
-
         <WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")>
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function NamespaceDeclarationName_Unqualified() As Task

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -46,7 +46,6 @@ namespace Microsoft.CodeAnalysis.Completion
 
     internal static class CompletionControllerOptions
     {
-        public static readonly Option<bool> AlwaysShowBuilder = new Option<bool>(nameof(CompletionControllerOptions), nameof(AlwaysShowBuilder), defaultValue: false);
         public static readonly Option<bool> FilterOutOfScopeLocals = new Option<bool>(nameof(CompletionControllerOptions), nameof(FilterOutOfScopeLocals), defaultValue: true);
         public static readonly Option<bool> ShowXmlDocCommentCompletion = new Option<bool>(nameof(CompletionControllerOptions), nameof(ShowXmlDocCommentCompletion), defaultValue: true);
     }

--- a/src/Features/Core/Portable/Completion/SuggestionMode/SuggestionModeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/SuggestionMode/SuggestionModeCompletionProvider.cs
@@ -15,16 +15,8 @@ namespace Microsoft.CodeAnalysis.Completion.SuggestionMode
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            if (context.Options.GetOption(CompletionControllerOptions.AlwaysShowBuilder))
-            {
-                var text = await context.Document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
-                context.SuggestionModeItem = this.CreateEmptySuggestionModeItem();
-            }
-            else
-            {
-                context.SuggestionModeItem = await this.GetSuggestionModeItemAsync(
-                    context.Document, context.Position, context.CompletionListSpan, context.Trigger, context.CancellationToken).ConfigureAwait(false);
-            }
+            context.SuggestionModeItem = await this.GetSuggestionModeItemAsync(
+                context.Document, context.Position, context.CompletionListSpan, context.Trigger, context.CancellationToken).ConfigureAwait(false);
         }
 
         protected CompletionItem CreateEmptySuggestionModeItem()

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -668,7 +668,7 @@ $$</Document>
         End Sub
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
-        Public Async Function BuilderSettingRetainedBetweenComputations() As Task
+        Public Async Function BuilderSettingRetainedBetweenComputations_Watch() As Task
             Dim text = <Workspace>
                            <Project Language="C#" CommonReferences="true">
                                <Document>$$</Document>
@@ -683,6 +683,36 @@ $$</Document>
                        </Workspace>
 
             Using state = TestState.CreateCSharpTestState(text, isImmediateWindow:=False)
+                state.SendTypeChars("args")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("args", state.GetCurrentViewLineText())
+                Await state.AssertCompletionSession()
+                Assert.NotNull(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                state.SendToggleCompletionMode()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                state.SendTypeChars(".")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+            End Using
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
+        Public Async Function BuilderSettingRetainedBetweenComputations_Watch_Immediate() As Task
+            Dim text = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document>$$</Document>
+                               <Document>class Program
+{
+    static void Main(string[] args)
+    [|{|]
+
+    }
+}</Document>
+                           </Project>
+                       </Workspace>
+
+            Using state = TestState.CreateCSharpTestState(text, isImmediateWindow:=True)
                 state.SendTypeChars("args")
                 Await state.WaitForAsynchronousOperationsAsync()
                 Assert.Equal("args", state.GetCurrentViewLineText())

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -687,13 +687,13 @@ $$</Document>
                 Await state.WaitForAsynchronousOperationsAsync()
                 Assert.Equal("args", state.GetCurrentViewLineText())
                 Await state.AssertCompletionSession()
-                Assert.NotNull(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                Assert.True(state.CurrentCompletionPresenterSession.SuggestionMode)
                 state.SendToggleCompletionMode()
                 Await state.WaitForAsynchronousOperationsAsync()
-                Assert.Null(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                Assert.False(state.CurrentCompletionPresenterSession.SuggestionMode)
                 state.SendTypeChars(".")
                 Await state.WaitForAsynchronousOperationsAsync()
-                Assert.Null(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                Assert.False(state.CurrentCompletionPresenterSession.SuggestionMode)
             End Using
         End Function
 
@@ -717,13 +717,13 @@ $$</Document>
                 Await state.WaitForAsynchronousOperationsAsync()
                 Assert.Equal("args", state.GetCurrentViewLineText())
                 Await state.AssertCompletionSession()
-                Assert.NotNull(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                Assert.True(state.CurrentCompletionPresenterSession.SuggestionMode)
                 state.SendToggleCompletionMode()
                 Await state.WaitForAsynchronousOperationsAsync()
-                Assert.Null(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                Assert.False(state.CurrentCompletionPresenterSession.SuggestionMode)
                 state.SendTypeChars(".")
                 Await state.WaitForAsynchronousOperationsAsync()
-                Assert.Null(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                Assert.False(state.CurrentCompletionPresenterSession.SuggestionMode)
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -667,6 +667,36 @@ $$</Document>
             End Using
         End Sub
 
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.DebuggingIntelliSense)>
+        Public Async Function BuilderSettingRetainedBetweenComputations() As Task
+            Dim text = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document>$$</Document>
+                               <Document>class Program
+{
+    static void Main(string[] args)
+    [|{|]
+
+    }
+}</Document>
+                           </Project>
+                       </Workspace>
+
+            Using state = TestState.CreateCSharpTestState(text, False)
+                state.SendTypeChars("args")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Equal("args", state.GetCurrentViewLineText())
+                Await state.AssertCompletionSession()
+                Assert.NotNull(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                state.SendToggleCompletionMode()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+                state.SendTypeChars(".")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Null(state.CurrentCompletionPresenterSession.SuggestionModeItem)
+            End Using
+        End Function
+
         Private Async Function VerifyCompletionAndDotAfter(item As String, state As TestState) As Task
             state.SendTypeChars(item)
             Await state.WaitForAsynchronousOperationsAsync()

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/CSharpDebuggerIntellisenseTests.vb
@@ -682,7 +682,7 @@ $$</Document>
                            </Project>
                        </Workspace>
 
-            Using state = TestState.CreateCSharpTestState(text, False)
+            Using state = TestState.CreateCSharpTestState(text, isImmediateWindow:=False)
                 state.SendTypeChars("args")
                 Await state.WaitForAsynchronousOperationsAsync()
                 Assert.Equal("args", state.GetCurrentViewLineText())

--- a/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
+++ b/src/VisualStudio/Core/Test/DebuggerIntelliSense/TestState.vb
@@ -197,6 +197,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.DebuggerIntelliSense
             CurrentCompletionPresenterSession.SetSelectedItem(item)
         End Sub
 
+        Public Overloads Sub SendToggleCompletionMode()
+            Dim handler = DirectCast(CompletionCommandHandler, ICommandHandler(Of ToggleCompletionModeCommandArgs))
+            MyBase.SendToggleCompletionmode(Sub(a, n) handler.ExecuteCommand(a, n), Sub() Return)
+        End Sub
+
         Public Async Function AssertNoCompletionSession(Optional block As Boolean = True) As Task
             If block Then
                 Await WaitForAsynchronousOperationsAsync()


### PR DESCRIPTION
Start completion in the watch/immediate windows. If the user toggles suggestion mode off in the watch/immediate windows, leave it off. 