### PR TITLE
Reduce memory consumption of LongestCommonSubsequence

### DIFF
--- a/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
+++ b/src/Workspaces/Core/Portable/Differencing/LongestCommonSubsequence.cs
@@ -11,73 +11,150 @@ namespace Microsoft.CodeAnalysis.Differencing
     /// </summary>
     internal abstract class LongestCommonSubsequence<TSequence>
     {
-        private const int DeleteCost = 1;
-        private const int InsertCost = 1;
-        private const int UpdateCost = 2;
+        // VArray class enables array indexing in range [-d...d].
+        private class VArray
+        {
+            private int[] array;
+            private int offset;
+
+            public VArray(int d, VArray previousVArray) : this(d)
+            {
+                if (previousVArray != null)
+                {
+                    int copyDelta= offset - previousVArray.offset;
+                    if (copyDelta >= 0)
+                    {
+                        Debug.Assert(previousVArray.array.Length + 2 * copyDelta == array.Length);
+                        Array.Copy(previousVArray.array, 0, array, copyDelta, previousVArray.array.Length);
+                    }
+                    else
+                    {
+                        Debug.Assert(previousVArray.array.Length + 2 * copyDelta == array.Length);
+                        Array.Copy(previousVArray.array, -copyDelta, array, 0, array.Length);
+                    }
+                }
+            }
+
+            public VArray(int d)
+            {
+                offset = d;
+                array = new int[2 * d + 1];
+            }
+
+            public int this[int index]
+            {
+                get
+                {
+                    return array[index + offset];
+                }
+                set
+                {
+                    array[index + offset] = value;
+                }
+            }
+        }
 
         protected abstract bool ItemsEqual(TSequence oldSequence, int oldIndex, TSequence newSequence, int newIndex);
 
         protected IEnumerable<KeyValuePair<int, int>> GetMatchingPairs(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
         {
-            int[,] d = ComputeCostMatrix(oldSequence, oldLength, newSequence, newLength);
-            int i = oldLength;
-            int j = newLength;
+            Stack<VArray> stackOfVs = ComputeEditPaths(oldSequence, oldLength, newSequence, newLength);
 
-            while (i != 0 && j != 0)
+            int x = oldLength;
+            int y = newLength;
+
+            for (int d = stackOfVs.Count - 1; x > 0 || y > 0; d--)
             {
-                if (d[i, j] == d[i - 1, j] + DeleteCost)
+                VArray currentV = stackOfVs.Pop();
+                int k = x - y;
+
+                // "snake" == single delete or insert followed by 0 or more diagonals
+                // snake end point is in V
+                int yEnd = currentV[k];
+                int xEnd = yEnd + k;
+
+                // does the snake first go down (insert) or right(delete)?
+                bool right = (k == d || (k != -d && currentV[k - 1] > currentV[k + 1]));
+                int kPrev = right ? k - 1 : k + 1;
+
+                // snake start point
+                int yStart = currentV[kPrev];
+                int xStart = yStart + kPrev;
+
+                // snake mid point
+                int yMid = right ? yStart : yStart + 1;
+                int xMid = yMid + k;
+
+                // return the matching pairs between (xMid, yMid) and (xEnd, yEnd) = diagonal part of the snake
+                while (xEnd > xMid)
                 {
-                    i--;
+                    Debug.Assert(yEnd > yMid);
+                    xEnd--;
+                    yEnd--;
+                    yield return new KeyValuePair<int, int>(xEnd, yEnd);
                 }
-                else if (d[i, j] == d[i, j - 1] + InsertCost)
-                {
-                    j--;
-                }
-                else
-                {
-                    i--;
-                    j--;
-                    yield return new KeyValuePair<int, int>(i, j);
-                }
+
+                x = xStart;
+                y = yStart;
             }
+
         }
 
         protected IEnumerable<SequenceEdit> GetEdits(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
         {
-            int[,] d = ComputeCostMatrix(oldSequence, oldLength, newSequence, newLength);
-            int i = oldLength;
-            int j = newLength;
+            Stack<VArray> stackOfVs = ComputeEditPaths(oldSequence, oldLength, newSequence, newLength);
 
-            while (i != 0 && j != 0)
-            {
-                if (d[i, j] == d[i - 1, j] + DeleteCost)
-                {
-                    i--;
-                    yield return new SequenceEdit(i, -1);
-                }
-                else if (d[i, j] == d[i, j - 1] + InsertCost)
-                {
-                    j--;
-                    yield return new SequenceEdit(-1, j);
-                }
-                else
-                {
-                    i--;
-                    j--;
-                    yield return new SequenceEdit(i, j);
-                }
-            }
+            int x = oldLength;
+            int y = newLength;
 
-            while (i > 0)
+            for (int d = stackOfVs.Count - 1; x > 0 || y > 0; d--)
             {
-                i--;
-                yield return new SequenceEdit(i, -1);
-            }
+                VArray currentV = stackOfVs.Pop();
+                int k = x - y;
 
-            while (j > 0)
-            {
-                j--;
-                yield return new SequenceEdit(-1, j);
+                // "snake" == single delete or insert followed by 0 or more diagonals
+                // snake end point is in V
+                int yEnd = currentV[k];
+                int xEnd = yEnd + k;
+
+                // does the snake first go down (insert) or right(delete)?
+                bool right = (k == d || (k != -d && currentV[k - 1] > currentV[k + 1]));
+                int kPrev = right ? k - 1 : k + 1;
+
+                // snake start point
+                int yStart = currentV[kPrev];
+                int xStart = yStart + kPrev;
+
+                // snake mid point
+                int yMid = right ? yStart : yStart + 1;
+                int xMid = yMid + k;
+
+                // return the matching pairs between (xMid, yMid) and (xEnd, yEnd) = diagonal part of the snake
+                while (xEnd > xMid)
+                {
+                    Debug.Assert(yEnd > yMid);
+                    xEnd--;
+                    yEnd--;
+                    yield return new SequenceEdit(xEnd, yEnd);
+                }
+
+                // return the insert/delete between (xStart, yStart) and (xMid, yMid) = the vertical/horizontal part of the snake
+                if (xMid > 0 || yMid > 0)
+                {
+                    if (xStart == xMid)
+                    {
+                        // insert
+                        yield return new SequenceEdit(-1, --yMid);
+                    }
+                    else
+                    {
+                        // delete
+                        yield return new SequenceEdit(--xMid, -1);
+                    }
+                }
+
+                x = xStart;
+                y = yStart;
             }
         }
 
@@ -110,57 +187,88 @@ namespace Microsoft.CodeAnalysis.Differencing
         }
 
         /// <summary>
-        /// Calculates costs of all paths in an edit graph starting from vertex (0,0) and ending in vertex (lengthA, lengthB). 
+        /// Calculates a list of "V arrays" using Eugene W. Myers O(ND) Difference Algoritm
         /// </summary>
         /// <remarks>
-        /// The edit graph for A and B has a vertex at each point in the grid (i,j), i in [0, lengthA] and j in [0, lengthB].
         /// 
+        /// The algorithm works on an imaginary edit graph for A and B which has a vertex at each point in the grid(i, j), i in [0, lengthA] and j in [0, lengthB].
         /// The vertices of the edit graph are connected by horizontal, vertical, and diagonal directed edges to form a directed acyclic graph.
         /// Horizontal edges connect each vertex to its right neighbor. 
         /// Vertical edges connect each vertex to the neighbor below it.
         /// Diagonal edges connect vertex (i,j) to vertex (i-1,j-1) if <see cref="ItemsEqual"/>(sequenceA[i-1],sequenceB[j-1]) is true.
         /// 
-        /// Editing starts with S = []. 
-        /// Move along horizontal edge (i-1,j)-(i,j) represents the fact that sequenceA[i-1] is not added to S.
-        /// Move along vertical edge (i,j-1)-(i,j) represents an insert of sequenceB[j-1] to S.
-        /// Move along diagonal edge (i-1,j-1)-(i,j) represents an addition of sequenceB[j-1] to S via an acceptable 
-        /// change of sequenceA[i-1] to sequenceB[j-1].
+        /// Move right along horizontal edge (i-1,j)-(i,j) represents a delete of sequenceA[i-1].
+        /// Move down along vertical edge (i,j-1)-(i,j) represents an insert of sequenceB[j-1].
+        /// Move along diagonal edge (i-1,j-1)-(i,j) represents an match of sequenceA[i-1] to sequenceB[j-1].
+        /// The number of diagonal edges on the path from (0,0) to (lengthA, lengthB) is the length of the longest common sub.
+        ///
+        /// The function does not actually allocate this graph. Instead it uses Eugene W. Myers' O(ND) Difference Algoritm to calculate a list of "V arrays" and returns it in a Stack. 
+        /// A "V array" is a list of end points of so called "snakes". 
+        /// A "snake" is a path with a single horizontal (delete) or vertical (insert) move followed by 0 or more diagonals (matching pairs).
         /// 
-        /// In every vertex the cheapest outgoing edge is selected. 
-        /// The number of diagonal edges on the path from (0,0) to (lengthA, lengthB) is the length of the longest common subsequence.
+        /// See https://www.codeproject.com/articles/42279/investigating-myers-diff-algorithm-part-of.
+        /// 
+        /// (Unlike the algorithm in the article this implementation stores 'y' indexed and prefers 'right' moves instead of 'down' moves in ambiguous situations
+        /// to preserve the behavior of the original diff algorithm (deletes first, inserts after)).
+        /// 
+        /// The number of items in the list is the length of the shortest edit script = the number of inserts/edits between the two sequences = D. 
+        /// The list can be used to determine the matching pairs in the sequences (GetMatchingPairs method) or the full editing script (GetEdits method).
+        /// 
+        /// The algorithm uses O(ND) time and memory where D is the number of delete/inserts and N is the sum of lengths of the two sequences.
+        /// 
+        /// VArrays store just the y index because x can be calculated: x = y + k.
         /// </remarks>
-        private int[,] ComputeCostMatrix(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
+        private Stack<VArray> ComputeEditPaths(TSequence oldSequence, int oldLength, TSequence newSequence, int newLength)
         {
-            var la = oldLength + 1;
-            var lb = newLength + 1;
+            Stack<VArray> stackOfVs = new Stack<VArray>();
+            VArray previousV = null;
+            VArray currentV = null;
+            bool reachedEnd= false;
 
-            // TODO: Optimization possible: O(ND) time, O(N) space
-            // EUGENE W. MYERS: An O(ND) Difference Algorithm and Its Variations
-            var d = new int[la, lb];
-
-            d[0, 0] = 0;
-            for (int i = 1; i <= oldLength; i++)
+            for (int d = 0; d <= oldLength + newLength && !reachedEnd; d++)
             {
-                d[i, 0] = d[i - 1, 0] + DeleteCost;
-            }
+                previousV = currentV;
+                // V is in range [-d...d] => use d to offset the k-based array indices to non-negative values
+                currentV = new VArray(d == 0 ? 1 : d, previousV);
 
-            for (int j = 1; j <= newLength; j++)
-            {
-                d[0, j] = d[0, j - 1] + InsertCost;
-            }
-
-            for (int i = 1; i <= oldLength; i++)
-            {
-                for (int j = 1; j <= newLength; j++)
+                for (int k = -d; k <= d; k += 2)
                 {
-                    int m1 = d[i - 1, j - 1] + (ItemsEqual(oldSequence, i - 1, newSequence, j - 1) ? 0 : UpdateCost);
-                    int m2 = d[i - 1, j] + DeleteCost;
-                    int m3 = d[i, j - 1] + InsertCost;
-                    d[i, j] = Math.Min(Math.Min(m1, m2), m3);
-                }
-            }
+                    // down or right? 
+                    bool right = (k == d || (k != -d && currentV[k - 1] > currentV[k + 1]));
+                    int kPrev = right ? k - 1 : k + 1;
 
-            return d;
+                    // start point
+                    int yStart = currentV[kPrev];
+                    int xStart = yStart + kPrev;
+
+                    // mid point
+                    int yMid = right ? yStart : yStart + 1;
+                    int xMid = yMid + k;
+
+                    // end point
+                    int xEnd = xMid;
+                    int yEnd = yMid;
+
+                    // follow diagonal
+                    while (xEnd < oldLength && yEnd < newLength && ItemsEqual(oldSequence, xEnd, newSequence, yEnd))
+                    {
+                        xEnd++;
+                        yEnd++;
+                    }
+
+                    // save end point
+                    currentV[k] = yEnd;
+                    Debug.Assert(xEnd == yEnd + k);
+
+                    // check for solution
+                    if (xEnd >= oldLength && yEnd >= newLength)
+                    {
+                        reachedEnd = true;
+                    }
+                }
+                stackOfVs.Push(currentV);
+            }
+            return stackOfVs;
         }
     }
 }

--- a/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
@@ -94,10 +94,10 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
         }
 
         [Fact]
-        public void InsertOnly1()
+        public void InsertToEmpty()
         {
             string str1 = "";
-            string str2 = "ABCDE";
+            string str2 = "ABC";
 
             VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { });
 
@@ -106,13 +106,14 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
         }
 
+
         [Fact]
-        public void InsertOnly2()
+        public void InsertAtBeginning()
         {
             string str1 = "ABC";
-            string str2 = "ABXYZC";
+            string str2 = "XYZABC";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 }, { 2, 5 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 3 }, { 1, 4 }, { 2, 5 } });
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -120,7 +121,33 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
         }
 
         [Fact]
-        public void DeleteOnly1()
+        public void InsertAtEnd()
+        {
+            string str1 = "ABC";
+            string str2 = "ABCXYZ";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 }, { 2, 2 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
+        }
+
+        [Fact]
+        public void InsertInMidlle()
+        {
+            string str1 = "ABC";
+            string str2 = "ABXYC";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 }, { 2, 4 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
+        }
+
+        [Fact]
+        public void DeleteToEmpty()
         {
             string str1 = "ABC";
             string str2 = "";
@@ -133,7 +160,33 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
         }
 
         [Fact]
-        public void DeleteOnly2()
+        public void DeleteAtBeginning()
+        {
+            string str1 = "ABCD";
+            string str2 = "C";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 2, 0 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.75);
+        }
+
+        [Fact]
+        public void DeleteAtEnd()
+        {
+            string str1 = "ABCD";
+            string str2 = "AB";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
+        }
+
+        [Fact]
+        public void DeleteInMiddle()
         {
             string str1 = "ABCDE";
             string str2 = "ADE";
@@ -146,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
         }
 
         [Fact]
-        public void Replace1()
+        public void ReplaceAll()
         {
             string str1 = "ABC";
             string str2 = "XYZ";
@@ -159,7 +212,33 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
         }
 
         [Fact]
-        public void Replace2()
+        public void ReplaceAtBeginning()
+        {
+            string str1 = "ABCD";
+            string str2 = "XYD";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 3, 2 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.75);
+        }
+
+        [Fact]
+        public void ReplaceAtEnd()
+        {
+            string str1 = "ABCD";
+            string str2 = "ABXYZ";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.6);
+        }
+
+        [Fact]
+        public void ReplaceInMiddle()
         {
             string str1 = "ABCDE";
             string str2 = "AXDE";
@@ -203,11 +282,27 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABCABBA";
             string str2 = "CBABAC";
 
+            // 2 possible matches:
+            // { { 1, 1 }, { 3, 2 }, { 4, 3 }, { 6, 4 } }
+            // { { 2, 0 }, { 3, 2 }, { 4, 3 }, { 6, 4 } }
             VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 1, 1 }, { 3, 2 }, { 4, 3 }, { 6, 4 } });
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
             Assert.Equal(lcs.ComputeDistance(str1, str2), 0.429, 3);
+        }
+
+        [Fact]
+        public void Reorder1()
+        {
+            string str1 = "AB";
+            string str2 = "BA";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 1 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
         }
     }
 }

--- a/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Text;
 using Xunit;
 using System.Collections.Generic;
 
@@ -33,16 +34,15 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             }
         }
 
-        private void VerifyMatchingPairs(IEnumerable<KeyValuePair<int, int>> actualPairs, Dictionary<int, int> expectedPairs)
+        private void VerifyMatchingPairs(IEnumerable<KeyValuePair<int, int>> actualPairs, string expectedPairsStr)
         {
-            int actPairsCount = 0;
+            StringBuilder sb = new StringBuilder(expectedPairsStr.Length);
             foreach (KeyValuePair<int, int> actPair in actualPairs)
             {
-                Assert.True(expectedPairs.TryGetValue(actPair.Key, out int expValue));
-                Assert.Equal(actPair.Value, expValue);
-                actPairsCount++;
+                sb.AppendFormat("[{0},{1}]", actPair.Key, actPair.Value);
             }
-            Assert.Equal(actPairsCount, expectedPairs.Count);
+            string actualPairsStr = sb.ToString();
+            Assert.Equal(expectedPairsStr, actualPairsStr);
         }
 
         private void VerifyEdits(string oldStr, string newStr, IEnumerable<SequenceEdit> edits)
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "";
             string str2 = "";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>(){ });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "";
             string str2 = "ABC";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABC";
             string str2 = "XYZABC";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 3 }, { 1, 4 }, { 2, 5 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[2,5][1,4][0,3]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABC";
             string str2 = "ABCXYZ";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 }, { 2, 2 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[2,2][1,1][0,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABC";
             string str2 = "ABXYC";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 }, { 2, 4 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[2,4][1,1][0,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -152,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABC";
             string str2 = "";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABCD";
             string str2 = "C";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 2, 0 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[2,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABCD";
             string str2 = "AB";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[1,1][0,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABCDE";
             string str2 = "ADE";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 3, 1 }, { 4, 2 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[4,2][3,1][0,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABC";
             string str2 = "XYZ";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABCD";
             string str2 = "XYD";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 3, 2 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[3,2]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABCD";
             string str2 = "ABXYZ";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[1,1][0,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABCDE";
             string str2 = "AXDE";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 3, 2 }, { 4, 3 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[4,3][3,2][0,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "ABBCDEFIJ";
             string str2 = "AABDEEGH";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 2 }, { 4, 3 }, { 5, 4 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[5,4][4,3][1,2][0,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -269,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "AAABBCCDDD";
             string str2 = "ABXCD";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 3, 1 }, { 5, 3 }, { 7, 4 } });
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[7,4][5,3][3,1][0,0]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -283,9 +283,9 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str2 = "CBABAC";
 
             // 2 possible matches:
-            // { { 1, 1 }, { 3, 2 }, { 4, 3 }, { 6, 4 } }
-            // { { 2, 0 }, { 3, 2 }, { 4, 3 }, { 6, 4 } }
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 1, 1 }, { 3, 2 }, { 4, 3 }, { 6, 4 } });
+            // "[6,4][4,3][3,2][1,1]" <- this one is backwards compatible
+            // "[6,4][4,3][3,2][2,0]"
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[6,4][4,3][3,2][1,1]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 
@@ -298,7 +298,10 @@ namespace Microsoft.CodeAnalysis.Differencing.UnitTests
             string str1 = "AB";
             string str2 = "BA";
 
-            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 1 } });
+            // 2 possible matches:
+            // "[0,1]" <- this one is backwards compatible
+            // "[1,0]"
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), "[0,1]");
 
             VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
 

--- a/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
+++ b/src/Workspaces/CoreTest/Differencing/LongestCommonSubsequenceTests.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Differencing.UnitTests
+{
+    public class LongestCommonSubsequenceTests
+    {
+        LongestCommonSubsequenceString lcs = new LongestCommonSubsequenceString();
+
+        private class LongestCommonSubsequenceString : LongestCommonSubsequence<string>
+        {
+            protected override bool ItemsEqual(string oldSequence, int oldIndex, string newSequence, int newIndex)
+            {
+                return oldSequence[oldIndex] == newSequence[newIndex];
+            }
+
+            public IEnumerable<KeyValuePair<int, int>> GetMatchingPairs(string oldSequence, string newSequence)
+            {
+                return GetMatchingPairs(oldSequence, oldSequence.Length, newSequence, newSequence.Length);
+            }
+
+            public IEnumerable<SequenceEdit> GetEdits(string oldSequence, string newSequence)
+            {
+                return GetEdits(oldSequence, oldSequence.Length, newSequence, newSequence.Length);
+            }
+
+            public double ComputeDistance(string oldSequence, string newSequence)
+            {
+                return ComputeDistance(oldSequence, oldSequence.Length, newSequence, newSequence.Length);
+            }
+        }
+
+        private void VerifyMatchingPairs(IEnumerable<KeyValuePair<int, int>> actualPairs, Dictionary<int, int> expectedPairs)
+        {
+            int actPairsCount = 0;
+            foreach (KeyValuePair<int, int> actPair in actualPairs)
+            {
+                Assert.True(expectedPairs.TryGetValue(actPair.Key, out int expValue));
+                Assert.Equal(actPair.Value, expValue);
+                actPairsCount++;
+            }
+            Assert.Equal(actPairsCount, expectedPairs.Count);
+        }
+
+        private void VerifyEdits(string oldStr, string newStr, IEnumerable<SequenceEdit> edits)
+        {
+            char[] oldChars = oldStr.ToCharArray();
+            char[] newChars = new char[newStr.Length];
+
+            foreach (SequenceEdit edit in edits)
+            {
+                Assert.True(edit.Kind == EditKind.Delete || edit.Kind == EditKind.Insert || edit.Kind == EditKind.Update);
+                switch (edit.Kind)
+                {
+                    case EditKind.Delete:
+                        Assert.True(edit.OldIndex < oldStr.Length);
+                        oldChars[edit.OldIndex] = '\0';
+                        break;
+
+                    case EditKind.Insert:
+                        Assert.True(edit.NewIndex < newStr.Length);
+                        newChars[edit.NewIndex] = newStr[edit.NewIndex];
+                        break;
+
+                    case EditKind.Update:
+                        Assert.True(edit.OldIndex < oldStr.Length);
+                        Assert.True(edit.NewIndex < newStr.Length);
+                        newChars[edit.NewIndex] = oldStr[edit.OldIndex];
+                        oldChars[edit.OldIndex] = '\0';
+                        break;
+                }
+            }
+
+            string editedStr = new String(newChars);
+            Assert.Equal(editedStr, newStr);
+
+            Array.ForEach(oldChars, (c) => { Assert.Equal('\0', c); });
+        }
+
+        [Fact]
+        public void EmptyStrings()
+        {
+            string str1 = "";
+            string str2 = "";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>(){ });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.0);
+        }
+
+        [Fact]
+        public void InsertOnly1()
+        {
+            string str1 = "";
+            string str2 = "ABCDE";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
+        }
+
+        [Fact]
+        public void InsertOnly2()
+        {
+            string str1 = "ABC";
+            string str2 = "ABXYZC";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 1 }, { 2, 5 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.5);
+        }
+
+        [Fact]
+        public void DeleteOnly1()
+        {
+            string str1 = "ABC";
+            string str2 = "";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
+        }
+
+        [Fact]
+        public void DeleteOnly2()
+        {
+            string str1 = "ABCDE";
+            string str2 = "ADE";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 3, 1 }, { 4, 2 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
+        }
+
+        [Fact]
+        public void Replace1()
+        {
+            string str1 = "ABC";
+            string str2 = "XYZ";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 1.0);
+        }
+
+        [Fact]
+        public void Replace2()
+        {
+            string str1 = "ABCDE";
+            string str2 = "AXDE";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 3, 2 }, { 4, 3 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.4);
+        }
+
+        [Fact]
+        public void Combination1()
+        {
+            string str1 = "ABBCDEFIJ";
+            string str2 = "AABDEEGH";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 1, 2 }, { 4, 3 }, { 5, 4 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.556, 3);
+        }
+
+        [Fact]
+        public void Combination2()
+        {
+            string str1 = "AAABBCCDDD";
+            string str2 = "ABXCD";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 0, 0 }, { 3, 1 }, { 5, 3 }, { 7, 4 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.6);
+        }
+
+        [Fact]
+        public void Combination3()
+        {
+            string str1 = "ABCABBA";
+            string str2 = "CBABAC";
+
+            VerifyMatchingPairs(lcs.GetMatchingPairs(str1, str2), new Dictionary<int, int>() { { 1, 1 }, { 3, 2 }, { 4, 3 }, { 6, 4 } });
+
+            VerifyEdits(str1, str2, lcs.GetEdits(str1, str2));
+
+            Assert.Equal(lcs.ComputeDistance(str1, str2), 0.429, 3);
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -73,6 +73,7 @@
     <Compile Include="CodeStyle\EditorConfigCodeStyleParserTests.cs" />
     <Compile Include="DependentTypeFinderTests.cs" />
     <Compile Include="EditorConfigStorageLocation\EditorConfigStorageLocationTests.cs" />
+    <Compile Include="Differencing\LongestCommonSubsequenceTests.cs" />
     <Compile Include="Editting\SyntaxEditorTests.cs" />
     <Compile Include="Execution\Extensions.cs" />
     <Compile Include="Execution\SnapshotSerializationTestBase.cs" />


### PR DESCRIPTION
Changed implementation of LongestCommonSubsequence to use a less memory-intensive algorithm.
The old algorithm allocated O(oldSequence.Length * newSequence.Length) of memory.
The new algorithm is O((oldSequence.Length + newSequence.Length) * (# of inserts and deletes))
in both time and space.

Fixes #9497

**TODO:**
- [x] Verify OOM does not happen anymore
- [x] ~~Optimize allocations for ComputeDistance~~
- [x] ~~Is it worth to keep the previous algorithm for small inputs ?~~
- [x] Check on licence for https://www.codeproject.com/articles/42279/investigating-myers-diff-algorithm-part-of
