### PR TITLE
Build cleanup

### DIFF
--- a/build/Defaults/Desktop/app.config
+++ b/build/Defaults/Desktop/app.config
@@ -74,26 +74,10 @@
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
       </dependentAssembly>
 
-      <!-- Even though all of our references are to Dev15 binaries we are still pulling in the interactive window 
+      <!-- Even though all of our references are to Dev15 binaries we are still pulling in BasicUndo
            which references Dev14.  Until that moves to Dev15 we need these redirects -->
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="4.0.0.0-4.5.65535.65535" newVersion="4.5.24.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.ComponentModelHost" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.CoreUtility" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Editor" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Text.Data" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
@@ -101,26 +85,9 @@
         <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Text.Internal" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.VisualStudio.Text.UI" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Text.UI.Wpf" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Language.Intellisense" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Language.StandardClassification" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="2.0.0.0-14.0.0.0" newVersion="15.0.0.0"/>
-      </dependentAssembly>
-
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -25,6 +25,8 @@
     <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0-rc3-61304-09</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>1.1.0</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
+    <MicrosoftVisualStudioInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioInteractiveWindowVersion>
+    <MicrosoftVisualStudioVsInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioVsInteractiveWindowVersion>
     <RoslynToolsMicrosoftLocateVSVersion>0.2.4-beta</RoslynToolsMicrosoftLocateVSVersion>
     <RoslynToolsMicrosoftSignToolVersion>0.3.0-beta</RoslynToolsMicrosoftSignToolVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.2.4-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>

--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -17,8 +17,6 @@
     <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">rc4</RoslynNuGetMoniker>
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>
-    <!-- Currently we version IW the same as Roslyn. -->
-    <MicrosoftVisualStudioInteractiveWindowVersion>$(RoslynAssemblyVersionBase)</MicrosoftVisualStudioInteractiveWindowVersion>
 
     <!-- We should not be signing a build anywhere except for in MicroBuild, which will always specify 'BUILD_BUILDNUMBER'-->
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>

--- a/build/config/RepoUtilData.json
+++ b/build/config/RepoUtilData.json
@@ -28,6 +28,8 @@
         "Microsoft.VisualBasic",
         "Microsoft.Composition",
         "Microsoft.CSharp",
+        "Microsoft.VisualStudio.InteractiveWindow",
+        "Microsoft.VisualStudio.VsInteractiveWindow",
         "MicroBuild.*",
         "ManagedEsent",
         "Microsoft.CodeAnalysis.Elfie",


### PR DESCRIPTION
Minor cleanup in build infrastructure:

- remove unnecessary test binding redirects
- remove special casing of MicrosoftVisualStudioInteractiveWindowVersion

No product changes.