### PR TITLE
Change the order of operands to object.Equals() for constant pattern match

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -136,8 +136,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _factory.StaticCall(
                 _factory.SpecialType(SpecialType.System_Object),
                 "Equals",
-                _factory.Convert(_factory.SpecialType(SpecialType.System_Object), input),
-                _factory.Convert(_factory.SpecialType(SpecialType.System_Object), boundConstant)
+                _factory.Convert(_factory.SpecialType(SpecialType.System_Object), boundConstant),
+                _factory.Convert(_factory.SpecialType(SpecialType.System_Object), input)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4295,6 +4295,40 @@ unsafe public class Typ
         }
 
         [Fact]
+        [WorkItem(16513, "https://github.com/dotnet/roslyn/issues/16513")]
+        public void OrderOfPatternOperands()
+        {
+            var source = @"
+using System;
+class Program
+{
+    public static void Main(string[] args)
+    {
+        object c = new C();
+        Console.WriteLine(c is 3);
+        c = 2;
+        Console.WriteLine(c is 3);
+        c = 3;
+        Console.WriteLine(c is 3);
+    }
+}
+class C
+{
+    override public bool Equals(object other)
+    {
+        return other is int x;
+    }
+    override public int GetHashCode() => 0;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics();
+            var comp = CompileAndVerify(compilation, expectedOutput: @"False
+False
+True");
+        }
+
+        [Fact]
         public void MultiplyInPattern()
         {
             // pointer types are not supported in patterns. Therefore an attempt to use


### PR DESCRIPTION
**Customer scenario**

The semantics of pattern-matching against a constant are different between the `is` operator and the `switch` statement. They were intended to be the same, but the order of operands to `object.Equals` in the generated code is backwards for the `is` operator. We need to fix this today, before RTM, so that users do not come to depend on the incorrect behavior (now-or-never language change). See also #16513.

**Bugs this fixes:** 

Fixes #16513

**Workarounds, if any**

Avoid using the new `is` operator with a constant right-hand-side.

**Risk**

Tiny. The fix is a one-line change to place the operands in the correct order.

**Performance impact**

None, as we are still executing the same code as before, albeit in a different order. However, with the changed order it will be possible for us to generate much better code in the future.

**Is this a regression from a previous update?**

No, as the feature is new.

**Root cause analysis:**

A subtle oversight in code generation. This might have been caught earlier if the compiler team had followed through on its plan to assign a developer to perform adversarial testing of each new feature under development.

**How was the bug found?**

Customer reported.

@dotnet/roslyn-compiler Please review this teensy tiny RTM fix.
