### PR TITLE
IsOptional should be false for ref/out parameters, except in COM interop scenarios.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -298,10 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // we could eliminate methods based on the number of arguments, but then we wouldn't be able to
             // fall back on them if no other candidates were available.
 
-            var refKind = parameter.RefKind;
-            return !isMethodGroupConversion && parameter.IsOptional &&
-                (refKind == RefKind.None ||
-                 (refKind == RefKind.Ref && parameter.ContainingSymbol.ContainingType.IsComImport));
+            return !isMethodGroupConversion && parameter.IsOptional;
         }
 
         private static int? NameUsedForPositional(AnalyzedArguments arguments, ParameterMap argsToParameters)

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -139,7 +139,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 //
                 // Also when we call f() where signature of f is void([Optional]params int[] args) 
                 // an empty array is created and passed to f.
-                return !IsParams && IsMetadataOptional;
+                //
+                // We also do not consider ref/out parameters as optional, unless in COM interop scenarios 
+                // and only for ref.
+                RefKind refKind;
+                return !IsParams && IsMetadataOptional &&
+                       ((refKind = RefKind) == RefKind.None ||
+                        (refKind == RefKind.Ref && ContainingSymbol.ContainingType.IsComImport));
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/PEParameterSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/PEParameterSymbolTests.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Reflection;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -44,6 +46,86 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
             compilation.VerifyDiagnostics(
                 // (5,16): error CS1744: Named argument 'value' specifies a parameter for which a positional argument has already been given
                 Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "value").WithArguments("value").WithLocation(5, 16));
+        }
+
+        [Fact]
+        [WorkItem(8018, "https://github.com/dotnet/roslyn/issues/8018")]
+        public void IsOptional()
+        {
+            var vbComp = CreateVisualBasicCompilation(@"
+Public Class Class1
+    Public Shared Sub Test(<System.Runtime.InteropServices.Out> Optional ByRef x As Object = Nothing,
+                           Optional ByRef y As Object = Nothing, Optional z As Integer = -1)
+
+    End Sub
+End Class
+
+
+<System.Runtime.InteropServices.ComImport>
+<System.Runtime.InteropServices.Guid(""00C7DAA6-9F86-4F05-9876-D8136B2D2503"")>
+Public Interface I1
+    Sub M1(<System.Runtime.InteropServices.Out> Optional ByRef x1 As Object = Nothing)
+    Sub M2(Optional ByRef y2 As Object = Nothing)
+End Interface
+").EmitToImageReference();
+
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        Class1.Test();
+
+        I1 i1 = null;
+        i1.M1();
+        i1.M2();
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, new[] { vbComp }, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            compilation.VerifyDiagnostics(
+                // (6,16): error CS7036: There is no argument given that corresponds to the required formal parameter 'x' of 'Class1.Test(out object, ref object, int)'
+                //         Class1.Test();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test").WithArguments("x", "Class1.Test(out object, ref object, int)").WithLocation(6, 16),
+                // (9,12): error CS7036: There is no argument given that corresponds to the required formal parameter 'x1' of 'I1.M1(out object)'
+                //         i1.M1();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M1").WithArguments("x1", "I1.M1(out object)").WithLocation(9, 12)
+                );
+
+            var m = compilation.GetMember<MethodSymbol>("Class1.Test");
+
+            Assert.Equal("void Class1.Test(out System.Object x, ref System.Object y, [System.Int32 z = -1])", m.ToTestDisplayString());
+
+            var x = m.Parameters[0];
+            var y = m.Parameters[1];
+            var z = m.Parameters[2];
+
+            Assert.False(x.IsOptional);
+            Assert.True(x.IsMetadataOptional);
+            Assert.Equal(RefKind.Out, x.RefKind);
+
+            Assert.False(y.IsOptional);
+            Assert.True(y.IsMetadataOptional);
+            Assert.Equal(RefKind.Ref, y.RefKind);
+
+            Assert.True(z.IsOptional);
+            Assert.True(z.IsMetadataOptional);
+            Assert.Equal(RefKind.None, z.RefKind);
+
+            var m1 = compilation.GetMember<MethodSymbol>("I1.M1");
+            Assert.Equal("void I1.M1(out System.Object x1)", m1.ToTestDisplayString());
+            var x1 = m1.Parameters[0];
+            Assert.False(x1.IsOptional);
+            Assert.True(x1.IsMetadataOptional);
+            Assert.Equal(RefKind.Out, x1.RefKind);
+
+            var m2 = compilation.GetMember<MethodSymbol>("I1.M2");
+            Assert.Equal("void I1.M2([ref System.Object y2 = null])", m2.ToTestDisplayString());
+            var y2 = m2.Parameters[0];
+            Assert.True(y2.IsOptional);
+            Assert.True(y2.IsMetadataOptional);
+            Assert.Equal(RefKind.Ref, y2.RefKind);
         }
     }
 }


### PR DESCRIPTION
Fixes #8018.

@dotnet/roslyn-compiler Please review.