### PR TITLE
Pass along the value that was unexpected when we encounter one.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Syntax/LambdaUtilities.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/LambdaUtilities.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return If(oldJoinCondition.Left Is oldBody, GetJoinLeftLambdaBody(newJoinClause), GetJoinRightLambdaBody(newJoinClause))
 
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(oldLambda.Kind)
             End Select
         End Function
 
@@ -587,7 +587,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return DirectCast(clause, JoinClauseSyntax).JoinedVariables
 
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(clause.Kind)
             End Select
         End Function
 

--- a/src/EditorFeatures/CSharp/AutomaticCompletion/CSharpBraceCompletionSessionProvider.cs
+++ b/src/EditorFeatures/CSharp/AutomaticCompletion/CSharpBraceCompletionSessionProvider.cs
@@ -80,9 +80,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.AutomaticCompletion
                 case BraceCompletionSessionProvider.Parenthesis.OpenCharacter: return new ParenthesisCompletionSession(syntaxFactsService);
                 case BraceCompletionSessionProvider.SingleQuote.OpenCharacter: return new CharLiteralCompletionSession(syntaxFactsService);
                 case BraceCompletionSessionProvider.LessAndGreaterThan.OpenCharacter: return new LessAndGreaterThanCompletionSession(syntaxFactsService);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(openingBrace);
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/IEditorInlineRenameService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor
                     return InlineRenameReplacementKind.UnresolvedConflict;
                 default:
                 case RelatedLocationType.PossiblyResolvableConflict:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(location.Type);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                         return RenameSpanKind.Complexified;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(kind);
                 }
             }
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Taggers/RenameTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Taggers/RenameTagger.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     tagKind = FixupTag.Instance;
                     break;
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(type);
             }
 
             tagSpan = new TagSpan<ITextMarkerTag>(span, tagKind);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/FileSystemCompletionHelper.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/FileSystem/FileSystemCompletionHelper.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.F
                     break;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(pathKind);
             }
 
             return result.ToImmutableAndFree();

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ClassificationTags.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ClassificationTags.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Classification
                     return ClassificationTypeNames.Text;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(textTag);
             }
         }
     }

--- a/src/EditorFeatures/VisualBasic/AutomaticCompletion/VisualBasicBraceCompletionSessionProvider.vb
+++ b/src/EditorFeatures/VisualBasic/AutomaticCompletion/VisualBasicBraceCompletionSessionProvider.vb
@@ -63,10 +63,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion
                     Else
                         Return New StringLiteralCompletionSession(syntaxFactsService)
                     End If
-
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(openingBrace)
             End Select
-
-            Throw ExceptionUtilities.Unreachable
         End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.SimplifyTypeNames
                     return CSharpFeaturesResources.Remove_this_qualification;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(diagnosticId);
             }
         }
 

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1725,7 +1725,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         return;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(_kind);
                 }
             }
 
@@ -1793,7 +1793,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         return;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(newNode.Kind());
                 }
             }
 
@@ -2209,7 +2209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         return;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(newNode.Kind());
                 }
             }
 
@@ -3039,7 +3039,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return ((ReturnStatementSyntax)statement).Expression;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(statement.Kind());
             }
         }
 

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -740,7 +740,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     break;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(lambda.Kind());
             }
         }
 
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return true;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(leftBlock.Parent.Kind());
             }
         }
 

--- a/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/SuppressionHelpers.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                     return true;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(diagnostic.Severity);
             }
         }
 

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeCodeAction.cs
@@ -42,9 +42,9 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                         return string.Format(FeaturesResources.Rename_type_to_0, _state.DocumentName);
                     case OperationKind.RenameFile:
                         return string.Format(FeaturesResources.Rename_file_to_0, _fileName);
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(_operationKind);
                 }
-
-                throw ExceptionUtilities.Unreachable;
             }
 
             public override string Title => _title;
@@ -65,9 +65,9 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                         return new RenameTypeEditor(_service, _state, _fileName, cancellationToken);
                     case OperationKind.RenameFile:
                         return new RenameFileEditor(_service, _state, _fileName, cancellationToken);
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(_operationKind);
                 }
-
-                throw ExceptionUtilities.Unreachable;
             }
 
             internal override bool PerformFinalApplicabilityCheck => true;

--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis
                     return ClassificationTypeNames.Text;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(taggedTextTag);
             }
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractOverrideCompletionProvider.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 case SymbolKind.Property:
                     return ((IPropertySymbol)symbol).Type;
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
             }
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 case DiagnosticSeverity.Error:
                     return ReportDiagnostic.Error;
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(severity);
             }
         }
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
                     break;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(diagnosticId);
             }
 
             if (descriptor == null)

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2117,7 +2117,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     case EditKind.Move:
                         // Move is always a Rude Edit.
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(edit.Kind);
 
                     case EditKind.Delete:
                         {
@@ -2382,7 +2382,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         break;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(edit.Kind);
                 }
 
                 semanticEdits.Add(new SemanticEdit(editKind, oldSymbol, newSymbol, syntaxMapOpt, preserveLocalVariables: syntaxMapOpt != null));

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     case MethodGenerationKind.ExplicitConversion:
                         return _service.GetExplicitConversionDisplayText(_state);
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(state.MethodGenerationKind);
                 }
             }
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -55,9 +55,10 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
                     case SymbolKind.Property:
                         return new WrappedPropertySymbol((IPropertySymbol)m, canImplementImplicitly, docCommentFormattingService);
-                }
 
-                throw ExceptionUtilities.Unreachable;
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(m.Kind);
+                }
             }
 
             public bool IsAnonymousType => _symbol.IsAnonymousType;

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 case SymbolKind.Event:
                     return CodeStyleOptions.QualifyEventAccess;
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(symbolKind);
             }
         }
     }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         ProcessDocumentEvent(args, asyncToken);
                         break;
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(args.Kind);
                 }
             }
 
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         break;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(e.Kind);
                 }
             }
 
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         EnqueueEvent(e.OldSolution, e.NewSolution, e.ProjectId, asyncToken);
                         break;
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(e.Kind);
                 }
             }
 
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         EnqueueEvent(e.OldSolution, e.NewSolution, asyncToken);
                         break;
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(e.Kind);
                 }
             }
 

--- a/src/Features/VisualBasic/Portable/CodeFixes/IncorrectExitContinue/IncorrectExitContinueCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/IncorrectExitContinue/IncorrectExitContinueCodeFixProvider.vb
@@ -267,7 +267,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.IncorrectExitContinue
                 Case SyntaxKind.GetAccessorBlock, SyntaxKind.SetAccessorBlock
                     Return SyntaxKind.ExitPropertyStatement
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(blockKind)
             End Select
         End Function
 
@@ -284,7 +284,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.IncorrectExitContinue
                 Case SyntaxKind.WhileBlock
                     Return SyntaxKind.ContinueWhileStatement
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(blockKind)
             End Select
         End Function
 

--- a/src/Features/VisualBasic/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
                     Return String.Format(VBFeaturesResources.Simplify_member_access_0, nodeText)
 
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(simplifyDiagnosticId)
             End Select
         End Function
 

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/RecommendationHelpers.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/RecommendationHelpers.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders
                                    arrayCreation.Initializer.CloseBraceToken,
                                    asNewClause.Type.GetLastToken(includeZeroWidth:=True))
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(asNewClause.NewExpression.Kind)
             End Select
 
             Return token = lastToken

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics.RemoveUnnecessaryCast
                 Case SyntaxKind.PredefinedCastExpression
                     Return DirectCast(node, PredefinedCastExpressionSyntax).IsUnnecessaryCast(model, assumeCallKeyword:=True, cancellationToken:=cancellationToken)
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
         End Function
 
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics.RemoveUnnecessaryCast
                 Case SyntaxKind.PredefinedCastExpression
                     Return DirectCast(node, PredefinedCastExpressionSyntax).Keyword.Span
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
         End Function
     End Class

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -1437,7 +1437,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         endToken = header.DeclarationKeyword
 
                     Case Else
-                        Throw ExceptionUtilities.Unreachable
+                        Throw ExceptionUtilities.UnexpectedValue(header.Kind)
                 End Select
             End If
 
@@ -1786,7 +1786,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return
 
                     Case Else
-                        Throw ExceptionUtilities.Unreachable
+                        Throw ExceptionUtilities.UnexpectedValue(_kind)
                 End Select
             End Sub
 
@@ -1865,7 +1865,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return
 
                     Case Else
-                        Throw ExceptionUtilities.Unreachable
+                        Throw ExceptionUtilities.UnexpectedValue(newNode.Kind)
                 End Select
             End Sub
 
@@ -2167,7 +2167,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return
 
                     Case Else
-                        Throw ExceptionUtilities.Unreachable
+                        Throw ExceptionUtilities.UnexpectedValue(oldNode.Kind)
                 End Select
             End Sub
 
@@ -2339,7 +2339,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                         Return
 
                     Case Else
-                        Throw ExceptionUtilities.Unreachable
+                        Throw ExceptionUtilities.UnexpectedValue(newNode.Kind)
                 End Select
             End Sub
 
@@ -3093,7 +3093,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                     Return DirectCast(statement, ReturnStatementSyntax).Expression
 
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(statement.Kind())
             End Select
         End Function
 

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -859,7 +859,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                             break;
 
                         default:
-                            throw ExceptionUtilities.Unreachable;
+                            throw ExceptionUtilities.UnexpectedValue(_lastEditSessionSummary);
                     }
 
                     log.Write("EnC state of '{0}' queried: {1}{2}",

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
@@ -589,7 +589,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                     break;
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(namedType.TypeKind);
             }
 
             node[DgmlNodeProperties.Icon] = IconHelper.GetIconName(iconGroupName, namedType.DeclaredAccessibility);

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectOptionsHelper.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProjectOptionsHelper.vb
@@ -267,7 +267,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                     Return ReportDiagnostic.Error
 
                 Case Else
-                    Throw ExceptionUtilities.Unreachable
+                    Throw ExceptionUtilities.UnexpectedValue(level)
             End Select
         End Function
 

--- a/src/Workspaces/CSharp/Portable/Extensions/BaseParameterListSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/BaseParameterListSyntaxExtensions.cs
@@ -20,9 +20,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((BracketedParameterListSyntax)parameterList).WithParameters(parameters);
                 case SyntaxKind.ParameterList:
                     return ((ParameterListSyntax)parameterList).WithParameters(parameters);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(parameterList.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/TypeDeclarationSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/TypeDeclarationSyntaxExtensions.cs
@@ -26,9 +26,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).AddMembers(members);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).AddMembers(members);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithMembers(
@@ -42,9 +42,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithMembers(members);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithMembers(members);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithAttributeLists(
@@ -58,9 +58,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithAttributeLists(attributes);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithAttributeLists(attributes);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithIdentifier(
@@ -74,9 +74,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithIdentifier(identifier);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithIdentifier(identifier);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithModifiers(
@@ -90,9 +90,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithModifiers(modifiers);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithModifiers(modifiers);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithTypeParameterList(
@@ -106,9 +106,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithTypeParameterList(list);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithTypeParameterList(list);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithBaseList(
@@ -122,9 +122,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithBaseList(list);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithBaseList(list);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithConstraintClauses(
@@ -138,9 +138,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithConstraintClauses(constraintClauses);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithConstraintClauses(constraintClauses);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithOpenBraceToken(
@@ -154,9 +154,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithOpenBraceToken(openBrace);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithOpenBraceToken(openBrace);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static TypeDeclarationSyntax WithCloseBraceToken(
@@ -170,9 +170,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return ((InterfaceDeclarationSyntax)node).WithCloseBraceToken(closeBrace);
                 case SyntaxKind.StructDeclaration:
                     return ((StructDeclarationSyntax)node).WithCloseBraceToken(closeBrace);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(node.Kind());
             }
-
-            throw ExceptionUtilities.Unreachable;
         }
 
         public static IList<bool> GetInsertionIndices(this TypeDeclarationSyntax destination, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllState.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllState.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                     return string.Format(WorkspacesResources.Fix_all_0_in_Solution, diagnosticId);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(this.Scope);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Formatting/Rules/BaseIndentationFormattingRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/BaseIndentationFormattingRule.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
                 case IndentBlockOption.AbsolutePosition:
                     return FormattingOperations.CreateIndentBlockOperation(operation.StartToken, operation.EndToken, AdjustTextSpan(operation.TextSpan), operation.IndentationDeltaOrPosition, operation.Option);
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(operation.Option);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                         break;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(lineOperation.Option);
                 }
             }
 
@@ -556,7 +556,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                         return existingWhitespaceBetween.Spaces;
 
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(rule.IndentationOperation);
                 }
             }
 
@@ -570,7 +570,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return Math.Max(rule.Spaces, 0);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(rule.SpaceOperation);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return IsMemberAccessible(symbol.ContainingType, symbol.DeclaredAccessibility, within, throughTypeOpt, out failedThroughTypeCheck);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
             }
         }
 
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return withinAssembly.IsSameAssemblyOrHasFriendAccessTo(assembly);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(declaredAccessibility);
             }
         }
 
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return IsProtectedSymbolAccessible(withinNamedType, withinAssembly, throughTypeOpt, originalContainingType, out failedThroughTypeCheck);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(declaredAccessibility);
             }
         }
 

--- a/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/ReduceTokensCodeCleanupProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeCleanup/Providers/ReduceTokensCodeCleanupProvider.vb
@@ -278,7 +278,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                         Dim asLong = CType(ConvertToULong(value), Long)
                         Return "&B" + Convert.ToString(asLong, 2)
                     Case Else
-                        Throw ExceptionUtilities.Unreachable
+                        Throw ExceptionUtilities.UnexpectedValue(base)
                 End Select
             End Function
 
@@ -296,7 +296,7 @@ Namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
                     Case SyntaxKind.IntegerLiteralToken
                         Return token.CopyAnnotationsTo(SyntaxFactory.IntegerLiteralToken(leading, newValueString, token.GetBase().Value, token.GetTypeCharacter(), DirectCast(newValue, ULong), trailing))
                     Case Else
-                        Throw ExceptionUtilities.Unreachable
+                        Throw ExceptionUtilities.UnexpectedValue(token.Kind)
                 End Select
             End Function
 

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/ExpressionGenerator.StringPiece.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/ExpressionGenerator.StringPiece.vb
@@ -68,9 +68,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                         Return GenerateStringConstantExpression("vbTab")
                     Case StringPieceKind.VerticalTab
                         Return GenerateStringConstantExpression("vbVerticalTab")
+                    Case Else
+                        Throw ExceptionUtilities.UnexpectedValue(Me.Kind)
                 End Select
-
-                Throw ExceptionUtilities.Unreachable
             End Function
 
             Private Shared Function GenerateStringConstantExpression(name As String) As MemberAccessExpressionSyntax

--- a/src/Workspaces/VisualBasic/Portable/Extensions/MethodBaseSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/MethodBaseSyntaxExtensions.vb
@@ -38,5 +38,4 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Throw ExceptionUtilities.Unreachable
         End Function
     End Module
-
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Extensions/TypeBlockSyntaxExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/TypeBlockSyntaxExtensions.vb
@@ -18,9 +18,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Return DirectCast(node, StructureBlockSyntax).WithInherits(list)
                 Case SyntaxKind.ClassBlock
                     Return DirectCast(node, ClassBlockSyntax).WithInherits(list)
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
-
-            Throw ExceptionUtilities.Unreachable
         End Function
 
         <Extension>
@@ -34,9 +34,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Return DirectCast(node, StructureBlockSyntax).WithImplements(list)
                 Case SyntaxKind.ClassBlock
                     Return DirectCast(node, ClassBlockSyntax).WithImplements(list)
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
-
-            Throw ExceptionUtilities.Unreachable
         End Function
 
         <Extension>
@@ -50,9 +50,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Return DirectCast(node, StructureBlockSyntax).AddMembers(members)
                 Case SyntaxKind.ClassBlock
                     Return DirectCast(node, ClassBlockSyntax).AddMembers(members)
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
-
-            Throw ExceptionUtilities.Unreachable
         End Function
 
         <Extension>
@@ -66,9 +66,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Return DirectCast(node, StructureBlockSyntax).WithMembers(members)
                 Case SyntaxKind.ClassBlock
                     Return DirectCast(node, ClassBlockSyntax).WithMembers(members)
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
-
-            Throw ExceptionUtilities.Unreachable
         End Function
 
         <Extension>
@@ -82,9 +82,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Return DirectCast(node, StructureBlockSyntax).WithBlockStatement(DirectCast([begin], StructureStatementSyntax))
                 Case SyntaxKind.ClassBlock
                     Return DirectCast(node, ClassBlockSyntax).WithBlockStatement(DirectCast([begin], ClassStatementSyntax))
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
-
-            Throw ExceptionUtilities.Unreachable
         End Function
 
         <Extension>
@@ -98,9 +98,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                     Return DirectCast(node, StructureBlockSyntax).WithEndBlockStatement([end])
                 Case SyntaxKind.ClassBlock
                     Return DirectCast(node, ClassBlockSyntax).WithEndBlockStatement([end])
+                Case Else
+                    Throw ExceptionUtilities.UnexpectedValue(node.Kind)
             End Select
-
-            Throw ExceptionUtilities.Unreachable
         End Function
 
         <Extension>


### PR DESCRIPTION
This helps in debugging because we can better track down what value we encountered that caused a problem.