### PR TITLE
CodeCleanup should not try adding parens to tuple element names.

### DIFF
--- a/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
@@ -2595,6 +2595,43 @@ End Class";
         }
 
         [Fact]
+        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        public async Task TestTupleLiteralUndeclared()
+        {
+            var code = @"[|
+Option Explicit Off
+
+Module Module1
+
+    Sub Main()
+         x = (first:=1,  second:=2)
+
+    End Sub
+
+    Sub Second
+    End Sub
+End Module
+|]";
+
+            var expected = @"
+Option Explicit Off
+
+Module Module1
+
+    Sub Main()
+        x = (first:=1, second:=2)
+
+    End Sub
+
+    Sub Second()
+    End Sub
+End Module
+";
+
+            await VerifyAsync(code, expected);
+        }
+
+        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
         [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncLambdaFunction()

--- a/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
+++ b/src/Workspaces/CoreTest/CodeCleanup/AddMissingTokensTests.cs
@@ -14,8 +14,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
 {
     public class AddMissingTokensTests
     {
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MultipleLineIfStatementThen()
         {
             var code = @"[|
@@ -31,8 +30,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TypeArgumentOf()
         {
             var code = @"[|
@@ -44,8 +42,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeCleanup
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TypeParameterOf()
         {
             var code = @"[|Class A(T)
@@ -57,8 +54,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodDeclaration()
         {
             var code = @"Class A
@@ -74,9 +70,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544318, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544318")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodInvocation_TypeArgParens()
         {
             var code = @"[|Imports System
@@ -104,8 +99,7 @@ Module Program
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodInvocation_Sub()
         {
             var code = @"Class A
@@ -123,8 +117,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodInvocation_Function()
         {
             var code = @"Class A
@@ -144,8 +137,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task IdentifierMethod_Return()
         {
             var code = @"Class A
@@ -171,8 +163,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task IdentifierMethod_Assign()
         {
             var code = @"Class A
@@ -200,8 +191,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task IdentifierMethod_DotName_DontAdd()
         {
             var code = @"Class A
@@ -229,8 +219,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodInvocation_DotName()
         {
             var code = @"Class A
@@ -258,8 +247,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodInvocation_Generic()
         {
             var code = @"Class A
@@ -287,8 +275,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodInvocation_Call()
         {
             var code = @"Class A
@@ -316,8 +303,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task EventHandler_AddressOf1()
         {
             var code = @"Class A
@@ -339,8 +325,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task EventHandler_AddressOf2()
         {
             var code = @"Class A
@@ -362,8 +347,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task Delegate_AddressOf()
         {
             var code = @"Class A
@@ -381,8 +365,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task EventDeclaration()
         {
             var code = @"Class A
@@ -404,8 +387,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task RaiseEvent()
         {
             var code = @"Class A
@@ -427,8 +409,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task DelegateInvocation()
         {
             var code = @"
@@ -442,8 +423,7 @@ End Class";
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task Attribute()
         {
             var code = @"[|<Obsolete>
@@ -463,8 +443,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ObjectCreation()
         {
             var code = @"[|Module Program
@@ -500,8 +479,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task Constructor()
         {
             var code = @"[|Class C
@@ -517,8 +495,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task DeclareStatement()
         {
             var code = @"[|Class C
@@ -532,8 +509,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task DelegateStatement()
         {
             var code = @"[|Class C
@@ -547,8 +523,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodStatementWithComment()
         {
             var code = @"[|Class C
@@ -564,8 +539,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MultipleLineIfStatementThenWithComment()
         {
             var code = @"[|
@@ -581,8 +555,7 @@ End Class";
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TypeArgumentOf_Comment_DontAdd()
         {
             var code = @"[|
@@ -597,8 +570,7 @@ End Class";
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TypeParameterOf_Comment()
         {
             var code = @"[|Class A( ' test
@@ -612,8 +584,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task MethodInvocation_Function_Comment()
         {
             var code = @"Class A
@@ -633,8 +604,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task IdentifierMethod_Return_Comment()
         {
             var code = @"Class A
@@ -660,8 +630,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ImplementsClause()
         {
             var code = @"Class Program
@@ -687,8 +656,7 @@ End Interface";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task OperatorStatement()
         {
             var code = @"[|Public Structure abc
@@ -710,8 +678,7 @@ End Structure";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task PropertyAndAccessorStatement()
         {
             var code = @"[|Class Class1
@@ -741,8 +708,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task LambdaExpression()
         {
             var code = @"[|Class Class1
@@ -758,9 +724,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544225, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544225")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task StructuredTrivia_Expression_DontCrash()
         {
             var code = @"[|#Const Foo1 = 1
@@ -778,9 +743,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544169, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544169")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task EventStatement_AsClause()
         {
             var code = @"[|Imports System.ComponentModel
@@ -795,9 +759,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544167, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544167")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task InvocationExpression_NoParenthesesForPredefinedCastExpression()
         {
             var code = @"[|Class Program
@@ -814,10 +777,9 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544178, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544178")]
         [WorkItem(544317, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544317")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ObjectCreationExpression()
         {
             var code = @"[|Class C
@@ -834,9 +796,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544317, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544317")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ObjectCreationExpression_Initializer()
         {
             var code = @"[|Public Class SomeClass
@@ -857,9 +818,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544178, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544178")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ObjectCreationExpression_GenericName()
         {
             var code = @"[|Imports System
@@ -881,9 +841,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544178, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544178")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ObjectCreationExpression_AsNewClause()
         {
             var code = @"[|Class C
@@ -896,9 +855,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544301, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544301")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ContinueStatement_While()
         {
             var code = @"Module M
@@ -919,9 +877,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544301, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544301")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ContinueStatement_For()
         {
             var code = @"Module M
@@ -942,9 +899,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544380, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544380")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task IfDirective()
         {
             var code = @"[|#If VBC_VER >= 9.0
@@ -959,9 +915,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544386, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544386")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task NamedFieldInitializer()
         {
             var code = @"[|Class S
@@ -984,9 +939,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544526, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544526")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task DontCrash_ImplementsStatement()
         {
             var code = @"[|Class C
@@ -1003,9 +957,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(544525, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544525")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task AccessorStatement_AddRemoveHandler_RaiseEvent()
         {
             var code = @"[|Class C
@@ -1032,9 +985,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(545176, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545176")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task CallStatement_Lambda()
         {
             var code = @"[|Module Program
@@ -1051,9 +1003,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(545256, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545256")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task HandlesClauseItem_DontAddParentheses()
         {
             var code = @"[|Structure s1
@@ -1070,9 +1021,8 @@ End Structure";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(545380, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545380")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task DontAddParenthesesInForEachControlVariable()
         {
             var code = @"[|Module Module1
@@ -1095,9 +1045,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(545380, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545380")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task DontAddParenthesesInForControlVariable()
         {
             var code = @"[|Module Module1
@@ -1120,9 +1069,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(545483, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545483")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task DontAddParenthesesForMissingName()
         {
             var code = @"[|Class C
@@ -1133,9 +1081,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(545483, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545483")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task CombinedDelegates()
         {
             var code = @"[|Imports System
@@ -1160,9 +1107,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(546581, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546581")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ThenOmittedWithSurroundingErrors()
         {
             var code = @"[|
@@ -1173,9 +1119,8 @@ End Class";
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
         [WorkItem(546581, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546581")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ThenOmittedWithSurroundingErrors1()
         {
             var code = @"[|
@@ -1186,9 +1131,8 @@ End Class";
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
         [WorkItem(546797, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546797")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ParenthesisWithLineContinuation()
         {
             var code = @"[|
@@ -1198,9 +1142,8 @@ End Class";
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
         [WorkItem(546806, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546806")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ThenWithLineContinuation()
         {
             var code = @"[|
@@ -1214,9 +1157,8 @@ End Class";
             await VerifyAsync(CreateMethod(code), CreateMethod(expected));
         }
 
-        [Fact]
         [WorkItem(531278, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531278")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task ThenInIfDirective()
         {
             var code = @"#Const ccConst = 0
@@ -1242,9 +1184,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(607792, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/607792")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task CaseKeywordInSelectStatement()
         {
             var code = @"
@@ -1284,9 +1225,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(530789, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530789")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task Bug530789()
         {
             var code = @"Imports System
@@ -1306,9 +1246,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(530039, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530039")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestArraySyntax()
         {
             var code = @"[|Module TestMod
@@ -1328,9 +1267,8 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncFunctionWithoutAsClause()
         {
             var code = @"[|
@@ -1416,9 +1354,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncFunctionWithoutAsClause_WithAddedImports()
         {
             var code = @"[|
@@ -1510,9 +1447,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestIteratorFunctionWithoutAsClause()
         {
             var code = @"[|
@@ -1592,9 +1528,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestIteratorFunctionWithoutAsClause_WithAddedImports()
         {
             var code = @"[|
@@ -1682,9 +1617,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncFunctionWithAsClause()
         {
             var code = @"[|
@@ -1852,9 +1786,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncFunctionWithAsClause_WithAddedImports()
         {
             var code = @"[|
@@ -2028,9 +1961,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestIteratorFunctionWithAsClause()
         {
             var code = @"[|
@@ -2224,9 +2156,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestIteratorFunctionWithAsClause_WithAddedImports()
         {
             var code = @"[|
@@ -2426,9 +2357,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncFunctionWithAliasedReturnType()
         {
             var code = @"[|
@@ -2456,9 +2386,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestIteratorFunctionWithAliasedReturnType()
         {
             var code = @"[|
@@ -2486,9 +2415,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncFunctionWithAliasedReturnType_2()
         {
             var code = @"[|
@@ -2514,9 +2442,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestIteratorFunctionWithAliasedReturnType_2()
         {
             var code = @"[|
@@ -2542,9 +2469,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncFunctionWithQualifiedNameReturnType()
         {
             var code = @"[|
@@ -2568,9 +2494,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestIteratorFunctionWithQualifiedNameReturnType()
         {
             var code = @"[|
@@ -2594,8 +2519,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [WorkItem(16781, "https://github.com/dotnet/roslyn/issues/16781")]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestTupleLiteralUndeclared()
         {
             var code = @"[|
@@ -2631,9 +2556,8 @@ End Module
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestAsyncLambdaFunction()
         {
             var code = @"[|
@@ -2699,9 +2623,8 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
         [WorkItem(602932, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602932")]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestIteratorLambdaFunction()
         {
             var code = @"[|
@@ -2767,8 +2690,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestNoParenthesesForArgument()
         {
             // making roslyn behavior same as dev12
@@ -2806,8 +2728,7 @@ End Class";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task TestNoParenthesesForNameOf()
         {
             var code = @"[|
@@ -2827,8 +2748,7 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task OptionExplicitOn()
         {
             var code = @"[|Option Explicit|]";
@@ -2838,8 +2758,7 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task OptionInferOn()
         {
             var code = @"[|Option Infer|]";
@@ -2849,8 +2768,7 @@ End Module";
             await VerifyAsync(code, expected);
         }
 
-        [Fact]
-        [Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
+        [Fact, Trait(Traits.Feature, Traits.Features.AddMissingTokens)]
         public async Task OptionStrictOn()
         {
             var code = @"[|Option Strict|]";

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
@@ -81,6 +81,10 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                 End If
 
                 ' can't/don't try to transform member access to invocation
+                '
+                ' can't/don't try to transform a name parented to a NameColonEqualsSyntax reference.
+                ' typical example is a tuple literal (Alice:=1, Bob:=2) 
+                '           that will turn 'Alice:=1' into 'Alice():=1' , which will not fit the syntax model.
                 If TypeOf name.Parent Is MemberAccessExpressionSyntax OrElse
                    TypeOf name.Parent Is TupleElementSyntax OrElse
                    name.CheckParent(Of AttributeSyntax)(Function(p) p.Name Is name) OrElse

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/AddMissingTokensCodeCleanupProvider.vb
@@ -105,6 +105,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                    name.CheckParent(Of SimpleArgumentSyntax)(Function(p) p.IsNamed AndAlso p.NameColonEquals.Name Is name) OrElse
                    name.CheckParent(Of CastExpressionSyntax)(Function(p) p.Type Is name) OrElse
                    name.CheckParent(Of SimpleArgumentSyntax)(Function(p) p.Expression Is name) OrElse
+                   name.CheckParent(Of NameColonEqualsSyntax)(Function(p) p.Name Is name) OrElse
                    name.CheckParent(Of NameOfExpressionSyntax)(Function(p) p.Argument Is name) Then
                     Return False
                 End If


### PR DESCRIPTION
Fixes  #16781

Because of the another bug, #16697, it is possible that tuple element names would bind to methods. That will require a bigger fix.

But regardless of that, the CodeCleanup should not try adding "()" to tuple names. No need to consult with semantic info (which is fairly expensive), when this will never be a right thing to do. It does not fit the syntax model and crashes with invalid cast exception.

**Customer scenario**

Customer gets pestered by failure popups when editing code around tuple literals. 
IDE invokes CodeCleanup, which throws. In my observation the errors get trapped and do not result in a crash of VS, but cause extremely annoying popup dialogs.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16781

**Workarounds, if any**

avoid tuple element names that match method names in VB

**Risk**

The risk is low. The fix blocks a codepath that has no chance of working.

**Performance impact**

Low. One extra condition to check in CodeCleanup. 

**Is this a regression from a previous update?**

New feature

**Root cause analysis:**

The bug shows up when editing VB tuple literals in a particular environment. - Element names should match a method declaration and some edits applied in IDE. 
While possible scenario, it would not be obvious to explicitly test it unless the problem is already known.

**How was the bug found?**

Internal use of the feature.
