### PR TITLE
Ensure apply operation is cancelled in event of exception.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -239,7 +239,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         edit.Replace(change.Span.Start, change.Span.Length, change.NewText);
                     }
 
-                    edit.Apply();
+                    edit.ApplyAndCancelOnException();
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -125,9 +125,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             if (projectionBuffer != null)
             {
                 // For TypeScript hosted in HTML the source buffers will have type names
-                // HTMLX and TypeScript. RazorCSharp has an HTMLX base type but should 
-                // not be associated with the HTML host type. Use ContentType.TypeName 
-                // instead of ContentType.IsOfType for HTMLX to ensure the Razor host 
+                // HTMLX and TypeScript. RazorCSharp has an HTMLX base type but should
+                // not be associated with the HTML host type. Use ContentType.TypeName
+                // instead of ContentType.IsOfType for HTMLX to ensure the Razor host
                 // type is identified correctly.
                 if (projectionBuffer.SourceBuffers.Any(b => b.ContentType.IsOfType(HTML) ||
                     string.Compare(HTMLX, b.ContentType.TypeName, StringComparison.OrdinalIgnoreCase) == 0))
@@ -755,7 +755,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 var currentVisibleSpanIndex = 0;
                 foreach (var change in changes)
                 {
-                    // Find the next visible span that either overlaps or intersects with 
+                    // Find the next visible span that either overlaps or intersects with
                     while (currentVisibleSpanIndex < visibleSpansInOriginal.Count &&
                            visibleSpansInOriginal[currentVisibleSpanIndex].End < change.Span.Start)
                     {
@@ -776,7 +776,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     affectedSpans.Add(currentVisibleSpanIndex);
                 }
 
-                edit.Apply();
+                edit.ApplyAndCancelOnException();
             }
         }
 

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Telemetry\VSTelemetryActivityLogger.cs" />
     <Compile Include="Telemetry\VSTelemetryCache.cs" />
     <Compile Include="Telemetry\VSTelemetryLogger.cs" />
+    <Compile Include="Utilities\ITextEditExtensions.cs" />
     <Compile Include="Utilities\IVsEditorAdaptersFactoryServiceExtensions.cs" />
     <Compile Include="Utilities\VSCodeAnalysisColors.cs" />
     <Compile Include="Implementation\WorkspaceCacheService.cs" />

--- a/src/VisualStudio/Core/Def/Utilities/ITextEditExtensions.cs
+++ b/src/VisualStudio/Core/Def/Utilities/ITextEditExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.Text
+{
+    internal static class ITextEditExtensions
+    {
+        /// <summary>
+        /// If exceptions are thrown we need to cancel the edit so subsequent edits can succeed.
+        /// Exceptions are not handled but thrown so we can still diagnose what the root cause is.
+        /// </summary>
+        /// <param name="edit"></param>
+        internal static void ApplyAndCancelOnException(this ITextEdit edit)
+        {
+            try
+            {
+                edit.Apply();
+            }
+            catch (Exception)
+            {
+                edit.Cancel();
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**

    The customer makes an edit in a C# or Visual Basic file.
    They are shown an error dialog and every subsequent
    attempt at typing in the editor  brings up a new error dialog.
    The user can no longer enter text.

**Bugs this fixes:** 

fixes VSO bug [298721](https://devdiv.visualstudio.com/DevDiv/_workitems?id=298721)
fixes VSO bug [360664](https://devdiv.visualstudio.com/DevDiv/_workitems?id=360664)
fixes VSO bug [364895](https://devdiv.visualstudio.com/DevDiv/_workitems?id=364895)
fixes VSO bug [364881](https://devdiv.visualstudio.com/DevDiv/_workitems?id=364881)

**Workarounds, if any**

    The user can close and reopen the file to re-enable text entry

**Risk**

    Low, this does not change any product code other then to correctly cancel an edit if an error is handled

**Performance impact**

    Low, this does not change any product code other then to correctly cancel an edit if an error is handled

**Is this a regression from a previous update?**

    Yes, bug was not reported in Dev14

**Root cause analysis:**

    If, in the course of applying an edit we get an exception, 
    we cause the buffer to be made unusable.  At the very 
    least we should free the buffer so future edits can be 
    applied to it without it needing to be recreated.

**How was the bug found?**

    Customer feedback