### PR TITLE
Add test coverage for Out Vars in global code in remaining executable statements.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -1127,6 +1127,16 @@ public class Cls
             Assert.False(model.LookupNames(reference.SpanStart).Contains(reference.Identifier.ValueText));
         }
 
+        private static void VerifyNotAnOutField(SemanticModel model, IdentifierNameSyntax reference)
+        {
+            var symbol = model.GetSymbolInfo(reference).Symbol;
+
+            Assert.NotEqual(SymbolKind.Field, symbol.Kind);
+
+            Assert.Same(symbol, model.LookupSymbols(reference.SpanStart, name: reference.Identifier.ValueText).Single());
+            Assert.True(model.LookupNames(reference.SpanStart).Contains(reference.Identifier.ValueText));
+        }
+
         private static void VerifyNotAnOutLocal(SemanticModel model, IdentifierNameSyntax reference)
         {
             var symbol = model.GetSymbolInfo(reference).Symbol;
@@ -2906,6 +2916,14 @@ public class X
             CompileAndVerify(compilation, expectedOutput:
 @"System.InvalidOperationException
 System.InvalidOperationException");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
         }
 
         [Fact]
@@ -7874,6 +7892,14 @@ public class X
             CompileAndVerify(compilation, expectedOutput:
 @"3
 3");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
         }
 
         [Fact]
@@ -8584,6 +8610,13 @@ public class X
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             CompileAndVerify(compilation, expectedOutput: @"1
 True");
+            
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").Single();
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
         }
 
         [Fact]
@@ -12105,6 +12138,55 @@ public class X
                 var yRef = GetReferences(tree, id).Single();
                 VerifyModelForOutVar(model, yDecl, yRef);
             }
+        }
+
+        [Fact]
+        public void Query_02()
+        {
+            var source =
+@"
+using System.Linq;
+
+public class X
+{
+    public static void Main()
+    {
+        Test1();
+    }
+
+    static void Test1()
+    {
+        var res = from x1 in new[] { TakeOutParam(1, out var y1) && Print(y1) ? 2 : 0}
+                  select Print(x1);
+
+        res.ToArray(); 
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+
+    static bool Print(object x) 
+    {
+        System.Console.WriteLine(x);
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation, expectedOutput:
+@"1
+2");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yDecl = GetOutVarDeclarations(tree, "y1").Single();
+            var yRef = GetReferences(tree, "y1").Single();
+            VerifyModelForOutVar(model, yDecl, yRef);
         }
 
         [Fact]
@@ -21408,6 +21490,1980 @@ public class Cls
                 //         Test1(out StaticType x1);
                 Diagnostic(ErrorCode.ERR_VarDeclIsStaticClass, "StaticType").WithArguments("Cls.StaticType").WithLocation(6, 19)
                 );
+        }
+        
+        [Fact]
+        public void GlobalCode_Catch_01()
+        {
+            var source =
+@"
+bool Dummy(params object[] x) {return true;}
+
+try {}
+catch when (TakeOutParam(out var x1) && x1 > 0)
+{
+    Dummy(x1);
+}
+
+var x4 = 11;
+Dummy(x4);
+
+try {}
+catch when (TakeOutParam(out var x4) && x4 > 0)
+{
+    Dummy(x4);
+}
+
+try {}
+catch when (x6 && TakeOutParam(out var x6))
+{
+    Dummy(x6);
+}
+
+try {}
+catch when (TakeOutParam(out var x7) && x7 > 0)
+{
+    var x7 = 12;
+    Dummy(x7);
+}
+
+try {}
+catch when (TakeOutParam(out var x8) && x8 > 0)
+{
+    Dummy(x8);
+}
+
+System.Console.WriteLine(x8);
+
+try {}
+catch when (TakeOutParam(out var x9) && x9 > 0)
+{   
+    Dummy(x9);
+    try {}
+    catch when (TakeOutParam(out var x9) && x9 > 0) // 2
+    {
+        Dummy(x9);
+    }
+}
+
+try {}
+catch when (TakeOutParam(y10, out var x10))
+{   
+    var y10 = 12;
+    Dummy(y10);
+}
+
+//    try {}
+//    catch when (TakeOutParam(y11, out var x11)
+//    {   
+//        let y11 = 12;
+//        Dummy(y11);
+//    }
+
+try {}
+catch when (Dummy(TakeOutParam(out var x14), 
+                    TakeOutParam(out var x14), // 2
+                    x14))
+{
+    Dummy(x14);
+}
+
+try {}
+catch (System.Exception x15)
+        when (Dummy(TakeOutParam(out var x15), x15))
+{
+    Dummy(x15);
+}
+
+static bool TakeOutParam(out int x) 
+{
+    x = 123;
+    return true;
+}
+static bool TakeOutParam(object y, out int x)
+{
+    x = 123;
+    return true;
+}
+";
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+                compilation.VerifyDiagnostics(
+                // (20,13): error CS0841: Cannot use local variable 'x6' before it is declared
+                // catch when (x6 && TakeOutParam(out var x6))
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(20, 13),
+                // (28,9): error CS0136: A local or parameter named 'x7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     var x7 = 12;
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x7").WithArguments("x7").WithLocation(28, 9),
+                // (38,26): error CS0103: The name 'x8' does not exist in the current context
+                // System.Console.WriteLine(x8);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(38, 26),
+                // (45,38): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     catch when (TakeOutParam(out var x9) && x9 > 0) // 2
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(45, 38),
+                // (52,26): error CS0103: The name 'y10' does not exist in the current context
+                // catch when (TakeOutParam(y10, out var x10))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "y10").WithArguments("y10").WithLocation(52, 26),
+                // (67,42): error CS0128: A local variable or function named 'x14' is already defined in this scope
+                //                     TakeOutParam(out var x14), // 2
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(67, 42),
+                // (75,42): error CS0128: A local variable or function named 'x15' is already defined in this scope
+                //         when (Dummy(TakeOutParam(out var x15), x15))
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x15").WithArguments("x15").WithLocation(75, 42)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                var model = compilation.GetSemanticModel(tree);
+
+                var x1Decl = GetOutVarDeclaration(tree, "x1");
+                var x1Ref = GetReferences(tree, "x1").ToArray();
+                Assert.Equal(2, x1Ref.Length);
+                VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+                var x4Decl = GetOutVarDeclaration(tree, "x4");
+                var x4Ref = GetReferences(tree, "x4").ToArray();
+                Assert.Equal(3, x4Ref.Length);
+                VerifyNotAnOutLocal(model, x4Ref[0]);
+                VerifyModelForOutVar(model, x4Decl, x4Ref[1], x4Ref[2]);
+
+                var x6Decl = GetOutVarDeclaration(tree, "x6");
+                var x6Ref = GetReferences(tree, "x6").ToArray();
+                Assert.Equal(2, x6Ref.Length);
+                VerifyModelForOutVar(model, x6Decl, x6Ref);
+
+                var x7Decl = GetOutVarDeclaration(tree, "x7");
+                var x7Ref = GetReferences(tree, "x7").ToArray();
+                Assert.Equal(2, x7Ref.Length);
+                VerifyModelForOutVar(model, x7Decl, x7Ref[0]);
+                VerifyNotAnOutLocal(model, x7Ref[1]);
+
+                var x8Decl = GetOutVarDeclaration(tree, "x8");
+                var x8Ref = GetReferences(tree, "x8").ToArray();
+                Assert.Equal(3, x8Ref.Length);
+                VerifyModelForOutVar(model, x8Decl, x8Ref[0], x8Ref[1]);
+                VerifyNotInScope(model, x8Ref[2]);
+
+                var x9Decl = GetOutVarDeclarations(tree, "x9").ToArray();
+                var x9Ref = GetReferences(tree, "x9").ToArray();
+                Assert.Equal(2, x9Decl.Length);
+                Assert.Equal(4, x9Ref.Length);
+                VerifyModelForOutVar(model, x9Decl[0], x9Ref[0], x9Ref[1]);
+                VerifyModelForOutVar(model, x9Decl[1], x9Ref[2], x9Ref[3]);
+
+                var y10Ref = GetReferences(tree, "y10").ToArray();
+                Assert.Equal(2, y10Ref.Length);
+                VerifyNotInScope(model, y10Ref[0]);
+                VerifyNotAnOutLocal(model, y10Ref[1]);
+
+                var x14Decl = GetOutVarDeclarations(tree, "x14").ToArray();
+                var x14Ref = GetReferences(tree, "x14").ToArray();
+                Assert.Equal(2, x14Decl.Length);
+                Assert.Equal(2, x14Ref.Length);
+                VerifyModelForOutVar(model, x14Decl[0], x14Ref);
+                VerifyModelForOutVarDuplicateInSameScope(model, x14Decl[1]);
+
+                var x15Decl = GetOutVarDeclaration(tree, "x15");
+                var x15Ref = GetReferences(tree, "x15").ToArray();
+                Assert.Equal(2, x15Ref.Length);
+                VerifyModelForOutVarDuplicateInSameScope(model, x15Decl);
+                VerifyNotAnOutLocal(model, x15Ref[0]);
+                VerifyNotAnOutLocal(model, x15Ref[1]);
+            }
+
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular);
+                int[] exclude = new int[] { (int)ErrorCode.ERR_EOFExpected,
+                                        (int)ErrorCode.ERR_CloseParenExpected,
+                                        (int)ErrorCode.ERR_SemicolonExpected,
+                                        (int)ErrorCode.ERR_TypeExpected,
+                                        (int)ErrorCode.ERR_NamespaceUnexpected,
+                                        (int)ErrorCode.ERR_TupleTooFewElements,
+                                        (int)ErrorCode.ERR_MemberNeedsType,
+                                        (int)ErrorCode.ERR_IdentifierExpected,
+                                        (int)ErrorCode.ERR_SyntaxError,
+                                        (int)ErrorCode.ERR_SingleTypeNameNotFound,
+                                        (int)ErrorCode.ERR_ConcreteMissingBody,
+                                        (int)ErrorCode.ERR_PredefinedValueTupleTypeNotFound,
+                                        (int)ErrorCode.ERR_TypeVarNotFound,
+                                        (int)ErrorCode.ERR_TupleElementNamesAttributeMissing
+                                      };
+
+                compilation.GetDiagnostics().Where(d => !exclude.Contains(d.Code)).Verify(
+                // (16,5): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //     Dummy(x4);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(16, 5),
+                // (47,9): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //         Dummy(x9);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(47, 9),
+                // (14,7): error CS0111: Type '<invalid-global-code>' already defines a member called 'when' with the same parameter types
+                // catch when (TakeOutParam(out var x4) && x4 > 0)
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "when").WithArguments("when", "<invalid-global-code>").WithLocation(14, 7),
+                // (26,7): error CS0111: Type '<invalid-global-code>' already defines a member called 'when' with the same parameter types
+                // catch when (TakeOutParam(out var x7) && x7 > 0)
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "when").WithArguments("when", "<invalid-global-code>").WithLocation(26, 7),
+                // (33,7): error CS0111: Type '<invalid-global-code>' already defines a member called 'when' with the same parameter types
+                // catch when (TakeOutParam(out var x8) && x8 > 0)
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "when").WithArguments("when", "<invalid-global-code>").WithLocation(33, 7),
+                // (41,7): error CS0111: Type '<invalid-global-code>' already defines a member called 'when' with the same parameter types
+                // catch when (TakeOutParam(out var x9) && x9 > 0)
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "when").WithArguments("when", "<invalid-global-code>").WithLocation(41, 7),
+                // (45,11): error CS0111: Type '<invalid-global-code>' already defines a member called 'when' with the same parameter types
+                //     catch when (TakeOutParam(out var x9) && x9 > 0) // 2
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "when").WithArguments("when", "<invalid-global-code>").WithLocation(45, 11),
+                // (75,9): error CS0111: Type '<invalid-global-code>' already defines a member called 'when' with the same parameter types
+                //         when (Dummy(TakeOutParam(out var x15), x15))
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "when").WithArguments("when", "<invalid-global-code>").WithLocation(75, 9)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                Assert.Empty(GetOutVarDeclarations(tree));
+                AssertNoGlobalStatements(tree);
+            }
+        }
+
+        [Fact]
+        public void GlobalCode_Catch_02()
+        {
+            var source =
+@"
+try
+{
+    throw new System.InvalidOperationException();
+}
+catch (System.Exception e) when (Dummy(TakeOutParam(e, out var x1), x1))
+{
+    System.Console.WriteLine(x1.GetType());
+}
+
+static bool Dummy(object y, object z) 
+{
+    System.Console.WriteLine(z.GetType());
+    return true;
+}
+
+static bool TakeOutParam<T>(T y, out T x) 
+{
+    x = y;
+    return true;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            CompileAndVerify(compilation, expectedOutput:
+@"System.InvalidOperationException
+System.InvalidOperationException");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+        }
+
+        [Fact]
+        public void GlobalCode_Block_01()
+        {
+            string source =
+@"
+{
+    H.TakeOutParam(1, out var x1);
+    H.Dummy(x1);
+}
+
+object x2;
+{
+    H.TakeOutParam(2, out var x2);
+    H.Dummy(x2);
+}
+{
+    H.TakeOutParam(3, out var x3);
+}
+H.Dummy(x3);
+
+class H
+{
+    public static bool Dummy(params object[] x) {return true;}
+    public static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+
+                compilation.VerifyDiagnostics(
+                // (15,9): error CS0103: The name 'x3' does not exist in the current context
+                // H.Dummy(x3);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x3").WithArguments("x3").WithLocation(15, 9)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                var model = compilation.GetSemanticModel(tree);
+
+                var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+                var x1Ref = GetReferences(tree, "x1").ToArray();
+                Assert.Equal(1, x1Ref.Length);
+                VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+                var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
+                var x2Ref = GetReferences(tree, "x2").Single();
+                VerifyModelForOutVar(model, x2Decl, x2Ref);
+
+                var x3Decl = GetOutVarDeclarations(tree, "x3").Single();
+                var x3Ref = GetReferences(tree, "x3").Single();
+                VerifyModelForOutVar(model, x3Decl);
+                VerifyNotInScope(model, x3Ref);
+            }
+
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular);
+                int[] exclude = new int[] { (int)ErrorCode.ERR_EOFExpected,
+                                        (int)ErrorCode.ERR_CloseParenExpected,
+                                        (int)ErrorCode.ERR_SemicolonExpected,
+                                        (int)ErrorCode.ERR_TypeExpected,
+                                        (int)ErrorCode.ERR_NamespaceUnexpected,
+                                        (int)ErrorCode.ERR_TupleTooFewElements,
+                                        (int)ErrorCode.ERR_TypeVarNotFound
+                                      };
+
+                compilation.GetDiagnostics().Where(d => !exclude.Contains(d.Code)).Verify(
+                // (9,31): error CS0102: The type '<invalid-global-code>' already contains a definition for 'x2'
+                //     H.TakeOutParam(2, out var x2);
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x2").WithArguments("<invalid-global-code>", "x2").WithLocation(9, 31)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                Assert.Empty(GetOutVarDeclarations(tree));
+                AssertNoGlobalStatements(tree);
+            }
+        }
+
+        [Fact]
+        public void GlobalCode_Block_02()
+        {
+            string source =
+@"
+{
+    H.TakeOutParam(1, out var x1);
+    System.Console.WriteLine(x1);
+    Test();
+
+    void Test()
+    {
+        System.Console.WriteLine(x1);
+    }
+}
+
+class H
+{
+    public static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+
+            CompileAndVerify(compilation, expectedOutput:
+@"1
+1").VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+        }
+
+        [Fact]
+        public void GlobalCode_For_01()
+        {
+            var source =
+@"
+bool Dummy(params object[] x) {return true;}
+
+for (
+        Dummy(TakeOutParam(true, out var x1) && x1)
+        ;;)
+{
+    Dummy(x1);
+}
+
+for ( // 2
+        Dummy(TakeOutParam(true, out var x2) && x2)
+        ;;)
+    Dummy(x2);
+
+var x4 = 11;
+Dummy(x4);
+
+for (
+        Dummy(TakeOutParam(true, out var x4) && x4)
+        ;;)
+    Dummy(x4);
+
+for (
+        Dummy(x6 && TakeOutParam(true, out var x6))
+        ;;)
+    Dummy(x6);
+
+for (
+        Dummy(TakeOutParam(true, out var x7) && x7)
+        ;;)
+{
+    var x7 = 12;
+    Dummy(x7);
+}
+
+for (
+        Dummy(TakeOutParam(true, out var x8) && x8)
+        ;;)
+    Dummy(x8);
+
+System.Console.WriteLine(x8);
+
+for (
+        Dummy(TakeOutParam(true, out var x9) && x9)
+        ;;)
+{   
+    Dummy(x9);
+    for (
+            Dummy(TakeOutParam(true, out var x9) && x9) // 2
+            ;;)
+        Dummy(x9);
+}
+
+for (
+        Dummy(TakeOutParam(y10, out var x10))
+        ;;)
+{   
+    var y10 = 12;
+    Dummy(y10);
+}
+
+//    for (
+//         Dummy(TakeOutParam(y11, out var x11))
+//         ;;)
+//    {   
+//        let y11 = 12;
+//        Dummy(y11);
+//    }
+
+for (
+        Dummy(TakeOutParam(y12, out var x12))
+        ;;)
+    var y12 = 12;
+
+//    for (
+//         Dummy(TakeOutParam(y13, out var x13))
+//         ;;)
+//        let y13 = 12;
+
+for (
+        Dummy(TakeOutParam(1, out var x14), 
+            TakeOutParam(2, out var x14), 
+            x14)
+        ;;)
+{
+    Dummy(x14);
+}
+
+static bool TakeOutParam(object y, out bool x) 
+{
+    x = true;
+    return true;
+}
+";
+
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+                compilation.VerifyDiagnostics(
+                // (74,5): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //     var y12 = 12;
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "var y12 = 12;").WithLocation(74, 5),
+                // (25,15): error CS0841: Cannot use local variable 'x6' before it is declared
+                //         Dummy(x6 && TakeOutParam(true, out var x6))
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(25, 15),
+                // (33,9): error CS0136: A local or parameter named 'x7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     var x7 = 12;
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x7").WithArguments("x7").WithLocation(33, 9),
+                // (42,26): error CS0103: The name 'x8' does not exist in the current context
+                // System.Console.WriteLine(x8);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(42, 26),
+                // (50,46): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //             Dummy(TakeOutParam(true, out var x9) && x9) // 2
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(50, 46),
+                // (56,28): error CS0103: The name 'y10' does not exist in the current context
+                //         Dummy(TakeOutParam(y10, out var x10))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "y10").WithArguments("y10").WithLocation(56, 28),
+                // (72,28): error CS0103: The name 'y12' does not exist in the current context
+                //         Dummy(TakeOutParam(y12, out var x12))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(72, 28),
+                // (83,37): error CS0128: A local variable or function named 'x14' is already defined in this scope
+                //             TakeOutParam(2, out var x14), 
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(83, 37),
+                // (11,1): warning CS0162: Unreachable code detected
+                // for ( // 2
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "for").WithLocation(11, 1),
+                // (74,9): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //     var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(74, 9)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                var model = compilation.GetSemanticModel(tree);
+
+                var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+                var x1Ref = GetReferences(tree, "x1").ToArray();
+                Assert.Equal(2, x1Ref.Length);
+                VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+                var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
+                var x2Ref = GetReferences(tree, "x2").ToArray();
+                Assert.Equal(2, x2Ref.Length);
+                VerifyModelForOutVar(model, x2Decl, x2Ref);
+
+                var x4Decl = GetOutVarDeclarations(tree, "x4").Single();
+                var x4Ref = GetReferences(tree, "x4").ToArray();
+                Assert.Equal(3, x4Ref.Length);
+                VerifyNotAnOutLocal(model, x4Ref[0]);
+                VerifyModelForOutVar(model, x4Decl, x4Ref[1], x4Ref[2]);
+
+                var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
+                var x6Ref = GetReferences(tree, "x6").ToArray();
+                Assert.Equal(2, x6Ref.Length);
+                VerifyModelForOutVar(model, x6Decl, x6Ref);
+
+                var x7Decl = GetOutVarDeclarations(tree, "x7").Single();
+                var x7Ref = GetReferences(tree, "x7").ToArray();
+                Assert.Equal(2, x7Ref.Length);
+                VerifyModelForOutVar(model, x7Decl, x7Ref[0]);
+                VerifyNotAnOutLocal(model, x7Ref[1]);
+
+                var x8Decl = GetOutVarDeclarations(tree, "x8").Single();
+                var x8Ref = GetReferences(tree, "x8").ToArray();
+                Assert.Equal(3, x8Ref.Length);
+                VerifyModelForOutVar(model, x8Decl, x8Ref[0], x8Ref[1]);
+                VerifyNotInScope(model, x8Ref[2]);
+
+                var x9Decl = GetOutVarDeclarations(tree, "x9").ToArray();
+                var x9Ref = GetReferences(tree, "x9").ToArray();
+                Assert.Equal(2, x9Decl.Length);
+                Assert.Equal(4, x9Ref.Length);
+                VerifyModelForOutVar(model, x9Decl[0], x9Ref[0], x9Ref[1]);
+                VerifyModelForOutVar(model, x9Decl[1], x9Ref[2], x9Ref[3]);
+
+                var y10Ref = GetReferences(tree, "y10").ToArray();
+                Assert.Equal(2, y10Ref.Length);
+                VerifyNotInScope(model, y10Ref[0]);
+                VerifyNotAnOutLocal(model, y10Ref[1]);
+
+                var y12Ref = GetReferences(tree, "y12").Single();
+                VerifyNotInScope(model, y12Ref);
+
+                var x14Decl = GetOutVarDeclarations(tree, "x14").ToArray();
+                var x14Ref = GetReferences(tree, "x14").ToArray();
+                Assert.Equal(2, x14Decl.Length);
+                Assert.Equal(2, x14Ref.Length);
+                VerifyModelForOutVar(model, x14Decl[0], x14Ref);
+                VerifyModelForOutVarDuplicateInSameScope(model, x14Decl[1]);
+            }
+
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular);
+                int[] exclude = new int[] { (int)ErrorCode.ERR_EOFExpected,
+                                        (int)ErrorCode.ERR_CloseParenExpected,
+                                        (int)ErrorCode.ERR_SemicolonExpected,
+                                        (int)ErrorCode.ERR_TypeExpected,
+                                        (int)ErrorCode.ERR_NamespaceUnexpected,
+                                        (int)ErrorCode.ERR_TupleTooFewElements,
+                                        (int)ErrorCode.ERR_MemberNeedsType,
+                                        (int)ErrorCode.ERR_IdentifierExpected,
+                                        (int)ErrorCode.ERR_SyntaxError,
+                                        (int)ErrorCode.ERR_SingleTypeNameNotFound,
+                                        (int)ErrorCode.ERR_ConcreteMissingBody,
+                                        (int)ErrorCode.ERR_PredefinedValueTupleTypeNotFound,
+                                        (int)ErrorCode.ERR_TypeVarNotFound,
+                                        (int)ErrorCode.ERR_TupleElementNamesAttributeMissing,
+                                        (int)ErrorCode.ERR_IdentifierExpectedKW
+                                      };
+
+                compilation.GetDiagnostics().Where(d => !exclude.Contains(d.Code)).Verify(
+                // (22,5): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //     Dummy(x4);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(22, 5),
+                // (52,9): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //         Dummy(x9);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(52, 9),
+                // (20,42): error CS0102: The type '<invalid-global-code>' already contains a definition for 'x4'
+                //         Dummy(TakeOutParam(true, out var x4) && x4)
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x4").WithArguments("<invalid-global-code>", "x4").WithLocation(20, 42),
+                // (83,13): error CS0111: Type '<invalid-global-code>' already defines a member called 'TakeOutParam' with the same parameter types
+                //             TakeOutParam(2, out var x14), 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "TakeOutParam").WithArguments("TakeOutParam", "<invalid-global-code>").WithLocation(83, 13),
+                // (33,9): error CS0102: The type '<invalid-global-code>' already contains a definition for 'x7'
+                //     var x7 = 12;
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x7").WithArguments("<invalid-global-code>", "x7").WithLocation(33, 9),
+                // (50,46): error CS0102: The type '<invalid-global-code>' already contains a definition for 'x9'
+                //             Dummy(TakeOutParam(true, out var x9) && x9) // 2
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x9").WithArguments("<invalid-global-code>", "x9").WithLocation(50, 46)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                Assert.Empty(GetOutVarDeclarations(tree));
+                AssertNoGlobalStatements(tree);
+            }
+        }
+
+        [Fact]
+        public void GlobalCode_For_02()
+        {
+            var source =
+@"
+bool f = true;
+
+for (Dummy(f, TakeOutParam((f ? 10 : 20), out var x0), x0); 
+        Dummy(f, TakeOutParam((f ? 1 : 2), out var x1), x1); 
+        Dummy(f, TakeOutParam((f ? 100 : 200), out var x2), x2), Dummy(true, null, x2))
+{
+    System.Console.WriteLine(x0);
+    System.Console.WriteLine(x1);
+    f = false;
+}
+
+static bool Dummy(bool x, object y, object z) 
+{
+    System.Console.WriteLine(z);
+    return x;
+}
+
+static bool TakeOutParam(int y, out int x) 
+{
+    x = y;
+    return true;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            CompileAndVerify(compilation, expectedOutput:
+@"10
+1
+10
+1
+200
+200
+2");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x0Decl = GetOutVarDeclarations(tree, "x0").Single();
+            var x0Ref = GetReferences(tree, "x0").ToArray();
+            Assert.Equal(2, x0Ref.Length);
+            VerifyModelForOutVar(model, x0Decl, x0Ref);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+            var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
+            var x2Ref = GetReferences(tree, "x2").ToArray();
+            Assert.Equal(2, x2Ref.Length);
+            VerifyModelForOutVar(model, x2Decl, x2Ref);
+        }
+
+        [Fact]
+        public void GlobalCode_Foreach_01()
+        {
+            var source =
+@"
+System.Collections.IEnumerable Dummy(params object[] x) {return null;}
+
+foreach (var i in Dummy(TakeOutParam(true, out var x1) && x1))
+{
+    Dummy(x1);
+}
+
+foreach (var i in Dummy(TakeOutParam(true, out var x2) && x2))
+    Dummy(x2);
+
+var x4 = 11;
+Dummy(x4);
+
+foreach (var i in Dummy(TakeOutParam(true, out var x4) && x4))
+    Dummy(x4);
+
+foreach (var i in Dummy(x6 && TakeOutParam(true, out var x6)))
+    Dummy(x6);
+
+foreach (var i in Dummy(TakeOutParam(true, out var x7) && x7))
+{
+    var x7 = 12;
+    Dummy(x7);
+}
+
+foreach (var i in Dummy(TakeOutParam(true, out var x8) && x8))
+    Dummy(x8);
+
+System.Console.WriteLine(x8);
+
+foreach (var i1 in Dummy(TakeOutParam(true, out var x9) && x9))
+{   
+    Dummy(x9);
+    foreach (var i2 in Dummy(TakeOutParam(true, out var x9) && x9)) // 2
+        Dummy(x9);
+}
+
+foreach (var i in Dummy(TakeOutParam(y10, out var x10)))
+{   
+    var y10 = 12;
+    Dummy(y10);
+}
+
+//    foreach (var i in Dummy(TakeOutParam(y11, out var x11)))
+//    {   
+//        let y11 = 12;
+//        Dummy(y11);
+//    }
+
+foreach (var i in Dummy(TakeOutParam(y12, out var x12)))
+    var y12 = 12;
+
+//    foreach (var i in Dummy(TakeOutParam(y13, out var x13)))
+//        let y13 = 12;
+
+foreach (var i in Dummy(TakeOutParam(1, out var x14), 
+                        TakeOutParam(2, out var x14), 
+                        x14))
+{
+    Dummy(x14);
+}
+
+foreach (var x15 in 
+                    Dummy(TakeOutParam(1, out var x15), x15))
+{
+    Dummy(x15);
+}
+
+static bool TakeOutParam(int y, out int x) 
+{
+    x = y;
+    return true;
+}
+
+static bool TakeOutParam(bool y, out bool x) 
+{
+    x = y;
+    return true;
+}
+";
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+                compilation.VerifyDiagnostics(
+                // (52,5): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //     var y12 = 12;
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "var y12 = 12;").WithLocation(52, 5),
+                // (18,25): error CS0841: Cannot use local variable 'x6' before it is declared
+                // foreach (var i in Dummy(x6 && TakeOutParam(true, out var x6)))
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(18, 25),
+                // (23,9): error CS0136: A local or parameter named 'x7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     var x7 = 12;
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x7").WithArguments("x7").WithLocation(23, 9),
+                // (30,26): error CS0103: The name 'x8' does not exist in the current context
+                // System.Console.WriteLine(x8);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(30, 26),
+                // (35,57): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     foreach (var i2 in Dummy(TakeOutParam(true, out var x9) && x9)) // 2
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(35, 57),
+                // (39,38): error CS0103: The name 'y10' does not exist in the current context
+                // foreach (var i in Dummy(TakeOutParam(y10, out var x10)))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "y10").WithArguments("y10").WithLocation(39, 38),
+                // (51,38): error CS0103: The name 'y12' does not exist in the current context
+                // foreach (var i in Dummy(TakeOutParam(y12, out var x12)))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(51, 38),
+                // (58,49): error CS0128: A local variable or function named 'x14' is already defined in this scope
+                //                         TakeOutParam(2, out var x14), 
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(58, 49),
+                // (64,14): error CS0136: A local or parameter named 'x15' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // foreach (var x15 in 
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x15").WithArguments("x15").WithLocation(64, 14),
+                // (52,9): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //     var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(52, 9)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                var model = compilation.GetSemanticModel(tree);
+
+                var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+                var x1Ref = GetReferences(tree, "x1").ToArray();
+                Assert.Equal(2, x1Ref.Length);
+                VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+                var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
+                var x2Ref = GetReferences(tree, "x2").ToArray();
+                Assert.Equal(2, x2Ref.Length);
+                VerifyModelForOutVar(model, x2Decl, x2Ref);
+
+                var x4Decl = GetOutVarDeclarations(tree, "x4").Single();
+                var x4Ref = GetReferences(tree, "x4").ToArray();
+                Assert.Equal(3, x4Ref.Length);
+                VerifyNotAnOutLocal(model, x4Ref[0]);
+                VerifyModelForOutVar(model, x4Decl, x4Ref[1], x4Ref[2]);
+
+                var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
+                var x6Ref = GetReferences(tree, "x6").ToArray();
+                Assert.Equal(2, x6Ref.Length);
+                VerifyModelForOutVar(model, x6Decl, x6Ref);
+
+                var x7Decl = GetOutVarDeclarations(tree, "x7").Single();
+                var x7Ref = GetReferences(tree, "x7").ToArray();
+                Assert.Equal(2, x7Ref.Length);
+                VerifyModelForOutVar(model, x7Decl, x7Ref[0]);
+                VerifyNotAnOutLocal(model, x7Ref[1]);
+
+                var x8Decl = GetOutVarDeclarations(tree, "x8").Single();
+                var x8Ref = GetReferences(tree, "x8").ToArray();
+                Assert.Equal(3, x8Ref.Length);
+                VerifyModelForOutVar(model, x8Decl, x8Ref[0], x8Ref[1]);
+                VerifyNotInScope(model, x8Ref[2]);
+
+                var x9Decl = GetOutVarDeclarations(tree, "x9").ToArray();
+                var x9Ref = GetReferences(tree, "x9").ToArray();
+                Assert.Equal(2, x9Decl.Length);
+                Assert.Equal(4, x9Ref.Length);
+                VerifyModelForOutVar(model, x9Decl[0], x9Ref[0], x9Ref[1]);
+                VerifyModelForOutVar(model, x9Decl[1], x9Ref[2], x9Ref[3]);
+
+                var y10Ref = GetReferences(tree, "y10").ToArray();
+                Assert.Equal(2, y10Ref.Length);
+                VerifyNotInScope(model, y10Ref[0]);
+                VerifyNotAnOutLocal(model, y10Ref[1]);
+
+                var y12Ref = GetReferences(tree, "y12").Single();
+                VerifyNotInScope(model, y12Ref);
+
+                var x14Decl = GetOutVarDeclarations(tree, "x14").ToArray();
+                var x14Ref = GetReferences(tree, "x14").ToArray();
+                Assert.Equal(2, x14Decl.Length);
+                Assert.Equal(2, x14Ref.Length);
+                VerifyModelForOutVar(model, x14Decl[0], x14Ref);
+                VerifyModelForOutVarDuplicateInSameScope(model, x14Decl[1]);
+
+                var x15Decl = GetOutVarDeclarations(tree, "x15").Single();
+                var x15Ref = GetReferences(tree, "x15").ToArray();
+                Assert.Equal(2, x15Ref.Length);
+                VerifyModelForOutVar(model, x15Decl, x15Ref[0]);
+                VerifyNotAnOutLocal(model, x15Ref[1]);
+            }
+
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular);
+                int[] exclude = new int[] { (int)ErrorCode.ERR_EOFExpected,
+                                        (int)ErrorCode.ERR_CloseParenExpected,
+                                        (int)ErrorCode.ERR_SemicolonExpected,
+                                        (int)ErrorCode.ERR_TypeExpected,
+                                        (int)ErrorCode.ERR_NamespaceUnexpected,
+                                        (int)ErrorCode.ERR_TupleTooFewElements,
+                                        (int)ErrorCode.ERR_MemberNeedsType,
+                                        (int)ErrorCode.ERR_IdentifierExpected,
+                                        (int)ErrorCode.ERR_SyntaxError,
+                                        (int)ErrorCode.ERR_SingleTypeNameNotFound,
+                                        (int)ErrorCode.ERR_ConcreteMissingBody,
+                                        (int)ErrorCode.ERR_PredefinedValueTupleTypeNotFound,
+                                        (int)ErrorCode.ERR_TypeVarNotFound,
+                                        (int)ErrorCode.ERR_TupleElementNamesAttributeMissing,
+                                        (int)ErrorCode.ERR_IdentifierExpectedKW
+                                      };
+
+                compilation.GetDiagnostics().Where(d => !exclude.Contains(d.Code)).Verify(
+                // (9,19): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // foreach (var i in Dummy(TakeOutParam(true, out var x2) && x2))
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(9, 19),
+                // (15,19): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // foreach (var i in Dummy(TakeOutParam(true, out var x4) && x4))
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(15, 19),
+                // (16,5): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //     Dummy(x4);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(16, 5),
+                // (21,19): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // foreach (var i in Dummy(TakeOutParam(true, out var x7) && x7))
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(21, 19),
+                // (27,19): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // foreach (var i in Dummy(TakeOutParam(true, out var x8) && x8))
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(27, 19),
+                // (32,20): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // foreach (var i1 in Dummy(TakeOutParam(true, out var x9) && x9))
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(32, 20),
+                // (35,24): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //     foreach (var i2 in Dummy(TakeOutParam(true, out var x9) && x9)) // 2
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(35, 24),
+                // (36,9): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //         Dummy(x9);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(36, 9),
+                // (57,19): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // foreach (var i in Dummy(TakeOutParam(1, out var x14), 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(57, 19),
+                // (65,21): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //                     Dummy(TakeOutParam(1, out var x15), x15))
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(65, 21)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                Assert.Empty(GetOutVarDeclarations(tree));
+                AssertNoGlobalStatements(tree);
+            }
+        }
+
+        [Fact]
+        public void GlobalCode_Foreach_02()
+        {
+            var source =
+@"
+bool f = true;
+
+foreach (var i in Dummy(TakeOutParam(3, out var x1), x1))
+{
+    System.Console.WriteLine(x1);
+}
+
+static System.Collections.IEnumerable Dummy(object y, object z) 
+{
+    System.Console.WriteLine(z);
+    return ""a"";
+}
+
+static bool TakeOutParam(int y, out int x) 
+{
+    x = y;
+    return true;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            CompileAndVerify(compilation, expectedOutput:
+@"3
+3");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+        }
+
+        [Fact]
+        public void GlobalCode_Lambda_01()
+        {
+            var source =
+@"
+bool Dummy(params object[] x) {return true;}
+
+Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x3) && x3 > 0));
+
+Dummy((System.Func<object, bool>) (o => x4 && TakeOutParam(o, out var x4)));
+
+Dummy((System.Func<object, object, bool>) ((o1, o2) => TakeOutParam(o1, out var x5) && 
+                                                        TakeOutParam(o2, out var x5) && 
+                                                        x5 > 0));
+
+Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x6) && x6 > 0), (System.Func<object, bool>) (o => TakeOutParam(o, out var x6) && x6 > 0));
+
+Dummy(x7, 1);
+Dummy(x7, 
+        (System.Func<object, bool>) (o => TakeOutParam(o, out var x7) && x7 > 0), 
+        x7);
+Dummy(x7, 2); 
+
+Dummy(TakeOutParam(true, out var x8) && x8, (System.Func<object, bool>) (o => TakeOutParam(o, out var y8) && x8));
+
+Dummy(TakeOutParam(true, out var x9), 
+        (System.Func<object, bool>) (o => TakeOutParam(o, out var x9) && 
+                                        x9 > 0), x9);
+
+Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x10) && 
+                                        x10 > 0),
+        TakeOutParam(true, out var x10), x10);
+
+var x11 = 11;
+Dummy(x11);
+Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x11) && 
+                                        x11 > 0), x11);
+
+Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x12) && 
+                                        x12 > 0), 
+        x12);
+var x12 = 11;
+Dummy(x12);
+
+static bool TakeOutParam(object y, out int x) 
+{
+    x = 123;
+    return true;
+}
+
+static bool TakeOutParam(bool y, out bool x) 
+{
+    x = true;
+    return true;
+}
+";
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+                compilation.VerifyDiagnostics(
+                // (6,41): error CS0841: Cannot use local variable 'x4' before it is declared
+                // Dummy((System.Func<object, bool>) (o => x4 && TakeOutParam(o, out var x4)));
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(6, 41),
+                // (9,82): error CS0128: A local variable or function named 'x5' is already defined in this scope
+                //                                                         TakeOutParam(o2, out var x5) && 
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(9, 82),
+                // (14,7): error CS0103: The name 'x7' does not exist in the current context
+                // Dummy(x7, 1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x7").WithArguments("x7").WithLocation(14, 7),
+                // (15,7): error CS0103: The name 'x7' does not exist in the current context
+                // Dummy(x7, 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x7").WithArguments("x7").WithLocation(15, 7),
+                // (17,9): error CS0103: The name 'x7' does not exist in the current context
+                //         x7);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x7").WithArguments("x7").WithLocation(17, 9),
+                // (18,7): error CS0103: The name 'x7' does not exist in the current context
+                // Dummy(x7, 2); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x7").WithArguments("x7").WithLocation(18, 7)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                var model = compilation.GetSemanticModel(tree);
+
+                var x3Decl = GetOutVarDeclarations(tree, "x3").Single();
+                var x3Ref = GetReferences(tree, "x3").Single();
+                VerifyModelForOutVar(model, x3Decl, x3Ref);
+
+                var x4Decl = GetOutVarDeclarations(tree, "x4").Single();
+                var x4Ref = GetReferences(tree, "x4").Single();
+                VerifyModelForOutVar(model, x4Decl, x4Ref);
+
+                var x5Decl = GetOutVarDeclarations(tree, "x5").ToArray();
+                var x5Ref = GetReferences(tree, "x5").Single();
+                Assert.Equal(2, x5Decl.Length);
+                VerifyModelForOutVar(model, x5Decl[0], x5Ref);
+                VerifyModelForOutVarDuplicateInSameScope(model, x5Decl[1]);
+
+                var x6Decl = GetOutVarDeclarations(tree, "x6").ToArray();
+                var x6Ref = GetReferences(tree, "x6").ToArray();
+                Assert.Equal(2, x6Decl.Length);
+                Assert.Equal(2, x6Ref.Length);
+                VerifyModelForOutVar(model, x6Decl[0], x6Ref[0]);
+                VerifyModelForOutVar(model, x6Decl[1], x6Ref[1]);
+
+                var x7Decl = GetOutVarDeclarations(tree, "x7").Single();
+                var x7Ref = GetReferences(tree, "x7").ToArray();
+                Assert.Equal(5, x7Ref.Length);
+                VerifyNotInScope(model, x7Ref[0]);
+                VerifyNotInScope(model, x7Ref[1]);
+                VerifyModelForOutVar(model, x7Decl, x7Ref[2]);
+                VerifyNotInScope(model, x7Ref[3]);
+                VerifyNotInScope(model, x7Ref[4]);
+
+                var x8Decl = GetOutVarDeclarations(tree, "x8").Single();
+                var x8Ref = GetReferences(tree, "x8").ToArray();
+                Assert.Equal(2, x8Ref.Length);
+                VerifyModelForOutField(model, x8Decl, x8Ref);
+
+                var x9Decl = GetOutVarDeclarations(tree, "x9").ToArray();
+                var x9Ref = GetReferences(tree, "x9").ToArray();
+                Assert.Equal(2, x9Decl.Length);
+                Assert.Equal(2, x9Ref.Length);
+                VerifyModelForOutField(model, x9Decl[0], x9Ref[1]);
+                VerifyModelForOutVar(model, x9Decl[1], x9Ref[0]);
+
+                var x10Decl = GetOutVarDeclarations(tree, "x10").ToArray();
+                var x10Ref = GetReferences(tree, "x10").ToArray();
+                Assert.Equal(2, x10Decl.Length);
+                Assert.Equal(2, x10Ref.Length);
+                VerifyModelForOutVar(model, x10Decl[0], x10Ref[0]);
+                VerifyModelForOutField(model, x10Decl[1], x10Ref[1]);
+
+                var x11Decl = GetOutVarDeclarations(tree, "x11").Single();
+                var x11Ref = GetReferences(tree, "x11").ToArray();
+                Assert.Equal(3, x11Ref.Length);
+                VerifyNotAnOutLocal(model, x11Ref[0]);
+                VerifyModelForOutVar(model, x11Decl, x11Ref[1]);
+                VerifyNotAnOutLocal(model, x11Ref[2]);
+
+                var x12Decl = GetOutVarDeclarations(tree, "x12").Single();
+                var x12Ref = GetReferences(tree, "x12").ToArray();
+                Assert.Equal(3, x12Ref.Length);
+                VerifyModelForOutVar(model, x12Decl, x12Ref[0]);
+                VerifyNotAnOutLocal(model, x12Ref[1]);
+                VerifyNotAnOutLocal(model, x12Ref[2]);
+            }
+
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular);
+                int[] exclude = new int[] { (int)ErrorCode.ERR_EOFExpected,
+                                        (int)ErrorCode.ERR_CloseParenExpected,
+                                        (int)ErrorCode.ERR_SemicolonExpected,
+                                        (int)ErrorCode.ERR_TypeExpected,
+                                        (int)ErrorCode.ERR_NamespaceUnexpected,
+                                        (int)ErrorCode.ERR_TupleTooFewElements,
+                                        (int)ErrorCode.ERR_MemberNeedsType,
+                                        (int)ErrorCode.ERR_IdentifierExpected,
+                                        (int)ErrorCode.ERR_SyntaxError,
+                                        (int)ErrorCode.ERR_SingleTypeNameNotFound,
+                                        (int)ErrorCode.ERR_ConcreteMissingBody,
+                                        (int)ErrorCode.ERR_PredefinedValueTupleTypeNotFound,
+                                        (int)ErrorCode.ERR_TypeVarNotFound,
+                                        (int)ErrorCode.ERR_TupleElementNamesAttributeMissing,
+                                        (int)ErrorCode.ERR_IdentifierExpectedKW
+                                      };
+
+                compilation.GetDiagnostics().Where(d => !exclude.Contains(d.Code)).Verify(
+                // (12,1): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x6) && x6 > 0), (System.Func<object, bool>) (o => TakeOutParam(o, out var x6) && x6 > 0));
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(12, 1),
+                // (18,1): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // Dummy(x7, 2); 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(18, 1),
+                // (22,1): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // Dummy(TakeOutParam(true, out var x9), 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(22, 1),
+                // (26,1): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x10) && 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(26, 1),
+                // (32,1): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x11) && 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(32, 1),
+                // (35,1): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                // Dummy((System.Func<object, bool>) (o => TakeOutParam(o, out var x12) && 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(35, 1),
+                // (20,79): error CS0111: Type '<invalid-global-code>' already defines a member called 'TakeOutParam' with the same parameter types
+                // Dummy(TakeOutParam(true, out var x8) && x8, (System.Func<object, bool>) (o => TakeOutParam(o, out var y8) && x8));
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "TakeOutParam").WithArguments("TakeOutParam", "<invalid-global-code>").WithLocation(20, 79),
+                // (23,43): error CS0111: Type '<invalid-global-code>' already defines a member called 'TakeOutParam' with the same parameter types
+                //         (System.Func<object, bool>) (o => TakeOutParam(o, out var x9) && 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "TakeOutParam").WithArguments("TakeOutParam", "<invalid-global-code>").WithLocation(23, 43)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                Assert.Empty(GetOutVarDeclarations(tree));
+                AssertNoGlobalStatements(tree);
+            }
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/16935")]
+        [WorkItem(16935, "https://github.com/dotnet/roslyn/issues/16935")]
+        public void GlobalCode_Lambda_02()
+        {
+            var source =
+@"
+System.Func<bool> l = () => TakeOutParam(1, out int x1) && Dummy(x1); 
+System.Console.WriteLine(l());
+
+static bool Dummy(int x) 
+{
+    System.Console.WriteLine(x);
+    return true;
+}
+
+static bool TakeOutParam(int y, out int x) 
+{
+    x = y;
+    return true;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            CompileAndVerify(compilation, expectedOutput: @"1
+True");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").Single();
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+        }
+
+        [Fact]
+        public void GlobalCode_Lambda_03()
+        {
+            var source =
+@"
+System.Console.WriteLine(((System.Func<bool>)(() => TakeOutParam(1, out int x1) && Dummy(x1)))());
+
+static bool Dummy(int x) 
+{
+    System.Console.WriteLine(x);
+    return true;
+}
+
+static bool TakeOutParam(int y, out int x) 
+{
+    x = y;
+    return true;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            CompileAndVerify(compilation, expectedOutput: @"1
+True");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").Single();
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+        }
+
+        [Fact]
+        public void GlobalCode_Query_01()
+        {
+            var source =
+@"
+using System.Linq;
+
+bool Dummy(params object[] x) {return true;}
+
+var r01 = from x in new[] { TakeOutParam(1, out var y1) ? y1 : 0, y1}
+            select x + y1;
+
+Dummy(y1); 
+
+var r02 = from x1 in new[] { TakeOutParam(1, out var y2) ? y2 : 0}
+            from x2 in new[] { TakeOutParam(x1, out var z2) ? z2 : 0, z2, y2}
+            select x1 + x2 + y2 + 
+                    z2;
+
+Dummy(z2); 
+
+var r03 = from x1 in new[] { TakeOutParam(1, out var y3) ? y3 : 0}
+            let x2 = TakeOutParam(x1, out var z3) && z3 > 0 && y3 < 0 
+            select new { x1, x2, y3,
+                        z3};
+
+Dummy(z3); 
+
+var r04 = from x1 in new[] { TakeOutParam(1, out var y4) ? y4 : 0}
+            join x2 in new[] { TakeOutParam(2, out var z4) ? z4 : 0, z4, y4}
+                    on x1 + y4 + z4 + (TakeOutParam(3, out var u4) ? u4 : 0) + 
+                            v4 
+                        equals x2 + y4 + z4 + (TakeOutParam(4, out var v4) ? v4 : 0) +
+                            u4 
+            select new { x1, x2, y4, z4, 
+                        u4, v4 };
+
+Dummy(z4); 
+Dummy(u4); 
+Dummy(v4); 
+
+var r05 = from x1 in new[] { TakeOutParam(1, out var y5) ? y5 : 0}
+            join x2 in new[] { TakeOutParam(2, out var z5) ? z5 : 0, z5, y5}
+                    on x1 + y5 + z5 + (TakeOutParam(3, out var u5) ? u5 : 0) + 
+                            v5 
+                        equals x2 + y5 + z5 + (TakeOutParam(4, out var v5) ? v5 : 0) +
+                            u5 
+            into g
+            select new { x1, y5, z5, g,
+                        u5, v5 };
+
+Dummy(z5); 
+Dummy(u5); 
+Dummy(v5); 
+
+var r06 = from x in new[] { TakeOutParam(1, out var y6) ? y6 : 0}
+            where x > y6 && TakeOutParam(1, out var z6) && z6 == 1
+            select x + y6 +
+                    z6;
+
+Dummy(z6); 
+
+var r07 = from x in new[] { TakeOutParam(1, out var y7) ? y7 : 0}
+            orderby x > y7 && TakeOutParam(1, out var z7) && z7 == 
+                    u7,
+                    x > y7 && TakeOutParam(1, out var u7) && u7 == 
+                    z7   
+            select x + y7 +
+                    z7 + u7;
+
+Dummy(z7); 
+Dummy(u7); 
+
+var r08 = from x in new[] { TakeOutParam(1, out var y8) ? y8 : 0}
+            select x > y8 && TakeOutParam(1, out var z8) && z8 == 1;
+
+Dummy(z8); 
+
+var r09 = from x in new[] { TakeOutParam(1, out var y9) ? y9 : 0}
+            group x > y9 && TakeOutParam(1, out var z9) && z9 == 
+                u9
+            by
+                x > y9 && TakeOutParam(1, out var u9) && u9 == 
+                z9;   
+
+Dummy(z9); 
+Dummy(u9); 
+
+var r10 = from x1 in new[] { TakeOutParam(1, out var y10) ? y10 : 0}
+            from y10 in new[] { 1 }
+            select x1 + y10;
+
+var r11 = from x1 in new[] { TakeOutParam(1, out var y11) ? y11 : 0}
+            let y11 = x1 + 1
+            select x1 + y11;
+
+static bool TakeOutParam<T>(T y, out T x) 
+{
+    x = y;
+    return true;
+}
+";
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+                compilation.VerifyDiagnostics(
+                // (12,57): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //             from x2 in new[] { TakeOutParam(x1, out var z2) ? z2 : 0, z2, y2}
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z2").WithLocation(12, 57),
+                // (14,21): error CS0103: The name 'z2' does not exist in the current context
+                //                     z2;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(14, 21),
+                // (19,47): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //             let x2 = TakeOutParam(x1, out var z3) && z3 > 0 && y3 < 0 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z3").WithLocation(19, 47),
+                // (21,25): error CS0103: The name 'z3' does not exist in the current context
+                //                         z3};
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z3").WithArguments("z3").WithLocation(21, 25),
+                // (28,29): error CS0103: The name 'v4' does not exist in the current context
+                //                             v4 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(28, 29),
+                // (27,64): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                     on x1 + y4 + z4 + (TakeOutParam(3, out var u4) ? u4 : 0) + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u4").WithLocation(27, 64),
+                // (30,29): error CS1938: The name 'u4' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                             u4 
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "u4").WithArguments("u4").WithLocation(30, 29),
+                // (29,72): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                         equals x2 + y4 + z4 + (TakeOutParam(4, out var v4) ? v4 : 0) +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v4").WithLocation(29, 72),
+                // (32,25): error CS0103: The name 'u4' does not exist in the current context
+                //                         u4, v4 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(32, 25),
+                // (32,29): error CS0103: The name 'v4' does not exist in the current context
+                //                         u4, v4 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(32, 29),
+                // (41,29): error CS0103: The name 'v5' does not exist in the current context
+                //                             v5 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(41, 29),
+                // (40,64): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                     on x1 + y5 + z5 + (TakeOutParam(3, out var u5) ? u5 : 0) + 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u5").WithLocation(40, 64),
+                // (43,29): error CS1938: The name 'u5' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                             u5 
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "u5").WithArguments("u5").WithLocation(43, 29),
+                // (42,72): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                         equals x2 + y5 + z5 + (TakeOutParam(4, out var v5) ? v5 : 0) +
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "v5").WithLocation(42, 72),
+                // (46,25): error CS0103: The name 'u5' does not exist in the current context
+                //                         u5, v5 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(46, 25),
+                // (46,29): error CS0103: The name 'v5' does not exist in the current context
+                //                         u5, v5 };
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(46, 29),
+                // (53,53): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //             where x > y6 && TakeOutParam(1, out var z6) && z6 == 1
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z6").WithLocation(53, 53),
+                // (55,21): error CS0103: The name 'z6' does not exist in the current context
+                //                     z6;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z6").WithArguments("z6").WithLocation(55, 21),
+                // (61,21): error CS0103: The name 'u7' does not exist in the current context
+                //                     u7,
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(61, 21),
+                // (60,55): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //             orderby x > y7 && TakeOutParam(1, out var z7) && z7 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z7").WithLocation(60, 55),
+                // (63,21): error CS0103: The name 'z7' does not exist in the current context
+                //                     z7   
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(63, 21),
+                // (62,55): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                     x > y7 && TakeOutParam(1, out var u7) && u7 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u7").WithLocation(62, 55),
+                // (65,21): error CS0103: The name 'z7' does not exist in the current context
+                //                     z7 + u7;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(65, 21),
+                // (65,26): error CS0103: The name 'u7' does not exist in the current context
+                //                     z7 + u7;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(65, 26),
+                // (71,54): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //             select x > y8 && TakeOutParam(1, out var z8) && z8 == 1;
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z8").WithLocation(71, 54),
+                // (80,17): error CS0103: The name 'z9' does not exist in the current context
+                //                 z9;   
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z9").WithArguments("z9").WithLocation(80, 17),
+                // (79,51): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //                 x > y9 && TakeOutParam(1, out var u9) && u9 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "u9").WithLocation(79, 51),
+                // (77,17): error CS0103: The name 'u9' does not exist in the current context
+                //                 u9
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u9").WithArguments("u9").WithLocation(77, 17),
+                // (76,53): error CS8201: Out variable and pattern variable declarations are not allowed within a query clause.
+                //             group x > y9 && TakeOutParam(1, out var z9) && z9 == 
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInQueryClause, "z9").WithLocation(76, 53),
+                // (16,7): error CS0103: The name 'z2' does not exist in the current context
+                // Dummy(z2); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(16, 7),
+                // (23,7): error CS0103: The name 'z3' does not exist in the current context
+                // Dummy(z3); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z3").WithArguments("z3").WithLocation(23, 7),
+                // (35,7): error CS0103: The name 'u4' does not exist in the current context
+                // Dummy(u4); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(35, 7),
+                // (36,7): error CS0103: The name 'v4' does not exist in the current context
+                // Dummy(v4); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(36, 7),
+                // (49,7): error CS0103: The name 'u5' does not exist in the current context
+                // Dummy(u5); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(49, 7),
+                // (50,7): error CS0103: The name 'v5' does not exist in the current context
+                // Dummy(v5); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(50, 7),
+                // (57,7): error CS0103: The name 'z6' does not exist in the current context
+                // Dummy(z6); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z6").WithArguments("z6").WithLocation(57, 7),
+                // (67,7): error CS0103: The name 'z7' does not exist in the current context
+                // Dummy(z7); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z7").WithArguments("z7").WithLocation(67, 7),
+                // (68,7): error CS0103: The name 'u7' does not exist in the current context
+                // Dummy(u7); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u7").WithArguments("u7").WithLocation(68, 7),
+                // (73,7): error CS0103: The name 'z8' does not exist in the current context
+                // Dummy(z8); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z8").WithArguments("z8").WithLocation(73, 7),
+                // (82,7): error CS0103: The name 'z9' does not exist in the current context
+                // Dummy(z9); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z9").WithArguments("z9").WithLocation(82, 7),
+                // (83,7): error CS0103: The name 'u9' does not exist in the current context
+                // Dummy(u9); 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "u9").WithArguments("u9").WithLocation(83, 7),
+                // (62,62): error CS0165: Use of unassigned local variable 'u7'
+                //                     x > y7 && TakeOutParam(1, out var u7) && u7 == 
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "u7").WithArguments("u7").WithLocation(62, 62),
+                // (76,60): error CS0165: Use of unassigned local variable 'z9'
+                //             group x > y9 && TakeOutParam(1, out var z9) && z9 == 
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z9").WithArguments("z9").WithLocation(76, 60)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                var model = compilation.GetSemanticModel(tree);
+
+                var y1Decl = GetOutVarDeclarations(tree, "y1").Single();
+                var y1Ref = GetReferences(tree, "y1").ToArray();
+                Assert.Equal(4, y1Ref.Length);
+                VerifyModelForOutField(model, y1Decl, y1Ref);
+
+                var y2Decl = GetOutVarDeclarations(tree, "y2").Single();
+                var y2Ref = GetReferences(tree, "y2").ToArray();
+                Assert.Equal(3, y2Ref.Length);
+                VerifyModelForOutField(model, y2Decl, y2Ref);
+
+                var z2Decl = GetOutVarDeclarations(tree, "z2").Single();
+                var z2Ref = GetReferences(tree, "z2").ToArray();
+                Assert.Equal(4, z2Ref.Length);
+                VerifyModelForOutVar(model, z2Decl, z2Ref[0], z2Ref[1]);
+                VerifyNotInScope(model, z2Ref[2]);
+                VerifyNotInScope(model, z2Ref[3]);
+
+                var y3Decl = GetOutVarDeclarations(tree, "y3").Single();
+                var y3Ref = GetReferences(tree, "y3").ToArray();
+                Assert.Equal(3, y3Ref.Length);
+                VerifyModelForOutField(model, y3Decl, y3Ref);
+
+                var z3Decl = GetOutVarDeclarations(tree, "z3").Single();
+                var z3Ref = GetReferences(tree, "z3").ToArray();
+                Assert.Equal(3, z3Ref.Length);
+                VerifyModelForOutVar(model, z3Decl, z3Ref[0]);
+                VerifyNotInScope(model, z3Ref[1]);
+                VerifyNotInScope(model, z3Ref[2]);
+
+                var y4Decl = GetOutVarDeclarations(tree, "y4").Single();
+                var y4Ref = GetReferences(tree, "y4").ToArray();
+                Assert.Equal(5, y4Ref.Length);
+                VerifyModelForOutField(model, y4Decl, y4Ref);
+
+                var z4Decl = GetOutVarDeclarations(tree, "z4").Single();
+                var z4Ref = GetReferences(tree, "z4").ToArray();
+                Assert.Equal(6, z4Ref.Length);
+                VerifyModelForOutField(model, z4Decl, z4Ref);
+
+                var u4Decl = GetOutVarDeclarations(tree, "u4").Single();
+                var u4Ref = GetReferences(tree, "u4").ToArray();
+                Assert.Equal(4, u4Ref.Length);
+                VerifyModelForOutVar(model, u4Decl, u4Ref[0]);
+                VerifyNotInScope(model, u4Ref[1]);
+                VerifyNotInScope(model, u4Ref[2]);
+                VerifyNotInScope(model, u4Ref[3]);
+
+                var v4Decl = GetOutVarDeclarations(tree, "v4").Single();
+                var v4Ref = GetReferences(tree, "v4").ToArray();
+                Assert.Equal(4, v4Ref.Length);
+                VerifyNotInScope(model, v4Ref[0]);
+                VerifyModelForOutVar(model, v4Decl, v4Ref[1]);
+                VerifyNotInScope(model, v4Ref[2]);
+                VerifyNotInScope(model, v4Ref[3]);
+
+                var y5Decl = GetOutVarDeclarations(tree, "y5").Single();
+                var y5Ref = GetReferences(tree, "y5").ToArray();
+                Assert.Equal(5, y5Ref.Length);
+                VerifyModelForOutField(model, y5Decl, y5Ref);
+
+                var z5Decl = GetOutVarDeclarations(tree, "z5").Single();
+                var z5Ref = GetReferences(tree, "z5").ToArray();
+                Assert.Equal(6, z5Ref.Length);
+                VerifyModelForOutField(model, z5Decl, z5Ref);
+
+                var u5Decl = GetOutVarDeclarations(tree, "u5").Single();
+                var u5Ref = GetReferences(tree, "u5").ToArray();
+                Assert.Equal(4, u5Ref.Length);
+                VerifyModelForOutVar(model, u5Decl, u5Ref[0]);
+                VerifyNotInScope(model, u5Ref[1]);
+                VerifyNotInScope(model, u5Ref[2]);
+                VerifyNotInScope(model, u5Ref[3]);
+
+                var v5Decl = GetOutVarDeclarations(tree, "v5").Single();
+                var v5Ref = GetReferences(tree, "v5").ToArray();
+                Assert.Equal(4, v5Ref.Length);
+                VerifyNotInScope(model, v5Ref[0]);
+                VerifyModelForOutVar(model, v5Decl, v5Ref[1]);
+                VerifyNotInScope(model, v5Ref[2]);
+                VerifyNotInScope(model, v5Ref[3]);
+
+                var y6Decl = GetOutVarDeclarations(tree, "y6").Single();
+                var y6Ref = GetReferences(tree, "y6").ToArray();
+                Assert.Equal(3, y6Ref.Length);
+                VerifyModelForOutField(model, y6Decl, y6Ref);
+
+                var z6Decl = GetOutVarDeclarations(tree, "z6").Single();
+                var z6Ref = GetReferences(tree, "z6").ToArray();
+                Assert.Equal(3, z6Ref.Length);
+                VerifyModelForOutVar(model, z6Decl, z6Ref[0]);
+                VerifyNotInScope(model, z6Ref[1]);
+                VerifyNotInScope(model, z6Ref[2]);
+
+                var y7Decl = GetOutVarDeclarations(tree, "y7").Single();
+                var y7Ref = GetReferences(tree, "y7").ToArray();
+                Assert.Equal(4, y7Ref.Length);
+                VerifyModelForOutField(model, y7Decl, y7Ref);
+
+                var z7Decl = GetOutVarDeclarations(tree, "z7").Single();
+                var z7Ref = GetReferences(tree, "z7").ToArray();
+                Assert.Equal(4, z7Ref.Length);
+                VerifyModelForOutVar(model, z7Decl, z7Ref[0]);
+                VerifyNotInScope(model, z7Ref[1]);
+                VerifyNotInScope(model, z7Ref[2]);
+                VerifyNotInScope(model, z7Ref[3]);
+
+                var u7Decl = GetOutVarDeclarations(tree, "u7").Single();
+                var u7Ref = GetReferences(tree, "u7").ToArray();
+                Assert.Equal(4, u7Ref.Length);
+                VerifyNotInScope(model, u7Ref[0]);
+                VerifyModelForOutVar(model, u7Decl, u7Ref[1]);
+                VerifyNotInScope(model, u7Ref[2]);
+                VerifyNotInScope(model, u7Ref[3]);
+
+                var y8Decl = GetOutVarDeclarations(tree, "y8").Single();
+                var y8Ref = GetReferences(tree, "y8").ToArray();
+                Assert.Equal(2, y8Ref.Length);
+                VerifyModelForOutField(model, y8Decl, y8Ref);
+
+                var z8Decl = GetOutVarDeclarations(tree, "z8").Single();
+                var z8Ref = GetReferences(tree, "z8").ToArray();
+                Assert.Equal(2, z8Ref.Length);
+                VerifyModelForOutVar(model, z8Decl, z8Ref[0]);
+                VerifyNotInScope(model, z8Ref[1]);
+
+                var y9Decl = GetOutVarDeclarations(tree, "y9").Single();
+                var y9Ref = GetReferences(tree, "y9").ToArray();
+                Assert.Equal(3, y9Ref.Length);
+                VerifyModelForOutField(model, y9Decl, y9Ref);
+
+                var z9Decl = GetOutVarDeclarations(tree, "z9").Single();
+                var z9Ref = GetReferences(tree, "z9").ToArray();
+                Assert.Equal(3, z9Ref.Length);
+                VerifyModelForOutVar(model, z9Decl, z9Ref[0]);
+                VerifyNotInScope(model, z9Ref[1]);
+                VerifyNotInScope(model, z9Ref[2]);
+
+                var u9Decl = GetOutVarDeclarations(tree, "u9").Single();
+                var u9Ref = GetReferences(tree, "u9").ToArray();
+                Assert.Equal(3, u9Ref.Length);
+                VerifyNotInScope(model, u9Ref[0]);
+                VerifyModelForOutVar(model, u9Decl, u9Ref[1]);
+                VerifyNotInScope(model, u9Ref[2]);
+
+                var y10Decl = GetOutVarDeclarations(tree, "y10").Single();
+                var y10Ref = GetReferences(tree, "y10").ToArray();
+                Assert.Equal(2, y10Ref.Length);
+                VerifyModelForOutField(model, y10Decl, y10Ref[0]);
+                VerifyNotAnOutField(model, y10Ref[1]);
+
+                var y11Decl = GetOutVarDeclarations(tree, "y11").Single();
+                var y11Ref = GetReferences(tree, "y11").ToArray();
+                Assert.Equal(2, y11Ref.Length);
+                VerifyModelForOutField(model, y11Decl, y11Ref[0]);
+                VerifyNotAnOutField(model, y11Ref[1]);
+            }
+
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular);
+                int[] exclude = new int[] { (int)ErrorCode.ERR_EOFExpected,
+                                        (int)ErrorCode.ERR_CloseParenExpected,
+                                        (int)ErrorCode.ERR_SemicolonExpected,
+                                        (int)ErrorCode.ERR_TypeExpected,
+                                        (int)ErrorCode.ERR_NamespaceUnexpected,
+                                        (int)ErrorCode.ERR_TupleTooFewElements,
+                                        (int)ErrorCode.ERR_MemberNeedsType,
+                                        (int)ErrorCode.ERR_IdentifierExpected,
+                                        (int)ErrorCode.ERR_SyntaxError,
+                                        (int)ErrorCode.ERR_SingleTypeNameNotFound,
+                                        (int)ErrorCode.ERR_ConcreteMissingBody,
+                                        (int)ErrorCode.ERR_PredefinedValueTupleTypeNotFound,
+                                        (int)ErrorCode.ERR_TypeVarNotFound,
+                                        (int)ErrorCode.ERR_TupleElementNamesAttributeMissing,
+                                        (int)ErrorCode.ERR_IdentifierExpectedKW,
+                                        (int)ErrorCode.ERR_NameNotInContext,
+                                        (int)ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer,
+                                        (int)ErrorCode.ERR_ExpressionVariableInQueryClause
+                                      };
+
+                compilation.GetDiagnostics().Where(d => !exclude.Contains(d.Code)).Verify(
+                // (29,48): error CS1938: The name 'TakeOutParam' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                         equals x2 + y4 + z4 + (TakeOutParam(4, out var v4) ? v4 : 0) +
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "TakeOutParam").WithArguments("TakeOutParam").WithLocation(29, 48),
+                // (30,29): error CS1938: The name 'u4' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                             u4 
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "u4").WithArguments("u4").WithLocation(30, 29),
+                // (42,48): error CS1938: The name 'TakeOutParam' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                         equals x2 + y5 + z5 + (TakeOutParam(4, out var v5) ? v5 : 0) +
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "TakeOutParam").WithArguments("TakeOutParam").WithLocation(42, 48),
+                // (43,29): error CS1938: The name 'u5' is not in scope on the right side of 'equals'.  Consider swapping the expressions on either side of 'equals'.
+                //                             u5 
+                Diagnostic(ErrorCode.ERR_QueryInnerKey, "u5").WithArguments("u5").WithLocation(43, 29),
+                // (86,18): error CS1931: The range variable 'y10' conflicts with a previous declaration of 'y10'
+                //             from y10 in new[] { 1 }
+                Diagnostic(ErrorCode.ERR_QueryRangeVariableOverrides, "y10").WithArguments("y10").WithLocation(86, 18),
+                // (90,17): error CS1931: The range variable 'y11' conflicts with a previous declaration of 'y11'
+                //             let y11 = x1 + 1
+                Diagnostic(ErrorCode.ERR_QueryRangeVariableOverrides, "y11").WithArguments("y11").WithLocation(90, 17)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                AssertNoGlobalStatements(tree);
+            }
+        }
+
+        [Fact]
+        public void GlobalCode_Query_02()
+        {
+            var source =
+@"
+using System.Linq;
+
+var res = from x1 in new[] { TakeOutParam(1, out var y1) && Print(y1) ? 2 : 0}
+            select Print(x1);
+
+res.ToArray(); 
+
+static bool TakeOutParam<T>(T y, out T x) 
+{
+    x = y;
+    return true;
+}
+
+static bool Print(object x) 
+{
+    System.Console.WriteLine(x);
+    return true;
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+
+            CompileAndVerify(compilation, expectedOutput:
+@"1
+2");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yDecl = GetOutVarDeclarations(tree, "y1").Single();
+            var yRef = GetReferences(tree, "y1").Single();
+            VerifyModelForOutField(model, yDecl, yRef);
+        }
+
+        [Fact]
+        public void GlobalCode_Using_01()
+        {
+            var source =
+@"
+System.IDisposable Dummy(params object[] x) {return null;}
+
+using (Dummy(TakeOutParam(true, out var x1), x1))
+{
+    Dummy(x1);
+}
+ 
+using (Dummy(TakeOutParam(true, out var x2), x2))
+    Dummy(x2);
+ 
+var x4 = 11;
+Dummy(x4);
+
+using (Dummy(TakeOutParam(true, out var x4), x4))
+    Dummy(x4);
+ 
+using (Dummy(x6 && TakeOutParam(true, out var x6)))
+    Dummy(x6);
+ 
+using (Dummy(TakeOutParam(true, out var x7) && x7))
+{
+    var x7 = 12;
+    Dummy(x7);
+}
+ 
+using (Dummy(TakeOutParam(true, out var x8), x8))
+    Dummy(x8);
+
+System.Console.WriteLine(x8);
+ 
+using (Dummy(TakeOutParam(true, out var x9), x9))
+{   
+    Dummy(x9);
+    using (Dummy(TakeOutParam(true, out var x9), x9)) // 2
+        Dummy(x9);
+}
+
+using (Dummy(TakeOutParam(y10, out var x10), x10))
+{   
+    var y10 = 12;
+    Dummy(y10);
+}
+
+//    using (Dummy(TakeOutParam(y11, out var x11), x11))
+//    {   
+//        let y11 = 12;
+//        Dummy(y11);
+//    }
+
+using (Dummy(TakeOutParam(y12, out var x12), x12))
+    var y12 = 12;
+
+//    using (Dummy(TakeOutParam(y13, out var x13), x13))
+//        let y13 = 12;
+ 
+using (Dummy(TakeOutParam(1, out var x14), 
+                TakeOutParam(2, out var x14), 
+                x14))
+{
+    Dummy(x14);
+}
+
+static bool TakeOutParam<T>(T y, out T x) 
+{
+    x = y;
+    return true;
+}
+";
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+                compilation.VerifyDiagnostics(
+                // (52,5): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //     var y12 = 12;
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "var y12 = 12;").WithLocation(52, 5),
+                // (18,14): error CS0841: Cannot use local variable 'x6' before it is declared
+                // using (Dummy(x6 && TakeOutParam(true, out var x6)))
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(18, 14),
+                // (23,9): error CS0136: A local or parameter named 'x7' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     var x7 = 12;
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x7").WithArguments("x7").WithLocation(23, 9),
+                // (30,26): error CS0103: The name 'x8' does not exist in the current context
+                // System.Console.WriteLine(x8);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(30, 26),
+                // (35,45): error CS0136: A local or parameter named 'x9' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //     using (Dummy(TakeOutParam(true, out var x9), x9)) // 2
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x9").WithArguments("x9").WithLocation(35, 45),
+                // (39,27): error CS0103: The name 'y10' does not exist in the current context
+                // using (Dummy(TakeOutParam(y10, out var x10), x10))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "y10").WithArguments("y10").WithLocation(39, 27),
+                // (51,27): error CS0103: The name 'y12' does not exist in the current context
+                // using (Dummy(TakeOutParam(y12, out var x12), x12))
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(51, 27),
+                // (58,41): error CS0128: A local variable or function named 'x14' is already defined in this scope
+                //                 TakeOutParam(2, out var x14), 
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(58, 41),
+                // (52,9): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //     var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(52, 9)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                var model = compilation.GetSemanticModel(tree);
+
+                var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+                var x1Ref = GetReferences(tree, "x1").ToArray();
+                Assert.Equal(2, x1Ref.Length);
+                VerifyModelForOutVar(model, x1Decl, x1Ref);
+
+                var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
+                var x2Ref = GetReferences(tree, "x2").ToArray();
+                Assert.Equal(2, x2Ref.Length);
+                VerifyModelForOutVar(model, x2Decl, x2Ref);
+
+                var x4Decl = GetOutVarDeclarations(tree, "x4").Single();
+                var x4Ref = GetReferences(tree, "x4").ToArray();
+                Assert.Equal(3, x4Ref.Length);
+                VerifyNotAnOutLocal(model, x4Ref[0]);
+                VerifyModelForOutVar(model, x4Decl, x4Ref[1], x4Ref[2]);
+
+                var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
+                var x6Ref = GetReferences(tree, "x6").ToArray();
+                Assert.Equal(2, x6Ref.Length);
+                VerifyModelForOutVar(model, x6Decl, x6Ref);
+
+                var x7Decl = GetOutVarDeclarations(tree, "x7").Single();
+                var x7Ref = GetReferences(tree, "x7").ToArray();
+                Assert.Equal(2, x7Ref.Length);
+                VerifyModelForOutVar(model, x7Decl, x7Ref[0]);
+                VerifyNotAnOutLocal(model, x7Ref[1]);
+
+                var x8Decl = GetOutVarDeclarations(tree, "x8").Single();
+                var x8Ref = GetReferences(tree, "x8").ToArray();
+                Assert.Equal(3, x8Ref.Length);
+                VerifyModelForOutVar(model, x8Decl, x8Ref[0], x8Ref[1]);
+                VerifyNotInScope(model, x8Ref[2]);
+
+                var x9Decl = GetOutVarDeclarations(tree, "x9").ToArray();
+                var x9Ref = GetReferences(tree, "x9").ToArray();
+                Assert.Equal(2, x9Decl.Length);
+                Assert.Equal(4, x9Ref.Length);
+                VerifyModelForOutVar(model, x9Decl[0], x9Ref[0], x9Ref[1]);
+                VerifyModelForOutVar(model, x9Decl[1], x9Ref[2], x9Ref[3]);
+
+                var x10Decl = GetOutVarDeclarations(tree, "x10").Single();
+                var x10Ref = GetReferences(tree, "x10").Single();
+                VerifyModelForOutVar(model, x10Decl, x10Ref);
+
+                var y10Ref = GetReferences(tree, "y10").ToArray();
+                Assert.Equal(2, y10Ref.Length);
+                VerifyNotInScope(model, y10Ref[0]);
+                VerifyNotAnOutLocal(model, y10Ref[1]);
+
+                var y12Ref = GetReferences(tree, "y12").Single();
+                VerifyNotInScope(model, y12Ref);
+
+                var x14Decl = GetOutVarDeclarations(tree, "x14").ToArray();
+                var x14Ref = GetReferences(tree, "x14").ToArray();
+                Assert.Equal(2, x14Decl.Length);
+                Assert.Equal(2, x14Ref.Length);
+                VerifyModelForOutVar(model, x14Decl[0], x14Ref);
+                VerifyModelForOutVarDuplicateInSameScope(model, x14Decl[1]);
+            }
+
+            {
+                var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseDll, parseOptions: TestOptions.Regular);
+                int[] exclude = new int[] { (int)ErrorCode.ERR_EOFExpected,
+                                        (int)ErrorCode.ERR_CloseParenExpected,
+                                        (int)ErrorCode.ERR_SemicolonExpected,
+                                        (int)ErrorCode.ERR_TypeExpected,
+                                        (int)ErrorCode.ERR_NamespaceUnexpected,
+                                        (int)ErrorCode.ERR_TupleTooFewElements,
+                                        (int)ErrorCode.ERR_IdentifierExpected,
+                                        (int)ErrorCode.ERR_MemberNeedsType,
+                                        (int)ErrorCode.ERR_IdentifierExpectedKW,
+                                        (int)ErrorCode.ERR_SingleTypeNameNotFound,
+                                        (int)ErrorCode.ERR_ConcreteMissingBody,
+                                        (int)ErrorCode.ERR_TypeVarNotFound,
+                                        (int)ErrorCode.ERR_DuplicateNameInClass
+                                      };
+
+                compilation.GetDiagnostics().Where(d => !exclude.Contains(d.Code)).Verify(
+                // (16,5): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //     Dummy(x4);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(16, 5),
+                // (36,9): error CS0111: Type '<invalid-global-code>' already defines a member called 'Dummy' with the same parameter types
+                //         Dummy(x9);
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "Dummy").WithArguments("Dummy", "<invalid-global-code>").WithLocation(36, 9),
+                // (58,17): error CS0111: Type '<invalid-global-code>' already defines a member called 'TakeOutParam' with the same parameter types
+                //                 TakeOutParam(2, out var x14), 
+                Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "TakeOutParam").WithArguments("TakeOutParam", "<invalid-global-code>").WithLocation(58, 17)
+                    );
+
+                var tree = compilation.SyntaxTrees.Single();
+                Assert.Empty(GetOutVarDeclarations(tree));
+                AssertNoGlobalStatements(tree);
+            }
+        }
+
+        [Fact]
+        public void GlobalCode_Using_02()
+        {
+            var source =
+@"
+using (System.IDisposable d1 = Dummy(new C(""a""), TakeOutParam(new C(""b""), out var x1)),
+                            d2 = Dummy(new C(""c""), TakeOutParam(new C(""d""), out var x2)))
+{
+    System.Console.WriteLine(d1);
+    System.Console.WriteLine(x1);
+    System.Console.WriteLine(d2);
+    System.Console.WriteLine(x2);
+}
+
+using (Dummy(new C(""e""), TakeOutParam(new C(""f""), out var x1)))
+{
+    System.Console.WriteLine(x1);
+}
+
+static System.IDisposable Dummy(System.IDisposable x, params object[] y) {return x;}
+
+static bool TakeOutParam<T>(T y, out T x) 
+{
+    x = y;
+    return true;
+}
+
+class C : System.IDisposable
+{
+    private readonly string _val;
+
+    public C(string val)
+    {
+        _val = val;
+    }
+
+    public void Dispose()
+    {
+        System.Console.WriteLine(""Disposing {0}"", _val);
+    }
+
+    public override string ToString()
+    {
+        return _val;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
+            CompileAndVerify(compilation, expectedOutput:
+@"a
+b
+c
+d
+Disposing c
+Disposing a
+f
+Disposing e");
         }
 
         [Fact]


### PR DESCRIPTION
Closes #14113.

@dotnet/roslyn-compiler Please review.