### PR TITLE
Remove LINQ allocations from FAR item display logic

### DIFF
--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -68,9 +68,9 @@ namespace Microsoft.CodeAnalysis
         {
             var pooled = PooledStringBuilder.GetInstance();
             var builder = pooled.Builder;
-            for (int i = 0; i < values.Length; i++)
+            foreach (var val in values)
             {
-                builder.Append(values[i].Text);
+                builder.Append(val.Text);
             }
 
             return pooled.ToStringAndFree();

--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -57,9 +58,22 @@ namespace Microsoft.CodeAnalysis
 
         public static string JoinText(this ImmutableArray<TaggedText> values)
         {
+            
             return values.IsDefault
                 ? null
-                : string.Join("", values.Select(t => t.Text));
+                : Join(values);
+        }
+
+        private static string Join(ImmutableArray<TaggedText> values)
+        {
+            var pooled = PooledStringBuilder.GetInstance();
+            var builder = pooled.Builder;
+            for (int i = 0; i < values.Length; i++)
+            {
+                builder.Append(values[i].Text);
+            }
+
+            return pooled.ToStringAndFree();
         }
 
         public static string ToClassificationTypeName(this string taggedTextTag)


### PR DESCRIPTION
This usage of .Select is responsible for 1.3% of allocations if you FAR for SyntaxNode.

**Customer scenario**

This will potentially make find all references faster for all customers.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/13326

**Workarounds, if any**

N/A, this is a performance improvement.

**Risk**

Extremely low, this replaces a call to .Select with a foreach loop.

**Performance impact**

Positive--allocation of the WhereSelectEnumerator was showing up in performance traces and now we will not allocate it.

**Is this a regression from a previous update?** 
N/A

**Root cause analysis:**

We prefer to use LINQ when possible and remove usages that show up on hot paths.

**How was the bug found?**

Ad hoc testing in response to telemetry showing FAR performance was out of goal.