### PR TITLE
Dynamic member access and indexers are not safe to return by reference.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1953,7 +1953,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return CheckEventValueKind((BoundEventAccess)expr, valueKind, diagnostics);
                 case BoundKind.DynamicMemberAccess:
                 case BoundKind.DynamicIndexerAccess:
-                    return true;
+                    return CheckDynamicValueKind(expr, valueKind, diagnostics);
                 default:
                     {
                         if (RequiresSettingValue(valueKind))
@@ -1975,6 +1975,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return true;
                     }
             }
+        }
+
+        private static bool CheckDynamicValueKind(BoundExpression expr, BindValueKind valueKind, DiagnosticBag diagnostics)
+        {
+            // dynamic expressions can be read and written to
+            // can even be passed by reference (which is implemented via a temp)
+            // it is not valid to return by reference though.
+            if (valueKind == BindValueKind.RefReturn)
+            {
+                Error(diagnostics, ErrorCode.ERR_RefReturnLvalueExpected, expr.Syntax);
+                return false;
+            }
+
+            return true;
         }
 
         private bool CheckEventValueKind(BoundEventAccess boundEvent, BindValueKind valueKind, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -2848,10 +2848,10 @@ public class C
     {
         dynamic d = ""qq"";
 
-        foo(ref d);
+        F(ref d);
     }
 
-    public static ref dynamic foo(ref dynamic d)
+    public static ref dynamic F(ref dynamic d)
     {
         return ref d.Length;
     }
@@ -2877,10 +2877,10 @@ public class C
     {
         dynamic d = ""qq"";
 
-        foo(ref d);
+        F(ref d);
     }
 
-    public static ref dynamic foo(ref dynamic d)
+    public static ref dynamic F(ref dynamic d)
     {
         return ref d[0];
     }
@@ -2907,15 +2907,15 @@ public class C
     {
         dynamic d = ""qq"";
 
-        foo(ref d);
+        F(ref d);
     }
 
-    public static ref dynamic foo(ref dynamic d)
+    public static ref dynamic F(ref dynamic d)
     {
-        return ref bar(ref d.Length);
+        return ref G(ref d.Length);
     }
 
-    public static ref dynamic bar(ref dynamic d)
+    public static ref dynamic G(ref dynamic d)
     {
         return ref d;
     }
@@ -2925,11 +2925,11 @@ public class C
 
             CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
                 // (14,28): error CS8156: An expression cannot be used in this context because it may not be returned by reference
-                //         return ref bar(ref d.Length);
+                //         return ref G(ref d.Length);
                 Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "d.Length").WithLocation(14, 28),
-                // (14,20): error CS8164: Cannot return by reference a result of 'C.bar(ref dynamic)' because the argument passed to parameter 'd' cannot be returned by reference
-                //         return ref bar(ref d.Length);
-                Diagnostic(ErrorCode.ERR_RefReturnCall, "bar(ref d.Length)").WithArguments("C.bar(ref dynamic)", "d").WithLocation(14, 20)
+                // (14,20): error CS8164: Cannot return by reference a result of 'C.G(ref dynamic)' because the argument passed to parameter 'd' cannot be returned by reference
+                //         return ref G(ref d.Length);
+                Diagnostic(ErrorCode.ERR_RefReturnCall, "G(ref d.Length)").WithArguments("C.G(ref dynamic)", "d").WithLocation(14, 20)
 
             );
         }


### PR DESCRIPTION
Fixes:#16947

Dynamic member accesses and index expressions can be passed by reference. It is done via passing a ref to a temp holding the result of dynamic operation.

Dynamic operations are not safe to return by reference  though.