### PR TITLE
allow use of a byref parameter inside of nameof

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' cannot access ByRef parameters in Lambdas
                 Dim parameterSymbolContainingSymbol As Symbol = parameterSymbol.ContainingSymbol
 
-                If _containingSymbol IsNot parameterSymbolContainingSymbol And Not _insideNameof Then
+                If _containingSymbol IsNot parameterSymbolContainingSymbol AndAlso Not _insideNameof Then
                     ' Need to go up the chain of containers and see if the last lambda we see
                     ' is a QueryLambda, before we reach parameter's container. 
                     If Binder.IsTopMostEnclosingLambdaAQueryLambda(_containingSymbol, parameterSymbolContainingSymbol) Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass.vb
@@ -67,12 +67,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' cannot access ByRef parameters in Lambdas
                 Dim parameterSymbolContainingSymbol As Symbol = parameterSymbol.ContainingSymbol
 
-                If _containingSymbol IsNot parameterSymbolContainingSymbol Then
+                If _containingSymbol IsNot parameterSymbolContainingSymbol And Not _insideNameof Then
                     ' Need to go up the chain of containers and see if the last lambda we see
                     ' is a QueryLambda, before we reach parameter's container. 
                     If Binder.IsTopMostEnclosingLambdaAQueryLambda(_containingSymbol, parameterSymbolContainingSymbol) Then
                         Binder.ReportDiagnostic(Me._diagnostics, node.Syntax, ERRID.ERR_CannotLiftByRefParamQuery1, parameterSymbol.Name)
-                    ElseIf Not Me._insideNameof Then
+                    Else
                         Binder.ReportDiagnostic(Me._diagnostics, node.Syntax, ERRID.ERR_CannotLiftByRefParamLambda1, parameterSymbol.Name)
                     End If
                 End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass.vb
@@ -102,9 +102,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function GetMeAccessError() As ERRID
-
-
-
             Dim meParameter As ParameterSymbol = Me._containingSymbol.MeParameter
             If meParameter IsNot Nothing AndAlso meParameter.IsByRef Then
                 If _containingSymbol.MethodKind = MethodKind.LambdaMethod Then

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
@@ -3545,7 +3545,7 @@ TP
         End Sub
 
         <Fact, WorkItem(10839, "https://github.com/dotnet/roslyn/issues/10839")>
-        Public Sub NameOfLambda()
+        Public Sub NameOfByRefInLambda()
             Dim compilationDef =
                 <compilation>
                     <file name="a.vb">
@@ -3567,5 +3567,28 @@ End Module
             CompileAndVerify(comp, expectedOutput:="x").VerifyDiagnostics()
         End Sub
 
+        <Fact, WorkItem(10839, "https://github.com/dotnet/roslyn/issues/10839")>
+        Public Sub NameOfByRefInQuery()
+            Dim compilationDef =
+                <compilation>
+                    <file name="a.vb">
+Imports System.Linq
+
+Module Program
+    Sub DoSomething(ByRef x As Integer)
+        Dim f = from x in {1, 2, 3}
+                select nameof(x)
+        System.Console.WriteLine(f.Aggregate("", Function(a, b) a + b))
+    End Sub
+    Sub Main()
+        Dim x =  5
+        DoSomething(x)
+    End Sub
+End Module
+                </file>
+                </compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.DebugExe)
+            CompileAndVerify(comp, expectedOutput:="xxx").VerifyDiagnostics()
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
@@ -3544,5 +3544,28 @@ TP
 ]]>).VerifyDiagnostics()
         End Sub
 
+        <Fact, WorkItem(10839, "https://github.com/dotnet/roslyn/issues/10839")>
+        Public Sub NameOfLambda()
+            Dim compilationDef =
+                <compilation>
+                    <file name="a.vb">
+Module Program
+    Sub DoSomething(ByRef x As Integer)
+        Dim f = Function()
+                    Return NameOf(x)
+                End Function
+        System.Console.WriteLine(f())
+    End Sub
+    Sub Main()
+        Dim x =  5
+        DoSomething(x)
+    End Sub
+End Module
+                </file>
+                </compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.DebugExe)
+            CompileAndVerify(comp, expectedOutput:="x").VerifyDiagnostics()
+        End Sub
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
@@ -3587,7 +3587,7 @@ Module Program
 End Module
                 </file>
                 </compilation>
-            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.DebugExe)
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, options:=TestOptions.DebugExe, additionalRefs:={LinqAssemblyRef})
             CompileAndVerify(comp, expectedOutput:="xxx").VerifyDiagnostics()
         End Sub
     End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NameOfTests.vb
@@ -3576,7 +3576,7 @@ Imports System.Linq
 
 Module Program
     Sub DoSomething(ByRef x As Integer)
-        Dim f = from x in {1, 2, 3}
+        Dim f = from y in {1, 2, 3}
                 select nameof(x)
         System.Console.WriteLine(f.Aggregate("", Function(a, b) a + b))
     End Sub


### PR DESCRIPTION
**Customer scenario**
The customer uses a byref parameter inside of a nameof that is inside of a closure.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/10839

**Workarounds, if any**

Don't use nameof, use strings instead.

**Risk**

Low.

**Performance impact**

No added allocations.  Additional code is extremely minimal.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Reported by a customer in https://github.com/dotnet/roslyn/issues/10467