### PR TITLE
Ensure that we don't break if we recurse into methods during symbol-key reader

### DIFF
--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -86,8 +86,7 @@ namespace Microsoft.CodeAnalysis
                 // method type parameter in our parameter-list or return type, we won't recurse
                 // into it, but will instead only write out the type parameter ordinal.  This
                 // happens with cases like Foo<T>(T t);
-                Debug.Assert(!visitor.WritingSignature);
-                visitor.WritingSignature = true;
+                visitor.PushMethod(symbol);
 
                 visitor.WriteParameterTypesArray(symbol.OriginalDefinition.Parameters);
 
@@ -101,8 +100,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 // Done writing the signature.  Go back to normal mode.
-                Debug.Assert(visitor.WritingSignature);
-                visitor.WritingSignature = false;
+                visitor.PopMethod(symbol);
             }
 
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
@@ -191,14 +189,11 @@ namespace Microsoft.CodeAnalysis
                     // Also set the current method so that we can properly resolve
                     // method type parameter ordinals.
                     reader.Position = beforeParametersPosition;
-
-                    Debug.Assert(reader.CurrentMethod == null);
-                    reader.CurrentMethod = method;
+                    reader.PushMethod(method);
 
                     var result = Resolve(reader, isPartialMethodImplementationPart, method);
 
-                    Debug.Assert(reader.CurrentMethod == method);
-                    reader.CurrentMethod = null;
+                    reader.PopMethod(method);
 
                     if (result != null)
                     {

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -99,7 +99,8 @@ namespace Microsoft.CodeAnalysis
                     visitor.WriteSymbolKey(null);
                 }
 
-                // Done writing the signature.  Go back to normal mode.
+                // Done writing the signature of this method.  Remove it from the set of methods
+                // we're writing signatures for.
                 visitor.PopMethod(symbol);
             }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -184,10 +184,10 @@ namespace Microsoft.CodeAnalysis
                     // the parameters (and possibly the return type).  This is more complicated 
                     // because those symbols might refer to method type parameters.  In order
                     // for resolution to work on those type parameters, we have to keep track
-                    // in the reader that we're on this specific method.
+                    // in the reader that we're resolving this method. 
 
-                    // Restore our position to right before the list of parameters.
-                    // Also set the current method so that we can properly resolve
+                    // Restore our position to right before the list of parameters.  Also, push
+                    // this method into our method-resolution-stack so that we can properly resolve
                     // method type parameter ordinals.
                     reader.Position = beforeParametersPosition;
                     reader.PushMethod(method);

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -361,9 +361,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             public void PushMethod(IMethodSymbol method)
-            {
-                _methodSymbolStack.Add(method);
-            }
+                => _methodSymbolStack.Add(method);
 
             public void PopMethod(IMethodSymbol method)
             {

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis
             public bool IgnoreAssemblyKey { get; private set; }
             public SymbolEquivalenceComparer Comparer { get; private set; }
 
-            public IMethodSymbol CurrentMethod;
+            private List<IMethodSymbol> _methodSymbolStack = new List<IMethodSymbol>();
 
             private SymbolKeyReader()
             {
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis
                 Compilation = null;
                 IgnoreAssemblyKey = false;
                 Comparer = null;
-                CurrentMethod = null;
+                _methodSymbolStack.Clear();
 
                 // Place us back in the pool for future use.
                 s_readerPool.Free(this);
@@ -360,10 +360,23 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
-            internal SyntaxTree GetSyntaxTree(string filePath)
+            public void PushMethod(IMethodSymbol method)
             {
-                return this.Compilation.SyntaxTrees.FirstOrDefault(t => t.FilePath == filePath);
+                _methodSymbolStack.Add(method);
             }
+
+            public void PopMethod(IMethodSymbol method)
+            {
+                Contract.ThrowIfTrue(_methodSymbolStack.Count == 0);
+                Contract.ThrowIfFalse(method.Equals(_methodSymbolStack.Last()));
+                _methodSymbolStack.RemoveAt(_methodSymbolStack.Count - 1);
+            }
+
+            public IMethodSymbol ResolveMethod(int index)
+                => _methodSymbolStack[index];
+
+            internal SyntaxTree GetSyntaxTree(string filePath)
+                => this.Compilation.SyntaxTrees.FirstOrDefault(t => t.FilePath == filePath);
 
             #region Symbols
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -61,7 +62,8 @@ namespace Microsoft.CodeAnalysis
 
             public Compilation Compilation { get; private set; }
             public CancellationToken CancellationToken { get; private set; }
-            public bool WritingSignature;
+
+            private List<IMethodSymbol> _methodSymbolStack = new List<IMethodSymbol>();
 
             internal int _nestingCount;
             private int _nextId;
@@ -80,6 +82,7 @@ namespace Microsoft.CodeAnalysis
             {
                 _symbolToId.Clear();
                 _stringBuilder.Clear();
+                _methodSymbolStack.Clear();
                 Compilation = null;
                 CancellationToken = default(CancellationToken);
                 _nestingCount = 0;
@@ -148,8 +151,8 @@ namespace Microsoft.CodeAnalysis
                     return;
                 }
 
-                var shouldWriteOrdinal = ShouldWriteTypeParameterOrdinal(symbol);
                 int id;
+                var shouldWriteOrdinal = ShouldWriteTypeParameterOrdinal(symbol, out var methodIndex);
                 if (!shouldWriteOrdinal)
                 {
                     if (_symbolToId.TryGetValue(symbol, out id))
@@ -494,10 +497,10 @@ namespace Microsoft.CodeAnalysis
                 // If it's a reference to a method type parameter, and we're currently writing
                 // out a signture, then only write out the ordinal of type parameter.  This 
                 // helps prevent recursion problems in cases like "Foo<T>(T t).
-                if (ShouldWriteTypeParameterOrdinal(typeParameterSymbol))
+                if (ShouldWriteTypeParameterOrdinal(typeParameterSymbol, out int methodIndex))
                 {
                     WriteType(SymbolKeyType.TypeParameterOrdinal);
-                    TypeParameterOrdinalSymbolKey.Create(typeParameterSymbol, this);
+                    TypeParameterOrdinalSymbolKey.Create(typeParameterSymbol, methodIndex, this);
                 }
                 else
                 {
@@ -507,11 +510,39 @@ namespace Microsoft.CodeAnalysis
                 return null;
             }
 
-            private bool ShouldWriteTypeParameterOrdinal(ISymbol symbol)
+            public bool ShouldWriteTypeParameterOrdinal(ISymbol symbol, out int methodIndex)
             {
-                return WritingSignature &&
-                    symbol.Kind == SymbolKind.TypeParameter &&
-                    ((ITypeParameterSymbol)symbol).TypeParameterKind != TypeParameterKind.Type;
+                if (symbol.Kind == SymbolKind.TypeParameter)
+                {
+                    var typeParameter = (ITypeParameterSymbol)symbol;
+                    if (typeParameter.TypeParameterKind == TypeParameterKind.Method)
+                    {
+                        for (int i = 0, n = _methodSymbolStack.Count; i < n; i++)
+                        {
+                            var method = _methodSymbolStack[i];
+                            if (typeParameter.DeclaringMethod.Equals(method))
+                            {
+                                methodIndex = i;
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                methodIndex = -1;
+                return false;
+            }
+
+            public void PushMethod(IMethodSymbol method)
+            {
+                _methodSymbolStack.Add(method);
+            }
+
+            public void PopMethod(IMethodSymbol method)
+            {
+                Contract.ThrowIfTrue(_methodSymbolStack.Count == 0);
+                Contract.ThrowIfFalse(method.Equals(_methodSymbolStack.Last()));
+                _methodSymbolStack.RemoveAt(_methodSymbolStack.Count - 1);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -534,9 +534,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             public void PushMethod(IMethodSymbol method)
-            {
-                _methodSymbolStack.Add(method);
-            }
+                => _methodSymbolStack.Add(method);
 
             public void PopMethod(IMethodSymbol method)
             {

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterOrdinalSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterOrdinalSymbolKey.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -8,17 +9,18 @@ namespace Microsoft.CodeAnalysis
     {
         private static class TypeParameterOrdinalSymbolKey
         {
-            public static void Create(ITypeParameterSymbol symbol, SymbolKeyWriter visitor)
+            public static void Create(ITypeParameterSymbol symbol, int methodIndex, SymbolKeyWriter visitor)
             {
-                Debug.Assert(visitor.WritingSignature);
-                Debug.Assert(symbol.TypeParameterKind == TypeParameterKind.Method);
+                Contract.ThrowIfFalse(symbol.TypeParameterKind == TypeParameterKind.Method);
+                visitor.WriteInteger(methodIndex);
                 visitor.WriteInteger(symbol.Ordinal);
             }
 
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader)
             {
+                var methodIndex = reader.ReadInteger();
                 var ordinal = reader.ReadInteger();
-                var typeParameter = reader.CurrentMethod.TypeParameters[ordinal];
+                var typeParameter = reader.ResolveMethod(methodIndex).TypeParameters[ordinal];
                 return new SymbolKeyResolution(typeParameter);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/16585
