### PR TITLE
lower server stream buffer size.

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Shared/ServerDirectStream.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServerDirectStream.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         private class ServerDirectStream : Stream
         {
-            // 128KB buffer size
-            private const int BUFFERSIZE = 128 * 1024;
+            // 12KB buffer size
+            private const int BUFFERSIZE = 12 * 1024;
 
             private readonly string _name;
             private readonly NamedPipeServerStream _pipe;


### PR DESCRIPTION
Adrian was reporting high LOH fragmentation in OOP process due to this. I did some experiment and lowered buffer size to 12K that seems keeping current synch perf similar to now but way lower buffer size.

basically it keeps syncing whole roslyn to OOP process around 6-8 seconds.