### PR TITLE
Fix crash in roundtripping a symbol that references a LocalFunction's TypeParameter.

### DIFF
--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -21,13 +21,11 @@ namespace Microsoft.CodeAnalysis
                     containingSymbol = containingSymbol.ContainingSymbol;
                 }
 
+                var compilation = ((ISourceAssemblySymbol)symbol.ContainingAssembly).Compilation;
                 var kind = symbol.Kind;
                 var localName = symbol.Name;
-                Contract.ThrowIfNull(
-                    visitor.Compilation,
-                    message: $"visitor cannot be created with a null compilation and visit a {nameof(BodyLevelSymbolKey)}.");
                 var ordinal = 0;
-                foreach (var possibleSymbol in EnumerateSymbols(visitor.Compilation, containingSymbol, kind, localName, visitor.CancellationToken))
+                foreach (var possibleSymbol in EnumerateSymbols(compilation, containingSymbol, kind, localName, visitor.CancellationToken))
                 {
                     if (possibleSymbol.symbol.Equals(symbol))
                     {

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -60,7 +60,6 @@ namespace Microsoft.CodeAnalysis
             private readonly Dictionary<ISymbol, int> _symbolToId = new Dictionary<ISymbol, int>();
             private readonly StringBuilder _stringBuilder = new StringBuilder();
 
-            public Compilation Compilation { get; private set; }
             public CancellationToken CancellationToken { get; private set; }
 
             private List<IMethodSymbol> _methodSymbolStack = new List<IMethodSymbol>();
@@ -83,7 +82,6 @@ namespace Microsoft.CodeAnalysis
                 _symbolToId.Clear();
                 _stringBuilder.Clear();
                 _methodSymbolStack.Clear();
-                Compilation = null;
                 CancellationToken = default(CancellationToken);
                 _nestingCount = 0;
                 _nextId = 0;
@@ -92,16 +90,15 @@ namespace Microsoft.CodeAnalysis
                 s_writerPool.Free(this);
             }
 
-            public static SymbolKeyWriter GetWriter(Compilation compilation, CancellationToken cancellationToken)
+            public static SymbolKeyWriter GetWriter(CancellationToken cancellationToken)
             {
                 var visitor = s_writerPool.Allocate();
-                visitor.Initialize(compilation, cancellationToken);
+                visitor.Initialize(cancellationToken);
                 return visitor;
             }
 
-            private void Initialize(Compilation compilation, CancellationToken cancellationToken)
+            private void Initialize(CancellationToken cancellationToken)
             {
-                Compilation = compilation;
                 CancellationToken = cancellationToken;
             }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
@@ -116,9 +116,7 @@ namespace Microsoft.CodeAnalysis
 
         public static string ToString(ISymbol symbol, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var compilation = (symbol.ContainingAssembly as ISourceAssemblySymbol)?.Compilation;
-
-            using (var writer = SymbolKeyWriter.GetWriter(compilation, cancellationToken))
+            using (var writer = SymbolKeyWriter.GetWriter(cancellationToken))
             {
                 writer.WriteFirstSymbolKey(symbol);
                 return writer.CreateKey();


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=377839

**Customer scenario**

Customer uses a generic local function (a new, high profile C# feature).  They then use some type from metadata, using the type parameter from that local function.  i.e.:

```c#
public void Method()
{
  void LocalFunction<T>()
  {
     Enumerable.Empty<T>(); // note the usage of T.
  }
}
```

This causes a crash in the innards of our OutOfProcess system due to how we serialize out this symbolic information.  Specifically, we had an assumption that a metadata-symbol (i.e. Enumerable.Empty) can not refer to a *body-level* symbol (i.e. the Type-Parameter from the local function).

This may seem like a corner case.  however, it's really easy to hit this through many paths (for example, using linq inside a local function).

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=377839

**Workarounds, if any**

Customer does not combine these features.  That's undiscoverable and a large take-back for these features.

**Risk**

Very low.

**Performance impact**

Low.

**Is this a regression from a previous update?**

No.  This is a new feature, and a combination of many features working together (LocalFunctions + Oop).

**Root cause analysis:**

Test hole.  We did not consider the interaction of local-functions, metadata-generic-symbols, and OOP.

**How was the bug found?**

Customer reported.