### PR TITLE
Fix crash while resolving a method-type-parameter.

### DIFF
--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -144,8 +144,13 @@ namespace Microsoft.CodeAnalysis
                 {
                     // We didn't find any candidates.  We still need to stream through this
                     // method signature so the reader is in a proper position.
+
+                    // Push an null-method to our stack so that any method-type-parameters
+                    // can at least be read (if not resolved) properly.
+                    reader.PushMethod(methodOpt: null);
                     var parameterTypeResolutions = reader.ReadSymbolKeyArray();
                     var returnType = GetFirstSymbol<ITypeSymbol>(reader.ReadSymbolKey());
+                    reader.PopMethod(methodOpt: null);
                 }
 
                 return CreateSymbolInfo(result);

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -360,13 +360,13 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
-            public void PushMethod(IMethodSymbol method)
-                => _methodSymbolStack.Add(method);
+            public void PushMethod(IMethodSymbol methodOpt)
+                => _methodSymbolStack.Add(methodOpt);
 
-            public void PopMethod(IMethodSymbol method)
+            public void PopMethod(IMethodSymbol methodOpt)
             {
                 Contract.ThrowIfTrue(_methodSymbolStack.Count == 0);
-                Contract.ThrowIfFalse(method.Equals(_methodSymbolStack.Last()));
+                Contract.ThrowIfFalse(Equals(methodOpt, _methodSymbolStack.Last()));
                 _methodSymbolStack.RemoveAt(_methodSymbolStack.Count - 1);
             }
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterOrdinalSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.TypeParameterOrdinalSymbolKey.cs
@@ -20,8 +20,11 @@ namespace Microsoft.CodeAnalysis
             {
                 var methodIndex = reader.ReadInteger();
                 var ordinal = reader.ReadInteger();
-                var typeParameter = reader.ResolveMethod(methodIndex).TypeParameters[ordinal];
-                return new SymbolKeyResolution(typeParameter);
+                var method = reader.ResolveMethod(methodIndex);
+                var typeParameter = method?.TypeParameters[ordinal];
+                return typeParameter == null
+                    ? default(SymbolKeyResolution)
+                    : new SymbolKeyResolution(typeParameter);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Shared.Utilities;
@@ -105,7 +106,9 @@ namespace Microsoft.CodeAnalysis
         {
             using (var reader = SymbolKeyReader.GetReader(symbolKey, compilation, ignoreAssemblyKey, cancellationToken))
             {
-                return reader.ReadFirstSymbolKey();
+                var result = reader.ReadFirstSymbolKey();
+                Debug.Assert(reader.Position == symbolKey.Length);
+                return result;
             }
         }
 

--- a/src/Workspaces/CoreTest/SymbolKeyTests.cs
+++ b/src/Workspaces/CoreTest/SymbolKeyTests.cs
@@ -579,6 +579,33 @@ class C
             Assert.NotNull(SymbolKey.Create(xSymbol));
         }
 
+        [Fact]
+        public void TestGenericMethodTypeParameterMissing1()
+        {
+            var source1 = @"
+public class C
+{
+    void M<T>(T t) { }
+}
+";
+
+            var source2 = @"
+public class C
+{
+}
+";
+
+            var compilation1 = GetCompilation(source1, LanguageNames.CSharp);
+            var compilation2 = GetCompilation(source2, LanguageNames.CSharp);
+
+            var methods = GetDeclaredSymbols(compilation1).OfType<IMethodSymbol>();
+            foreach (var method in methods)
+            {
+                var key = SymbolKey.Create(method);
+                key.Resolve(compilation2);
+            }
+        }
+
         [Fact, WorkItem(377839, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=377839")]
         public void TestConstructedMethodInsideLocalFunctionWithTypeParameters()
         {


### PR DESCRIPTION
**Customer scenario**

While editing, user gets a gold-bar telling them there was an exception thrown in the 'add using' analyzer.

I believe this to be a situatoin that would happen primarily in cross-language scenarios.  And involves trying to 'resolve' a symbol from one language 'A' in another language 'B', when that language 'B' does not have an up-to-date view of the compiler results of language 'A'.

i.e. user is editing in C# project.  The then go to VB project which reference that C# project.  if they added a method** to C# and then tried to refer to it from VB, it's possible that they might get this gold bar in a short period of time before the C# compiler finishes producing hte assembly for C#.

We've gotten scattered reports of this, but only recently figured the necessary steps to resolve it.

I believe the situatoin should be relatively uncommon.  And the experience is just that someone gets a gold bar telling them that 'add using has been disabled'.  It's a bad experience.  But it's not a crash/data-loss.

** Note: teh method must also be generic.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/17056

**Workarounds, if any**

User re-enables the 'add using' feature by choosing that button on the gold-bar.

**Risk**

Very low.

**Performance impact**

Very low.

**Is this a regression from a previous update?**

Yes.   We rewrote this system during VS2017 and missed this edge case.

**Root cause analysis:**

In order to find talk about symbols across multiple languages, we have a system called SymbolKey that allows us to take a symbol from one language, and find it in the other.  This system was rewritten in VS2017 to be more memory and perf efficient.  This was important because this is also how we communicate with OOP.

However, because of this, the system also got a bit more complex.  And an error path was not sufficiently tested.  Specifically, if we started with the SymbolKey for a *generic* method, and we tried to resolve that in a location where that method didn't exist, then we will crash.  

**How was the bug found?**

Customer/internal reports.