### PR TITLE
removed additional cost I can find from trace compared to code before…

### DIFF
--- a/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
+++ b/src/VisualStudio/Core/Def/SolutionEventMonitor.cs
@@ -13,7 +13,10 @@ namespace Microsoft.VisualStudio.LanguageServices
     /// </summary>
     internal sealed class SolutionEventMonitor : IDisposable
     {
-        private GlobalOperationNotificationService _notificationService;
+        private const string SolutionBuilding = "Solution Building";
+        private const string SolutionOpening = "Solution Opening";
+
+        private IGlobalOperationNotificationService _notificationService;
         private Dictionary<string, GlobalOperationRegistration> _operations = new Dictionary<string, GlobalOperationRegistration>();
 
         public SolutionEventMonitor(VisualStudioWorkspace workspace)
@@ -21,8 +24,23 @@ namespace Microsoft.VisualStudio.LanguageServices
             var notificationService = workspace.Services.GetService<IGlobalOperationNotificationService>() as GlobalOperationNotificationService;
             if (notificationService != null)
             {
+                // subscribe to events only if it is normal service. if it is one from unit test or other, don't bother to subscribe
                 _notificationService = notificationService;
+
+                // make sure we set initial state correctly. otherwise, we can get into a race where we might miss the very first events
+                if (KnownUIContexts.SolutionBuildingContext.IsActive)
+                {
+                    ContextChanged(active: true, operation: SolutionBuilding);
+                }
+
                 KnownUIContexts.SolutionBuildingContext.UIContextChanged += SolutionBuildingContextChanged;
+
+                // make sure we set initial state correctly. otherwise, we can get into a race where we might miss the very first events
+                if (KnownUIContexts.SolutionOpeningContext.IsActive)
+                {
+                    ContextChanged(active: true, operation: SolutionOpening);
+                }
+
                 KnownUIContexts.SolutionOpeningContext.UIContextChanged += SolutionOpeningContextChanged;
             }
         }
@@ -46,15 +64,15 @@ namespace Microsoft.VisualStudio.LanguageServices
 
         private void SolutionBuildingContextChanged(object sender, UIContextChangedEventArgs e)
         {
-            ContextChangedWorker(e, "Solution Building");
+            ContextChanged(e.Activated, SolutionBuilding);
         }
 
         private void SolutionOpeningContextChanged(object sender, UIContextChangedEventArgs e)
         {
-            ContextChangedWorker(e, "Solution Opening");
+            ContextChanged(e.Activated, SolutionOpening);
         }
 
-        private void ContextChangedWorker(UIContextChangedEventArgs e, string operation)
+        private void ContextChanged(bool active, string operation)
         {
             if (_notificationService == null)
             {
@@ -63,7 +81,7 @@ namespace Microsoft.VisualStudio.LanguageServices
 
             TryCancelPendingNotification(operation);
 
-            if (e.Activated)
+            if (active)
             {
                 _operations[operation] = _notificationService.Start(operation);
             }
@@ -75,6 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             {
                 globalOperation.Done();
                 globalOperation.Dispose();
+
                 _operations.Remove(operation);
             }
         }

--- a/src/VisualStudio/Core/Test.Next/Services/AssetServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetServiceTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Remote;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Roslyn.VisualStudio.Next.UnitTests.Mocks;
 using Xunit;
 
@@ -114,7 +115,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
                 var source = new TestAssetSource(storage, sessionId, map);
 
                 var service = new AssetService(sessionId, storage);
-                await service.SynchronizeProjectAssetsAsync(await project.State.GetChecksumAsync(CancellationToken.None), CancellationToken.None);
+                await service.SynchronizeProjectAssetsAsync(SpecializedCollections.SingletonEnumerable(await project.State.GetChecksumAsync(CancellationToken.None)), CancellationToken.None);
 
                 object data;
                 foreach (var kv in map)

--- a/src/Workspaces/Remote/Core/Services/AssetService.cs
+++ b/src/Workspaces/Remote/Core/Services/AssetService.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public async Task SynchronizeProjectAssetsAsync(Checksum projectChecksum, CancellationToken cancellationToken)
+        public async Task SynchronizeProjectAssetsAsync(IEnumerable<Checksum> projectChecksums, CancellationToken cancellationToken)
         {
             // this will pull in assets that belong to the given project checksum to this remote host.
             // this one is not supposed to be used for functionality but only for perf. that is why it doesn't return anything.
@@ -96,10 +96,10 @@ namespace Microsoft.CodeAnalysis.Remote
             // one can call this method to make cache hot for all assets that belong to the project checksum so that GetAssetAsync call will most likely cache hit.
             // it is most likely since we might change cache hueristic in future which make data to live a lot shorter in the cache, and the data might get expired
             // before one actually consume the data. 
-            using (Logger.LogBlock(FunctionId.AssetService_SynchronizeProjectAssetsAsync, Checksum.GetChecksumLogInfo, projectChecksum, cancellationToken))
+            using (Logger.LogBlock(FunctionId.AssetService_SynchronizeProjectAssetsAsync, Checksum.GetChecksumsLogInfo, projectChecksums, cancellationToken))
             {
                 var syncer = new ChecksumSynchronizer(this);
-                await syncer.SynchronizeProjectAssetsAsync(projectChecksum, cancellationToken).ConfigureAwait(false);
+                await syncer.SynchronizeProjectAssetsAsync(projectChecksums, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Workspaces/Remote/Core/Services/ChecksumSynchronizer.cs
+++ b/src/Workspaces/Remote/Core/Services/ChecksumSynchronizer.cs
@@ -23,10 +23,8 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task SynchronizeAssetsAsync(IEnumerable<Checksum> checksums, CancellationToken cancellationToken)
         {
             using (await s_gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
-            using (var pooledObject = SharedPools.Default<HashSet<Checksum>>().GetPooledObject())
             {
-                AddIfNeeded(pooledObject.Object, checksums);
-                await _assetService.SynchronizeAssetsAsync(pooledObject.Object, cancellationToken).ConfigureAwait(false);
+                await SynchronizeAssets_NoLockAsync(checksums, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -40,100 +38,77 @@ namespace Microsoft.CodeAnalysis.Remote
                 var solutionChecksumObject = await _assetService.GetAssetAsync<SolutionStateChecksums>(solutionChecksum, cancellationToken).ConfigureAwait(false);
 
                 // second, get direct children of the solution
-                await SynchronizeSolutionAsync(solutionChecksumObject, cancellationToken).ConfigureAwait(false);
+                await SynchronizeAssets_NoLockAsync(solutionChecksumObject.Children, cancellationToken).ConfigureAwait(false);
 
-                // third, get direct children for all projects in the solution
-                await SynchronizeProjectsAsync(solutionChecksumObject, cancellationToken).ConfigureAwait(false);
-
-                // last, get direct children for all documents in the solution
-                await SynchronizeDocumentsAsync(solutionChecksumObject, cancellationToken).ConfigureAwait(false);
+                // third and last get direct children for all projects and documents in the solution 
+                await SynchronizeProjectAssets_NoLockAsync(solutionChecksumObject.Projects, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public async Task SynchronizeProjectAssetsAsync(Checksum projectChecksum, CancellationToken cancellationToken)
+        public async Task SynchronizeProjectAssetsAsync(IEnumerable<Checksum> projectChecksums, CancellationToken cancellationToken)
         {
             using (await s_gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
+            {
+                await SynchronizeProjectAssets_NoLockAsync(projectChecksums, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task SynchronizeProjectAssets_NoLockAsync(IEnumerable<Checksum> projectChecksums, CancellationToken cancellationToken)
+        {
+            // get children of project checksum objects at once
+            await SynchronizeProjectsAsync(projectChecksums, cancellationToken).ConfigureAwait(false);
+
+            // get children of document checksum objects at once
             using (var pooledObject = SharedPools.Default<HashSet<Checksum>>().GetPooledObject())
             {
                 var checksums = pooledObject.Object;
 
-                var projectChecksumObject = await _assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, cancellationToken).ConfigureAwait(false);
-                AddIfNeeded(checksums, projectChecksumObject.Children);
-
-                foreach (var checksum in projectChecksumObject.Documents)
+                foreach (var projectChecksum in projectChecksums)
                 {
-                    var documentChecksumObject = await _assetService.GetAssetAsync<DocumentStateChecksums>(checksum, cancellationToken).ConfigureAwait(false);
-                    AddIfNeeded(checksums, documentChecksumObject.Children);
-                }
+                    var projectChecksumObject = await _assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, cancellationToken).ConfigureAwait(false);
 
-                foreach (var checksum in projectChecksumObject.AdditionalDocuments)
-                {
-                    var documentChecksumObject = await _assetService.GetAssetAsync<DocumentStateChecksums>(checksum, cancellationToken).ConfigureAwait(false);
-                    AddIfNeeded(checksums, documentChecksumObject.Children);
+                    await CollectChecksumChildrenAsync(checksums, projectChecksumObject.Documents, cancellationToken).ConfigureAwait(false);
+                    await CollectChecksumChildrenAsync(checksums, projectChecksumObject.AdditionalDocuments, cancellationToken).ConfigureAwait(false);
                 }
 
                 await _assetService.SynchronizeAssetsAsync(checksums, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task SynchronizeSolutionAsync(SolutionStateChecksums solutionChecksumObject, CancellationToken cancellationToken)
-        {
-            // get children of solution checksum object at once
-            using (var pooledObject = SharedPools.Default<HashSet<Checksum>>().GetPooledObject())
-            {
-                var solutionChecksums = pooledObject.Object;
-
-                AddIfNeeded(solutionChecksums, solutionChecksumObject.Children);
-                await _assetService.SynchronizeAssetsAsync(solutionChecksums, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        private async Task SynchronizeProjectsAsync(SolutionStateChecksums solutionChecksumObject, CancellationToken cancellationToken)
+        private async Task SynchronizeProjectsAsync(IEnumerable<Checksum> projectChecksums, CancellationToken cancellationToken)
         {
             // get children of project checksum objects at once
             using (var pooledObject = SharedPools.Default<HashSet<Checksum>>().GetPooledObject())
             {
-                var projectChecksums = pooledObject.Object;
+                var checksums = pooledObject.Object;
 
-                foreach (var projectChecksum in solutionChecksumObject.Projects)
-                {
-                    var projectChecksumObject = await _assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, cancellationToken).ConfigureAwait(false);
-                    AddIfNeeded(projectChecksums, projectChecksumObject.Children);
-                }
-
-                await _assetService.SynchronizeAssetsAsync(projectChecksums, cancellationToken).ConfigureAwait(false);
+                await CollectChecksumChildrenAsync(checksums, projectChecksums, cancellationToken).ConfigureAwait(false);
+                await _assetService.SynchronizeAssetsAsync(checksums, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task SynchronizeDocumentsAsync(SolutionStateChecksums solutionChecksumObject, CancellationToken cancellationToken)
+        private async Task SynchronizeAssets_NoLockAsync(IEnumerable<object> checksumOrCollections, CancellationToken cancellationToken)
         {
-            // get children of document checksum objects at once
+            // get children of solution checksum object at once
             using (var pooledObject = SharedPools.Default<HashSet<Checksum>>().GetPooledObject())
             {
-                var documentChecksums = pooledObject.Object;
+                var checksums = pooledObject.Object;
 
-                foreach (var projectChecksum in solutionChecksumObject.Projects)
-                {
-                    var projectChecksumObject = await _assetService.GetAssetAsync<ProjectStateChecksums>(projectChecksum, cancellationToken).ConfigureAwait(false);
-
-                    foreach (var checksum in projectChecksumObject.Documents)
-                    {
-                        var documentChecksumObject = await _assetService.GetAssetAsync<DocumentStateChecksums>(checksum, cancellationToken).ConfigureAwait(false);
-                        AddIfNeeded(documentChecksums, documentChecksumObject.Children);
-                    }
-
-                    foreach (var checksum in projectChecksumObject.AdditionalDocuments)
-                    {
-                        var documentChecksumObject = await _assetService.GetAssetAsync<DocumentStateChecksums>(checksum, cancellationToken).ConfigureAwait(false);
-                        AddIfNeeded(documentChecksums, documentChecksumObject.Children);
-                    }
-                }
-
-                await _assetService.SynchronizeAssetsAsync(documentChecksums, cancellationToken).ConfigureAwait(false);
+                AddIfNeeded(checksums, checksumOrCollections);
+                await _assetService.SynchronizeAssetsAsync(checksums, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private void AddIfNeeded(HashSet<Checksum> checksums, IReadOnlyList<object> checksumOrCollections)
+        private async Task CollectChecksumChildrenAsync(HashSet<Checksum> set, IEnumerable<Checksum> checksums, CancellationToken cancellationToken)
+        {
+            foreach (var checksum in checksums)
+            {
+                var checksumObject = await _assetService.GetAssetAsync<ChecksumWithChildren>(checksum, cancellationToken).ConfigureAwait(false);
+                AddIfNeeded(set, checksumObject.Children);
+            }
+        }
+
+        private void AddIfNeeded(HashSet<Checksum> checksums, IEnumerable<object> checksumOrCollections)
         {
             foreach (var checksumOrCollection in checksumOrCollections)
             {
@@ -152,14 +127,6 @@ namespace Microsoft.CodeAnalysis.Remote
                 }
 
                 throw ExceptionUtilities.UnexpectedValue(checksumOrCollection);
-            }
-        }
-
-        private void AddIfNeeded(HashSet<Checksum> checksums, IEnumerable<Checksum> collection)
-        {
-            foreach (var checksum in collection)
-            {
-                AddIfNeeded(checksums, checksum);
             }
         }
 


### PR DESCRIPTION
… primary workspace changes.

**Customer scenario**

User opens solution in VS. VS allocates less and use less refset while opening solution.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/364131
https://github.com/dotnet/roslyn/issues/16410

**Workarounds, if any**

no workaround

**Risk**

since there is no functional changes. it won't have risk regarding that. so far manual testing shows better perf. also verified with private RPS run that code that caused the regression no longer run,

this PR also went through private testing from vendor and didn't find any issue.

**Performance impact**

it should improve allocations and refset perf.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

While OOP is changed to use new design to make it better on VM and CPU usage, Allocation and Refset usage got increased. this is to reduce that back to where it used to be.

fix here do following this.

1. make sure OOP synchronization happens after solution opening (modal portion) is done
2. make sure OOP synchronization do bulk synchronization as much as possible.
3. delay checksum calculation until it is needed.

**How was the bug found?**

performance testing and manual performance investigation.