### PR TITLE
Utilise PooledStringBuilder

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -16,7 +16,7 @@ Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module CompilationUtils
 
-    Private ReadOnly Property _pooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
+    Private ReadOnly Property _pooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = ParserTestUtilities.PooledStringBuilderPool
 
     Private Function ParseSources(sources As IEnumerable(Of String), parseOptions As VisualBasicParseOptions) As IEnumerable(Of SyntaxTree)
         Return sources.Select(Function(s) VisualBasicSyntaxTree.ParseText(s, parseOptions))

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -888,7 +888,7 @@ Friend Module CompilationUtils
                     .AppendLine("UNEXPECTED ERROR MESSAGES:")
                     .AppendLine(actualText.Substring(expectedText.Length))
 
-                    Assert.True(False, messages.ToStringAndFree())
+                    Assert.True(False, .ToString())
                 Else
                     Dim expectedLines = expectedText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
                     Dim actualLines = actualText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
@@ -912,7 +912,7 @@ Friend Module CompilationUtils
                     Next
 
                     If appendedLines > 0 Then
-                        Assert.True(False, messages.Builder.ToString())
+                        Assert.True(False, .ToString())
                     Else
                         CompareLineByLine(expectedText, actualText)
                     End If

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -16,7 +16,9 @@ Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module CompilationUtils
 
-    Private ReadOnly _pooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool
+    Private ReadOnly _pooledStringBuilderPool As New ObjectPool(Of PooledStringBuilder)(
+        New ObjectPool(Of PooledStringBuilder).Factory(Function() PooledStringBuilder.GetInstance), 64)
+
 
     Private Function ParseSources(sources As IEnumerable(Of String), parseOptions As VisualBasicParseOptions) As IEnumerable(Of SyntaxTree)
         Return sources.Select(Function(s) VisualBasicSyntaxTree.ParseText(s, parseOptions))

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -16,9 +16,8 @@ Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module CompilationUtils
 
-    Private ReadOnly _pooledStringBuilderPool As New ObjectPool(Of PooledStringBuilder)(
-        New ObjectPool(Of PooledStringBuilder).Factory(Function() PooledStringBuilder.GetInstance), 64)
-
+    Private ReadOnly _pooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = ParserTestUtilities.PooledStringBuilderPool
+    'PooledStringBuilder.CreatePool(64)
 
     Private Function ParseSources(sources As IEnumerable(Of String), parseOptions As VisualBasicParseOptions) As IEnumerable(Of SyntaxTree)
         Return sources.Select(Function(s) VisualBasicSyntaxTree.ParseText(s, parseOptions))

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -926,8 +926,8 @@ Friend Module CompilationUtils
         Dim expectedReader = New StringReader(expected)
         Dim actualReader = New StringReader(actual)
 
-        Dim expectedBuilder = _PooledStringBuilderPool.Allocate()
-        Dim actualBuilder = _PooledStringBuilderPool.Allocate()
+        Dim expectedBuilder = _pooledStringBuilderPool.Allocate()
+        Dim actualBuilder = _pooledStringBuilderPool.Allocate()
         Dim expectedLine = expectedReader.ReadLine()
         Dim actualLine = actualReader.ReadLine()
 
@@ -1220,7 +1220,7 @@ Friend Module CompilationUtils
             End If
             builder.Builder.Append(str)
         Next
-        Return builder.ToStringAndFree
+        Return builder.ToStringAndFree()
     End Function
 
     Public Sub CheckSymbolsUnordered(Of TSymbol As ISymbol)(symbols As ImmutableArray(Of TSymbol), ParamArray descriptions As String())

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -912,14 +912,13 @@ Friend Module CompilationUtils
                     Next
 
                     If appendedLines > 0 Then
-                        Assert.True(False, messages.ToStringAndFree())
-                        Exit Sub
+                        Assert.True(False, messages.Builder.ToString())
                     Else
                         CompareLineByLine(expectedText, actualText)
                     End If
                 End If
-                messages.Free()
             End With
+            messages.Free()
         End If
     End Sub
 

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -884,43 +884,44 @@ Friend Module CompilationUtils
         Dim actualText = DumpAllDiagnostics(errors.ToArray(), suppressInfos)
         If expectedText <> actualText Then
 
-            Dim messages As New StringBuilder
-            messages.AppendLine()
+            Dim messages = PooledStringBuilderPool.Allocate()
+            With messages.Builder
+                .AppendLine()
 
-            If actualText.StartsWith(expectedText, StringComparison.Ordinal) AndAlso actualText.Substring(expectedText.Length).Trim().Length > 0 Then
-                messages.AppendLine("UNEXPECTED ERROR MESSAGES:")
-                messages.AppendLine(actualText.Substring(expectedText.Length))
+                If actualText.StartsWith(expectedText, StringComparison.Ordinal) AndAlso actualText.Substring(expectedText.Length).Trim().Length > 0 Then
+                    .AppendLine("UNEXPECTED ERROR MESSAGES:")
+                    .AppendLine(actualText.Substring(expectedText.Length))
 
-                Assert.True(False, messages.ToString())
-            Else
-                Dim expectedLines = expectedText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
-                Dim actualLines = actualText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
-
-                Dim appendedLines As Integer = 0
-
-                messages.AppendLine("MISSING ERROR MESSAGES:")
-                For Each l In expectedLines
-                    If Not actualLines.Contains(l) Then
-                        messages.AppendLine(l)
-                        appendedLines += 1
-                    End If
-                Next
-
-                messages.AppendLine("UNEXPECTED ERROR MESSAGES:")
-                For Each l In actualLines
-                    If Not expectedLines.Contains(l) Then
-                        messages.AppendLine(l)
-                        appendedLines += 1
-                    End If
-                Next
-
-                If appendedLines > 0 Then
-                    Assert.True(False, messages.ToString())
+                    Assert.True(False, messages.ToStringAndFree())
                 Else
-                    CompareLineByLine(expectedText, actualText)
-                End If
+                    Dim expectedLines = expectedText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
+                    Dim actualLines = actualText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
 
-            End If
+                    Dim appendedLines As Integer = 0
+
+                    .AppendLine("MISSING ERROR MESSAGES:")
+                    For Each l In expectedLines
+                        If Not actualLines.Contains(l) Then
+                            .AppendLine(l)
+                            appendedLines += 1
+                        End If
+                    Next
+
+                    .AppendLine("UNEXPECTED ERROR MESSAGES:")
+                    For Each l In actualLines
+                        If Not expectedLines.Contains(l) Then
+                            .AppendLine(l)
+                            appendedLines += 1
+                        End If
+                    Next
+
+                    If appendedLines > 0 Then
+                        Assert.True(False, messages.ToStringAndFree())
+                    Else
+                        CompareLineByLine(expectedText, actualText)
+                    End If
+                End If
+            End With
         End If
     End Sub
 
@@ -1215,7 +1216,7 @@ Friend Module CompilationUtils
 
     Public Function SortAndMergeStrings(ParamArray strings As String()) As String
         Array.Sort(strings)
-        Dim builder = _pooledStringBuilderPool.Allocate
+        Dim builder = _pooledStringBuilderPool.Allocate()
         For Each str In strings
             If builder.Length > 0 Then
                 builder.Builder.AppendLine()

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -13,9 +13,10 @@ Imports Roslyn.Test.Utilities
 Imports Roslyn.Test.Utilities.TestBase
 Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
+
 Friend Module CompilationUtils
 
-    Private ReadOnly Property _PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
+    Private ReadOnly Property _pooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
 
     Private Function ParseSources(sources As IEnumerable(Of String), parseOptions As VisualBasicParseOptions) As IEnumerable(Of SyntaxTree)
         Return sources.Select(Function(s) VisualBasicSyntaxTree.ParseText(s, parseOptions))

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -16,7 +16,7 @@ Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module CompilationUtils
 
-    Private ReadOnly Property _pooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = ParserTestUtilities.PooledStringBuilderPool
+    Private ReadOnly _pooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool
 
     Private Function ParseSources(sources As IEnumerable(Of String), parseOptions As VisualBasicParseOptions) As IEnumerable(Of SyntaxTree)
         Return sources.Select(Function(s) VisualBasicSyntaxTree.ParseText(s, parseOptions))
@@ -979,7 +979,7 @@ Friend Module CompilationUtils
 
         Array.Sort(diagnosticsAndIndices, Function(diag1, diag2) CompareErrors(diag1, diag2))
 
-        Dim builder = _PooledStringBuilderPool.Allocate()
+        Dim builder = _pooledStringBuilderPool.Allocate()
         For Each e In diagnosticsAndIndices
             If Not suppressInfos OrElse e.Diagnostic.Severity > DiagnosticSeverity.Info Then
                 builder.Builder.Append(ErrorText(e.Diagnostic))
@@ -1213,7 +1213,7 @@ Friend Module CompilationUtils
 
     Public Function SortAndMergeStrings(ParamArray strings As String()) As String
         Array.Sort(strings)
-        Dim builder = _PooledStringBuilderPool.Allocate
+        Dim builder = _pooledStringBuilderPool.Allocate
         For Each str In strings
             If builder.Length > 0 Then
                 builder.Builder.AppendLine()

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,7 +13,7 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(If(Environment.Is64BitProcess, 64, 32))
+    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(If(Environment.Is64BitProcess, 128, 64))
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,7 +13,7 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(If(Environment.Is64BitProcess, 128, 64))
+    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(If(Environment.Is64BitProcess, 96, 64))
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -80,9 +80,13 @@ Friend Module ParserTestUtilities
             Dim errors = PooledStringBuilderPool.Allocate()
             AppendSyntaxErrors(tree.GetDiagnostics(), errors.Builder)
             Assert.Equal(root.ContainsDiagnostics, errors.Builder.Length > 0)
-            Assert.False(root.ContainsDiagnostics, errors.ToStringAndFree())
+            If root.ContainsDiagnostics Then
+                errors.Free()
+            Else
+                Assert.False(root.ContainsDiagnostics, errors.ToStringAndFree())
+            End If
         Else
-            Assert.True(root.ContainsDiagnostics, "Tree was expected to contain errors.")
+                Assert.True(root.ContainsDiagnostics, "Tree was expected to contain errors.")
             If errorCodesOnly Then
                 tree.GetDiagnostics().VerifyErrorCodes(expectedDiagnostics)
             Else
@@ -643,7 +647,11 @@ Public Module VerificationHelpers
                 .AppendLine("Actual Errors (on " & node.Kind().ToString & node.Span.ToString & ")")
                 AppendSyntaxErrors(tree.GetDiagnostics(node), errorMessage.Builder)
             End With
-            Assert.False(errorScenarioFailed, errorMessage.ToStringAndFree())
+            If errorScenarioFailed Then
+                Assert.False(errorScenarioFailed, errorMessage.ToStringAndFree())
+            Else
+                errorMessage.Free()
+            End If
         End If
     End Sub
 

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,7 +13,7 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(64)
+    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(If(Environment.Is64BitProcess, 64, 32))
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,7 +13,7 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property _PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
+    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree
@@ -551,7 +551,7 @@ Public Module VerificationHelpers
 #Region "Private Helpers"
 
     Private Function GetErrorString(id As Integer, message As String, start As String, [end] As String) As String
-        Dim errorString = ParserTestUtilities._PooledStringBuilderPool.Allocate()
+        Dim errorString = PooledStringBuilderPool.Allocate()
         With errorString.Builder
             .Append(vbTab)
             .Append("<error id=""")
@@ -634,7 +634,7 @@ Public Module VerificationHelpers
         Next
 
         If errorScenarioFailed Then
-            Dim errorMessage = ParserTestUtilities._PooledStringBuilderPool.Allocate()
+            Dim errorMessage = ParserTestUtilities.PooledStringBuilderPool.Allocate()
             With errorMessage.Builder
                 .AppendLine()
                 .AppendLine("Expected Subset:")

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -78,7 +78,7 @@ Friend Module ParserTestUtilities
         ' Verify Errors
         If expectedDiagnostics Is Nothing Then
             Dim errors = PooledStringBuilderPool.Allocate()
-            AppendSyntaxErrors(tree.GetDiagnostics(), errors)
+            AppendSyntaxErrors(tree.GetDiagnostics(), errors.Builder)
             Assert.Equal(root.ContainsDiagnostics, errors.Builder.Length > 0)
             Assert.False(root.ContainsDiagnostics, errors.ToStringAndFree())
         Else
@@ -541,10 +541,10 @@ Public Module VerificationHelpers
         End Function
     End Class
 
-    Friend Sub AppendSyntaxErrors(errors As IEnumerable(Of Diagnostic), output As PooledStringBuilder)
+    Friend Sub AppendSyntaxErrors(errors As IEnumerable(Of Diagnostic), output As StringBuilder)
         For Each e In errors
             Dim span = e.Location.SourceSpan
-            output.Builder.AppendLine(GetErrorString(e.Code, e.GetMessage(EnsureEnglishUICulture.PreferredOrNull), span.Start.ToString(), span.End.ToString()))
+            output.AppendLine(GetErrorString(e.Code, e.GetMessage(EnsureEnglishUICulture.PreferredOrNull), span.Start.ToString(), span.End.ToString()))
         Next
     End Sub
 
@@ -642,7 +642,7 @@ Public Module VerificationHelpers
                     .AppendLine(GetErrorString(CInt(e.@id), If(e.@message, "?"), If(e.@start, "?"), If(e.@end, "?")))
                 Next
                 .AppendLine("Actual Errors (on " & node.Kind().ToString & node.Span.ToString & ")")
-                AppendSyntaxErrors(tree.GetDiagnostics(node), errorMessage)
+                AppendSyntaxErrors(tree.GetDiagnostics(node), errorMessage.Builder)
             End With
             Assert.False(errorScenarioFailed, errorMessage.ToStringAndFree())
         End If

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,8 +13,7 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property PooledStringBuilderPool As New ObjectPool(Of PooledStringBuilder)(
-                New ObjectPool(Of PooledStringBuilder).Factory(Function() PooledStringBuilder.GetInstance), 64)
+    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(64)
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,7 +13,7 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(If(Environment.Is64BitProcess, 96, 64))
+    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool(64)
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,8 +13,8 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
-
+    Friend ReadOnly Property PooledStringBuilderPool As New ObjectPool(Of PooledStringBuilder)(
+        New ObjectPool(Of PooledStringBuilder).Factory(Function() PooledStringBuilder.GetInstance), 64)
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree
         Return ParseAndVerify(code.Value, expectedErrors)

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -80,13 +80,9 @@ Friend Module ParserTestUtilities
             Dim errors = PooledStringBuilderPool.Allocate()
             AppendSyntaxErrors(tree.GetDiagnostics(), errors.Builder)
             Assert.Equal(root.ContainsDiagnostics, errors.Builder.Length > 0)
-            If root.ContainsDiagnostics Then
-                errors.Free()
-            Else
-                Assert.False(root.ContainsDiagnostics, errors.ToStringAndFree())
-            End If
+            Assert.False(root.ContainsDiagnostics, errors.ToStringAndFree())
         Else
-                Assert.True(root.ContainsDiagnostics, "Tree was expected to contain errors.")
+            Assert.True(root.ContainsDiagnostics, "Tree was expected to contain errors.")
             If errorCodesOnly Then
                 tree.GetDiagnostics().VerifyErrorCodes(expectedDiagnostics)
             Else

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,7 +13,7 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
+    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = ParserTestUtilities.PooledStringBuilderPool ' PooledStringBuilder.CreatePool()
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -10,8 +10,10 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.SyntaxFacts
 Imports Roslyn.Test.Utilities
 Imports Xunit
+Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
+    Friend ReadOnly Property _PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree
@@ -75,10 +77,10 @@ Friend Module ParserTestUtilities
 
         ' Verify Errors
         If expectedDiagnostics Is Nothing Then
-            Dim errors As New StringBuilder()
+            Dim errors = _PooledStringBuilderPool.Allocate()
             AppendSyntaxErrors(tree.GetDiagnostics(), errors)
-            Assert.False(root.ContainsDiagnostics, errors.ToString())
-            Assert.Equal(root.ContainsDiagnostics, errors.Length > 0)
+            Assert.Equal(root.ContainsDiagnostics, errors.Builder.Length > 0)
+            Assert.False(root.ContainsDiagnostics, errors.ToStringAndFree())
         Else
             Assert.True(root.ContainsDiagnostics, "Tree was expected to contain errors.")
             If errorCodesOnly Then
@@ -539,38 +541,41 @@ Public Module VerificationHelpers
         End Function
     End Class
 
-    Friend Sub AppendSyntaxErrors(errors As IEnumerable(Of Diagnostic), output As StringBuilder)
+    Friend Sub AppendSyntaxErrors(errors As IEnumerable(Of Diagnostic), output As PooledStringBuilder)
         For Each e In errors
             Dim span = e.Location.SourceSpan
-            output.AppendLine(GetErrorString(e.Code, e.GetMessage(EnsureEnglishUICulture.PreferredOrNull), span.Start.ToString(), span.End.ToString()))
+            output.Builder.AppendLine(GetErrorString(e.Code, e.GetMessage(EnsureEnglishUICulture.PreferredOrNull), span.Start.ToString(), span.End.ToString()))
         Next
     End Sub
 
 #Region "Private Helpers"
 
     Private Function GetErrorString(id As Integer, message As String, start As String, [end] As String) As String
-        Dim errorString As New StringBuilder()
-        errorString.Append(vbTab)
-        errorString.Append("<error id=""")
-        errorString.Append(id)
-        errorString.Append("""")
-        If message IsNot Nothing Then
-            errorString.Append(" message=""")
-            errorString.Append(message)
-            errorString.Append("""")
-        End If
-        If start IsNot Nothing Then
-            errorString.Append(" start=""")
-            errorString.Append(start)
-            errorString.Append("""")
-        End If
-        If [end] IsNot Nothing Then
-            errorString.Append(" end=""")
-            errorString.Append([end])
-            errorString.Append("""")
-        End If
-        errorString.Append("/>")
-        Return errorString.ToString()
+        Dim errorString = ParserTestUtilities._PooledStringBuilderPool.Allocate()
+        With errorString.Builder
+            .Append(vbTab)
+            .Append("<error id=""")
+            .Append(id)
+            .Append("""")
+            If message IsNot Nothing Then
+                .Append(" message=""")
+                .Append(message)
+                .Append("""")
+            End If
+            If start IsNot Nothing Then
+                .Append(" start=""")
+                .Append(start)
+                .Append("""")
+            End If
+            If [end] IsNot Nothing Then
+                .Append(" end=""")
+                .Append([end])
+                .Append("""")
+            End If
+            .Append("/>")
+        End With
+        Return errorString.ToStringAndFree()
+
     End Function
 
     Private Function AreErrorsEquivalent(syntaxError As Diagnostic, xmlError As XElement) As Boolean
@@ -629,15 +634,17 @@ Public Module VerificationHelpers
         Next
 
         If errorScenarioFailed Then
-            Dim errorMessage As New StringBuilder()
-            errorMessage.AppendLine()
-            errorMessage.AppendLine("Expected Subset:")
-            For Each e In expectedErrors.<error>
-                errorMessage.AppendLine(GetErrorString(CInt(e.@id), If(e.@message, "?"), If(e.@start, "?"), If(e.@end, "?")))
-            Next
-            errorMessage.AppendLine("Actual Errors (on " & node.Kind().ToString & node.Span.ToString & ")")
-            AppendSyntaxErrors(tree.GetDiagnostics(node), errorMessage)
-            Assert.False(errorScenarioFailed, errorMessage.ToString())
+            Dim errorMessage = ParserTestUtilities._PooledStringBuilderPool.Allocate()
+            With errorMessage.Builder
+                .AppendLine()
+                .AppendLine("Expected Subset:")
+                For Each e In expectedErrors.<error>
+                    .AppendLine(GetErrorString(CInt(e.@id), If(e.@message, "?"), If(e.@start, "?"), If(e.@end, "?")))
+                Next
+                .AppendLine("Actual Errors (on " & node.Kind().ToString & node.Span.ToString & ")")
+                AppendSyntaxErrors(tree.GetDiagnostics(node), errorMessage)
+            End With
+            Assert.False(errorScenarioFailed, errorMessage.ToStringAndFree())
         End If
     End Sub
 

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -77,7 +77,7 @@ Friend Module ParserTestUtilities
 
         ' Verify Errors
         If expectedDiagnostics Is Nothing Then
-            Dim errors = _PooledStringBuilderPool.Allocate()
+            Dim errors = PooledStringBuilderPool.Allocate()
             AppendSyntaxErrors(tree.GetDiagnostics(), errors)
             Assert.Equal(root.ContainsDiagnostics, errors.Builder.Length > 0)
             Assert.False(root.ContainsDiagnostics, errors.ToStringAndFree())

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -13,7 +13,7 @@ Imports Xunit
 Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
-    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = ParserTestUtilities.PooledStringBuilderPool ' PooledStringBuilder.CreatePool()
+    Friend ReadOnly Property PooledStringBuilderPool As ObjectPool(Of PooledStringBuilder) = PooledStringBuilder.CreatePool()
 
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -14,7 +14,8 @@ Imports Microsoft.CodeAnalysis.Collections
 
 Friend Module ParserTestUtilities
     Friend ReadOnly Property PooledStringBuilderPool As New ObjectPool(Of PooledStringBuilder)(
-        New ObjectPool(Of PooledStringBuilder).Factory(Function() PooledStringBuilder.GetInstance), 64)
+                New ObjectPool(Of PooledStringBuilder).Factory(Function() PooledStringBuilder.GetInstance), 64)
+
     ' TODO (tomat): only checks error codes; we should also check error span and arguments
     Public Function ParseAndVerify(code As XCData, Optional expectedErrors As XElement = Nothing) As SyntaxTree
         Return ParseAndVerify(code.Value, expectedErrors)
@@ -575,7 +576,6 @@ Public Module VerificationHelpers
             .Append("/>")
         End With
         Return errorString.ToStringAndFree()
-
     End Function
 
     Private Function AreErrorsEquivalent(syntaxError As Diagnostic, xmlError As XElement) As Boolean
@@ -634,7 +634,7 @@ Public Module VerificationHelpers
         Next
 
         If errorScenarioFailed Then
-            Dim errorMessage = ParserTestUtilities.PooledStringBuilderPool.Allocate()
+            Dim errorMessage = PooledStringBuilderPool.Allocate()
             With errorMessage.Builder
                 .AppendLine()
                 .AppendLine("Expected Subset:")

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -79,10 +79,10 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <returns></returns>
         public static ObjectPool<PooledStringBuilder> CreatePool(int size = 32)
         {
-            const int lower_bound = 32;
-            const int upper_bound = 256;
+            const int LowerBound = 32;
+            const int UpperBound = 256;
             ObjectPool<PooledStringBuilder> pool = null;
-            size = (size < lower_bound ? lower_bound: (size > upper_bound ? upper_bound : size));
+            size = (size < LowerBound ? LowerBound: (size > UpperBound ? UpperBound : size));
             pool = new ObjectPool<PooledStringBuilder>(() => new PooledStringBuilder(pool), size);
             return pool;
         }

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <summary>
         /// If someone need to create a private pool
         /// </summary>
-        /// <param name="size">Initial size of the pool.</param>
+        /// <param name="size">The size of the pool.</param>
         /// <returns></returns>
         public static ObjectPool<PooledStringBuilder> CreatePool(int size = 32)
         {

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -75,14 +75,11 @@ namespace Microsoft.CodeAnalysis.Collections
         /// <summary>
         /// If someone need to create a private pool
         /// </summary>
-        /// <param name="size">Initial size of the pool. Bounded to 32 &lt;= Size &lt;= 256)</param>
+        /// <param name="size">Initial size of the pool.</param>
         /// <returns></returns>
         public static ObjectPool<PooledStringBuilder> CreatePool(int size = 32)
         {
-            const int LowerBound = 32;
-            const int UpperBound = 256;
             ObjectPool<PooledStringBuilder> pool = null;
-            size = (size < LowerBound ? LowerBound: (size > UpperBound ? UpperBound : size));
             pool = new ObjectPool<PooledStringBuilder>(() => new PooledStringBuilder(pool), size);
             return pool;
         }

--- a/src/Dependencies/PooledObjects/PooledStringBuilder.cs
+++ b/src/Dependencies/PooledObjects/PooledStringBuilder.cs
@@ -72,10 +72,18 @@ namespace Microsoft.CodeAnalysis.Collections
         private static readonly ObjectPool<PooledStringBuilder> s_poolInstance = CreatePool();
 
         // if someone needs to create a private pool;
-        public static ObjectPool<PooledStringBuilder> CreatePool()
+        /// <summary>
+        /// If someone need to create a private pool
+        /// </summary>
+        /// <param name="size">Initial size of the pool. Bounded to 32 &lt;= Size &lt;= 256)</param>
+        /// <returns></returns>
+        public static ObjectPool<PooledStringBuilder> CreatePool(int size = 32)
         {
+            const int lower_bound = 32;
+            const int upper_bound = 256;
             ObjectPool<PooledStringBuilder> pool = null;
-            pool = new ObjectPool<PooledStringBuilder>(() => new PooledStringBuilder(pool), 32);
+            size = (size < lower_bound ? lower_bound: (size > upper_bound ? upper_bound : size));
+            pool = new ObjectPool<PooledStringBuilder>(() => new PooledStringBuilder(pool), size);
             return pool;
         }
 


### PR DESCRIPTION
Make use of a pooled string builder with a commonly call methods, that eventually get called by VB UnitTests. This change doesn't affect the layout or source of any test.