### PR TITLE
Always create dedicated InitializerSemanticModel for parameter default value.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out BoundExpression valueBeforeConversion)
         {
             Debug.Assert(this.InParameterDefaultValue);
-            Debug.Assert(this.ContainingMember().Kind == SymbolKind.Method || this.ContainingMember().Kind == SymbolKind.Property);
+            Debug.Assert(this.ContainingMemberOrLambda.Kind == SymbolKind.Method || this.ContainingMemberOrLambda.Kind == SymbolKind.Property);
 
             // UNDONE: The binding and conversion has to be executed in a checked context.
             Binder defaultValueBinder = this.GetBinder(defaultValueSyntax);

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -224,12 +224,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var oldMethod = _containingMemberOrLambda;
                 _containingMemberOrLambda = match;
 
-                var parameterBinder = _enclosing.WithContainingMemberOrLambda(match).WithAdditionalFlags(BinderFlags.ParameterDefaultValue);
-                foreach (var parameter in node.ParameterList.Parameters)
-                {
-                    Visit(parameter.Default, parameterBinder);
-                }
-
                 if (body != null)
                 {
                     Binder binder = match.IsGenericMethod

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -21,6 +21,12 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly CSharpCompilation _compilation;
         private readonly SyntaxTree _syntaxTree;
+
+        /// <summary>
+        /// Note, the name of this field could be somewhat confusing because it is also 
+        /// used to store models for attributes and default parameter values, which are
+        /// not members.
+        /// </summary>
         private ImmutableDictionary<CSharpSyntaxNode, MemberSemanticModel> _memberModels = ImmutableDictionary<CSharpSyntaxNode, MemberSemanticModel>.Empty;
 
         private readonly BinderFactory _binderFactory;
@@ -736,19 +742,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 switch (memberDecl.Kind())
                 {
-                    case SyntaxKind.DelegateDeclaration:
-                        {
-                            DelegateDeclarationSyntax delegateDecl = (DelegateDeclarationSyntax)memberDecl;
-                            return GetOrAddModelForParameterDefaultValue(delegateDecl.ParameterList.Parameters, span);
-                        }
                     case SyntaxKind.MethodDeclaration:
                     case SyntaxKind.ConversionOperatorDeclaration:
                     case SyntaxKind.OperatorDeclaration:
                         {
                             var methodDecl = (BaseMethodDeclarationSyntax)memberDecl;
                             var expressionBody = methodDecl.GetExpressionBodySyntax();
-                            return GetOrAddModelForParameterDefaultValue(methodDecl.ParameterList.Parameters, span) ??
-                                   GetOrAddModelIfContains(expressionBody, span) ??
+                            return GetOrAddModelIfContains(expressionBody, span) ??
                                    GetOrAddModelIfContains(methodDecl.Body, span);
                         }
 
@@ -756,8 +756,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             ConstructorDeclarationSyntax constructorDecl = (ConstructorDeclarationSyntax)memberDecl;
                             var expressionBody = constructorDecl.GetExpressionBodySyntax();
-                            return GetOrAddModelForParameterDefaultValue(constructorDecl.ParameterList.Parameters, span) ??
-                                   GetOrAddModelIfContains(constructorDecl.Initializer, span) ??
+                            return GetOrAddModelIfContains(constructorDecl.Initializer, span) ??
                                    GetOrAddModelIfContains(expressionBody, span) ??
                                    GetOrAddModelIfContains(constructorDecl.Body, span);
                         }
@@ -773,9 +772,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case SyntaxKind.IndexerDeclaration:
                         {
                             var indexerDecl = (IndexerDeclarationSyntax)memberDecl;
-                            return GetOrAddModelForParameterDefaultValue(
-                                indexerDecl.ParameterList.Parameters, span) ??
-                                GetOrAddModelIfContains(indexerDecl.ExpressionBody, span);
+                            return GetOrAddModelIfContains(indexerDecl.ExpressionBody, span);
                         }
 
                     case SyntaxKind.FieldDeclaration:
@@ -821,6 +818,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case SyntaxKind.Attribute:
                         return GetOrAddModel(memberDecl);
+
+                    case SyntaxKind.Parameter:
+                        return GetOrAddModelForParameter((ParameterSyntax)memberDecl, span);
                 }
             }
 
@@ -840,18 +840,42 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        // Check each parameter for a default value containing span, and create an InitializerSemanticModel for binding the default value if so.
-        // Otherwise, return null.
-        private MemberSemanticModel GetOrAddModelForParameterDefaultValue(SeparatedSyntaxList<ParameterSyntax> parameterList, TextSpan span)
+        // Check parameter for a default value containing span, and create an InitializerSemanticModel for binding the default value if so.
+        // Otherwise, return model for enclosing context.
+        private MemberSemanticModel GetOrAddModelForParameter(ParameterSyntax paramDecl, TextSpan span)
         {
-            foreach (ParameterSyntax paramDecl in parameterList)
+            EqualsValueClauseSyntax defaultValueSyntax = paramDecl.Default;
+            MemberSemanticModel containing = paramDecl.Parent != null ? GetMemberModel(paramDecl.Parent) : null;
+
+            if (containing == null)
             {
-                MemberSemanticModel model = GetOrAddModelIfContains(paramDecl.Default, span);
-                if (model != null)
-                    return model;
+                return GetOrAddModelIfContains(defaultValueSyntax, span);
             }
 
-            return null;
+            if (defaultValueSyntax != null && defaultValueSyntax.FullSpan.Contains(span))
+            {
+                var parameterSymbol = (ParameterSymbol)containing.GetDeclaredSymbol(paramDecl);
+                if ((object)parameterSymbol != null)
+                {
+                    return ImmutableInterlocked.GetOrAdd(ref _memberModels, defaultValueSyntax, 
+                                                         (equalsValue, tuple) =>
+                                                            InitializerSemanticModel.Create(
+                                                                tuple.compilation,
+                                                                tuple.paramDecl,
+                                                                tuple.parameterSymbol,
+                                                                tuple.containing.GetEnclosingBinder(tuple.paramDecl.SpanStart).
+                                                                    CreateBinderForParameterDefaultValue(tuple.parameterSymbol, 
+                                                                                            (EqualsValueClauseSyntax)equalsValue)),
+                                                         (compilation: this.Compilation,
+                                                          paramDecl: paramDecl,
+                                                          parameterSymbol: parameterSymbol,
+                                                          containing: containing)
+                                                         );
+                }
+            }
+
+
+            return containing;
         }
 
         private static CSharpSyntaxNode GetMemberDeclaration(SyntaxNode node)
@@ -1124,7 +1148,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool IsMemberDeclaration(CSharpSyntaxNode node)
         {
-            return (node is MemberDeclarationSyntax) || (node is AccessorDeclarationSyntax) || (node is AttributeSyntax);
+            return (node is MemberDeclarationSyntax) || (node is AccessorDeclarationSyntax) || 
+                   (node.Kind() == SyntaxKind.Attribute) || (node.Kind() == SyntaxKind.Parameter);
         }
 
         private bool IsRegularCSharp

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -238,11 +238,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 binder = binderFactory.GetBinder(defaultSyntax);
             }
 
-            Binder binderForDefault = binder.GetBinder(defaultSyntax);
-            if (binderForDefault == null)
-            {
-                binderForDefault = binder.CreateBinderForParameterDefaultValue(this, defaultSyntax);
-            }
+            Debug.Assert(binder.GetBinder(defaultSyntax) == null);
+
+            Binder binderForDefault = binder.CreateBinderForParameterDefaultValue(this, defaultSyntax);
             Debug.Assert(binderForDefault.InParameterDefaultValue);
             Debug.Assert(binderForDefault.ContainingMemberOrLambda == ContainingSymbol);
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -940,12 +940,11 @@ public class Cls
         private static void VerifyModelForOutVarInNotExecutableCode(
             SemanticModel model,
             DeclarationExpressionSyntax decl,
-            bool boundNodesMissing,
             IdentifierNameSyntax reference)
         {
             VerifyModelForOutVar(
                 model, decl, isDelegateCreation: false, isExecutableCode: false, isShadowed: false,
-                verifyDataFlow: true, boundNodesMissing: boundNodesMissing, references: reference);
+                verifyDataFlow: true, references: reference);
         }
 
         private static void VerifyModelForOutVar(
@@ -955,7 +954,6 @@ public class Cls
             bool isExecutableCode,
             bool isShadowed,
             bool verifyDataFlow = true,
-            bool boundNodesMissing = false, // See https://github.com/dotnet/roslyn/issues/16374
             params IdentifierNameSyntax[] references)
         {
             var variableDeclaratorSyntax = GetVariableDesignation(decl);
@@ -993,7 +991,7 @@ public class Cls
                 Assert.Equal(local.Type, model.GetSymbolInfo(typeSyntax).Symbol);
             }
 
-            AssertInfoForDeclarationExpressionSyntax(model, decl, expectedSymbol: local, expectedType: local.Type, boundNodesMissing: boundNodesMissing);
+            AssertInfoForDeclarationExpressionSyntax(model, decl, expectedSymbol: local, expectedType: local.Type);
 
             foreach (var reference in references)
             {
@@ -1013,8 +1011,7 @@ public class Cls
             SemanticModel model,
             DeclarationExpressionSyntax decl,
             Symbol expectedSymbol = null,
-            TypeSymbol expectedType = null,
-            bool boundNodesMissing = false
+            TypeSymbol expectedType = null
             )
         {
             var symbolInfo = model.GetSymbolInfo(decl);
@@ -1024,19 +1021,8 @@ public class Cls
             Assert.Equal(symbolInfo, ((CSharpSemanticModel)model).GetSymbolInfo(decl));
 
             var typeInfo = model.GetTypeInfo(decl);
-            if (boundNodesMissing)
-            {
-                // This works around a bug that the semantic model does not cache the expression
-                // that is the default value of a local function parameter.
-                // See https://github.com/dotnet/roslyn/issues/16374
-                Assert.Equal(true, ((TypeSymbol)typeInfo.Type).IsErrorType());
-                Assert.Equal(true, ((TypeSymbol)typeInfo.ConvertedType).IsErrorType());
-            }
-            else
-            {
-                Assert.Equal(expectedType, typeInfo.Type);
-                Assert.Equal(expectedType, typeInfo.ConvertedType);
-            }
+            Assert.Equal(expectedType, typeInfo.Type);
+            Assert.Equal(expectedType, typeInfo.ConvertedType);
             Assert.Equal(typeInfo, ((CSharpSemanticModel)model).GetTypeInfo(decl));
 
             var conversion = model.ClassifyConversion(decl, model.Compilation.ObjectType, false);
@@ -28919,14 +28905,176 @@ class C
                 var decl = GetOutVarDeclaration(tree, name);
                 var refs = GetReferences(tree, name).ToArray();
                 Assert.Equal(4, refs.Length);
-                var boundNodesMissing = i == 2; // See https://github.com/dotnet/roslyn/issues/16374
-                VerifyModelForOutVarInNotExecutableCode(model, decl, boundNodesMissing: boundNodesMissing, reference: refs[0]);
+                VerifyModelForOutVarInNotExecutableCode(model, decl, refs[0]);
                 VerifyNotInScope(model, refs[1]);
                 VerifyNotInScope(model, refs[2]);
                 VerifyNotInScope(model, refs[3]);
                 var symbol = (ILocalSymbol)model.GetDeclaredSymbol(decl.Designation);
                 Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
             }
+        }
+
+        [Fact]
+        public void DeclarationInAnonymousMethodParameterDefault()
+        {
+            var text = @"
+class C
+{
+    public static void Main(int arg)
+    {
+        System.Action<bool, int> d1 = delegate (
+                                                bool b = M(M(out int z1), z1), 
+                                                int s2 = z1) 
+                                            { var t = z1; };
+        System.Action<bool, int> d2 = delegate (
+                                                bool b = M(M(out var z2), z2), 
+                                                int s2 = z2)  
+                                            { var t = z2; };
+
+        int x = z1 + z2;
+        d1 = d2 = null;
+    }
+    static int M(out int z) => z = 1;
+    static int M(int a, int b) => a+b;
+}
+";
+            // the scope of an expression variable introduced in the default expression
+            // of a lambda parameter is that default expression.
+            var compilation = CreateCompilationWithMscorlib45(text);
+            compilation.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.ERR_DefaultValueNotAllowed).Verify(
+                // (9,55): error CS0103: The name 'z1' does not exist in the current context
+                //                                             { var t = z1; };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z1").WithArguments("z1").WithLocation(9, 55),
+                // (13,55): error CS0103: The name 'z2' does not exist in the current context
+                //                                             { var t = z2; };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(13, 55),
+                // (15,17): error CS0103: The name 'z1' does not exist in the current context
+                //         int x = z1 + z2;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z1").WithArguments("z1").WithLocation(15, 17),
+                // (15,22): error CS0103: The name 'z2' does not exist in the current context
+                //         int x = z1 + z2;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(15, 22)
+                );
+
+            var tree = compilation.SyntaxTrees[0];
+            var model = compilation.GetSemanticModel(tree);
+
+            var z1 = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "z1").First();
+            Assert.Equal("System.Int32", model.GetTypeInfo(z1).Type.ToTestDisplayString());
+
+            for (int i = 1; i <= 2; i++)
+            {
+                var name = $"z{i}";
+                var decl = GetOutVarDeclaration(tree, name);
+                var refs = GetReferences(tree, name).ToArray();
+                Assert.Equal(4, refs.Length);
+                VerifyModelForOutVarInNotExecutableCode(model, decl, refs[0]);
+                VerifyNotInScope(model, refs[1]);
+                VerifyNotInScope(model, refs[2]);
+                VerifyNotInScope(model, refs[3]);
+                var symbol = (ILocalSymbol)model.GetDeclaredSymbol(decl.Designation);
+                Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
+            }
+        }
+
+        [Fact]
+        public void Scope_LocalFunction_Attribute_01()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        void Local1(
+            [Test(p = TakeOutParam(out int x3) && x3 > 0)]
+            [Test(p = x4 && TakeOutParam(out int x4))]
+            [Test(p = TakeOutParam(51, out int x5) && 
+                      TakeOutParam(52, out int x5) && 
+                      x5 > 0)]
+            [Test(p1 = TakeOutParam(out int x6) && x6 > 0, 
+                  p2 = TakeOutParam(out int x6) && x6 > 0)]
+            [Test(p = TakeOutParam(out int x7) && x7 > 0)]
+            [Test(p = x7 > 2)]
+            int p1)
+        {
+            Dummy(x7, p1);
+        }
+
+        Local1(1);
+    }
+
+    bool Dummy(params object[] x) {return true;}
+
+    static bool TakeOutParam(out int x) 
+    {
+        x = 123;
+        return true;
+    }
+    static bool TakeOutParam(object y, out int x)
+    {
+        x = 123;
+        return true;
+    }
+}
+
+class Test : System.Attribute
+{
+    public bool p {get; set;}
+    public bool p1 {get; set;}
+    public bool p2 {get; set;}
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            compilation.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.ERR_AttributesInLocalFuncDecl &&
+                                                    d.Code != (int)ErrorCode.ERR_BadAttributeArgument).Verify(
+                // (18,19): error CS0103: The name 'x7' does not exist in the current context
+                //             Dummy(x7, p1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x7").WithArguments("x7").WithLocation(18, 19),
+                // (8,23): error CS0841: Cannot use local variable 'x4' before it is declared
+                //             [Test(p = x4 && TakeOutParam(out int x4))]
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(8, 23),
+                // (10,48): error CS0128: A local variable or function named 'x5' is already defined in this scope
+                //                       TakeOutParam(52, out int x5) && 
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(10, 48),
+                // (13,45): error CS0128: A local variable or function named 'x6' is already defined in this scope
+                //                   p2 = TakeOutParam(out int x6) && x6 > 0)]
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x6").WithArguments("x6").WithLocation(13, 45),
+                // (15,23): error CS0103: The name 'x7' does not exist in the current context
+                //             [Test(p = x7 > 2)]
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x7").WithArguments("x7").WithLocation(15, 23)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x3Decl = GetOutVarDeclaration(tree, "x3");
+            var x3Ref = GetReference(tree, "x3");
+            VerifyModelForOutVarInNotExecutableCode(model, x3Decl, x3Ref);
+
+            var x4Decl = GetOutVarDeclaration(tree, "x4");
+            var x4Ref = GetReference(tree, "x4");
+            VerifyModelForOutVarInNotExecutableCode(model, x4Decl, x4Ref);
+
+            var x5Decl = GetOutVarDeclarations(tree, "x5").ToArray();
+            var x5Ref = GetReference(tree, "x5");
+            Assert.Equal(2, x5Decl.Length);
+            VerifyModelForOutVarInNotExecutableCode(model, x5Decl[0], x5Ref);
+            VerifyModelForOutVarDuplicateInSameScope(model, x5Decl[1]);
+
+            var x6Decl = GetOutVarDeclarations(tree, "x6").ToArray();
+            var x6Ref = GetReferences(tree, "x6").ToArray();
+            Assert.Equal(2, x6Decl.Length);
+            Assert.Equal(2, x6Ref.Length);
+            VerifyModelForOutVarInNotExecutableCode(model, x6Decl[0], x6Ref);
+            VerifyModelForOutVarDuplicateInSameScope(model, x6Decl[1]);
+
+            var x7Decl = GetOutVarDeclaration(tree, "x7");
+            var x7Ref = GetReferences(tree, "x7").ToArray();
+            Assert.Equal(3, x7Ref.Length);
+            VerifyModelForOutVarInNotExecutableCode(model, x7Decl, x7Ref[0]);
+            VerifyNotInScope(model, x7Ref[1]);
+            VerifyNotInScope(model, x7Ref[2]);
         }
     }
 

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ParameterSymbol.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.ParameterSymbol.vb
@@ -534,5 +534,107 @@ end class
 </Workspace>
             Await TestAPIAndFeature(input)
         End Function
+
+        <WorkItem(16757, "https://github.com/dotnet/roslyn/issues/16757")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)>
+        Public Async Function TestParameterInLocalFunction1() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void Main()
+            {
+                void Local(int {|Definition:$$i|})
+                {
+                    Console.WriteLine([|i|]);
+                }
+
+                Local(1);
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(16757, "https://github.com/dotnet/roslyn/issues/16757")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)>
+        Public Async Function TestParameterInLocalFunction2() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void Main()
+            {
+                void Local(int {|Definition:$$i|})
+                {
+                }
+
+                Local([|i|]:1);
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(16757, "https://github.com/dotnet/roslyn/issues/16757")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)>
+        Public Async Function TestParameterInLocalFunction3() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void Main()
+            {
+                void Local(int {|Definition:i|})
+                {
+                    Console.WriteLine([|$$i|]);
+                }
+
+                Local(1);
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(16757, "https://github.com/dotnet/roslyn/issues/16757")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)>
+        Public Async Function TestParameterInLocalFunction4() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void Main()
+            {
+                void Local(int {|Definition:i|})
+                {
+                }
+
+                Local([|$$i|]:1);
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Even for cases when the parameter is not part of a type member declaration, i.e. owned by an anonymous method or a local function.
Fixes #16748. Fixes #16374.

Also implement SemanticModel.GetDeclaredSymbol(ParameterSyntax) for parameters of a Local Function.
Fixes #16757.

@dotnet/roslyn-compiler Please review.