### PR TITLE
Run Apply Changes on UI Thread

### DIFF
--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -2,6 +2,7 @@
 
 Imports System.Threading
 Imports System.Threading.Tasks
+Imports System.Windows.Threading
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 
@@ -79,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
 
         ''' <summary>
         ''' Commits any dirty region, if one exists.
-        ''' 
+        '''
         ''' To improve perf, passing false to isExplicitFormat will avoid semantic checks when expanding
         ''' the formatting span to an entire block
         ''' </summary>
@@ -115,7 +116,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     End If
 
                     Dim tree = _dirtyState.BaseDocument.GetSyntaxTreeSynchronously(cancellationToken)
-                    _commitFormatter.CommitRegionAsync(info.SpanToFormat, isExplicitFormat, info.UseSemantics, dirtyRegion, _dirtyState.BaseSnapshot, tree, cancellationToken).Wait(cancellationToken)
+                    _commitFormatter.CommitRegion(info.SpanToFormat, isExplicitFormat, info.UseSemantics, dirtyRegion, _dirtyState.BaseSnapshot, tree, cancellationToken)
                 End Using
             Finally
                 ' We may have tracked a dirty region while committing or it may have been aborted.

--- a/src/EditorFeatures/VisualBasic/LineCommit/ICommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/ICommitFormatter.vb
@@ -1,7 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
-Imports System.Threading.Tasks
 Imports Microsoft.VisualStudio.Text
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
@@ -12,13 +11,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
         ''' by this function. Further, if the operation is cancelled, the buffer may be left in a
         ''' partially committed state that must be rolled back by the transaction.
         ''' </summary>
-        Function CommitRegionAsync(
+        Sub CommitRegion(
             spanToFormat As SnapshotSpan,
             isExplicitFormat As Boolean,
             useSemantics As Boolean,
             dirtyRegion As SnapshotSpan,
             baseSnapshot As ITextSnapshot,
             baseTree As SyntaxTree,
-            cancellationToken As CancellationToken) As Task
+            cancellationToken As CancellationToken)
     End Interface
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -121,13 +121,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                 _testWorkspace = testWorkspace
             End Sub
 
-            Public Async Function CommitRegionAsync(spanToFormat As SnapshotSpan,
+            Public Sub CommitRegion(spanToFormat As SnapshotSpan,
                                     isExplicitFormat As Boolean,
                                     useSemantics As Boolean,
                                     dirtyRegion As SnapshotSpan,
                                     baseSnapshot As ITextSnapshot,
                                     baseTree As SyntaxTree,
-                                    cancellationToken As CancellationToken) As Task Implements ICommitFormatter.CommitRegionAsync
+                                    cancellationToken As CancellationToken) Implements ICommitFormatter.CommitRegion
                 GotCommit = True
                 UsedSemantics = useSemantics
 
@@ -140,8 +140,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                 End If
 
                 Dim realCommitFormatter As New CommitFormatter()
-                Await realCommitFormatter.CommitRegionAsync(spanToFormat, isExplicitFormat, useSemantics, dirtyRegion, baseSnapshot, baseTree, cancellationToken)
-            End Function
+                realCommitFormatter.CommitRegion(spanToFormat, isExplicitFormat, useSemantics, dirtyRegion, baseSnapshot, baseTree, cancellationToken)
+            End Sub
         End Class
     End Class
 End Namespace


### PR DESCRIPTION
**Customer scenario**

Customer types in a VB file (Venus or Razor tend to encounter this more often) and sometimes an error pops up saying an exception has occurred and they should check their activity log and they can no longer make edits to the file until they close and reopen it.

**Bugs this fixes:** 

VSO bug [289109](https://devdiv.visualstudio.com/DevDiv/_workitems?id=289109)
VSO bug [361874](https://devdiv.visualstudio.com/DevDiv/_workitems?id=361874)

**Workarounds, if any**

close and reopening the file re-creates the text buffer allowing editing to continue until this case is hit again.

**Risk**

Low, this fix ensures that thread ownership exceptions will no longer be thrown by the buffer, it is a very minimal fix.

**Performance impact**

None, this fixes threading behavior to be correct.  The amount of information being processed is no being changed.

**Is this a regression from a previous update?**
    Yes, it was introduced with this PR https://github.com/dotnet/roslyn/pull/6664

**Root cause analysis:**

    Calling Wait() on a task means it will block the current thread until
    the underlying task is complete, however that task may still run on a
    background thread.  We are seeing an error where the async method is
    being scheduled to a background thread when we try and commit an edit to
    the buffer.  Edits to the buffer can only be made from the UI thread so
    exceptions are thrown.

    The simplest fix here is to not make the method async at all.

**How was the bug found?**
    Customers reported this via VS Feedback, there was also a failing test in the web teams repo that found this.