### PR TITLE
Gather better info when AddDeclarationConflictsAsync crashes

### DIFF
--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
@@ -177,63 +178,75 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             IDictionary<Location, Location> reverseMappedLocations,
             CancellationToken cancellationToken)
         {
-            if (renamedSymbol.ContainingSymbol.IsKind(SymbolKind.NamedType))
+            try
             {
-                var otherThingsNamedTheSame = renamedSymbol.ContainingType.GetMembers(renamedSymbol.Name)
-                                                       .Where(s => !s.Equals(renamedSymbol) &&
-                                                                   string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal) &&
-                                                                   (s.Kind != SymbolKind.Method || renamedSymbol.Kind != SymbolKind.Method));
-
-                AddConflictingSymbolLocations(otherThingsNamedTheSame, conflictResolution, reverseMappedLocations);
-            }
-
-
-            if (renamedSymbol.IsKind(SymbolKind.Namespace) && renamedSymbol.ContainingSymbol.IsKind(SymbolKind.Namespace))
-            {
-                var otherThingsNamedTheSame = ((INamespaceSymbol)renamedSymbol.ContainingSymbol).GetMembers(renamedSymbol.Name)
-                                                        .Where(s => !s.Equals(renamedSymbol) &&
-                                                                    !s.IsKind(SymbolKind.Namespace) &&
-                                                                    string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal));
-
-                AddConflictingSymbolLocations(otherThingsNamedTheSame, conflictResolution, reverseMappedLocations);
-            }
-
-            if (renamedSymbol.IsKind(SymbolKind.NamedType) && renamedSymbol.ContainingSymbol is INamespaceOrTypeSymbol)
-            {
-                var otherThingsNamedTheSame = ((INamespaceOrTypeSymbol)renamedSymbol.ContainingSymbol).GetMembers(renamedSymbol.Name)
-                                                        .Where(s => !s.Equals(renamedSymbol) &&
-                                                                    string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal));
-
-                var conflictingSymbolLocations = otherThingsNamedTheSame.Where(s => !s.IsKind(SymbolKind.Namespace));
-                if (otherThingsNamedTheSame.Any(s => s.IsKind(SymbolKind.Namespace)))
+                if (renamedSymbol.ContainingSymbol.IsKind(SymbolKind.NamedType))
                 {
-                    conflictingSymbolLocations = conflictingSymbolLocations.Concat(renamedSymbol);
+                    var otherThingsNamedTheSame = renamedSymbol.ContainingType.GetMembers(renamedSymbol.Name)
+                                                           .Where(s => !s.Equals(renamedSymbol) &&
+                                                                       string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal) &&
+                                                                       (s.Kind != SymbolKind.Method || renamedSymbol.Kind != SymbolKind.Method));
+
+                    AddConflictingSymbolLocations(otherThingsNamedTheSame, conflictResolution, reverseMappedLocations);
                 }
 
-                AddConflictingSymbolLocations(conflictingSymbolLocations, conflictResolution, reverseMappedLocations);
-            }
 
-            // Some types of symbols (namespaces, cref stuff, etc) might not have ContainingAssemblies
-            if (renamedSymbol.ContainingAssembly != null)
-            {
-                var project = conflictResolution.NewSolution.GetProject(renamedSymbol.ContainingAssembly, cancellationToken);
-
-                // There also might be language specific rules we need to include
-                var languageRenameService = project.LanguageServices.GetService<IRenameRewriterLanguageService>();
-                var languageConflicts = await languageRenameService.ComputeDeclarationConflictsAsync(
-                    conflictResolution.ReplacementText,
-                    renamedSymbol,
-                    renameSymbol,
-                    referencedSymbols,
-                    conflictResolution.OldSolution,
-                    conflictResolution.NewSolution,
-                    reverseMappedLocations,
-                    cancellationToken).ConfigureAwait(false);
-
-                foreach (var languageConflict in languageConflicts)
+                if (renamedSymbol.IsKind(SymbolKind.Namespace) && renamedSymbol.ContainingSymbol.IsKind(SymbolKind.Namespace))
                 {
-                    conflictResolution.AddOrReplaceRelatedLocation(new RelatedLocation(languageConflict.SourceSpan, conflictResolution.OldSolution.GetDocument(languageConflict.SourceTree).Id, RelatedLocationType.UnresolvableConflict));
+                    var otherThingsNamedTheSame = ((INamespaceSymbol)renamedSymbol.ContainingSymbol).GetMembers(renamedSymbol.Name)
+                                                            .Where(s => !s.Equals(renamedSymbol) &&
+                                                                        !s.IsKind(SymbolKind.Namespace) &&
+                                                                        string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal));
+
+                    AddConflictingSymbolLocations(otherThingsNamedTheSame, conflictResolution, reverseMappedLocations);
                 }
+
+                if (renamedSymbol.IsKind(SymbolKind.NamedType) && renamedSymbol.ContainingSymbol is INamespaceOrTypeSymbol)
+                {
+                    var otherThingsNamedTheSame = ((INamespaceOrTypeSymbol)renamedSymbol.ContainingSymbol).GetMembers(renamedSymbol.Name)
+                                                            .Where(s => !s.Equals(renamedSymbol) &&
+                                                                        string.Equals(s.MetadataName, renamedSymbol.MetadataName, StringComparison.Ordinal));
+
+                    var conflictingSymbolLocations = otherThingsNamedTheSame.Where(s => !s.IsKind(SymbolKind.Namespace));
+                    if (otherThingsNamedTheSame.Any(s => s.IsKind(SymbolKind.Namespace)))
+                    {
+                        conflictingSymbolLocations = conflictingSymbolLocations.Concat(renamedSymbol);
+                    }
+
+                    AddConflictingSymbolLocations(conflictingSymbolLocations, conflictResolution, reverseMappedLocations);
+                }
+
+                // Some types of symbols (namespaces, cref stuff, etc) might not have ContainingAssemblies
+                if (renamedSymbol.ContainingAssembly != null)
+                {
+                    var project = conflictResolution.NewSolution.GetProject(renamedSymbol.ContainingAssembly, cancellationToken);
+
+                    // There also might be language specific rules we need to include
+                    var languageRenameService = project.LanguageServices.GetService<IRenameRewriterLanguageService>();
+                    var languageConflicts = await languageRenameService.ComputeDeclarationConflictsAsync(
+                        conflictResolution.ReplacementText,
+                        renamedSymbol,
+                        renameSymbol,
+                        referencedSymbols,
+                        conflictResolution.OldSolution,
+                        conflictResolution.NewSolution,
+                        reverseMappedLocations,
+                        cancellationToken).ConfigureAwait(false);
+
+                    foreach (var languageConflict in languageConflicts)
+                    {
+                        conflictResolution.AddOrReplaceRelatedLocation(new RelatedLocation(languageConflict.SourceSpan, conflictResolution.OldSolution.GetDocument(languageConflict.SourceTree).Id, RelatedLocationType.UnresolvableConflict));
+                    }
+                }
+            }
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            {
+                // A NullReferenceException is happening in this method, but the dumps do not
+                // contain information about this stack frame because this method is async and
+                // therefore the exception filter in IdentifyConflictsAsync is insufficient.
+                // See https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=378642
+
+                throw ExceptionUtilities.Unreachable;
             }
         }
 


### PR DESCRIPTION
Related to https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=378642

Escrow Template
================

**Customer scenario**: They are renaming something and the product sometimes crashes. This is new in RC3, and has happened twice a day so far.

**Bugs this fixes:** It will help us eventually fix https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=378642

**Workarounds, if any**: Unknown

**Risk**: None. The product is already going to crash in this scenario, this just changes how the dump will be collected.

**Performance impact**: None, just a try/catch around a codepath that is asynchronous anyway, and is not on a hot path.

**Is this a regression from a previous update?**: Yes. The crash we're trying to learn about is new in RC3.

**Root cause analysis:** Unknown

**How did we miss it?** Unknown

**How was the bug found?** Watson