### PR TITLE
Stop applying ComVisible attribute to embedded value types.

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypesManager.cs
@@ -572,15 +572,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             var compilation = ModuleBeingBuilt.Compilation;
             return compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor);
         }
-
-        protected override CSharpAttributeData CreateComVisibleAttribute()
-        {
-            var compilation = ModuleBeingBuilt.Compilation;
-            return compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_InteropServices_ComVisibleAttribute__ctor,
-                                                      ImmutableArray.Create(new TypedConstant(compilation.GetSpecialType(SpecialType.System_Boolean),
-                                                                                              TypedConstantKind.Primitive,
-                                                                                              value:true)), 
-                                                      isOptionalUse:true);
-        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -1201,10 +1201,9 @@ class UsePia4
                     Assert.Equal(TypeAttributes.Public | TypeAttributes.SequentialLayout | TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit, test2.Flags);
 
                     attributes = test2.GetAttributes();
-                    Assert.Equal(3, attributes.Length);
+                    Assert.Equal(2, attributes.Length);
                     Assert.Equal("System.Runtime.CompilerServices.CompilerGeneratedAttribute", attributes[0].ToString());
                     Assert.Equal(@"System.Runtime.InteropServices.TypeIdentifierAttribute(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"", ""Test2"")", attributes[1].ToString());
-                    Assert.Equal("System.Runtime.InteropServices.ComVisibleAttribute(true)", attributes[2].ToString());
 
                     var itest3 = module.GlobalNamespace.GetTypeMembers("ITest3").Single();
                     Assert.Equal(TypeKind.Interface, itest3.TypeKind);
@@ -1262,10 +1261,9 @@ class UsePia4
                     Assert.Equal(TypeAttributes.Public | TypeAttributes.AutoLayout | TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.AnsiClass, test9.Flags);
 
                     attributes = test9.GetAttributes();
-                    Assert.Equal(3, attributes.Length);
+                    Assert.Equal(2, attributes.Length);
                     Assert.Equal("System.Runtime.CompilerServices.CompilerGeneratedAttribute", attributes[0].ToString());
                     Assert.Equal(@"System.Runtime.InteropServices.TypeIdentifierAttribute(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"", ""Test9"")", attributes[1].ToString());
-                    Assert.Equal("System.Runtime.InteropServices.ComVisibleAttribute(true)", attributes[2].ToString());
 
                     var fieldToEmit = test9.GetFieldsToEmit().ToArray().AsImmutableOrNull();
                     Assert.Equal(3, fieldToEmit.Length);

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -203,11 +203,6 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
                 builder.AddOptional(CreateTypeIdentifierAttribute(hasGuid && IsInterface, syntaxNodeOpt, diagnostics));
 
-                if (UnderlyingNamedType.IsValueType)
-                {
-                    builder.AddOptional(TypeManager.CreateComVisibleAttribute());
-                }
-
                 return builder.ToImmutableAndFree();
             }
 

--- a/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
@@ -156,7 +156,6 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
         protected abstract void ReportNameCollisionBetweenEmbeddedTypes(TEmbeddedType typeA, TEmbeddedType typeB, DiagnosticBag diagnostics);
         protected abstract void ReportNameCollisionWithAlreadyDeclaredType(TEmbeddedType type, DiagnosticBag diagnostics);
         protected abstract TAttributeData CreateCompilerGeneratedAttribute();
-        protected abstract TAttributeData CreateComVisibleAttribute();
 
         private sealed class TypeComparer : IComparer<TEmbeddedType>
         {

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -494,15 +494,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Return compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor)
         End Function
 
-        Protected Overrides Function CreateComVisibleAttribute() As VisualBasicAttributeData
-            Dim compilation = ModuleBeingBuilt.Compilation
-            Return compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_InteropServices_ComVisibleAttribute__ctor,
-                                                      ImmutableArray.Create(New TypedConstant(compilation.GetSpecialType(SpecialType.System_Boolean),
-                                                                                              TypedConstantKind.Primitive,
-                                                                                              value:=True)),
-                                                      isOptionalUse:=True)
-        End Function
-
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
@@ -1033,10 +1033,9 @@ End Class
                                                            Assert.Equal(TypeAttributes.Public Or TypeAttributes.SequentialLayout Or TypeAttributes.Class Or TypeAttributes.Sealed Or TypeAttributes.AnsiClass Or TypeAttributes.BeforeFieldInit, test2.TypeDefFlags)
 
                                                            attributes = test2.GetAttributes()
-                                                           Assert.Equal(3, attributes.Length)
+                                                           Assert.Equal(2, attributes.Length)
                                                            Assert.Equal("System.Runtime.CompilerServices.CompilerGeneratedAttribute", attributes(0).ToString())
                                                            Assert.Equal("System.Runtime.InteropServices.TypeIdentifierAttribute(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"", ""Test2"")", attributes(1).ToString())
-                                                           Assert.Equal("System.Runtime.InteropServices.ComVisibleAttribute(True)", attributes(2).ToString())
 
                                                            Dim itest3 = [module].GlobalNamespace.GetMember(Of NamedTypeSymbol)("ITest3")
                                                            Assert.Equal(TypeKind.Interface, itest3.TypeKind)
@@ -1094,10 +1093,9 @@ End Class
                                                            Assert.Equal(TypeAttributes.Public Or TypeAttributes.AutoLayout Or TypeAttributes.Class Or TypeAttributes.Sealed Or TypeAttributes.AnsiClass, test9.TypeDefFlags)
 
                                                            attributes = test9.GetAttributes()
-                                                           Assert.Equal(3, attributes.Length)
+                                                           Assert.Equal(2, attributes.Length)
                                                            Assert.Equal("System.Runtime.CompilerServices.CompilerGeneratedAttribute", attributes(0).ToString())
                                                            Assert.Equal("System.Runtime.InteropServices.TypeIdentifierAttribute(""f9c2d51d-4f44-45f0-9eda-c9d599b58257"", ""Test9"")", attributes(1).ToString())
-                                                           Assert.Equal("System.Runtime.InteropServices.ComVisibleAttribute(True)", attributes(2).ToString())
 
                                                            Dim fieldToEmit = test9.GetFieldsToEmit().ToArray().AsImmutableOrNull()
                                                            Assert.Equal(3, fieldToEmit.Length)


### PR DESCRIPTION
**Customer scenario**
Customer uses tlbexp tool on an assembly that embeds value types (structures or enums). The output now includes type declarations for the embedded value types, which causes a build break due to a name conflict with types declared elsewhere. Broke VS build.  

**Bugs this fixes:** 
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=370269.
Related to #16177.
Reverting behavior change introduced in https://github.com/dotnet/roslyn/pull/16279.

**Workarounds, if any**
None, except stop using NoPia.

**Risk**
Low. Reverting to the previous behavior.

**Performance impact**
Low

**Is this a regression from a previous update?**
Yes.

**Root cause analysis:**
Interaction of different tools.

**How was the bug found?**
Toolset update for VS codebase.

@dotnet/roslyn-compiler, @jcouv, @cston Please review.  