### PR TITLE
Update the VisualStudioInstanceFactory to close the _currentlyRunningInstance before setting it to null.

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -79,6 +79,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
             if (!canReuse)
             {
+                _currentlyRunningInstance?.Close();
                 _currentlyRunningInstance = null;
             }
         }
@@ -221,6 +222,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         public void Dispose()
         {
             _currentlyRunningInstance?.Close();
+            _currentlyRunningInstance = null;
 
             // We want to make sure everybody cleaned up their contexts by the end of everything
             ThrowExceptionIfAlreadyHasActiveContext();


### PR DESCRIPTION
FYI. @jasonmalinowski, @dotnet/roslyn-infrastructure 

This should prevent us from getting a ton of stray VS instances when a scenario fails on the CI machines.

Also, do we want to target `dev15.0.x` with this so tests will behave better there as well?