### PR TITLE
Clean up some lifetime state management in AbstractLanguageService

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
@@ -62,10 +62,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         internal AnalyzerFileWatcherService AnalyzerFileWatcherService { get; private set; }
 
         /// <summary>
-        /// Whether or not we have been torn down.  This is currently only used to make sure we are
-        /// not torn down twice.
+        /// Whether or not we have been set up. This is set once everything is wired up and cleared once tear down has begun.
         /// </summary>
-        private bool _isTornDown;
+        /// <remarks>
+        /// We don't set this until we've completed setup. If something goes sideways during it, we will never register
+        /// with the shell and thus have a floating thing around that can't be safely shut down either. We're in a bad
+        /// state but trying to proceed will only make things worse.
+        /// </remarks>
+        private bool _isSetUp;
 
         protected AbstractLanguageService(
             TPackage package)
@@ -105,6 +109,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             // debugging).  We must not assume anything about our initial state and must instead
             // query for all the information we need at this point.
             this.Initialize();
+
+            _isSetUp = true;
         }
 
         private object CreateComAggregate()
@@ -114,14 +120,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         internal void TearDown()
         {
-            if (_isTornDown)
+            if (!_isSetUp)
             {
                 throw new InvalidOperationException();
             }
 
-            _isTornDown = true;
-
+            _isSetUp = false;
             GC.SuppressFinalize(this);
+
             this.Uninitialize();
             this.DisconnectFromServices();
             this.RemoveServices();
@@ -129,7 +135,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         ~AbstractLanguageService()
         {
-            if (!Environment.HasShutdownStarted)
+            if (!Environment.HasShutdownStarted && _isSetUp)
             {
                 throw new InvalidOperationException("TearDown not called!");
             }


### PR DESCRIPTION
This type follows the pattern that we assert in the finalizer that it
should have been cleaned up. If the type failed to initialize, we would
throw and crash the process even though the underlying failure is
already past at that point. I'm not saying we shouldn't crash there,
but that's a separate decision and we should then target the correct
place.

*Review:* @dotnet/roslyn-ide