### PR TITLE
Avoid deadlocks when unloading unloading multitargeted Asp.NET projects, or .NET Standard (CPS) Projects (directly or via Solution close) referencing Shared Projects

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -50,6 +50,27 @@ namespace Microsoft.CodeAnalysis
         private Action<string> _testMessageLogger;
 
         /// <summary>
+        /// <see cref="OnProjectRemoved"/> takes the <see cref="_serializationLock"/>, but can also
+        /// cause Shared Project IVsHierarchys to notify us that their context hierarchy has
+        /// changed while we are still holding the lock. In response to this, we try to set the new
+        /// active context document for open files, which also tries to take the lock, and we 
+        /// deadlock.
+        /// 
+        /// For.NET Framework Projects that reference Shared Projects, two things prevent deadlocks
+        /// when projects unload. During solution close, any Shared Projects are disconnected
+        /// before the projects start to unload, so no IVsHierarchy events are fired. During a
+        /// single project unload, we receive notification of the context hierarchy change before
+        /// the project is unloaded, avoiding any IVsHierarchy events if we tell the shared
+        /// hierarchy to set its context hierarchy to what it already is.
+        /// 
+        /// Neither of these behaviors are safe to rely on with .NET Standard (CPS) projects, so we
+        /// have to prevent the deadlock ourselves. We do this by remembering if we're already in 
+        /// the serialization lock due to project unload, and then not take the lock to update 
+        /// document contexts if so (but continuing to lock if it's not during a project unload).
+        /// </summary>
+        private ThreadLocal<bool> _isProjectUnloading = new ThreadLocal<bool>(() => false);
+
+        /// <summary>
         /// Constructs a new workspace instance.
         /// </summary>
         /// <param name="host">The <see cref="HostServices"/> this workspace uses</param>
@@ -415,15 +436,24 @@ namespace Microsoft.CodeAnalysis
         {
             using (_serializationLock.DisposableWait())
             {
-                CheckProjectIsInCurrentSolution(projectId);
-                this.CheckProjectCanBeRemoved(projectId);
+                _isProjectUnloading.Value = true;
 
-                var oldSolution = this.CurrentSolution;
+                try
+                {
+                    CheckProjectIsInCurrentSolution(projectId);
+                    this.CheckProjectCanBeRemoved(projectId);
 
-                this.ClearProjectData(projectId);
-                var newSolution = this.SetCurrentSolution(oldSolution.RemoveProject(projectId));
+                    var oldSolution = this.CurrentSolution;
 
-                this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.ProjectRemoved, oldSolution, newSolution, projectId);
+                    this.ClearProjectData(projectId);
+                    var newSolution = this.SetCurrentSolution(oldSolution.RemoveProject(projectId));
+
+                    this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.ProjectRemoved, oldSolution, newSolution, projectId);
+                }
+                finally
+                {
+                    _isProjectUnloading.Value = false;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14479

The problem here is that unloading projects takes a serialization lock,
which can cause Shared Project IVsHierarchys to notify us that their
context hierarchy has changed while the lock is still held. In response 
to this, we try to set the new active context document for open files, 
which also tries to take the serialization lock, and we deadlock.

For .NET Framework Projects that reference Shared Projects, two things
prevent deadlocks when projects unload. During solution close, any
Shared Projects are disconnected before the projects start to unload, so
no IVsHierarchy events are fired. During a single project unload, we
receive notification of the context hierarchy change before the project
is unloaded, avoiding any IVsHierarchy events if we tell the shared
hierarchy to set its context hierarchy to what it already is.

Neither of these behaviors are safe to rely on with .NET Standard (CPS)
or multitargeted Asp.NET projects, so we have to prevent the deadlock 
ourselves. We do this by remembering if we're already in the 
serialization lock due to project unload, and then not take the lock to 
update document contexts if so (but continuing to lock if it's not 
during a project unload).

Escrow Template 
================

**Customer scenario** In a multitargeted Asp.NET project, closing the solution with open documents can cause the product to hang. In regular CPS projects (e.g. .NET Standard) that reference a Shared Project, closing the solution with open documents belonging to the Shared Project causes the product to hang. In both cases, it can hang **before saving the solution**.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/14479
[Tracking] https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=296432 

**Workarounds, if any**: Close all open documents before closing the solution.

**Risk**: Fairly low. We avoid taking a lock when the lock has already been taken for us.

**Performance impact**: Essentially none. No allocations or complexity changes. 

**Is this a regression from a previous update?**: No. It's been broken since CPS projects started being used.

**Root cause analysis:** The Roslyn Workspace was getting lucky that the old project system handled Shared Projects in a way that naturally avoided this reentrancy.

**How did we miss it?**  Everything worked fine with the old project system, so it was never noticed.

**How was the bug found?** Automated tests and exploratory testing by the CPS team. I don't _know_ of any customer reports.