### PR TITLE
Avoid GUID conflicts for Naming Styles Symbol Specifications (causes Naming Styles to not work and the Tools | Options page to not load)

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/SymbolSpecification/SymbolSpecificationViewModel.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style.N
         public SymbolSpecificationViewModel(
             string languageName,
             bool canBeDeleted,
-            INotificationService notificationService) : this(languageName, SymbolSpecification.All, canBeDeleted, notificationService) { }
+            INotificationService notificationService) : this(languageName, CreateDefaultSymbolSpecification(), canBeDeleted, notificationService) { }
 
         public SymbolSpecificationViewModel(string languageName, SymbolSpecification specification, bool canBeDeleted, INotificationService notificationService)
         {

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/NamingStylePreferences.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/NamingStylePreferences.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
     /// </summary>
     internal class NamingStylePreferences : IEquatable<NamingStylePreferences>
     {
-        private readonly static int s_serializationVersion = 3;
+        private readonly static int s_serializationVersion = 4;
 
         public readonly ImmutableArray<SymbolSpecification> SymbolSpecifications;
         public readonly ImmutableArray<NamingStyle> NamingStyles;
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             => CreateXElement().ToString().GetHashCode();
 
         private static readonly string _defaultNamingPreferencesString = $@"
-<NamingPreferencesInfo SerializationVersion=""3"">
+<NamingPreferencesInfo SerializationVersion=""4"">
   <SymbolSpecifications>
     <SymbolSpecification ID=""5c545a62-b14d-460a-88d8-e936c0a39316"" Name=""{WorkspacesResources.Class}"">
       <ApplicableSymbolKindList>

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
@@ -13,33 +13,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 {
     internal class SymbolSpecification
     {
-        public static readonly SymbolSpecification All = new SymbolSpecification(
-            id: Guid.NewGuid(),
-            symbolSpecName: null,
-            symbolKindList: ImmutableArray.Create(
-                new SymbolKindOrTypeKind(SymbolKind.Namespace),
-                new SymbolKindOrTypeKind(TypeKind.Class),
-                new SymbolKindOrTypeKind(TypeKind.Struct),
-                new SymbolKindOrTypeKind(TypeKind.Interface),
-                new SymbolKindOrTypeKind(TypeKind.Delegate),
-                new SymbolKindOrTypeKind(TypeKind.Enum),
-                new SymbolKindOrTypeKind(TypeKind.Module),
-                new SymbolKindOrTypeKind(TypeKind.Pointer),
-                new SymbolKindOrTypeKind(TypeKind.TypeParameter),
-                new SymbolKindOrTypeKind(SymbolKind.Property),
-                new SymbolKindOrTypeKind(SymbolKind.Method),
-                new SymbolKindOrTypeKind(SymbolKind.Field),
-                new SymbolKindOrTypeKind(SymbolKind.Event),
-                new SymbolKindOrTypeKind(SymbolKind.Parameter)),
-            accessibilityList: ImmutableArray.Create(
-                Accessibility.Public,
-                Accessibility.Internal,
-                Accessibility.Private,
-                Accessibility.Protected,
-                Accessibility.ProtectedAndInternal,
-                Accessibility.ProtectedOrInternal),
-            modifiers: ImmutableArray<ModifierKind>.Empty);
-
         public Guid ID { get; }
         public string Name { get; }
 
@@ -58,6 +31,40 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             ApplicableAccessibilityList = accessibilityList;
             RequiredModifierList = modifiers;
             ApplicableSymbolKindList = symbolKindList;
+        }
+
+        public static SymbolSpecification CreateDefaultSymbolSpecification()
+        {
+            // This is used to create new, empty symbol specifications for users to then customize.
+            // Since these customized specifications will eventually coexist with all the other
+            // existing specifications, always use a new, distinct guid.
+
+            return new SymbolSpecification(
+                id: Guid.NewGuid(),
+                symbolSpecName: null,
+                symbolKindList: ImmutableArray.Create(
+                    new SymbolKindOrTypeKind(SymbolKind.Namespace),
+                    new SymbolKindOrTypeKind(TypeKind.Class),
+                    new SymbolKindOrTypeKind(TypeKind.Struct),
+                    new SymbolKindOrTypeKind(TypeKind.Interface),
+                    new SymbolKindOrTypeKind(TypeKind.Delegate),
+                    new SymbolKindOrTypeKind(TypeKind.Enum),
+                    new SymbolKindOrTypeKind(TypeKind.Module),
+                    new SymbolKindOrTypeKind(TypeKind.Pointer),
+                    new SymbolKindOrTypeKind(TypeKind.TypeParameter),
+                    new SymbolKindOrTypeKind(SymbolKind.Property),
+                    new SymbolKindOrTypeKind(SymbolKind.Method),
+                    new SymbolKindOrTypeKind(SymbolKind.Field),
+                    new SymbolKindOrTypeKind(SymbolKind.Event),
+                    new SymbolKindOrTypeKind(SymbolKind.Parameter)),
+                accessibilityList: ImmutableArray.Create(
+                    Accessibility.Public,
+                    Accessibility.Internal,
+                    Accessibility.Private,
+                    Accessibility.Protected,
+                    Accessibility.ProtectedAndInternal,
+                    Accessibility.ProtectedOrInternal),
+                modifiers: ImmutableArray<ModifierKind>.Empty);
         }
 
         internal bool AppliesTo(ISymbol symbol)


### PR DESCRIPTION
Fixes #16431

Escrow Template
================

**Customer scenario**: The user adds two Naming Styles Symbol Specifications in the same VS session, and the Naming Styles analyzer stops working altogether, and the Naming Styles Tools | Options page will no longer load if one of these symbol specifications are actually used in a rule.

**Bugs this fixes:** #16431

**Workarounds, if any**: The user can only add one Symbol Specification per VS session. Once two have been added, fixing it requires manual edits to your CurrentSettings.vssettings file.

**Risk**: Very low. This code is in the Naming Styles option pages code, and nothing sits on top of that layer. It's essentially the same code as before, we just create a new guid for each new Symbol Specification instead of accidentally caching the guid.

**Performance impact**: We make a new SymbolSpecification object each time the user adds a symbol specification, but that is extremely minor and is done extremely infrequently.

**Is this a regression from a previous update?** Yes, this is a regression from RC.2

**Root cause analysis:** I believe a refactoring was done as part of a larger effort which introduced the caching of the new Symbol Specification guid.

**How was the bug found?**: Ad-hoc testing