### PR TITLE
Bind pattern labels when producing switch label map

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -223,6 +223,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         boundLabelExpression = ConvertCaseExpression(labelSyntax, boundLabelExpression, sectionBinder, ref boundLabelConstantOpt, tempDiagnosticBag);
                         break;
 
+                    case SyntaxKind.CasePatternSwitchLabel:
+                        // bind the pattern, to cause its pattern variables to be inferred if necessary
+                        var matchLabel = (CasePatternSwitchLabelSyntax)labelSyntax;
+                        var pattern = sectionBinder.BindPattern(
+                            matchLabel.Pattern, SwitchGoverningExpression, SwitchGoverningType, labelSyntax.HasErrors, tempDiagnosticBag, wasSwitchCase: true);
+                        break;
+
                     default:
                         // No constant value
                         break;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4547,7 +4547,7 @@ public class Program1717
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/16559")]
+        [Fact, WorkItem(16559, "https://github.com/dotnet/roslyn/issues/16559")]
         public void Fuzz5815()
         {
             var program = @"
@@ -4565,20 +4565,24 @@ public class Program5815
     private static object M() => null;
 }";
             CreateCompilationWithMscorlib45(program).VerifyDiagnostics(
+                // (9,18): error CS0150: A constant value is expected
+                //             case true ? x3 : 4:
+                Diagnostic(ErrorCode.ERR_ConstantExpected, "true ? x3 : 4").WithLocation(9, 18)
                 );
         }
 
-        [Fact(Skip = "This test generator is capable of producing crashes that are not yet fixed; see, for example, Fuzz5815")]
+        [Fact(Skip = "This test generator runs too long to use frequently")]
         public void Fuzz()
         {
-            int dt = Math.Abs(new DateTime().Ticks.GetHashCode() % 10000000);
-            for (int i = 1; i < 100000; i++)
+            const int numTests = 1000000;
+            int dt = (int)Math.Abs(DateTime.Now.Ticks % 1000000000);
+            for (int i = 1; i < numTests; i++)
             {
                 PatternMatchingFuzz(i + dt);
             }
         }
 
-        public void PatternMatchingFuzz(int dt)
+        private static void PatternMatchingFuzz(int dt)
         {
             Random r = new Random(dt);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4548,6 +4548,39 @@ public class Program1717
         }
 
         [Fact, WorkItem(16559, "https://github.com/dotnet/roslyn/issues/16559")]
+        public void CasePatternVariableUsedInCaseExpression()
+        {
+            var program = @"
+public class Program5815
+{
+    public static void Main(object o)
+    {
+        switch (o)
+        {
+            case Color Color:
+            case Color? Color2:
+                break;
+        }
+    }
+    private static object M() => null;
+}";
+            CreateCompilationWithMscorlib45(program).VerifyDiagnostics(
+                // (9,32): error CS1525: Invalid expression term 'break'
+                //             case Color? Color2:
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("break").WithLocation(9, 32),
+                // (9,32): error CS1003: Syntax error, ':' expected
+                //             case Color? Color2:
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments(":", "break").WithLocation(9, 32),
+                // (8,18): error CS0118: 'Color' is a variable but is used like a type
+                //             case Color Color:
+                Diagnostic(ErrorCode.ERR_BadSKknown, "Color").WithArguments("Color", "variable", "type").WithLocation(8, 18),
+                // (9,25): error CS0103: The name 'Color2' does not exist in the current context
+                //             case Color? Color2:
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Color2").WithArguments("Color2").WithLocation(9, 25)
+                );
+        }
+
+        [Fact, WorkItem(16559, "https://github.com/dotnet/roslyn/issues/16559")]
         public void Fuzz5815()
         {
             var program = @"


### PR DESCRIPTION
**Customer scenario**

Attempting to use a nullable type in a type switch (which is illegal), the compiler can interpret that as a ?: operator, and attempt to bind the expression when producing a map from switch cases to the labels. But since we do not bind the pattern cases, that can result in infinite recursion when trying to bind a reference to the pattern variable. For example
```cs
switch (o)
{
    case Color Color:
    case Color? Color2:
        break;
}
```

**Bugs this fixes:** 

Fixes #16559

**Workarounds, if any**

Don't attempt to use nullable types in the typeswitch.

**Risk**

Very low, as this just causes the compiler to bind something earlier than it previously did.

**Performance impact**

Likely none for the same reason.

**Is this a regression from a previous update?**

No; this bug is in a new feature.

**Root cause analysis:**

Lack of dedicated testing team, and failure to follow-through on Engineering plans to assign a developer to an adversarial testing role for each feature under development.

**How was the bug found?**

Bug found by new test generator written to test random (and therefore unexpected) scenarios. It also identified small test cases for the three Watson crashes, which were fixed in the previous PR.

@AlekseyTs @agocke @dotnet/roslyn-compiler Please review this small RTM fix for a pattern-matching crash.

See also https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=369796