### PR TITLE
Properly detect and handle delegate relaxations when ByRef returns are involved.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -728,6 +728,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
+            if (method.ReturnsByRef != delegateMethod.ReturnsByRef)
+            {
+                Error(diagnostics, ErrorCode.ERR_DelegateRefMismatch, errorLocation, method, delegateType);
+                diagnostics.Add(errorLocation, useSiteDiagnostics);
+                return false;
+            }
+
             diagnostics.Add(errorLocation, useSiteDiagnostics);
             return true;
         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3257,6 +3257,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ref mismatch between &apos;{0}&apos; and delegate &apos;{1}&apos;.
+        /// </summary>
+        internal static string ERR_DelegateRefMismatch {
+            get {
+                return ResourceManager.GetString("ERR_DelegateRefMismatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The best overloaded Add method &apos;{0}&apos; for the collection initializer element is obsolete. {1}.
         /// </summary>
         internal static string ERR_DeprecatedCollectionInitAddStr {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1179,6 +1179,9 @@
   <data name="ERR_BadRetType" xml:space="preserve">
     <value>'{1} {0}' has the wrong return type</value>
   </data>
+  <data name="ERR_DelegateRefMismatch" xml:space="preserve">
+    <value>Ref mismatch between '{0}' and delegate '{1}'</value>
+  </data>
   <data name="ERR_DuplicateConstraintClause" xml:space="preserve">
     <value>A constraint clause has already been specified for type parameter '{0}'. All of the constraints for a type parameter must be specified in a single where clause.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1436,9 +1436,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_MustDeclareForeachIteration = 8186,
         ERR_TupleElementNamesInDeconstruction = 8187,
         ERR_ExpressionTreeContainsThrowExpression = 8188,
+        ERR_DelegateRefMismatch = 8189,
         #endregion stragglers for C# 7
 
-        // Available  = 8189-8195
+        // Available  = 8190-8195
 
         #region diagnostics for out var
         ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList = 8196,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2409,7 +2409,11 @@ class C
 }
 ";
 
-            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
+                // (15,15): error CS8189: Ref mismatch between 'C.M()' and delegate 'D'
+                //         new D(M)();
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "M").WithArguments("C.M()", "D").WithLocation(15, 15)
+                );
         }
 
         [Fact]
@@ -2467,7 +2471,11 @@ class C
 }
 ";
 
-            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
+                // (19,11): error CS8189: Ref mismatch between 'C.M()' and delegate 'D'
+                //         M(M);
+                Diagnostic(ErrorCode.ERR_DelegateRefMismatch, "M").WithArguments("C.M()", "D").WithLocation(19, 11)
+                );
         }
 
         [Fact, WorkItem(1078958, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1078958")]

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
@@ -631,9 +631,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' determine conversions based on return type
             Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
+            Dim targetMethodSymbol = DirectCast(analysisResult.Candidate.UnderlyingSymbol, MethodSymbol)
 
             If Not ignoreMethodReturnType Then
-                methodConversions = methodConversions Or Conversions.ClassifyMethodConversionBasedOnReturnType(analysisResult.Candidate.ReturnType, toMethod.ReturnType, useSiteDiagnostics)
+                methodConversions = methodConversions Or
+                                    Conversions.ClassifyMethodConversionBasedOnReturn(targetMethodSymbol.ReturnType, targetMethodSymbol.ReturnsByRef,
+                                                                                      toMethod.ReturnType, toMethod.ReturnsByRef, useSiteDiagnostics)
 
                 If diagnostics.Add(addressOfOperandSyntax, useSiteDiagnostics) Then
                     ' Suppress additional diagnostics 
@@ -645,7 +648,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(toMethod.ParameterCount > 0)
 
                 ' special flag for ignoring all arguments (zero argument relaxation)
-                If analysisResult.Candidate.ParameterCount = 0 Then
+                If targetMethodSymbol.ParameterCount = 0 Then
                     methodConversions = methodConversions Or MethodConversionKind.AllArgumentsIgnored
                 Else
                     ' We can get here if all method's parameters are Optional/ParamArray, however, 
@@ -670,7 +673,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             End If
 
-            Dim targetMethodSymbol = DirectCast(analysisResult.Candidate.UnderlyingSymbol, MethodSymbol)
+            ' Stubs for ByRef returning methods are not supported.
+            ' We could easily support a stub for the case when return value is dropped,
+            ' but enabling other kinds of stubs later can lead to breaking changes
+            ' because those relaxations could be "better".
+            If Not ignoreMethodReturnType AndAlso targetMethodSymbol.ReturnsByRef AndAlso
+               Conversions.IsDelegateRelaxationSupportedFor(methodConversions) AndAlso
+               Conversions.IsStubRequiredForMethodConversion(methodConversions) Then
+                methodConversions = methodConversions Or MethodConversionKind.Error_StubNotSupported
+            End If
 
             If Conversions.IsDelegateRelaxationSupportedFor(methodConversions) Then
                 Dim typeArgumentInferenceDiagnosticsOpt = analysisResult.TypeArgumentInferenceDiagnosticsOpt

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Lambda.vb
@@ -200,8 +200,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim targetForInference As UnboundLambda.TargetSignature = target
 
                     If Not targetForInference.ReturnType.IsVoidType() Then
-                        targetForInference = New UnboundLambda.TargetSignature(targetForInference.ParameterTypes, targetForInference.IsByRef,
-                                                                               Compilation.GetSpecialType(SpecialType.System_Void)) ' No need to report use-site error.
+                        targetForInference = New UnboundLambda.TargetSignature(targetForInference.ParameterTypes, targetForInference.ParameterIsByRef,
+                                                                               Compilation.GetSpecialType(SpecialType.System_Void), ' No need to report use-site error.
+                                                                               returnsByRef:=False)
                     End If
 
                     Dim typeInfo As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic)) = source.InferReturnType(targetForInference)
@@ -783,11 +784,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim diagnostics = DiagnosticBag.GetInstance()
 
             ' Using Void as return type, because BuildBoundLambdaParameters doesn't use it and it is as good as any other value.
-            Dim targetSignature As New UnboundLambda.TargetSignature(ImmutableArray(Of ParameterSymbol).Empty, Compilation.GetSpecialType(SpecialType.System_Void))
+            Dim targetSignature As New UnboundLambda.TargetSignature(ImmutableArray(Of ParameterSymbol).Empty, Compilation.GetSpecialType(SpecialType.System_Void), returnsByRef:=False)
             Dim parameters As ImmutableArray(Of BoundLambdaParameterSymbol) = BuildBoundLambdaParameters(source, targetSignature, diagnostics)
 
             Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic))
-            returnTypeInfo = source.InferReturnType(New UnboundLambda.TargetSignature(StaticCast(Of ParameterSymbol).From(parameters), targetSignature.ReturnType))
+            returnTypeInfo = source.InferReturnType(New UnboundLambda.TargetSignature(StaticCast(Of ParameterSymbol).From(parameters), targetSignature.ReturnType, targetSignature.ReturnsByRef))
             Dim returnType As TypeSymbol = returnTypeInfo.Key
 
             If Not returnTypeInfo.Value.IsDefaultOrEmpty Then
@@ -873,11 +874,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If source.ReturnType IsNot Nothing Then
                     commonReturnType = If(source.IsFunctionLambda AndAlso source.ReturnType.IsVoidType(), LambdaSymbol.ReturnTypeVoidReplacement, source.ReturnType)
                 ElseIf commonReturnType Is Nothing OrElse commonReturnType Is LambdaSymbol.ErrorRecoveryInferenceError Then
-                    commonReturnType = source.InferReturnType(New UnboundLambda.TargetSignature(commonParameterTypes.AsImmutableOrNull(), isByRef, Compilation.GetSpecialType(SpecialType.System_Void))).Key
+                    commonReturnType = source.InferReturnType(New UnboundLambda.TargetSignature(commonParameterTypes.AsImmutableOrNull(),
+                                                                                                isByRef,
+                                                                                                Compilation.GetSpecialType(SpecialType.System_Void),
+                                                                                                returnsByRef:=False)).Key
                 End If
 
                 Interlocked.CompareExchange(source.BindingCache.ErrorRecoverySignature,
-                                            New UnboundLambda.TargetSignature(commonParameterTypes.AsImmutableOrNull(), isByRef, commonReturnType),
+                                            New UnboundLambda.TargetSignature(commonParameterTypes.AsImmutableOrNull(), isByRef, commonReturnType, returnsByRef:=False),
                                             Nothing)
             End If
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/UnboundLambda.vb
@@ -133,18 +133,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Class TargetSignature
             Public ReadOnly ParameterTypes As ImmutableArray(Of TypeSymbol)
             Public ReadOnly ReturnType As TypeSymbol
-            Private ReadOnly _isByRef As BitVector
+            Public ReadOnly ReturnsByRef As Boolean
+            Public ReadOnly ParameterIsByRef As BitVector
 
-            Public Sub New(parameterTypes As ImmutableArray(Of TypeSymbol), isByRef As BitVector, returnType As TypeSymbol)
+            Public Sub New(parameterTypes As ImmutableArray(Of TypeSymbol), parameterIsByRef As BitVector, returnType As TypeSymbol, returnsByRef As Boolean)
                 Debug.Assert(Not parameterTypes.IsDefault)
-                Debug.Assert(Not isByRef.IsNull)
+                Debug.Assert(Not parameterIsByRef.IsNull)
                 Debug.Assert(returnType IsNot Nothing)
                 Me.ParameterTypes = parameterTypes
-                Me._isByRef = isByRef
+                Me.ParameterIsByRef = parameterIsByRef
                 Me.ReturnType = returnType
+                Me.ReturnsByRef = returnsByRef
             End Sub
 
-            Public Sub New(params As ImmutableArray(Of ParameterSymbol), returnType As TypeSymbol)
+            Public Sub New(params As ImmutableArray(Of ParameterSymbol), returnType As TypeSymbol, returnsByRef As Boolean)
                 Debug.Assert(Not params.IsDefault)
                 Debug.Assert(returnType IsNot Nothing)
 
@@ -166,19 +168,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Me.ParameterTypes = types.AsImmutableOrNull
                 End If
 
-                Me._isByRef = isByRef
+                Me.ParameterIsByRef = isByRef
                 Me.ReturnType = returnType
+                Me.ReturnsByRef = returnsByRef
             End Sub
 
             Public Sub New(method As MethodSymbol)
-                Me.New(method.Parameters, method.ReturnType)
+                Me.New(method.Parameters, method.ReturnType, method.ReturnsByRef)
             End Sub
-
-            Public ReadOnly Property IsByRef As BitVector
-                Get
-                    Return _isByRef
-                End Get
-            End Property
 
             Public Overrides Function GetHashCode() As Integer
                 Dim hashVal As Integer = 0
@@ -205,12 +202,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 For i As Integer = 0 To ParameterTypes.Length - 1
                     If Me.ParameterTypes(i) <> other.ParameterTypes(i) OrElse
-                       Me._isByRef(i) <> other._isByRef(i) Then
+                       Me.ParameterIsByRef(i) <> other.ParameterIsByRef(i) Then
                         Return False
                     End If
                 Next
 
-                Return Me.ReturnType = other.ReturnType
+                Return Me.ReturnsByRef = other.ReturnsByRef AndAlso Me.ReturnType = other.ReturnType
             End Function
         End Class
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -2153,7 +2153,7 @@ HandleAsAGeneralExpression:
                             Dim unboundLambda = DirectCast(argument, UnboundLambda)
 
                             If unboundLambda.IsFunctionLambda Then
-                                Dim inferenceSignature As New UnboundLambda.TargetSignature(delegateParams, unboundLambda.Binder.Compilation.GetSpecialType(SpecialType.System_Void))
+                                Dim inferenceSignature As New UnboundLambda.TargetSignature(delegateParams, unboundLambda.Binder.Compilation.GetSpecialType(SpecialType.System_Void), returnsByRef:=False)
                                 Dim returnTypeInfo As KeyValuePair(Of TypeSymbol, ImmutableArray(Of Diagnostic)) = unboundLambda.InferReturnType(inferenceSignature)
 
                                 If Not returnTypeInfo.Value.IsDefault AndAlso returnTypeInfo.Value.HasAnyErrors() Then
@@ -2171,8 +2171,9 @@ HandleAsAGeneralExpression:
 
                                 Else
                                     Dim boundLambda As BoundLambda = unboundLambda.Bind(New UnboundLambda.TargetSignature(inferenceSignature.ParameterTypes,
-                                                                                                                          inferenceSignature.IsByRef,
-                                                                                                                          returnTypeInfo.Key))
+                                                                                                                          inferenceSignature.ParameterIsByRef,
+                                                                                                                          returnTypeInfo.Key,
+                                                                                                                          returnsByRef:=False))
 
                                     Debug.Assert(boundLambda.LambdaSymbol.ReturnType Is returnTypeInfo.Key)
                                     If Not boundLambda.HasErrors AndAlso Not boundLambda.Diagnostics.HasAnyErrors Then
@@ -2238,7 +2239,8 @@ HandleAsAGeneralExpression:
 
                                 If Not invokeMethod.IsSub AndAlso (unboundLambda.Flags And SourceMemberFlags.Async) <> 0 Then
                                     Dim boundLambda As BoundLambda = unboundLambda.Bind(New UnboundLambda.TargetSignature(delegateParams,
-                                                                            unboundLambda.Binder.Compilation.GetSpecialType(SpecialType.System_Void)))
+                                                                            unboundLambda.Binder.Compilation.GetSpecialType(SpecialType.System_Void),
+                                                                            returnsByRef:=False))
 
                                     If Not boundLambda.HasErrors AndAlso Not boundLambda.Diagnostics.HasAnyErrors() Then
                                         If _asyncLambdaSubToFunctionMismatch Is Nothing Then


### PR DESCRIPTION
**Customer scenario**
- Supplying a lambda in place of a delegate that has ByRef return doesn't cause any compilation error, but an invalid code is generated.
- Mismatch in ByRef-ness of return between the target delegate and supplied method doesn't cause any compilation error, but an invalid code is generated.  
- A delegate relaxation for a ByRef returning method that requires a stub doesn't cause any compilation error, but an invalid code is generated.

**Bugs this fixes:** 
Fixes #13206.
Tracked by VSO https://devdiv.visualstudio.com/DevDiv/_workitems?id=369827.

**Workarounds, if any**
No

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No, new feature.

**Root cause analysis:**
New feature.

**How was the bug found?**
Ad hoc testing

@dotnet/roslyn-compiler, @cston Please review.