### PR TITLE
Update DSR dependencies to release

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -20,9 +20,9 @@
     <MicrosoftCSharpVersion>4.3.0</MicrosoftCSharpVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
-    <MicrosoftDiaSymReaderVersion>1.1.0-rc3-61303-01</MicrosoftDiaSymReaderVersion>
+    <MicrosoftDiaSymReaderVersion>1.1.0</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.5.0-beta1</MicrosoftDiaSymReaderNativeVersion>
-    <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0-rc3-61304-09</MicrosoftDiaSymReaderPortablePdbVersion>
+    <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>1.1.0</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
     <RoslynToolsMicrosoftLocateVSVersion>0.2.4-beta</RoslynToolsMicrosoftLocateVSVersion>

--- a/src/Compilers/CSharp/Test/Emit/project.json
+++ b/src/Compilers/CSharp/Test/Emit/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",
     "xunit.runner.visualstudio": "2.2.0-beta4-build1194"

--- a/src/Compilers/Server/VBCSCompilerTests/project.json
+++ b/src/Compilers/Server/VBCSCompilerTests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.Build": "14.3.0",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "Moq": "4.2.1402.2112",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",

--- a/src/Compilers/VisualBasic/Test/Emit/project.json
+++ b/src/Compilers/VisualBasic/Test/Emit/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",
     "xunit.runner.visualstudio": "2.2.0-beta4-build1194"

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/project.json
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.VisualStudio.Debugger.Engine": "14.3.25422",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",
     "xunit.runner.visualstudio": "2.2.0-beta4-build1194"

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/project.json
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.VisualStudio.Debugger.Engine": "14.3.25422",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01"
+    "Microsoft.DiaSymReader": "1.1.0"
   },
   "frameworks": {
     "netstandard1.3": {

--- a/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/project.json
+++ b/src/ExpressionEvaluator/Core/Test/ExpressionCompiler/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.VisualStudio.Debugger.Engine": "14.3.25422",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",
     "xunit.runner.visualstudio": "2.2.0-beta4-build1194"

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/project.json
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.VisualStudio.Debugger.Engine": "14.3.25422",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",
     "xunit.runner.visualstudio": "2.2.0-beta4-build1194"

--- a/src/Setup/DevDivPackages/Debugger/project.json
+++ b/src/Setup/DevDivPackages/Debugger/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0-rc3-61304-09",
+    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
     "System.Diagnostics.Process": "4.3.0",
     "System.IO.FileSystem": "4.3.0",
     "System.IO.FileSystem.Primitives": "4.3.0",

--- a/src/Setup/DevDivPackages/Roslyn/project.json
+++ b/src/Setup/DevDivPackages/Roslyn/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "Microsoft.DiaSymReader.Native": "1.5.0-beta1",
     "Microsoft.CodeAnalysis.Elfie": "0.10.6-rc2",
     "System.Collections.Immutable": "1.3.1",

--- a/src/Test/PdbUtilities/project.json
+++ b/src/Test/PdbUtilities/project.json
@@ -3,8 +3,8 @@
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "Microsoft.DiaSymReader.Native": "1.5.0-beta1",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0-rc3-61304-09",
+    "Microsoft.DiaSymReader": "1.1.0",
+    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
     "System.Collections.Immutable": "1.3.1",
     "System.Reflection.Metadata": "1.4.2",
     "System.Xml.ReaderWriter": "4.3.0"

--- a/src/Test/Utilities/Desktop/project.json
+++ b/src/Test/Utilities/Desktop/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "2.0.0-pre-20160714",
     "Microsoft.DiaSymReader.Native": "1.5.0-beta1",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",
     "xunit.runner.visualstudio": "2.2.0-beta4-build1194"

--- a/src/Test/Utilities/Portable.FX45/project.json
+++ b/src/Test/Utilities/Portable.FX45/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "2.0.0-pre-20160714",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",
     "xunit.runner.visualstudio": "2.2.0-beta4-build1194"

--- a/src/Tools/Source/Pdb2Xml/project.json
+++ b/src/Tools/Source/Pdb2Xml/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01"
+    "Microsoft.DiaSymReader": "1.1.0"
   },
   "frameworks": {
     "net46": { }

--- a/src/VisualStudio/Core/Def/project.json
+++ b/src/VisualStudio/Core/Def/project.json
@@ -36,7 +36,7 @@
     "Microsoft.VisualStudio.TextManager.Interop.12.0": "12.0.30110",
     "Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime": "12.1.30328",
     "Microsoft.VisualStudio.Designer.Interfaces": "1.1.4322",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
+    "Microsoft.DiaSymReader": "1.1.0",
     "Microsoft.MSXML": "8.0.0.0-alpha",
     "Microsoft.Build": "15.1.0-preview-000458-02",
     "VSLangProj": "7.0.3300-alpha",

--- a/src/VisualStudio/Setup.Dependencies/project.json
+++ b/src/VisualStudio/Setup.Dependencies/project.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "Microsoft.VisualStudio.Shell.Framework": "15.0.26014-alpha",
     "Microsoft.VisualStudio.Shell.15.0": "15.0.26014-alpha",
-    "Microsoft.DiaSymReader": "1.1.0-rc3-61303-01",
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0-rc3-61304-09",
+    "Microsoft.DiaSymReader": "1.1.0",
+    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
     "System.Collections.Immutable": "1.3.1",
     "System.Collections": "4.3.0",
     "System.Collections.Concurrent": "4.3.0",

--- a/src/VisualStudio/Setup/project.json
+++ b/src/VisualStudio/Setup/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0-rc3-61304-09",
+    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
     "ManagedEsent": "1.9.4"
   },
   "frameworks": {


### PR DESCRIPTION
**Customer scenario**

Updates Roslyn to use release versions of managed DiaSymReader dependencies.

**Bugs this fixes:** 

VSO 370635

**Workarounds, if any**
None.

**Risk**

Small. There is no product change between RC3 and RTW bits of DSR and DSRP. The only change is in file versions. Assembly versions are also unchanged.

**Performance impact**

None

**Is this a regression from a previous update?**

**Root cause analysis:**

**How was the bug found?**
