### PR TITLE
Format 'unsafe' blocks according to user settings.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/BlockSyntaxStructureTests.cs
@@ -38,6 +38,42 @@ class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestUnsafe1()
+        {
+            const string code = @"
+class C
+{
+    void M()
+    {
+        {|hint:unsafe{|textspan:
+        {$$
+        }|}|}
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestFixed1()
+        {
+            const string code = @"
+class C
+{
+    void M()
+    {
+        {|hint:fixed(int* i = &j){|textspan:
+        {$$
+        }|}|}
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
         public async Task TestUsing1()
         {
             const string code = @"

--- a/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/BlockSyntaxStructureProvider.cs
@@ -130,6 +130,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 case SyntaxKind.CatchClause: return BlockTypes.Statement;
                 case SyntaxKind.FinallyClause: return BlockTypes.Statement;
 
+                case SyntaxKind.UnsafeStatement: return BlockTypes.Statement;
+                case SyntaxKind.FixedStatement: return BlockTypes.Statement;
                 case SyntaxKind.LockStatement: return BlockTypes.Statement;
                 case SyntaxKind.UsingStatement: return BlockTypes.Statement;
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -11,19 +11,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         private bool IsControlBlock(SyntaxNode node)
         {
-            var parent = node != null ? node.Parent : null;
+            if (node.Kind() == SyntaxKind.SwitchStatement)
+            {
+                return true;
+            }
 
-            return (node != null && node.Kind() == SyntaxKind.SwitchStatement) ||
-                   (parent != null &&
-                   (parent.Kind() == SyntaxKind.IfStatement || parent.Kind() == SyntaxKind.ElseClause ||
-                    parent.Kind() == SyntaxKind.WhileStatement || parent.Kind() == SyntaxKind.DoStatement ||
-                    parent.Kind() == SyntaxKind.ForEachStatement || parent.Kind() == SyntaxKind.ForEachVariableStatement ||
-                    parent.Kind() == SyntaxKind.UsingStatement ||
-                    parent.Kind() == SyntaxKind.ForStatement || parent.Kind() == SyntaxKind.TryStatement ||
-                    parent.Kind() == SyntaxKind.CatchClause || parent.Kind() == SyntaxKind.FinallyClause ||
-                    parent.Kind() == SyntaxKind.LockStatement || parent.Kind() == SyntaxKind.CheckedStatement ||
-                    parent.Kind() == SyntaxKind.UncheckedStatement || parent.Kind() == SyntaxKind.SwitchSection ||
-                    parent.Kind() == SyntaxKind.FixedStatement));
+            var parentKind = node?.Parent.Kind();
+            switch (parentKind.GetValueOrDefault())
+            {
+                case SyntaxKind.IfStatement:
+                case SyntaxKind.ElseClause:
+                case SyntaxKind.WhileStatement:
+                case SyntaxKind.DoStatement:
+                case SyntaxKind.ForEachStatement:
+                case SyntaxKind.ForEachVariableStatement:
+                case SyntaxKind.UsingStatement:
+                case SyntaxKind.ForStatement:
+                case SyntaxKind.TryStatement:
+                case SyntaxKind.CatchClause:
+                case SyntaxKind.FinallyClause:
+                case SyntaxKind.LockStatement:
+                case SyntaxKind.CheckedStatement:
+                case SyntaxKind.UncheckedStatement:
+                case SyntaxKind.SwitchSection:
+                case SyntaxKind.FixedStatement:
+                case SyntaxKind.UnsafeStatement:
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, OptionSet optionSet, NextOperation<AdjustSpacesOperation> nextOperation)

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -1538,17 +1538,18 @@ public class foo : System.Object
         }
 
         [WorkItem(751789, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/751789")]
+        [WorkItem(8808, "https://developercommunity.visualstudio.com/content/problem/8808/c-structure-guide-lines-for-unsafe-fixed.html")]
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task NewLineForOpenBracesNonDefault()
         {
             var changingOptions = new Dictionary<OptionKey, object>();
-            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInTypes, false);
-            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInMethods, false);
-            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInAnonymousMethods, false);
-            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInControlBlocks, false);
-            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInAnonymousTypes, false);
-            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInObjectCollectionArrayInitializers, false);
-            changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody, false);
+            changingOptions.Add(NewLinesForBracesInTypes, false);
+            changingOptions.Add(NewLinesForBracesInMethods, false);
+            changingOptions.Add(NewLinesForBracesInAnonymousMethods, false);
+            changingOptions.Add(NewLinesForBracesInControlBlocks, false);
+            changingOptions.Add(NewLinesForBracesInAnonymousTypes, false);
+            changingOptions.Add(NewLinesForBracesInObjectCollectionArrayInitializers, false);
+            changingOptions.Add(NewLinesForBracesInLambdaExpressionBody, false);
             await AssertFormatAsync(@"class f00 {
     void br() {
         Func<int, int> ret = x => {
@@ -1581,6 +1582,12 @@ public class foo : System.Object
         switch (switchVar) {
             default:
                 break;
+        }
+
+        unsafe {
+        }
+
+        fixed (int* p = &i) {
         }
     }
 }
@@ -1634,6 +1641,14 @@ var obj1 = new foo
  {
             default: 
                 break;
+        }
+
+        unsafe
+{
+        }
+
+        fixed (int* p = &i)
+{
         }
 }
 }


### PR DESCRIPTION
Fixes https://developercommunity.visualstudio.com/content/problem/8808/c-structure-guide-lines-for-unsafe-fixed.html