### PR TITLE
Allow build output to be redirected externally

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Choose>
     <When Condition="'$(RoslynProjectType)' == 'ExeNonDeployment'">

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir">
 
   <Choose>
     <When Condition="'$(RoslynProjectType)' == 'ExeNonDeployment'">
@@ -62,9 +62,11 @@
       <PropertyGroup>
         <AllowedReferenceRelatedFileExtensions>$(AllowedReferenceRelatedFileExtensions);.pdb</AllowedReferenceRelatedFileExtensions>
         <CopyNuGetImplementations>true</CopyNuGetImplementations>
+        <OutDir Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable'">$(OutDir)CoreClrTest</OutDir>
+        <OutDir Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable'">$(OutDir)UnitTests\Portable\</OutDir>
       </PropertyGroup>
     </When>
-    <When Condition="'$(RoslynProjectType)' == 'Custom' OR $(RoslynProjectType) == 'DeploymentTest'">
+    <When Condition="'$(RoslynProjectType)' == 'Custom'">
       <!-- Do nothing -->
     </When>
     <When Condition="'$(RoslynProjectType)' == '' AND '$(OutputType)' == 'Library'">
@@ -102,10 +104,17 @@
     </Otherwise>
   </Choose>
 
+  <!-- 
+    DocumentationFile needs to be set before importing common targets. 
+    C# common targets (unlike VB) prefix DocumentationFile path with IntermediateOutputPath.
+  -->
+  <PropertyGroup Condition="'$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(Nonshipping)' != 'true' AND '$(AssemblyName)' != ''">
+    <DocumentationFile Condition="'$(ProjectLanguage)' == 'VB'">$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile Condition="'$(ProjectLanguage)' == 'CSharp'">$(IntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <OutputPath>$(OutDir)</OutputPath>
-    <DocumentationFile Condition="'$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(Nonshipping)' != 'true' AND '$(ProjectLanguage)' == 'VB' AND '$(AssemblyName)' != ''">$(AssemblyName).xml</DocumentationFile>
-    <DocumentationFile Condition="'$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(Nonshipping)' != 'true' AND '$(ProjectLanguage)' == 'CSharp' AND '$(AssemblyName)' != ''">$(BaseIntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
     <RoslynPublicKey>0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</RoslynPublicKey>
     <RoslynInternalKey>002400000480000094000000060200000024000052534131000400000100010055e0217eb635f69281051f9a823e0c7edd90f28063eb6c7a742a19b4f6139778ee0af438f47aed3b6e9f99838aa8dba689c7a71ddb860c96d923830b57bbd5cd6119406ddb9b002cf1c723bf272d6acbb7129e9d6dd5a5309c94e0ff4b2c884d45a55f475cd7dba59198086f61f5a8c8b5e601c0edbf269733f6f578fc8579c2</RoslynInternalKey>
 

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir">
 
   <Import Project="Versions.props" />
 
@@ -10,9 +10,9 @@
     <DeveloperBuild>false</DeveloperBuild>
     <DeveloperBuild Condition="'$(OfficialBuild)' != 'true' AND '$(JenkinsBuild)' != 'true'">true</DeveloperBuild>
 
-    <ProjectDir>$(MSBuildThisFileDirectory)..\..\</ProjectDir>
-    <NuGetToolPath>$(ProjectDir)nuget.exe</NuGetToolPath>
-    <ToolsetPackagesDir>$(ProjectDir)build\ToolsetPackages\</ToolsetPackagesDir>
+    <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\'))</RepoRoot>
+    <NuGetToolPath>$(RepoRoot)nuget.exe</NuGetToolPath>
+    <ToolsetPackagesDir>$(RepoRoot)build\ToolsetPackages\</ToolsetPackagesDir>
     <ToolsetPackagesSemaphore>$(ToolsetPackagesDir)toolsetpackages.semaphore</ToolsetPackagesSemaphore>
     <ToolsetCompilerPackageName>Microsoft.Net.Compilers</ToolsetCompilerPackageName>
     <ToolsetCompilerPackageVersion>2.0.0-rc2-61102-09</ToolsetCompilerPackageVersion>
@@ -26,8 +26,10 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <SignAssembly>true</SignAssembly>
     <UseRoslynAnalyzers Condition="'$(UseRoslynAnalyzers)' == ''">true</UseRoslynAnalyzers>
-    <OutDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\Binaries\$(Configuration)'))\</OutDir>
-    <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\Binaries\Obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
+    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$(RepoRoot)Binaries\</BaseOutputPath>
+    <OutDir>$(BaseOutputPath)$(Configuration)\</OutDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RepoRoot)Binaries\Obj\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(MSBuildProjectName)\</IntermediateOutputPath>
 
     <!-- Workaround until we move to Microsoft.Net.Compilers.nupkg with this fix: https://github.com/dotnet/roslyn/commit/05c12ebfcdd08a02dbceded5327a8da7a7df23be:
          Use the Microsoft.Net.Compilers.props file with the fix checked into the repo instead of the one that comes along with the nuget package:
@@ -186,7 +188,7 @@
       <PropertyGroup>
         <ProjectLanguage>C++</ProjectLanguage>
         <!-- Put intermediate outputs in the same place as managed projects for sanity -->
-        <IntDir>$(ProjectDir)obj\$(Configuration)\</IntDir>
+        <IntDir>$(IntermediateOutputPath)</IntDir>
 
         <!-- We just always want to build with whatever toolset matches the VS you're building with -->
         <PlatformToolset>v$(VisualStudioReferenceMajorVersion)0</PlatformToolset>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -47,7 +47,17 @@
          Microsoft.Common.CurrentVersion.targets to see how it is consumed -->
     <WindowsAppContainer>false</WindowsAppContainer>
 
-    <CompilerGeneratorToolsDir>$(OutDir)Exes\DeployCompilerGeneratorToolsRuntime\</CompilerGeneratorToolsDir>
+    <!-- Workaround for Live Unit Testing bug (https://github.com/dotnet/testimpact/issues/1393) 
+         When building a solution LUT follows dependency graph provided by a Roslyn Solution. 
+         Such dependency graph doesn't include edges for P2P references marked ReferenceOutputAssembly=false. 
+         CSharpCodeAnalysis and BasicCodeAnalysis reference DeployCompilerGeneratorToolsRuntime with ReferenceOutputAssembly=false.
+         
+         If we are building for Live Unit Testing we use the uninstrumented generator tools
+         (for this to work we require that the solution has been built to the original directory).
+    -->
+    <CompilerGeneratorToolsDir Condition="'$(LiveUnitTestingOriginalBaseOutputPath)' == ''">$(OutDir)\Exes\DeployCompilerGeneratorToolsRuntime\</CompilerGeneratorToolsDir>
+    <CompilerGeneratorToolsDir Condition="'$(LiveUnitTestingOriginalBaseOutputPath)' != ''">$(LiveUnitTestingOriginalBaseOutputPath)$(Configuration)\Exes\DeployCompilerGeneratorToolsRuntime\</CompilerGeneratorToolsDir>
+    
     <MSBuildAssemblyNameFragment>Core</MSBuildAssemblyNameFragment>
 
     <!-- To copy .dll.config and .exe.config files of the referenced projects to the output dir

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="OutDir">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="Versions.props" />
 

--- a/src/Test/DeployCoreClrTestRuntime/DeployCoreClrTestRuntime.csproj
+++ b/src/Test/DeployCoreClrTestRuntime/DeployCoreClrTestRuntime.csproj
@@ -19,7 +19,6 @@
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
     <RoslynProjectType>DeploymentTest</RoslynProjectType>
-    <OutDir>$(OutDir)CoreClrTest</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />

--- a/src/Test/DeployDesktopTestRuntime/DeployDesktopTestRuntime.csproj
+++ b/src/Test/DeployDesktopTestRuntime/DeployDesktopTestRuntime.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkIdentifier />
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <RoslynProjectType>DeploymentTest</RoslynProjectType>
-    <OutDir>$(OutDir)UnitTests\Portable\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -5,9 +5,9 @@
 
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <ProjectDir>$(MSBuildThisFileDirectory)..\..\..\</ProjectDir>
+    <RepoRoot>$(MSBuildThisFileDirectory)..\..\..\</RepoRoot>
     <BranchName Condition="'$(BranchName)' == ''">$(BUILD_SOURCEBRANCH)</BranchName>
-    <BinariesPath>$(ProjectDir)Binaries\$(Configuration)</BinariesPath>
+    <BinariesPath>$(RepoRoot)Binaries\$(Configuration)</BinariesPath>
     <RoslynNuGetApiKey Condition="'$(RoslynNuGetApiKey)' == ''">"no key"</RoslynNuGetApiKey>
     <PublishAssetsArgs Condition="'$(SkipPublish)' == 'true'">-test</PublishAssetsArgs>
   </PropertyGroup>
@@ -22,22 +22,22 @@
   </PropertyGroup>
 
   <Target Name="Build">
-    <Exec Command="Restore.cmd /clean" WorkingDirectory="$(ProjectDir)" Condition="'$(SkipRestore)' != 'true'" />
+    <Exec Command="Restore.cmd /clean" WorkingDirectory="$(RepoRoot)" Condition="'$(SkipRestore)' != 'true'" />
 
-    <MSBuild Projects="$(ProjectDir)Roslyn.sln" BuildInParallel="true" Properties="DeployExtension=false" />
+    <MSBuild Projects="$(RepoRoot)Roslyn.sln" BuildInParallel="true" Properties="DeployExtension=false" />
 
-    <Exec Command="$(NuGetPackageRoot)\GitLink\$(GitLinkVersion)\lib\net45\GitLink.exe $(ProjectDir) -u https://github.com/dotnet/roslyn -f Roslyn.sln -c $(Configuration)" />
+    <Exec Command="$(NuGetPackageRoot)\GitLink\$(GitLinkVersion)\lib\net45\GitLink.exe $(RepoRoot) -u https://github.com/dotnet/roslyn -f Roslyn.sln -c $(Configuration)" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)..\..\..\build\scripts\create-perftests.ps1 &quot;$(BinariesPath)&quot;" />
 
-    <MSBuild Projects="$(ProjectDir)src\Setup\SetupStep1.proj" Properties="DeployExtension=false" />
+    <MSBuild Projects="$(RepoRoot)src\Setup\SetupStep1.proj" Properties="DeployExtension=false" />
 
-    <Exec Command="$(NuGetPackageRoot)\RoslynTools.Microsoft.SignTool\$(RoslynToolsMicrosoftSignToolVersion)\tools\SignTool.exe $(SignRoslynArgs) &quot;$(BinariesPath)&quot;" WorkingDirectory="$(ProjectDir)" />
+    <Exec Command="$(NuGetPackageRoot)\RoslynTools.Microsoft.SignTool\$(RoslynToolsMicrosoftSignToolVersion)\tools\SignTool.exe $(SignRoslynArgs) &quot;$(BinariesPath)&quot;" WorkingDirectory="$(RepoRoot)" />
 
-    <MSBuild Projects="$(ProjectDir)src\NuGet\NuGet.proj" />
-    <MSBuild Projects="$(ProjectDir)src\Setup\SetupStep2.proj" Properties="$(SetupStep2Properties);DeployExtension=false" />
+    <MSBuild Projects="$(RepoRoot)src\NuGet\NuGet.proj" />
+    <MSBuild Projects="$(RepoRoot)src\Setup\SetupStep2.proj" Properties="$(SetupStep2Properties);DeployExtension=false" />
 
-    <MSBuild Projects="$(ProjectDir)BuildAndTest.proj" Targets="Test" Condition="'$(SkipTest)' != 'true'" />
+    <MSBuild Projects="$(RepoRoot)BuildAndTest.proj" Targets="Test" Condition="'$(SkipTest)' != 'true'" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)..\..\..\build\scripts\check-toolset-insertion.ps1 &quot;$(MSBuildThisFileDirectory)..\..\..&quot; &quot;$(BinariesPath)&quot;" />
     


### PR DESCRIPTION
Enables LUT to work on Roslyn.sln

Makes it possible to redirect output like so:
```
msbuild Roslyn.sln /p:BaseOutputPath=C:\Temp\Output\ /p:BaseIntermediateOutputPath=C:\Temp\Intermediate\
```