### PR TITLE
changed all caller to call JsonRpc.StartListener once all states are set

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -16,7 +16,7 @@ using StreamJsonRpc;
 
 namespace Roslyn.Test.Utilities.Remote
 {
-    internal class InProcRemoteHostClient : RemoteHostClient
+    internal sealed class InProcRemoteHostClient : RemoteHostClient
     {
         private readonly InProcRemoteServices _inprocServices;
         private readonly JsonRpc _rpc;
@@ -47,10 +47,12 @@ namespace Roslyn.Test.Utilities.Remote
         {
             _inprocServices = inprocServices;
 
-            _rpc = JsonRpc.Attach(stream, target: this);
+            _rpc = new JsonRpc(stream, stream, target: this);
 
             // handle disconnected situation
             _rpc.Disconnected += OnRpcDisconnected;
+
+            _rpc.StartListening();
         }
 
         public AssetStorage AssetStorage => _inprocServices.AssetStorage;

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
@@ -25,7 +25,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             var target = useThisAsCallback ? this : callbackTarget;
             _cancellationToken = cancellationToken;
 
-            _rpc = JsonRpc.Attach(stream, target);
+            _rpc = new JsonRpc(stream, stream, target);
+
             _rpc.Disconnected += OnDisconnected;
         }
 
@@ -82,6 +83,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             OnDisposed();
 
             _rpc.Dispose();
+        }
+
+        protected void StartListening()
+        {
+            // due to this issue - https://github.com/dotnet/roslyn/issues/16900#issuecomment-277378950
+            // _rpc need to be explicitly started
+            _rpc.StartListening();
         }
 
         protected virtual void OnDisposed()

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
@@ -114,6 +114,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             {
                 // this one doesn't need cancellation token since it has nothing to cancel
                 _callbackTarget = callbackTarget;
+
+                StartListening();
             }
         }
 
@@ -137,6 +139,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             {
                 _owner = owner;
                 _source = new CancellationTokenSource();
+
+                StartListening();
             }
 
             private PinnedRemotableDataScope PinnedScope => _owner.PinnedScope;

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
     using Workspace = Microsoft.CodeAnalysis.Workspace;
 
-    internal partial class ServiceHubRemoteHostClient : RemoteHostClient
+    internal sealed partial class ServiceHubRemoteHostClient : RemoteHostClient
     {
         private readonly HubClient _hubClient;
         private readonly JsonRpc _rpc;
@@ -81,10 +81,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             _hubClient = hubClient;
             _hostGroup = hostGroup;
 
-            _rpc = JsonRpc.Attach(stream, target: this);
+            _rpc = new JsonRpc(stream, stream, target: this);
 
             // handle disconnected situation
             _rpc.Disconnected += OnRpcDisconnected;
+
+            _rpc.StartListening();
         }
 
         protected override async Task<Session> CreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService.cs
@@ -9,8 +9,9 @@ namespace Microsoft.CodeAnalysis.Remote
     internal partial class CodeAnalysisService : ServiceHubServiceBase
     {
         public CodeAnalysisService(Stream stream, IServiceProvider serviceProvider) :
-            base(stream, serviceProvider)
+            base(serviceProvider, stream)
         {
+            Rpc.StartListening();
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -39,9 +39,10 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         public RemoteHostService(Stream stream, IServiceProvider serviceProvider) :
-            base(stream, serviceProvider)
+            base(serviceProvider, stream)
         {
             // this service provide a way for client to make sure remote host is alive
+            Rpc.StartListening();
         }
 
         public string Connect(string host)

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
@@ -13,10 +13,12 @@ namespace Microsoft.CodeAnalysis.Remote
         private readonly SymbolSearchUpdateEngine _updateEngine;
 
         public RemoteSymbolSearchUpdateEngine(Stream stream, IServiceProvider serviceProvider)
-            : base(stream, serviceProvider)
+            : base(serviceProvider, stream)
         {
             _updateEngine = new SymbolSearchUpdateEngine(
                 new LogService(this), updateCancellationToken: this.CancellationToken);
+
+            Rpc.StartListening();
         }
 
         public Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory)

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.cs
@@ -20,9 +20,11 @@ namespace Microsoft.CodeAnalysis.Remote
         private AssetSource _source;
 
         public SnapshotService(Stream stream, IServiceProvider serviceProvider) :
-            base(stream, serviceProvider)
+            base(serviceProvider, stream)
         {
             _gate = new object();
+
+            Rpc.StartListening();
         }
 
         public override void Initialize(int sessionId, byte[] solutionChecksum)


### PR DESCRIPTION
**Customer scenario**

VS crashes seemingly at random point while using C#/VB/Typescript and etc which uses Roslyn underneath.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16900

**Workarounds, if any**

There is no workaround except turning off OOP through hidden reg key.

**Risk**

Code change is simple, so I dont see much risk but will create private bits to ask vendor to do some private testing.

**Performance impact**

N/A - this is fixing race by starting service little bit later point.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

There was some confusion when service hub side service starts/ready while caller in VS side gets stream to the service. due to it, we had a race where VS side start using service prematurely when service hub service is not fully ready yet. 

more detail explanation from service hub team is at https://github.com/dotnet/roslyn/issues/16900#issuecomment-277378950

now we make sure we use service once all required states are set.

**How was the bug found?**

customer report and watson.

http://watson/Failure?FailureSearchText=a38cbd5e-c8e2-cf1c-471b-02b5f717b084&DateTimeFormat=UTC&MaxRows=100&DisplayMetric=CabCount&AppScope_AppVersion=15.0.26124.*&AppScope_AppVersion=15.0.26127.*%20