### PR TITLE
Reduce compiler's sensitivity to deep/fluent expressions (causing stack overflows)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -632,14 +632,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return BindThrowExpression((ThrowExpressionSyntax)node, diagnostics);
 
                 case SyntaxKind.RefType:
-                    {
-                        return BindRefType(node, diagnostics);
-                    }
+                    return BindRefType(node, diagnostics);
 
                 case SyntaxKind.RefExpression:
-                    {
-                        return BindRefExpression(node, diagnostics);
-                    }
+                    return BindRefExpression(node, diagnostics);
 
                 case SyntaxKind.DeclarationExpression:
                     return BindDeclarationExpression((DeclarationExpressionSyntax)node, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -633,18 +633,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case SyntaxKind.RefType:
                     {
-                        var firstToken = node.GetFirstToken();
-                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken);
-                        return new BoundTypeExpression(node, null, CreateErrorType("ref"));
+                        return BindRefType(node, diagnostics);
                     }
 
                 case SyntaxKind.RefExpression:
                     {
-                        var firstToken = node.GetFirstToken();
-                        diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken);
-                        return new BoundBadExpression(
-                            node, LookupResultKind.Empty, ImmutableArray<Symbol>.Empty, ImmutableArray<BoundNode>.Empty,
-                            CreateErrorType("ref"));
+                        return BindRefExpression(node, diagnostics);
                     }
 
                 case SyntaxKind.DeclarationExpression:
@@ -657,6 +651,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(false, "Unexpected SyntaxKind " + node.Kind());
                     return BadExpression(node);
             }
+        }
+
+        private BoundExpression BindRefExpression(ExpressionSyntax node, DiagnosticBag diagnostics)
+        {
+            var firstToken = node.GetFirstToken();
+            diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken);
+            return new BoundBadExpression(
+                node, LookupResultKind.Empty, ImmutableArray<Symbol>.Empty, ImmutableArray<BoundNode>.Empty,
+                CreateErrorType("ref"));
+        }
+
+        private BoundExpression BindRefType(ExpressionSyntax node, DiagnosticBag diagnostics)
+        {
+            var firstToken = node.GetFirstToken();
+            diagnostics.Add(ErrorCode.ERR_UnexpectedToken, firstToken.GetLocation(), firstToken);
+            return new BoundTypeExpression(node, null, CreateErrorType("ref"));
         }
 
         private BoundExpression BindThrowExpression(ThrowExpressionSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -56,6 +56,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             _variablesBuilder = save;
         }
 
+        public override void Visit(SyntaxNode node)
+        {
+            if (node != null)
+            {
+                // no stackguard
+                ((CSharpSyntaxNode)node).Accept(this);
+            }
+        }
+
         public override void VisitVariableDeclarator(VariableDeclaratorSyntax node)
         {
             if (node.ArgumentList != null)


### PR DESCRIPTION
**Customer scenario**
The customer uses a long/fluent invocation, such as `new C().M().M(). ... .M();`. That invocation would compile for very long expressions (2550 iterations on my box) with version 1.3.2 of the compiler. But such invocation only compiles for 630 iterations with dev15 RC3.
With this fix, it is possible to compile 1690 iterations (a 30% reduction from 1.3.2).
This manifests as a VS crash.

**Bugs this fixes:** 
Mitigates https://github.com/dotnet/roslyn/issues/16669

**Workarounds, if any**
Update your code and chop of the fluent expression into chunks.

**Root cause analysis:**
There are three factors which caused this:
1. The size of a stack frame for some binding methods grew. The largest one is `BindExpressionInternal` which grew from 72 bytes (in 1.3.2) to 272 bytes (in RC.3). It is called recursively when binding fluent expressions.
2. The binding now involves an `ExpressionVariableFinder`, which was introduced to detect locals declared by expressions. This requires a walk through the syntax of the fluent expression and is currently implemented as a recursion.
3. When the `ExpressionVariableFinder` does this recursive walk, it uses a BCL API to check if it is getting close to a stack overflow. Unfortunately, this API is trigger happy. Although the default stack size is 1MB, this API gives up at 500kB+1.

The fix in this PR involves two parts:
1. We reduce problem (1) above, by extracting two blocks of code from `BindExpressionInternal` to new methods. This reduces the size of the stack frame from 272 back to 116. This is still up from 72 (in 1.3.2).
2. We removing problem (3) above, by modifying the `ExpressionVariableFinder` to walk the syntax without a stack guard. This allows the full 1MB of stack space to be used.

Note that problem (1) is largely but not completely mitigated and problem (2) remains. This results in a 30% overall decrease in expressions we can normally. 
Further optimizations can be done past RTW:
- we may be able to further reduce the frame size for some methods,
- we could improve the stack guard to be less trigger happy,
- when we get close to the stack size limit, we could pause the thread and continue the recursive computation on a fresh thread (starting from a shallow stack again),
- modify some of our node walking to avoid recursion.

**Risk**
**Performance impact**
Low. See description of the fix above.

**Is this a regression from a previous update?**
Yes, this is a progressive regression from 1.3.2.
On "1.3.2" the max is around 2550.
On "2.0.0-beta1" the max is around 900.
On "2.0.0-beta5" the max is around 670.
On “2.0.0-rc” the max is around 670.
On “2.0.0-rc2” the max is around 630.

We're adding a test for such long expressions, so that we catch such regressions in the future. The difficulty is that the stack and thread size is platform and environment dependent, so we're still looking for a good way to control that in our automation.

**How was the bug found?**
We had multiple customer reports that we categorized as "by design". The user should not write such massive expressions. But apparently a number of customers do and I started to suspect the compiler may have become more sensitive to stack overflows. Ad hoc testing confirmed this.