### PR TITLE
Create a Symbols directory for archiving / indexing

### DIFF
--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -55,7 +55,6 @@
         "Exes\\vbccore\\vbc.exe",
         "Exes\\vbi\\vbi.exe",
         "Exes\\vbicore\\vbi.exe",
-        "Exes\\Pdb2Xml\\Microsoft.DiaSymReader.PortablePdb.dll",
         "Exes\\Pdb2Xml\\Pdb2Xml.exe",
         "Vsix\\CompilerExtension\\Roslyn.Compilers.Extension.dll",
         "Vsix\\Templates\\Roslyn.Templates.dll",

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -50,6 +50,8 @@
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)publish-assets.ps1 -binariesPath &quot;$(BinariesPath)&quot; -branchName $(BranchName) -apiKey $(RoslynNuGetApiKey) $(PublishAssetsArgs)" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)copy-insertion-items.ps1 -binariesPath &quot;$(BinariesPath)&quot; $(CopyInsertionFileArgs)" />
+
+    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)copy-symbols.ps1 -binariesPath &quot;$(BinariesPath)&quot; $(CopyInsertionFileArgs)" />
   </Target>
 
 </Project>

--- a/src/Tools/MicroBuild/copy-symbols.ps1
+++ b/src/Tools/MicroBuild/copy-symbols.ps1
@@ -1,0 +1,35 @@
+# Copy our symbols to the Symbols directory.  This simplifies the logic of our achiving 
+# and indexing steps.  
+Param(
+    [string]$binariesPath = $null
+)
+set-strictmode -version 2.0
+$ErrorActionPreference="Stop"
+
+try
+{
+    $symbolsPath = join-path $binariesPath "Symbols"
+    mkdir $symbolsPath -ErrorAction SilentlyContinue | out-null
+
+    $signToolDataPath = join-path $PSScriptRoot "..\..\..\build\config\SignToolData.json"
+    $json = gc -raw $signToolDataPath | ConvertFrom-Json
+    foreach ($block in $json.sign) {
+        foreach ($fileName in $block.values) {
+            $ext = [IO.Path]::GetExtension($fileName)
+            if ($ext -eq ".dll" -or $ext -eq ".exe") {
+                $filePath = join-path $binariesPath $fileName
+                cp $filePath $symbolSPath
+
+                $pdbPath = [IO.Path]::ChangeExtension($filePath, "pdb")
+                cp $pdbPath $symbolsPath
+            }
+        }
+    }
+
+    exit 0
+}
+catch [exception]
+{
+    write-host $_.Exception
+    exit -1
+}


### PR DESCRIPTION
This changes our MicroBuild process to create a Symbols directory that
contains all of the EXE, DLL, PDBs we need for archiving / indexing
support.  It will help simplify the MicroBuild work and further
abstract it away from how we build artifacts.

