### PR TITLE
The subsumption tree must treat an unconstrained type parameter as possibly null.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/SubsumptionDiagnosticBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SubsumptionDiagnosticBuilder.cs
@@ -241,9 +241,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     {
                                         var type = td.Key;
                                         var decision = td.Value;
+                                        // if the pattern's type is already handled by the previous pattern
+                                        // or the previous pattern handles all of the (non-null) input data...
                                         if (ExpressionOfTypeMatchesPatternType(
-                                                declarationPattern.DeclaredType.Type.TupleUnderlyingTypeOrSelf(), type, ref _useSiteDiagnostics) == true)
+                                                declarationPattern.DeclaredType.Type.TupleUnderlyingTypeOrSelf(), type, ref _useSiteDiagnostics) == true ||
+                                            ExpressionOfTypeMatchesPatternType(byType.Type, type, ref _useSiteDiagnostics) == true)
                                         {
+                                            // then we check if the pattern is subsumed by the previous decision
                                             var error = CheckSubsumed(pattern, decision, inputCouldBeNull);
                                             if (error != 0)
                                             {

--- a/src/Compilers/CSharp/Portable/BoundTree/DecisionTree.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DecisionTree.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expression = new BoundLocal(expression.Syntax, temp, null, type);
             }
 
-            if (!expression.Type.IsValueType || expression.Type.IsNullableType()) // is it possible the input may be null?
+            if (expression.Type.CanContainNull())
             {
                 // We need the ByType decision tree to separate null from non-null values.
                 // Note that, for the purpose of the decision tree (and subsumption), we

--- a/src/Compilers/CSharp/Portable/BoundTree/DecisionTree.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DecisionTree.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 expression = new BoundLocal(expression.Syntax, temp, null, type);
             }
 
-            if (expression.Type.CanBeAssignedNull())
+            if (!expression.Type.IsValueType || expression.Type.IsNullableType()) // is it possible the input may be null?
             {
                 // We need the ByType decision tree to separate null from non-null values.
                 // Note that, for the purpose of the decision tree (and subsumption), we

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
@@ -286,15 +286,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var defaultLabel = _factory.GenerateLabel("byTypeDefault");
 
                     // input is not a constant
-                    if (byType.Type.CanBeAssignedNull())
+                    if (byType.Type.CanContainNull())
                     {
                         // first test for null
                         var notNullLabel = _factory.GenerateLabel("notNull");
                         var inputExpression = byType.Expression;
-                        var nullValue = _factory.Null(byType.Type);
+                        var objectType = _factory.SpecialType(SpecialType.System_Object);
+                        var nullValue = _factory.Null(objectType);
                         BoundExpression notNull = byType.Type.IsNullableType()
                             ? _localRewriter.RewriteNullableNullEquality(_factory.Syntax, BinaryOperatorKind.NullableNullNotEqual, byType.Expression, nullValue, _factory.SpecialType(SpecialType.System_Boolean))
-                            : _factory.ObjectNotEqual(byType.Expression, nullValue);
+                            : _factory.ObjectNotEqual(nullValue, _factory.Convert(objectType, byType.Expression));
                         _loweredDecisionTree.Add(_factory.ConditionalGoto(notNull, notNullLabel, true));
                         LowerDecisionTree(byType.Expression, byType.WhenNull);
                         if (byType.WhenNull?.MatchIsComplete != true)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -27,6 +27,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return type.IsReferenceType || type.IsPointerType() || type.IsNullableType();
         }
 
+        public static bool CanContainNull(this TypeSymbol type)
+        {
+            // unbound type parameters might contain null, even though they cannot be *assigned* null.
+            return !type.IsValueType || type.IsNullableType();
+        }
+
         public static bool CanBeConst(this TypeSymbol typeSymbol)
         {
             Debug.Assert((object)typeSymbol != null);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4759,5 +4759,92 @@ class Derived : Base
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(13, 17)
                 );
         }
+
+        [Fact, WorkItem(16688, "https://github.com/dotnet/roslyn/issues/16688")]
+        public void TypeParameterSubsumption03()
+        {
+            var program = @"
+using System.Collections.Generic;
+public class Program
+{
+    private static void Pattern<T>(T thing) where T : class
+    {
+        switch (thing)
+        {
+            case T tThing:
+                break;
+            case IEnumerable<object> s:
+                break;
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(program).VerifyDiagnostics(
+                // (11,18): error CS8120: The switch case has already been handled by a previous case.
+                //             case IEnumerable<object> s:
+                Diagnostic(ErrorCode.ERR_PatternIsSubsumed, "IEnumerable<object> s").WithLocation(11, 18),
+                // (12,17): warning CS0162: Unreachable code detected
+                //                 break;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(12, 17)
+                );
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/16696")]
+        public void TypeParameterSubsumption04()
+        {
+            var program = @"
+using System.Collections.Generic;
+public class Program
+{
+    private static void Pattern<T, TDerived>(object thing) where T : class where TDerived : T
+    {
+        switch (thing)
+        {
+            case IEnumerable<T> sequence:
+                break;
+            case IEnumerable<TDerived> derivedSequence:
+                break;
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(program).VerifyDiagnostics(
+                // (11,18): error CS8120: The switch case has already been handled by a previous case.
+                //             case IEnumerable<TDerived> derivedSequence:
+                Diagnostic(ErrorCode.ERR_PatternIsSubsumed, "IEnumerable<TDerived> derivedSequence").WithLocation(11, 18),
+                // (12,17): warning CS0162: Unreachable code detected
+                //                 break;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(12, 17)
+                );
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/16696")]
+        public void TypeParameterSubsumption05()
+        {
+            var program = @"
+using System.Collections.Generic;
+public class Program
+{
+    private static void Pattern<T, TDerived>(object thing) where T : class where TDerived : T
+    {
+        switch (thing)
+        {
+            case IEnumerable<object> s:
+                break;
+            case IEnumerable<TDerived> derivedSequence:
+                break;
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(program).VerifyDiagnostics(
+                // (11,18): error CS8120: The switch case has already been handled by a previous case.
+                //             case IEnumerable<TDerived> derivedSequence:
+                Diagnostic(ErrorCode.ERR_PatternIsSubsumed, "IEnumerable<TDerived> derivedSequence").WithLocation(11, 18),
+                // (12,17): warning CS0162: Unreachable code detected
+                //                 break;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(12, 17)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4666,7 +4666,7 @@ public class Program{0}
         }
 
         [Fact]
-        public void TypeParameterSubsumption()
+        public void TypeParameterSubsumption01()
         {
             var program = @"
 using System;
@@ -4718,6 +4718,46 @@ Neither
 TBase
 TDerived
 Neither");
+        }
+
+        [Fact]
+        public void TypeParameterSubsumption02()
+        {
+            var program = @"
+using System;
+public class Program
+{
+    static void PatternMatching<TBase, TDerived>(TBase o) where TDerived : TBase
+    {
+        switch (o)
+        {
+            case TBase tb:
+                Console.WriteLine(nameof(TBase));
+                break;
+            case TDerived td:
+                Console.WriteLine(nameof(TDerived));
+                break;
+            default:
+                Console.WriteLine(""Neither"");
+                break;
+        }
+    }
+}
+class Base
+{
+}
+class Derived : Base
+{
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(program).VerifyDiagnostics(
+                // (12,18): error CS8120: The switch case has already been handled by a previous case.
+                //             case TDerived td:
+                Diagnostic(ErrorCode.ERR_PatternIsSubsumed, "TDerived td").WithLocation(12, 18),
+                // (13,17): warning CS0162: Unreachable code detected
+                //                 Console.WriteLine(nameof(TDerived));
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(13, 17)
+                );
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4665,7 +4665,7 @@ public class Program{0}
             CreateCompilationWithMscorlib45(program).GetDiagnostics();
         }
 
-        [Fact]
+        [Fact, WorkItem(16671, "https://github.com/dotnet/roslyn/issues/16671")]
         public void TypeParameterSubsumption01()
         {
             var program = @"
@@ -4720,7 +4720,7 @@ TDerived
 Neither");
         }
 
-        [Fact]
+        [Fact, WorkItem(16671, "https://github.com/dotnet/roslyn/issues/16671")]
         public void TypeParameterSubsumption02()
         {
             var program = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -4796,11 +4796,11 @@ public class Program
 using System.Collections.Generic;
 public class Program
 {
-    private static void Pattern<T, TDerived>(object thing) where T : class where TDerived : T
+    private static void Pattern<TBase, TDerived>(object thing) where TBase : class where TDerived : TBase
     {
         switch (thing)
         {
-            case IEnumerable<T> sequence:
+            case IEnumerable<TBase> sequence:
                 break;
             case IEnumerable<TDerived> derivedSequence:
                 break;
@@ -4825,7 +4825,7 @@ public class Program
 using System.Collections.Generic;
 public class Program
 {
-    private static void Pattern<T, TDerived>(object thing) where T : class where TDerived : T
+    private static void Pattern<TBase, TDerived>(object thing) where TBase : class where TDerived : TBase
     {
         switch (thing)
         {


### PR DESCRIPTION
**Customer scenario**

Using a pattern switch on a value whose type is an unconstrained type parameter results in bad code (that would fail verification) or an incorrect error message. Since few users run with verification enabled, this can result in loss of customer data. For example, this
```cs
        static void PatternMatching<TBase, TDerived>(TBase o) where TDerived : TBase
        {
            switch (o)
            {
                case TDerived td:
                    Console.WriteLine(nameof(TDerived));
                    Console.WriteLine(td.GetType());
                    break;
                default:
                    Console.WriteLine("Unmatched");
                    break;
            }
        }
```
is incorrectly compiled to this
```cs
private static void PatternMatching<TBase, TDerived>(TBase o) where TDerived : TBase
{
    TDerived td = o;
    Console.WriteLine("TDerived");
    Console.WriteLine(td.GetType());
}
```

**Bugs this fixes:** 

Fixes #16671

**Workarounds, if any**

Do not use the new type switch feature with type parameter types.

**Risk**

Low. Code change affects only the problematic scenario.

**Performance impact**

Low. Replaces one simple test (may this type be assigned null) with another (may a value of this type be null).

**Is this a regression from a previous update?**

No; the bug is in a new feature.

**Root cause analysis:**

Insufficient test coverage of scenarios that cross-cut language features. Failure to follow through on our plan to assign a developer to an adversarial test role for each feature under development.

**How was the bug found?**

Customer reported.

@AlekseyTs @agocke @dotnet/roslyn-compiler Please review this RTM bug fix.

See also https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=373449