### PR TITLE
Arrow-expression-bodies should auto-collapse when 'collapse to definitions' is invoked.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/ArrowExpressionClauseStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/ArrowExpressionClauseStructureTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure
             => new ArrowExpressionClauseStructureProvider();
 
         [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
-        public async Task TestArrowExpressionClause1()
+        public async Task TestArrowExpressionClause_Method1()
         {
             await VerifyBlockSpansAsync(
 @"
@@ -24,6 +24,39 @@ class C
     {|hintspan:void M(){|textspan: $$=> expression
         ? trueCase
         : falseCase;|}|};
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_Property1()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    {|hintspan:int M{|textspan: $$=> expression
+        ? trueCase
+        : falseCase;|}|};
+}
+",
+                Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestArrowExpressionClause_LocalFunction()
+        {
+            await VerifyBlockSpansAsync(
+@"
+class C
+{
+    void M()
+    {
+        {|hintspan:void F(){|textspan: $$=> expression
+            ? trueCase
+            : falseCase;|}|};
+    }
 }
 ",
                 Region("textspan", "hintspan", CSharpStructureHelpers.Ellipsis, autoCollapse: false));

--- a/src/Features/CSharp/Portable/Structure/Providers/ArrowExpressionClauseStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/ArrowExpressionClauseStructureProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Structure;
@@ -21,7 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 isCollapsible: true,
                 textSpan: TextSpan.FromBounds(previousToken.Span.End, node.Parent.Span.End),
                 hintSpan: node.Parent.Span,
-                type: BlockTypes.Nonstructural));
+                type: BlockTypes.Nonstructural,
+                autoCollapse: !node.IsParentKind(SyntaxKind.LocalFunctionStatement)));
         }
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=365306&triage=true