### PR TITLE
Enable Code Fixes in F# (RC3 regression)

### DIFF
--- a/src/EditorFeatures/Core/ContentTypeNames.cs
+++ b/src/EditorFeatures/Core/ContentTypeNames.cs
@@ -10,5 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor
         public const string VisualBasicContentType = "Basic";
         public const string VisualBasicSignatureHelpContentType = "Basic Signature Help";
         public const string XamlContentType = "XAML";
+        public const string JavaScriptContentTypeName = "JavaScript";
+        public const string TypeScriptContentTypeName = "TypeScript";
     }
 }

--- a/src/EditorFeatures/Core/ContentTypeNames.cs
+++ b/src/EditorFeatures/Core/ContentTypeNames.cs
@@ -10,6 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor
         public const string VisualBasicContentType = "Basic";
         public const string VisualBasicSignatureHelpContentType = "Basic Signature Help";
         public const string XamlContentType = "XAML";
+        public const string FSharpContentType = "F#";
         public const string JavaScriptContentTypeName = "JavaScript";
         public const string TypeScriptContentTypeName = "TypeScript";
     }

--- a/src/EditorFeatures/Core/ContentTypeNames.cs
+++ b/src/EditorFeatures/Core/ContentTypeNames.cs
@@ -10,8 +10,5 @@ namespace Microsoft.CodeAnalysis.Editor
         public const string VisualBasicContentType = "Basic";
         public const string VisualBasicSignatureHelpContentType = "Basic Signature Help";
         public const string XamlContentType = "XAML";
-        public const string FSharpContentType = "F#";
-        public const string JavaScriptContentTypeName = "JavaScript";
-        public const string TypeScriptContentTypeName = "TypeScript";
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -36,11 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
     [Export(typeof(ISuggestedActionsSourceProvider))]
     [Export(typeof(SuggestedActionsSourceProvider))]
-    [VisualStudio.Utilities.ContentType(ContentTypeNames.CSharpContentType)]
-    [VisualStudio.Utilities.ContentType(ContentTypeNames.VisualBasicContentType)]
-    [VisualStudio.Utilities.ContentType(ContentTypeNames.JavaScriptContentTypeName)]
-    [VisualStudio.Utilities.ContentType(ContentTypeNames.TypeScriptContentTypeName)]
-    [VisualStudio.Utilities.ContentType(ContentTypeNames.XamlContentType)]
+    [VisualStudio.Utilities.ContentType(ContentTypeNames.RoslynContentType)]
     [VisualStudio.Utilities.ContentType(ContentTypeNames.FSharpContentType)]
     [VisualStudio.Utilities.Name("Roslyn Code Fix")]
     [VisualStudio.Utilities.Order]

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
     [Export(typeof(ISuggestedActionsSourceProvider))]
     [Export(typeof(SuggestedActionsSourceProvider))]
     [VisualStudio.Utilities.ContentType(ContentTypeNames.RoslynContentType)]
-    [VisualStudio.Utilities.ContentType(ContentTypeNames.FSharpContentType)]
+    [VisualStudio.Utilities.ContentType(ContentTypeNames.XamlContentType)]
     [VisualStudio.Utilities.Name("Roslyn Code Fix")]
     [VisualStudio.Utilities.Order]
     internal class SuggestedActionsSourceProvider : ISuggestedActionsSourceProvider

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -41,6 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
     [VisualStudio.Utilities.ContentType(ContentTypeNames.JavaScriptContentTypeName)]
     [VisualStudio.Utilities.ContentType(ContentTypeNames.TypeScriptContentTypeName)]
     [VisualStudio.Utilities.ContentType(ContentTypeNames.XamlContentType)]
+    [VisualStudio.Utilities.ContentType(ContentTypeNames.FSharpContentType)]
     [VisualStudio.Utilities.Name("Roslyn Code Fix")]
     [VisualStudio.Utilities.Order]
     internal class SuggestedActionsSourceProvider : ISuggestedActionsSourceProvider


### PR DESCRIPTION
**Customer scenario**

In RC3, Code Fixes no longer work in F#. The F# community has put in a significant amount of effort to add new Roslyn-based Code Fixes and it would be a great shame if we can't get this fixed for RTM.

**Bugs this fixes:** 

Fixes Microsoft/visualfsharp#2329

**Workarounds, if any**

No workaround

**Risk**

No risk

**Performance impact**

Low. Will act the same as RC2

**Is this a regression from a previous update?**

This is a regression from RC3

**How was the bug found?**

F# contributor testing