### PR TITLE
let OOP to be killed

### DIFF
--- a/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
+++ b/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor
                     {
                         base.HandleException(provider, exception);
 
-                        _errorReportingService?.ShowErrorInfo(String.Format(WorkspacesResources._0_encountered_an_error_and_has_been_disabled,  provider.GetType().Name),
+                        _errorReportingService?.ShowErrorInfoInActiveView(String.Format(WorkspacesResources._0_encountered_an_error_and_has_been_disabled,  provider.GetType().Name),
                             new ErrorReportingUI(WorkspacesResources.Show_Stack_Trace, ErrorReportingUI.UIKind.HyperLink, () => ShowDetailedErrorInfo(exception), closeAfterAction: false),
                             new ErrorReportingUI(WorkspacesResources.Enable, ErrorReportingUI.UIKind.Button, () => { EnableProvider(provider); LogEnableProvider(provider); }),
                             new ErrorReportingUI(WorkspacesResources.Enable_and_ignore_future_errors, ErrorReportingUI.UIKind.Button, () => { EnableProvider(provider); LogEnableProvider(provider); }),

--- a/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
@@ -13,7 +13,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
             Logger.Log(FunctionId.Extension_Exception, exception.StackTrace);
         }
 
-        public void ShowErrorInfo(string message, params ErrorReportingUI[] items)
+        public void ShowErrorInfoInActiveView(string message, params ErrorReportingUI[] items)
+        {
+            ShowGlobalErrorInfo(message, items);
+        }
+
+        public void ShowGlobalErrorInfo(string message, params ErrorReportingUI[] items)
         {
             Logger.Log(FunctionId.Extension_Exception, message);
         }

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerExecutor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioDiagnosticAnalyzerExecutor.cs
@@ -151,6 +151,11 @@ This data should always be correct as we're never persisting the data between se
 
         private void ReportAnalyzerExceptions(Project project, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> exceptions)
         {
+            if (exceptions == null)
+            {
+                return;
+            }
+
             foreach (var kv in exceptions)
             {
                 var analyzer = kv.Key;

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -29,5 +29,30 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         [ExportOption]
         public static readonly Option<bool> RemoteHostTest = new Option<bool>(nameof(InternalFeatureOnOffOptions), nameof(RemoteHostTest), defaultValue: false);
+
+        // VS behavior options on unintentional OOP shutdown
+        public enum VsBehaviors : int
+        {
+            /// <summary>
+            /// Crash VS
+            /// </summary>
+            CrashVS = 0,
+
+            /// <summary>
+            /// Show info bar and let VS keep running. some features might keep running inproc based on how they are implemented.
+            /// </summary>
+            ShowInfoBarAndRunFeaturesInProcIfPossible = 1,
+
+            /// <summary>
+            /// Show info bar and disable all features.
+            /// </summary>
+            ShowInfoBarAndDisableAllFeatures = 2
+        }
+
+        // Define VS behavior on unintentional OOP shutdown such as user killing OOP process
+        [ExportOption]
+        public static readonly Option<int> VsBehaviorOnUnintentionalRemoteHostShutdown = new Option<int>(
+            nameof(InternalFeatureOnOffOptions), nameof(VsBehaviorOnUnintentionalRemoteHostShutdown), defaultValue: (int)VsBehaviors.ShowInfoBarAndRunFeaturesInProcIfPossible,
+            storageLocations: new LocalUserProfileStorageLocation(InternalFeatureOnOffOptions.LocalRegistryPath + nameof(VsBehaviorOnUnintentionalRemoteHostShutdown)));
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -29,30 +29,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         [ExportOption]
         public static readonly Option<bool> RemoteHostTest = new Option<bool>(nameof(InternalFeatureOnOffOptions), nameof(RemoteHostTest), defaultValue: false);
-
-        // VS behavior options on unintentional OOP shutdown
-        public enum VsBehaviors : int
-        {
-            /// <summary>
-            /// Crash VS
-            /// </summary>
-            CrashVS = 0,
-
-            /// <summary>
-            /// Show info bar and let VS keep running. some features might keep running inproc based on how they are implemented.
-            /// </summary>
-            ShowInfoBarAndRunFeaturesInProcIfPossible = 1,
-
-            /// <summary>
-            /// Show info bar and disable all features.
-            /// </summary>
-            ShowInfoBarAndDisableAllFeatures = 2
-        }
-
-        // Define VS behavior on unintentional OOP shutdown such as user killing OOP process
-        [ExportOption]
-        public static readonly Option<int> VsBehaviorOnUnintentionalRemoteHostShutdown = new Option<int>(
-            nameof(InternalFeatureOnOffOptions), nameof(VsBehaviorOnUnintentionalRemoteHostShutdown), defaultValue: (int)VsBehaviors.ShowInfoBarAndRunFeaturesInProcIfPossible,
-            storageLocations: new LocalUserProfileStorageLocation(InternalFeatureOnOffOptions.LocalRegistryPath + nameof(VsBehaviorOnUnintentionalRemoteHostShutdown)));
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServices
                                 // make sure we show info bar only once for the same solution.
                                 _workspace.Options = _workspace.Options.WithChangedOption(RuntimeOptions.FullSolutionAnalysisInfoBarShown, true);
 
-                                _workspace.Services.GetService<IErrorReportingService>().ShowErrorInfo(ServicesVSResources.Visual_Studio_has_suspended_some_advanced_features_to_improve_performance,
+                                _workspace.Services.GetService<IErrorReportingService>().ShowGlobalErrorInfo(ServicesVSResources.Visual_Studio_has_suspended_some_advanced_features_to_improve_performance,
                                     new ErrorReportingUI(ServicesVSResources.Re_enable, ErrorReportingUI.UIKind.Button, () =>
                                         _workspace.Options = _workspace.Options.WithChangedOption(RuntimeOptions.FullSolutionAnalysis, true)),
                                     new ErrorReportingUI(ServicesVSResources.Learn_more, ErrorReportingUI.UIKind.HyperLink, () =>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -2123,6 +2123,16 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unfortunately, a process used by Visual Studio has encountered an unrecoverable error.  We recommend saving your work, and then closing and restarting Visual Studio..
+        /// </summary>
+        internal static string Unfortunately_a_process_used_by_Visual_Studio_has_encountered_an_unrecoverable_error_We_recommend_saving_your_work_and_then_closing_and_restarting_Visual_Studio {
+            get {
+                return ResourceManager.GetString("Unfortunately_a_process_used_by_Visual_Studio_has_encountered_an_unrecoverable_er" +
+                        "ror_We_recommend_saving_your_work_and_then_closing_and_restarting_Visual Studio", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Uninstall &apos;{0}&apos;.
         /// </summary>
         internal static string Uninstall_0 {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -867,4 +867,7 @@ Additional information: {1}</value>
   <data name="Remove" xml:space="preserve">
     <value>Remove</value>
   </data>
+  <data name="Unfortunately_a_process_used_by_Visual_Studio_has_encountered_an_unrecoverable_error_We_recommend_saving_your_work_and_then_closing_and_restarting_Visual Studio" xml:space="preserve">
+    <value>Unfortunately, a process used by Visual Studio has encountered an unrecoverable error.  We recommend saving your work, and then closing and restarting Visual Studio.</value>
+  </data>
 </root>

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultMap.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultMap.cs
@@ -38,9 +38,9 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
             ImmutableDictionary<TKey, AnalyzerTelemetryInfo> telemetryInfo,
             ImmutableDictionary<TKey, ImmutableArray<DiagnosticData>> exceptions)
         {
-            AnalysisResult = analysisResult;
-            TelemetryInfo = telemetryInfo;
-            Exceptions = exceptions;
+            AnalysisResult = analysisResult ?? ImmutableDictionary<TKey, TValue>.Empty;
+            TelemetryInfo = telemetryInfo ?? ImmutableDictionary<TKey, AnalyzerTelemetryInfo>.Empty;
+            Exceptions = exceptions ?? ImmutableDictionary<TKey, ImmutableArray<DiagnosticData>>.Empty;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
@@ -8,7 +8,21 @@ namespace Microsoft.CodeAnalysis.Extensions
 {
     internal interface IErrorReportingService : IWorkspaceService
     {
-        void ShowErrorInfo(string message, params ErrorReportingUI[] items);
+        /// <summary>
+        /// Show error info in an active view.
+        /// 
+        /// Different host can have different definition on what active view means.
+        /// </summary>
+        void ShowErrorInfoInActiveView(string message, params ErrorReportingUI[] items);
+
+        /// <summary>
+        /// Show global error info.
+        /// 
+        /// this kind error info should be something that affects whole roslyn such as
+        /// background compilation is disabled due to memory issue and etc
+        /// </summary>
+        void ShowGlobalErrorInfo(string message, params ErrorReportingUI[] items);
+
         void ShowDetailedErrorInfo(Exception exception);
     }
 

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -87,8 +87,19 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             public abstract Task InvokeAsync(string targetName, params object[] arguments);
+
+            /// <summary>
+            /// All caller must guard itself from it returning default(T) which can happen if OOP is killed
+            /// unintentionally such as user killed OOP process.
+            /// </summary>
             public abstract Task<T> InvokeAsync<T>(string targetName, params object[] arguments);
+
             public abstract Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync);
+
+            /// <summary>
+            /// All caller must guard itself from it returning default(T) which can happen if OOP is killed
+            /// unintentionally such as user killed OOP process.
+            /// </summary>
             public abstract Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync);
 
             public void AddAdditionalAssets(CustomAsset asset)

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -115,5 +115,57 @@ namespace Microsoft.CodeAnalysis.Remote
                 PinnedScope.Dispose();
             }
         }
+
+        public class NoOpClient : RemoteHostClient
+        {
+            public NoOpClient(Workspace workspace) :
+                base(workspace)
+            {
+            }
+
+            protected override Task<Session> CreateServiceSessionAsync(
+                string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<Session>(new NoOpSession(snapshot, cancellationToken));
+            }
+
+            protected override void OnConnected()
+            {
+                // do nothing
+            }
+
+            protected override void OnDisconnected()
+            {
+                // do nothing
+            }
+
+            private class NoOpSession : Session
+            {
+                public NoOpSession(PinnedRemotableDataScope scope, CancellationToken cancellationToken) :
+                    base(scope, cancellationToken)
+                {
+                }
+
+                public override Task InvokeAsync(string targetName, params object[] arguments)
+                {
+                    return SpecializedTasks.EmptyTask;
+                }
+
+                public override Task<T> InvokeAsync<T>(string targetName, params object[] arguments)
+                {
+                    return SpecializedTasks.Default<T>();
+                }
+
+                public override Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync)
+                {
+                    return SpecializedTasks.EmptyTask;
+                }
+
+                public override Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync)
+                {
+                    return SpecializedTasks.Default<T>();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Customer kills VS ServiceHub processes and VS crash.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/16859

**Workarounds, if any**

don't kill ServiceHub processes.

**Risk**

we no longer explicitly kill VS when we detect OOP is gone, but there can be still some cases where OOP is killed at right moment which cause OOP features to throw exceptions we didn't know about. and that exception caused VS to crash.

also, if user decides to keep using VS after killing OOP, VS is in unknown state. can't guarantee VS will work as it should.

**Performance impact**

I don't see any performance impact since this code is only related to specific user action (killing OOP processes). after that, VS is unstable anyway. we explicitly ask users to close and re-open VS.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

the crash happened because we had code that explicitly killed VS when OOP is killed unintentionally. now, we removed that code and instead show this if that happens.

![image](https://cloud.githubusercontent.com/assets/1333179/23020059/153a0b4c-f3fa-11e6-9eb5-359f1ee17a12.png)

**How was the bug found?**

Watson, customer reports