### PR TITLE
Use UnexpectedValue instead of Unreachable

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return new BoundFieldAccess(this.Syntax, this.ReceiverOpt, field, constantValueOpt: null, hasErrors: this.HasErrors || inferenceFailed);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(this.VariableSymbol.Kind);
             }
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     designation = (SingleVariableDesignationSyntax)((DeclarationExpressionSyntax)this.Syntax).Designation;
                     break;
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(this.Syntax.Kind());
             }
 
             Binder.Error(

--- a/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutVariablePendingInference.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                 this.HasErrors || inferenceFailed);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(this.VariableSymbol.Kind);
             }
 
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1921,7 +1921,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         right = udBinOp.Right;
                         break;
                     default:
-                        throw ExceptionUtilities.Unreachable;
+                        throw ExceptionUtilities.UnexpectedValue(binary.Kind);
                 }
 
                 var op = kind.Operator();

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     typeMap = TypeMap.Empty.WithConcatAlphaRename(lambdaNode.Symbol, this, out typeParameters, out constructedFromTypeParameters, null);
                     break;
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(closureKind);
             }
 
             if (!structClosures.IsDefaultOrEmpty && typeParameters.Length != 0)

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis
                 case DiagnosticSeverity.Error:
                     return ReportDiagnostic.Error;
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(severity);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions_Accessibility.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return IsMemberAccessible(symbol.ContainingType, symbol.DeclaredAccessibility, within, throughTypeOpt, out failedThroughTypeCheck);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(symbol.Kind);
             }
         }
 
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return withinAssembly.IsSameAssemblyOrHasFriendAccessTo(assembly);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(declaredAccessibility);
             }
         }
 
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     return IsProtectedSymbolAccessible(withinNamedType, withinAssembly, throughTypeOpt, originalContainingType, out failedThroughTypeCheck);
 
                 default:
-                    throw ExceptionUtilities.Unreachable;
+                    throw ExceptionUtilities.UnexpectedValue(declaredAccessibility);
             }
         }
 


### PR DESCRIPTION
I've investigated a Watson dump file with Unreachable exception. It would have been easier to diagnose if it had been an UnexpectedValue exception instead.
While fixing that instance in `IsSymbolAccessibleCore`, I'm also fixing two other instances in the same file.

@dotnet/roslyn-compiler for review.