### PR TITLE
add support for StrongNameProvider for LUT.

### DIFF
--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -516,6 +516,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private static string GetXmlResolverBasePath(string filePath)
         {
+            // Given filePath can be any arbitary string project is created with.
+            // for primary solution in host such as VSWorkspace, ETA or MSBuildWorkspace
+            // filePath will point to actual file on disk, but in memory solultion, or
+            // one from AdhocWorkspace and etc, FilePath can be a random string.
+            // Make sure we return only if given filePath is in right form.
             if (!PathUtilities.IsAbsolute(filePath))
             {
                 // xmlFileResolver can only deal with absolute path
@@ -529,6 +534,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private ImmutableArray<string> GetStrongNameKeyPaths(ProjectInfo.ProjectAttributes info)
         {
+            // Given FilePath/OutputFilePath can be any arbitary strings project is created with.
+            // for primary solution in host such as VSWorkspace, ETA or MSBuildWorkspace
+            // filePath will point to actual file on disk, but in memory solultion, or
+            // one from AdhocWorkspace and etc, FilePath/OutputFilePath can be a random string.
+            // Make sure we return only if given filePath is in right form.
             if (info.FilePath == null && info.OutputFilePath == null)
             {
                 // return empty since that is what IDE does for this case

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -510,11 +510,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
         private CompilationOptions FixUpCompilationOptions(ProjectInfo.ProjectAttributes info, CompilationOptions compilationOptions)
         {
-            return compilationOptions.WithXmlReferenceResolver(new XmlFileResolver(GetXmlResolverBasePath(info.FilePath)))
+            return compilationOptions.WithXmlReferenceResolver(GetXmlResolver(info.FilePath))
                                      .WithStrongNameProvider(new DesktopStrongNameProvider(GetStrongNameKeyPaths(info)));
         }
 
-        private static string GetXmlResolverBasePath(string filePath)
+        private static XmlFileResolver GetXmlResolver(string filePath)
         {
             // Given filePath can be any arbitary string project is created with.
             // for primary solution in host such as VSWorkspace, ETA or MSBuildWorkspace
@@ -524,12 +524,11 @@ namespace Microsoft.CodeAnalysis.Remote
             if (!PathUtilities.IsAbsolute(filePath))
             {
                 // xmlFileResolver can only deal with absolute path
-                // return null if file path is not something xml file resolver can handle.
-                // it knows how to handle null
-                return null;
+                // return Default
+                return XmlFileResolver.Default;
             }
 
-            return PathUtilities.GetDirectoryName(filePath);
+            return new XmlFileResolver(PathUtilities.GetDirectoryName(filePath));
         }
 
         private ImmutableArray<string> GetStrongNameKeyPaths(ProjectInfo.ProjectAttributes info)

--- a/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionCreator.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -160,7 +162,11 @@ namespace Microsoft.CodeAnalysis.Remote
             // changed compilation options
             if (oldProjectChecksums.CompilationOptions != newProjectChecksums.CompilationOptions)
             {
-                project = project.WithCompilationOptions(await _assetService.GetAssetAsync<CompilationOptions>(newProjectChecksums.CompilationOptions, _cancellationToken).ConfigureAwait(false));
+                project = project.WithCompilationOptions(
+                    FixUpCompilationOptions(
+                        project.State.ProjectInfo.Attributes,
+                        await _assetService.GetAssetAsync<CompilationOptions>(
+                            newProjectChecksums.CompilationOptions, _cancellationToken).ConfigureAwait(false)));
             }
 
             // changed parse options
@@ -424,7 +430,11 @@ namespace Microsoft.CodeAnalysis.Remote
 
             Contract.ThrowIfFalse(_baseSolution.Workspace.Services.IsSupported(projectInfo.Language));
 
-            var compilationOptions = await _assetService.GetAssetAsync<CompilationOptions>(projectSnapshot.CompilationOptions, _cancellationToken).ConfigureAwait(false);
+            var compilationOptions = FixUpCompilationOptions(
+                projectInfo,
+                await _assetService.GetAssetAsync<CompilationOptions>(
+                    projectSnapshot.CompilationOptions, _cancellationToken).ConfigureAwait(false));
+
             var parseOptions = await _assetService.GetAssetAsync<ParseOptions>(projectSnapshot.ParseOptions, _cancellationToken).ConfigureAwait(false);
 
             var p2p = await CreateCollectionAsync<ProjectReference>(projectSnapshot.ProjectReferences).ConfigureAwait(false);
@@ -496,6 +506,50 @@ namespace Microsoft.CodeAnalysis.Remote
         private Project AddDocument(Project project, DocumentInfo documentInfo)
         {
             return project.Solution.AddDocument(documentInfo).GetProject(project.Id);
+        }
+
+        private CompilationOptions FixUpCompilationOptions(ProjectInfo.ProjectAttributes info, CompilationOptions compilationOptions)
+        {
+            return compilationOptions.WithXmlReferenceResolver(new XmlFileResolver(GetXmlResolverBasePath(info.FilePath)))
+                                     .WithStrongNameProvider(new DesktopStrongNameProvider(GetStrongNameKeyPaths(info)));
+        }
+
+        private static string GetXmlResolverBasePath(string filePath)
+        {
+            if (!PathUtilities.IsAbsolute(filePath))
+            {
+                // xmlFileResolver can only deal with absolute path
+                // return null if file path is not something xml file resolver can handle.
+                // it knows how to handle null
+                return null;
+            }
+
+            return PathUtilities.GetDirectoryName(filePath);
+        }
+
+        private ImmutableArray<string> GetStrongNameKeyPaths(ProjectInfo.ProjectAttributes info)
+        {
+            if (info.FilePath == null && info.OutputFilePath == null)
+            {
+                // return empty since that is what IDE does for this case
+                // see AbstractProject.GetStrongNameKeyPaths
+                return ImmutableArray<string>.Empty;
+            }
+
+            var builder = ArrayBuilder<string>.GetInstance();
+            if (info.FilePath != null && PathUtilities.IsAbsolute(info.FilePath))
+            {
+                // desktop strong name provider only knows how to deal with absolute path
+                builder.Add(PathUtilities.GetDirectoryName(info.FilePath));
+            }
+
+            if (info.OutputFilePath != null && PathUtilities.IsAbsolute(info.OutputFilePath))
+            {
+                // desktop strong name provider only knows how to deal with absolute path
+                builder.Add(PathUtilities.GetDirectoryName(info.OutputFilePath));
+            }
+
+            return builder.ToImmutableAndFree();
         }
     }
 }


### PR DESCRIPTION
this support wasn't there before since code lens nor solution analysis requires it.

**Customer scenario**

Dll built for LUT in out of proc doesn't have proper strong name signed which causes tests to fail to run.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16563

**Workarounds, if any**

turn off OOP through internal reg key

**Risk**

OOP now set strong name provider as IDE have set in proc. so I expect it to behave same as IDE.

**Performance impact**

There can be impact on LUT since strong name require stream to be written to disk before strong name signed.

http://source.roslyn.io/#Microsoft.CodeAnalysis/Compilation/Compilation.cs,2358

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Oop didn't set strong name provider since features such as FSA or code lens don't require strong name provider and works fine without it being set. that missed testing LUT case which require emit with strong name signed

**How was the bug found?**

dogfooding