### PR TITLE
added max file limit

### DIFF
--- a/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
@@ -366,6 +366,29 @@ namespace Roslyn.Utilities
             {
                 return File.GetLastWriteTimeUtc(fullPath);
             }
+            catch (IOException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new IOException(e.Message, e);
+            }
+        }
+
+        /// <exception cref="IOException"/>
+        internal static long GetFileLength(string fullPath)
+        {
+            Debug.Assert(PathUtilities.IsAbsolute(fullPath));
+            try
+            {
+                var info = new FileInfo(fullPath);
+                return info.Length;
+            }
+            catch (IOException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 throw new IOException(e.Message, e);

--- a/src/Workspaces/Core/Desktop/Workspace/FileTextLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/FileTextLoader.cs
@@ -7,11 +7,28 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
+    internal static class FileTextLoaderOptions
+    {
+        /// <summary>
+        /// Hidden registry key to control maximum size of a text file we will read into memory. 
+        /// we have this option to reduce a chance of OOM when user adds massive size files to the solution.
+        /// Default threshold is 100MB which came from some internal data on big files and some discussion.
+        /// 
+        /// User can override default value by setting DWORD value on FileLengthThreshold in 
+        /// "[VS HIVE]\Roslyn\Internal\Performance\Text"
+        /// </summary>
+        [ExportOption]
+        internal static readonly Option<long> FileLengthThreshold = new Option<long>(nameof(FileTextLoaderOptions), nameof(FileLengthThreshold), defaultValue: 100 * 1024 * 1024,
+            storageLocations: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\Text\FileLengthThreshold"));
+    }
+
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public class FileTextLoader : TextLoader
     {
@@ -69,6 +86,8 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="IOException"></exception>
         public override async Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
         {
+            ValidateFileLength(workspace, _path);
+
             DateTime prevLastWriteTime = FileUtilities.GetFileTimeStamp(_path);
 
             TextAndVersion textAndVersion;
@@ -168,6 +187,8 @@ namespace Microsoft.CodeAnalysis
 
         internal override TextAndVersion LoadTextAndVersionSynchronously(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
         {
+            ValidateFileLength(workspace, _path);
+
             DateTime prevLastWriteTime = FileUtilities.GetFileTimeStamp(_path);
 
             TextAndVersion textAndVersion;
@@ -197,6 +218,31 @@ namespace Microsoft.CodeAnalysis
         private string GetDebuggerDisplay()
         {
             return nameof(Path) + " = " + Path;
+        }
+
+        private static void ValidateFileLength(Workspace workspace, string path)
+        {
+            // Validate file length is under our threshold. 
+            // Otherwise, rather than reading the content into the memory, we will throw
+            // InvalidDataException to caller of FileTextLoader.LoadText to deal with 
+            // the situation.
+            // 
+            // check this (http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Workspace/Solution/TextDocumentState.cs,132)
+            // to see how workspace deal with exception from FileTextLoader. other consumer can handle the exception differently
+            var fileLength = FileUtilities.GetFileLength(path);
+            var threshold = workspace.Options.GetOption(FileTextLoaderOptions.FileLengthThreshold);
+            if (fileLength > threshold)
+            {
+                // log max file length which will log to VS telemetry in VS host
+                Logger.Log(FunctionId.FileTextLoader_FileLengthThresholdExceeded, KeyValueLogMessage.Create(m =>
+                {
+                    m["FileLength"] = fileLength;
+                    m["Ext"] = PathUtilities.GetExtension(path);
+                }));
+
+                var message = string.Format(WorkspacesResources.File_0_size_of_1_exceeds_maximum_allowed_size_of_2, path, fileLength, threshold);
+                throw new InvalidDataException(message);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/FileTextLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/FileTextLoader.cs
@@ -84,6 +84,7 @@ namespace Microsoft.CodeAnalysis
         /// Load a text and a version of the document in the workspace.
         /// </summary>
         /// <exception cref="IOException"></exception>
+        /// <exception cref="InvalidDataException"></exception>
         public override async Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
         {
             ValidateFileLength(workspace, _path);
@@ -185,6 +186,11 @@ namespace Microsoft.CodeAnalysis
             return textAndVersion;
         }
 
+        /// <summary>
+        /// Load a text and a version of the document in the workspace.
+        /// </summary>
+        /// <exception cref="IOException"></exception>
+        /// <exception cref="InvalidDataException"></exception>
         internal override TextAndVersion LoadTextAndVersionSynchronously(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
         {
             ValidateFileLength(workspace, _path);

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -361,5 +361,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         JsonRpcSession_RequestAssetAsync,
         SolutionSynchronizationService_GetRemotableData,
         AssetService_SynchronizeProjectAssetsAsync,
+        FileTextLoader_FileLengthThresholdExceeded,
     }
 }

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -693,6 +693,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File &apos;{0}&apos; size of {1} exceeds maximum allowed size of {2}.
+        /// </summary>
+        internal static string File_0_size_of_1_exceeds_maximum_allowed_size_of_2 {
+            get {
+                return ResourceManager.GetString("File_0_size_of_1_exceeds_maximum_allowed_size_of_2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to File was externally modified: {0}..
         /// </summary>
         internal static string File_was_externally_modified_colon_0 {

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -610,4 +610,7 @@
   <data name="The_first_word_0_must_begin_with_a_lower_case_character" xml:space="preserve">
     <value>The first word, '{0}', must begin with a lower case character</value>
   </data>
+  <data name="File_0_size_of_1_exceeds_maximum_allowed_size_of_2" xml:space="preserve">
+    <value>File '{0}' size of {1} exceeds maximum allowed size of {2}</value>
+  </data>
 </root>

--- a/src/Workspaces/CoreTest/Host/WorkspaceServices/TestOptionsServiceFactory.cs
+++ b/src/Workspaces/CoreTest/Host/WorkspaceServices/TestOptionsServiceFactory.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Options.Providers;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    [ExportWorkspaceServiceFactory(typeof(IOptionService), ServiceLayer.Host), Shared]
+    internal class TestOptionsServiceFactory : IWorkspaceServiceFactory
+    {
+        private readonly ImmutableArray<Lazy<IOptionProvider>> _providers;
+
+        [ImportingConstructor]
+        public TestOptionsServiceFactory(
+            [ImportMany] IEnumerable<Lazy<IOptionProvider>> optionProviders)
+        {
+            _providers = optionProviders.ToImmutableArray();
+        }
+
+        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+        {
+            // give out new option service per workspace
+            return new OptionServiceFactory.OptionService(
+                new GlobalOptionService(_providers, SpecializedCollections.EmptyEnumerable<Lazy<IOptionPersister>>()),
+                workspaceServices);
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Execution\SnapshotSerializationTestBase.cs" />
     <Compile Include="Execution\SnapshotSerializationTests.cs" />
     <Compile Include="ExtensionOrdererTests.cs" />
+    <Compile Include="Host\WorkspaceServices\TestOptionsServiceFactory.cs" />
     <Compile Include="Host\WorkspaceServices\TestProjectCacheService.cs" />
     <Compile Include="Host\WorkspaceServices\TestTemporaryStorageService.cs" />
     <Compile Include="LinkedFileDiffMerging\LinkedFileDiffMergingTests.TextMerging.cs" />


### PR DESCRIPTION
**Customer scenario**

User has big file (over 100MB) in solution and VS crashes OOM.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16796

**Workarounds, if any**

remove the massive file from solution or split the file into smaller chunk

**Risk**

since we are now limiting size of text file (100MB) we will read, if someone had a big file which is big but not big enought to make VS OOM, that file will be no longer read into VS (Roslyn).

but we provide regkey to change default threshold, so we do still provide a workaround for such user.

**Performance impact**

there should be no change on performance

**Is this a regression from a previous update?**

No

**Root cause analysis:**

we need to read in whole file into memory to operate, we do chunk them so that it doesn't go to the LOH, but still we read whole thing in memory to operate rather than reading in or map portion of a file to operate. but naturally that sets limit on how much big file we can support, especially since devenv is in 32bit process. this fix explicitly set limit so that we reduce chance of going OOM.

since we at least chunk, we won't OOM due to lack of giant continuous memory block.

**How was the bug found?**

customer report.