### PR TITLE
Fix IInlineRenameInfo.GetFinalSymbolName not being respected

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             AssertIsForeground();
             VerifyNotDismissed();
-            this.ReplacementText = replacementText;
+            this.ReplacementText = _renameInfo.GetFinalSymbolName(replacementText);
 
             Action propagateEditAction = delegate
             {
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     newSolution = previewService.PreviewChanges(
                         string.Format(EditorFeaturesResources.Preview_Changes_0, EditorFeaturesResources.Rename),
                         "vs.csharp.refactoring.rename",
-                        string.Format(EditorFeaturesResources.Rename_0_to_1_colon, this.OriginalSymbolName, _renameInfo.GetFinalSymbolName(this.ReplacementText)),
+                        string.Format(EditorFeaturesResources.Rename_0_to_1_colon, this.OriginalSymbolName, this.ReplacementText),
                         _renameInfo.FullDisplayName,
                         _renameInfo.Glyph,
                         _conflictResolutionTask.Result.NewSolution,


### PR DESCRIPTION
**Customer scenario**

IInlineRenameInfo.GetFinalSymbolName is not respected - the result of it is only used in a dialog window for previewing renaming. The result of the function is currently not used for determining what the final symbol name should be. This PR fixes this issue.

Example of the current buggy behaviour:
![image](https://cloud.githubusercontent.com/assets/64654/22391965/9083960a-e4ec-11e6-9153-3594fac70b19.png)

**Bugs this fixes:** 

Fixes #16460 

**Workarounds, if any**

No workaround

**Risk**

No risk. All references to Roslyn GetFinalSymbolName simply return the same string they are passed in.

**Performance impact**

No performance impact.

**Is this a regression from a previous update?**

**Root cause analysis:**

No automated tests covering inline renaming (from what I could gather).

**How was the bug found?**

F# contributor testing (@vasily-kirichenko)