### PR TITLE
Capture better dumps for DevDiv #363724

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
@@ -51,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     let texts = GetDisplayAndInsertionText(symbol, context)
                     group symbol by texts into g
                     select this.CreateItem(
-                        g.Key.displayText, g.Key.insertionText, g.ToList(), context, 
+                        g.Key.displayText, g.Key.insertionText, g.ToList(), context,
                         invalidProjectMap, totalProjects, preselect);
 
             return q.ToList();
@@ -233,9 +234,16 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         private Task<ImmutableArray<ISymbol>> GetSymbolsWorker(int position, bool preselect, SyntaxContext context, OptionSet options, CancellationToken cancellationToken)
         {
-            return preselect
-                ? GetPreselectedSymbolsWorker(context, position, options, cancellationToken)
-                : GetSymbolsWorker(context, position, options, cancellationToken);
+            try
+            {
+                return preselect
+                    ? GetPreselectedSymbolsWorker(context, position, options, cancellationToken)
+                    : GetSymbolsWorker(context, position, options, cancellationToken);
+            }
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
         }
 
         private HashSet<ISymbol> UnionSymbols(List<Tuple<DocumentId, SyntaxContext, ImmutableArray<ISymbol>>> linkedContextSymbolLists, out Dictionary<ISymbol, SyntaxContext> originDictionary)
@@ -312,7 +320,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         /// <param name="linkedContextSymbolLists">The symbols recommended in linked documents</param>
         /// <returns>The list of projects each recommended symbol did NOT appear in.</returns>
         protected Dictionary<ISymbol, List<ProjectId>> FindSymbolsMissingInLinkedContexts(
-            HashSet<ISymbol> expectedSymbols, 
+            HashSet<ISymbol> expectedSymbols,
             IEnumerable<Tuple<DocumentId, SyntaxContext, ImmutableArray<ISymbol>>> linkedContextSymbolLists)
         {
             var missingSymbols = new Dictionary<ISymbol, List<ProjectId>>(LinkedFilesSymbolEquivalenceComparer.Instance);


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems?id=363724&fullScreen=true&_a=edit

Very infrequently, ImplementsClauseCompletionProvider is asked to provide symbols with a null context. It's not clear why this would happen. Add a FatalError.Report if we try to call any provider with a null context.
Tag @dotnet/roslyn-ide for review

Captures better dumps for https://devdiv.visualstudio.com/DevDiv/_workitems?id=363724&fullScreen=true&_a=edit

**Customer scenario**

There is an infrequent and difficult to diagnose crash in completion. This change adds an exception filter that will capture better dumps when the crash occurs

**Bugs this fixes:** 

Gathers more data for https://devdiv.visualstudio.com/DevDiv/_workitems?id=363724&fullScreen=true&_a=edit

**Workarounds, if any**

N/A, this is a reporting change.

**Risk**

Low, this change just adds an exception filter.

**Performance impact**

Low, no allocation or complexity changes

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

N/A

**How was the bug found?**

Watson hits (currently 12).