### PR TITLE
Update syntax generator to correctly write enums

### DIFF
--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/GreenNodes/GreenNodeWriter.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/GreenNodes/GreenNodeWriter.vb
@@ -442,6 +442,8 @@ Friend Class GreenNodeWriter
         Select Case type
             Case "Integer"
                 Return "ReadInt32"
+            Case "SyntaxKind"
+                Return "ReadInt32"
             Case "Boolean"
                 Return "ReadBoolean"
             Case Else
@@ -452,6 +454,8 @@ Friend Class GreenNodeWriter
     Private Function WriterMethod(type As String) As String
         Select Case type
             Case "Integer"
+                Return "WriteInt32"
+            Case "SyntaxKind"
                 Return "WriteInt32"
             Case "Boolean"
                 Return "WriteBoolean"


### PR DESCRIPTION
Previously we would read/write enums as objects.  Now we correctly write them out as integers

Fixes #17099