### PR TITLE
ensure that TryParse is used for all user input in editorconfig

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -12,79 +12,79 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeForIntrinsicTypes = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(UseImplicitTypeForIntrinsicTypes), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_var_for_built_in_types", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_var_for_built_in_types"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeForIntrinsicTypes")});
 
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWhereApparent = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(UseImplicitTypeWhereApparent), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_var_when_type_is_apparent", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_var_when_type_is_apparent"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWhereApparent")});
 
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWherePossible = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(UseImplicitTypeWherePossible), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_var_elsewhere", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_var_elsewhere"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWherePossible")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferConditionalDelegateCall = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferConditionalDelegateCall), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_conditional_delegate_call", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_conditional_delegate_call"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.PreferConditionalDelegateCall")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferPatternMatchingOverAsWithNullCheck = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferPatternMatchingOverAsWithNullCheck), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_pattern_matching_over_as_with_null_check", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_pattern_matching_over_as_with_null_check"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferPatternMatchingOverAsWithNullCheck)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferPatternMatchingOverIsWithCastCheck = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferPatternMatchingOverIsWithCastCheck), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_pattern_matching_over_is_with_cast_check", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_pattern_matching_over_is_with_cast_check"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferPatternMatchingOverIsWithCastCheck)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedConstructors = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedConstructors), defaultValue: CodeStyleOptions.FalseWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_constructors", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_constructors"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedConstructors)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedMethods = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedMethods), defaultValue: CodeStyleOptions.FalseWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_methods", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_methods"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedMethods)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedOperators = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedOperators), defaultValue: CodeStyleOptions.FalseWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_operators", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_operators"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedOperators)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedProperties = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedProperties), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_properties", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_properties"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedProperties)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedIndexers = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedIndexers), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_indexers", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_indexers"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedIndexers)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedAccessors = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedAccessors), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_accessors", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_accessors"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedAccessors)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferBraces = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferBraces), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_prefer_braces", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_prefer_braces"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferBraces)}")});
 
         public static IEnumerable<Option<CodeStyleOption<bool>>> GetCodeStyleOptions()

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
@@ -6,36 +6,46 @@ namespace Microsoft.CodeAnalysis.CodeStyle
     {
         public static CodeStyleOption<bool> ParseEditorConfigCodeStyleOption(string arg)
         {
+            TryParseEditorConfigCodeStyleOption(arg, out var option);
+            return option;
+        }
+
+        public static bool TryParseEditorConfigCodeStyleOption(string arg, out CodeStyleOption<bool> option)
+        {
             var args = arg.Split(':');
-            bool isEnabled = false;
+            var isEnabled = false;
             if (args.Length != 2)
             {
                 if (args.Length == 1)
                 {
                     if (bool.TryParse(args[0].Trim(), out isEnabled) && !isEnabled)
                     {
-                        return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
+                        option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
+                        return true;
                     }
                     else
                     {
-                        return CodeStyleOption<bool>.Default;
+                        option = CodeStyleOption<bool>.Default;
+                        return false;
                     }
                 }
-                return CodeStyleOption<bool>.Default;
+                option = CodeStyleOption<bool>.Default;
+                return false;
             }
 
             if (!bool.TryParse(args[0].Trim(), out isEnabled))
             {
-                return CodeStyleOption<bool>.Default;
+                option = CodeStyleOption<bool>.Default;
+                return false;
             }
 
             switch (args[1].Trim())
             {
-                case EditorConfigSeverityStrings.Silent: return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
-                case EditorConfigSeverityStrings.Suggestion: return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Suggestion);
-                case EditorConfigSeverityStrings.Warning: return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Warning);
-                case EditorConfigSeverityStrings.Error: return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Error);
-                default: return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
+                case EditorConfigSeverityStrings.Silent: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None); return true;
+                case EditorConfigSeverityStrings.Suggestion: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Suggestion); return true;
+                case EditorConfigSeverityStrings.Warning: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Warning); return true;
+                case EditorConfigSeverityStrings.Error: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Error); return true;
+                default: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None); return false;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Options/EditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfigStorageLocation.cs
@@ -27,11 +27,7 @@ namespace Microsoft.CodeAnalysis.Options
                 if (allRawConventions.TryGetValue(KeyName, out object value))
                 {
                     result = _parseValue(value.ToString(), type);
-                    if (result == null)
-                    {
-                        return false;
-                    }
-                    return true;
+                    return result != null;
                 }
             }
             else if (_tryParseDictionary != null)
@@ -53,19 +49,11 @@ namespace Microsoft.CodeAnalysis.Options
             {
                 if (type == typeof(int))
                 {
-                    if (int.TryParse(s, out var value))
-                    {
-                        return value;
-                    }
-                    return null;
+                    return int.TryParse(s, out var value) ? (object)value : null;
                 }
                 else if (type == typeof(bool))
                 {
-                    if (bool.TryParse(s, out var value))
-                    {
-                        return value;
-                    }
-                    return null;
+                    return bool.TryParse(s, out var value) ? (object)value : null;
                 }
                 else if (type == typeof(CodeStyleOption<bool>))
                 {

--- a/src/Workspaces/Core/Portable/Options/EditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfigStorageLocation.cs
@@ -32,7 +32,8 @@ namespace Microsoft.CodeAnalysis.Options
             }
             else if (type == typeof(CodeStyleOption<bool>))
             {
-                return ParseEditorConfigCodeStyleOption(s);
+                var value = CodeStyleOption<bool>.Default;
+                return TryParseEditorConfigCodeStyleOption(s, out value) ? value : null;
             }
             else
             {

--- a/src/Workspaces/Core/Portable/Options/EditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfigStorageLocation.cs
@@ -27,6 +27,10 @@ namespace Microsoft.CodeAnalysis.Options
                 if (allRawConventions.TryGetValue(KeyName, out object value))
                 {
                     result = _parseValue(value.ToString(), type);
+                    if (result == null)
+                    {
+                        return false;
+                    }
                     return true;
                 }
             }
@@ -49,11 +53,19 @@ namespace Microsoft.CodeAnalysis.Options
             {
                 if (type == typeof(int))
                 {
-                    return int.Parse(s);
+                    if (int.TryParse(s, out var value))
+                    {
+                        return value;
+                    }
+                    return null;
                 }
                 else if (type == typeof(bool))
                 {
-                    return bool.Parse(s);
+                    if (bool.TryParse(s, out var value))
+                    {
+                        return value;
+                    }
+                    return null;
                 }
                 else if (type == typeof(CodeStyleOption<bool>))
                 {


### PR DESCRIPTION
We got several reports in RC of Parse(int) throwing exceptions.  This PR changes the  editorconfig parsing of options to only use TryParse.  It also simplifies several cases where we were passing a parsing function unnecessarily.