### PR TITLE
[Not ready for review] Fix GetForEachSymbolInfo in the presence of out var

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -773,7 +773,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override ForEachStatementInfo GetForEachStatementInfo(CommonForEachStatementSyntax node)
         {
-            BoundForEachStatement boundForEach = (BoundForEachStatement)GetUpperBoundNode(node);
+            // Declaration expressions can result in having a BoundBlock associated with a given foreach statement,
+            // in addition to a BoundForEachStatement
+            BoundForEachStatement boundForEach = GetBoundNodes(node).OfType<BoundForEachStatement>().FirstOrDefault();
 
             if (boundForEach == null)
             {

--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -43,6 +43,39 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InlineDeclaration
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task InlineVariableInForEach()
+        {
+            await TestAsync(
+@"using System;
+using System.Collections.Generic;
+class C
+{
+    void M()
+    {
+        [|int|] i;
+        foreach (var x in M2(out i)) { }
+    }
+    IEnumerable<object> M2(out int j)
+    {
+        throw null;
+    }
+}",
+@"using System;
+using System.Collections.Generic;
+class C
+{
+    void M()
+    {
+        foreach (var x in M2(out int i)) { }
+    }
+    IEnumerable<object> M2(out int j)
+    {
+        throw null;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
         public async Task InlineInNestedCall()
         {
             await TestAsync(


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/16306

`GetForEachStatementInfo` called `GetUpperBoundNode` on a `ForEachStatementSyntax` and it was expecting to get a `BoundForEachStatement` back.
But in fact, when we bind this statement and there is an out var, we produce two bound nodes for the same `ForEachStatementSyntax`. The first one is a `BoundBlock` which holds the local declared by the out var, and the second one is the `BoundForEachStatement` which is expected.
`GetUpperBoundNode` would always pick the first one (that's the "highest bound node"). But that one does not have the info we need for the foreach semantic model.

@dotnet/roslyn-compiler for review (post-dev15).