### PR TITLE
Task-like: Add arity check for generic async method builder

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                  builderType.DeclaredAccessibility == desiredAccessibility)
             {
                 bool isArityOk = isGeneric
-                                 ? builderType.IsUnboundGenericType && builderType.ContainingType?.IsGenericType != true
+                                 ? builderType.IsUnboundGenericType && builderType.ContainingType?.IsGenericType != true && builderType.Arity == 1
                                  : !builderType.IsGenericType;
                 if (isArityOk)
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -4840,38 +4840,37 @@ using System.Runtime.CompilerServices;
 
 public class Program
 {
-  public async MyAwesomeType<string> CustomTask()
-  {
-    await Task.Delay(1000);
-    return string.Empty;
-  }
+    public async MyAwesomeType<string> CustomTask() { await Task.Delay(1000); return string.Empty; }
 }
 
 [AsyncMethodBuilder(typeof(CustomAsyncTaskMethodBuilder<,>))]
 public struct MyAwesomeType<T>
 {
-  public T Result { get; set; }
+    public T Result { get; set; }
 }
 
 public class CustomAsyncTaskMethodBuilder<T, V>
 {
-  public MyAwesomeType<T> Task => default(MyAwesomeType<T>);
-  public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
-  public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
-  public static CustomAsyncTaskMethodBuilder<T, V> Create() { return default(CustomAsyncTaskMethodBuilder<T, V>); }
-  public void SetException(Exception exception) { }
-  public void SetResult(T t) { }
-  public void SetStateMachine(IAsyncStateMachine stateMachine) { }
-  public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public MyAwesomeType<T> Task => default(MyAwesomeType<T>);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public static CustomAsyncTaskMethodBuilder<T, V> Create() { return default(CustomAsyncTaskMethodBuilder<T, V>); }
+    public void SetException(Exception exception) { }
+    public void SetResult(T t) { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
 }
-
 
 namespace System.Runtime.CompilerServices
 {
     public class AsyncMethodBuilderAttribute : System.Attribute { public AsyncMethodBuilderAttribute(Type type) { } }
 }";
-            var compilation = CreateCompilation(source);
-            compilation.VerifyEmitDiagnostics();
+            var compilation = CreateCompilation(source, options: TestOptions.DebugDll);
+            compilation.VerifyEmitDiagnostics(
+                // (8,53): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     public async MyAwesomeType<string> CustomTask() { await Task.Delay(1000); return string.Empty; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "{ await Task.Delay(1000); return string.Empty; }").WithLocation(8, 53)
+                );
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -4830,5 +4830,48 @@ class C
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.IAsyncStateMachine", "SetStateMachine").WithLocation(62, 37));
         }
 
+        [Fact, WorkItem(16531, "https://github.com/dotnet/roslyn/issues/16531")]
+        public void ArityMismatch()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+  public async MyAwesomeType<string> CustomTask()
+  {
+    await Task.Delay(1000);
+    return string.Empty;
+  }
+}
+
+[AsyncMethodBuilder(typeof(CustomAsyncTaskMethodBuilder<,>))]
+public struct MyAwesomeType<T>
+{
+  public T Result { get; set; }
+}
+
+public class CustomAsyncTaskMethodBuilder<T, V>
+{
+  public MyAwesomeType<T> Task => default(MyAwesomeType<T>);
+  public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+  public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+  public static CustomAsyncTaskMethodBuilder<T, V> Create() { return default(CustomAsyncTaskMethodBuilder<T, V>); }
+  public void SetException(Exception exception) { }
+  public void SetResult(T t) { }
+  public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+  public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+}
+
+
+namespace System.Runtime.CompilerServices
+{
+    public class AsyncMethodBuilderAttribute : System.Attribute { public AsyncMethodBuilderAttribute(Type type) { } }
+}";
+            var compilation = CreateCompilation(source);
+            compilation.VerifyEmitDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

When creating a custom task-like type, the customer uses an async method builder type of wrong arity (anything other than 1 for a generic task). The compiler crashes, but should report an error diagnostic.
```C#
[AsyncMethodBuilder(typeof(CustomAsyncTaskMethodBuilder<,>))]
public struct MyAwesomeType<T> { }
```

**Bugs this fixes:** 

Fixes https://github.com/dotnet/roslyn/issues/16531

**Workarounds, if any**
Use valid code.

**Risk**
**Performance impact**
Low. This is adding an arity==1 check in the validation of the async method builder.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
Missed this negative test case.

**How was the bug found?**
Customer reported.

@cston @dotnet/roslyn-compiler for review.