### PR TITLE
Downgrade SyntaxVisualizerExtension dependencies

### DIFF
--- a/build/config/RepoUtilData.json
+++ b/build/config/RepoUtilData.json
@@ -1,6 +1,14 @@
 ﻿{
   "fixedPackages": {
     "Microsoft.VSSDK.BuildTools": [ "14.3.25420" ],
+    "Microsoft.VisualStudio.CoreUtility": [ "[14.0.23205]" ],
+    "Microsoft.VisualStudio.Editor": [ "[14.0.23205]" ],
+    "Microsoft.VisualStudio.Text.Data": [ "[14.0.23205]" ],
+    "Microsoft.VisualStudio.Text.Logic": [ "[14.0.23205]" ],
+    "Microsoft.VisualStudio.Text.UI": [ "[14.0.23205]" ],
+    "Microsoft.VisualStudio.Text.UI.Wpf": [ "[14.0.23205]" ],
+    "Microsoft.VisualStudio.Utilities": [ "[14.0.23205]" ],
+    "Microsoft.VisualStudio.Shell.14.0": [ "[14.0.23205]" ],
     "Newtonsoft.Json": "9.0.1",
     "System.Reflection.Metadata": "1.0.21",
     "System.Collections.Immutable": "1.1.36",

--- a/src/Setup/Templates/source.extension.vsixmanifest
+++ b/src/Setup/Templates/source.extension.vsixmanifest
@@ -32,5 +32,6 @@
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.VSSDK" Version="[15.0,16.0)" DisplayName="Visual Studio SDK" />
   </Prerequisites>
 </PackageManifest>

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerContainer.xaml
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerContainer.xaml
@@ -4,7 +4,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
              xmlns:s="clr-namespace:Roslyn.SyntaxVisualizer.Control;assembly=Roslyn.SyntaxVisualizer.Control"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/project.json
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/project.json
@@ -1,36 +1,34 @@
-{
+﻿{
   "dependencies": {
     "EnvDTE": "8.0.0",
     "EnvDTE80": "8.0.0",
-    "Microsoft.Composition": "1.0.27",
     "Microsoft.CodeAnalysis.Analyzers": "1.1.0",
     "Microsoft.CodeAnalysis.Common": "1.0.1",
     "Microsoft.CodeAnalysis.EditorFeatures.Text": "1.0.1",
     "Microsoft.CodeAnalysis.Workspaces.Common": "1.0.1",
-    "Microsoft.VisualStudio.CoreUtility": "15.0.26014-alpha",
-    "Microsoft.VisualStudio.Editor": "15.0.26014-alpha",
-    "Microsoft.VisualStudio.Text.Data": "15.0.26014-alpha",
-    "Microsoft.VisualStudio.Text.Logic": "15.0.26014-alpha",
-    "Microsoft.VisualStudio.Text.UI": "15.0.26014-alpha",
-    "Microsoft.VisualStudio.Text.UI.Wpf": "15.0.26014-alpha",
-    "Microsoft.VisualStudio.Utilities": "15.0.26014-alpha",
+    "Microsoft.Composition": "1.0.27",
+    "Microsoft.VisualStudio.CoreUtility": "[14.0.23205]",
+    "Microsoft.VisualStudio.Editor": "[14.0.23205]",
     "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
-    "Microsoft.VisualStudio.Shell.Framework": "15.0.26014-alpha",
-    "Microsoft.VisualStudio.Shell.15.0": "15.0.26014-alpha",
-    "Microsoft.VisualStudio.Shell.Immutable.10.0": "15.0.26014-alpha",
+    "Microsoft.VisualStudio.Shell.14.0": "[14.0.23205]",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
+    "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",
     "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
-    "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",
+    "Microsoft.VisualStudio.Text.Data": "[14.0.23205]",
+    "Microsoft.VisualStudio.Text.Logic": "[14.0.23205]",
+    "Microsoft.VisualStudio.Text.UI": "[14.0.23205]",
+    "Microsoft.VisualStudio.Text.UI.Wpf": "[14.0.23205]",
     "Microsoft.VisualStudio.TextManager.Interop": "7.10.6070",
-    "Microsoft.VisualStudio.ComponentModelHost": "15.0.26014-alpha",
+    "Microsoft.VisualStudio.Utilities": "[14.0.23205]",
     "System.Collections.Immutable": "1.1.36",
-    "System.Reflection.Metadata": "1.0.21"
+    "System.Reflection.Metadata": "1.0.21",
+    "VSSDK.ComponentModelHost": "[12.0.4]"
   },
   "frameworks": {
-    "net46": { }
+    "net46": {}
   },
   "runtimes": {
-    "win7": { }
+    "win7": {}
   }
 }


### PR DESCRIPTION
Build against Dev14 assemblies so these extensions continue to work on both Dev14 and Dev15.

NOTE: This affects the Roslyn SDK which is independent from out shipping binares