### PR TITLE
Prevent error on Analyzer project creation

### DIFF
--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
@@ -39,7 +39,7 @@
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
       <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
-      <package id="NuGet.CommandLine" />
+      <package id="NuGet.CommandLine" version="2.8.5" />
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/DiagnosticAnalyzer.vstemplate
@@ -41,7 +41,7 @@
       <package id="System.Collections.Immutable" version="1.1.36" skipAssemblyReferences="false" />
       <package id="System.Reflection.Metadata" version="1.0.21" skipAssemblyReferences="false" />
       <package id="Microsoft.Composition" version="1.0.27" skipAssemblyReferences="false" />
-      <package id="NuGet.CommandLine" />
+      <package id="NuGet.CommandLine" version="2.8.5" />
     </packages>
   </WizardData>
 </VSTemplate>


### PR DESCRIPTION
Nuget in Dev15 requires vstemplates to have both "id" and "version" this change prevents an error on RC.3 and above