### PR TITLE
Don't emit casing-related naming violations when the violating character has no casing (making the feature noisy/unusable in other cultures)

### DIFF
--- a/src/EditorFeatures/Test2/Diagnostics/NamingStyles/NamingStyleTests.IdentifierCreation.Compliance.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/NamingStyles/NamingStyleTests.IdentifierCreation.Compliance.vb
@@ -90,6 +90,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
             Dim namingStyle = CreateNamingStyle(wordSeparator:="_t_", capitalizationScheme:=Capitalization.PascalCase)
             TestNameCompliance(namingStyle, "Pascal_t_Case")
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)>
+        Public Sub TestPascalCaseAllowsUncasedCharacters()
+            Dim namingStyle = CreateNamingStyle(wordSeparator:="_", capitalizationScheme:=Capitalization.PascalCase)
+            TestNameCompliance(namingStyle, "私の家_2nd")
+        End Sub
 #End Region
 
 #Region "camelCase"
@@ -139,6 +145,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
         Public Sub TestCamelCaseIgnoresSeeminglyNoncompliantWordSeparator()
             Dim namingStyle = CreateNamingStyle(wordSeparator:="_t_", capitalizationScheme:=Capitalization.CamelCase)
             TestNameCompliance(namingStyle, "camel_t_Case")
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)>
+        Public Sub TestCamelCaseAllowsUncasedCharacters()
+            Dim namingStyle = CreateNamingStyle(wordSeparator:="_", capitalizationScheme:=Capitalization.CamelCase)
+            TestNameCompliance(namingStyle, "私の家_2nd")
         End Sub
 #End Region
 
@@ -190,6 +202,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
             Dim namingStyle = CreateNamingStyle(wordSeparator:="_T_", capitalizationScheme:=Capitalization.FirstUpper)
             TestNameCompliance(namingStyle, "First_T_upper")
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)>
+        Public Sub TestFirstUpperAllowsUncasedCharacters()
+            Dim namingStyle = CreateNamingStyle(capitalizationScheme:=Capitalization.FirstUpper)
+            TestNameCompliance(namingStyle, "私の家")
+        End Sub
 #End Region
 
 #Region "ALLUPPER"
@@ -234,6 +252,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
             Dim namingStyle = CreateNamingStyle(wordSeparator:="_t_", capitalizationScheme:=Capitalization.AllUpper)
             TestNameCompliance(namingStyle, "ALL_t_UPPER")
         End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)>
+        Public Sub TestAllUpperAllowsUncasedCharacters()
+            Dim namingStyle = CreateNamingStyle(capitalizationScheme:=Capitalization.AllUpper)
+            TestNameCompliance(namingStyle, "私AB23CのDE家")
+        End Sub
 #End Region
 
 #Region "alllower"
@@ -277,6 +301,12 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
         Public Sub TestAllLowerIgnoresSeeminglyNoncompliantWordSeparator()
             Dim namingStyle = CreateNamingStyle(wordSeparator:="_T_", capitalizationScheme:=Capitalization.AllLower)
             TestNameCompliance(namingStyle, "all_T_lower")
+        End Sub
+
+        <Fact, Trait(Traits.Feature, Traits.Features.NamingStyle)>
+        Public Sub TestAllLowerAllowsUncasedCharacters()
+            Dim namingStyle = CreateNamingStyle(capitalizationScheme:=Capitalization.AllLower)
+            TestNameCompliance(namingStyle, "私ab23cのde家")
         End Sub
 #End Region
     End Class

--- a/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/NamingStyle.cs
@@ -136,14 +136,14 @@ namespace Microsoft.CodeAnalysis.NamingStyles
         private static string Substring(string name, TextSpan wordSpan)
             => name.Substring(wordSpan.Start, wordSpan.Length);
 
-        private static Func<string, TextSpan, bool> s_firstCharIsLowerCase = (val, span) => char.IsLower(val[span.Start]);
-        private static Func<string, TextSpan, bool> s_firstCharIsUpperCase = (val, span) => char.IsUpper(val[span.Start]);
+        private static Func<string, TextSpan, bool> s_firstCharIsLowerCase = (val, span) => !DoesCharacterHaveCasing(val[span.Start]) || char.IsLower(val[span.Start]);
+        private static Func<string, TextSpan, bool> s_firstCharIsUpperCase = (val, span) => !DoesCharacterHaveCasing(val[span.Start]) || char.IsUpper(val[span.Start]);
 
         private static Func<string, TextSpan, bool> s_wordIsAllUpperCase = (val, span) =>
         {
             for (int i = span.Start, n = span.End; i < n; i++)
             {
-                if (!char.IsUpper(val[i]))
+                if (DoesCharacterHaveCasing(val[i]) && !char.IsUpper(val[i]))
                 {
                     return false;
                 }
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.NamingStyles
         {
             for (int i = span.Start, n = span.End; i < n; i++)
             {
-                if (!char.IsLower(val[i]))
+                if (DoesCharacterHaveCasing(val[i]) && !char.IsLower(val[i]))
                 {
                     return false;
                 }
@@ -263,6 +263,8 @@ namespace Microsoft.CodeAnalysis.NamingStyles
                 WorkspacesResources.The_first_word_0_must_begin_with_an_upper_case_character,
                 WorkspacesResources.These_non_leading_words_must_begin_with_a_lowercase_letter_colon_0,
                 out reason);
+
+        private static bool DoesCharacterHaveCasing(char c) => char.ToLower(c) != char.ToUpper(c);
 
         private string CreateCompliantNameDirectly(string name)
         {


### PR DESCRIPTION
Fixes #15326, #15486

Escrow Template
================

**Customer scenario**: A Japanese user (for example) has the default Naming Styles applied but uses an identifier where the first character is neither upper-case nor lower-case. We currently flag this as a violation of that Naming Style. Note that this will be their default experience out-of-the-box.

**Bugs this fixes:** #15326, #15486

**Workarounds, if any:** They can manually turn off all Naming Rules.

**Risk**: Low. We just add a check to see if the character being inspected has casing at all to 4 different places. This is specific to the Naming Styles feature, and nothing else relies on this code.

**Performance impact**: For the more common naming styles, it can create an additional struct per symbol (the .ToUpper or .ToLower'd version of the first character). For the less common naming styles, it can create an additional struct per character in each symbol analyzed.

**Is this a regression from a previous update?** No.

**Root cause analysis:** It was missed as part of the original feature work. There are unit tests to validate and protect against regressions.

**How was the bug found?** Customer reports and dogfooding.