### PR TITLE
Do not fail in the NamingStyleCodeFix when we cannot find the symbol (causes the failure InfoBar to be shown)

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/NamingStyle/AbstractNamingStyleCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/NamingStyle/AbstractNamingStyleCodeFixProvider.cs
@@ -36,6 +36,16 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
             var model = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
             var symbol = model.GetDeclaredSymbol(node, context.CancellationToken);
 
+            // TODO: We should always be able to find the symbol that generated this diagnostic,
+            // but this cannot always be done by simply asking for the declared symbol on the node 
+            // from the symbol's declaration location.
+            // See https://github.com/dotnet/roslyn/issues/16588
+
+            if (symbol == null)
+            {
+                return;
+            }
+
             var fixedNames = style.MakeCompliant(symbol.Name);
             foreach (var fixedName in fixedNames)
             {


### PR DESCRIPTION
Fixes #15788 


We should always be able to find the symbol that generated this
diagnostic, but this cannot always be done by simply asking for the
declared symbol on the node from the symbol's declaration location.
Issue #16588 is tracking a more complete fix for this that always
successfully finds the symbol.

Escrow Template
================

**Customer scenario**: In the known cases of this, the customer has an invalid declaration that we believe violates naming rules. We issue the naming violation diagnostic, but then the CodeFix for it fails and shows the infobar.

**Bugs this fixes:** #15788 

**Workarounds, if any:** It can be avoided in the first place by deleting all Naming Rules. Once the error has happened, the InfoBar shows and the user can disable Naming Rules for the rest of the VS session, or re-enable it.

**Risk**: Low. This just introduces a null check and does not provide a CodeFix if we cannot find the symbol with the offending name. Nothing sits on top of this code.

**Performance impact**: None. This is just a null check.

**Is this a regression from a previous update?**: No.

**Root cause analysis:** Not enough testing was initially done around the analysis and fixing of invalid identifiers.

**How was the bug found?** Dogfooding