### PR TITLE
added error which only build support

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilerDiagnosticAnalyzer.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilerDiagnosticAnalyzer.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.CSharp
                         continue;
 
                     case (int)ErrorCode.ERR_MissingPredefinedMember:
+                    case (int)ErrorCode.ERR_PredefinedTypeNotFound:
                         // make it build only error.
                         continue;
                     case (int)ErrorCode.ERR_NoEntryPoint:


### PR DESCRIPTION
adding one more build only errors to csharp compiler diagnostic analyzer.

this will let us show errors from build to users without trying to replace it with live errors.

fix https://github.com/dotnet/roslyn/issues/7093

