### PR TITLE
Disallow __arglist in local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -448,6 +448,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             var hasErrors = localSymbol.ScopeBinder
                 .ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
+            foreach (var p in node.ParameterList.Parameters)
+            {
+                if (p.IsArgList)
+                {
+                    diagnostics.Add(ErrorCode.ERR_IllegalVarArgs, p.Location);
+                }
+            }
+
             BoundBlock block;
             if (node.Body != null)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -448,14 +448,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var hasErrors = localSymbol.ScopeBinder
                 .ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
-            foreach (var p in node.ParameterList.Parameters)
-            {
-                if (p.IsArgList)
-                {
-                    diagnostics.Add(ErrorCode.ERR_IllegalVarArgs, p.Location);
-                }
-            }
-
             BoundBlock block;
             if (node.Body != null)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -112,6 +112,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             // force lazy init
             ComputeParameters();
+
+            foreach (var p in _syntax.ParameterList.Parameters)
+            {
+                if (p.IsArgList)
+                {
+                    addTo.Add(ErrorCode.ERR_IllegalVarArgs, p.Location);
+                }
+            }
+
             ComputeReturnType();
 
             var diags = ImmutableInterlocked.InterlockedExchange(ref _diagnostics, default(ImmutableArray<Diagnostic>));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -1244,18 +1244,24 @@ class Program
 }
 ";
             VerifyDiagnostics(source,
-    // (10,31): error CS0190: The __arglist construct is valid only within a variable argument method
-    //             Console.WriteLine(__arglist);
-    Diagnostic(ErrorCode.ERR_ArgsInvalid, "__arglist").WithLocation(10, 31),
-    // (18,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
-    //             Console.WriteLine(__arglist);
-    Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(18, 31),
-    // (26,31): error CS0190: The __arglist construct is valid only within a variable argument method
-    //             Console.WriteLine(__arglist);
-    Diagnostic(ErrorCode.ERR_ArgsInvalid, "__arglist").WithLocation(26, 31),
-    // (34,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
-    //             Console.WriteLine(__arglist);
-    Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(34, 31)
+                // (10,31): error CS0190: The __arglist construct is valid only within a variable argument method
+                //             Console.WriteLine(__arglist);
+                Diagnostic(ErrorCode.ERR_ArgsInvalid, "__arglist").WithLocation(10, 31),
+                // (18,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                //             Console.WriteLine(__arglist);
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(18, 31),
+                // (24,20): error CS1669: __arglist is not valid in this context
+                //         void Local(__arglist)
+                Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(24, 20),
+                // (26,31): error CS0190: The __arglist construct is valid only within a variable argument method
+                //             Console.WriteLine(__arglist);
+                Diagnostic(ErrorCode.ERR_ArgsInvalid, "__arglist").WithLocation(26, 31),
+                // (32,20): error CS1669: __arglist is not valid in this context
+                //         void Local(__arglist)
+                Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(32, 20),
+                // (34,31): error CS4013: Instance of type 'RuntimeArgumentHandle' cannot be used inside an anonymous function, query expression, iterator block or async method
+                //             Console.WriteLine(__arglist);
+                Diagnostic(ErrorCode.ERR_SpecialByRefInLambda, "__arglist").WithArguments("System.RuntimeArgumentHandle").WithLocation(34, 31)
     );
         }
 
@@ -1429,10 +1435,12 @@ class Program
 }
 ";
             VerifyDiagnostics(source,
-    // (9,26): error CS1636: __arglist is not allowed in the parameter list of iterators
-    //         IEnumerable<int> Local(__arglist)
-    Diagnostic(ErrorCode.ERR_VarargsIterator, "Local").WithLocation(9, 26)
-    );
+                // (9,26): error CS1636: __arglist is not allowed in the parameter list of iterators
+                //         IEnumerable<int> Local(__arglist)
+                Diagnostic(ErrorCode.ERR_VarargsIterator, "Local").WithLocation(9, 26),
+                // (9,32): error CS1669: __arglist is not valid in this context
+                //         IEnumerable<int> Local(__arglist)
+                Diagnostic(ErrorCode.ERR_IllegalVarArgs, "__arglist").WithLocation(9, 32));
         }
 
         [Fact]


### PR DESCRIPTION

**Customer scenario**

Currently declaring a local function with an __arglist parameter is not illegal, but it should be.
Disallowing this later is a breaking change.

**Bugs this fixes:** 

Fixes #10765

**Workarounds, if any**

None.

**Risk**

This is a very small change that's specific to local functions. The change is well understood -- it is the same as the check done in lambdas. This change also only prohibits functionality.

**Performance impact**

None.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

New feature

**How was the bug found?**

Customer reported.