### PR TITLE
Initial check in to start the work on "readonly ref" feature.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -171,7 +171,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Indicates whether or not the method returns by reference
         /// </summary>
-        public bool ReturnsByRef { get { return this.RefKind != RefKind.None; } }
+        public bool ReturnsByRef
+        {
+            get
+            {
+                Debug.Assert(this.RefKind != RefKind.Out);
+                return this.RefKind == RefKind.Ref;
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether or not the method returns by readonly reference
+        /// </summary>
+        public bool ReturnsByReadonlyRef
+        {
+            get
+            {
+                Debug.Assert(this.RefKind != RefKind.Out);
+                return this.RefKind == RefKind.In;
+            }
+        }
 
         /// <summary>
         /// Gets the ref kind of the method's return value

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -93,6 +93,7 @@ Microsoft.CodeAnalysis.IDiscardSymbol.Type.get -> Microsoft.CodeAnalysis.ITypeSy
 Microsoft.CodeAnalysis.IFieldSymbol.CorrespondingTupleField.get -> Microsoft.CodeAnalysis.IFieldSymbol
 Microsoft.CodeAnalysis.ILocalSymbol.IsRef.get -> bool
 Microsoft.CodeAnalysis.IMethodSymbol.RefCustomModifiers.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CustomModifier>
+Microsoft.CodeAnalysis.IMethodSymbol.ReturnsByReadonlyRef.get -> bool
 Microsoft.CodeAnalysis.IMethodSymbol.ReturnsByRef.get -> bool
 Microsoft.CodeAnalysis.INamedTypeSymbol.GetTypeArgumentCustomModifiers(int ordinal) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CustomModifier>
 Microsoft.CodeAnalysis.INamedTypeSymbol.IsComImport.get -> bool
@@ -189,6 +190,7 @@ Microsoft.CodeAnalysis.OperationKind.WithStatement = 82 -> Microsoft.CodeAnalysi
 Microsoft.CodeAnalysis.OperationKind.YieldBreakStatement = 12 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.YieldReturnStatement = 16 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.PortableExecutableReference.GetMetadataId() -> Microsoft.CodeAnalysis.MetadataId
+Microsoft.CodeAnalysis.RefKind.In = 3 -> Microsoft.CodeAnalysis.RefKind
 Microsoft.CodeAnalysis.SemanticModel.GetOperation(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.ArgumentKind
 Microsoft.CodeAnalysis.Semantics.ArgumentKind.DefaultValue = 4 -> Microsoft.CodeAnalysis.Semantics.ArgumentKind

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbol.cs
@@ -75,6 +75,12 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         bool ReturnsByRef { get; }
 
+        // PROTOTYPE(readonlyRef): this is very preliminary. We need to have _some_ API for now.
+        /// <summary>
+        /// Returns true if this method returns by readonly reference.
+        /// </summary>
+        bool ReturnsByReadonlyRef { get; }
+
         /// <summary>
         /// Gets the return type of the method.
         /// </summary>

--- a/src/Compilers/Core/Portable/Symbols/RefKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/RefKind.cs
@@ -22,7 +22,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Indicates an "out" parameter.
         /// </summary>
-        Out = 2
+        Out = 2,
+
+        /// <summary>
+        /// Indicates an "in" parameter.
+        /// </summary>
+        In = 3,
     }
 
     internal static class RefKindExtensions
@@ -33,6 +38,7 @@ namespace Microsoft.CodeAnalysis
             {
                 case RefKind.Out: return "out";
                 case RefKind.Ref: return "ref";
+                case RefKind.In: return "in";
                 default: return null;
             }
         }
@@ -43,6 +49,7 @@ namespace Microsoft.CodeAnalysis
             {
                 case RefKind.Out: return "out ";
                 case RefKind.Ref: return "ref ";
+                case RefKind.In: return "in ";
                 default: return string.Empty;
             }
         }

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -949,6 +949,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IMethodSymbol_ReturnsByReadonlyRef As Boolean Implements IMethodSymbol.ReturnsByReadonlyRef
+            Get
+                ' PROTOTYPE(readonlyRef): NYI
+                Return False
+            End Get
+        End Property
+
         Private ReadOnly Property IMethodSymbol_ReturnType As ITypeSymbol Implements IMethodSymbol.ReturnType
             Get
                 Return Me.ReturnType

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
@@ -178,6 +178,14 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
+            public bool ReturnsByReadonlyRef
+            {
+                get
+                {
+                    return _symbol.ReturnsByReadonlyRef;
+                }
+            }
+
             public ITypeSymbol ReturnType
             {
                 get

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public abstract int Arity { get; }
         public abstract bool ReturnsVoid { get; }
         public abstract bool ReturnsByRef { get; }
+        public abstract bool ReturnsByReadonlyRef { get; }
         public abstract ITypeSymbol ReturnType { get; }
         public abstract ImmutableArray<ITypeSymbol> TypeArguments { get; }
         public abstract ImmutableArray<ITypeParameterSymbol> TypeParameters { get; }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedMethodSymbol.cs
@@ -48,6 +48,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
+        public override bool ReturnsByReadonlyRef
+        {
+            get
+            {
+                return _constructedFrom.ReturnsByReadonlyRef;
+            }
+        }
+
         public override ITypeSymbol ReturnType
         {
             get

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationMethodSymbol.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
     internal partial class CodeGenerationMethodSymbol : CodeGenerationAbstractMethodSymbol
     {
         private readonly ITypeSymbol _returnType;
-        private readonly bool _returnsByRef;
+        private readonly RefKind _refKind;
         private readonly ImmutableArray<ITypeParameterSymbol> _typeParameters;
         private readonly ImmutableArray<IParameterSymbol> _parameters;
         private readonly ImmutableArray<IMethodSymbol> _explicitInterfaceImplementations;
@@ -33,7 +33,8 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             : base(containingType, attributes, declaredAccessibility, modifiers, name, returnTypeAttributes)
         {
             _returnType = returnType;
-            _returnsByRef = returnsByRef;
+            // PROTOTYPE(readonlyRef): NYI 
+            _refKind = returnsByRef ? RefKind.Ref: RefKind.None;
             _typeParameters = typeParameters.AsImmutableOrEmpty();
             _parameters = parameters.AsImmutableOrEmpty();
             _explicitInterfaceImplementations = explicitInterfaceSymbolOpt == null
@@ -114,7 +115,15 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
             get
             {
-                return _returnsByRef;
+                return _refKind == RefKind.Ref;
+            }
+        }
+
+        public override bool ReturnsByReadonlyRef
+        {
+            get
+            {
+                return _refKind == RefKind.In;
             }
         }
 


### PR DESCRIPTION
Introducing new `RefKind.In` - to represent readonly ref parameters.
Also introduces a _very preliminary_  ReturnsByReadonlyRef API to represent readonly ref returns.