### PR TITLE
Updating the VisualStudioInstanceFactory to force clearing of the MEF cache before starting VS.

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -204,6 +204,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             var vsExeFile = Path.Combine(installationPath, @"Common7\IDE\devenv.exe");
 
+            // BUG: Currently building with /p:DeployExtension=true does not always cause the MEF cache to recompose...
+            //      So, run clearcache and updateconfiguration to workaround https://devdiv.visualstudio.com/DevDiv/_workitems?id=385351.
+            Process.Start(vsExeFile, $"/clearcache {VsLaunchArgs}").WaitForExit();
+            Process.Start(vsExeFile, $"/updateconfiguration {VsLaunchArgs}").WaitForExit();
             Process.Start(vsExeFile, $"/resetsettings General.vssettings /command \"File.Exit\" {VsLaunchArgs}").WaitForExit();
 
             // Make sure we kill any leftover processes spawned by the host


### PR DESCRIPTION
FYI. @jasonmalinowski, @dotnet/roslyn-infrastructure

This should allow the integration tests to detect the deployed extensions but will also mask further MEF composition issues.

Additionally, do we want to target dev15.0.x with this so tests will behave better there as well?