### PR TITLE
Ensure package is loaded by loading CPS project

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -242,7 +242,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var semantic = state.GetAnalysisData(AnalysisKind.Semantic);
 
                 var project = document.Project;
-                var fullAnalysis = ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project);
+
+                // if project didn't successfully loaded, then it is same as FSA off
+                var fullAnalysis = ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project) && 
+                                   await project.HasSuccessfullyLoadedAsync(CancellationToken.None).ConfigureAwait(false);
 
                 // keep from build flag if full analysis is off
                 var fromBuild = fullAnalysis ? false : lastResult.FromBuild;


### PR DESCRIPTION
**Customer scenario**

Customer opens .NET core solution/project and doesn't see any errors populated in error list until user opens a file.

change also include a fix to make initial build + missing references case's error list experience better. 

**Bugs this fixes:** 

https://github.com/dotnet/roslyn-project-system/issues/1411

**Workarounds, if any**

Opens a file.

**Risk**

Now, opening .Net core loads bunch of VS services it doesn't used to (which was wrong behavior). they used to be loaded when user opens a file first time. some could view this as perf regression, but the perf gain was just due to a broken functionality.

**Performance impact**

we now loads same set of services as legacy csharp projects when project is opened first time in VS. which .NET core used to do when first file is opened. time it spent should be exactly same as legacy csharp project since they share same code.

**Is this a regression from a previous update?**

no

**Root cause analysis:**

when CSharp/Roslyn packages are initialized first time, we connect bunch of VS services with Roslyn's such as error list, FAR, solution crawler, object browser, misc projects and etc.

legacy project system did this when it is first loaded into VS. but .NET core delayed that to first time a file is opened in VS. meaning all those features won't work until a file is opened in VS. 

now, .NET core (CPS) force those things to be loaded same way as legacy project.

**How was the bug found?**

dogfooding, customer report.