### PR TITLE
Run scripts with their own working directories

### DIFF
--- a/src/Test/Perf/Runner/Program.cs
+++ b/src/Test/Perf/Runner/Program.cs
@@ -161,11 +161,14 @@ namespace Runner
                 var state = await RunFileInItsDirectory(script).ConfigureAwait(false);
                 var tests = RuntimeSettings.ResultTests;
                 RuntimeSettings.ResultTests = null;
-                foreach (var test in tests)
+                if (tests != null)
                 {
-                    test.SetWorkingDirectory(Path.GetDirectoryName(script));
+                    foreach (var test in tests)
+                    {
+                        test.SetWorkingDirectory(Path.GetDirectoryName(script));
+                    }
+                    testInstances.AddRange(tests);
                 }
-                testInstances.AddRange(tests);
             }
 
 

--- a/src/Test/Perf/Runner/Program.cs
+++ b/src/Test/Perf/Runner/Program.cs
@@ -35,7 +35,7 @@ namespace Runner
                 {"ci-test", "mention that we are running in the continuous integration lab", _ => isCiTest = true},
                 {"no-trace-upload", "disable the uploading of traces", _ => shouldUploadTrace = false},
                 {"trace-upload_destination=", "set the trace uploading destination", loc => { traceDestination = loc; } },
-                {"search-directory=", "the directory to recursively search for tests", dir => { searchDirectory = dir; } } 
+                {"search-directory=", "the directory to recursively search for tests", dir => { searchDirectory = dir; } }
             };
 
             parameterOptions.Parse(args);
@@ -158,23 +158,14 @@ namespace Runner
             {
                 var scriptName = Path.GetFileNameWithoutExtension(script);
                 Log($"Collecting tests from {scriptName}");
-                try
+                var state = await RunFileInItsDirectory(script).ConfigureAwait(false);
+                var tests = RuntimeSettings.ResultTests;
+                RuntimeSettings.ResultTests = null;
+                foreach (var test in tests)
                 {
-                    var state = await RunFile(script).ConfigureAwait(false);
-                    var tests = RuntimeSettings.ResultTests;
-                    RuntimeSettings.ResultTests = null;
-                    foreach (var test in tests)
-                    {
-                        test.SetWorkingDirectory(Path.GetDirectoryName(script));
-                    }
-                    testInstances.AddRange(tests);
+                    test.SetWorkingDirectory(Path.GetDirectoryName(script));
                 }
-                catch (Exception e)
-                {
-                    Log($"Encountered exception collecting tests from {scriptName}");
-                    Log(e.Message);
-                    Log(e.StackTrace);
-                }
+                testInstances.AddRange(tests);
             }
 
 

--- a/src/Test/Perf/Runner/Tools.cs
+++ b/src/Test/Perf/Runner/Tools.cs
@@ -13,6 +13,29 @@ namespace Roslyn.Test.Performance.Runner
 {
     public static class Tools
     {
+        public static async Task<ScriptState<object>> RunFileInItsDirectory(string fileName)
+        {
+            var workingDirectory = Environment.CurrentDirectory;
+            try
+            {
+                var scriptDirectory = Path.GetDirectoryName(Path.GetFullPath(fileName));
+                Environment.CurrentDirectory = scriptDirectory;
+                var result = await RunFile(fileName).ConfigureAwait(false);
+                return result;
+            }
+            catch(Exception e)
+            {
+                Log($"Encountered exception collecting tests from {fileName}");
+                Log(e.Message);
+                Log(e.StackTrace);
+                return null;
+            }
+            finally
+            {
+                Environment.CurrentDirectory = workingDirectory;
+            }
+        }
+
         /// Runs the script at fileName and returns a task containing the
         /// state of the script.
         public static async Task<ScriptState<object>> RunFile(string fileName)
@@ -34,7 +57,7 @@ namespace Roslyn.Test.Performance.Runner
         {
             foreach (var fileName in Directory.EnumerateFiles(directoryName, "*.csx"))
             {
-                yield return fileName;
+                yield return Path.GetFullPath(fileName); ;
             }
 
 
@@ -42,7 +65,7 @@ namespace Roslyn.Test.Performance.Runner
             {
                 foreach (var fileName in GetAllCsxRecursive(childDir))
                 {
-                    yield return fileName;
+                    yield return Path.GetFullPath(fileName);
                 }
             }
         }


### PR DESCRIPTION
 When running csx scripts to collect perf tests, run each script with the working directory set to the directory of the script. This makes it *much* simpler to use relative paths for #r statements.

cc @TyOverby @mavasani @KevinH-MS 