### PR TITLE
Fix race conditions caused by doing something *after* the corresponding symbol completion bit was set.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/CompletionPart.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/CompletionPart.cs
@@ -26,10 +26,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // For method symbols
         ReturnTypeAttributes = 1 << 1,
 
-        // For symbols with parameters: method and property symbols.
+        // For methods.
         Parameters = 1 << 2,
 
-        // For symbols with type: method, property and field symbols
+        // For symbols with type: method, and field symbols. Properties are handled separately.
         Type = 1 << 3,
 
         // For named type symbols
@@ -81,7 +81,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         TypeParameterSymbolAll = Attributes | TypeParameterConstraints,
 
         // For property symbols
-        PropertySymbolAll = Attributes | Parameters | Type,
+        StartPropertyParameters = 1 << 4,
+        FinishPropertyParameters = 1 << 5,
+        StartPropertyType = 1 << 6,
+        FinishPropertyType = 1 << 7,
+        PropertySymbolAll = Attributes | StartPropertyParameters | FinishPropertyParameters | StartPropertyType | FinishPropertyType,
 
         // For alias symbols
         AliasTarget = 1 << 4,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEnumConstantSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEnumConstantSymbol.cs
@@ -115,17 +115,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         state.NotePartComplete(CompletionPart.Type);
                         break;
 
-                    case CompletionPart.ConstantValue:
-                        GetConstantValue(ConstantFieldsInProgress.Empty, earlyDecodingWellKnownAttributes: false);
-                        break;
-
                     case CompletionPart.FixedSize:
                         Debug.Assert(!this.IsFixed);
-                        if (state.NotePartComplete(CompletionPart.FixedSize)) // Not applicable
-                        {
-                            // FixedSize is the last completion part for fields.
-                            DeclaringCompilation.SymbolDeclaredEvent(this);
-                        }
+                        state.NotePartComplete(CompletionPart.FixedSize);
+                        break;
+
+                    case CompletionPart.ConstantValue:
+                        GetConstantValue(ConstantFieldsInProgress.Empty, earlyDecodingWellKnownAttributes: false);
                         break;
 
                     case CompletionPart.None:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -177,9 +177,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if ((_lazyCustomAttributesBag == null || !_lazyCustomAttributesBag.IsSealed) &&
                 LoadAndValidateAttributes(OneOrMany.Create(this.AttributeDeclarationSyntaxList), ref _lazyCustomAttributesBag))
             {
-                var completed = state.NotePartComplete(CompletionPart.Attributes);
-                Debug.Assert(completed);
                 DeclaringCompilation.SymbolDeclaredEvent(this);
+                var wasCompletedThisThread = state.NotePartComplete(CompletionPart.Attributes);
+                Debug.Assert(wasCompletedThisThread);
             }
 
             return _lazyCustomAttributesBag;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -739,7 +739,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     Console.WriteLine("Thread {0}, Field {1}, StartsCycle {2}", Thread.CurrentThread.ManagedThreadId, this, startsCycle);
 #endif
                     this.AddDeclarationDiagnostics(diagnostics);
-                    this.state.NotePartComplete(CompletionPart.ConstantValue);
+                    // CompletionPart.ConstantValue is the last part for a field
+                    DeclaringCompilation.SymbolDeclaredEvent(this);
+                    var wasSetThisThread = this.state.NotePartComplete(CompletionPart.ConstantValue);
+                    Debug.Assert(wasSetThisThread);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -122,11 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (Interlocked.CompareExchange(ref _fixedSize, size, FixedSizeNotInitialized) == FixedSizeNotInitialized)
                     {
                         this.AddDeclarationDiagnostics(diagnostics);
-                        if (state.NotePartComplete(CompletionPart.FixedSize))
-                        {
-                            // FixedSize is the last completion part for fields.
-                            DeclaringCompilation.SymbolDeclaredEvent(this);
-                        }
+                        state.NotePartComplete(CompletionPart.FixedSize);
                     }
 
                     diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -120,12 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 Debug.Assert(!this.IsFixed, "Subclasses representing fixed fields must override");
-                if (state.NotePartComplete(CompletionPart.FixedSize))
-                {
-                    // FixedSize is the last completion part for fields.
-                    DeclaringCompilation.SymbolDeclaredEvent(this);
-                }
-
+                state.NotePartComplete(CompletionPart.FixedSize);
                 return 0;
             }
         }
@@ -244,12 +239,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         GetFieldType(ConsList<FieldSymbol>.Empty);
                         break;
 
-                    case CompletionPart.ConstantValue:
-                        GetConstantValue(ConstantFieldsInProgress.Empty, earlyDecodingWellKnownAttributes: false);
-                        break;
-
                     case CompletionPart.FixedSize:
                         int discarded = this.FixedSize;
+                        break;
+
+                    case CompletionPart.ConstantValue:
+                        GetConstantValue(ConstantFieldsInProgress.Empty, earlyDecodingWellKnownAttributes: false);
                         break;
 
                     case CompletionPart.None:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamespaceSymbol.cs
@@ -232,7 +232,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     // We may produce a SymbolDeclaredEvent for the enclosing namespace before events for its contained members
                     DeclaringCompilation.SymbolDeclaredEvent(this);
-                    _state.NotePartComplete(CompletionPart.NameToMembersMap);
+                    var wasSetThisThread = _state.NotePartComplete(CompletionPart.NameToMembersMap);
+                    Debug.Assert(wasSetThisThread);
                 }
 
                 diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolCompletionState.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolCompletionState.cs
@@ -67,6 +67,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 #pragma warning restore 0420
         }
 
+        /// <summary>
+        /// Produce the next (i.e. lowest) CompletionPart (bit) that is not set.
+        /// </summary>
         internal CompletionPart NextIncompletePart
         {
             get


### PR DESCRIPTION
**Customer scenario**

Compiler occasionally crashes while using VS normally, causing VS to crash.

**Bugs this fixes:** 

Fixes #16706

**Workarounds, if any**

None known.

**Risk**

Low. The changes slightly reorganize code to eliminate race conditions.

**Performance impact**

Tiny, if any. No new operations added, but rather existing operations are now performed in a different order.

**Is this a regression from a previous update?**

This has been a longstanding bug in the Roslyn C# compiler since the addition of support for analyzers.

**Root cause analysis:**

Race conditions are difficult to detect, diagnose, repair, and test for. The fixes included in this PR resulted from a survey of our use of completion bits throughout the C# compiler and a systematic elimination of race conditions caused by doing something *after* the caller was the unique setter of some bit. A test written to prevent regressions here (see #16753) has exhibited a different race condition previously unknown (i.e. it fails), so it is not included with this PR.

**How was the bug found?**

Customer reported. The customer also provided a very clear explanation of where (one instance of) the race condition can be found in the compiler.

@dotnet/roslyn-compiler May I please have a couple of reviews of this bug fix for 2.1?
