### PR TITLE
Bump the NuGet moniker to -rc5

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -14,7 +14,7 @@
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
-    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">rc4</RoslynNuGetMoniker>
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">rc5</RoslynNuGetMoniker>
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>
 


### PR DESCRIPTION
We've shipped -rc4 packages to nuget.org, so any future builds should
be versioned higher.

Tagging @jaredpar, @jmarolf, @Pilchie and @tannergooding to discuss if this makes sense. I think it does. This at least makes internal test builds clearer, even if we don't ship those.