### PR TITLE
allow waiters to be consumed from internal VS tests

### DIFF
--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -430,6 +430,10 @@ Public Class BuildDevDivInsertionFiles
             Next
         Next
 
+        ' Finally, include these to allow the waiters to be imported and consumed in VS tests.
+        filesToInsert.Add(New NugetFileInfo("Dlls\Diagnostics\Roslyn.Hosting.Diagnostics.dll"))
+        filesToInsert.Add(New NugetFileInfo("Vsix\VisualStudioIntegrationTestSetup\Microsoft.VisualStudio.IntegrationTest.Setup.vsix"))
+
         ProcessVsixFiles(filesToInsert, dependencies)
 
         ' Generate Roslyn.nuspec:


### PR DESCRIPTION
Internal VS tests need a way to know when the C# and VB language services are ready to be consumed.  We have internal waiters that serve this purpose well.

This PR simply publishes the appropriate files for consumption from internal VS tests via the ExternalApis package.

Once a build with these changes has been inserted into the VS build, and internal PR will go out to consume the waiters.

@dotnet/roslyn-ide @jaredpar