### PR TITLE
Move VsdConfig targets into core targets directory

### DIFF
--- a/build/Targets/Vsdconfig.targets
+++ b/build/Targets/Vsdconfig.targets
@@ -6,8 +6,12 @@
           BeforeTargets="AfterCompile"
           Inputs="@(VsdConfigXml);$(IntermediateOutputPath)\$(AssemblyName).dll"
           Outputs="$(OutDir)\$(AssemblyName).vsdconfig"
-          Condition="'$(BuildingProject)' == 'true' AND '$(SkipGenerateVsdconfig)' != 'true'">
-    <Exec Command="&quot;$(DevEnvDir)\..\..\VSSDK\VisualStudioIntegration\Tools\Bin\vsdconfigtool.exe&quot; @(VsdConfigXml -> '&quot;%(RelativeDir)%(FileName)%(Extension)&quot;', ' ') &quot;$(IntermediateOutputPath)\$(AssemblyName).dll&quot; &quot;$(OutDir)\$(AssemblyName).vsdconfig&quot;" />
+          Condition="'$(BuildingProject)' == 'true' AND '@(VsdConfigXml)' != ''">
+    <PropertyGroup>
+      <_VsdConfigTool>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(VisualStudioBuildToolsVersion)\tools\VSSDK\bin\vsdconfigtool.exe</_VsdConfigTool>
+    </PropertyGroup>
+
+    <Exec Command="&quot;$(_VsdConfigTool)&quot; @(VsdConfigXml -> '&quot;%(RelativeDir)%(FileName)%(Extension)&quot;', ' ') &quot;$(IntermediateOutputPath)\$(AssemblyName).dll&quot; &quot;$(OutDir)\$(AssemblyName).vsdconfig&quot;" />
   </Target>
 
   <Target Name="VsdConfigOutputGroup" Outputs="@(VsdConfigOutputGroupOutput)">

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.csproj
@@ -88,6 +88,6 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <Import Project="..\..\..\..\Tools\Vsdconfig\Vsdconfig.targets" />
+  <Import Project="..\..\..\..\..\build\Targets\Vsdconfig.targets" />
   <Import Project="..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/NetFX20/CSharpResultProvider.NetFX20.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/NetFX20/CSharpResultProvider.NetFX20.csproj
@@ -47,6 +47,6 @@
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="..\CSharpResultProvider.projitems" Label="Shared" />
-  <Import Project="..\..\..\..\..\Tools\Vsdconfig\Vsdconfig.targets" />
+  <Import Project="..\..\..\..\..\..\build\Targets\Vsdconfig.targets" />
   <Import Project="..\..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/ExpressionEvaluator/CSharp/Source/ResultProvider/Portable/CSharpResultProvider.Portable.csproj
+++ b/src/ExpressionEvaluator/CSharp/Source/ResultProvider/Portable/CSharpResultProvider.Portable.csproj
@@ -48,6 +48,6 @@
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="..\CSharpResultProvider.projitems" Label="Shared" />
-  <Import Project="..\..\..\..\..\Tools\Vsdconfig\Vsdconfig.targets" />
+  <Import Project="..\..\..\..\..\..\build\Targets\Vsdconfig.targets" />
   <Import Project="..\..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.csproj
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/FunctionResolver.csproj
@@ -72,6 +72,6 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <Import Project="..\..\..\..\Tools\Vsdconfig\Vsdconfig.targets" />
+  <Import Project="..\..\..\..\..\build\Targets\Vsdconfig.targets" />
   <Import Project="..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
@@ -105,6 +105,6 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <Import Project="..\..\..\..\Tools\Vsdconfig\Vsdconfig.targets" />
+  <Import Project="..\..\..\..\..\build\Targets\Vsdconfig.targets" />
   <Import Project="..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/BasicResultProvider.NetFX20.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/BasicResultProvider.NetFX20.vbproj
@@ -59,6 +59,6 @@
     <Folder Include="My Project\" />
   </ItemGroup>
   <Import Project="..\BasicResultProvider.projitems" Label="Shared" />
-  <Import Project="..\..\..\..\..\Tools\Vsdconfig\Vsdconfig.targets" />
+  <Import Project="..\..\..\..\..\..\build\Targets\Vsdconfig.targets" />
   <Import Project="..\..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Portable/BasicResultProvider.Portable.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Portable/BasicResultProvider.Portable.vbproj
@@ -57,6 +57,6 @@
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="..\BasicResultProvider.projitems" Label="Shared" />
-  <Import Project="..\..\..\..\..\Tools\Vsdconfig\Vsdconfig.targets" />
+  <Import Project="..\..\..\..\..\..\build\Targets\Vsdconfig.targets" />
   <Import Project="..\..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>


### PR DESCRIPTION
The VsdConfig.targets file was not located in our core targets location.
Moving there as this is the appropriate place for all targets / props
files in our build.

Additionally changed it to use the vsdconfig from our NuGet packages
directory instead of hard coding Visual Studio.

