### PR TITLE
Add test binding redirect for System.Xml.XmlDocument

### DIFF
--- a/build/Defaults/Desktop/app.config
+++ b/build/Defaults/Desktop/app.config
@@ -66,6 +66,10 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XmlDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
       </dependentAssembly>

--- a/build/Defaults/Portable/app.config
+++ b/build/Defaults/Portable/app.config
@@ -66,6 +66,10 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Xml.XmlDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
       </dependentAssembly>


### PR DESCRIPTION
Port of https://github.com/dotnet/roslyn/pull/16956 to master.

The app.config files used for unit tests are missing a binding redirect likely needed due to recent changes to PDB validation test helpers.

Fixes #16790.