### PR TITLE
Enable override completion to use expression body accessors

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Classification\TotalClassifierTests.cs" />
     <Compile Include="Classification\TotalClassifierTests_Dynamic.cs" />
     <Compile Include="CodeActions\AbstractCSharpCodeActionTest.cs" />
+    <Compile Include="Completion\CompletionProviders\OverrideCompletionProviderTests_ExpressionBody.cs" />
     <Compile Include="ConvertToInterpolatedString\ConvertConcatenationToInterpolatedStringTests.cs" />
     <Compile Include="ConvertToInterpolatedString\ConvertPlaceholderToInterpolatedStringTests.cs" />
     <Compile Include="CodeActions\EncapsulateField\EncapsulateFieldTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests_ExpressionBody.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests_ExpressionBody.cs
@@ -1,0 +1,87 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders
+{
+    // OverrideCompletionProviderTests overrides SetWorkspaceOptions to disable
+    // expression-body members. This class does the opposite.
+    public class OverrideCompletionProviderTests_ExpressionBody : AbstractCSharpCompletionProviderTests
+    {
+        public OverrideCompletionProviderTests_ExpressionBody(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
+        {
+        }
+
+        internal override CompletionProvider CreateCompletionProvider()
+        {
+            return new OverrideCompletionProvider();
+        }
+
+        protected override void SetWorkspaceOptions(TestWorkspace workspace)
+        {
+            workspace.Options = workspace.Options.WithChangedOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CodeStyleOptions.TrueWithSuggestionEnforcement)
+                                                 .WithChangedOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CodeStyleOptions.TrueWithSuggestionEnforcement)
+                                                 .WithChangedOption(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CodeStyleOptions.TrueWithSuggestionEnforcement);
+        }
+
+        [WorkItem(16331, "https://github.com/dotnet/roslyn/issues/16334")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitProducesExpressionBodyProperties()
+        {
+            var markupBeforeCommit = @"class B
+{
+    public virtual int A { get; set; }
+    class C : B
+    {
+        override A$$
+    }
+}";
+
+            var expectedCodeAfterCommit = @"class B
+{
+    public virtual int A { get; set; }
+    class C : B
+    {
+        public override int A { get => base.A$$; set => base.A = value; }
+    }
+}";
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "A", expectedCodeAfterCommit);
+        }
+
+        [WorkItem(16331, "https://github.com/dotnet/roslyn/issues/16334")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitProducesExpressionBodyMethod()
+        {
+            var markupBeforeCommit = @"class B
+{
+    public virtual int A() => 2;
+    class C : B
+    {
+        override A$$
+    }
+}";
+
+            var expectedCodeAfterCommit = @"class B
+{
+    public virtual int A() => 2;
+    class C : B
+    {
+        public override int A() => base.A();$$
+    }
+}";
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "A()", expectedCodeAfterCommit);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests_ExpressionBody.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests_ExpressionBody.cs
@@ -61,6 +61,32 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
         [WorkItem(16331, "https://github.com/dotnet/roslyn/issues/16334")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitProducesExpressionBodyGetterOnlyProperty()
+        {
+            var markupBeforeCommit = @"class B
+{
+    public virtual int A { get; }
+    class C : B
+    {
+        override A$$
+    }
+}";
+
+            var expectedCodeAfterCommit = @"class B
+{
+    public virtual int A { get; }
+    class C : B
+    {
+        public override int A => base.A;$$
+    }
+}";
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "A", expectedCodeAfterCommit);
+        }
+
+
+        [WorkItem(16331, "https://github.com/dotnet/roslyn/issues/16334")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CommitProducesExpressionBodyMethod()
         {
             var markupBeforeCommit = @"class B

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OverrideCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OverrideCompletionProvider.cs
@@ -205,7 +205,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 if (propertyDeclaration.AccessorList != null && propertyDeclaration.AccessorList.Accessors.Any())
                 {
                     // move to the end of the last statement of the first accessor
-                    var firstAccessorStatement = propertyDeclaration.AccessorList.Accessors.First().Body.Statements.Last();
+                    var firstAccessor = propertyDeclaration.AccessorList.Accessors[0];
+                    var firstAccessorStatement = (SyntaxNode)firstAccessor.Body?.Statements.LastOrDefault() ??
+                        firstAccessor.ExpressionBody.Expression;
                     return firstAccessorStatement.GetLocation().SourceSpan.End;
                 }
                 else


### PR DESCRIPTION
Fixes #16334

