### PR TITLE
Don't trigger a semantic change when the text change has no changes

### DIFF
--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SemanticChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.SemanticChangedEventSource.cs
@@ -48,7 +48,10 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             {
                 // Whenever this subject buffer has changed, we always consider that to be a 
                 // semantic change.
-                this.RaiseChanged();
+                if (e.Changes.Any())
+                {
+                    RaiseChanged();
+                }
             }
 
             private void OnOpenedDocumentSemanticChanged(object sender, Document document)


### PR DESCRIPTION
This happens in projection scenarios when you edit a different subject buffer,
the end result being that we trigger a full re-classification of the entire view
every time something changes in the html portion of a razor/aspx file.