### PR TITLE
Fix NullReferenceException in BoundCall.DeriveArgument.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Diagnostics\DiagnosticAnalyzerTests.AllInOne.cs" />
     <Compile Include="Diagnostics\DiagnosticAnalyzerTests.cs" />
     <Compile Include="Diagnostics\GetDiagnosticsTests.cs" />
+    <Compile Include="Diagnostics\IOperationTests.cs" />
     <Compile Include="Diagnostics\OperationAnalyzerTests.cs" />
     <Compile Include="FlowAnalysis\FlowDiagnosticTests.cs" />
     <Compile Include="FlowAnalysis\FlowTestBase.cs" />

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/IOperationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/IOperationTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class IOperationTests : CompilingTestBase
+    {
+        [Fact]
+        [WorkItem(382240, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=382240")]
+        public void NullInPlaceOfParamArray()
+        {
+            var text = @"
+public class Cls
+{
+    public static void Main()
+    {
+        Test1(null);
+        Test2(new object(), null);
+    }
+
+    static void Test1(params int[] x)
+    {
+    }
+
+    static void Test2(int y, params int[] x)
+    {
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(text, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular);
+            compilation.VerifyDiagnostics(
+                // (7,15): error CS1503: Argument 1: cannot convert from 'object' to 'int'
+                //         Test2(new object(), null);
+                Diagnostic(ErrorCode.ERR_BadArgType, "new object()").WithArguments("1", "object", "int").WithLocation(7, 15)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var nodes = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ToArray();
+
+            compilation.VerifyOperationTree(nodes[0], expectedOperationTree:
+@"IInvocationExpression (static void Cls.Test1(params System.Int32[] x)) (OperationKind.InvocationExpression, Type: System.Void)
+  IArgument (Matching Parameter: x) (OperationKind.Argument)
+    IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: System.Int32[], Constant: null)
+      ILiteralExpression (Text: null) (OperationKind.LiteralExpression, Type: null, Constant: null)");
+
+            compilation.VerifyOperationTree(nodes[1], expectedOperationTree:
+@"IInvocationExpression (static void Cls.Test2(System.Int32 y, params System.Int32[] x)) (OperationKind.InvocationExpression, Type: System.Void, IsInvalid)
+  IArgument (Matching Parameter: y) (OperationKind.Argument)
+    IObjectCreationExpression (Constructor: System.Object..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Object)
+  IArgument (Matching Parameter: x) (OperationKind.Argument)
+    ILiteralExpression (Text: null) (OperationKind.LiteralExpression, Type: null, Constant: null)");
+        }
+    }
+}

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -790,7 +790,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             LogString(nameof(ILiteralExpression));
 
-            if (operation.ConstantValue.HasValue && operation.ConstantValue.Value.ToString() == operation.Text)
+            object value;
+            if (operation.ConstantValue.HasValue && ((value = operation.ConstantValue.Value) == null ? "null" : value.ToString()) == operation.Text)
             {
                 LogString($" (Text: {operation.Text})");
             }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=382240.

**Customer scenario**

Customer's code calls a method with a params parameter. A ```null``` literal, or another expression that doesn't have a natural type (could be a tuple literal, a method group, etc., I think) is passed as an argument corresponding to the params parameter. The method is not an applicable candidate given the supplied argument list, conversions do not exist, etc.

Here is an example of the call and the target method:
```
Test2(new object(), null);
    static void Test2(int y, params int[] x)
    {
    }
```

An attempt to get an IOperation tree for the invocation expression results in a NullReferenceException.

- The user of the API will see a crash.
- When an analyzer used by IDE encounters that, the exception with be caught and reported as an "analyzer driver threw an exception with this call stack" diagnostic in the error list, and we will report the non fatal watson.

**User Experience**

When this exception occurs, user will see a diagnostic "AD0002" with a message that "analyzer driver has crashed with this callstack" in the error list. We de-dupe this diagnostic across the project, so user will see at most one instance of this diagnostic per project.

**Bugs this fixes:** 
Added a null check to prevent null reference dereference.
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=382240.

**Workarounds, if any**

None.

**Risk**

Low

**Performance impact**

None.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

A unit-test is added.

**How was the bug found?**

Non-fatal Watson.

@dotnet/roslyn-compiler Please review.
CC @dotnet/roslyn-interactive
