### PR TITLE
Add a feature that warns if a method can be made static

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Diagnostics\PreferFrameworkType\PreferFrameworkTypeTests_FixAllTests.cs" />
     <Compile Include="Extensions\ContextQuery\IsPossibleDeconstructionDesignationTests.cs" />
     <Compile Include="Extensions\ContextQuery\PossibleTupleContextTests.cs" />
+    <Compile Include="MakeMethodStatic\MakeMethodStaticTests.cs" />
     <Compile Include="QualifyMemberAccess\QualifyMemberAccessTests.cs" />
     <Compile Include="QualifyMemberAccess\QualifyMemberAccessTests_FixAllTests.cs" />
     <Compile Include="Diagnostics\SpellCheck\SpellCheckTests.cs" />

--- a/src/EditorFeatures/CSharpTest/MakeMethodStatic/MakeMethodStaticTests.cs
+++ b/src/EditorFeatures/CSharpTest/MakeMethodStatic/MakeMethodStaticTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.MakeMethodStatic;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.MakeMethodStatic;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.MakeMethodStatic
+{
+    public partial class MakeMethodStaticTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (new CSharpMakeMethodStaticDiagnosticAnalyzer(), new CSharpMakeMethodStaticCodeFixProvider());
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodStatic)]
+        public async Task Test()
+        {
+            await TestAsync(
+@"class C
+{
+    void [||]Method() { }
+    void Usages(C instance) 
+    {
+        Method();
+        this.Method();
+        instance.Method();
+        new C().Method();
+
+        Action _ = Method;
+        Action _ = this.Method;
+        Action _ = instance.Method;
+        Action _ = new C().Method;
+    }
+}",
+@"class C
+{
+    static void Method() { }
+    void Usages(C instance) 
+    {
+        Method();
+        Method();
+        Method();
+        Method();
+
+        Action _ = Method;
+        Action _ = Method;
+        Action _ = Method;
+        Action _ = Method;
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -67,6 +67,7 @@ namespace Roslyn.Test.Utilities
             public const string CodeActionsInvertIf = "CodeActions.InvertIf";
             public const string CodeActionsInvokeDelegateWithConditionalAccess = "CodeActions.InvokeDelegateWithConditionalAccess";
             public const string CodeActionsLambdaSimplifier = "CodeActions.LambdaSimplifier";
+            public const string CodeActionsMakeMethodStatic = "CodeActions.MakeMethodStatic";
             public const string CodeActionsMakeMethodSynchronous = "CodeActions.MakeMethodSynchronous";
             public const string CodeActionsMoveDeclarationNearReference = "CodeActions.MoveDeclarationNearReference";
             public const string CodeActionsMoveToTopOfFile = "CodeActions.MoveToTopOfFile";

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -69,6 +69,8 @@
     </Compile>
     <Compile Include="ImplementAbstractClass\CSharpImplementAbstractClassCodeFixProvider.cs" />
     <Compile Include="ImplementInterface\CSharpImplementInterfaceCodeFixProvider.cs" />
+    <Compile Include="MakeMethodStatic\CSharpMakeMethodStaticCodeFixProvider.cs" />
+    <Compile Include="MakeMethodStatic\CSharpMakeMethodStaticDiagnosticAnalyzer.cs" />
     <Compile Include="Structure\Providers\ArrowExpressionClauseStructureProvider.cs" />
     <Compile Include="ConvertToInterpolatedString\CSharpConvertConcatenationToInterpolatedStringRefactoringProvider.cs" />
     <Compile Include="RemoveUnnecessaryImports\CSharpRemoveUnnecessaryImportsService.cs" />

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -630,11 +630,29 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Make method static.
+        /// </summary>
+        internal static string Make_method_static {
+            get {
+                return ResourceManager.GetString("Make_method_static", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;member name&gt; = .
         /// </summary>
         internal static string member_name {
             get {
                 return ResourceManager.GetString("member_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method can be made static.
+        /// </summary>
+        internal static string Method_can_be_made_static {
+            get {
+                return ResourceManager.GetString("Method_can_be_made_static", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -506,4 +506,10 @@
   <data name="Warning_Extracting_a_local_function_reference_may_produce_invalid_code" xml:space="preserve">
     <value>Warning: Extracting a local function reference may produce invalid code</value>
   </data>
+  <data name="Make_method_static" xml:space="preserve">
+    <value>Make method static</value>
+  </data>
+  <data name="Method_can_be_made_static" xml:space="preserve">
+    <value>Method can be made static</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/MakeMethodStatic/CSharpMakeMethodStaticCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodStatic/CSharpMakeMethodStaticCodeFixProvider.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.MakeMethodStatic
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal sealed class CSharpMakeMethodStaticCodeFixProvider : AbstractMakeMethodStaticCodeFixProvider<MemberAccessExpressionSyntax>
+    {
+    }
+}

--- a/src/Features/CSharp/Portable/MakeMethodStatic/CSharpMakeMethodStaticCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodStatic/CSharpMakeMethodStaticCodeFixProvider.cs
@@ -2,6 +2,7 @@
 
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.MakeMethodStatic
@@ -9,5 +10,6 @@ namespace Microsoft.CodeAnalysis.MakeMethodStatic
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     internal sealed class CSharpMakeMethodStaticCodeFixProvider : AbstractMakeMethodStaticCodeFixProvider<MemberAccessExpressionSyntax>
     {
+        public override string Title => CSharpFeaturesResources.Make_method_static;
     }
 }

--- a/src/Features/CSharp/Portable/MakeMethodStatic/CSharpMakeMethodStaticDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/MakeMethodStatic/CSharpMakeMethodStaticDiagnosticAnalyzer.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.MakeMethodStatic;
+
+namespace Microsoft.CodeAnalysis.CSharp.MakeMethodStatic
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal sealed class CSharpMakeMethodStaticDiagnosticAnalyzer : AbstractMakeMethodStaticDiagnosticAnalyzer<SyntaxKind, MethodDeclarationSyntax>
+    {
+        public CSharpMakeMethodStaticDiagnosticAnalyzer()
+            : base(new LocalizableResourceString(nameof(CSharpFeaturesResources.Make_method_static), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources)),
+                   new LocalizableResourceString(nameof(CSharpFeaturesResources.Method_can_be_made_static), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources)))
+        {
+        }
+
+        protected override SyntaxKind GetMethodDeclarationSyntaxKind()
+            => SyntaxKind.MethodDeclaration;
+
+        protected override SyntaxNode GetBody(MethodDeclarationSyntax declaration)
+            => (SyntaxNode)declaration.Body ?? declaration.ExpressionBody?.Expression;
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -44,6 +44,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public const string UseExplicitTupleNameDiagnosticId = "IDE0033";
 
+        public const string MakeMethodStaticDiagnosticId = "IDE0034";
+
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";
         public const string AnalyzerDependencyConflictId = "IDE1002";

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -124,6 +124,8 @@
     <Compile Include="AddPackage\InstallPackageDirectlyCodeAction.cs" />
     <Compile Include="ImplementType\ImplementTypeOptions.cs" />
     <Compile Include="ImplementType\ImplementTypeOptionsProvider.cs" />
+    <Compile Include="MakeMethodStatic\AbstractMakeMethodStaticCodeFixProvider.cs" />
+    <Compile Include="MakeMethodStatic\AbstractMakeMethodStaticDiagnosticAnalyzer.cs" />
     <Compile Include="RemoveUnnecessaryImports\AbstractRemoveUnnecessaryImportsCodeFixProvider.cs" />
     <Compile Include="RemoveUnnecessaryImports\IUnnecessaryImportsService.cs" />
     <Compile Include="NavigateTo\AbstractNavigateToSearchService.SearchResult.cs" />

--- a/src/Features/Core/Portable/MakeMethodStatic/AbstractMakeMethodStaticCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodStatic/AbstractMakeMethodStaticCodeFixProvider.cs
@@ -21,9 +21,11 @@ namespace Microsoft.CodeAnalysis.MakeMethodStatic
         public sealed override ImmutableArray<string> FixableDiagnosticIds
             => ImmutableArray.Create(IDEDiagnosticIds.MakeMethodStaticDiagnosticId);
 
+        public abstract string Title { get; }
+
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            context.RegisterCodeFix(new MyCodeAction(
+            context.RegisterCodeFix(new MyCodeAction(Title,
                 c => FixAsync(context.Document, context.Diagnostics[0], c)),
                 context.Diagnostics);
             return SpecializedTasks.EmptyTask;
@@ -58,12 +60,10 @@ namespace Microsoft.CodeAnalysis.MakeMethodStatic
             }
         }
 
-        // TODO: should be solution?
         private sealed class MyCodeAction : CodeAction.DocumentChangeAction
         {
-            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedSolution)
-                // TODO: use localized string
-                : base(title: "", createChangedDocument: createChangedSolution)
+            public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedSolution)
+                : base(title, createChangedDocument: createChangedSolution)
             {
             }
         }

--- a/src/Features/Core/Portable/MakeMethodStatic/AbstractMakeMethodStaticCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodStatic/AbstractMakeMethodStaticCodeFixProvider.cs
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodStatic
             var root = editor.OriginalRoot;
             var generator = editor.Generator;
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var diagnostic in diagnostics)
             {
@@ -45,7 +46,6 @@ namespace Microsoft.CodeAnalysis.MakeMethodStatic
                 editor.ReplaceNode(declaration, (d, g) => g.WithModifiers(d, DeclarationModifiers.Static));
 
                 var methodSymbol = semanticModel.GetDeclaredSymbol(declaration);
-                var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var references = await SymbolFinder.FindReferencesAsync(
                     methodSymbol, document.Project.Solution, cancellationToken).ConfigureAwait(false);
                 var locations = references.Single(r => r.Definition == methodSymbol).Locations;

--- a/src/Features/Core/Portable/MakeMethodStatic/AbstractMakeMethodStaticCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodStatic/AbstractMakeMethodStaticCodeFixProvider.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.MakeMethodStatic
+{
+    internal abstract class AbstractMakeMethodStaticCodeFixProvider<TMemberAccessSyntax> : SyntaxEditorBasedCodeFixProvider
+        where TMemberAccessSyntax : SyntaxNode
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(IDEDiagnosticIds.MakeMethodStaticDiagnosticId);
+
+        public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(new MyCodeAction(
+                c => FixAsync(context.Document, context.Diagnostics[0], c)),
+                context.Diagnostics);
+            return SpecializedTasks.EmptyTask;
+        }
+
+        protected sealed override async Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics,
+            SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            var root = editor.OriginalRoot;
+            var generator = editor.Generator;
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var declaration = diagnostic.Location.FindNode(cancellationToken);
+                editor.ReplaceNode(declaration, (d, g) => g.WithModifiers(d, DeclarationModifiers.Static));
+
+                var methodSymbol = semanticModel.GetDeclaredSymbol(declaration);
+                var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var references = await SymbolFinder.FindReferencesAsync(
+                    methodSymbol, document.Project.Solution, cancellationToken).ConfigureAwait(false);
+                var locations = references.Single(r => r.Definition == methodSymbol).Locations;
+                var usages = locations.Select(loc => syntaxRoot.FindToken(loc.Location.SourceSpan.Start).Parent.FirstAncestorOrSelf<TMemberAccessSyntax>());
+                foreach (var usage in usages)
+                {
+                    if (usage != null)
+                    {
+                        editor.ReplaceNode(usage, generator.IdentifierName(methodSymbol.Name));
+                    }
+                }
+            }
+        }
+
+        // TODO: should be solution?
+        private sealed class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedSolution)
+                // TODO: use localized string
+                : base(title: "", createChangedDocument: createChangedSolution)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/MakeMethodStatic/AbstractMakeMethodStaticDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/MakeMethodStatic/AbstractMakeMethodStaticDiagnosticAnalyzer.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.MakeMethodStatic
+{
+    internal abstract class AbstractMakeMethodStaticDiagnosticAnalyzer<TSyntaxKind, TMethodDeclarationSyntax>
+        : AbstractCodeStyleDiagnosticAnalyzer
+        where TSyntaxKind : struct
+        where TMethodDeclarationSyntax : SyntaxNode
+    {
+        protected AbstractMakeMethodStaticDiagnosticAnalyzer(LocalizableString title, LocalizableString message)
+            : base(IDEDiagnosticIds.MakeMethodStaticDiagnosticId, title, message)
+        {
+        }
+
+        protected sealed override void InitializeWorker(AnalysisContext context)
+            => context.RegisterSyntaxNodeAction(AnalyzeNode, GetMethodDeclarationSyntaxKind());
+
+        public sealed override bool OpenFileOnly(Workspace workspace) => true;
+        public sealed override DiagnosticAnalyzerCategory GetAnalyzerCategory()
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var declaration = (TMethodDeclarationSyntax)context.Node;
+            var semanticModel = context.SemanticModel;
+            var cancellationToken = context.CancellationToken;
+
+            var methodSymbol = semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
+            if (methodSymbol == null)
+            {
+                return;
+            }
+
+            if (methodSymbol.IsStatic ||
+                methodSymbol.DeclaredAccessibility != Accessibility.Private)
+            {
+                return;
+            }
+
+            var body = GetBody(declaration);
+            if (body == null)
+            {
+                return;
+            }
+
+            var dataFlowAnalysisData = semanticModel.AnalyzeDataFlow(body);
+            var isInstanceMemberUsed =
+                dataFlowAnalysisData.ReadInside.Any(IsThis)
+                || methodSymbol.ContainingType.IsValueType
+                && dataFlowAnalysisData.WrittenInside.Any(IsThis);
+
+            if (isInstanceMemberUsed)
+            {
+                return;
+            }
+
+            // TODO: Get the severity from user preference
+            context.ReportDiagnostic(Diagnostic.Create(
+                CreateDescriptorWithSeverity(DiagnosticSeverity.Info),
+                declaration.GetLocation()));
+        }
+
+        protected abstract SyntaxNode GetBody(TMethodDeclarationSyntax declaration);
+        protected abstract TSyntaxKind GetMethodDeclarationSyntaxKind();
+
+        private static bool IsThis(ISymbol s) => (s as IParameterSymbol)?.IsThis == true;
+    }
+}


### PR DESCRIPTION
Fixes #16621

- [ ] Properties
- [ ] Excluding inapplicable methods (e.g. interface implementations)
- [ ] Non-private members
  - [ ] Add `using` if needed
- [ ] Should we preserve side-effects or is that desirable to be omitted?
- [ ] User facing options


