### PR TITLE
Improve EnC error message when DPL is on

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/EncDebuggingSessionInfo.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EncDebuggingSessionInfo.cs
@@ -4,10 +4,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
-    internal class EncDebuggingSessionInfo
+    internal sealed class EncDebuggingSessionInfo
     {
         public readonly List<EncEditSessionInfo> EditSessions = new List<EncEditSessionInfo>();
-        public int EmptyEditSessions;
+        public int EmptyEditSessions { get; private set; }
+        public bool ReadOnlyEditAttemptedProjectNotBuiltOrLoaded { get; private set; }
 
         internal void EndEditSession(EncEditSessionInfo encEditSessionInfo)
         {
@@ -19,6 +20,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 EditSessions.Add(encEditSessionInfo);
             }
+        }
+
+        internal void LogReadOnlyEditAttemptedProjectNotBuiltOrLoaded()
+        {
+            ReadOnlyEditAttemptedProjectNotBuiltOrLoaded = true;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/DebugLogMessage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/DebugLogMessage.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
 
         private const string SessionCount = nameof(SessionCount);
         private const string EmptySessionCount = nameof(EmptySessionCount);
+        private const string ReadOnlyEditAttemptedProjectNotBuiltOrLoaded = nameof(ReadOnlyEditAttemptedProjectNotBuiltOrLoaded);
 
         private const string HadCompilationErrors = nameof(HadCompilationErrors);
         private const string HadRudeEdits = nameof(HadRudeEdits);
@@ -61,6 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             map[SessionId] = sessionId;
             map[SessionCount] = session.EditSessions.Count;
             map[EmptySessionCount] = session.EmptyEditSessions;
+            map[ReadOnlyEditAttemptedProjectNotBuiltOrLoaded] = session.ReadOnlyEditAttemptedProjectNotBuiltOrLoaded;
         }
 
         private static void CreateSessionEditKeyValue(Dictionary<string, object> map, int sessionId, int editSessionId, EncEditSessionInfo editSession)

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -153,6 +153,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             }
 
             // NotifyEncEditDisallowedByProject is broken if the project isn't built at the time the debugging starts (debugger bug 877586).
+            // TODO: localize messages https://github.com/dotnet/roslyn/issues/16656
 
             string message;
             if (sessionReason == SessionReadOnlyReason.Running)
@@ -166,6 +167,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                 switch (projectReason)
                 {
                     case ProjectReadOnlyReason.MetadataNotAvailable:
+                        // TODO: Remove once https://github.com/dotnet/roslyn/issues/16657 is addressed
                         bool deferredLoad = (_vsProject.ServiceProvider.GetService(typeof(SVsSolution)) as IVsSolution7)?.IsSolutionLoadDeferred() == true;
                         if (deferredLoad)
                         {

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -175,6 +175,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                                       Environment.NewLine +
                                       "'Lightweight solution load' is enabled for the current solution. " +
                                       "Disable it to ensure that all projects are loaded when debugging starts.";
+
+                            s_encDebuggingSessionInfo?.LogReadOnlyEditAttemptedProjectNotBuiltOrLoaded();
                         }
                         else
                         {


### PR DESCRIPTION
**Customer scenario**

When DPL is on EnC doesn’t work for projects that were not loaded when the debugging session starts.
The error reported today doesn't help the customer to work around the issue: 

> Changes are not allowed if the project wasn't built when debugging started.

Change the error message to following when DPL is detected:

>  Changes are not allowed if the project wasn't loaded and built when debugging started.
>  
> 'Lightweight solution load' is enabled for the current solution.
> Disable it to ensure that all projects are loaded when debugging starts.

**Bugs this fixes:** 

VSO 361549

**Workarounds, if any**

N/A

**Risk**

Small.

**Performance impact**

None.

**Is this a regression from a previous update?**

Yes. Regression in EnC was introduced by DPL.

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

Internal testing.