### PR TITLE
support creating remote session that doesn't require solution 

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -68,7 +68,7 @@ namespace Roslyn.Test.Utilities.Remote
             // this is what consumer actually use to communicate information
             var serviceStream = await _inprocServices.RequestServiceAsync(serviceName, cancellationToken).ConfigureAwait(false);
 
-            return await JsonRpcSession.CreateAsync(snapshot, snapshotStream, callbackTarget, serviceStream, cancellationToken).ConfigureAwait(false);
+            return await JsonRpcSession.CreateAsync(snapshot, callbackTarget, serviceStream, snapshotStream, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void OnConnected()

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
@@ -17,28 +17,28 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 {
     internal class JsonRpcSession : RemoteHostClient.Session
     {
-        private static int s_sessionId = 0;
+        private static int s_sessionId = 1;
 
         // current session id
         private readonly int _currentSessionId;
 
-        // communication channel related to snapshot information
-        private readonly SnapshotJsonRpcClient _snapshotClient;
-
         // communication channel related to service information
         private readonly ServiceJsonRpcClient _serviceClient;
+
+        // communication channel related to snapshot information
+        private readonly SnapshotJsonRpcClient _snapshotClientOpt;
 
         // close connection when cancellation has raised
         private readonly CancellationTokenRegistration _cancellationRegistration;
 
         public static async Task<JsonRpcSession> CreateAsync(
             PinnedRemotableDataScope snapshot,
-            Stream snapshotStream,
             object callbackTarget,
             Stream serviceStream,
+            Stream snapshotStreamOpt,
             CancellationToken cancellationToken)
         {
-            var session = new JsonRpcSession(snapshot, snapshotStream, callbackTarget, serviceStream, cancellationToken);
+            var session = new JsonRpcSession(snapshot, callbackTarget, serviceStream, snapshotStreamOpt, cancellationToken);
 
             await session.InitializeAsync().ConfigureAwait(false);
 
@@ -47,17 +47,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         private JsonRpcSession(
             PinnedRemotableDataScope snapshot,
-            Stream snapshotStream,
             object callbackTarget,
             Stream serviceStream,
+            Stream snapshotStreamOpt,
             CancellationToken cancellationToken) :
             base(snapshot, cancellationToken)
         {
             // get session id
             _currentSessionId = Interlocked.Increment(ref s_sessionId);
 
-            _snapshotClient = new SnapshotJsonRpcClient(this, snapshotStream, cancellationToken);
             _serviceClient = new ServiceJsonRpcClient(serviceStream, callbackTarget, cancellationToken);
+            _snapshotClientOpt = snapshot == null ? null : new SnapshotJsonRpcClient(this, snapshotStreamOpt, cancellationToken);
 
             // dispose session when cancellation has raised
             _cancellationRegistration = CancellationToken.Register(Dispose);
@@ -66,8 +66,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         private async Task InitializeAsync()
         {
             // all roslyn remote service must based on ServiceHubServiceBase which implements Initialize method
-            await _snapshotClient.InvokeAsync(WellKnownServiceHubServices.ServiceHubServiceBase_Initialize, _currentSessionId, PinnedScope.SolutionChecksum).ConfigureAwait(false);
-            await _serviceClient.InvokeAsync(WellKnownServiceHubServices.ServiceHubServiceBase_Initialize, _currentSessionId, PinnedScope.SolutionChecksum).ConfigureAwait(false);
+            if (_snapshotClientOpt != null)
+            {
+                await _snapshotClientOpt.InvokeAsync(WellKnownServiceHubServices.ServiceHubServiceBase_Initialize, _currentSessionId, PinnedScopeOpt.SolutionChecksum).ConfigureAwait(false);
+            }
+
+            await _serviceClient.InvokeAsync(WellKnownServiceHubServices.ServiceHubServiceBase_Initialize, _currentSessionId, PinnedScopeOpt?.SolutionChecksum).ConfigureAwait(false);
         }
 
         public override Task InvokeAsync(string targetName, params object[] arguments)
@@ -97,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             // dispose service and snapshot channels
             _serviceClient.Dispose();
-            _snapshotClient.Dispose();
+            _snapshotClientOpt?.Dispose();
         }
 
         /// <summary>
@@ -137,13 +141,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             public SnapshotJsonRpcClient(JsonRpcSession owner, Stream stream, CancellationToken cancellationToken)
                 : base(stream, callbackTarget: null, useThisAsCallback: true, cancellationToken: cancellationToken)
             {
+                Contract.ThrowIfNull(owner.PinnedScopeOpt);
+
                 _owner = owner;
                 _source = new CancellationTokenSource();
 
                 StartListening();
             }
 
-            private PinnedRemotableDataScope PinnedScope => _owner.PinnedScope;
+            private PinnedRemotableDataScope PinnedScope => _owner.PinnedScopeOpt;
 
             /// <summary>
             /// this is callback from remote host side to get asset associated with checksum from VS.

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -97,14 +97,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         protected override async Task<Session> CreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
         {
             // get stream from service hub to communicate snapshot/asset related information
-            // this is the back channel the system uses to move data between VS and remote host
-            var snapshotStream = await RequestServiceAsync(_hubClient, WellKnownServiceHubServices.SnapshotService, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
+            // this is the back channel the system uses to move data between VS and remote host for solution related information
+            var snapshotStream = snapshot == null ? null : await RequestServiceAsync(_hubClient, WellKnownServiceHubServices.SnapshotService, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
             // get stream from service hub to communicate service specific information
             // this is what consumer actually use to communicate information
             var serviceStream = await RequestServiceAsync(_hubClient, serviceName, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
-            return await JsonRpcSession.CreateAsync(snapshot, snapshotStream, callbackTarget, serviceStream, cancellationToken).ConfigureAwait(false);
+            return await JsonRpcSession.CreateAsync(snapshot, callbackTarget, serviceStream, snapshotStream, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void OnConnected()

--- a/src/Workspaces/Core/Desktop/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/Workspaces/Core/Desktop/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -24,8 +24,6 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                 var client = await workspace.GetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
                 if (client != null)
                 {
-                    var emptySolution = workspace.CreateSolution(workspace.CurrentSolution.Id);
-
                     // We create a single session and use it for the entire lifetime of this process.
                     // That single session will be used to do all communication with the remote process.
                     // This is because each session will cause a new instance of the RemoteSymbolSearchUpdateEngine
@@ -34,7 +32,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                     // much less clean and would make some of the state management much more complex.
                     var session = await client.CreateServiceSessionAsync(
                         WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine,
-                        emptySolution, logService, cancellationToken).ConfigureAwait(false);
+                        logService,
+                        cancellationToken).ConfigureAwait(false);
 
                     return new RemoteUpdateEngine(session);
                 }


### PR DESCRIPTION
Another OOP clean up.

adding back a support that let one to create remote session that doesn't require solution. 

if a feature want to delegate some of its work to OOP, but if it doesn't involve any solution to do its job, it can use this new API to do so.