### PR TITLE
Support `foreach` statements that use different type from enumerable

### DIFF
--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -95,10 +95,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                     return true;
                 }
             }
-            else if (typeName.IsParentKind(SyntaxKind.ForEachStatement))
+            else if (typeName.Parent is ForEachStatementSyntax foreachStatment)
             {
-                issueSpan = candidateIssueSpan;
-                return true;
+                var foreachStatementInfo = semanticModel.GetForEachStatementInfo(foreachStatment);
+                if (foreachStatementInfo.ElementConversion.IsIdentityOrImplicitReference())
+                {
+                    issueSpan = candidateIssueSpan;
+                    return true;
+                }
             }
 
             issueSpan = default(TextSpan);


### PR DESCRIPTION
Check the type of conversion being used in the foreach statement before deciding if we should offer to convert it to var.
Fixes https://github.com/dotnet/roslyn/issues/14052