### PR TITLE
Make debug command line arguments parsing consistent on Unix platforms

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool concurrentBuild = true;
             bool deterministic = false; // TODO(5431): Enable deterministic mode by default
             bool emitPdb = false;
-            DebugInformationFormat debugInformationFormat = DebugInformationFormat.Pdb;
+            DebugInformationFormat debugInformationFormat = PathUtilities.IsUnixLikePlatform ? DebugInformationFormat.PortablePdb : DebugInformationFormat.Pdb;
             bool debugPlus = false;
             string pdbPath = null;
             bool noStdLib = IsScriptRunner; // don't add mscorlib from sdk dir when running scripts

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim concurrentBuild As Boolean = True
             Dim deterministic As Boolean = False
             Dim emitPdb As Boolean
-            Dim debugInformationFormat As DebugInformationFormat = DebugInformationFormat.Pdb
+            Dim debugInformationFormat As DebugInformationFormat = If(PathUtilities.IsUnixLikePlatform, DebugInformationFormat.PortablePdb, DebugInformationFormat.Pdb)
             Dim noStdLib As Boolean = False
             Dim utf8output As Boolean = False
             Dim outputFileName As String = Nothing


### PR DESCRIPTION
**Customer scenario**

https://github.com/dotnet/roslyn/commit/d837ae8589b8106e4b301fb879332a8003fabe61 changed default debug format on non-windows platforms but only for explicitly passed `full` or `pdbonly` arguments which makes it inconsistent with windows and documentation.

Without this change `csc /debug` or `csc /debug+` still fail with 

`error CS0041: Unexpected error writing debug information -- 'Windows PDB writer is not available -- could not find Microsoft.DiaSymReader.Native.amd64.dll'`
