### PR TITLE
support navigating to external file in error list

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -401,20 +401,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                         return false;
                     }
 
-                    // this item is not navigatable
-                    if (item.DocumentId == null)
-                    {
-                        return false;
-                    }
-
                     var trackingLinePosition = GetTrackingLineColumn(item.Workspace, item.DocumentId, index);
                     if (trackingLinePosition != LinePosition.Zero)
                     {
-                        return TryNavigateTo(item.Workspace, item.DocumentId, trackingLinePosition.Line, trackingLinePosition.Character, previewTab);
+                        return TryNavigateTo(
+                            item.Workspace,
+                            item.ProjectId,
+                            item.DocumentId,
+                            item.DataLocation?.OriginalFilePath,
+                            trackingLinePosition.Line,
+                            trackingLinePosition.Character,
+                            previewTab);
                     }
 
-                    return TryNavigateTo(item.Workspace, item.DocumentId,
-                            item.DataLocation?.OriginalStartLine ?? 0, item.DataLocation?.OriginalStartColumn ?? 0, previewTab);
+                    return TryNavigateTo(item.Workspace, item.ProjectId, item.DocumentId,
+                            item.DataLocation?.OriginalFilePath, item.DataLocation?.OriginalStartLine ?? 0, item.DataLocation?.OriginalStartColumn ?? 0,
+                            previewTab);
                 }
 
                 protected override bool IsEquivalent(DiagnosticData item1, DiagnosticData item2)

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioBaseTodoListTable.cs
@@ -309,10 +309,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                     var trackingLinePosition = GetTrackingLineColumn(item.Workspace, item.DocumentId, index);
                     if (trackingLinePosition != LinePosition.Zero)
                     {
-                        return TryNavigateTo(item.Workspace, item.DocumentId, trackingLinePosition.Line, trackingLinePosition.Character, previewTab);
+                        return TryNavigateTo(item.Workspace, item.DocumentId.ProjectId, item.DocumentId,
+                            item.OriginalFilePath, trackingLinePosition.Line, trackingLinePosition.Character, previewTab);
                     }
 
-                    return TryNavigateTo(item.Workspace, item.DocumentId, item.OriginalLine, item.OriginalColumn, previewTab);
+                    return TryNavigateTo(item.Workspace, item.DocumentId.ProjectId, item.DocumentId,
+                        item.OriginalFilePath, item.OriginalLine, item.OriginalColumn, previewTab);
                 }
 
                 protected override bool IsEquivalent(TodoItem item1, TodoItem item2)

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -251,14 +251,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                         return false;
                     }
 
-                    // this item is not navigatable
-                    if (item.DocumentId == null)
-                    {
-                        return false;
-                    }
-
-                    return TryNavigateTo(item.Workspace, GetProperDocumentId(item),
-                                         item.DataLocation?.OriginalStartLine ?? 0, item.DataLocation?.OriginalStartColumn ?? 0, previewTab);
+                    return TryNavigateTo(item.Workspace, item.ProjectId, GetProperDocumentId(item),
+                                         item.DataLocation?.OriginalFilePath,
+                                         item.DataLocation?.OriginalStartLine ?? 0,
+                                         item.DataLocation?.OriginalStartColumn ?? 0,
+                                         previewTab);
                 }
 
                 private DocumentId GetProperDocumentId(DiagnosticData data)

--- a/src/VisualStudio/Core/Def/Implementation/Utilities/NavigationHelper.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Utilities/NavigationHelper.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Utilities
+{
+    internal static class NavigationHelper
+    {
+        public static bool TryNavigateToPosition(this IServiceProvider serviceProvider, string filePath, int line, int column)
+        {
+            var docTable = (IVsRunningDocumentTable)serviceProvider.GetService(typeof(SVsRunningDocumentTable));
+            var textManager = (IVsTextManager)serviceProvider.GetService(typeof(SVsTextManager));
+            if (docTable == null || textManager == null)
+            {
+                return false;
+            }
+
+            return TryNavigateToPosition(docTable, textManager, filePath, line, column);
+        }
+
+        public static bool TryNavigateToPosition(this VisualStudioWorkspaceImpl workspace, string filePath, int line, int column)
+        {
+            var docTable = workspace.GetVsService<SVsRunningDocumentTable, IVsRunningDocumentTable>();
+            var textManager = workspace.GetVsService<SVsTextManager, IVsTextManager>();
+            if (docTable == null || textManager == null)
+            {
+                return false;
+            }
+
+            return TryNavigateToPosition(docTable, textManager, filePath, line, column);
+        }
+
+        public static bool TryNavigateToPosition(this IVsRunningDocumentTable docTable, IVsTextManager textManager, string filePath, int line, int column)
+        {
+            if (ErrorHandler.Failed(docTable.FindAndLockDocument(
+                (uint)_VSRDTFLAGS.RDT_NoLock, filePath,
+                out var hierarchy, out var itemid, out var bufferPtr, out var cookie)))
+            {
+                return false;
+            }
+
+            try
+            {
+                var lines = Marshal.GetObjectForIUnknown(bufferPtr) as IVsTextLines;
+                if (lines == null)
+                {
+                    return false;
+                }
+
+                return ErrorHandler.Succeeded(textManager.NavigateToLineAndColumn(
+                    lines, VSConstants.LOGVIEWID.TextView_guid,
+                    line, column, line, column));
+            }
+            finally
+            {
+                if (bufferPtr != IntPtr.Zero)
+                {
+                    Marshal.Release(bufferPtr);
+                }
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Implementation\Utilities\BrowserHelper.cs" />
     <Compile Include="Implementation\Utilities\AutomationDelegatingListView.cs" />
     <Compile Include="Implementation\Utilities\HyperlinkStyleHelper.cs" />
+    <Compile Include="Implementation\Utilities\NavigationHelper.cs" />
     <Compile Include="Implementation\Venus\VenusTaskExtensions.cs" />
     <Compile Include="Implementation\Versions\SemanticVersionTrackingService.cs" />
     <Compile Include="Implementation\ContainedLanguageRefactorNotifyService.cs" />


### PR DESCRIPTION
**Customer scenario**

user built and got build error (not live error) at xaml file in error list. user double-clicked on the item but VS didn't navigate to the position in xaml file.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=365348

**Workarounds, if any**

double click from output window

**Risk**

it doesn't change any existing behavior and this is for very specific case, so I think risk is low. it now let VS open to any arbitrary file returned by analyzers (including compiler), but we already does that in other features so it shouldn't be doing something we didn't do before.

**Performance impact**

this code change is for explicit user command. no perf impact.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

our error list never allowed users to open and go to a file that is not part of Roslyn solution. now we allow that.

**How was the bug found?**

customer report.