### PR TITLE
Tolerate space in path when building (Fix for #16702)

### DIFF
--- a/src/Tools/Vsdconfig/Vsdconfig.targets
+++ b/src/Tools/Vsdconfig/Vsdconfig.targets
@@ -7,7 +7,7 @@
           Inputs="@(VsdConfigXml);$(IntermediateOutputPath)\$(AssemblyName).dll"
           Outputs="$(OutDir)\$(AssemblyName).vsdconfig"
           Condition="'$(BuildingProject)' == 'true' AND '$(SkipGenerateVsdconfig)' != 'true'">
-    <Exec Command="&quot;$(DevEnvDir)\..\..\VSSDK\VisualStudioIntegration\Tools\Bin\vsdconfigtool.exe&quot; @(VsdConfigXml -> '%(RelativeDir)%(FileName)%(Extension)', ' ') &quot;$(IntermediateOutputPath)\$(AssemblyName).dll&quot; &quot;$(OutDir)\$(AssemblyName).vsdconfig&quot;" />
+    <Exec Command="&quot;$(DevEnvDir)\..\..\VSSDK\VisualStudioIntegration\Tools\Bin\vsdconfigtool.exe&quot; &quot;@(VsdConfigXml -> '%(RelativeDir)%(FileName)%(Extension)', ' ')&quot; &quot;$(IntermediateOutputPath)\$(AssemblyName).dll&quot; &quot;$(OutDir)\$(AssemblyName).vsdconfig&quot;" />
   </Target>
 
   <Target Name="VsdConfigOutputGroup" Outputs="@(VsdConfigOutputGroupOutput)">

--- a/src/Tools/Vsdconfig/Vsdconfig.targets
+++ b/src/Tools/Vsdconfig/Vsdconfig.targets
@@ -7,7 +7,7 @@
           Inputs="@(VsdConfigXml);$(IntermediateOutputPath)\$(AssemblyName).dll"
           Outputs="$(OutDir)\$(AssemblyName).vsdconfig"
           Condition="'$(BuildingProject)' == 'true' AND '$(SkipGenerateVsdconfig)' != 'true'">
-    <Exec Command="&quot;$(DevEnvDir)\..\..\VSSDK\VisualStudioIntegration\Tools\Bin\vsdconfigtool.exe&quot; &quot;@(VsdConfigXml -> '%(RelativeDir)%(FileName)%(Extension)', ' ')&quot; &quot;$(IntermediateOutputPath)\$(AssemblyName).dll&quot; &quot;$(OutDir)\$(AssemblyName).vsdconfig&quot;" />
+    <Exec Command="&quot;$(DevEnvDir)\..\..\VSSDK\VisualStudioIntegration\Tools\Bin\vsdconfigtool.exe&quot; @(VsdConfigXml -> '&quot;%(RelativeDir)%(FileName)%(Extension)&quot;', ' ') &quot;$(IntermediateOutputPath)\$(AssemblyName).dll&quot; &quot;$(OutDir)\$(AssemblyName).vsdconfig&quot;" />
   </Target>
 
   <Target Name="VsdConfigOutputGroup" Outputs="@(VsdConfigOutputGroupOutput)">


### PR DESCRIPTION
**Customer scenario**

Roslyn fails to build when the sources have a space in their path.

**Bugs this fixes:** 

#16702

**Workarounds, if any**

Roslyn builds without this fix from a path with no spaces.

**Risk**

Very low risk.

**Performance impact**

No impact, infra change.

**Is this a regression from a previous update?**

Yes, Roslyn used to build from the same path.

**Root cause analysis:**

Standardized working directories in MSFT, so no one noticed that before?

**How was the bug found?**

Contributor tinkering with the compiler.