### PR TITLE
Re-enable test that verifies ref return cannot be inlined

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
 }");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/12838"), Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task WithRefInitializer1()
         {
             await TestMissingAsync(

--- a/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/InlineTemporary/InlineTemporaryCodeRefactoringProvider.cs
@@ -69,9 +69,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary
                 return;
             }
 
-            if (variableDeclarator.Initializer.Kind() == SyntaxKind.RefExpression)
+            if (variableDeclaration.Type.Kind() == SyntaxKind.RefType)
             {
-                // TODO: inlining byref temps is NYI
+                // TODO: inlining ref returns:
+                // https://github.com/dotnet/roslyn/issues/17132
                 return;
             }
 


### PR DESCRIPTION
Fixes #12838
Test from commit https://github.com/dotnet/roslyn/commit/c7349324e98e5a9dbc38b9c8a89f09b41d3c2012
@dotnet/roslyn-ide 
@dotnet/roslyn-compiler 