### PR TITLE
Disallow Rename Tracking on named tuple elements (to match Inline Rename and prevent a crash)

### DIFF
--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -179,6 +179,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                         }
                         else
                         {
+                            // We do not yet support renaming (inline rename or rename tracking) on
+                            // named tuple elements.
+                            if (renameSymbolInfo.Symbols.Single().ContainingType?.IsTupleType() == true)
+                            {
+                                return TriggerIdentifierKind.NotRenamable;
+                            }
+
                             return await DetermineIfRenamableSymbolAsync(renameSymbolInfo.Symbols.Single(), document, token).ConfigureAwait(false);
                         }
                     }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -1284,15 +1284,16 @@ End Class
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
-        public async Task RenameExplicitTupleField()
+        [WorkItem(371205, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371205")]
+        public async Task RenameTrackingNotOnExplicitTupleReturnDeclaration_CSharp()
         {
             var code = @"
 class C
 {
     void M()
     {
-        (int Item1, int) x = (1, 2);
-        var y = x.Item1$$;
+        (int abc$$, int) x = (1, 2);
+        var y = x.abc;
     }
 }";
             using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
@@ -1300,32 +1301,20 @@ class C
                 state.EditorOperations.Backspace();
                 state.EditorOperations.Backspace();
 
-                await state.AssertTag("Item1", "Ite", invokeAction: true);
-
-                // Make sure the rename completed            
-                var expectedCode = @"
-class C
-{
-    void M()
-    {
-        (int Ite, int) x = (1, 2);
-        var y = x.Ite;
-    }
-}";
-                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
                 await state.AssertNoTag();
             }
         }
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
-        public async Task RenameExplicitTupleFieldVB()
+        [WorkItem(371205, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371205")]
+        public async Task RenameTrackingNotOnExplicitTupleReturnDeclaration_VB()
         {
             var code = @"
 class C
     Sub M()
-        Dim x as (Item1 as integer, int Item2 as integer) = (1, 2)
-        Dim y = x.Item1$$
+        Dim x as (abc$$ as integer, int Item2 as integer) = (1, 2)
+        Dim y = x.abc
     End Sub
 End Class";
             using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
@@ -1333,97 +1322,22 @@ End Class";
                 state.EditorOperations.Backspace();
                 state.EditorOperations.Backspace();
 
-                await state.AssertTag("Item1", "Ite", invokeAction: true);
-
-                // Make sure the rename completed            
-                var expectedCode = @"
-class C
-    Sub M()
-        Dim x as (Ite as integer, int Item2 as integer) = (1, 2)
-        Dim y = x.Ite
-    End Sub
-End Class";
-                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
-                await state.AssertNoTag();
-            }
-        }
-
-
-        [WpfFact]
-        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
-        public async Task RenameExplicitTupleField01()
-        {
-            var code = @"
-class C
-{
-    void M()
-    {
-        (int Ite, int) x = (1, 2);
-        var y = x.Ite$$;
-    }
-}";
-            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
-            {
-                state.EditorOperations.InsertText("m1");
-
-                await state.AssertTag("Ite", "Item1", invokeAction: true);
-
-                // Make sure the rename completed            
-                var expectedCode = @"
-class C
-{
-    void M()
-    {
-        (int Item1, int) x = (1, 2);
-        var y = x.Item1;
-    }
-}";
-                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
                 await state.AssertNoTag();
             }
         }
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
-        public async Task RenameExplicitTupleField01VB()
-        {
-            var code = @"
-class C
-    Sub M()
-        Dim x as (Ite as Integer, Item2 as Integer) = (1, 2)
-        var y = x.Ite$$
-    End Sub
-End Class";
-            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
-            {
-                state.EditorOperations.InsertText("m1");
-
-                await state.AssertTag("Ite", "Item1", invokeAction: true);
-
-                // Make sure the rename completed            
-                var expectedCode = @"
-class C
-    Sub M()
-        Dim x as (Item1 as Integer, Item2 as Integer) = (1, 2)
-        var y = x.Item1
-    End Sub
-End Class";
-                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
-                await state.AssertNoTag();
-            }
-        }
-
-        [WpfFact]
-        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
-        public async Task RenameExplicitTupleFieldExtended()
+        [WorkItem(371205, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371205")]
+        public async Task RenameTrackingNotOnExplicitTupleFieldReference_CSharp()
         {
             var code = @"
 class C
 {
     void M()
     {
-        (int, int, int, int, int, int, int, int, int Item9, int) x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        var y = x.Item9$$;
+        (int abc, int) x = (1, 2);
+        var y = x.abc$$;
     }
 }";
             using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
@@ -1431,32 +1345,20 @@ class C
                 state.EditorOperations.Backspace();
                 state.EditorOperations.Backspace();
 
-                await state.AssertTag("Item9", "Ite", invokeAction: true);
-
-                // Make sure the rename completed            
-                var expectedCode = @"
-class C
-{
-    void M()
-    {
-        (int, int, int, int, int, int, int, int, int Ite, int) x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        var y = x.Ite;
-    }
-}";
-                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
                 await state.AssertNoTag();
             }
         }
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
-        public async Task RenameExplicitTupleFieldExtendedVB()
+        [WorkItem(371205, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371205")]
+        public async Task RenameTrackingNotOnExplicitTupleFieldReference_VB()
         {
             var code = @"
 class C
     Sub M()
-        Dim x as (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Item9 As Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        var y = x.Item9$$;
+        Dim x as (abc as integer, int Item2 as integer) = (1, 2)
+        Dim y = x.abc$$
     End Sub
 End Class";
             using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
@@ -1464,17 +1366,44 @@ End Class";
                 state.EditorOperations.Backspace();
                 state.EditorOperations.Backspace();
 
-                await state.AssertTag("Item9", "Ite", invokeAction: true);
+                await state.AssertNoTag();
+            }
+        }
 
-                // Make sure the rename completed            
-                var expectedCode = @"
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        [WorkItem(371205, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371205")]
+        public async Task RenameTrackingNotOnExplicitTupleElementsInDeclarations_CSharp()
+        {
+            var code = @"
 class C
+{
+    void M()
+    {
+        var t = (x$$: 1, y: 2);
+    }
+}";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("2");
+                await state.AssertNoTag();
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        [WorkItem(371205, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371205")]
+        public async Task RenameTrackingNotOnExplicitTupleElementsInDeclarations_VB()
+        {
+            var code = @"
+Class C
     Sub M()
-        Dim x as (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Ite As Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        var y = x.Ite;
+        Dim t = (x$$:=1, y:=2)
     End Sub
 End Class";
-                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.InsertText("2");
                 await state.AssertNoTag();
             }
         }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371205

Escrow Template
===========

**Customer scenario**: Given an existing tuple declaration with named elements, the user types over one of the element names, which results in the Rename Tracking dotted border showing up around the new identifier. Trying to show the lightbulb for the Rename Tracking fix causes VS to crash.

**Bugs this fixes:**  https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=371205

**Workarounds, if any:** Not really. Somehow know to not show the lightbulb when Rename Tracking is active on a named tuple element.

**Risk**: Low. We just take one new scenario in the Rename Tracking code and report that we cannot rename the element (this matches the behavior of Inline Rename now).

**Performance impact**: None. No new allocations or complexity changes.

**Is this a regression from a previous update?**: 

In RC2, Rename Tracking was available from tuple element references only, and it worked without crashing. In the latest bits, it's available from both the declarations and references (a change), and crashes in either case (a change). Nothing significant changed in Rename Tracking or the rename engine during that time, or in the way tuple element symbols are treated/reported by the compiler (as per @VSadov). As such, we are not sure what changed to cause the references-only scenario to stop working.

However, Rename Tracking probably shouldn't have been enabled here in the first place, to stay in sync with Inline Rename. More info below.

**Root cause analysis:** 

In RC2, tuple elements were not available for *Inline Rename* at all. In fact, there is an explicit comment from the compiler team about Inline Rename being disabled on tuple elements because it is complicated. http://source.roslyn.io/#Microsoft.CodeAnalysis.EditorFeatures/Implementation/InlineRename/AbstractEditorInlineRenameService.cs,78

Inline Rename and Rename Tracking should be consistent on what they're willing to rename, but unfortunately some of the code that determines whether a symbol is renamable is not shared between Inline Rename and Rename Tracking (this problem is now tracked by https://github.com/dotnet/roslyn/issues/16732). It looks like Inline Rename was disabled by the compiler team while Rename Tracking was not.

There were tests that seemed to be asserting that Rename Tracking should work in these situations and appeared to be invoking the fix without failure. However, trying these tests in the actual IDE caused crashes. I do not know how these tests were passing, and have filed https://github.com/dotnet/roslyn/issues/16712 to figure out the disconnect between the behavior in tests and the behavior in the IDE. Regardless, I have updated those unit tests to ensure Rename Tracking stays off for tuple elements (that actually test what they claim to test, I've stepped through under a debugger) until we're ready to light them up for *both* forms of Rename. The work to light up both forms of Rename, filed by the compiler team at the time, is tracked by https://github.com/dotnet/roslyn/issues/10898 (now duped against https://github.com/dotnet/roslyn/issues/16566)

**How was the bug found?** Exploratory testing