### PR TITLE
Add test and fix for QuickInfo crash on discard

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -2524,6 +2524,99 @@ class C
                 MainDescription("Foo"));
         }
 
+        [WorkItem(16662, "https://github.com/dotnet/roslyn/issues/16662")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestShortDiscardInAssignment()
+        {
+            await TestAsync(
+@"class C
+{
+    int M()
+    {
+        $$_ = M();
+    }
+}",
+                MainDescription("int _"));
+        }
+
+        [WorkItem(16662, "https://github.com/dotnet/roslyn/issues/16662")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestUnderscoreLocalInAssignment()
+        {
+            await TestAsync(
+@"class C
+{
+    int M()
+    {
+        var $$_ = M();
+    }
+}",
+                MainDescription($"({FeaturesResources.local_variable}) int _"));
+        }
+
+        [WorkItem(16662, "https://github.com/dotnet/roslyn/issues/16662")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestShortDiscardInOutVar()
+        {
+            await TestAsync(
+@"class C
+{
+    void M(out int i)
+    {
+        M(out $$_);
+        i = 0;
+    }
+}",
+                MainDescription($"int _"));
+        }
+
+        [WorkItem(16667, "https://github.com/dotnet/roslyn/issues/16667")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestDiscardInOutVar()
+        {
+            await TestAsync(
+@"class C
+{
+    void M(out int i)
+    {
+        M(out var $$_);
+        i = 0;
+    }
+}"); // No quick info (see issue #16667)
+        }
+
+        [WorkItem(16667, "https://github.com/dotnet/roslyn/issues/16667")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestDiscardInIsPattern()
+        {
+            await TestAsync(
+@"class C
+{
+    void M()
+    {
+        if (3 is int $$_) { }
+    }
+}"); // No quick info (see issue #16667)
+        }
+
+        [WorkItem(16667, "https://github.com/dotnet/roslyn/issues/16667")]
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TestDiscardInSwitchPattern()
+        {
+            await TestAsync(
+@"class C
+{
+    void M()
+    {
+        switch (3)
+        {
+            case int $$_:
+                return;
+        }
+    }
+}"); // No quick info (see issue #16667)
+        }
+
         [WorkItem(540871, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540871")]
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task TestLiterals()

--- a/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/ISymbolExtensions_2.cs
@@ -47,6 +47,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return Glyph.Label;
 
                 case SymbolKind.Local:
+                case SymbolKind.Discard:
                     return Glyph.Local;
 
                 case SymbolKind.NamedType:

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
@@ -104,6 +104,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return IsNamedTypeAccessible((INamedTypeSymbol)symbol, within);
 
                 case SymbolKind.ErrorType:
+                case SymbolKind.Discard:
                     return true;
 
                 case SymbolKind.TypeParameter:


### PR DESCRIPTION
**Customer scenario**

Type a discard `_ = M();` and hover over the underscore to trigger QuickInfo. The IDE will crash.

**Bugs this fixes:** 
https://github.com/dotnet/roslyn/issues/16662

**Workarounds, if any**
Don't user discards or don't hover over them.

**Risk**
**Performance impact**
Low. Adding case in QuickInfo code for recently added discard symbol.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
New feature which was subjected to some ad-hoc IDE testing, but not the full IDE test plan.

**How was the bug found?**
Reported by internal users.

After my fix, we'll get this QuickInfo:
![image](https://cloud.githubusercontent.com/assets/12466233/22171825/df7f6bcc-df4b-11e6-988d-78b7c0a29a77.png)
I filed a follow-up bug for further aesthetic improvements (non-crashing issues): https://github.com/dotnet/roslyn/issues/16667

@CyrusNajmabadi @dotnet/roslyn-ide for review.
FYI @dotnet/roslyn-compiler 