### PR TITLE
Avoid creating "steps" in deconstruction binding and optimize output

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -110,12 +110,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // we could still not infer a type for the RHS
                 FailRemainingInferences(checkedVariables, diagnostics);
+                var voidType = GetSpecialType(SpecialType.System_Void, diagnostics, node);
 
+                var type = boundRHS.Type ?? voidType;
                 return new BoundDeconstructionAssignmentOperator(
                             node,
                             DeconstructionVariablesAsTuple(node, checkedVariables, diagnostics, hasErrors: true),
-                            boundRHS,
-                            GetSpecialType(SpecialType.System_Void, diagnostics, node),
+                            new BoundConversion(boundRHS.Syntax, boundRHS, Conversion.Deconstruction, @checked: false, explicitCastInCode: false,
+                                constantValueOpt: null, type: type, hasErrors: true),
+                            voidType,
                             hasErrors: true);
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="expression">A variable set to the first expression in the left that isn't a declaration or discard</param>
         /// <param name="rightPlaceholder"></param>
         /// <returns></returns>
-        internal BoundAssignmentOperator BindDeconstruction(
+        internal BoundDeconstructionAssignmentOperator BindDeconstruction(
             CSharpSyntaxNode deconstruction,
             ExpressionSyntax left,
             ExpressionSyntax right,
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return assignment;
         }
 
-        private BoundAssignmentOperator BindDeconstructionAssignment(
+        private BoundDeconstructionAssignmentOperator BindDeconstructionAssignment(
                                                         CSharpSyntaxNode node,
                                                         ExpressionSyntax left,
                                                         BoundExpression boundRHS,
@@ -111,11 +111,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // we could still not infer a type for the RHS
                 FailRemainingInferences(checkedVariables, diagnostics);
 
-                return new BoundAssignmentOperator(
+                return new BoundDeconstructionAssignmentOperator(
                             node,
                             DeconstructionVariablesAsTuple(node, checkedVariables, diagnostics, hasErrors: true),
                             boundRHS,
-                            RefKind.None,
                             GetSpecialType(SpecialType.System_Void, diagnostics, node),
                             hasErrors: true);
             }
@@ -145,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors: hasErrors)
             { WasCompilerGenerated = true };
 
-            return new BoundAssignmentOperator(node, lhsTuple, boundConversion, RefKind.None, returnType);
+            return new BoundDeconstructionAssignmentOperator(node, lhsTuple, boundConversion, returnType);
         }
 
         /// <summary>When boundRHS is a tuple literal, fix it up by inferring its types.</summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -12,7 +13,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
     /// This portion of the binder converts deconstruction-assignment syntax (AssignmentExpressionSyntax nodes with the left
-    /// being a tuple expression or declaration expression) into a BoundDeconstructionAssignmentOperator (or bad node).
+    /// being a tuple expression or declaration expression) into a BoundAssignmentOperator (or bad node).
+    /// The BoundAssignmentOperator will have:
+    /// - a BoundTupleLiteral as its Left,
+    /// - a BoundConversion as its Right, holding:
+    ///     - a tree of Conversion objects with Kind=Deconstruction, information about a Deconstruct method (optional) and
+    ///         an array of nested Conversions (like a tuple conversion),
+    ///     - an BoundExpression as its Operand.
     /// </summary>
     internal partial class Binder
     {
@@ -60,85 +67,88 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private static void FreeDeconstructionVariables(ArrayBuilder<DeconstructionVariable> variables)
+        /// <summary>
+        /// Bind a deconstruction assignment.
+        /// </summary>
+        /// <param name="deconstruction">The deconstruction operation</param>
+        /// <param name="left">The left (tuple) operand</param>
+        /// <param name="right">The right (deconstrucible) operand</param>
+        /// <param name="diagnostics">Where to report diagnostics</param>
+        /// <param name="declaration">A variable set to the first variable declaration found in the left</param>
+        /// <param name="expression">A variable set to the first expression in the left that isn't a declaration or discard</param>
+        /// <param name="rightPlaceholder"></param>
+        /// <returns></returns>
+        internal BoundAssignmentOperator BindDeconstruction(
+            CSharpSyntaxNode deconstruction,
+            ExpressionSyntax left,
+            ExpressionSyntax right,
+            DiagnosticBag diagnostics,
+            ref DeclarationExpressionSyntax declaration,
+            ref ExpressionSyntax expression,
+            BoundDeconstructValuePlaceholder rightPlaceholder = null)
         {
-            foreach (var v in variables)
-            {
-                if (v.HasNestedVariables)
-                {
-                    FreeDeconstructionVariables(v.NestedVariables);
-                }
-            }
+            DeconstructionVariable locals = BindDeconstructionVariables(left, diagnostics, ref declaration, ref expression);
+            Debug.Assert(locals.HasNestedVariables);
 
-            variables.Free();
+            BoundExpression boundRight = rightPlaceholder ?? BindValue(right, diagnostics, BindValueKind.RValue);
+            boundRight = FixTupleLiteral(locals.NestedVariables, boundRight, deconstruction, diagnostics);
+
+            var assignment = BindDeconstructionAssignment(deconstruction, left, boundRight, locals.NestedVariables, diagnostics);
+            DeconstructionVariable.FreeDeconstructionVariables(locals.NestedVariables);
+
+            return assignment;
         }
 
-        /// <summary>
-        /// There are two kinds of deconstruction-assignments which this binding handles: tuple and non-tuple.
-        ///
-        /// Returns a BoundDeconstructionAssignmentOperator with a list of deconstruction steps and assignment steps.
-        /// Deconstruct steps for tuples have no invocation to Deconstruct, but steps for non-tuples do.
-        /// The caller is responsible for releasing all the ArrayBuilders in checkedVariables.
-        /// </summary>
-        private BoundDeconstructionAssignmentOperator BindDeconstructionAssignment(
+        private BoundAssignmentOperator BindDeconstructionAssignment(
                                                         CSharpSyntaxNode node,
                                                         ExpressionSyntax left,
-                                                        ExpressionSyntax right,
+                                                        BoundExpression boundRHS,
                                                         ArrayBuilder<DeconstructionVariable> checkedVariables,
-                                                        DiagnosticBag diagnostics,
-                                                        BoundDeconstructValuePlaceholder rhsPlaceholder = null)
+                                                        DiagnosticBag diagnostics)
         {
-            // receiver for first Deconstruct step
-            var boundRHS = rhsPlaceholder ?? BindValue(right, diagnostics, BindValueKind.RValue);
-
-            boundRHS = FixTupleLiteral(checkedVariables, boundRHS, node, diagnostics);
-
             if ((object)boundRHS.Type == null || boundRHS.Type.IsErrorType())
             {
                 // we could still not infer a type for the RHS
                 FailRemainingInferences(checkedVariables, diagnostics);
 
-                return new BoundDeconstructionAssignmentOperator(
-                            node, DeconstructVariablesAsTuple(left, checkedVariables), boundRHS,
-                            ImmutableArray<BoundDeconstructionDeconstructStep>.Empty,
-                            ImmutableArray<BoundDeconstructionAssignmentStep>.Empty,
-                            ImmutableArray<BoundDeconstructionAssignmentStep>.Empty,
-                            ImmutableArray<BoundDeconstructionConstructionStep>.Empty,
+                return new BoundAssignmentOperator(
+                            node,
+                            DeconstructionVariablesAsTuple(node, checkedVariables, diagnostics, hasErrors: true),
+                            boundRHS,
+                            RefKind.None,
                             GetSpecialType(SpecialType.System_Void, diagnostics, node),
                             hasErrors: true);
             }
 
-            var deconstructionSteps = ArrayBuilder<BoundDeconstructionDeconstructStep>.GetInstance(1);
-            var conversionSteps = ArrayBuilder<BoundDeconstructionAssignmentStep>.GetInstance(1);
-            var assignmentSteps = ArrayBuilder<BoundDeconstructionAssignmentStep>.GetInstance(1);
-            var constructionStepsOpt = ArrayBuilder<BoundDeconstructionConstructionStep>.GetInstance(1);
-
-            bool hasErrors = !DeconstructIntoSteps(
-                                    new BoundDeconstructValuePlaceholder(boundRHS.Syntax, boundRHS.Type),
+            Conversion conversion;
+            bool hasErrors = !MakeDeconstructionConversion(
+                                    boundRHS.Type,
                                     node,
+                                    boundRHS.Syntax,
                                     diagnostics,
                                     checkedVariables,
-                                    deconstructionSteps,
-                                    conversionSteps,
-                                    assignmentSteps,
-                                    constructionStepsOpt);
-
-            TypeSymbol returnType = hasErrors ?
-                                    CreateErrorType() :
-                                    constructionStepsOpt.Last().OutputPlaceholder.Type;
-
-            var deconstructions = deconstructionSteps.ToImmutableAndFree();
-            var conversions = conversionSteps.ToImmutableAndFree();
-            var assignments = assignmentSteps.ToImmutableAndFree();
-            var constructions = constructionStepsOpt.ToImmutableAndFree();
+                                    out conversion);
 
             FailRemainingInferences(checkedVariables, diagnostics);
 
-            return new BoundDeconstructionAssignmentOperator(
-                            node, DeconstructVariablesAsTuple(left, checkedVariables), boundRHS,
-                            deconstructions, conversions, assignments, constructions, returnType, hasErrors: hasErrors);
+            var lhsTuple = DeconstructionVariablesAsTuple(left, checkedVariables, diagnostics, hasErrors);
+            TypeSymbol returnType = hasErrors ? CreateErrorType() : lhsTuple.Type;
+
+            var boundConversion = new BoundConversion(
+                boundRHS.Syntax,
+                boundRHS,
+                conversion,
+                @checked: false,
+                explicitCastInCode: false,
+                constantValueOpt: null,
+                type: returnType,
+                hasErrors: hasErrors)
+            { WasCompilerGenerated = true };
+
+            return new BoundAssignmentOperator(node, lhsTuple, boundConversion, RefKind.None, returnType);
         }
 
+        /// <summary>When boundRHS is a tuple literal, fix it up by inferring its types.</summary>
         private BoundExpression FixTupleLiteral(ArrayBuilder<DeconstructionVariable> checkedVariables, BoundExpression boundRHS, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             if (boundRHS.Kind == BoundKind.TupleLiteral)
@@ -161,91 +171,93 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Whether the target is a tuple or a type that requires Deconstruction, this will generate and stack appropriate deconstruction and assignment steps.
+        /// Recursively builds a Conversion object with Kind=Deconstruction including information about any necessary
+        /// Deconstruct method and any element-wise conversion.
+        ///
         /// Note that the variables may either be plain or nested variables.
         /// The variables may be updated with inferred types if they didn't have types initially.
         /// Returns false if there was an error.
-        /// Pass in constructionStepsOpt as null if construction steps should not be computed.
         /// </summary>
-        private bool DeconstructIntoSteps(
-                        BoundDeconstructValuePlaceholder targetPlaceholder,
-                        CSharpSyntaxNode syntax,
+        private bool MakeDeconstructionConversion(
+                        TypeSymbol type,
+                        SyntaxNode syntax,
+                        SyntaxNode rightSyntax,
                         DiagnosticBag diagnostics,
                         ArrayBuilder<DeconstructionVariable> variables,
-                        ArrayBuilder<BoundDeconstructionDeconstructStep> deconstructionSteps,
-                        ArrayBuilder<BoundDeconstructionAssignmentStep> conversionSteps,
-                        ArrayBuilder<BoundDeconstructionAssignmentStep> assignmentSteps,
-                        ArrayBuilder<BoundDeconstructionConstructionStep> constructionStepsOpt)
+                        out Conversion conversion)
         {
-            Debug.Assert(targetPlaceholder.Type != null);
+            Debug.Assert(type != null);
+            ImmutableArray<TypeSymbol> tupleOrDeconstructedTypes;
+            conversion = Conversion.Deconstruction;
 
-            BoundDeconstructionDeconstructStep step;
-
-            if (targetPlaceholder.Type.IsTupleType)
+            // Figure out the deconstruct method (if one is required) and determine the types we get from the RHS at this level
+            DeconstructionInfo deconstructInfo = null;
+            if (type.IsTupleType)
             {
                 // tuple literal such as `(1, 2)`, `(null, null)`, `(x.P, y.M())`
-                step = MakeTupleDeconstructStep(targetPlaceholder, syntax, diagnostics, variables);
+                tupleOrDeconstructedTypes = type.TupleElementTypes;
+                SetInferredTypes(variables, tupleOrDeconstructedTypes, diagnostics);
+
+                if (variables.Count != tupleOrDeconstructedTypes.Length)
+                {
+                    Error(diagnostics, ErrorCode.ERR_DeconstructWrongCardinality, syntax, tupleOrDeconstructedTypes.Length, variables.Count);
+                    return false;
+                }
             }
             else
             {
-                step = MakeNonTupleDeconstructStep(targetPlaceholder, syntax, diagnostics, variables);
+                ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders;
+                var inputPlaceholder = new BoundDeconstructValuePlaceholder(syntax, type);
+                var deconstructInvocation = MakeDeconstructInvocationExpression(variables.Count,
+                    inputPlaceholder, rightSyntax, diagnostics, out outPlaceholders);
+
+                if (deconstructInvocation.HasAnyErrors)
+                {
+                    return false;
+                }
+
+                deconstructInfo = new DeconstructionInfo(deconstructInvocation, inputPlaceholder, outPlaceholders);
+
+                tupleOrDeconstructedTypes = outPlaceholders.SelectAsArray(p => p.Type);
+                SetInferredTypes(variables, tupleOrDeconstructedTypes, diagnostics);
             }
 
-            if (step == null)
+            // Figure out whether those types will need conversions, including further deconstructions
+            bool hasErrors = false;
+
+            int count = variables.Count;
+            var nestedConversions = ArrayBuilder<Conversion>.GetInstance(count);
+            for (int i = 0; i < count; i++)
             {
-                return false;
+                var variable = variables[i];
+
+                Conversion nestedConversion;
+                if (variable.HasNestedVariables)
+                {
+                    var elementSyntax = syntax.Kind() == SyntaxKind.TupleExpression ? ((TupleExpressionSyntax)syntax).Arguments[i] : syntax;
+
+                    hasErrors |= !MakeDeconstructionConversion(tupleOrDeconstructedTypes[i], syntax, rightSyntax, diagnostics,
+                        variable.NestedVariables, out nestedConversion);
+                }
+                else
+                {
+                    var single = variable.Single;
+                    HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                    nestedConversion = this.Conversions.ClassifyConversionFromType(tupleOrDeconstructedTypes[i], single.Type, ref useSiteDiagnostics);
+                    diagnostics.Add(single.Syntax, useSiteDiagnostics);
+
+                    if (!nestedConversion.IsImplicit)
+                    {
+                        hasErrors = true;
+                        GenerateImplicitConversionError(diagnostics, Compilation, single.Syntax, nestedConversion, tupleOrDeconstructedTypes[i], single.Type);
+                    }
+                }
+                nestedConversions.Add(nestedConversion);
             }
 
-            deconstructionSteps.Add(step);
+            conversion = new Conversion(ConversionKind.Deconstruction, deconstructInfo, nestedConversions.ToImmutableAndFree());
 
-            // outputs will either need a conversion step and assignment step, or if they are nested variables, they will need further deconstruction
-            return DeconstructOrAssignOutputs(step, variables, syntax, diagnostics, deconstructionSteps, conversionSteps, assignmentSteps, constructionStepsOpt);
-        }
-
-        /// <summary>
-        /// The produces a deconstruction step with no Deconstruct method since the tuple already has distinct elements.
-        /// </summary>
-        private BoundDeconstructionDeconstructStep MakeTupleDeconstructStep(
-                                                        BoundDeconstructValuePlaceholder targetPlaceholder,
-                                                        CSharpSyntaxNode syntax,
-                                                        DiagnosticBag diagnostics,
-                                                        ArrayBuilder<DeconstructionVariable> variables)
-        {
-            Debug.Assert(targetPlaceholder.Type.IsTupleType);
-
-            var tupleTypes = targetPlaceholder.Type.TupleElementTypes;
-            SetInferredTypes(variables, tupleTypes, diagnostics);
-
-            if (variables.Count != tupleTypes.Length)
-            {
-                Error(diagnostics, ErrorCode.ERR_DeconstructWrongCardinality, syntax, tupleTypes.Length, variables.Count);
-                return null;
-            }
-
-            return new BoundDeconstructionDeconstructStep(syntax, null, targetPlaceholder, tupleTypes.SelectAsArray((t, i, v) => new BoundDeconstructValuePlaceholder(v[i].Syntax, t), variables));
-        }
-
-        /// <summary>
-        /// This will generate and stack appropriate deconstruction and assignment steps for a non-tuple type.
-        /// Returns null if there was an error (if a suitable Deconstruct method was not found).
-        /// </summary>
-        private BoundDeconstructionDeconstructStep MakeNonTupleDeconstructStep(
-                                                            BoundDeconstructValuePlaceholder targetPlaceholder,
-                                                            CSharpSyntaxNode syntax,
-                                                            DiagnosticBag diagnostics,
-                                                            ArrayBuilder<DeconstructionVariable> variables)
-        {
-            // symbol and parameters for Deconstruct
-            ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders;
-            var deconstructInvocation = MakeDeconstructInvocationExpression(variables.Count, targetPlaceholder, syntax, diagnostics, out outPlaceholders);
-            if (deconstructInvocation.HasAnyErrors)
-            {
-                return null;
-            }
-
-            SetInferredTypes(variables, outPlaceholders.SelectAsArray(p => p.Type), diagnostics);
-
-            return new BoundDeconstructionDeconstructStep(syntax, deconstructInvocation, targetPlaceholder, outPlaceholders);
+            return !hasErrors;
         }
 
         /// <summary>
@@ -330,115 +342,49 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Holds the variables on the LHS of a deconstruction as a tree of bound expressions.
         /// </summary>
-        private class DeconstructionVariable
+        [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
+        internal class DeconstructionVariable
         {
-            public readonly BoundExpression Single;
-            public readonly ArrayBuilder<DeconstructionVariable> NestedVariables;
-            public readonly SyntaxNode Syntax;
+            internal readonly BoundExpression Single;
+            internal readonly ArrayBuilder<DeconstructionVariable> NestedVariables;
+            internal readonly CSharpSyntaxNode Syntax;
 
-            public DeconstructionVariable(BoundExpression variable, SyntaxNode syntax)
+            internal DeconstructionVariable(BoundExpression variable, SyntaxNode syntax)
             {
                 Single = variable;
                 NestedVariables = null;
-                Syntax = syntax;
+                Syntax = (CSharpSyntaxNode)syntax;
             }
 
-            public DeconstructionVariable(ArrayBuilder<DeconstructionVariable> variables, CSharpSyntaxNode syntax)
+            internal DeconstructionVariable(ArrayBuilder<DeconstructionVariable> variables, SyntaxNode syntax)
             {
                 Single = null;
                 NestedVariables = variables;
-                Syntax = syntax;
+                Syntax = (CSharpSyntaxNode)syntax;
             }
 
-            public bool HasNestedVariables => NestedVariables != null;
-        }
+            internal bool HasNestedVariables => NestedVariables != null;
 
-        /// <summary>
-        /// Takes the outputs from the previous deconstructionStep and depending on the structure of variables, will:
-        /// - generate further deconstructions,
-        /// - or simply conversions and assignments.
-        ///
-        /// Returns true for success, but false if has errors.
-        /// </summary>
-        private bool DeconstructOrAssignOutputs(
-                        BoundDeconstructionDeconstructStep deconstructionStep,
-                        ArrayBuilder<DeconstructionVariable> variables,
-                        CSharpSyntaxNode syntax,
-                        DiagnosticBag diagnostics,
-                        ArrayBuilder<BoundDeconstructionDeconstructStep> deconstructionSteps,
-                        ArrayBuilder<BoundDeconstructionAssignmentStep> conversionSteps,
-                        ArrayBuilder<BoundDeconstructionAssignmentStep> assignmentSteps,
-                        ArrayBuilder<BoundDeconstructionConstructionStep> constructionStepsOpt)
-        {
-            bool hasErrors = false;
-            var constructionInputs = constructionStepsOpt == null ? null : ArrayBuilder<BoundDeconstructValuePlaceholder>.GetInstance();
-
-            int count = variables.Count;
-            for (int i = 0; i < count; i++)
+            internal static void FreeDeconstructionVariables(ArrayBuilder<DeconstructionVariable> variables)
             {
-                var variable = variables[i];
-                var valuePlaceholder = deconstructionStep.OutputPlaceholders[i];
-
-                if (variable.HasNestedVariables)
+                foreach (var v in variables)
                 {
-                    var nested = variable.NestedVariables;
-                    if (!DeconstructIntoSteps(valuePlaceholder, syntax, diagnostics, nested, deconstructionSteps, conversionSteps, assignmentSteps, constructionStepsOpt))
+                    if (v.HasNestedVariables)
                     {
-                        hasErrors = true;
-                    }
-                    else if (constructionInputs != null)
-                    {
-                        constructionInputs.Add(constructionStepsOpt.Last().OutputPlaceholder);
+                        FreeDeconstructionVariables(v.NestedVariables);
                     }
                 }
-                else
-                {
-                    var conversion = MakeDeconstructionAssignmentStep(variable.Single, valuePlaceholder, syntax, diagnostics);
-                    conversionSteps.Add(conversion);
 
-                    var assignment = MakeDeconstructionAssignmentStep(variable.Single, conversion.OutputPlaceholder, syntax, diagnostics);
-                    assignmentSteps.Add(assignment);
-
-                    if (constructionInputs != null)
-                    {
-                        constructionInputs.Add(conversion.OutputPlaceholder);
-                    }
-                }
+                variables.Free();
             }
-
-            if (constructionStepsOpt != null)
+            private string GetDebuggerDisplay()
             {
-                if (hasErrors)
+                if (Single != null)
                 {
-                    constructionInputs.Free();
+                    return Single.GetDebuggerDisplay();
                 }
-                else
-                {
-                    var construct = MakeDeconstructionConstructionStep(syntax, diagnostics, constructionInputs.ToImmutableAndFree());
-                    constructionStepsOpt.Add(construct);
-                }
+                return $"Nested variables ({NestedVariables.Count})";
             }
-
-            return !hasErrors;
-        }
-
-        private BoundDeconstructionConstructionStep MakeDeconstructionConstructionStep(CSharpSyntaxNode node, DiagnosticBag diagnostics,
-                                                        ImmutableArray<BoundDeconstructValuePlaceholder> constructionInputs)
-        {
-            var tuple = TupleTypeSymbol.Create(
-                locationOpt: null,
-                elementTypes: constructionInputs.SelectAsArray(e => e.Type),
-                elementLocations: constructionInputs.SelectAsArray(e => e.Syntax.Location),
-                elementNames: default(ImmutableArray<string>),
-                compilation: Compilation,
-                diagnostics: diagnostics,
-                syntax: node,
-                shouldCheckConstraints: true);
-
-            var outputPlaceholder = new BoundDeconstructValuePlaceholder(node, tuple) { WasCompilerGenerated = true };
-
-            BoundExpression construction = new BoundTupleLiteral(node, default(ImmutableArray<string>), constructionInputs.CastArray<BoundExpression>(), tuple);
-            return new BoundDeconstructionConstructionStep(node, construction, outputPlaceholder);
         }
 
         /// <summary>
@@ -516,22 +462,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 shouldCheckConstraints: false);
         }
 
-        /// <summary>
-        /// Figures out how to assign from inputPlaceholder into receivingVariable and bundles the information (leaving holes for the actual source and receiver) into an AssignmentInfo.
-        /// </summary>
-        private BoundDeconstructionAssignmentStep MakeDeconstructionAssignmentStep(
-                                                    BoundExpression receivingVariable, BoundDeconstructValuePlaceholder inputPlaceholder,
-                                                    CSharpSyntaxNode node, DiagnosticBag diagnostics)
-        {
-            var outputPlaceholder = new BoundDeconstructValuePlaceholder(receivingVariable.Syntax, receivingVariable.Type) { WasCompilerGenerated = true };
-
-            // each assignment has a placeholder for a receiver and another for the source
-            BoundAssignmentOperator op = BindAssignment(receivingVariable.Syntax, outputPlaceholder, inputPlaceholder, diagnostics);
-
-            return new BoundDeconstructionAssignmentStep(node, op, outputPlaceholder);
-        }
-
-        private BoundTupleLiteral DeconstructVariablesAsTuple(SyntaxNode syntax, ArrayBuilder<DeconstructionVariable> variables)
+        private BoundTupleLiteral DeconstructionVariablesAsTuple(CSharpSyntaxNode syntax, ArrayBuilder<DeconstructionVariable> variables, DiagnosticBag diagnostics, bool hasErrors)
         {
             int count = variables.Count;
             var valuesBuilder = ArrayBuilder<BoundExpression>.GetInstance(count);
@@ -541,7 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (variable.HasNestedVariables)
                 {
-                    var nestedTuple = DeconstructVariablesAsTuple(variable.Syntax, variable.NestedVariables);
+                    var nestedTuple = DeconstructionVariablesAsTuple(variable.Syntax, variable.NestedVariables, diagnostics, hasErrors);
                     valuesBuilder.Add(nestedTuple);
                     typesBuilder.Add(nestedTuple.Type);
                 }
@@ -554,10 +485,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 locationsBuilder.Add(variable.Syntax.Location);
             }
 
-            // MakeDeconstructionConstructionStep constructs the final tuple type and checks constraints already.
             var type = TupleTypeSymbol.Create(syntax.Location,
                 typesBuilder.ToImmutableAndFree(), locationsBuilder.ToImmutableAndFree(),
-                elementNames: default(ImmutableArray<string>), compilation: this.Compilation, shouldCheckConstraints: false);
+                elementNames: default(ImmutableArray<string>), compilation: this.Compilation,
+                shouldCheckConstraints: !hasErrors, syntax: syntax, diagnostics: hasErrors ? null : diagnostics);
 
             return new BoundTupleLiteral(syntax: syntax, argumentNamesOpt: default(ImmutableArray<string>),
                 arguments: valuesBuilder.ToImmutableAndFree(), type: type);
@@ -570,10 +501,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// The overload resolution is similar to writing `receiver.Deconstruct(out var x1, out var x2, ...)`.
         /// </summary>
         private BoundExpression MakeDeconstructInvocationExpression(
-                                    int numCheckedVariables, BoundExpression receiver, CSharpSyntaxNode syntax,
+                                    int numCheckedVariables, BoundExpression receiver, SyntaxNode rightSyntax,
                                     DiagnosticBag diagnostics, out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders)
         {
-            var receiverSyntax = receiver.Syntax;
+            var receiverSyntax = (CSharpSyntaxNode)receiver.Syntax;
             if (numCheckedVariables < 2)
             {
                 Error(diagnostics, ErrorCode.ERR_DeconstructTooFewElements, receiverSyntax);
@@ -584,7 +515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (receiver.Type.IsDynamic())
             {
-                Error(diagnostics, ErrorCode.ERR_CannotDeconstructDynamic, receiverSyntax);
+                Error(diagnostics, ErrorCode.ERR_CannotDeconstructDynamic, rightSyntax);
                 outPlaceholders = default(ImmutableArray<BoundDeconstructValuePlaceholder>);
 
                 return BadExpression(receiverSyntax, receiver);
@@ -597,7 +528,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 for (int i = 0; i < numCheckedVariables; i++)
                 {
-                    var variable = new OutDeconstructVarPendingInference(syntax);
+                    var variable = new OutDeconstructVarPendingInference(receiverSyntax);
                     analyzedArguments.Arguments.Add(variable);
                     analyzedArguments.RefKinds.Add(RefKind.Out);
                     outVars.Add(variable);
@@ -605,7 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 const string methodName = "Deconstruct";
                 var memberAccess = BindInstanceMemberAccess(
-                                        receiverSyntax, receiverSyntax, receiver, methodName, rightArity: 0,
+                                        rightSyntax, receiverSyntax, receiver, methodName, rightArity: 0,
                                         typeArgumentsSyntax: default(SeparatedSyntaxList<TypeSyntax>), typeArguments: default(ImmutableArray<TypeSymbol>),
                                         invoked: true, diagnostics: diagnostics);
 
@@ -614,7 +545,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (memberAccess.Kind != BoundKind.MethodGroup)
                 {
-                    return MissingDeconstruct(receiver, syntax, numCheckedVariables, diagnostics, out outPlaceholders, receiver);
+                    return MissingDeconstruct(receiver, rightSyntax, numCheckedVariables, diagnostics, out outPlaceholders, receiver);
                 }
 
                 // After the overload resolution completes, the last step is to coerce the arguments with inferred types.
@@ -622,20 +553,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // So the generated invocation expression will contain placeholders instead of those outVar nodes.
                 // Those placeholders are also recorded in the outVar for easy access below, by the `SetInferredType` call on the outVar nodes.
                 BoundExpression result = BindMethodGroupInvocation(
-                                            receiverSyntax, receiverSyntax, methodName, (BoundMethodGroup)memberAccess, analyzedArguments, diagnostics, queryClause: null,
+                                            rightSyntax, rightSyntax, methodName, (BoundMethodGroup)memberAccess, analyzedArguments, diagnostics, queryClause: null,
                                             allowUnexpandedForm: true);
 
                 result.WasCompilerGenerated = true;
 
                 if (result.HasErrors && !receiver.HasAnyErrors)
                 {
-                    return MissingDeconstruct(receiver, syntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
+                    return MissingDeconstruct(receiver, rightSyntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
                 }
 
                 // Verify all the parameters (except "this" for extension methods) are out parameters
                 if (result.Kind != BoundKind.Call)
                 {
-                    return MissingDeconstruct(receiver, syntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
+                    return MissingDeconstruct(receiver, rightSyntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
                 }
 
                 var deconstructMethod = ((BoundCall)result).Method;
@@ -644,18 +575,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (parameters[i].RefKind != RefKind.Out)
                     {
-                        return MissingDeconstruct(receiver, syntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
+                        return MissingDeconstruct(receiver, rightSyntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
                     }
                 }
 
                 if (deconstructMethod.ReturnType.GetSpecialTypeSafe() != SpecialType.System_Void)
                 {
-                    return MissingDeconstruct(receiver, syntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
+                    return MissingDeconstruct(receiver, rightSyntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
                 }
 
                 if (outVars.Any(v => (object)v.Placeholder == null))
                 {
-                    return MissingDeconstruct(receiver, syntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
+                    return MissingDeconstruct(receiver, rightSyntax, numCheckedVariables, diagnostics, out outPlaceholders, result);
                 }
 
                 outPlaceholders = outVars.SelectAsArray(v => v.Placeholder);
@@ -669,40 +600,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundBadExpression MissingDeconstruct(BoundExpression receiver, CSharpSyntaxNode syntax, int numParameters, DiagnosticBag diagnostics,
+        private BoundBadExpression MissingDeconstruct(BoundExpression receiver, SyntaxNode rightSyntax, int numParameters, DiagnosticBag diagnostics,
                                     out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders, BoundNode childNode)
         {
-            Error(diagnostics, ErrorCode.ERR_MissingDeconstruct, receiver.Syntax, receiver.Type, numParameters);
+            Error(diagnostics, ErrorCode.ERR_MissingDeconstruct, rightSyntax, receiver.Type, numParameters);
             outPlaceholders = default(ImmutableArray<BoundDeconstructValuePlaceholder>);
 
-            return BadExpression(syntax, childNode);
-        }
-
-        /// <summary>
-        /// Bind a deconstruction assignment.
-        /// </summary>
-        /// <param name="deconstruction">The deconstruction operation</param>
-        /// <param name="left">The left (tuple) operand</param>
-        /// <param name="right">The right (deconstrucible) operand</param>
-        /// <param name="diagnostics">Where to report diagnostics</param>
-        /// <param name="declaration">A variable set to the first variable declaration found in the left</param>
-        /// <param name="expression">A variable set to the first expression in the left that isn't a declaration or discard</param>
-        /// <param name="rightPlaceholder"></param>
-        /// <returns></returns>
-        internal BoundDeconstructionAssignmentOperator BindDeconstruction(
-            CSharpSyntaxNode deconstruction,
-            ExpressionSyntax left,
-            ExpressionSyntax right,
-            DiagnosticBag diagnostics,
-            ref DeclarationExpressionSyntax declaration,
-            ref ExpressionSyntax expression,
-            BoundDeconstructValuePlaceholder rightPlaceholder = null)
-        {
-            DeconstructionVariable locals = BindDeconstructionVariables(left, diagnostics, ref declaration, ref expression);
-            Debug.Assert(locals.HasNestedVariables);
-            var result = BindDeconstructionAssignment(deconstruction, left, right, locals.NestedVariables, diagnostics, rhsPlaceholder: rightPlaceholder);
-            FreeDeconstructionVariables(locals.NestedVariables);
-            return result;
+            return BadExpression(rightSyntax, childNode);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -447,10 +447,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // The tuple created here is not identical to the one created by
-            // MakeDeconstructionConstructionStep. It represents a smaller
+            // DeconstructionVariablesAsTuple. It represents a smaller
             // tree of types used for figuring out natural types in tuple literal.
             // Therefore, we do not check constraints here as it would report errors
-            // that are already reported later. MakeDeconstructionConstructionStep
+            // that are already reported later. DeconstructionVariablesAsTuple
             // constructs the final tuple type and checks constraints.
             return TupleTypeSymbol.Create(
                 locationOpt: null,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// - a BoundConversion as its Right, holding:
     ///     - a tree of Conversion objects with Kind=Deconstruction, information about a Deconstruct method (optional) and
     ///         an array of nested Conversions (like a tuple conversion),
-    ///     - an BoundExpression as its Operand.
+    ///     - a BoundExpression as its Operand.
     /// </summary>
     internal partial class Binder
     {
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             conversion = Conversion.Deconstruction;
 
             // Figure out the deconstruct method (if one is required) and determine the types we get from the RHS at this level
-            DeconstructionInfo deconstructInfo = null;
+            var deconstructInfo = default(DeconstructionInfo);
             if (type.IsTupleType)
             {
                 // tuple literal such as `(1, 2)`, `(null, null)`, `(x.P, y.M())`

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -170,14 +170,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, inferredType ?? CreateErrorType("var"));
             DeclarationExpressionSyntax declaration = null;
             ExpressionSyntax expression = null;
-            BoundDeconstructionAssignmentOperator deconstruction = BindDeconstruction(
-                                                                    variables,
-                                                                    variables,
-                                                                    right: null,
-                                                                    diagnostics: diagnostics,
-                                                                    rightPlaceholder: valuePlaceholder,
-                                                                    declaration: ref declaration,
-                                                                    expression: ref expression);
+            BoundAssignmentOperator deconstruction = BindDeconstruction(
+                                                        variables,
+                                                        variables,
+                                                        right: _syntax.Expression,
+                                                        diagnostics: diagnostics,
+                                                        rightPlaceholder: valuePlaceholder,
+                                                        declaration: ref declaration,
+                                                        expression: ref expression);
 
             return new BoundExpressionStatement(_syntax, deconstruction);
         }
@@ -243,10 +243,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, iterationVariableType);
                             DeclarationExpressionSyntax declaration = null;
                             ExpressionSyntax expression = null;
-                            BoundDeconstructionAssignmentOperator deconstruction = BindDeconstruction(
+                            BoundAssignmentOperator deconstruction = BindDeconstruction(
                                                                                     variables,
                                                                                     variables,
-                                                                                    right: null,
+                                                                                    right: _syntax.Expression,
                                                                                     diagnostics: diagnostics,
                                                                                     rightPlaceholder: valuePlaceholder,
                                                                                     declaration: ref declaration,

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, inferredType ?? CreateErrorType("var"));
             DeclarationExpressionSyntax declaration = null;
             ExpressionSyntax expression = null;
-            BoundAssignmentOperator deconstruction = BindDeconstruction(
+            BoundDeconstructionAssignmentOperator deconstruction = BindDeconstruction(
                                                         variables,
                                                         variables,
                                                         right: _syntax.Expression,
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var valuePlaceholder = new BoundDeconstructValuePlaceholder(_syntax.Expression, iterationVariableType);
                             DeclarationExpressionSyntax declaration = null;
                             ExpressionSyntax expression = null;
-                            BoundAssignmentOperator deconstruction = BindDeconstruction(
+                            BoundDeconstructionAssignmentOperator deconstruction = BindDeconstruction(
                                                                                     variables,
                                                                                     variables,
                                                                                     right: _syntax.Expression,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -69,10 +69,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private class DeconstructionUncommonData : UncommonData
         {
-            internal DeconstructionUncommonData(DeconstructionInfo deconstructionInfo, ImmutableArray<Conversion> nestedConversions)
+            internal DeconstructionUncommonData(DeconstructionInfo deconstructionInfoOpt, ImmutableArray<Conversion> nestedConversions)
                 : base(false, false, default(UserDefinedConversionResult), null, nestedConversions)
             {
-                _deconstructionInfo = deconstructionInfo;
+                Debug.Assert(!nestedConversions.IsDefaultOrEmpty);
+                _deconstructionInfo = deconstructionInfoOpt;
             }
 
             internal DeconstructionInfo _deconstructionInfo;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -73,10 +73,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 : base(false, false, default(UserDefinedConversionResult), null, nestedConversions)
             {
                 Debug.Assert(!nestedConversions.IsDefaultOrEmpty);
-                _deconstructionInfo = deconstructionInfoOpt;
+                DeconstructionInfo = deconstructionInfoOpt;
             }
 
-            internal DeconstructionInfo _deconstructionInfo;
+            readonly internal DeconstructionInfo DeconstructionInfo;
         }
 
         private Conversion(
@@ -350,7 +350,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return ((DeconstructionUncommonData)_uncommonData)?._deconstructionInfo;
+                var uncommonData = (DeconstructionUncommonData)_uncommonData;
+                return uncommonData == null ? default(DeconstructionInfo) : uncommonData.DeconstructionInfo;
             }
         }
 
@@ -916,7 +917,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if ((object)self.DeconstructionInfo != null)
                 {
                     sub.Add(new TreeDumperNode("deconstructionInfo", null,
-                        new[] { BoundTreeDumperNodeProducer.MakeTree(self.DeconstructionInfo._invocation)}));
+                        new[] { BoundTreeDumperNodeProducer.MakeTree(self.DeconstructionInfo.Invocation)}));
                 }
 
                 var underlyingConversions = self.UnderlyingConversions;
@@ -933,16 +934,17 @@ namespace Microsoft.CodeAnalysis.CSharp
     }
 
     /// <summary>Stores all the information from binding for calling a Deconstruct method.</summary>
-    internal class DeconstructionInfo
+    internal struct DeconstructionInfo
     {
         internal DeconstructionInfo(BoundExpression invocation, BoundDeconstructValuePlaceholder inputPlaceholder,
             ImmutableArray<BoundDeconstructValuePlaceholder> outputPlaceholders)
         {
-             (_invocation, _inputPlaceholder, _outputPlaceholders) = (invocation, inputPlaceholder, outputPlaceholders);
+             (Invocation, InputPlaceholder, OutputPlaceholders) = (invocation, inputPlaceholder, outputPlaceholders);
         }
 
-        internal BoundExpression _invocation;
-        internal BoundDeconstructValuePlaceholder _inputPlaceholder;
-        internal ImmutableArray<BoundDeconstructValuePlaceholder> _outputPlaceholders;
+        readonly internal BoundExpression Invocation;
+        readonly internal BoundDeconstructValuePlaceholder InputPlaceholder;
+        readonly internal ImmutableArray<BoundDeconstructValuePlaceholder> OutputPlaceholders;
+        internal bool IsDefault => (object)Invocation == null;
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -42,5 +42,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         // implement them for compatibility with the native compiler.
         IntPtr,
         InterpolatedString, // a conversion from an interpolated string to IFormattable or FormattableString
+        Deconstruction, // The Deconstruction conversion is not part of the language, it is an implementation detail 
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.PointerToVoid:
                 case ConversionKind.NullToPointer:
                 case ConversionKind.InterpolatedString:
+                case ConversionKind.Deconstruction:
                     return true;
 
                 case ConversionKind.ExplicitNumeric:

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 #endif
 
-        private string GetDebuggerDisplay()
+        internal string GetDebuggerDisplay()
         {
             var result = GetType().Name;
             if (Syntax != null)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -393,7 +393,7 @@
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
 
     <Field Name="Left" Type="BoundTupleExpression" Null="disallow"/>
-    <Field Name="Right" Type="BoundExpression" Null="disallow"/>
+    <Field Name="Right" Type="BoundConversion" Null="disallow"/>
   </Node>
 
   <Node Name="BoundNullCoalescingOperator" Base="BoundExpression">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -388,6 +388,14 @@
     <Field Name="RefKind" Type="RefKind" Null="NotApplicable"/>
   </Node>
 
+  <Node Name="BoundDeconstructionAssignmentOperator" Base="BoundExpression">
+    <!-- Non-null type is required for this node kind -->
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+
+    <Field Name="Left" Type="BoundTupleExpression" Null="disallow"/>
+    <Field Name="Right" Type="BoundExpression" Null="disallow"/>
+  </Node>
+
   <Node Name="BoundNullCoalescingOperator" Base="BoundExpression">
     <Field Name="LeftOperand" Type="BoundExpression"/>
     <Field Name="RightOperand" Type="BoundExpression"/>
@@ -873,7 +881,7 @@
 
   <!-- All the information need to apply a deconstruction at each iteration of a foreach loop involving a deconstruction-declaration. -->
   <Node Name="BoundForEachDeconstructStep" Base="BoundNode">
-    <Field Name="DeconstructionAssignment" Type="BoundAssignmentOperator" Null="disallow"/>
+    <Field Name="DeconstructionAssignment" Type="BoundDeconstructionAssignmentOperator" Null="disallow"/>
     <Field Name="TargetPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -388,35 +388,6 @@
     <Field Name="RefKind" Type="RefKind" Null="NotApplicable"/>
   </Node>
 
-  <Node Name="BoundDeconstructionAssignmentOperator" Base="BoundExpression">
-    <!-- Non-null type is required for this node kind -->
-    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-
-    <Field Name="Left" Type="BoundTupleExpression"/>
-    <Field Name="Right" Type="BoundExpression"/>
-
-    <Field Name="DeconstructSteps" Type="ImmutableArray&lt;BoundDeconstructionDeconstructStep&gt;" Null="disallow" SkipInVisitor="true" />
-    <Field Name="ConversionSteps" Type="ImmutableArray&lt;BoundDeconstructionAssignmentStep&gt;" Null="disallow" SkipInVisitor="true"/>
-    <Field Name="AssignmentSteps" Type="ImmutableArray&lt;BoundDeconstructionAssignmentStep&gt;" Null="disallow" SkipInVisitor="true"/>
-    <Field Name="ConstructionStepsOpt" Type="ImmutableArray&lt;BoundDeconstructionConstructionStep&gt;" Null="allow" SkipInVisitor="true"/>
-  </Node>
-
-  <Node Name="BoundDeconstructionDeconstructStep" Base="BoundNode">
-    <Field Name="DeconstructInvocationOpt" Type="BoundExpression" Null="allow"/>
-    <Field Name="InputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
-    <Field Name="OutputPlaceholders" Type="ImmutableArray&lt;BoundDeconstructValuePlaceholder&gt;" Null="disallow"/>
-  </Node>
-
-  <Node Name="BoundDeconstructionAssignmentStep" Base="BoundNode">
-    <Field Name="Assignment" Type="BoundAssignmentOperator" Null="disallow"/>
-    <Field Name="OutputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
-  </Node>
-
-  <Node Name="BoundDeconstructionConstructionStep" Base="BoundNode">
-    <Field Name="Construct" Type="BoundExpression" Null="disallow"/>
-    <Field Name="OutputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
-  </Node>
-
   <Node Name="BoundNullCoalescingOperator" Base="BoundExpression">
     <Field Name="LeftOperand" Type="BoundExpression"/>
     <Field Name="RightOperand" Type="BoundExpression"/>
@@ -902,7 +873,7 @@
 
   <!-- All the information need to apply a deconstruction at each iteration of a foreach loop involving a deconstruction-declaration. -->
   <Node Name="BoundForEachDeconstructStep" Base="BoundNode">
-    <Field Name="DeconstructionAssignment" Type="BoundDeconstructionAssignmentOperator" Null="disallow"/>
+    <Field Name="DeconstructionAssignment" Type="BoundAssignmentOperator" Null="disallow"/>
     <Field Name="TargetPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -1022,21 +1022,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundDeconstructionAssignmentOperator : BoundExpression
-    {
-        protected override OperationKind ExpressionKind => OperationKind.None;
-
-        public override void Accept(OperationVisitor visitor)
-        {
-            visitor.VisitNoneOperation(this);
-        }
-
-        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-        {
-            return visitor.VisitNoneOperation(this, argument);
-        }
-    }
-
     internal partial class BoundCompoundAssignmentOperator : ICompoundAssignmentExpression
     {
         BinaryOperationKind ICompoundAssignmentExpression.BinaryOperationKind => Expression.DeriveBinaryOperationKind(this.Operator.Kind);

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -1022,6 +1022,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal sealed partial class BoundDeconstructionAssignmentOperator : BoundExpression
+    {
+        // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
+        protected override OperationKind ExpressionKind => OperationKind.None;
+
+        public override void Accept(OperationVisitor visitor)
+        {
+            // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
+            visitor.VisitNoneOperation(this);
+        }
+
+        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
+        {
+            // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
+            return visitor.VisitNoneOperation(this, argument);
+        }
+    }
+
     internal partial class BoundCompoundAssignmentOperator : ICompoundAssignmentExpression
     {
         BinaryOperationKind ICompoundAssignmentExpression.BinaryOperationKind => Expression.DeriveBinaryOperationKind(this.Operator.Kind);

--- a/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
@@ -262,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundForEachStatement : IForEachLoopStatement
     {
-        ILocalSymbol IForEachLoopStatement.IterationVariable => this.DeconstructionOpt == null?
+        ILocalSymbol IForEachLoopStatement.IterationVariable => this.IterationVariables.Length == 1?
                                                                         this.IterationVariables.FirstOrDefault():
                                                                         null;
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -968,29 +968,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
-            if (IsDeconstruction(result))
-            {
-                result = null;
-            }
-
             return result as IOperation;
-        }
-
-        private bool IsDeconstruction(BoundNode node)
-        {
-            if (node.Kind == BoundKind.AssignmentOperator)
-            {
-                var assigment = (BoundAssignmentOperator)node;
-                if (assigment.Right.Kind == BoundKind.Conversion)
-                {
-                    var conversion = (BoundConversion)assigment.Right;
-                    if (conversion.Conversion.Kind == ConversionKind.Deconstruction)
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
         }
 
         internal override SymbolInfo GetSymbolInfoWorker(CSharpSyntaxNode node, SymbolInfoOptions options, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -968,7 +968,29 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
             }
 
+            if (IsDeconstruction(result))
+            {
+                result = null;
+            }
+
             return result as IOperation;
+        }
+
+        private bool IsDeconstruction(BoundNode node)
+        {
+            if (node.Kind == BoundKind.AssignmentOperator)
+            {
+                var assigment = (BoundAssignmentOperator)node;
+                if (assigment.Right.Kind == BoundKind.Conversion)
+                {
+                    var conversion = (BoundConversion)assigment.Right;
+                    if (conversion.Conversion.Kind == ConversionKind.Deconstruction)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         internal override SymbolInfo GetSymbolInfoWorker(CSharpSyntaxNode node, SymbolInfoOptions options, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1233,6 +1233,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
                     }
 
+                case BoundKind.TupleLiteral:
+                    ((BoundTupleExpression)node).VisitAllElements((x, self) => self.Assign(x, value: null, refKind: refKind), this);
+                    break;
+
                 default:
                     // Other kinds of left-hand-sides either represent things not tracked (e.g. array elements)
                     // or errors that have been reported earlier (e.g. assignment to a unary increment)
@@ -1850,14 +1854,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitAssignmentOperator(BoundAssignmentOperator node)
         {
             base.VisitAssignmentOperator(node);
-            if (node.Left.Kind == BoundKind.TupleLiteral)
-            {
-                ((BoundTupleExpression)node.Left).VisitAllElements((x, self) => self.Assign(x, value: null, refKind: RefKind.None), this);
-            }
-            else
-            {
-                Assign(node.Left, node.Right, refKind: node.RefKind);
-            }
+            Assign(node.Left, node.Right, refKind: node.RefKind);
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1850,15 +1850,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitAssignmentOperator(BoundAssignmentOperator node)
         {
             base.VisitAssignmentOperator(node);
-            Assign(node.Left, node.Right, refKind: node.RefKind);
-            return null;
-        }
-
-        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
-        {
-            base.VisitDeconstructionAssignmentOperator(node);
-            node.Left.VisitAllElements((x, self) => self.Assign(x, value: null, refKind: RefKind.None), this);
-
+            if (node.Left.Kind == BoundKind.TupleLiteral)
+            {
+                ((BoundTupleExpression)node.Left).VisitAllElements((x, self) => self.Assign(x, value: null, refKind: RefKind.None), this);
+            }
+            else
+            {
+                Assign(node.Left, node.Right, refKind: node.RefKind);
+            }
             return null;
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1858,6 +1858,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
+        {
+            base.VisitDeconstructionAssignmentOperator(node);
+            Assign(node.Left, node.Right);
+            return null;
+        }
+
         public override BoundNode VisitIncrementOperator(BoundIncrementOperator node)
         {
             base.VisitIncrementOperator(node);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1677,6 +1677,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
+        {
+            VisitLvalue(node.Left);
+            VisitRvalue(node.Right);
+            return null;
+        }
+
         public override sealed BoundNode VisitOutDeconstructVarPendingInference(OutDeconstructVarPendingInference node)
         {
             // OutDeconstructVarPendingInference nodes are only used within initial binding, but don't survive past that stage

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -546,6 +546,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
                     }
 
+                case BoundKind.TupleLiteral:
+                    ((BoundTupleExpression)node).VisitAllElements((x, self) => self.VisitLvalue(x), this);
+                    break;
+
                 default:
                     VisitRvalue(node);
                     break;
@@ -1646,13 +1650,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitAssignmentOperator(BoundAssignmentOperator node)
         {
-            if (node.Left.Kind == BoundKind.TupleLiteral)
-            {
-                ((BoundTupleExpression)node.Left).VisitAllElements((x, self) => self.VisitLvalue(x), this);
-                VisitRvalue(node.Right);
-                return null;
-            }
-
             // TODO: should events be handled specially too?
             if (RegularPropertyAccess(node.Left))
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1646,6 +1646,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitAssignmentOperator(BoundAssignmentOperator node)
         {
+            if (node.Left.Kind == BoundKind.TupleLiteral)
+            {
+                ((BoundTupleExpression)node.Left).VisitAllElements((x, self) => self.VisitLvalue(x), this);
+                VisitRvalue(node.Right);
+                return null;
+            }
+
             // TODO: should events be handled specially too?
             if (RegularPropertyAccess(node.Left))
             {
@@ -1669,14 +1676,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 WriteArgument(node.Right, node.RefKind, method: null);
             }
-
-            return null;
-        }
-
-        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
-        {
-            node.Left.VisitAllElements((x, self) => self.VisitLvalue(x), this);
-            VisitRvalue(node.Right);
 
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else
                 {
                     // deconstruction foreach declares multiple variables
-                   deconstructionAssignment.Left.VisitAllElements((x, self) => self.Visit(x), this);
+                    ((BoundTupleExpression)deconstructionAssignment.Left).VisitAllElements((x, self) => self.Visit(x), this);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -268,17 +268,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(removed);
         }
 
-        /// <summary>
-        /// Remove all the listed placeholders.
-        /// </summary>
-        private void RemovePlaceholderReplacements(ArrayBuilder<BoundValuePlaceholderBase> placeholders)
-        {
-            foreach (var placeholder in placeholders)
-            {
-                RemovePlaceholderReplacement(placeholder);
-            }
-        }
-
         public override sealed BoundNode VisitOutDeconstructVarPendingInference(OutDeconstructVarPendingInference node)
         {
             // OutDeconstructVarPendingInference nodes are only used within initial binding, but don't survive past that stage

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -17,7 +18,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression VisitAssignmentOperator(BoundAssignmentOperator node, bool used)
         {
-            var loweredRight = VisitExpression(node.Right);
+            var right = node.Right;
+
+            if (right.Kind == BoundKind.Conversion)
+            {
+                var conversion = (BoundConversion)right;
+                if (conversion.Conversion.Kind == ConversionKind.Deconstruction)
+                {
+                    return RewriteDeconstruction((BoundTupleExpression)node.Left, conversion.Conversion, conversion.Operand);
+                }
+            }
+
+            var loweredRight = VisitExpression(right);
 
             BoundExpression left = node.Left;
             BoundExpression loweredLeft;
@@ -37,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (eventAccess.EventSymbol.IsWindowsRuntimeEvent)
                         {
                             Debug.Assert(node.RefKind == RefKind.None);
-                            return VisitWindowsRuntimeEventFieldAssignmentOperator(node.Syntax, eventAccess, node.Right);
+                            return VisitWindowsRuntimeEventFieldAssignmentOperator(node.Syntax, eventAccess, right);
                         }
                         goto default;
                     }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -19,16 +19,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression VisitAssignmentOperator(BoundAssignmentOperator node, bool used)
         {
             var right = node.Right;
-
-            if (right.Kind == BoundKind.Conversion)
-            {
-                var conversion = (BoundConversion)right;
-                if (conversion.Conversion.Kind == ConversionKind.Deconstruction)
-                {
-                    return RewriteDeconstruction((BoundTupleExpression)node.Left, conversion.Conversion, conversion.Operand);
-                }
-            }
-
             var loweredRight = VisitExpression(right);
 
             BoundExpression left = node.Left;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -5,194 +5,152 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed partial class LocalRewriter
     {
-        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
+        /// <summary>
+        /// The left represents a tree of L-values. The structure of right is a sub-set of that tree.
+        /// The conversion holds nested conversisons and deconstruction information, which matches the tree from the left,
+        /// and it provides the information to fill in the missing parts of the tree from the right and convert it to
+        /// the tree from the left.
+        ///
+        /// A bound sequence is returned which has different phases of side-effects:
+        /// - the initialization phase includes side-effects from the left, followed by evaluations of the right
+        /// - the deconstruction phase includes all the invocations of Deconstruct methods and tuple element accesses below a Deconstruct call
+        /// - the conversion phase
+        /// - the assignment phase
+        /// </summary>
+        private BoundExpression RewriteDeconstruction(BoundTupleExpression left, Conversion conversion, BoundExpression right)
         {
             var temps = ArrayBuilder<LocalSymbol>.GetInstance();
-            var stores = ArrayBuilder<BoundExpression>.GetInstance();
-            var placeholders = ArrayBuilder<BoundValuePlaceholderBase>.GetInstance();
+            var effects = DeconstructionSideEffects.GetInstance();
+            ArrayBuilder<Binder.DeconstructionVariable> lhsTargets = GetAssignmentTargetsAndSideEffects(left, temps, effects.init);
 
-            // evaluate left-hand-side side-effects
-            ImmutableArray<BoundExpression> lhsTargets = GetAssignmentTargetsAndSideEffects(node.Left, temps, stores);
-
-            // get or make right-hand-side values
-            BoundExpression loweredRight = VisitExpression(node.Right);
-
-            ApplyDeconstructions(node, temps, stores, placeholders, loweredRight);
-            ApplyConversions(node, temps, stores, placeholders);
-            ApplyAssignments(node, stores, lhsTargets);
-
-            BoundExpression returnValue = MakeReturnValue(node, placeholders);
-            BoundExpression result = _factory.Sequence(temps.ToImmutable(), stores.ToImmutable(), returnValue);
-
-            RemovePlaceholderReplacements(placeholders);
-            placeholders.Free();
-
-            temps.Free();
-            stores.Free();
+            BoundExpression returnTuple = ApplyDeconstructionConversion(lhsTargets, right, conversion, temps, effects, inInit: true);
+            BoundExpression result = _factory.Sequence(temps.ToImmutableAndFree(), effects.ToImmutableAndFree(), VisitExpression(returnTuple));
+            Binder.DeconstructionVariable.FreeDeconstructionVariables(lhsTargets);
 
             return result;
         }
 
-        /// <summary>
-        /// Applies the deconstructions.
-        /// Adds any new locals to the temps and any new expressions to be evaluated to the stores.
-        /// </summary>
-        private void ApplyDeconstructions(BoundDeconstructionAssignmentOperator node, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores, ArrayBuilder<BoundValuePlaceholderBase> placeholders, BoundExpression loweredRight)
+        private BoundTupleLiteral ApplyDeconstructionConversion(ArrayBuilder<Binder.DeconstructionVariable> leftTargets,
+            BoundExpression right, Conversion conversion, ArrayBuilder<LocalSymbol> temps, DeconstructionSideEffects effects,
+            bool inInit)
         {
-            var firstDeconstructStep = node.DeconstructSteps[0];
-            AddPlaceholderReplacement(firstDeconstructStep.InputPlaceholder, loweredRight);
-            placeholders.Add(firstDeconstructStep.InputPlaceholder);
+            Debug.Assert(conversion.Kind == ConversionKind.Deconstruction);
+            ImmutableArray<BoundExpression> rightParts = GetRightParts(right, conversion, ref temps, effects, ref inInit);
 
-            foreach (BoundDeconstructionDeconstructStep deconstruction in node.DeconstructSteps)
+            ImmutableArray<Conversion> underlyingConversions = conversion.UnderlyingConversions;
+            Debug.Assert(!underlyingConversions.IsDefault);
+            Debug.Assert(leftTargets.Count == rightParts.Length && leftTargets.Count == conversion.UnderlyingConversions.Length);
+
+            var builder = ArrayBuilder<BoundExpression>.GetInstance(leftTargets.Count);
+            for (int i = 0; i < leftTargets.Count; i++)
             {
-                if (deconstruction.DeconstructInvocationOpt == null)
+                BoundExpression resultPart;
+                if (leftTargets[i].HasNestedVariables)
                 {
-                    // tuple case
-                    AccessTupleFields(node, deconstruction, temps, stores, placeholders);
+                    resultPart = ApplyDeconstructionConversion(leftTargets[i].NestedVariables, rightParts[i],
+                        underlyingConversions[i], temps, effects, inInit);
                 }
                 else
                 {
-                    CallDeconstruct(node, deconstruction, temps, stores, placeholders);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Applies the conversions.
-        /// Adds any new locals to the temps and any new expressions to be evaluated to the stores.
-        /// </summary>
-        private void ApplyConversions(BoundDeconstructionAssignmentOperator node, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores, ArrayBuilder<BoundValuePlaceholderBase> placeholders)
-        {
-            int numConversions = node.ConversionSteps.Length;
-            var conversionLocals = ArrayBuilder<BoundExpression>.GetInstance();
-
-            foreach (var conversionInfo in node.ConversionSteps)
-            {
-                // lower the conversions and assignments to locals
-                var localSymbol = new SynthesizedLocal(_factory.CurrentMethod, conversionInfo.OutputPlaceholder.Type, SynthesizedLocalKind.LoweringTemp);
-                var localBound = new BoundLocal(node.Syntax,
-                                               localSymbol,
-                                               null,
-                                               conversionInfo.OutputPlaceholder.Type)
-                { WasCompilerGenerated = true };
-
-                temps.Add(localSymbol);
-                conversionLocals.Add(localBound);
-
-                AddPlaceholderReplacement(conversionInfo.OutputPlaceholder, localBound);
-                placeholders.Add(conversionInfo.OutputPlaceholder);
-
-                var conversion = VisitExpression(conversionInfo.Assignment);
-
-                stores.Add(conversion);
-            }
-        }
-
-        /// <summary>
-        /// Applies the assignments.
-        /// Adds any new expressions to be evaluated to the stores.
-        /// </summary>
-        private void ApplyAssignments(BoundDeconstructionAssignmentOperator node, ArrayBuilder<BoundExpression> stores, ImmutableArray<BoundExpression> lhsTargets)
-        {
-            int numAssignments = node.AssignmentSteps.Length;
-            for (int i = 0; i < numAssignments; i++)
-            {
-                if (lhsTargets[i].Kind == BoundKind.DiscardExpression)
-                {
-                    // skip assignment step for discards
-                    continue;
-                }
-
-                var assignmentInfo = node.AssignmentSteps[i];
-                AddPlaceholderReplacement(assignmentInfo.OutputPlaceholder, lhsTargets[i]);
-
-                var assignment = assignmentInfo.Assignment;
-
-                // All the input placeholders for the assignments should already be set with lowered nodes
-                Debug.Assert(assignment.Left.Kind == BoundKind.DeconstructValuePlaceholder);
-                Debug.Assert(assignment.Right.Kind == BoundKind.DeconstructValuePlaceholder);
-                var rewrittenLeft = (BoundExpression)Visit(assignment.Left);
-                var rewrittenRight = (BoundExpression)Visit(assignment.Right);
-
-                var loweredAssignment = MakeAssignmentOperator(assignment.Syntax, rewrittenLeft, rewrittenRight, assignment.Type,
-                                            used: true, isChecked: false, isCompoundAssignment: false);
-
-                RemovePlaceholderReplacement(assignmentInfo.OutputPlaceholder);
-
-                stores.Add(loweredAssignment);
-            }
-        }
-
-        /// <summary>
-        /// Makes an expression that constructs the return value for the deconstruction:
-        /// a series of tuple constructions, that are chained with the help of placeholders.
-        /// The placeholders that are set are added to the list for later clearing.
-        /// </summary>
-        private BoundExpression MakeReturnValue(BoundDeconstructionAssignmentOperator node, ArrayBuilder<BoundValuePlaceholderBase> placeholders)
-        {
-            BoundExpression loweredConstruction = null;
-            foreach (var constructionInfo in node.ConstructionStepsOpt)
-            {
-                // All the input placeholders for the constructions should already be set
-                loweredConstruction = (BoundExpression)Visit(constructionInfo.Construct);
-
-                AddPlaceholderReplacement(constructionInfo.OutputPlaceholder, loweredConstruction);
-                placeholders.Add(constructionInfo.OutputPlaceholder);
-            }
-
-            Debug.Assert(loweredConstruction != null);
-            return loweredConstruction;
-        }
-
-        /// <summary>
-        /// Adds the side effects to stores and returns temporaries (as a flat list) to access them.
-        /// </summary>
-        private ImmutableArray<BoundExpression> GetAssignmentTargetsAndSideEffects(BoundTupleExpression variables, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
-        {
-            var assignmentTargets = ArrayBuilder<BoundExpression>.GetInstance(variables.Arguments.Length);
-
-            variables.VisitAllElements(
-                (variable, args) =>
-                {
-                    if (variable.Kind == BoundKind.DiscardExpression)
+                    var rightPart = rightParts[i];
+                    if (inInit)
                     {
-                        args.targets.Add(variable);
+                        rightPart = EvaluateSideEffectingArgumentToTemp(VisitExpression(rightPart), inInit ? effects.init : effects.deconstructions, ref temps);
                     }
-                    else
-                    {
-                        args.targets.Add(args.self.TransformCompoundAssignmentLHS(variable, args.stores, args.temps, isDynamicAssignment: variable.Type.IsDynamic()));
-                    }
-                },
-                (temps: temps, stores: stores, targets: assignmentTargets, self: this)
-            );
+                    BoundExpression leftTarget = leftTargets[i].Single;
 
-            return assignmentTargets.ToImmutableAndFree();
+                    resultPart = EvaluateConversionToTemp(rightPart, underlyingConversions[i], leftTarget.Type, temps,
+                        effects.conversions);
+
+                    if (leftTarget.Kind != BoundKind.DiscardExpression)
+                    {
+                        effects.assignments.Add(MakeAssignmentOperator(resultPart.Syntax, leftTarget, resultPart, leftTarget.Type,
+                            used: true, isChecked: false, isCompoundAssignment: false));
+                    }
+                }
+                builder.Add(resultPart);
+            }
+
+            var tupleType = TupleTypeSymbol.Create(locationOpt: null, elementTypes: builder.SelectAsArray(e => e.Type),
+                elementLocations: default(ImmutableArray<Location>), elementNames: default(ImmutableArray<string>),
+                compilation: _compilation, shouldCheckConstraints: false);
+
+            return new BoundTupleLiteral(right.Syntax, default(ImmutableArray<string>), builder.ToImmutableAndFree(), tupleType);
         }
 
-        private void AccessTupleFields(BoundDeconstructionAssignmentOperator node, BoundDeconstructionDeconstructStep deconstruction, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores, ArrayBuilder<BoundValuePlaceholderBase> placeholders)
+        private ImmutableArray<BoundExpression> GetRightParts(BoundExpression right, Conversion conversion,
+            ref ArrayBuilder<LocalSymbol> temps, DeconstructionSideEffects effects, ref bool inInit)
         {
-            var target = PlaceholderReplacement(deconstruction.InputPlaceholder);
-            var tupleType = target.Type.IsTupleType ? target.Type : TupleTypeSymbol.Create((NamedTypeSymbol)target.Type);
+            ImmutableArray<BoundExpression> rightParts;
+
+            var deconstructionInfo = conversion.DeconstructionInfo;
+            if ((object)deconstructionInfo != null)
+            {
+                Debug.Assert(right.Kind != BoundKind.TupleLiteral && right.Kind != BoundKind.ConvertedTupleLiteral);
+
+                BoundExpression evaluationResult = EvaluateSideEffectingArgumentToTemp(VisitExpression(right),
+                    inInit ? effects.init : effects.deconstructions, ref temps);
+
+                rightParts = InvokeDeconstructMethod(deconstructionInfo, evaluationResult, effects.deconstructions, ref temps);
+                inInit = false;
+            }
+            else if (right.Kind == BoundKind.TupleLiteral || right.Kind == BoundKind.ConvertedTupleLiteral)
+            {
+                rightParts = ((BoundTupleExpression)right).Arguments;
+            }
+            else if (right.Kind == BoundKind.Conversion)
+            {
+                var tupleConversion = (BoundConversion)right;
+                Debug.Assert(tupleConversion.Conversion.Kind == ConversionKind.ImplicitTupleLiteral);
+                rightParts = ((BoundTupleExpression)tupleConversion.Operand).Arguments;
+            }
+            else if (right.Type.IsTupleType)
+            {
+                rightParts = AccessTupleFields(VisitExpression(right), temps, effects.deconstructions);
+                inInit = false;
+            }
+            else
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+
+            return rightParts;
+        }
+
+        // This returns accessors and may create a temp for the tuple, but will not create temps for the tuple elements.
+        private ImmutableArray<BoundExpression> AccessTupleFields(BoundExpression expression, ArrayBuilder<LocalSymbol> temps,
+            ArrayBuilder<BoundExpression> effects)
+        {
+            Debug.Assert(expression.Type.IsTupleType);
+            var tupleType = expression.Type;
             var tupleElementTypes = tupleType.TupleElementTypes;
 
             var numElements = tupleElementTypes.Length;
 
-            SyntaxNode syntax = node.Syntax;
-
             // save the target as we need to access it multiple times
-            BoundAssignmentOperator assignmentToTemp;
-            BoundLocal savedTuple = _factory.StoreToTemp(target, out assignmentToTemp);
-            stores.Add(assignmentToTemp);
-            temps.Add(savedTuple.LocalSymbol);
+            BoundExpression tuple;
+            if (CanChangeValueBetweenReads(expression, localsMayBeAssignedOrCaptured: true))
+            {
+                BoundAssignmentOperator assignmentToTemp;
+                BoundLocal savedTuple = _factory.StoreToTemp(expression, out assignmentToTemp);
+                effects.Add(assignmentToTemp);
+                temps.Add(savedTuple.LocalSymbol);
+                tuple = savedTuple;
+            }
+            else
+            {
+                tuple = expression;
+            }
 
             // list the tuple fields accessors
             var fields = tupleType.TupleElements;
-
+            var builder = ArrayBuilder<BoundExpression>.GetInstance(numElements);
             for (int i = 0; i < numElements; i++)
             {
                 var field = fields[i];
@@ -200,53 +158,143 @@ namespace Microsoft.CodeAnalysis.CSharp
                 DiagnosticInfo useSiteInfo = field.GetUseSiteDiagnostic();
                 if ((object)useSiteInfo != null && useSiteInfo.Severity == DiagnosticSeverity.Error)
                 {
-                    Symbol.ReportUseSiteDiagnostic(useSiteInfo, _diagnostics, syntax.Location);
+                    Symbol.ReportUseSiteDiagnostic(useSiteInfo, _diagnostics, expression.Syntax.Location);
                 }
-                var fieldAccess = MakeTupleFieldAccess(syntax, field, savedTuple, null, LookupResultKind.Empty);
+                var fieldAccess = MakeTupleFieldAccess(expression.Syntax, field, tuple, null, LookupResultKind.Empty);
+                builder.Add(fieldAccess);
+            }
+            return builder.ToImmutableAndFree();
+        }
 
-                AddPlaceholderReplacement(deconstruction.OutputPlaceholders[i], fieldAccess);
-                placeholders.Add(deconstruction.OutputPlaceholders[i]);
+        private BoundExpression EvaluateConversionToTemp(BoundExpression expression, Conversion conversion,
+            TypeSymbol destinationType, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> effects)
+        {
+            if (conversion.IsIdentity)
+            {
+                return expression;
+            }
+            var evalConversion = MakeConversionNode(expression.Syntax, expression, conversion, destinationType, @checked: false);
+            return EvaluateSideEffectingArgumentToTemp(evalConversion, effects, ref temps);
+        }
+
+        private ImmutableArray<BoundExpression> InvokeDeconstructMethod(DeconstructionInfo deconstruction, BoundExpression target,
+            ArrayBuilder<BoundExpression> effects, ref ArrayBuilder<LocalSymbol> temps)
+        {
+            AddPlaceholderReplacement(deconstruction._inputPlaceholder, target);
+
+            var outputPlaceholders = deconstruction._outputPlaceholders;
+            var outLocals = ArrayBuilder<BoundExpression>.GetInstance(outputPlaceholders.Length);
+            foreach (var outputPlaceholder in outputPlaceholders)
+            {
+                var localSymbol = new SynthesizedLocal(_factory.CurrentMethod, outputPlaceholder.Type, SynthesizedLocalKind.LoweringTemp);
+
+                var localBound = new BoundLocal(target.Syntax, localSymbol, constantValueOpt: null, type: outputPlaceholder.Type)
+                    { WasCompilerGenerated = true };
+
+                temps.Add(localSymbol);
+                AddPlaceholderReplacement(outputPlaceholder, localBound);
+                outLocals.Add(localBound);
+            }
+
+            effects.Add(VisitExpression(deconstruction._invocation));
+
+            RemovePlaceholderReplacement(deconstruction._inputPlaceholder);
+            foreach (var outputPlaceholder in outputPlaceholders)
+            {
+                RemovePlaceholderReplacement(outputPlaceholder);
+            }
+
+            return outLocals.ToImmutableAndFree();
+        }
+
+        BoundExpression EvaluateSideEffectingArgumentToTemp( BoundExpression arg, ArrayBuilder<BoundExpression> effects,
+            ref ArrayBuilder<LocalSymbol> temps)
+        {
+            if (CanChangeValueBetweenReads(arg, localsMayBeAssignedOrCaptured: true))
+            {
+                BoundAssignmentOperator store;
+                var temp = _factory.StoreToTemp(arg, out store);
+
+                if (temps == null)
+                {
+                    temps = ArrayBuilder<LocalSymbol>.GetInstance();
+                }
+
+                temps.Add(temp.LocalSymbol);
+                effects.Add(store);
+                return temp;
+            }
+            else
+            {
+                return arg;
             }
         }
 
         /// <summary>
-        /// Prepares local variables to be used in Deconstruct call
-        /// Adds a invocation of Deconstruct with those as out parameters onto the 'stores' sequence
-        /// Returns the expressions for those out parameters
+        /// Adds the side effects to stores and returns temporaries to access them.
+        /// The caller is responsible for releasing the nested ArrayBuilders.
+        /// The variables should be unlowered.
         /// </summary>
-        private void CallDeconstruct(BoundDeconstructionAssignmentOperator node, BoundDeconstructionDeconstructStep deconstruction, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores, ArrayBuilder<BoundValuePlaceholderBase> placeholders)
+        private ArrayBuilder<Binder.DeconstructionVariable> GetAssignmentTargetsAndSideEffects(BoundTupleExpression variables, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> effects)
         {
-            Debug.Assert((object)deconstruction.DeconstructInvocationOpt != null);
+            var assignmentTargets = ArrayBuilder<Binder.DeconstructionVariable>.GetInstance(variables.Arguments.Length);
 
-            SyntaxNode syntax = node.Syntax;
-
-            // prepare out parameters for Deconstruct
-            var deconstructParameters = deconstruction.OutputPlaceholders;
-            var outParametersBuilder = ArrayBuilder<BoundExpression>.GetInstance(deconstructParameters.Length);
-
-            for (var i = 0; i < deconstructParameters.Length; i++)
+            foreach (var variable in variables.Arguments)
             {
-                var deconstructParameter = deconstructParameters[i];
-                var localSymbol = new SynthesizedLocal(_factory.CurrentMethod, deconstructParameter.Type, SynthesizedLocalKind.LoweringTemp);
+                switch (variable.Kind)
+                {
+                    case BoundKind.DiscardExpression:
+                        assignmentTargets.Add(new Binder.DeconstructionVariable(variable, variable.Syntax));
+                        break;
 
-                var localBound = new BoundLocal(syntax,
-                                                localSymbol,
-                                                null,
-                                                deconstructParameter.Type
-                                                )
-                { WasCompilerGenerated = true };
+                    case BoundKind.TupleLiteral:
+                        var tuple = (BoundTupleExpression)variable;
+                        assignmentTargets.Add(new Binder.DeconstructionVariable(GetAssignmentTargetsAndSideEffects(tuple, temps, effects), tuple.Syntax));
+                        break;
 
-                temps.Add(localSymbol);
-                outParametersBuilder.Add(localBound);
+                    case BoundKind.ConvertedTupleLiteral:
+                        throw ExceptionUtilities.UnexpectedValue(variable.Kind);
 
-                AddPlaceholderReplacement(deconstruction.OutputPlaceholders[i], localBound);
-                placeholders.Add(deconstruction.OutputPlaceholders[i]);
+                    default:
+                        var temp = this.TransformCompoundAssignmentLHS(variable, effects, temps, isDynamicAssignment: variable.Type.IsDynamic());
+                        assignmentTargets.Add(new Binder.DeconstructionVariable(temp, variable.Syntax));
+                        break;
+                }
             }
 
-            var outParameters = outParametersBuilder.ToImmutableAndFree();
+            return assignmentTargets;
+        }
 
-            // invoke Deconstruct with placeholders replaced by locals
-            stores.Add(VisitExpression(deconstruction.DeconstructInvocationOpt));
+        internal class DeconstructionSideEffects
+        {
+            internal ArrayBuilder<BoundExpression> init;
+            internal ArrayBuilder<BoundExpression> deconstructions;
+            internal ArrayBuilder<BoundExpression> conversions;
+            internal ArrayBuilder<BoundExpression> assignments;
+
+            internal static DeconstructionSideEffects GetInstance()
+            {
+                var result = new DeconstructionSideEffects();
+                result.init = ArrayBuilder<BoundExpression>.GetInstance();
+                result.deconstructions = ArrayBuilder<BoundExpression>.GetInstance();
+                result.conversions = ArrayBuilder<BoundExpression>.GetInstance();
+                result.assignments = ArrayBuilder<BoundExpression>.GetInstance();
+
+                return result;
+            }
+
+            internal ImmutableArray<BoundExpression> ToImmutableAndFree()
+            {
+                init.AddRange(deconstructions);
+                init.AddRange(conversions);
+                init.AddRange(assignments);
+
+                deconstructions.Free();
+                conversions.Free();
+                assignments.Free();
+
+                return init.ToImmutableAndFree();
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> rightParts;
 
             var deconstructionInfo = conversion.DeconstructionInfo;
-            if ((object)deconstructionInfo != null)
+            if (!deconstructionInfo.IsDefault)
             {
                 Debug.Assert(right.Kind != BoundKind.TupleLiteral && right.Kind != BoundKind.ConvertedTupleLiteral);
 
@@ -192,9 +192,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ImmutableArray<BoundExpression> InvokeDeconstructMethod(DeconstructionInfo deconstruction, BoundExpression target,
             ArrayBuilder<BoundExpression> effects, ref ArrayBuilder<LocalSymbol> temps)
         {
-            AddPlaceholderReplacement(deconstruction._inputPlaceholder, target);
+            AddPlaceholderReplacement(deconstruction.InputPlaceholder, target);
 
-            var outputPlaceholders = deconstruction._outputPlaceholders;
+            var outputPlaceholders = deconstruction.OutputPlaceholders;
             var outLocals = ArrayBuilder<BoundExpression>.GetInstance(outputPlaceholders.Length);
             foreach (var outputPlaceholder in outputPlaceholders)
             {
@@ -208,9 +208,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 outLocals.Add(localBound);
             }
 
-            effects.Add(VisitExpression(deconstruction._invocation));
+            effects.Add(VisitExpression(deconstruction.Invocation));
 
-            RemovePlaceholderReplacement(deconstruction._inputPlaceholder);
+            RemovePlaceholderReplacement(deconstruction.InputPlaceholder);
             foreach (var outputPlaceholder in outputPlaceholders)
             {
                 RemovePlaceholderReplacement(outputPlaceholder);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -14,11 +14,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
         {
             var right = node.Right;
-            Debug.Assert(right.Kind == BoundKind.Conversion);
-            var conversion = (BoundConversion)right;
-            Debug.Assert(conversion.Conversion.Kind == ConversionKind.Deconstruction);
+            Debug.Assert(right.Conversion.Kind == ConversionKind.Deconstruction);
 
-            return RewriteDeconstruction(node.Left, conversion.Conversion, conversion.Operand);
+            return RewriteDeconstruction(node.Left, right.Conversion, right.Operand);
         }
 
         /// <summary>
@@ -34,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// - the assignment phase
         /// </summary>
         private BoundExpression RewriteDeconstruction(BoundTupleExpression left, Conversion conversion, BoundExpression right)
+
         {
             var temps = ArrayBuilder<LocalSymbol>.GetInstance();
             var effects = DeconstructionSideEffects.GetInstance();

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -11,6 +11,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed partial class LocalRewriter
     {
+        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
+        {
+            var right = node.Right;
+            Debug.Assert(right.Kind == BoundKind.Conversion);
+            var conversion = (BoundConversion)right;
+            Debug.Assert(conversion.Conversion.Kind == ConversionKind.Deconstruction);
+
+            return RewriteDeconstruction(node.Left, conversion.Conversion, conversion.Operand);
+        }
+
         /// <summary>
         /// The left represents a tree of L-values. The structure of right can be missing parts of the tree on the left.
         /// The conversion holds nested conversisons and deconstruction information, which matches the tree from the left,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3329,6 +3329,33 @@ static class Extension
         }
 
         [Fact]
+        public void DeconstructExtensionOnInterface()
+        {
+            string source = @"
+public interface Interface { }
+class C : Interface
+{
+    static void Main()
+    {
+        var (x, y) = new C();
+        System.Console.Write($""{x} {y}"");
+    }
+}
+static class Extension
+{
+    public static void Deconstruct(this Interface value, out int item1, out string item2)
+    {
+        item1 = 42;
+        item2 = ""hello"";
+    }
+}
+";
+
+            var comp = CompileAndVerify(source, expectedOutput: "42 hello", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void ForEachIEnumerableDeclarationWithDeconstruct()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1479,7 +1479,7 @@ public static class Extensions
             comp.VerifyDiagnostics(
                 // (8,25): error CS0029: Cannot implicitly convert type 'int' to 'string'
                 //         (x, y, z) = (1, 2);
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "2").WithArguments("int", "string"),
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "2").WithArguments("int", "string").WithLocation(8, 25),
                 // (8,9): error CS8132: Cannot deconstruct a tuple of '2' elements into '3' variables.
                 //         (x, y, z) = (1, 2);
                 Diagnostic(ErrorCode.ERR_DeconstructWrongCardinality, "(x, y, z) = (1, 2)").WithArguments("2", "3").WithLocation(8, 9)
@@ -2324,6 +2324,7 @@ class C
                 Assert.Equal(@"(1, 2)", nestedLiteral.ToString());
                 Assert.Equal("(System.Int32, System.Int32)", model.GetTypeInfo(nestedLiteral).Type.ToTestDisplayString());
                 Assert.Equal("(System.Int32, System.Int32)", model.GetTypeInfo(nestedLiteral).ConvertedType.ToTestDisplayString());
+                Assert.Equal(ConversionKind.Identity, model.GetConversion(nestedLiteral).Kind);
             };
 
             var comp = CompileAndVerify(source, expectedOutput: " (1, 2)", additionalRefs: s_valueTupleRefs, sourceSymbolValidator: validator);
@@ -5086,10 +5087,10 @@ class C
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "_").WithArguments("string", "int").WithLocation(11, 30),
                 // (11,22): error CS8186: A foreach loop must declare its iteration variables.
                 //             foreach ((var y, _) in new[] { (1, "hello") }) { System.Console.Write("4"); } // error
-                Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "(var y, _)"),
+                Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "(var y, _)").WithLocation(11, 22),
                 // (10,17): warning CS0168: The variable '_' is declared but never used
                 //             int _;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "_").WithArguments("_")
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "_").WithArguments("_").WithLocation(10, 17)
                 );
         }
 
@@ -5829,13 +5830,13 @@ class Program
             compilation.VerifyDiagnostics(
                 // (6,34): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
                 //         foreach ((M(out var x1), args is var x2, _) in new[] { (1, 2, 3) })
-                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "args is var x2"),
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "args is var x2").WithLocation(6, 34),
                 // (6,34): error CS0029: Cannot implicitly convert type 'int' to 'bool'
                 //         foreach ((M(out var x1), args is var x2, _) in new[] { (1, 2, 3) })
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "args is var x2").WithArguments("int", "bool").WithLocation(6, 34),
                 // (6,18): error CS8186: A foreach loop must declare its iteration variables.
                 //         foreach ((M(out var x1), args is var x2, _) in new[] { (1, 2, 3) })
-                Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "(M(out var x1), args is var x2, _)")
+                Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "(M(out var x1), args is var x2, _)").WithLocation(6, 18)
                 );
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -98,33 +98,30 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size       48 (0x30)
+  // Code size       44 (0x2c)
   .maxstack  3
   .locals init (long V_0, //x
                 string V_1, //y
                 int V_2,
-                string V_3,
-                string V_4)
+                string V_3)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldloca.s   V_2
   IL_0007:  ldloca.s   V_3
-  IL_0009:  call       ""void C.Deconstruct(out int, out string)""
+  IL_0009:  callvirt   ""void C.Deconstruct(out int, out string)""
   IL_000e:  ldloc.2
   IL_000f:  conv.i8
-  IL_0010:  ldloc.3
-  IL_0011:  stloc.s    V_4
-  IL_0013:  dup
-  IL_0014:  stloc.0
-  IL_0015:  ldloc.s    V_4
-  IL_0017:  stloc.1
-  IL_0018:  pop
-  IL_0019:  ldloc.0
-  IL_001a:  box        ""long""
-  IL_001f:  ldstr      "" ""
-  IL_0024:  ldloc.1
-  IL_0025:  call       ""string string.Concat(object, object, object)""
-  IL_002a:  call       ""void System.Console.WriteLine(string)""
-  IL_002f:  ret
+  IL_0010:  dup
+  IL_0011:  stloc.0
+  IL_0012:  ldloc.3
+  IL_0013:  stloc.1
+  IL_0014:  pop
+  IL_0015:  ldloc.0
+  IL_0016:  box        ""long""
+  IL_001b:  ldstr      "" ""
+  IL_0020:  ldloc.1
+  IL_0021:  call       ""string string.Concat(object, object, object)""
+  IL_0026:  call       ""void System.Console.WriteLine(string)""
+  IL_002b:  ret
 }");
         }
 
@@ -156,32 +153,24 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size       47 (0x2f)
+  // Code size       39 (0x27)
   .maxstack  3
-  .locals init (int V_0, //x
-                string V_1, //y
-                int V_2,
-                string V_3,
-                string V_4)
+  .locals init (string V_0, //y
+                int V_1,
+                string V_2)
   IL_0000:  newobj     ""C..ctor()""
-  IL_0005:  ldloca.s   V_2
-  IL_0007:  ldloca.s   V_3
-  IL_0009:  call       ""void C.Deconstruct(out int, out string)""
-  IL_000e:  ldloc.2
-  IL_000f:  ldloc.3
-  IL_0010:  stloc.s    V_4
-  IL_0012:  dup
-  IL_0013:  stloc.0
-  IL_0014:  ldloc.s    V_4
-  IL_0016:  stloc.1
-  IL_0017:  pop
-  IL_0018:  ldloc.0
-  IL_0019:  box        ""int""
-  IL_001e:  ldstr      "" ""
-  IL_0023:  ldloc.1
-  IL_0024:  call       ""string string.Concat(object, object, object)""
-  IL_0029:  call       ""void System.Console.WriteLine(string)""
-  IL_002e:  ret
+  IL_0005:  ldloca.s   V_1
+  IL_0007:  ldloca.s   V_2
+  IL_0009:  callvirt   ""void C.Deconstruct(out int, out string)""
+  IL_000e:  ldloc.1
+  IL_000f:  ldloc.2
+  IL_0010:  stloc.0
+  IL_0011:  box        ""int""
+  IL_0016:  ldstr      "" ""
+  IL_001b:  ldloc.0
+  IL_001c:  call       ""string string.Concat(object, object, object)""
+  IL_0021:  call       ""void System.Console.WriteLine(string)""
+  IL_0026:  ret
 }");
         }
 
@@ -840,84 +829,21 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size      152 (0x98)
-  .maxstack  10
-  .locals init (int V_0, //y
-                long V_1,
-                long V_2,
-                long V_3,
-                long V_4,
-                long V_5,
-                long V_6,
-                long V_7,
-                long V_8,
-                long V_9,
-                int V_10)
-  IL_0000:  ldc.i4.1
+  // Code size       31 (0x1f)
+  .maxstack  3
+  .locals init (int V_0) //y
+  IL_0000:  ldc.i4.4
   IL_0001:  conv.i8
-  IL_0002:  ldc.i4.1
-  IL_0003:  conv.i8
-  IL_0004:  ldc.i4.1
-  IL_0005:  conv.i8
-  IL_0006:  ldc.i4.1
-  IL_0007:  conv.i8
-  IL_0008:  ldc.i4.1
-  IL_0009:  conv.i8
-  IL_000a:  ldc.i4.1
-  IL_000b:  conv.i8
-  IL_000c:  ldc.i4.1
-  IL_000d:  conv.i8
-  IL_000e:  ldc.i4.1
-  IL_000f:  conv.i8
-  IL_0010:  ldc.i4.4
-  IL_0011:  conv.i8
-  IL_0012:  ldc.i4.2
-  IL_0013:  newobj     ""System.ValueTuple<long, long, int>..ctor(long, long, int)""
-  IL_0018:  newobj     ""System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>..ctor(long, long, long, long, long, long, long, (long, long, int))""
-  IL_001d:  dup
-  IL_001e:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item1""
-  IL_0023:  stloc.1
-  IL_0024:  dup
-  IL_0025:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item2""
-  IL_002a:  stloc.2
-  IL_002b:  dup
-  IL_002c:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item3""
-  IL_0031:  stloc.3
-  IL_0032:  dup
-  IL_0033:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item4""
-  IL_0038:  stloc.s    V_4
-  IL_003a:  dup
-  IL_003b:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item5""
-  IL_0040:  stloc.s    V_5
-  IL_0042:  dup
-  IL_0043:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item6""
-  IL_0048:  stloc.s    V_6
-  IL_004a:  dup
-  IL_004b:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item7""
-  IL_0050:  stloc.s    V_7
-  IL_0052:  dup
-  IL_0053:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
-  IL_0058:  ldfld      ""long System.ValueTuple<long, long, int>.Item1""
-  IL_005d:  stloc.s    V_8
-  IL_005f:  dup
-  IL_0060:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
-  IL_0065:  ldfld      ""long System.ValueTuple<long, long, int>.Item2""
-  IL_006a:  stloc.s    V_9
-  IL_006c:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
-  IL_0071:  ldfld      ""int System.ValueTuple<long, long, int>.Item3""
-  IL_0076:  stloc.s    V_10
-  IL_0078:  ldloc.s    V_9
-  IL_007a:  ldloc.s    V_10
-  IL_007c:  stloc.0
-  IL_007d:  box        ""long""
-  IL_0082:  ldstr      "" ""
-  IL_0087:  ldloc.0
-  IL_0088:  box        ""int""
-  IL_008d:  call       ""string string.Concat(object, object, object)""
-  IL_0092:  call       ""void System.Console.WriteLine(string)""
-  IL_0097:  ret
-}
-");
+  IL_0002:  ldc.i4.2
+  IL_0003:  stloc.0
+  IL_0004:  box        ""long""
+  IL_0009:  ldstr      "" ""
+  IL_000e:  ldloc.0
+  IL_000f:  box        ""int""
+  IL_0014:  call       ""string string.Concat(object, object, object)""
+  IL_0019:  call       ""void System.Console.WriteLine(string)""
+  IL_001e:  ret
+}");
         }
 
         [Fact]
@@ -1014,34 +940,23 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size       52 (0x34)
+  // Code size       32 (0x20)
   .maxstack  3
   .locals init (string V_0, //x
-                string V_1, //y
-                string V_2,
-                string V_3)
+                string V_1) //y
   IL_0000:  ldstr      ""goodbye""
   IL_0005:  stloc.0
   IL_0006:  ldnull
-  IL_0007:  ldstr      ""hello""
-  IL_000c:  newobj     ""System.ValueTuple<string, string>..ctor(string, string)""
-  IL_0011:  dup
-  IL_0012:  ldfld      ""string System.ValueTuple<string, string>.Item1""
-  IL_0017:  stloc.2
-  IL_0018:  ldfld      ""string System.ValueTuple<string, string>.Item2""
-  IL_001d:  stloc.3
-  IL_001e:  ldloc.2
-  IL_001f:  stloc.0
-  IL_0020:  ldloc.3
-  IL_0021:  stloc.1
-  IL_0022:  ldstr      ""{0}{1}""
-  IL_0027:  ldloc.0
-  IL_0028:  ldloc.1
-  IL_0029:  call       ""string string.Format(string, object, object)""
-  IL_002e:  call       ""void System.Console.WriteLine(string)""
-  IL_0033:  ret
-}
-");
+  IL_0007:  stloc.0
+  IL_0008:  ldstr      ""hello""
+  IL_000d:  stloc.1
+  IL_000e:  ldstr      ""{0}{1}""
+  IL_0013:  ldloc.0
+  IL_0014:  ldloc.1
+  IL_0015:  call       ""string string.Format(string, object, object)""
+  IL_001a:  call       ""void System.Console.WriteLine(string)""
+  IL_001f:  ret
+} ");
         }
 
         [Fact]
@@ -1067,20 +982,15 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       19 (0x13)
+  // Code size       15 (0xf)
   .maxstack  3
   .locals init (int V_0,
-                int V_1,
-                int V_2)
+                int V_1)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldloca.s   V_0
   IL_0007:  ldloca.s   V_1
-  IL_0009:  call       ""void C.Deconstruct(out int, out int)""
-  IL_000e:  ldloc.0
-  IL_000f:  ldloc.1
-  IL_0010:  stloc.2
-  IL_0011:  pop
-  IL_0012:  ret
+  IL_0009:  callvirt   ""void C.Deconstruct(out int, out int)""
+  IL_000e:  ret
 }");
         }
 
@@ -1108,27 +1018,24 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       39 (0x27)
+  // Code size       37 (0x25)
   .maxstack  3
   .locals init (System.ValueTuple<int, int> V_0, //z
                 int V_1,
-                int V_2,
-                int V_3)
+                int V_2)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldloca.s   V_1
   IL_0007:  ldloca.s   V_2
-  IL_0009:  call       ""void C.Deconstruct(out int, out int)""
+  IL_0009:  callvirt   ""void C.Deconstruct(out int, out int)""
   IL_000e:  ldloc.1
   IL_000f:  ldloc.2
-  IL_0010:  stloc.3
-  IL_0011:  ldloc.3
-  IL_0012:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
-  IL_0017:  stloc.0
-  IL_0018:  ldloca.s   V_0
-  IL_001a:  constrained. ""System.ValueTuple<int, int>""
-  IL_0020:  callvirt   ""string object.ToString()""
-  IL_0025:  pop
-  IL_0026:  ret
+  IL_0010:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
+  IL_0015:  stloc.0
+  IL_0016:  ldloca.s   V_0
+  IL_0018:  constrained. ""System.ValueTuple<int, int>""
+  IL_001e:  callvirt   ""string object.ToString()""
+  IL_0023:  pop
+  IL_0024:  ret
 }");
         }
 
@@ -1432,25 +1339,19 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Swap", @"
 {
-  // Code size       41 (0x29)
+  // Code size       25 (0x19)
   .maxstack  2
-  .locals init (int V_0,
-                int V_1)
+  .locals init (int V_0)
   IL_0000:  ldsfld     ""int C.y""
   IL_0005:  ldsfld     ""int C.x""
-  IL_000a:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
-  IL_000f:  dup
-  IL_0010:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-  IL_0015:  stloc.0
-  IL_0016:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-  IL_001b:  stloc.1
-  IL_001c:  ldloc.0
-  IL_001d:  stsfld     ""int C.x""
-  IL_0022:  ldloc.1
-  IL_0023:  stsfld     ""int C.y""
-  IL_0028:  ret
+  IL_000a:  stloc.0
+  IL_000b:  dup
+  IL_000c:  stsfld     ""int C.x""
+  IL_0011:  ldloc.0
+  IL_0012:  stsfld     ""int C.y""
+  IL_0017:  pop
+  IL_0018:  ret
 }
-
 ");
         }
 
@@ -1462,7 +1363,7 @@ class C
 {
     static void Main()
     {
-        (object i, object ii) x = (1,2);
+        (object i, object ii) x = (1, 2);
         object y;
 
         (x.ii, y) = x;
@@ -1526,7 +1427,7 @@ class C : Base
         }
 
         [Fact]
-        public void DeconstructUsingExtensionMethod()
+        public void NestedDeconstructUsingSystemTupleExtensionMethod()
         {
             string source = @"
 using System;
@@ -1548,25 +1449,35 @@ class C
         }
 
         [Fact]
-        public void NestedDeconstructUsingExtensionMethod()
+        public void DeconstructUsingValueTupleExtensionMethod()
         {
             string source = @"
-using System;
 class C
 {
     static void Main()
     {
         int x;
         string y, z;
-        (x, (y, z)) = Tuple.Create(1, Tuple.Create(""hello"", ""world""));
-
-        System.Console.WriteLine(x + "" "" + y + "" "" + z);
+        (x, y, z) = (1, 2);
+    }
+}
+public static class Extensions
+{
+    public static void Deconstruct(this (int, int) self, out int x, out string y, out string z)
+    {
+        throw null;
     }
 }
 ";
-
-            var comp = CompileAndVerify(source, expectedOutput: "1 hello world", additionalRefs: s_valueTupleRefs, parseOptions: TestOptions.Regular.WithRefsFeature());
-            comp.VerifyDiagnostics();
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, SystemCoreRef });
+            comp.VerifyDiagnostics(
+                // (8,25): error CS0029: Cannot implicitly convert type 'int' to 'string'
+                //         (x, y, z) = (1, 2);
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "2").WithArguments("int", "string"),
+                // (8,9): error CS8132: Cannot deconstruct a tuple of '2' elements into '3' variables.
+                //         (x, y, z) = (1, 2);
+                Diagnostic(ErrorCode.ERR_DeconstructWrongCardinality, "(x, y, z) = (1, 2)").WithArguments("2", "3").WithLocation(8, 9)
+                );
         }
 
         [Fact]
@@ -1777,7 +1688,7 @@ class C1
                 // (9,18): error CS0411: The type arguments for method 'C1.Deconstruct<T>(out int, out T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         (x, y) = new C1();
                 Diagnostic(ErrorCode.ERR_CantInferMethTypeArgs, "new C1()").WithArguments("C1.Deconstruct<T>(out int, out T)").WithLocation(9, 18),
-                // (9,18): error CS8129: No Deconstruct instance or extension method was found for type 'C1', with 2 out parameters.
+                // (9,18): error CS8129: No Deconstruct instance or extension method was found for type 'C1', with 2 out parameters and a void return type.
                 //         (x, y) = new C1();
                 Diagnostic(ErrorCode.ERR_MissingDeconstruct, "new C1()").WithArguments("C1", "2").WithLocation(9, 18)
                 );
@@ -2150,33 +2061,19 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size       51 (0x33)
+  // Code size       29 (0x1d)
   .maxstack  3
-  .locals init (int V_0, //x1
-                string V_1, //x2
-                int V_2,
-                string V_3)
+  .locals init (string V_0) //x2
   IL_0000:  ldc.i4.1
   IL_0001:  ldstr      ""hello""
-  IL_0006:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
-  IL_000b:  dup
-  IL_000c:  ldfld      ""int System.ValueTuple<int, string>.Item1""
-  IL_0011:  stloc.2
-  IL_0012:  ldfld      ""string System.ValueTuple<int, string>.Item2""
-  IL_0017:  stloc.3
-  IL_0018:  ldloc.2
-  IL_0019:  stloc.0
-  IL_001a:  ldloc.3
-  IL_001b:  stloc.1
-  IL_001c:  ldloc.0
-  IL_001d:  box        ""int""
-  IL_0022:  ldstr      "" ""
-  IL_0027:  ldloc.1
-  IL_0028:  call       ""string string.Concat(object, object, object)""
-  IL_002d:  call       ""void System.Console.WriteLine(string)""
-  IL_0032:  ret
-}
-");
+  IL_0006:  stloc.0
+  IL_0007:  box        ""int""
+  IL_000c:  ldstr      "" ""
+  IL_0011:  ldloc.0
+  IL_0012:  call       ""string string.Concat(object, object, object)""
+  IL_0017:  call       ""void System.Console.WriteLine(string)""
+  IL_001c:  ret
+}");
         }
 
         [Fact]
@@ -2973,51 +2870,44 @@ class C
 
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       76 (0x4c)
+  // Code size       70 (0x46)
   .maxstack  2
   .locals init (System.Collections.Generic.IEnumerator<(int, int)> V_0,
-                int V_1, //x1
-                int V_2, //x2
-                int V_3,
-                int V_4)
+                int V_1, //x2
+                System.ValueTuple<int, int> V_2)
   IL_0000:  call       ""System.Collections.Generic.IEnumerable<(int, int)> C.M()""
   IL_0005:  callvirt   ""System.Collections.Generic.IEnumerator<(int, int)> System.Collections.Generic.IEnumerable<(int, int)>.GetEnumerator()""
   IL_000a:  stloc.0
   .try
   {
-    IL_000b:  br.s       IL_0037
+    IL_000b:  br.s       IL_0031
     IL_000d:  ldloc.0
     IL_000e:  callvirt   ""(int, int) System.Collections.Generic.IEnumerator<(int, int)>.Current.get""
-    IL_0013:  dup
-    IL_0014:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-    IL_0019:  stloc.3
-    IL_001a:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-    IL_001f:  stloc.s    V_4
-    IL_0021:  ldloc.3
-    IL_0022:  stloc.1
-    IL_0023:  ldloc.s    V_4
-    IL_0025:  stloc.2
+    IL_0013:  stloc.2
+    IL_0014:  ldloc.2
+    IL_0015:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+    IL_001a:  ldloc.2
+    IL_001b:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+    IL_0020:  stloc.1
+    IL_0021:  box        ""int""
     IL_0026:  ldloc.1
     IL_0027:  box        ""int""
-    IL_002c:  ldloc.2
-    IL_002d:  box        ""int""
-    IL_0032:  call       ""void C.Print(object, object)""
-    IL_0037:  ldloc.0
-    IL_0038:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
-    IL_003d:  brtrue.s   IL_000d
-    IL_003f:  leave.s    IL_004b
+    IL_002c:  call       ""void C.Print(object, object)""
+    IL_0031:  ldloc.0
+    IL_0032:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
+    IL_0037:  brtrue.s   IL_000d
+    IL_0039:  leave.s    IL_0045
   }
   finally
   {
-    IL_0041:  ldloc.0
-    IL_0042:  brfalse.s  IL_004a
-    IL_0044:  ldloc.0
-    IL_0045:  callvirt   ""void System.IDisposable.Dispose()""
-    IL_004a:  endfinally
+    IL_003b:  ldloc.0
+    IL_003c:  brfalse.s  IL_0044
+    IL_003e:  ldloc.0
+    IL_003f:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0044:  endfinally
   }
-  IL_004b:  ret
-}
-");
+  IL_0045:  ret
+}");
         }
 
         [Fact]
@@ -3064,63 +2954,60 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       99 (0x63)
+  // Code size       96 (0x60)
   .maxstack  4
   .locals init ((int, int)[] V_0,
                 int V_1,
                 int V_2, //x1
                 int V_3, //x2
-                int V_4,
-                int V_5)
+                System.ValueTuple<int, int> V_4)
   IL_0000:  call       ""(int, int)[] C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldc.i4.0
   IL_0007:  stloc.1
-  IL_0008:  br.s       IL_005c
+  IL_0008:  br.s       IL_0059
   IL_000a:  ldloc.0
   IL_000b:  ldloc.1
   IL_000c:  ldelem     ""System.ValueTuple<int, int>""
-  IL_0011:  dup
-  IL_0012:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-  IL_0017:  stloc.s    V_4
-  IL_0019:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-  IL_001e:  stloc.s    V_5
-  IL_0020:  ldloc.s    V_4
-  IL_0022:  stloc.2
-  IL_0023:  ldloc.s    V_5
-  IL_0025:  stloc.3
-  IL_0026:  ldc.i4.4
-  IL_0027:  newarr     ""object""
-  IL_002c:  dup
-  IL_002d:  ldc.i4.0
-  IL_002e:  ldloc.2
-  IL_002f:  box        ""int""
-  IL_0034:  stelem.ref
-  IL_0035:  dup
-  IL_0036:  ldc.i4.1
-  IL_0037:  ldstr      "" ""
-  IL_003c:  stelem.ref
-  IL_003d:  dup
-  IL_003e:  ldc.i4.2
-  IL_003f:  ldloc.3
-  IL_0040:  box        ""int""
-  IL_0045:  stelem.ref
-  IL_0046:  dup
-  IL_0047:  ldc.i4.3
-  IL_0048:  ldstr      "" - ""
-  IL_004d:  stelem.ref
-  IL_004e:  call       ""string string.Concat(params object[])""
-  IL_0053:  call       ""void System.Console.Write(string)""
-  IL_0058:  ldloc.1
-  IL_0059:  ldc.i4.1
-  IL_005a:  add
-  IL_005b:  stloc.1
-  IL_005c:  ldloc.1
-  IL_005d:  ldloc.0
-  IL_005e:  ldlen
-  IL_005f:  conv.i4
-  IL_0060:  blt.s      IL_000a
-  IL_0062:  ret
+  IL_0011:  stloc.s    V_4
+  IL_0013:  ldloc.s    V_4
+  IL_0015:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_001a:  stloc.2
+  IL_001b:  ldloc.s    V_4
+  IL_001d:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_0022:  stloc.3
+  IL_0023:  ldc.i4.4
+  IL_0024:  newarr     ""object""
+  IL_0029:  dup
+  IL_002a:  ldc.i4.0
+  IL_002b:  ldloc.2
+  IL_002c:  box        ""int""
+  IL_0031:  stelem.ref
+  IL_0032:  dup
+  IL_0033:  ldc.i4.1
+  IL_0034:  ldstr      "" ""
+  IL_0039:  stelem.ref
+  IL_003a:  dup
+  IL_003b:  ldc.i4.2
+  IL_003c:  ldloc.3
+  IL_003d:  box        ""int""
+  IL_0042:  stelem.ref
+  IL_0043:  dup
+  IL_0044:  ldc.i4.3
+  IL_0045:  ldstr      "" - ""
+  IL_004a:  stelem.ref
+  IL_004b:  call       ""string string.Concat(params object[])""
+  IL_0050:  call       ""void System.Console.Write(string)""
+  IL_0055:  ldloc.1
+  IL_0056:  ldc.i4.1
+  IL_0057:  add
+  IL_0058:  stloc.1
+  IL_0059:  ldloc.1
+  IL_005a:  ldloc.0
+  IL_005b:  ldlen
+  IL_005c:  conv.i4
+  IL_005d:  blt.s      IL_000a
+  IL_005f:  ret
 }");
         }
 
@@ -3167,17 +3054,15 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size      114 (0x72)
+  // Code size      107 (0x6b)
   .maxstack  3
   .locals init ((int, int)[,] V_0,
                 int V_1,
                 int V_2,
                 int V_3,
                 int V_4,
-                int V_5, //x1
-                int V_6, //x2
-                int V_7,
-                int V_8)
+                int V_5, //x2
+                System.ValueTuple<int, int> V_6)
   IL_0000:  call       ""(int, int)[,] C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -3192,45 +3077,41 @@ class C
   IL_0017:  ldc.i4.0
   IL_0018:  callvirt   ""int System.Array.GetLowerBound(int)""
   IL_001d:  stloc.3
-  IL_001e:  br.s       IL_006d
+  IL_001e:  br.s       IL_0066
   IL_0020:  ldloc.0
   IL_0021:  ldc.i4.1
   IL_0022:  callvirt   ""int System.Array.GetLowerBound(int)""
   IL_0027:  stloc.s    V_4
-  IL_0029:  br.s       IL_0064
+  IL_0029:  br.s       IL_005d
   IL_002b:  ldloc.0
   IL_002c:  ldloc.3
   IL_002d:  ldloc.s    V_4
   IL_002f:  call       ""(int, int)[*,*].Get""
-  IL_0034:  dup
-  IL_0035:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-  IL_003a:  stloc.s    V_7
-  IL_003c:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-  IL_0041:  stloc.s    V_8
-  IL_0043:  ldloc.s    V_7
-  IL_0045:  stloc.s    V_5
-  IL_0047:  ldloc.s    V_8
-  IL_0049:  stloc.s    V_6
+  IL_0034:  stloc.s    V_6
+  IL_0036:  ldloc.s    V_6
+  IL_0038:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_003d:  ldloc.s    V_6
+  IL_003f:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_0044:  stloc.s    V_5
+  IL_0046:  box        ""int""
   IL_004b:  ldloc.s    V_5
   IL_004d:  box        ""int""
-  IL_0052:  ldloc.s    V_6
-  IL_0054:  box        ""int""
-  IL_0059:  call       ""void C.Print(object, object)""
-  IL_005e:  ldloc.s    V_4
-  IL_0060:  ldc.i4.1
-  IL_0061:  add
-  IL_0062:  stloc.s    V_4
-  IL_0064:  ldloc.s    V_4
-  IL_0066:  ldloc.2
-  IL_0067:  ble.s      IL_002b
-  IL_0069:  ldloc.3
-  IL_006a:  ldc.i4.1
-  IL_006b:  add
-  IL_006c:  stloc.3
-  IL_006d:  ldloc.3
-  IL_006e:  ldloc.1
-  IL_006f:  ble.s      IL_0020
-  IL_0071:  ret
+  IL_0052:  call       ""void C.Print(object, object)""
+  IL_0057:  ldloc.s    V_4
+  IL_0059:  ldc.i4.1
+  IL_005a:  add
+  IL_005b:  stloc.s    V_4
+  IL_005d:  ldloc.s    V_4
+  IL_005f:  ldloc.2
+  IL_0060:  ble.s      IL_002b
+  IL_0062:  ldloc.3
+  IL_0063:  ldc.i4.1
+  IL_0064:  add
+  IL_0065:  stloc.3
+  IL_0066:  ldloc.3
+  IL_0067:  ldloc.1
+  IL_0068:  ble.s      IL_0020
+  IL_006a:  ret
 }");
         }
 
@@ -3284,48 +3165,40 @@ static class Extension
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       69 (0x45)
+  // Code size       60 (0x3c)
   .maxstack  3
   .locals init (string V_0,
                 int V_1,
-                int V_2, //x1
-                int V_3, //x2
-                int V_4,
-                int V_5,
-                int V_6)
+                int V_2, //x2
+                int V_3,
+                int V_4)
   IL_0000:  call       ""string C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldc.i4.0
   IL_0007:  stloc.1
-  IL_0008:  br.s       IL_003b
+  IL_0008:  br.s       IL_0032
   IL_000a:  ldloc.0
   IL_000b:  ldloc.1
   IL_000c:  callvirt   ""char string.this[int].get""
-  IL_0011:  ldloca.s   V_4
-  IL_0013:  ldloca.s   V_5
+  IL_0011:  ldloca.s   V_3
+  IL_0013:  ldloca.s   V_4
   IL_0015:  call       ""void Extension.Deconstruct(char, out int, out int)""
-  IL_001a:  ldloc.s    V_4
-  IL_001c:  ldloc.s    V_5
-  IL_001e:  stloc.s    V_6
-  IL_0020:  dup
-  IL_0021:  stloc.2
-  IL_0022:  ldloc.s    V_6
-  IL_0024:  stloc.3
-  IL_0025:  pop
-  IL_0026:  ldloc.2
-  IL_0027:  box        ""int""
-  IL_002c:  ldloc.3
-  IL_002d:  box        ""int""
-  IL_0032:  call       ""void C.Print(object, object)""
-  IL_0037:  ldloc.1
-  IL_0038:  ldc.i4.1
-  IL_0039:  add
-  IL_003a:  stloc.1
-  IL_003b:  ldloc.1
-  IL_003c:  ldloc.0
-  IL_003d:  callvirt   ""int string.Length.get""
-  IL_0042:  blt.s      IL_000a
-  IL_0044:  ret
+  IL_001a:  ldloc.3
+  IL_001b:  ldloc.s    V_4
+  IL_001d:  stloc.2
+  IL_001e:  box        ""int""
+  IL_0023:  ldloc.2
+  IL_0024:  box        ""int""
+  IL_0029:  call       ""void C.Print(object, object)""
+  IL_002e:  ldloc.1
+  IL_002f:  ldc.i4.1
+  IL_0030:  add
+  IL_0031:  stloc.1
+  IL_0032:  ldloc.1
+  IL_0033:  ldloc.0
+  IL_0034:  callvirt   ""int string.Length.get""
+  IL_0039:  blt.s      IL_000a
+  IL_003b:  ret
 }");
         }
 
@@ -3512,7 +3385,7 @@ Deconstructing (5, 6)
 
             comp.VerifyIL("C.Main",
 @"{
-  // Code size      103 (0x67)
+  // Code size       95 (0x5f)
   .maxstack  3
   .locals init (System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>> V_0,
                 long V_1, //x1
@@ -3521,15 +3394,13 @@ Deconstructing (5, 6)
                 int V_4,
                 Pair<int, int> V_5,
                 int V_6,
-                int V_7,
-                int V_8,
-                int V_9)
+                int V_7)
   IL_0000:  call       ""System.Collections.Generic.IEnumerable<Pair<int, Pair<int, int>>> C.M()""
   IL_0005:  callvirt   ""System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>> System.Collections.Generic.IEnumerable<Pair<int, Pair<int, int>>>.GetEnumerator()""
   IL_000a:  stloc.0
   .try
   {
-    IL_000b:  br.s       IL_0052
+    IL_000b:  br.s       IL_004a
     IL_000d:  ldloc.0
     IL_000e:  callvirt   ""Pair<int, Pair<int, int>> System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>>.Current.get""
     IL_0013:  ldloca.s   V_4
@@ -3541,38 +3412,34 @@ Deconstructing (5, 6)
     IL_0022:  callvirt   ""void Pair<int, int>.Deconstruct(out int, out int)""
     IL_0027:  ldloc.s    V_4
     IL_0029:  conv.i8
-    IL_002a:  ldloc.s    V_6
-    IL_002c:  stloc.s    V_8
-    IL_002e:  ldloc.s    V_7
-    IL_0030:  stloc.s    V_9
-    IL_0032:  dup
-    IL_0033:  stloc.1
-    IL_0034:  ldloc.s    V_8
-    IL_0036:  stloc.2
-    IL_0037:  ldloc.s    V_9
-    IL_0039:  stloc.3
-    IL_003a:  pop
-    IL_003b:  ldloc.1
-    IL_003c:  box        ""long""
-    IL_0041:  ldloc.2
-    IL_0042:  box        ""int""
-    IL_0047:  ldloc.3
-    IL_0048:  box        ""int""
-    IL_004d:  call       ""void C.Print(object, object, object)""
-    IL_0052:  ldloc.0
-    IL_0053:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
-    IL_0058:  brtrue.s   IL_000d
-    IL_005a:  leave.s    IL_0066
+    IL_002a:  dup
+    IL_002b:  stloc.1
+    IL_002c:  ldloc.s    V_6
+    IL_002e:  stloc.2
+    IL_002f:  ldloc.s    V_7
+    IL_0031:  stloc.3
+    IL_0032:  pop
+    IL_0033:  ldloc.1
+    IL_0034:  box        ""long""
+    IL_0039:  ldloc.2
+    IL_003a:  box        ""int""
+    IL_003f:  ldloc.3
+    IL_0040:  box        ""int""
+    IL_0045:  call       ""void C.Print(object, object, object)""
+    IL_004a:  ldloc.0
+    IL_004b:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
+    IL_0050:  brtrue.s   IL_000d
+    IL_0052:  leave.s    IL_005e
   }
   finally
   {
-    IL_005c:  ldloc.0
-    IL_005d:  brfalse.s  IL_0065
-    IL_005f:  ldloc.0
-    IL_0060:  callvirt   ""void System.IDisposable.Dispose()""
-    IL_0065:  endfinally
+    IL_0054:  ldloc.0
+    IL_0055:  brfalse.s  IL_005d
+    IL_0057:  ldloc.0
+    IL_0058:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_005d:  endfinally
   }
-  IL_0066:  ret
+  IL_005e:  ret
 }
 ");
         }
@@ -3952,71 +3819,61 @@ System.Console.Write($""{x} {y}"");
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42", sourceSymbolValidator: validator);
             verifier.VerifyIL("<<Initialize>>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      151 (0x97)
+  // Code size      129 (0x81)
   .maxstack  3
   .locals init (int V_0,
                 object V_1,
-                string V_2,
-                int V_3,
-                System.Exception V_4)
+                System.Exception V_2)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int <<Initialize>>d__0.<>1__state""
   IL_0006:  stloc.0
   .try
   {
-    IL_0007:  ldstr      ""hello""
-    IL_000c:  ldc.i4.s   42
-    IL_000e:  newobj     ""System.ValueTuple<string, int>..ctor(string, int)""
-    IL_0013:  dup
-    IL_0014:  ldfld      ""string System.ValueTuple<string, int>.Item1""
-    IL_0019:  stloc.2
-    IL_001a:  ldfld      ""int System.ValueTuple<string, int>.Item2""
-    IL_001f:  stloc.3
-    IL_0020:  ldarg.0
-    IL_0021:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_0026:  ldloc.2
-    IL_0027:  stfld      ""string x""
-    IL_002c:  ldarg.0
-    IL_002d:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_0032:  ldloc.3
-    IL_0033:  stfld      ""int y""
-    IL_0038:  ldstr      ""{0} {1}""
-    IL_003d:  ldarg.0
-    IL_003e:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_0043:  ldfld      ""string x""
-    IL_0048:  ldarg.0
-    IL_0049:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_004e:  ldfld      ""int y""
-    IL_0053:  box        ""int""
-    IL_0058:  call       ""string string.Format(string, object, object)""
-    IL_005d:  call       ""void System.Console.Write(string)""
-    IL_0062:  nop
-    IL_0063:  ldnull
-    IL_0064:  stloc.1
-    IL_0065:  leave.s    IL_0081
+    IL_0007:  ldarg.0
+    IL_0008:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_000d:  ldstr      ""hello""
+    IL_0012:  stfld      ""string x""
+    IL_0017:  ldarg.0
+    IL_0018:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_001d:  ldc.i4.s   42
+    IL_001f:  stfld      ""int y""
+    IL_0024:  ldstr      ""{0} {1}""
+    IL_0029:  ldarg.0
+    IL_002a:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_002f:  ldfld      ""string x""
+    IL_0034:  ldarg.0
+    IL_0035:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_003a:  ldfld      ""int y""
+    IL_003f:  box        ""int""
+    IL_0044:  call       ""string string.Format(string, object, object)""
+    IL_0049:  call       ""void System.Console.Write(string)""
+    IL_004e:  nop
+    IL_004f:  ldnull
+    IL_0050:  stloc.1
+    IL_0051:  leave.s    IL_006b
   }
   catch System.Exception
   {
-    IL_0067:  stloc.s    V_4
-    IL_0069:  ldarg.0
-    IL_006a:  ldc.i4.s   -2
-    IL_006c:  stfld      ""int <<Initialize>>d__0.<>1__state""
-    IL_0071:  ldarg.0
-    IL_0072:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-    IL_0077:  ldloc.s    V_4
-    IL_0079:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
-    IL_007e:  nop
-    IL_007f:  leave.s    IL_0096
+    IL_0053:  stloc.2
+    IL_0054:  ldarg.0
+    IL_0055:  ldc.i4.s   -2
+    IL_0057:  stfld      ""int <<Initialize>>d__0.<>1__state""
+    IL_005c:  ldarg.0
+    IL_005d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+    IL_0062:  ldloc.2
+    IL_0063:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_0068:  nop
+    IL_0069:  leave.s    IL_0080
   }
-  IL_0081:  ldarg.0
-  IL_0082:  ldc.i4.s   -2
-  IL_0084:  stfld      ""int <<Initialize>>d__0.<>1__state""
-  IL_0089:  ldarg.0
-  IL_008a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-  IL_008f:  ldloc.1
-  IL_0090:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
-  IL_0095:  nop
-  IL_0096:  ret
+  IL_006b:  ldarg.0
+  IL_006c:  ldc.i4.s   -2
+  IL_006e:  stfld      ""int <<Initialize>>d__0.<>1__state""
+  IL_0073:  ldarg.0
+  IL_0074:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_0079:  ldloc.1
+  IL_007a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_007f:  nop
+  IL_0080:  ret
 }");
         }
 
@@ -4136,13 +3993,12 @@ System.Console.Write($""{x1} {x2} {x3}"");
             var verifier = CompileAndVerify(comp, expectedOutput: "1 2 3");
             verifier.VerifyIL("<<Initialize>>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      182 (0xb6)
+  // Code size      178 (0xb2)
   .maxstack  4
   .locals init (int V_0,
                 object V_1,
-                int V_2,
-                int V_3,
-                System.Exception V_4)
+                System.ValueTuple<int, int> V_2,
+                System.Exception V_3)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int <<Initialize>>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -4154,61 +4010,59 @@ System.Console.Write($""{x1} {x2} {x3}"");
     IL_000e:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
     IL_0013:  ldflda     ""int x1""
     IL_0018:  call       ""(int, int) M(out int)""
-    IL_001d:  dup
-    IL_001e:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-    IL_0023:  stloc.2
-    IL_0024:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-    IL_0029:  stloc.3
-    IL_002a:  ldarg.0
-    IL_002b:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_0030:  ldloc.2
-    IL_0031:  stfld      ""int x2""
-    IL_0036:  ldarg.0
-    IL_0037:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_003c:  ldloc.3
-    IL_003d:  stfld      ""int x3""
-    IL_0042:  ldstr      ""{0} {1} {2}""
-    IL_0047:  ldarg.0
-    IL_0048:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_004d:  ldfld      ""int x1""
-    IL_0052:  box        ""int""
-    IL_0057:  ldarg.0
-    IL_0058:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_005d:  ldfld      ""int x2""
-    IL_0062:  box        ""int""
-    IL_0067:  ldarg.0
-    IL_0068:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_006d:  ldfld      ""int x3""
-    IL_0072:  box        ""int""
-    IL_0077:  call       ""string string.Format(string, object, object, object)""
-    IL_007c:  call       ""void System.Console.Write(string)""
-    IL_0081:  nop
-    IL_0082:  ldnull
-    IL_0083:  stloc.1
-    IL_0084:  leave.s    IL_00a0
+    IL_001d:  stloc.2
+    IL_001e:  ldarg.0
+    IL_001f:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_0024:  ldloc.2
+    IL_0025:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+    IL_002a:  stfld      ""int x2""
+    IL_002f:  ldarg.0
+    IL_0030:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_0035:  ldloc.2
+    IL_0036:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+    IL_003b:  stfld      ""int x3""
+    IL_0040:  ldstr      ""{0} {1} {2}""
+    IL_0045:  ldarg.0
+    IL_0046:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_004b:  ldfld      ""int x1""
+    IL_0050:  box        ""int""
+    IL_0055:  ldarg.0
+    IL_0056:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_005b:  ldfld      ""int x2""
+    IL_0060:  box        ""int""
+    IL_0065:  ldarg.0
+    IL_0066:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_006b:  ldfld      ""int x3""
+    IL_0070:  box        ""int""
+    IL_0075:  call       ""string string.Format(string, object, object, object)""
+    IL_007a:  call       ""void System.Console.Write(string)""
+    IL_007f:  nop
+    IL_0080:  ldnull
+    IL_0081:  stloc.1
+    IL_0082:  leave.s    IL_009c
   }
   catch System.Exception
   {
-    IL_0086:  stloc.s    V_4
-    IL_0088:  ldarg.0
-    IL_0089:  ldc.i4.s   -2
-    IL_008b:  stfld      ""int <<Initialize>>d__0.<>1__state""
-    IL_0090:  ldarg.0
-    IL_0091:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-    IL_0096:  ldloc.s    V_4
-    IL_0098:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
-    IL_009d:  nop
-    IL_009e:  leave.s    IL_00b5
+    IL_0084:  stloc.3
+    IL_0085:  ldarg.0
+    IL_0086:  ldc.i4.s   -2
+    IL_0088:  stfld      ""int <<Initialize>>d__0.<>1__state""
+    IL_008d:  ldarg.0
+    IL_008e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+    IL_0093:  ldloc.3
+    IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_0099:  nop
+    IL_009a:  leave.s    IL_00b1
   }
-  IL_00a0:  ldarg.0
-  IL_00a1:  ldc.i4.s   -2
-  IL_00a3:  stfld      ""int <<Initialize>>d__0.<>1__state""
-  IL_00a8:  ldarg.0
-  IL_00a9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-  IL_00ae:  ldloc.1
-  IL_00af:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
-  IL_00b4:  nop
-  IL_00b5:  ret
+  IL_009c:  ldarg.0
+  IL_009d:  ldc.i4.s   -2
+  IL_009f:  stfld      ""int <<Initialize>>d__0.<>1__state""
+  IL_00a4:  ldarg.0
+  IL_00a5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_00aa:  ldloc.1
+  IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_00b0:  nop
+  IL_00b1:  ret
 }
 ");
         }
@@ -5199,10 +5053,10 @@ class C
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "_").WithArguments("string", "int").WithLocation(11, 30),
                 // (11,22): error CS8186: A foreach loop must declare its iteration variables.
                 //             foreach ((var y, _) in new[] { (1, "hello") }) { System.Console.Write("4"); } // error
-                Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "(var y, _)").WithLocation(11, 22),
+                Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "(var y, _)"),
                 // (10,17): warning CS0168: The variable '_' is declared but never used
                 //             int _;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "_").WithArguments("_").WithLocation(10, 17)
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "_").WithArguments("_")
                 );
         }
 
@@ -5913,13 +5767,13 @@ class Program
             compilation.VerifyDiagnostics(
                 // (6,34): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
                 //         foreach ((M(out var x1), args is var x2, _) in new[] { (1, 2, 3) })
-                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "args is var x2").WithLocation(6, 34),
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "args is var x2"),
                 // (6,34): error CS0029: Cannot implicitly convert type 'int' to 'bool'
                 //         foreach ((M(out var x1), args is var x2, _) in new[] { (1, 2, 3) })
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "args is var x2").WithArguments("int", "bool").WithLocation(6, 34),
                 // (6,18): error CS8186: A foreach loop must declare its iteration variables.
                 //         foreach ((M(out var x1), args is var x2, _) in new[] { (1, 2, 3) })
-                Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "(M(out var x1), args is var x2, _)").WithLocation(6, 18)
+                Diagnostic(ErrorCode.ERR_MustDeclareForeachIteration, "(M(out var x1), args is var x2, _)")
                 );
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
@@ -6130,7 +5984,7 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/15614")]
+        [Fact]
         void InvokeVarForLvalueInParens()
         {
             var source = @"
@@ -6149,7 +6003,9 @@ class Program
 }";
             var compilation = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics();
-            CompileAndVerify(compilation, expectedOutput: "10");
+
+            // PEVerify fails with ref return https://github.com/dotnet/roslyn/issues/12285
+            CompileAndVerify(compilation, expectedOutput: "10", verify: false);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -92,6 +92,12 @@ class C
                 var lhs = tree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>().First();
                 Assert.Equal(@"(x, y)", lhs.ToString());
                 Assert.Equal("(System.Int64, System.String)", model.GetTypeInfo(lhs).Type.ToTestDisplayString());
+
+                var right = tree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().Single();
+                Assert.Equal(@"new C()", right.ToString());
+                Assert.Equal("C", model.GetTypeInfo(right).Type.ToTestDisplayString());
+                Assert.Equal("C", model.GetTypeInfo(right).ConvertedType.ToTestDisplayString());
+                Assert.Equal(ConversionKind.Identity, model.GetConversion(right).Kind);
             };
 
             var comp = CompileAndVerify(source, expectedOutput: "1 hello", additionalRefs: s_valueTupleRefs, sourceSymbolValidator: validator);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -19655,19 +19655,19 @@ public class C
 
             var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp");
             comp.VerifyEmitDiagnostics(
-                // (25,9): error CS8128: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                // (25,28): error CS8128: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (int x1, int y1) = GetCoordinates();
-                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "(int x1, int y1) = GetCoordinates()").WithArguments("Item1", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(25, 9),
-                // (25,9): error CS8128: Member 'Item2' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "GetCoordinates()").WithArguments("Item1", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(25, 28),
+                // (25,28): error CS8128: Member 'Item2' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (int x1, int y1) = GetCoordinates();
-                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "(int x1, int y1) = GetCoordinates()").WithArguments("Item2", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(25, 9),
-                // (26,9): error CS8128: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "GetCoordinates()").WithArguments("Item2", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(25, 28),
+                // (26,28): error CS8128: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (int x2, int y2) = GetCoordinates2();
-                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "(int x2, int y2) = GetCoordinates2()").WithArguments("Item1", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(26, 9),
-                // (26,9): error CS8128: Member 'Item2' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "GetCoordinates2()").WithArguments("Item1", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(26, 28),
+                // (26,28): error CS8128: Member 'Item2' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (int x2, int y2) = GetCoordinates2();
-                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "(int x2, int y2) = GetCoordinates2()").WithArguments("Item2", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(26, 9)
-            );
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "GetCoordinates2()").WithArguments("Item2", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(26, 28)
+                );
         }
 
         [Fact, WorkItem(13494, "https://github.com/dotnet/roslyn/issues/13494")]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTupleTests.cs
@@ -238,7 +238,6 @@ string.Format(@"<symbols>
           <slot kind=""0"" offset=""59"" />
           <slot kind=""0"" offset=""62"" />
           <slot kind=""temp"" />
-          <slot kind=""temp"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
@@ -247,16 +246,16 @@ string.Format(@"<symbols>
         <entry offset=""0x2"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""15"" />
         <entry offset=""0x9"" hidden=""true"" />
         <entry offset=""0xb"" startLine=""6"" startColumn=""13"" endLine=""6"" endColumn=""23"" />
-        <entry offset=""0x24"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
-        <entry offset=""0x25"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
-        <entry offset=""0x26"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""15"" />
-        <entry offset=""0x30"" hidden=""true"" />
-        <entry offset=""0x3b"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0x20"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
+        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
+        <entry offset=""0x22"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""15"" />
+        <entry offset=""0x2c"" hidden=""true"" />
+        <entry offset=""0x37"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x3c"">
-        <scope startOffset=""0xb"" endOffset=""0x26"">
-          <local name=""a"" il_index=""1"" il_start=""0xb"" il_end=""0x26"" attributes=""0"" />
-          <local name=""b"" il_index=""2"" il_start=""0xb"" il_end=""0x26"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0x38"">
+        <scope startOffset=""0xb"" endOffset=""0x22"">
+          <local name=""a"" il_index=""1"" il_start=""0xb"" il_end=""0x22"" attributes=""0"" />
+          <local name=""b"" il_index=""2"" il_start=""0xb"" il_end=""0x22"" attributes=""0"" />
         </scope>
       </scope>
     </method>

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/IOperationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/IOperationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 using System.Linq;
+using Microsoft.CodeAnalysis.Semantics;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -81,13 +82,19 @@ public class C
 
             var assignments = tree.GetRoot().DescendantNodes().OfType<AssignmentExpressionSyntax>().ToArray();
             Assert.Equal("(x, y, z) = (1, 2, 3)", assignments[0].ToString());
-            Assert.Equal(null, model.GetOperation(assignments[0]));
+            IOperation operation1 = model.GetOperation(assignments[0]);
+            Assert.NotNull(operation1);
+            Assert.False(operation1 is IAssignmentExpression);
 
             Assert.Equal("(x, y, z) = new C()", assignments[1].ToString());
-            Assert.Equal(null, model.GetOperation(assignments[1]));
+            IOperation operation2 = model.GetOperation(assignments[1]);
+            Assert.NotNull(operation2);
+            Assert.False(operation2 is IAssignmentExpression);
 
             Assert.Equal("var (a, b) = (1, 2)", assignments[2].ToString());
-            Assert.Null(model.GetOperation(assignments[2]));
+            IOperation operation3 = model.GetOperation(assignments[2]);
+            Assert.NotNull(operation3);
+            Assert.False(operation3 is IAssignmentExpression);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/IOperationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/IOperationTests.cs
@@ -84,16 +84,19 @@ public class C
             Assert.Equal("(x, y, z) = (1, 2, 3)", assignments[0].ToString());
             IOperation operation1 = model.GetOperation(assignments[0]);
             Assert.NotNull(operation1);
+            Assert.Equal(OperationKind.None, operation1.Kind);
             Assert.False(operation1 is IAssignmentExpression);
 
             Assert.Equal("(x, y, z) = new C()", assignments[1].ToString());
             IOperation operation2 = model.GetOperation(assignments[1]);
             Assert.NotNull(operation2);
+            Assert.Equal(OperationKind.None, operation2.Kind);
             Assert.False(operation2 is IAssignmentExpression);
 
             Assert.Equal("var (a, b) = (1, 2)", assignments[2].ToString());
             IOperation operation3 = model.GetOperation(assignments[2]);
             Assert.NotNull(operation3);
+            Assert.Equal(OperationKind.None, operation3.Kind);
             Assert.False(operation3 is IAssignmentExpression);
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/IOperationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/IOperationTests.cs
@@ -87,7 +87,7 @@ public class C
             Assert.Equal(null, model.GetOperation(assignments[1]));
 
             Assert.Equal("var (a, b) = (1, 2)", assignments[2].ToString());
-            Assert.Equal(null, model.GetOperation(assignments[2]));
+            Assert.Null(model.GetOperation(assignments[2]));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -280,7 +280,7 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
-                // (9,18): error CS8129: No Deconstruct instance or extension method was found for type 'C', with 2 out parameters.
+                // (9,18): error CS8129: No Deconstruct instance or extension method was found for type 'C', with 2 out parameters and a void return type.
                 //         (x, y) = new C();
                 Diagnostic(ErrorCode.ERR_MissingDeconstruct, "new C()").WithArguments("C", "2").WithLocation(9, 18)
                 );
@@ -407,7 +407,7 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
-                // (11,18): error CS8129: No Deconstruct instance or extension method was found for type 'C', with 2 out parameters.
+                // (11,18): error CS8129: No Deconstruct instance or extension method was found for type 'C', with 2 out parameters and a void return type.
                 //         (x, y) = new C() { Deconstruct = DeconstructMethod };
                 Diagnostic(ErrorCode.ERR_MissingDeconstruct, "new C() { Deconstruct = DeconstructMethod }").WithArguments("C", "2").WithLocation(11, 18)
                 );
@@ -508,12 +508,12 @@ class C
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (8,9): error CS0266: Cannot implicitly convert type 'int' to 'byte'. An explicit conversion exists (are you missing a cast?)
+                // (8,10): error CS0266: Cannot implicitly convert type 'int' to 'byte'. An explicit conversion exists (are you missing a cast?)
                 //         (x, y) = new C();
-                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "(x, y) = new C()").WithArguments("int", "byte").WithLocation(8, 9),
-                // (8,9): error CS0029: Cannot implicitly convert type 'int' to 'string'
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "x").WithArguments("int", "byte").WithLocation(8, 10),
+                // (8,13): error CS0029: Cannot implicitly convert type 'int' to 'string'
                 //         (x, y) = new C();
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(x, y) = new C()").WithArguments("int", "string").WithLocation(8, 9)
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "y").WithArguments("int", "string").WithLocation(8, 13)
                 );
         }
 
@@ -811,17 +811,15 @@ class C
         int y;
 
         (x, y) = (1, 2);
+        System.Console.WriteLine($""{x} {y}"");
     }
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp");
+            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            comp.VerifyEmitDiagnostics(
-                // (22,9): error CS8128: Member 'Item2' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
-                //         (x, y) = (1, 2);
-                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "(x, y) = (1, 2)").WithArguments("Item2", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(22, 9)
-                );
+            comp.VerifyEmitDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "1 2");
         }
 
         [Fact]
@@ -1173,7 +1171,7 @@ class C
             comp.VerifyDiagnostics(
                 // (7,17): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //         var y = (x, x) = new C();
-                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(x, x) = new C()").WithArguments("System.ValueTuple`2").WithLocation(7, 17)
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(x, x)").WithArguments("System.ValueTuple`2").WithLocation(7, 17)
                 );
         }
 
@@ -1327,28 +1325,16 @@ class C
             comp.VerifyDiagnostics(
                 // (6,13): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         var (x1, x2) = Pair.Create(1, 2);
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(x1, x2)").WithArguments("tuples", "7").WithLocation(6, 13),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(x1, x2)").WithArguments("tuples", "7"),
                 // (7,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         (int x3, int x4) = Pair.Create(1, 2);
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x3, int x4)").WithArguments("tuples", "7").WithLocation(7, 9),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x3, int x4)").WithArguments("tuples", "7"),
                 // (8,18): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         foreach ((int x5, var (x6, x7)) in new[] { Pair.Create(1, Pair.Create(2, 3)) }) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x5, var (x6, x7))").WithArguments("tuples", "7").WithLocation(8, 18),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x5, var (x6, x7))").WithArguments("tuples", "7"),
                 // (9,14): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         for ((int x8, var (x9, x10)) = Pair.Create(1, Pair.Create(2, 3)); ; ) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x8, var (x9, x10))").WithArguments("tuples", "7").WithLocation(9, 14),
-                // (8,32): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x6'.
-                //         foreach ((int x5, var (x6, x7)) in new[] { Pair.Create(1, Pair.Create(2, 3)) }) { }
-                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x6").WithArguments("x6").WithLocation(8, 32),
-                // (8,36): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x7'.
-                //         foreach ((int x5, var (x6, x7)) in new[] { Pair.Create(1, Pair.Create(2, 3)) }) { }
-                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x7").WithArguments("x7").WithLocation(8, 36),
-                // (9,28): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x9'.
-                //         for ((int x8, var (x9, x10)) = Pair.Create(1, Pair.Create(2, 3)); ; ) { }
-                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x9").WithArguments("x9").WithLocation(9, 28),
-                // (9,32): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x10'.
-                //         for ((int x8, var (x9, x10)) = Pair.Create(1, Pair.Create(2, 3)); ; ) { }
-                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x10").WithArguments("x10").WithLocation(9, 32)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x8, var (x9, x10))").WithArguments("tuples", "7")
                 );
         }
 
@@ -2700,6 +2686,9 @@ unsafe class C
                 // (6,15): error CS0103: The name 'x1' does not exist in the current context
                 //         (int* x1, int y1) = c;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(6, 15),
+                // (6,19): error CS0266: Cannot implicitly convert type 'dynamic' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //         (int* x1, int y1) = c;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "int y1").WithArguments("dynamic", "int").WithLocation(6, 19),
                 // (6,9): error CS8184: A deconstruction cannot mix declarations and expressions on the left-hand-side.
                 //         (int* x1, int y1) = c;
                 Diagnostic(ErrorCode.ERR_MixedDeconstructionUnsupported, "(int* x1, int y1)").WithLocation(6, 9),
@@ -2709,6 +2698,9 @@ unsafe class C
                 // (7,15): error CS0103: The name 'x2' does not exist in the current context
                 //         (var* x2, int y2) = c;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "x2").WithArguments("x2").WithLocation(7, 15),
+                // (7,19): error CS0266: Cannot implicitly convert type 'dynamic' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //         (var* x2, int y2) = c;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "int y2").WithArguments("dynamic", "int").WithLocation(7, 19),
                 // (7,9): error CS8184: A deconstruction cannot mix declarations and expressions on the left-hand-side.
                 //         (var* x2, int y2) = c;
                 Diagnostic(ErrorCode.ERR_MixedDeconstructionUnsupported, "(var* x2, int y2)").WithLocation(7, 9),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -1325,16 +1325,16 @@ class C
             comp.VerifyDiagnostics(
                 // (6,13): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         var (x1, x2) = Pair.Create(1, 2);
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(x1, x2)").WithArguments("tuples", "7"),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(x1, x2)").WithArguments("tuples", "7").WithLocation(6, 13),
                 // (7,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         (int x3, int x4) = Pair.Create(1, 2);
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x3, int x4)").WithArguments("tuples", "7"),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x3, int x4)").WithArguments("tuples", "7").WithLocation(7, 9),
                 // (8,18): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         foreach ((int x5, var (x6, x7)) in new[] { Pair.Create(1, Pair.Create(2, 3)) }) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x5, var (x6, x7))").WithArguments("tuples", "7"),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x5, var (x6, x7))").WithArguments("tuples", "7").WithLocation(8, 18),
                 // (9,14): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         for ((int x8, var (x9, x10)) = Pair.Create(1, Pair.Create(2, 3)); ; ) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x8, var (x9, x10))").WithArguments("tuples", "7")
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x8, var (x9, x10))").WithArguments("tuples", "7").WithLocation(9, 14)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -1506,18 +1506,18 @@ public class C
 
             var expectedDiagnostics = new[]
             {
-                // (8,12): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
+               // (8,12): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //     public (int, int) TestTuple()
-                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(int, int)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(8, 12),
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(int, int)").WithArguments("System.ValueTuple<T1, T2>"),
                 // (4,19): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //     public System.ValueTuple<string, string> TestValueTuple()
-                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "ValueTuple<string, string>").WithArguments("System.ValueTuple<T1, T2>").WithLocation(4, 19),
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "ValueTuple<string, string>").WithArguments("System.ValueTuple<T1, T2>"),
                 // (14,16): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //         return (1, 2);
-                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(1, 2)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(14, 16),
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(1, 2)").WithArguments("System.ValueTuple<T1, T2>"),
                 // (19,9): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //         (x, y) = new C();
-                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(x, y) = new C()").WithArguments("System.ValueTuple<T1, T2>").WithLocation(19, 9)
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(x, y)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(19, 9)
             };
 
             var comp1 = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseDll,

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -1506,15 +1506,15 @@ public class C
 
             var expectedDiagnostics = new[]
             {
-               // (8,12): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
+                // (8,12): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //     public (int, int) TestTuple()
-                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(int, int)").WithArguments("System.ValueTuple<T1, T2>"),
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(int, int)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(8, 12),
                 // (4,19): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //     public System.ValueTuple<string, string> TestValueTuple()
-                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "ValueTuple<string, string>").WithArguments("System.ValueTuple<T1, T2>"),
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "ValueTuple<string, string>").WithArguments("System.ValueTuple<T1, T2>").WithLocation(4, 19),
                 // (14,16): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //         return (1, 2);
-                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(1, 2)").WithArguments("System.ValueTuple<T1, T2>"),
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(1, 2)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(14, 16),
                 // (19,9): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //         (x, y) = new C();
                 Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(x, y)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(19, 9)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/MayHaveSideEffectsVisitor.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/MayHaveSideEffectsVisitor.cs
@@ -27,6 +27,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return this.SetMayHaveSideEffects();
         }
 
+        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
+        {
+            return this.SetMayHaveSideEffects();
+        }
+
         // Calls are treated as having side effects, but properties and
         // indexers are not. (Since this visitor is run on the bound tree
         // before lowering, properties are not represented as calls.)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/MayHaveSideEffectsVisitor.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/MayHaveSideEffectsVisitor.cs
@@ -27,11 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             return this.SetMayHaveSideEffects();
         }
 
-        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
-        {
-            return this.SetMayHaveSideEffects();
-        }
-
         // Calls are treated as having side effects, but properties and
         // indexers are not. (Since this visitor is run on the bound tree
         // before lowering, properties are not represented as calls.)

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DeclarationTests.cs
@@ -119,11 +119,9 @@ class C
 
                    testData.GetMethodData("<>x.<>m0(C)").VerifyIL(@"
 {
-  // Code size      112 (0x70)
+  // Code size       92 (0x5c)
   .maxstack  4
-  .locals init (System.Guid V_0,
-                int V_1,
-                string V_2)
+  .locals init (System.Guid V_0)
   IL_0000:  ldtoken    ""int""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""z1""
@@ -140,26 +138,18 @@ class C
   IL_0035:  ldloc.0
   IL_0036:  ldnull
   IL_0037:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
-  IL_003c:  ldc.i4.1
-  IL_003d:  ldnull
-  IL_003e:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
-  IL_0043:  dup
-  IL_0044:  ldfld      ""int System.ValueTuple<int, string>.Item1""
-  IL_0049:  stloc.1
-  IL_004a:  ldfld      ""string System.ValueTuple<int, string>.Item2""
-  IL_004f:  stloc.2
-  IL_0050:  ldstr      ""z1""
-  IL_0055:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
-  IL_005a:  ldloc.1
-  IL_005b:  stind.i4
-  IL_005c:  ldstr      ""z2""
-  IL_0061:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
-  IL_0066:  ldloc.2
-  IL_0067:  stind.ref
-  IL_0068:  ldloc.1
-  IL_0069:  ldloc.2
-  IL_006a:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
-  IL_006f:  ret
+  IL_003c:  ldstr      ""z1""
+  IL_0041:  call       ""int Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<int>(string)""
+  IL_0046:  ldc.i4.1
+  IL_0047:  stind.i4
+  IL_0048:  ldstr      ""z2""
+  IL_004d:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
+  IL_0052:  ldnull
+  IL_0053:  stind.ref
+  IL_0054:  ldc.i4.1
+  IL_0055:  ldnull
+  IL_0056:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
+  IL_005b:  ret
 }");
                });
         }
@@ -206,11 +196,9 @@ class C
 
                    testData.GetMethodData("<>x.<>m0(C)").VerifyIL(@"
 {
-  // Code size       70 (0x46)
+  // Code size       50 (0x32)
   .maxstack  4
-  .locals init (System.Guid V_0,
-                int V_1,
-                string V_2)
+  .locals init (System.Guid V_0)
   IL_0000:  ldtoken    ""string""
   IL_0005:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
   IL_000a:  ldstr      ""z2""
@@ -219,22 +207,14 @@ class C
   IL_0017:  ldloc.0
   IL_0018:  ldnull
   IL_0019:  call       ""void Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, string, System.Guid, byte[])""
-  IL_001e:  ldc.i4.1
-  IL_001f:  ldnull
-  IL_0020:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
-  IL_0025:  dup
-  IL_0026:  ldfld      ""int System.ValueTuple<int, string>.Item1""
-  IL_002b:  stloc.1
-  IL_002c:  ldfld      ""string System.ValueTuple<int, string>.Item2""
-  IL_0031:  stloc.2
-  IL_0032:  ldstr      ""z2""
-  IL_0037:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
-  IL_003c:  ldloc.2
-  IL_003d:  stind.ref
-  IL_003e:  ldloc.1
-  IL_003f:  ldloc.2
-  IL_0040:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
-  IL_0045:  ret
+  IL_001e:  ldstr      ""z2""
+  IL_0023:  call       ""string Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress<string>(string)""
+  IL_0028:  ldnull
+  IL_0029:  stind.ref
+  IL_002a:  ldc.i4.1
+  IL_002b:  ldnull
+  IL_002c:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
+  IL_0031:  ret
 }
 ");
                });


### PR DESCRIPTION
The initial binding for deconstruction now produces a `BoundAssignmentOperator` (instead of a `BoundDeconstructionAssignmentOperator`).

The `BoundAssignmentOperator` has:
 - a `BoundTupleLiteral` as its Left,
 - a `BoundConversion` as its Right, holding:
     - a tree of `Conversion` objects with Kind=Deconstruction, information about a Deconstruct method (optional) and an array of nested `Conversions` (like a tuple conversion),
     - an `BoundExpression` as its Operand.

A number of optimizations just fell out from this change. Most deconstructions don't construct a `ValueTuple` anymore and most un-necessary temps are now avoided.

Fixes https://github.com/dotnet/roslyn/issues/16869 (don't construct ValueTuple in simple deconstruction)
Fixes https://github.com/dotnet/roslyn/issues/13632 (don't use temps in simple deconstruction)
Fixes https://github.com/dotnet/roslyn/issues/13631 (don't construct ValueTuple in simple deconstruction)
Fixes https://github.com/dotnet/roslyn/issues/13270 (Phase ordering and bound node design issues for tuple deconstruction)
Fixes https://github.com/dotnet/roslyn/issues/16311 (Avoid creating the tuple return type for deconstruction twice)
Fixes https://github.com/dotnet/roslyn/issues/16166 (don't construct ValueTuple un-necessarily)

@dotnet/roslyn-compiler for review.