### PR TITLE
Expand the lifetime of locals declared within CasePatternSwitchLabelSyntax to the entire switch body.

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -672,6 +672,18 @@
   </Node>
 
   <!--
+  This node is used to represent a visibility scope for locals, 
+  for which lifetime is extended beyond the visibility scope. 
+  At the moment, only locals declared within CasePatternSwitchLabelSyntax 
+  have their lifetime expanded to the entire switch body, whereas their 
+  visibility scope is the declaring switch section. The node is added into 
+  the tree during lowering phase.
+  -->
+  <Node Name="BoundScope" Base="BoundStatementList">
+    <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
+  </Node>
+
+  <!--
   BoundStateMachineScope represents a scope within a translated iterator/async method.
   It is used to emit debugging information that allows the EE to map 
   fields to locals.

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -2082,6 +2082,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             get { return SynthesizedLocalKind.OptimizerTemp; }
         }
 
+        internal override SyntaxNode ScopeDesignatorOpt
+        {
+            get { return null; }
+        }
+
         internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax)
         {
             throw new NotImplementedException();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1144,10 +1144,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitBlock(BoundBlock node)
         {
-            foreach (var statement in node.Statements)
+            VisitStatements(node.Statements);
+            return null;
+        }
+
+        private void VisitStatements(ImmutableArray<BoundStatement> statements)
+        {
+            foreach (var statement in statements)
             {
                 VisitStatement(statement);
             }
+        }
+
+        public override BoundNode VisitScope(BoundScope node)
+        {
+            VisitStatements(node.Statements);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaCapturedVariable.cs
@@ -70,6 +70,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return GeneratedNames.MakeSynthesizedInstrumentationPayloadLocalFieldName(uniqueId++);
                 }
+
+                if (local.SynthesizedKind == SynthesizedLocalKind.UserDefined && local.ScopeDesignatorOpt?.Kind() == SyntaxKind.SwitchSection)
+                {
+                    return GeneratedNames.MakeHoistedLocalFieldName(local.SynthesizedKind, uniqueId++, local.Name);
+                }
             }
 
             Debug.Assert(variable.Name != null);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -1002,6 +1002,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node.Update(newLocals.ToImmutableAndFree(), node.LocalFunctions, newStatements.ToImmutableAndFree());
         }
 
+        public override BoundNode VisitScope(BoundScope node)
+        {
+            Debug.Assert(!node.Locals.IsEmpty);
+            var newLocals = ArrayBuilder<LocalSymbol>.GetInstance();
+            RewriteLocals(node.Locals, newLocals);
+
+            var statements = VisitList(node.Statements);
+            if (newLocals.Count == 0)
+            {
+                newLocals.Free();
+                return new BoundStatementList(node.Syntax, statements);
+            }
+
+            return node.Update(newLocals.ToImmutableAndFree(), statements);
+        }
+
         public override BoundNode VisitCatchBlock(BoundCatchBlock node)
         {
             // Test if this frame has captured variables and requires the introduction of a closure class.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
@@ -82,9 +82,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 // at this point the end of result is unreachable.
 
+                _declaredTemps.AddOptional(initialTemp);
+                _declaredTemps.AddRange(node.InnerLocals);
+
                 // output the sections of code
                 foreach (var section in node.SwitchSections)
                 {
+                    // Lifetime of these locals is expanded to the entire switch body.
+                    _declaredTemps.AddRange(section.Locals);
+
                     // Start with the part of the decision tree that is in scope of the section variables.
                     // Its endpoint is not reachable (it jumps back into the decision tree code).
                     var sectionSyntax = (SyntaxNode)section.Syntax;
@@ -98,14 +104,23 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // Add the translated body of the switch section
                     sectionBuilder.AddRange(_localRewriter.VisitList(section.Statements));
+
                     sectionBuilder.Add(_factory.Goto(node.BreakLabel));
-                    result.Add(_factory.Block(section.Locals, sectionBuilder.ToImmutableAndFree()));
+
+                    ImmutableArray<BoundStatement> statements = sectionBuilder.ToImmutableAndFree();
+                    if (section.Locals.IsEmpty)
+                    {
+                        result.Add(_factory.StatementList(statements));
+                    }
+                    else
+                    {
+                        result.Add(new BoundScope(section.Syntax, section.Locals, statements));
+                    }
                     // at this point the end of result is unreachable.
                 }
 
                 result.Add(_factory.Label(node.BreakLabel));
-                _declaredTemps.AddOptional(initialTemp);
-                _declaredTemps.AddRange(node.InnerLocals);
+
                 BoundStatement translatedSwitch = _factory.Block(_declaredTemps.ToImmutableArray(), node.InnerLocalFunctions, result.ToImmutableAndFree());
 
                 // Only add instrumentation (such as a sequence point) if the node is not compiler-generated.

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -138,6 +138,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return node.Update(newLocals, newLocalFunctions, newStatements);
         }
 
+        public override abstract BoundNode VisitScope(BoundScope node);
+
         public override BoundNode VisitSequence(BoundSequence node)
         {
             var newLocals = RewriteLocals(node.Locals);

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -25,6 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get;
         }
 
+        /// <summary>
+        /// Syntax node that is used as the scope designator. Otherwise, null.
+        /// </summary>
+        internal abstract SyntaxNode ScopeDesignatorOpt { get; }
+
         internal abstract LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax);
 
         internal abstract bool IsImportedFromMetadata

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -76,6 +76,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _scopeBinder; }
         }
 
+        internal override SyntaxNode ScopeDesignatorOpt
+        {
+            get { return _scopeBinder.ScopeDesignator; }
+        }
+
         /// <summary>
         /// Binder that should be used to bind type syntax for the local.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -102,6 +102,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _kind; }
         }
 
+        internal override SyntaxNode ScopeDesignatorOpt
+        {
+            get { return null; }
+        }
+
         internal override SyntaxToken IdentifierToken
         {
             get { return default(SyntaxToken); }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -38,6 +38,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _originalVariable.SynthesizedKind; }
         }
 
+        internal override SyntaxNode ScopeDesignatorOpt
+        {
+            get { return _originalVariable.ScopeDesignatorOpt; }
+        }
+
         public override string Name
         {
             get { return _originalVariable.Name; }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -2150,7 +2150,7 @@ class Program
         }
 
         [Fact]
-        public void SwitchWithPattern()
+        public void SwitchWithPattern_01()
         {
             string source = @"
 using System;
@@ -2203,11 +2203,11 @@ class Student : Person { public double GPA; }
           <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
-          <slot kind=""1"" offset=""11"" />
           <slot kind=""0"" offset=""59"" />
-          <slot kind=""21"" offset=""0"" />
           <slot kind=""0"" offset=""163"" />
           <slot kind=""0"" offset=""250"" />
+          <slot kind=""1"" offset=""11"" />
+          <slot kind=""21"" offset=""0"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -2226,13 +2226,109 @@ class Student : Person { public double GPA; }
       </sequencePoints>
       <scope startOffset=""0x0"" endOffset=""0xcc"">
         <scope startOffset=""0x36"" endOffset=""0x6e"">
-          <local name=""s"" il_index=""6"" il_start=""0x36"" il_end=""0x6e"" attributes=""0"" />
+          <local name=""s"" il_index=""5"" il_start=""0x36"" il_end=""0x6e"" attributes=""0"" />
         </scope>
         <scope startOffset=""0x6e"" endOffset=""0x94"">
-          <local name=""s"" il_index=""8"" il_start=""0x6e"" il_end=""0x94"" attributes=""0"" />
+          <local name=""s"" il_index=""6"" il_start=""0x6e"" il_end=""0x94"" attributes=""0"" />
         </scope>
         <scope startOffset=""0x94"" endOffset=""0xb5"">
-          <local name=""t"" il_index=""9"" il_start=""0x94"" il_end=""0xb5"" attributes=""0"" />
+          <local name=""t"" il_index=""7"" il_start=""0x94"" il_end=""0xb5"" attributes=""0"" />
+        </scope>
+      </scope>
+    </method>
+  </methods>
+</symbols>"
+);
+        }
+
+        [Fact]
+        public void SwitchWithPattern_02()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    private static List<List<int>> l = new List<List<int>>();
+
+    static void Main(string[] args)
+    {
+        Student s = new Student();
+        s.Name = ""Bozo"";
+        s.GPA = 2.3;
+        Operate(s);  
+    }
+
+    static System.Func<string> Operate(Person p)
+    {
+        switch (p)
+        {
+            case Student s when s.GPA > 3.5:
+                return () => $""Student {s.Name} ({s.GPA:N1})"";
+            case Student s:
+                return () => $""Student {s.Name} ({s.GPA:N1})"";
+            case Teacher t:
+                return () => $""Teacher {t.Name} of {t.Subject}"";
+            default:
+                return () => $""Person {p.Name}"";
+        }
+    }
+}
+
+class Person { public string Name; }
+class Teacher : Person { public string Subject; }
+class Student : Person { public double GPA; }
+";
+            // we just want this to compile without crashing/asserting
+            var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            c.VerifyPdb("Program.Operate",
+@"<symbols>
+  <methods>
+    <method containingType=""Program"" name=""Operate"" parameterNames=""p"">
+      <customDebugInfo>
+        <forward declaringType=""Program"" methodName=""Main"" parameterNames=""args"" />
+        <encLocalSlotMap>
+          <slot kind=""30"" offset=""0"" />
+          <slot kind=""30"" offset=""383"" />
+          <slot kind=""temp"" />
+          <slot kind=""temp"" />
+          <slot kind=""temp"" />
+          <slot kind=""temp"" />
+          <slot kind=""temp"" />
+          <slot kind=""1"" offset=""11"" />
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
+        <encLambdaMap>
+          <methodOrdinal>2</methodOrdinal>
+          <closure offset=""383"" />
+          <closure offset=""0"" />
+          <lambda offset=""109"" closure=""0"" />
+          <lambda offset=""202"" closure=""0"" />
+          <lambda offset=""295"" closure=""0"" />
+          <lambda offset=""383"" closure=""1"" />
+        </encLambdaMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" hidden=""true"" />
+        <entry offset=""0xd"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
+        <entry offset=""0xe"" hidden=""true"" />
+        <entry offset=""0x20"" hidden=""true"" />
+        <entry offset=""0x50"" hidden=""true"" />
+        <entry offset=""0x57"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" />
+        <entry offset=""0x6f"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""63"" />
+        <entry offset=""0x7f"" hidden=""true"" />
+        <entry offset=""0x89"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""63"" />
+        <entry offset=""0x99"" hidden=""true"" />
+        <entry offset=""0xa3"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""65"" />
+        <entry offset=""0xb3"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""49"" />
+        <entry offset=""0xc3"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0xc6"">
+        <local name=""CS$&lt;&gt;8__locals0"" il_index=""0"" il_start=""0x0"" il_end=""0xc6"" attributes=""0"" />
+        <scope startOffset=""0xe"" endOffset=""0xc3"">
+          <local name=""CS$&lt;&gt;8__locals1"" il_index=""1"" il_start=""0xe"" il_end=""0xc3"" attributes=""0"" />
         </scope>
       </scope>
     </method>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -2375,5 +2375,174 @@ class C
                 Assert.Equal(symbol, model.GetSymbolInfo(refs[0]).Symbol);
             });
         }
+
+        [Fact]
+        [WorkItem(15536, "https://github.com/dotnet/roslyn/issues/15536")]
+        public void CallFromDifferentSwitchSection_01()
+        {
+            var source = @"
+class Program
+{
+    static void Main()
+    {
+        Test(string.Empty);
+    }
+
+    static void Test(object o)
+    {
+        switch (o)
+        {
+            case string x:
+                Assign();
+                Print();
+                break;
+            case int x:
+                void Assign() { x = 5; }
+                void Print() => System.Console.WriteLine(x);
+                break;
+        }
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlib46(source, parseOptions: DefaultParseOptions, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "5");
+        }
+
+        [Fact]
+        [WorkItem(15536, "https://github.com/dotnet/roslyn/issues/15536")]
+        public void CallFromDifferentSwitchSection_02()
+        {
+            var source = @"
+class Program
+{
+    static void Main()
+    {
+        Test(string.Empty);
+    }
+
+    static void Test(object o)
+    {
+        switch (o)
+        {
+            case int x:
+                void Assign() { x = 5; }
+                void Print() => System.Console.WriteLine(x);
+                break;
+            case string x:
+                Assign();
+                Print();
+                break;
+        }
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlib46(source, parseOptions: DefaultParseOptions, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "5");
+        }
+
+        [Fact]
+        [WorkItem(15536, "https://github.com/dotnet/roslyn/issues/15536")]
+        public void CallFromDifferentSwitchSection_03()
+        {
+            var source = @"
+class Program
+{
+    static void Main()
+    {
+        Test(string.Empty);
+    }
+
+    static void Test(object o)
+    {
+        switch (o)
+        {
+            case string x:
+                Assign();
+                System.Action p = Print;
+                p();
+                break;
+            case int x:
+                void Assign() { x = 5; }
+                void Print() => System.Console.WriteLine(x);
+                break;
+        }
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlib46(source, parseOptions: DefaultParseOptions, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "5");
+        }
+
+        [Fact]
+        [WorkItem(15536, "https://github.com/dotnet/roslyn/issues/15536")]
+        public void CallFromDifferentSwitchSection_04()
+        {
+            var source = @"
+class Program
+{
+    static void Main()
+    {
+        Test(string.Empty);
+    }
+
+    static void Test(object o)
+    {
+        switch (o)
+        {
+            case int x:
+                void Assign() { x = 5; }
+                void Print() => System.Console.WriteLine(x);
+                break;
+            case string x:
+                Assign();
+                System.Action p = Print;
+                p();
+                break;
+        }
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlib46(source, parseOptions: DefaultParseOptions, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: "5");
+        }
+
+        [Fact]
+        [WorkItem(15536, "https://github.com/dotnet/roslyn/issues/15536")]
+        public void CallFromDifferentSwitchSection_05()
+        {
+            var source = @"
+class Program
+{
+    static void Main()
+    {
+        Test(string.Empty);
+    }
+
+    static void Test(object o)
+    {
+        switch (o)
+        {
+            case string x:
+                Local1();
+                break;
+             case int x:
+                void Local1() => Local2(x = 5);
+                break;
+             case char x:
+                void Local2(int y)
+                {
+                    System.Console.WriteLine(x = 'a');
+                    System.Console.WriteLine(y);
+                }
+                break;
+        }
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlib46(source, parseOptions: DefaultParseOptions, options: TestOptions.DebugExe);
+            CompileAndVerify(comp, expectedOutput: 
+@"a
+5");
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
@@ -43,6 +43,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return SynthesizedLocalKind.UserDefined; }
         }
 
+        internal override SyntaxNode ScopeDesignatorOpt
+        {
+            get { return null; }
+        }
+
         internal sealed override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax)
         {
             throw ExceptionUtilities.Unreachable;

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -124,6 +124,658 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             });
         }
 
+        [Fact]
+        public void LocalsInSwitch()
+        {
+            var source =
+@"class C
+{
+    void M(object o)
+    {
+        switch (o)
+        {
+            case string s:
+                var a = s;
+#line 1000
+                return;
+            case int s:
+#line 2000
+                return;
+            default:
+                return;
+        }
+    }
+}";
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M", atLineNumber: 1000);
+
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
+
+                Assert.Equal(locals.Count, 4);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (object V_0,
+                string V_1,
+                int V_2,
+                object V_3,
+                string V_4, //a
+                string V_5, //s
+                int V_6,
+                object V_7,
+                int? V_8)
+  IL_0000:  ldarg.0
+  IL_0001:  ret
+}");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "o", expectedILOpt:
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (object V_0,
+                string V_1,
+                int V_2,
+                object V_3,
+                string V_4, //a
+                string V_5, //s
+                int V_6,
+                object V_7,
+                int? V_8)
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "a", expectedILOpt:
+@"{
+  // Code size        3 (0x3)
+  .maxstack  1
+  .locals init (object V_0,
+                string V_1,
+                int V_2,
+                object V_3,
+                string V_4, //a
+                string V_5, //s
+                int V_6,
+                object V_7,
+                int? V_8)
+  IL_0000:  ldloc.s    V_4
+  IL_0002:  ret
+}
+");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "s", expectedILOpt:
+@"{
+  // Code size        3 (0x3)
+  .maxstack  1
+  .locals init (object V_0,
+                string V_1,
+                int V_2,
+                object V_3,
+                string V_4, //a
+                string V_5, //s
+                int V_6,
+                object V_7,
+                int? V_8)
+  IL_0000:  ldloc.s    V_5
+  IL_0002:  ret
+}");
+                locals.Free();
+
+                context = CreateMethodContext(runtime, "C.M", atLineNumber: 2000);
+
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
+
+                Assert.Equal(locals.Count, 4);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (object V_0,
+                string V_1,
+                int V_2,
+                object V_3,
+                string V_4, //a
+                string V_5,
+                int V_6, //s
+                object V_7,
+                int? V_8)
+  IL_0000:  ldarg.0
+  IL_0001:  ret
+}");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "o", expectedILOpt:
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (object V_0,
+                string V_1,
+                int V_2,
+                object V_3,
+                string V_4, //a
+                string V_5,
+                int V_6, //s
+                object V_7,
+                int? V_8)
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "a", expectedILOpt:
+@"{
+  // Code size        3 (0x3)
+  .maxstack  1
+  .locals init (object V_0,
+                string V_1,
+                int V_2,
+                object V_3,
+                string V_4, //a
+                string V_5,
+                int V_6, //s
+                object V_7,
+                int? V_8)
+  IL_0000:  ldloc.s    V_4
+  IL_0002:  ret
+}
+");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "s", expectedILOpt:
+@"{
+  // Code size        3 (0x3)
+  .maxstack  1
+  .locals init (object V_0,
+                string V_1,
+                int V_2,
+                object V_3,
+                string V_4, //a
+                string V_5,
+                int V_6, //s
+                object V_7,
+                int? V_8)
+  IL_0000:  ldloc.s    V_6
+  IL_0002:  ret
+}");
+                locals.Free();
+            });
+        }
+
+        [Fact]
+        [WorkItem(16594, "https://github.com/dotnet/roslyn/issues/16594")]
+        public void LocalsInSwitchWithLambda()
+        {
+            var source =
+@"class C
+{
+    System.Action M(object o)
+    {
+        switch (o)
+        {
+            case string s:
+                var a = s;
+#line 1000
+                return () =>
+                       {
+#line 2000
+                           System.Console.WriteLine(s + a); 
+                       };
+            case int s:
+#line 3000
+                return () =>
+                       {
+#line 4000
+                           System.Console.WriteLine(s); 
+                       };
+            default:
+                return null;
+        }
+    }
+}";
+            var compilation0 = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M", atLineNumber: 1000);
+
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
+
+                Assert.Equal(locals.Count, 3);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                object V_1,
+                string V_2,
+                int V_3,
+                object V_4,
+                object V_5,
+                int? V_6,
+                System.Action V_7)
+  IL_0000:  ldarg.0
+  IL_0001:  ret
+}");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "o", expectedILOpt:
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                object V_1,
+                string V_2,
+                int V_3,
+                object V_4,
+                object V_5,
+                int? V_6,
+                System.Action V_7)
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "a", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                object V_1,
+                string V_2,
+                int V_3,
+                object V_4,
+                object V_5,
+                int? V_6,
+                System.Action V_7)
+  IL_0000:  ldloc.0
+  IL_0001:  ldfld      ""string C.<>c__DisplayClass0_0.a""
+  IL_0006:  ret
+}
+");
+                // We should be able to evaluate "s" within this context, https://github.com/dotnet/roslyn/issues/16594.
+//                VerifyLocal(testData, typeName, locals[3], "<>m3", "s", expectedILOpt:
+//@"{
+//  // Code size        8 (0x8)
+//  .maxstack  1
+//  .locals init (C.<>c__DisplayClass0_1 V_0, //CS$<>8__locals0
+//                object V_1,
+//                string V_2,
+//                int V_3,
+//                object V_4,
+//                object V_5,
+//                int? V_6,
+//                C.<>c__DisplayClass0_0 V_7, //CS$<>8__locals1
+//                System.Action V_8,
+//                C.<>c__DisplayClass0_2 V_9)
+//  IL_0000:  ldloc.s    V_7
+//  IL_0002:  ldfld      ""string C.<>c__DisplayClass0_0.s""
+//  IL_0007:  ret
+//}");
+                locals.Free();
+
+                context = CreateMethodContext(runtime, "C.M", atLineNumber: 3000);
+
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
+
+                Assert.Equal(locals.Count, 3);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                object V_1,
+                string V_2,
+                int V_3,
+                object V_4,
+                object V_5,
+                int? V_6,
+                System.Action V_7)
+  IL_0000:  ldarg.0
+  IL_0001:  ret
+}");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "o", expectedILOpt:
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                object V_1,
+                string V_2,
+                int V_3,
+                object V_4,
+                object V_5,
+                int? V_6,
+                System.Action V_7)
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "a", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
+                object V_1,
+                string V_2,
+                int V_3,
+                object V_4,
+                object V_5,
+                int? V_6,
+                System.Action V_7)
+  IL_0000:  ldloc.0
+  IL_0001:  ldfld      ""string C.<>c__DisplayClass0_0.a""
+  IL_0006:  ret
+}
+");
+                // We should be able to evaluate "s" within this context, https://github.com/dotnet/roslyn/issues/16594.
+//                VerifyLocal(testData, typeName, locals[3], "<>m3", "s", expectedILOpt:
+//@"{
+//  // Code size        8 (0x8)
+//  .maxstack  1
+//  .locals init (C.<>c__DisplayClass0_1 V_0, //CS$<>8__locals0
+//                object V_1,
+//                string V_2,
+//                int V_3,
+//                object V_4,
+//                object V_5,
+//                int? V_6,
+//                C.<>c__DisplayClass0_0 V_7,
+//                System.Action V_8,
+//                C.<>c__DisplayClass0_2 V_9) //CS$<>8__locals2
+//  IL_0000:  ldloc.s    V_9
+//  IL_0002:  ldfld      ""int C.<>c__DisplayClass0_2.s""
+//  IL_0007:  ret
+//}");
+                locals.Free();
+
+                context = CreateMethodContext(runtime, "C.<>c__DisplayClass0_0.<M>b__0", atLineNumber: 2000);
+
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
+
+                Assert.Equal(locals.Count, 1);
+                // We should be able to evaluate "s" within this context, https://github.com/dotnet/roslyn/issues/16594.
+//                VerifyLocal(testData, typeName, locals[0], "<>m0", "s", expectedILOpt:
+//@"{
+//  // Code size        7 (0x7)
+//  .maxstack  1
+//  IL_0000:  ldarg.0
+//  IL_0001:  ldfld      ""string C.<>c__DisplayClass0_0.s""
+//  IL_0006:  ret
+//}");
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "a", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""string C.<>c__DisplayClass0_0.a""
+  IL_0006:  ret
+}");
+                locals.Free();
+
+                context = CreateMethodContext(runtime, "C.<>c__DisplayClass0_0.<M>b__1", atLineNumber: 4000);
+
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
+
+                Assert.Equal(locals.Count, 1);
+                // We should be able to evaluate "s" within this context, https://github.com/dotnet/roslyn/issues/16594.
+//                VerifyLocal(testData, typeName, locals[0], "<>m0", "s", expectedILOpt:
+//@"{
+//  // Code size        7 (0x7)
+//  .maxstack  1
+//  IL_0000:  ldarg.0
+//  IL_0001:  ldfld      ""int C.<>c__DisplayClass0_2.s""
+//  IL_0006:  ret
+//}");
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "a", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""string C.<>c__DisplayClass0_0.a""
+  IL_0006:  ret
+}");
+                locals.Free();
+            });
+        }
+
+        [Fact]
+        public void LocalsInSwitchWithAwait()
+        {
+            var source =
+@"
+using System.Threading.Tasks;
+
+class C
+{
+    async Task<object> F()
+    {
+        return new object();
+    }
+
+    async Task<object> M(object o)
+    {
+        switch (o)
+        {
+            case string s:
+                var a = s;
+#line 1000
+                await F();
+                System.Console.WriteLine(s + a); 
+                return o;
+            case int s:
+#line 2000
+                await F();
+                System.Console.WriteLine(s); 
+                return o;
+            default:
+                return o;
+        }
+    }
+}";
+            var compilation0 = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugDll, 
+                references: new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef });
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<M>d__1.MoveNext", atLineNumber: 1000);
+
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
+
+                Assert.Equal(locals.Count, 4);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                object V_1,
+                object V_2,
+                string V_3,
+                int V_4,
+                object V_5,
+                object V_6,
+                int? V_7,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
+                C.<M>d__1 V_9,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_10,
+                System.Exception V_11)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""C C.<M>d__1.<>4__this""
+  IL_0006:  ret
+}");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "o", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                object V_1,
+                object V_2,
+                string V_3,
+                int V_4,
+                object V_5,
+                object V_6,
+                int? V_7,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
+                C.<M>d__1 V_9,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_10,
+                System.Exception V_11)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""object C.<M>d__1.o""
+  IL_0006:  ret
+}");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "a", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                object V_1,
+                object V_2,
+                string V_3,
+                int V_4,
+                object V_5,
+                object V_6,
+                int? V_7,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
+                C.<M>d__1 V_9,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_10,
+                System.Exception V_11)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""string C.<M>d__1.<a>5__1""
+  IL_0006:  ret
+}
+");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "s", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                object V_1,
+                object V_2,
+                string V_3,
+                int V_4,
+                object V_5,
+                object V_6,
+                int? V_7,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
+                C.<M>d__1 V_9,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_10,
+                System.Exception V_11)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""string C.<M>d__1.<s>5__2""
+  IL_0006:  ret
+}");
+                locals.Free();
+
+                context = CreateMethodContext(runtime, "C.<M>d__1.MoveNext", atLineNumber: 2000);
+
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                Assert.NotNull(assembly);
+                Assert.NotEqual(assembly.Count, 0);
+
+                Assert.Equal(locals.Count, 4);
+                VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                object V_1,
+                object V_2,
+                string V_3,
+                int V_4,
+                object V_5,
+                object V_6,
+                int? V_7,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
+                C.<M>d__1 V_9,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_10,
+                System.Exception V_11)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""C C.<M>d__1.<>4__this""
+  IL_0006:  ret
+}");
+                VerifyLocal(testData, typeName, locals[1], "<>m1", "o", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                object V_1,
+                object V_2,
+                string V_3,
+                int V_4,
+                object V_5,
+                object V_6,
+                int? V_7,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
+                C.<M>d__1 V_9,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_10,
+                System.Exception V_11)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""object C.<M>d__1.o""
+  IL_0006:  ret
+}");
+                VerifyLocal(testData, typeName, locals[2], "<>m2", "a", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                object V_1,
+                object V_2,
+                string V_3,
+                int V_4,
+                object V_5,
+                object V_6,
+                int? V_7,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
+                C.<M>d__1 V_9,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_10,
+                System.Exception V_11)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""string C.<M>d__1.<a>5__1""
+  IL_0006:  ret
+}
+");
+                VerifyLocal(testData, typeName, locals[3], "<>m3", "s", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                object V_1,
+                object V_2,
+                string V_3,
+                int V_4,
+                object V_5,
+                object V_6,
+                int? V_7,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_8,
+                C.<M>d__1 V_9,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_10,
+                System.Exception V_11)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<M>d__1.<s>5__3""
+  IL_0006:  ret
+}");
+                locals.Free();
+            });
+        }
+
         /// <summary>
         /// No local signature (debugging a .dmp with no heap). Local
         /// names are known but types are not so the locals are dropped.
@@ -1419,7 +2071,7 @@ struct S<T> where T : class
         }
 
         [Fact]
-        public void Async_StaticMethod()
+        public void Async_StaticMethod_01()
         {
             var source =
 @"using System.Threading.Tasks;
@@ -1475,6 +2127,123 @@ class C
                 System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.<y>5__1""
+  IL_0006:  ret
+}");
+                Assert.Equal(locals.Count, 2);
+                locals.Free();
+            });
+        }
+
+        [Fact]
+        public void Async_StaticMethod_02()
+        {
+            var source =
+@"using System.Threading.Tasks;
+class C
+{
+    static async Task<object> F(object o)
+    {
+        return o;
+    }
+    static async Task M(object x)
+    {
+        {
+#line 1000
+            int y = (int)await F(x);
+            await F(y);
+        }
+        {
+#line 2000
+            long y = (long)await F(x);
+            await F(y);
+        }
+    }
+}";
+            var compilation0 = CreateCompilationWithMscorlib45(
+                source,
+                options: TestOptions.DebugDll,
+                references: new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef });
+
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.<M>d__1.MoveNext", atLineNumber: 1000);
+
+                var testData = new CompilationTestData();
+                var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                string typeName;
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
+                object V_2,
+                C.<M>d__1 V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
+                System.Exception V_7)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""object C.<M>d__1.x""
+  IL_0006:  ret
+}");
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
+                object V_2,
+                C.<M>d__1 V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
+                System.Exception V_7)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<M>d__1.<y>5__1""
+  IL_0006:  ret
+}");
+                Assert.Equal(locals.Count, 2);
+                locals.Free();
+
+                context = CreateMethodContext(runtime, "C.<M>d__1.MoveNext", atLineNumber: 2000);
+
+                testData = new CompilationTestData();
+                locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+
+                VerifyLocal(testData, "<>x", locals[0], "<>m0", "x", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
+                object V_2,
+                C.<M>d__1 V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
+                System.Exception V_7)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""object C.<M>d__1.x""
+  IL_0006:  ret
+}");
+                VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
+@"{
+  // Code size        7 (0x7)
+  .maxstack  1
+  .locals init (int V_0,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
+                object V_2,
+                C.<M>d__1 V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
+                System.Exception V_7)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""long C.<M>d__1.<y>5__3""
   IL_0006:  ret
 }");
                 Assert.Equal(locals.Count, 2);


### PR DESCRIPTION
**Customer scenario**
When a lambda or a local function references a local declared within CasePatternSwitchLabelSyntax, either compiler crashes or an application crashes at runtime because corresponding closure isn't properly initialized.  

**Bugs this fixes:** 
Fixes #15536. 
Fixes #16066. 
Tracked by VSO https://devdiv.visualstudio.com/DevDiv/_workitems?id=369824

**Workarounds, if any**
Avoid directly referencing such locals in a lambda or a local function. 

**Risk**
Low. The fix is a targeted change for a pattern switch feature, which is the only feature affected by this issue. 

**Performance impact**
Low. We allocate one additional bound tree node per switch section with locals.

**Is this a regression from a previous update?**
No. New feature.

**Root cause analysis:**
A test gap for a new feature. Tests added.

**How was the bug found?**
Customer reported.

@dotnet/roslyn-compiler, @gafter, @agocke Please review.  