### PR TITLE
Tuple field symbol equality

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -6,11 +6,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    /// <summary>
-    /// Represents a non-element field of a tuple type (such as (int, byte).Rest)
-    /// that is backed by a real field within the tuple underlying type.
-    /// </summary>
-    internal class TupleFieldSymbol : WrappedFieldSymbol
+    internal abstract class TupleFieldSymbol : WrappedFieldSymbol
     {
         protected readonly TupleTypeSymbol _containingTuple;
 
@@ -63,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 // not negative and even
-                return (_tupleElementIndex & ((1<<31) | 1)) == 0 ;
+                return (_tupleElementIndex & ((1 << 31) | 1)) == 0;
             }
         }
 
@@ -116,12 +112,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        public override sealed int GetHashCode()
+        public override int GetHashCode()
         {
             return Hash.Combine(_containingTuple.GetHashCode(), _tupleElementIndex.GetHashCode());
         }
 
-        public override sealed bool Equals(object obj)
+        public override bool Equals(object obj)
         {
             var other = obj as TupleFieldSymbol;
 
@@ -130,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
-            // note we have to compare both index and name because 
+            // note we have to compare both index and name because
             // in nameless tuple there could be fields that differ only by index
             // and in named tupoles there could be fields that differ only by name
             return (object)other != null &&
@@ -140,25 +136,51 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     }
 
     /// <summary>
-    /// Represents an element field of a tuple type (such as (int, byte).Item1)
-    /// that is backed by a real field with the same name within the tuple underlying type.
+    /// Represents a non-element field of a tuple type (such as (int, byte).Rest)
+    /// that is backed by a real field within the tuple underlying type.
     /// </summary>
-    internal class TupleElementFieldSymbol : TupleFieldSymbol
+    internal sealed class TupleNonElementFieldSymbol : TupleFieldSymbol
+    {
+        public TupleNonElementFieldSymbol(TupleTypeSymbol container, FieldSymbol underlyingField, int tupleElementIndex)
+            : base(container, underlyingField, tupleElementIndex)
+        {
+        }
+
+        public sealed override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        public sealed override bool Equals(object obj)
+        {
+            if (!(obj is TupleNonElementFieldSymbol))
+            {
+                return false;
+            }
+
+            return base.Equals(obj);
+        }
+    }
+
+    /// <summary>
+    /// Represents an element field of a tuple type (such as (int, byte).Item1, (int a, byte).a, or (..., int j).Item10).
+    /// </summary>
+    internal abstract class TupleElementFieldSymbolBase : TupleFieldSymbol
     {
         private readonly ImmutableArray<Location> _locations;
-        private readonly TupleElementFieldSymbol _correspondingDefaultField;
+        private readonly TupleElementFieldSymbolBase _correspondingDefaultField;
 
         // default tuple elements like Item1 or Item20 could be provided by the user or
         // otherwise implicitly declared by compiler
         private readonly bool _isImplicitlyDeclared;
 
-        public TupleElementFieldSymbol(
-            TupleTypeSymbol container, 
-            FieldSymbol underlyingField, 
-            int tupleElementIndex, 
-            Location location, 
-            bool isImplicitlyDeclared, 
-            TupleElementFieldSymbol correspondingDefaultFieldOpt)
+        public TupleElementFieldSymbolBase(
+            TupleTypeSymbol container,
+            FieldSymbol underlyingField,
+            int tupleElementIndex,
+            Location location,
+            bool isImplicitlyDeclared,
+            TupleElementFieldSymbolBase correspondingDefaultFieldOpt)
 
             : base(container, underlyingField, (object)correspondingDefaultFieldOpt == null ? tupleElementIndex << 1 : (tupleElementIndex << 1) + 1)
         {
@@ -183,8 +205,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _isImplicitlyDeclared ? 
-                    ImmutableArray<SyntaxReference>.Empty : 
+                return _isImplicitlyDeclared ?
+                    ImmutableArray<SyntaxReference>.Empty :
                     GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(_locations);
             }
         }
@@ -233,32 +255,65 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     }
 
     /// <summary>
-    /// Represents an element field of a tuple type that is not backed by a real field 
+    /// Represents an element field of a tuple type (such as (int, byte).Item1)
+    /// that is backed by a real field with the same name within the tuple underlying type.
+    /// </summary>
+    internal sealed class TupleElementFieldSymbol : TupleElementFieldSymbolBase
+    {
+        public TupleElementFieldSymbol(
+            TupleTypeSymbol container,
+            FieldSymbol underlyingField,
+            int tupleElementIndex,
+            Location location,
+            bool isImplicitlyDeclared,
+            TupleElementFieldSymbol correspondingDefaultFieldOpt)
+            : base(container, underlyingField, tupleElementIndex, location, isImplicitlyDeclared, correspondingDefaultFieldOpt)
+        {
+        }
+
+        public sealed override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        public sealed override bool Equals(object obj)
+        {
+            if (!(obj is TupleElementFieldSymbol))
+            {
+                return false;
+            }
+
+            return base.Equals(obj);
+        }
+    }
+
+    /// <summary>
+    /// Represents an element field of a tuple type that is not backed by a real field
     /// with the same name within the tuple underlying type.
-    /// 
+    ///
     /// Examples
     ///     // alias to Item1 with a different name
-    ///     (int a, byte b).a                           
+    ///     (int a, byte b).a
     ///
     ///     // not backed directly by the underlying type
     ///     (int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8).i8
-    ///     
+    ///
     /// NOTE: For any virtual element, there is a nonvirtual way to access the same underlying field.
-    ///       In scenarios where we need to enumerate actual fields of a struct, 
+    ///       In scenarios where we need to enumerate actual fields of a struct,
     ///       virtual fields should be ignored.
     /// </summary>
-    internal sealed class TupleVirtualElementFieldSymbol : TupleElementFieldSymbol
+    internal sealed class TupleVirtualElementFieldSymbol : TupleElementFieldSymbolBase
     {
         private readonly string _name;
 
         public TupleVirtualElementFieldSymbol(
-            TupleTypeSymbol container, 
-            FieldSymbol underlyingField, 
-            string name, 
-            int tupleElementIndex, 
-            Location location, 
-            bool isImplicitlyDeclared, 
-            TupleElementFieldSymbol correspondingDefaultFieldOpt)
+            TupleTypeSymbol container,
+            FieldSymbol underlyingField,
+            string name,
+            int tupleElementIndex,
+            Location location,
+            bool isImplicitlyDeclared,
+            TupleElementFieldSymbolBase correspondingDefaultFieldOpt)
 
             : base(container, underlyingField, tupleElementIndex, location, isImplicitlyDeclared, correspondingDefaultFieldOpt)
         {
@@ -299,6 +354,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return true;
             }
+        }
+
+        public sealed override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        public sealed override bool Equals(object obj)
+        {
+            if (!(obj is TupleVirtualElementFieldSymbol))
+            {
+                return false;
+            }
+
+            return base.Equals(obj);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -112,12 +112,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result;
         }
 
-        public override int GetHashCode()
+        public abstract override int GetHashCode();
+
+        internal int GetHashCodeInternal()
         {
             return Hash.Combine(_containingTuple.GetHashCode(), _tupleElementIndex.GetHashCode());
         }
 
-        public override bool Equals(object obj)
+        public abstract override bool Equals(object obj);
+
+        internal bool EqualsInternal(object obj)
         {
             var other = obj as TupleFieldSymbol;
 
@@ -148,7 +152,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override int GetHashCode()
         {
-            return base.GetHashCode();
+            return GetHashCodeInternal();
         }
 
         public sealed override bool Equals(object obj)
@@ -158,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            return base.Equals(obj);
+            return EqualsInternal(obj);
         }
     }
 
@@ -273,7 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override int GetHashCode()
         {
-            return base.GetHashCode();
+            return GetHashCodeInternal();
         }
 
         public sealed override bool Equals(object obj)
@@ -283,7 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            return base.Equals(obj);
+            return EqualsInternal(obj);
         }
     }
 
@@ -358,7 +362,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override int GetHashCode()
         {
-            return base.GetHashCode();
+            return GetHashCodeInternal();
         }
 
         public sealed override bool Equals(object obj)
@@ -368,7 +372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            return base.Equals(obj);
+            return EqualsInternal(obj);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -817,7 +817,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 var fieldSymbol = field.AsMember(currentUnderlying);
 
                                 // Add a field with default name. It should be present regardless.
-                                TupleElementFieldSymbol defaultTupleField;
+                                TupleElementFieldSymbolBase defaultTupleField;
                                 if (currentNestingLevel != 0)
                                 {
                                     // This is a matching field, but it is in the extension tuple
@@ -863,7 +863,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             else if (currentNestingLevel == 0)
                             {
                                 // field at the top level didn't match a tuple backing field, simply add.
-                                members.Add(new TupleFieldSymbol(this, field.AsMember(currentUnderlying), -members.Count - 1));
+                                members.Add(new TupleNonElementFieldSymbol(this, field.AsMember(currentUnderlying), -members.Count - 1));
                             }
                             break;
 
@@ -1032,7 +1032,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             Debug.Assert((object)underlyingAssociatedField.ContainingSymbol == _underlyingType);
                             Debug.Assert(_underlyingType.GetMembers(underlyingAssociatedField.Name).IndexOf(underlyingAssociatedField) < 0);
-                            map.Add(underlyingAssociatedField.OriginalDefinition, new TupleFieldSymbol(this, underlyingAssociatedField, -i - 1));
+                            map.Add(underlyingAssociatedField.OriginalDefinition, new TupleNonElementFieldSymbol(this, underlyingAssociatedField, -i - 1));
                         }
 
                         map.Add(underlyingEvent.OriginalDefinition, member);

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -705,7 +705,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 Dim FieldSymbol = field.AsMember(currentUnderlying)
 
                                 ' Add a field with default name. It should be present regardless.
-                                Dim defaultTupleField As TupleElementFieldSymbol
+                                Dim defaultTupleField As TupleElementFieldSymbolBase
                                 If currentNestingLevel <> 0 Then
                                     ' This is a matching field, but it is in the extension tuple
                                     ' Make it virtual since we are not at the top level
@@ -745,7 +745,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 elementsMatchedByFields(tupleFieldIndex) = True ' mark as handled
                             ElseIf currentNestingLevel = 0 Then
                                 ' field at the top level didn't match a tuple backing field, simply add.
-                                members.Add(New TupleFieldSymbol(Me, field.AsMember(currentUnderlying), -members.Count - 1))
+                                members.Add(New TupleNonElementFieldSymbol(Me, field.AsMember(currentUnderlying), -members.Count - 1))
                             End If
 
                         Case SymbolKind.NamedType
@@ -863,7 +863,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                         If associatedField IsNot Nothing Then
                             Debug.Assert(associatedField.ContainingSymbol Is Me._underlyingType)
                             Debug.Assert(Me._underlyingType.GetMembers(associatedField.Name).IndexOf(associatedField) < 0)
-                            smallDictionary.Add(associatedField.OriginalDefinition, New TupleFieldSymbol(Me, associatedField, -i - 1))
+                            smallDictionary.Add(associatedField.OriginalDefinition, New TupleNonElementFieldSymbol(Me, associatedField, -i - 1))
                         End If
 
                         smallDictionary.Add(tupleUnderlyingEvent.OriginalDefinition, symbol)


### PR DESCRIPTION
Each kind of tuple field symbol should have it's own override for `Equals`. In the process, I refactored those classes to be either `abstract` or `sealed`.

Fixes https://github.com/dotnet/roslyn/issues/12637

@dotnet/roslyn-compiler for review for post-dev15 branch.