### PR TITLE
handle HubClient cancellation exception

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -129,6 +130,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 {
                     var descriptor = new ServiceDescriptor(serviceName) { HostGroup = hostGroup };
                     return await client.RequestServiceAsync(descriptor, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // if it is our own cancellation token, then rethrow
+                    // otherwise, let us retry.
+                    //
+                    // we do this since HubClient itself can throw its own cancellation token
+                    // when it couldn't connect to service hub service for some reasons
+                    // (ex, OOP process GC blocked and not responding to request)
+                    cancellationToken.ThrowIfCancellationRequested();
                 }
                 catch (RemoteInvocationException ex)
                 {

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
@@ -26,10 +26,16 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         protected BatchSimplificationFixAllProvider() { }
 
         protected override async Task AddDocumentFixesAsync(
-            Document document, ImmutableArray<Diagnostic> diagnostics, 
-            ConcurrentBag<(Diagnostic diagnostic, CodeAction action)> fixes, 
+            Document document, ImmutableArray<Diagnostic> diagnostics,
+            ConcurrentBag<(Diagnostic diagnostic, CodeAction action)> fixes,
             FixAllState fixAllState, CancellationToken cancellationToken)
         {
+            // quick bail out
+            if (diagnostics.IsEmpty)
+            {
+                return;
+            }
+
             var changedDocument = await AddSimplifierAnnotationsAsync(
                 document, diagnostics, fixAllState, cancellationToken).ConfigureAwait(false);
             var title = GetFixAllTitle(fixAllState);
@@ -69,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         protected virtual bool NeedsParentFixup { get { return false; } }
 
         private async Task<Document> AddSimplifierAnnotationsAsync(
-            Document document, ImmutableArray<Diagnostic> diagnostics, 
+            Document document, ImmutableArray<Diagnostic> diagnostics,
             FixAllState fixAllState, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
while investigating https://github.com/dotnet/roslyn/issues/16086 issue, found out that HubClient can throw its own cancellation when it couldn't connect to service hub process.

I am in talk with @AArnott and other people to see whether this is right behavior or not. but until then, I am putting guard in roslyn code so that we don't randomly get cancelled out when caller didn't ask for it.
