### PR TITLE
Restore detection of an ambiguous method type argument inference.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2501,6 +2501,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     best = MergeTupleNames(MergeDynamic(best, candidate, _conversions.CorLibrary), candidate);
                 }
+                else
+                {
+                    // best candidate is not unique
+                    return false;
+                }
 
                 OuterBreak:
                 ;


### PR DESCRIPTION
**Customer scenario**
Given a method ```void Assert<T>(T a, T b)```, customer supplies arguments that have different types, but the types are implicitly convertible to each other. The type argument inference is supposed to fail, but it succeeds by choosing one of the types in a non-deterministic manner (first in the collection of keys from a Dictionary, which doesn't guarantee any particular order). Method becomes applicable and can be chosen by Overload Resolution as the best candidate, silently changing runtime behavior of a program after it is built with new version of the compiler. 

**Bugs this fixes:** 
Fixes #16478.
Tracked by VSO https://devdiv.visualstudio.com/DevDiv/_workitems/edit/369821

**Workarounds, if any**
Explicitly supply type arguments.

**Risk**
Low. Targeted fix, putting back the code that got removed by accident.

**Performance impact**
Low. Simple, no new allocations fix.

**Is this a regression from a previous update?**
Yes, from VS2015.

**Root cause analysis:**
A test gap. Added tests.

**How was the bug found?**
Customer reported.

@dotnet/roslyn-compiler, @VSadov, @jcouv Please review.  