### PR TITLE
Fix crash when trying to remove a cast when comparing to an enum.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3931,5 +3931,49 @@ class Program
     }
 }");
         }
+
+        [WorkItem(17029, "https://github.com/dotnet/roslyn/issues/17029")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveCastOnEnumComparison1()
+        {
+            await TestMissingAsync(
+@"
+enum TransferTypeKey
+{
+    Transfer,
+    TransferToBeneficiary
+}
+
+class Program
+{
+    static void Main(dynamic p)
+    {
+        if (p.TYP != [|(int)TransferTypeKey.TransferToBeneficiary|])
+          throw new InvalidOperationException();
+    }
+}");
+        }
+
+        [WorkItem(17029, "https://github.com/dotnet/roslyn/issues/17029")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveCastOnEnumComparison2()
+        {
+            await TestMissingAsync(
+@"
+enum TransferTypeKey
+{
+    Transfer,
+    TransferToBeneficiary
+}
+
+class Program
+{
+    static void Main(dynamic p)
+    {
+        if ([|(int)TransferTypeKey.TransferToBeneficiary|] != p.TYP)
+          throw new InvalidOperationException();
+    }
+}");
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Shared.Utilities
@@ -367,7 +366,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 return true;
             }
 
-            // Handle equivalence of special built-in comparison operators between enum types and it's underlying enum type.
+            // Handle equivalence of special built-in comparison operators between enum types and 
+            // it's underlying enum type.
             if (symbol.Kind == SymbolKind.Method && newSymbol.Kind == SymbolKind.Method)
             {
                 var methodSymbol = (IMethodSymbol)symbol;
@@ -378,23 +378,23 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 {
                     var type = methodSymbol.ContainingType;
                     var newType = newMethodSymbol.ContainingType;
-                    if ((type != null && newType != null) &&
-                        (
-                            type.IsEnumType() &&
-                            type.EnumUnderlyingType != null &&
-                            type.EnumUnderlyingType.SpecialType == newType.SpecialType) ||
-                        (
-                            newType.IsEnumType() &&
-                            newType.EnumUnderlyingType != null &&
-                            newType.EnumUnderlyingType.SpecialType == type.SpecialType))
+                    if (type != null && newType != null)
                     {
-                        return true;
+                        if (EnumTypesAreCompatible(type, newType) ||
+                            EnumTypesAreCompatible(newType, type))
+                        {
+                            return true;
+                        }
                     }
                 }
             }
 
             return false;
         }
+
+        private static bool EnumTypesAreCompatible(INamedTypeSymbol type1, INamedTypeSymbol type2)
+            => type1.IsEnumType() &&
+               type1.EnumUnderlyingType?.SpecialType == type2.SpecialType;
 
         #endregion
 


### PR DESCRIPTION
**Customer scenario**

Customer writes code where a casted-enum is compared to a member of an 'interesting' type (i.e. dynamic, array, pointer, anything that isn't a member of a named type).

Product gets a gold bar, telling them one of our analyzers has crashed and has been disabled.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/17029

**Workarounds, if any**

Customer doesn't write that code.

**Risk**

Low.

**Performance impact**

Low.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

A very confusing conditional expression hid an incorrect check.

**How was the bug found?**

Customer reported.  As well as watson with 2,600 hits in RC.3 alone.