### PR TITLE
We should have structure guides and outlining for 'fixed' and 'unsafe' statements.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
@@ -38,6 +38,42 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestUnsafe1()
+        {
+            const string code = @"
+class C
+{
+    void M()
+    {
+        {|hint:unsafe{|textspan:
+        {$$
+        }|}|}
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestFixed1()
+        {
+            const string code = @"
+class C
+{
+    void M()
+    {
+        {|hint:fixed(int* i = &j){|textspan:
+        {$$
+        }|}|}
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public async Task TestUsing1()
         {
             const string code = @"

--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -130,6 +130,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 case SyntaxKind.CatchClause: return BlockTypes.Statement;
                 case SyntaxKind.FinallyClause: return BlockTypes.Statement;
 
+                case SyntaxKind.UnsafeStatement: return BlockTypes.Statement;
+                case SyntaxKind.FixedStatement: return BlockTypes.Statement;
                 case SyntaxKind.LockStatement: return BlockTypes.Statement;
                 case SyntaxKind.UsingStatement: return BlockTypes.Statement;
 


### PR DESCRIPTION
Fixes https://developercommunity.visualstudio.com/content/problem/8808/c-structure-guide-lines-for-unsafe-fixed.html