### PR TITLE
Show `base` keyword within expression-bodied accessors

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/BaseKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/BaseKeywordRecommenderTests.cs
@@ -120,5 +120,16 @@ class C
     {
         var c = new C { x = 2, y = 3, $$");
         }
+
+        [WorkItem(16335, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/16335")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task InExpressionBodyAcessor()
+        {
+            await VerifyKeywordAsync(@"
+class B
+{
+    public virtual int T { get => bas$$ }
+}");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 syntaxTree.IsDelegateReturnTypeContext(position, leftToken, cancellationToken),
                 syntaxTree.IsTypeOfExpressionContext(position, leftToken, cancellationToken),
                 syntaxTree.GetPrecedingModifiers(position, leftToken, cancellationToken),
-                syntaxTree.IsInstanceContext(position, leftToken, cancellationToken),
+                syntaxTree.IsInstanceContext(targetToken, semanticModel, cancellationToken),
                 syntaxTree.IsCrefContext(position, cancellationToken) && !leftToken.IsKind(SyntaxKind.DotToken),
                 syntaxTree.IsCatchFilterContext(position, leftToken),
                 isDestructorTypeContext,

--- a/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
@@ -331,7 +331,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             switch (memberDeclaration?.Kind())
             {
                 case SyntaxKind.PropertyDeclaration:
-                    return ((PropertyDeclarationSyntax)memberDeclaration).ExpressionBody;
+                    var propertyDeclaration = (PropertyDeclarationSyntax)memberDeclaration;
+                    return propertyDeclaration.ExpressionBody ??
+                        propertyDeclaration.AccessorList.Accessors.FirstOrDefault(a => a.ExpressionBody != null)
+                            ?.ExpressionBody;
                 case SyntaxKind.MethodDeclaration:
                     return ((MethodDeclarationSyntax)memberDeclaration).ExpressionBody;
                 case SyntaxKind.IndexerDeclaration:

--- a/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/MemberDeclarationSyntaxExtensions.cs
@@ -331,10 +331,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             switch (memberDeclaration?.Kind())
             {
                 case SyntaxKind.PropertyDeclaration:
-                    var propertyDeclaration = (PropertyDeclarationSyntax)memberDeclaration;
-                    return propertyDeclaration.ExpressionBody ??
-                        propertyDeclaration.AccessorList.Accessors.FirstOrDefault(a => a.ExpressionBody != null)
-                            ?.ExpressionBody;
+                    return ((PropertyDeclarationSyntax)memberDeclaration).ExpressionBody;
                 case SyntaxKind.MethodDeclaration:
                     return ((MethodDeclarationSyntax)memberDeclaration).ExpressionBody;
                 case SyntaxKind.IndexerDeclaration:


### PR DESCRIPTION
@dotnet/roslyn-ide for review
Fixes #16335