### PR TITLE
Fix missing variance checks for ref returning methods/properties

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             IsVarianceUnsafe(
                 method.ReturnType,
                 requireOutputSafety: true,
-                requireInputSafety: false,
+                requireInputSafety: method.RefKind != RefKind.None,
                 context: method,
                 locationProvider: returnTypeLocationProvider,
                 locationArg: method,
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 IsVarianceUnsafe(
                     property.Type,
                     requireOutputSafety: hasGetter,
-                    requireInputSafety: hasSetter,
+                    requireInputSafety: hasSetter || !(property.GetMethod?.RefKind == RefKind.None),
                     context: property,
                     locationProvider: p =>
                         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -2933,5 +2933,393 @@ public class C
 
             );
         }
+
+        [Fact]
+        public void RefReturnVarianceDelegate()
+        {
+            var source = @"
+using System;
+
+delegate ref T RefFunc1<T>();
+delegate ref T RefFunc2<in T>();
+delegate ref T RefFunc3<out T>();
+
+delegate ref Action<T> RefFunc1a<T>();
+delegate ref Action<T> RefFunc2a<in T>();
+delegate ref Action<T> RefFunc3a<out T>();
+         
+delegate ref Func<T> RefFunc1f<T>();
+delegate ref Func<T> RefFunc2f<in T>();
+delegate ref Func<T> RefFunc3f<out T>();
+
+";
+
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+                // (6,10): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'RefFunc3<T>.Invoke()'. 'T' is covariant.
+                // delegate ref T RefFunc3<out T>();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref T").WithArguments("RefFunc3<T>.Invoke()", "T", "covariant", "invariantly").WithLocation(6, 10),
+                // (5,10): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'RefFunc2<T>.Invoke()'. 'T' is contravariant.
+                // delegate ref T RefFunc2<in T>();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref T").WithArguments("RefFunc2<T>.Invoke()", "T", "contravariant", "invariantly").WithLocation(5, 10),
+                // (14,10): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'RefFunc3f<T>.Invoke()'. 'T' is covariant.
+                // delegate ref Func<T> RefFunc3f<out T>();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Func<T>").WithArguments("RefFunc3f<T>.Invoke()", "T", "covariant", "invariantly").WithLocation(14, 10),
+                // (13,10): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'RefFunc2f<T>.Invoke()'. 'T' is contravariant.
+                // delegate ref Func<T> RefFunc2f<in T>();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Func<T>").WithArguments("RefFunc2f<T>.Invoke()", "T", "contravariant", "invariantly").WithLocation(13, 10),
+                // (10,10): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'RefFunc3a<T>.Invoke()'. 'T' is covariant.
+                // delegate ref Action<T> RefFunc3a<out T>();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Action<T>").WithArguments("RefFunc3a<T>.Invoke()", "T", "covariant", "invariantly").WithLocation(10, 10),
+                // (9,10): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'RefFunc2a<T>.Invoke()'. 'T' is contravariant.
+                // delegate ref Action<T> RefFunc2a<in T>();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Action<T>").WithArguments("RefFunc2a<T>.Invoke()", "T", "contravariant", "invariantly").WithLocation(9, 10)
+
+            );
+        }
+
+        [Fact]
+        public void RefReturnVarianceMethod()
+        {
+            var source = @"
+using System;
+
+interface IM1<T> { ref T RefMethod(); }
+interface IM2<in T> { ref T RefMethod(); }
+interface IM3<out T> { ref T RefMethod(); }
+
+interface IM1a<T> { ref Action<T> RefMethod(); }
+interface IM2a<in T> { ref Action<T> RefMethod(); }
+interface IM3a<out T> { ref Action<T> RefMethod(); }
+
+interface IM1f<T> { ref Func<T> RefMethod(); }
+interface IM2f<in T> { ref Func<T> RefMethod(); }
+interface IM3f<out T> { ref Func<T> RefMethod(); }
+
+";
+
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+                // (6,24): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IM3<T>.RefMethod()'. 'T' is covariant.
+                // interface IM3<out T> { ref T RefMethod(); }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref T").WithArguments("IM3<T>.RefMethod()", "T", "covariant", "invariantly").WithLocation(6, 24),
+                // (10,25): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IM3a<T>.RefMethod()'. 'T' is covariant.
+                // interface IM3a<out T> { ref Action<T> RefMethod(); }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Action<T>").WithArguments("IM3a<T>.RefMethod()", "T", "covariant", "invariantly").WithLocation(10, 25),
+                // (9,24): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IM2a<T>.RefMethod()'. 'T' is contravariant.
+                // interface IM2a<in T> { ref Action<T> RefMethod(); }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Action<T>").WithArguments("IM2a<T>.RefMethod()", "T", "contravariant", "invariantly").WithLocation(9, 24),
+                // (13,24): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IM2f<T>.RefMethod()'. 'T' is contravariant.
+                // interface IM2f<in T> { ref Func<T> RefMethod(); }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Func<T>").WithArguments("IM2f<T>.RefMethod()", "T", "contravariant", "invariantly").WithLocation(13, 24),
+                // (14,25): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IM3f<T>.RefMethod()'. 'T' is covariant.
+                // interface IM3f<out T> { ref Func<T> RefMethod(); }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Func<T>").WithArguments("IM3f<T>.RefMethod()", "T", "covariant", "invariantly").WithLocation(14, 25),
+                // (5,23): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IM2<T>.RefMethod()'. 'T' is contravariant.
+                // interface IM2<in T> { ref T RefMethod(); }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref T").WithArguments("IM2<T>.RefMethod()", "T", "contravariant", "invariantly").WithLocation(5, 23)
+
+            );
+        }
+
+        [Fact]
+        public void RefReturnVarianceProperty()
+        {
+            var source = @"
+using System;
+
+interface IP1<T> { ref T RefProp{get;} }
+interface IP2<in T> { ref T RefProp{get;} }
+interface IP3<out T> { ref T RefProp{get;} }
+
+interface IP1a<T> { ref Action<T> RefProp{get;} }
+interface IP2a<in T> { ref Action<T> RefProp{get;} }
+interface IP3a<out T> { ref Action<T> RefProp{get;} }
+
+interface IP1f<T> { ref Func<T> RefProp{get;} }
+interface IP2f<in T> { ref Func<T> RefProp{get;} }
+interface IP3f<out T> { ref Func<T> RefProp{get;} }
+
+";
+
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+                // (5,23): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IP2<T>.RefProp'. 'T' is contravariant.
+                // interface IP2<in T> { ref T RefProp{get;} }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref T").WithArguments("IP2<T>.RefProp", "T", "contravariant", "invariantly").WithLocation(5, 23),
+                // (13,24): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IP2f<T>.RefProp'. 'T' is contravariant.
+                // interface IP2f<in T> { ref Func<T> RefProp{get;} }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Func<T>").WithArguments("IP2f<T>.RefProp", "T", "contravariant", "invariantly").WithLocation(13, 24),
+                // (9,24): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IP2a<T>.RefProp'. 'T' is contravariant.
+                // interface IP2a<in T> { ref Action<T> RefProp{get;} }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Action<T>").WithArguments("IP2a<T>.RefProp", "T", "contravariant", "invariantly").WithLocation(9, 24),
+                // (10,25): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IP3a<T>.RefProp'. 'T' is covariant.
+                // interface IP3a<out T> { ref Action<T> RefProp{get;} }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Action<T>").WithArguments("IP3a<T>.RefProp", "T", "covariant", "invariantly").WithLocation(10, 25),
+                // (14,25): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IP3f<T>.RefProp'. 'T' is covariant.
+                // interface IP3f<out T> { ref Func<T> RefProp{get;} }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref Func<T>").WithArguments("IP3f<T>.RefProp", "T", "covariant", "invariantly").WithLocation(14, 25),
+                // (6,24): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'IP3<T>.RefProp'. 'T' is covariant.
+                // interface IP3<out T> { ref T RefProp{get;} }
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "ref T").WithArguments("IP3<T>.RefProp", "T", "covariant", "invariantly").WithLocation(6, 24)
+
+            );
+        }
+
+        [Fact]
+        public void RefMethodGroupConversionError()
+        {
+            var source = @"
+using System;
+
+class Program
+{
+    delegate ref T RefFunc1<T>();
+
+    static void Main()
+    {
+        RefFunc1<object> f = M1;
+        f() = 1;
+    }
+
+    static ref string M1() => ref new string[]{""qq""}[0];
+}
+
+";
+
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+                // (10,30): error CS0407: 'string Program.M1()' has the wrong return type
+                //         RefFunc1<object> f = M1;
+                Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1()", "string").WithLocation(10, 30)
+            );
+        }
+
+        [Fact]
+        public void RefMethodGroupConversionError_WihResolution()
+        {
+            var source = @"
+using System;
+
+class Base
+{
+    public static Base Instance = new Base();
+}
+
+class Derived1: Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+class Derived2: Derived1
+{
+}
+
+class Derived3: Derived2
+{
+}
+
+class Program
+{
+    delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+    static void Main()
+    {
+        RefFunc1<Derived2, Base> f = M1;
+        System.Console.WriteLine(f(null));
+    }
+
+    static ref Base M1(Base arg) => ref Base.Instance;
+    static ref Derived1 M1(Derived1 arg) => ref Derived1.Instance;
+}
+
+";
+
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+                // (28,38): error CS0407: 'Derived1 Program.M1(Derived1)' has the wrong return type
+                //         RefFunc1<Derived2, Base> f = M1;
+                Diagnostic(ErrorCode.ERR_BadRetType, "M1").WithArguments("Program.M1(Derived1)", "Derived1").WithLocation(28, 38)
+            );
+        }
+
+        [Fact]
+        public void RefMethodGroupConversionNoError_WihResolution()
+        {
+            var source = @"
+using System;
+
+class Base
+{
+    public static Base Instance = new Base();
+}
+
+class Derived1 : Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+class Derived2 : Derived1
+{
+    public static new Derived2 Instance = new Derived2();
+}
+
+class Derived3 : Derived2
+{
+}
+
+class Program
+{
+    delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+    static void Main()
+    {
+        RefFunc1<Derived2, Base> f = M1;
+        System.Console.WriteLine(f(null));
+    }
+
+    static ref Base M1(Base arg) => throw null;
+    static ref Base M1(Derived1 arg) => ref Base.Instance;
+}
+";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: "Base", verify: true);
+        }
+
+        [Fact]
+        public void RefMethodGroupOevrloadResolutionErr()
+        {
+            var source = @"
+using System;
+
+class Base
+{
+    public static Base Instance = new Base();
+}
+
+class Derived1: Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+class Derived2: Derived1
+{
+    public static new Derived2 Instance = new Derived2();
+}
+
+class Derived3: Derived2
+{
+}
+
+class Program
+{
+    delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+    static void Main()
+    {
+        Test(M1);
+        Test(M3);
+    }
+
+    static ref Base M1(Derived1 arg) => ref Base.Instance;
+    static ref Base M3(Derived2 arg) => ref Base.Instance;
+
+    static void Test(RefFunc1<Derived2, Base> arg) => Console.WriteLine(arg);
+    static void Test(RefFunc1<Derived2, Derived1> arg) => Console.WriteLine(arg);
+}
+
+";
+
+            CreateCompilationWithMscorlib45AndCSruntime(source).VerifyEmitDiagnostics(
+                // (29,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Test(Program.RefFunc1<Derived2, Base>)' and 'Program.Test(Program.RefFunc1<Derived2, Derived1>)'
+                //         Test(M1);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Test").WithArguments("Program.Test(Program.RefFunc1<Derived2, Base>)", "Program.Test(Program.RefFunc1<Derived2, Derived1>)").WithLocation(29, 9),
+                // (30,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Test(Program.RefFunc1<Derived2, Base>)' and 'Program.Test(Program.RefFunc1<Derived2, Derived1>)'
+                //         Test(M3);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Test").WithArguments("Program.Test(Program.RefFunc1<Derived2, Base>)", "Program.Test(Program.RefFunc1<Derived2, Derived1>)").WithLocation(30, 9)
+            );
+        }
+
+        [Fact]
+        public void RefMethodGroupOverloadResolution()
+        {
+            var source = @"
+using System;
+
+class Base
+{
+    public static Base Instance = new Base();
+}
+
+class Derived1: Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+class Derived2: Derived1
+{
+    public static new Derived2 Instance = new Derived2();
+}
+
+class Derived3: Derived2
+{
+}
+
+class Program
+{
+    delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+    static void Main()
+    {
+        Test(M2);
+    }
+
+    static ref Derived1 M2(Base arg) => ref Derived1.Instance;
+
+    static void Test(RefFunc1<Derived2, Base> arg) => Console.WriteLine(arg);
+    static void Test(RefFunc1<Derived2, Derived1> arg) => Console.WriteLine(arg);
+}
+
+";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: "Program+RefFunc1`2[Derived2,Derived1]", verify: true);
+        }
+
+        [Fact]
+        public void RefLambdaOverloadResolution2()
+        {
+            var source = @"
+using System;
+
+class Base
+{
+    public static Base Instance = new Base();
+}
+
+class Derived1: Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+class Derived2: Derived1
+{
+    public static new Derived2 Instance = new Derived2();
+}
+
+class Program
+{
+    delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+    static void Main()
+    {
+        Test((t)=> Base.Instance);
+        Test((t)=> ref Base.Instance);
+    }
+
+    static void Test(RefFunc1<Derived1, Base> arg) => Console.WriteLine(arg);
+    static void Test(Func<Derived1, Base> arg) => Console.WriteLine(arg);
+}
+
+";
+
+            CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"System.Func`2[Derived1,Base]
+Program+RefFunc1`2[Derived1,Base]", verify: true);
+        }
+
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -4026,12 +4026,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return MethodConversionKind.Error_ByRefByValMismatch
             End If
 
-            Return ClassifyMethodConversionBasedOnReturnType(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, useSiteDiagnostics)
+            Return ClassifyMethodConversionBasedOnReturnType(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, convertFromMethodIsByRef, useSiteDiagnostics)
         End Function
 
         Public Shared Function ClassifyMethodConversionBasedOnReturnType(
             returnTypeOfConvertFromMethod As TypeSymbol,
             returnTypeOfConvertToMethod As TypeSymbol,
+            isRefReturning As Boolean,
             <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)
         ) As MethodConversionKind
             Debug.Assert(returnTypeOfConvertFromMethod IsNot Nothing)
@@ -4062,8 +4063,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim typeConversion As ConversionKind = ClassifyConversion(returnTypeOfConvertFromMethod, returnTypeOfConvertToMethod, useSiteDiagnostics).Key
 
-            Dim result As MethodConversionKind
+            If isRefReturning AndAlso Not IsIdentityConversion(typeConversion) Then
+                Return MethodConversionKind.Error_ReturnTypeMismatch
+            End If
 
+            Dim result As MethodConversionKind
             If IsNarrowingConversion(typeConversion) Then
                 result = MethodConversionKind.ReturnIsWidening
 
@@ -4240,7 +4244,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Debug.Assert(conversion.Operand.IsNothingLiteral() OrElse conversion.Operand.Kind = BoundKind.Lambda)
                 methodConversion = MethodConversionKind.Identity
             Else
-                methodConversion = ClassifyMethodConversionBasedOnReturnType(operandType, conversion.Type, useSiteDiagnostics)
+                methodConversion = ClassifyMethodConversionBasedOnReturnType(operandType, conversion.Type, isRefReturning:=False, useSiteDiagnostics:=useSiteDiagnostics)
             End If
 
             Return DetermineDelegateRelaxationLevel(methodConversion)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
@@ -1891,7 +1891,7 @@ BC31143: Method 'Public Overloads ByRef Function F() As Integer' does not have a
         End Sub
 
         <Fact>
-        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        <WorkItem(17140, "https://github.com/dotnet/roslyn/issues/17140")>
         Public Sub DelegateToByRefFunctionWithDerivedType()
             Dim comp1 = CreateCSharpCompilation(
 "
@@ -1943,7 +1943,7 @@ BC31143: Method 'Public Overloads ByRef Function F() As String' does not have a 
         End Sub
 
         <Fact>
-        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        <WorkItem(17140, "https://github.com/dotnet/roslyn/issues/17140")>
         Public Sub RefMethodGroupConversionError_WithResolution()
             Dim comp1 = CreateCSharpCompilation(
 "
@@ -1989,7 +1989,7 @@ End Module",
         End Sub
 
         <Fact>
-        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        <WorkItem(17140, "https://github.com/dotnet/roslyn/issues/17140")>
         Public Sub RefMethodGroupConversionNoError_WithResolution()
             Dim comp1 = CreateCSharpCompilation(
 "
@@ -2031,7 +2031,7 @@ End Module",
         End Sub
 
         <Fact>
-        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        <WorkItem(17140, "https://github.com/dotnet/roslyn/issues/17140")>
         Public Sub RefMethodGroupConversionNoError_WithResolution1()
             Dim comp1 = CreateCSharpCompilation(
 "
@@ -2077,7 +2077,7 @@ RefFunc1`2[Derived2,Base]")
         End Sub
 
         <Fact>
-        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        <WorkItem(17140, "https://github.com/dotnet/roslyn/issues/17140")>
         Public Sub RefMethodGroupOverloadResolution()
             Dim comp1 = CreateCSharpCompilation(
 "
@@ -2121,7 +2121,7 @@ End Module",
         End Sub
 
         <Fact>
-        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        <WorkItem(17140, "https://github.com/dotnet/roslyn/issues/17140")>
         Public Sub RefLambdaOverloadResolution()
             Dim comp1 = CreateCSharpCompilation(
 "
@@ -2165,7 +2165,7 @@ End Module",
         End Sub
 
         <Fact>
-        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        <WorkItem(17140, "https://github.com/dotnet/roslyn/issues/17140")>
         Public Sub DelegateToByRefFunctionWithBaseType()
             Dim comp1 = CreateCSharpCompilation(
 "

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenRefReturnTests.vb
@@ -1892,6 +1892,332 @@ BC31143: Method 'Public Overloads ByRef Function F() As Integer' does not have a
 
         <Fact>
         <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        Public Sub DelegateToByRefFunctionWithDerivedType()
+            Dim comp1 = CreateCSharpCompilation(
+"
+public delegate ref T D<T>();
+
+public class A<T>
+{
+#pragma warning disable 0649
+    private T _t;
+    public ref T F()
+    {
+        return ref _t;
+    }
+}
+public class B
+{
+    public static void F<T>(D<T> d, T t)
+    {
+        d() = t;
+    }
+}")
+            comp1.VerifyDiagnostics()
+            Dim comp2 = CreateVisualBasicCompilation(
+                Nothing,
+"Module M
+    Sub Main()
+        Dim o As New A(Of String)()
+
+        B.F(Of Object)(AddressOf o.F, new Object)
+        System.Console.Write(o.F())
+
+        B.F(Of Object)(New D(of Object)(AddressOf o.F), Nothing)
+        System.Console.Write(o.F())
+
+    End Sub
+End Module",
+                referencedCompilations:={comp1},
+                compilationOptions:=TestOptions.DebugExe)
+
+            comp2.AssertTheseDiagnostics(
+<expected>
+    BC31143: Method 'Public Overloads ByRef Function F() As String' does not have a signature compatible with delegate 'Delegate ByRef Function D(Of Object)() As Object'.
+        B.F(Of Object)(AddressOf o.F, new Object)
+                                 ~~~
+BC31143: Method 'Public Overloads ByRef Function F() As String' does not have a signature compatible with delegate 'Delegate ByRef Function D(Of Object)() As Object'.
+        B.F(Of Object)(New D(of Object)(AddressOf o.F), Nothing)
+                                                  ~~~
+</expected>)
+        End Sub
+
+        <Fact>
+        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        Public Sub RefMethodGroupConversionError_WithResolution()
+            Dim comp1 = CreateCSharpCompilation(
+"
+public class Base
+{
+    public static Base Instance = new Base();
+}
+
+public class Derived1 : Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+public class Derived2 : Derived1
+{
+}
+
+public delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+public class Methods
+{
+    public static ref Base M1(Base arg) => ref Base.Instance;
+    public static ref Derived1 M1(Derived1 arg) => ref Derived1.Instance;
+}
+")
+            Dim comp2 = CreateVisualBasicCompilation(
+                Nothing,
+"Module M
+    Sub Main()
+        Dim f as RefFunc1(OF Derived2, Base) = AddressOf Methods.M1
+        System.Console.WriteLine(f(Nothing))
+    End Sub
+End Module",
+                referencedCompilations:={comp1},
+                compilationOptions:=TestOptions.DebugExe)
+
+            comp2.AssertTheseDiagnostics(
+<expected>
+    BC31143: Method 'Public Shared Overloads ByRef Function M1(arg As Derived1) As Derived1' does not have a signature compatible with delegate 'Delegate ByRef Function RefFunc1(Of Derived2, Base)(arg As Derived2) As Base'.
+        Dim f as RefFunc1(OF Derived2, Base) = AddressOf Methods.M1
+                                                         ~~~~~~~~~~
+</expected>)
+        End Sub
+
+        <Fact>
+        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        Public Sub RefMethodGroupConversionNoError_WithResolution()
+            Dim comp1 = CreateCSharpCompilation(
+"
+public class Base
+{
+    public static Base Instance = new Base();
+}
+
+public class Derived1 : Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+public class Derived2 : Derived1
+{
+}
+
+public delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+public class Methods
+{
+    public static ref Base M1(Base arg) => throw null;
+    public static ref Base M1(Derived1 arg) => ref Base.Instance;
+}
+")
+            Dim comp2 = CreateVisualBasicCompilation(
+                Nothing,
+"Module M
+    Sub Main()
+        Dim f as RefFunc1(of Derived2, Base) = AddressOf Methods.M1
+        System.Console.WriteLine(f(Nothing))
+    End Sub
+End Module",
+                referencedCompilations:={comp1},
+                compilationOptions:=TestOptions.DebugExe)
+
+            Dim verifier = CompileAndVerify(comp2, expectedOutput:="Base")
+            verifier.VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        Public Sub RefMethodGroupConversionNoError_WithResolution1()
+            Dim comp1 = CreateCSharpCompilation(
+"
+public class Base
+{
+    public static Base Instance = new Base();
+}
+
+public class Derived1 : Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+public class Derived2 : Derived1
+{
+}
+
+public delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+public class Methods
+{
+    public static ref Base M1(Derived1 arg) => ref Base.Instance;
+    public static ref Base M3(Derived2 arg) => ref Base.Instance;
+
+    public static void Test(RefFunc1<Derived2, Base> arg) => System.Console.WriteLine(arg);
+    public static void Test(RefFunc1<Derived2, Derived1> arg) => System.Console.WriteLine(arg);}
+")
+            Dim comp2 = CreateVisualBasicCompilation(
+                Nothing,
+"Module M
+    Sub Main()
+        Methods.Test(AddressOf Methods.M1)
+        Methods.Test(AddressOf Methods.M3)
+    End Sub
+End Module",
+                referencedCompilations:={comp1},
+                compilationOptions:=TestOptions.DebugExe)
+
+            Dim verifier = CompileAndVerify(comp2, expectedOutput:="RefFunc1`2[Derived2,Base]
+RefFunc1`2[Derived2,Base]")
+            verifier.VerifyDiagnostics()
+
+        End Sub
+
+        <Fact>
+        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        Public Sub RefMethodGroupOverloadResolution()
+            Dim comp1 = CreateCSharpCompilation(
+"
+public class Base
+{
+    public static Base Instance = new Base();
+}
+
+public class Derived1 : Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+public class Derived2 : Derived1
+{
+}
+
+public delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+public class Methods
+{
+    public static ref Derived1 M2(Base arg) => ref Derived1.Instance;
+
+    public static void Test(RefFunc1<Derived2, Base> arg) => System.Console.WriteLine(arg);
+    public static void Test(RefFunc1<Derived2, Derived1> arg) => System.Console.WriteLine(arg);
+}
+")
+            Dim comp2 = CreateVisualBasicCompilation(
+                Nothing,
+"Module M
+    Sub Main()
+        Methods.Test(AddressOf Methods.M2)
+    End Sub
+End Module",
+                referencedCompilations:={comp1},
+                compilationOptions:=TestOptions.DebugExe)
+
+            Dim verifier = CompileAndVerify(comp2, expectedOutput:="RefFunc1`2[Derived2,Derived1]")
+            verifier.VerifyDiagnostics()
+
+        End Sub
+
+        <Fact>
+        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        Public Sub RefLambdaOverloadResolution()
+            Dim comp1 = CreateCSharpCompilation(
+"
+public class Base
+{
+    public static Base Instance = new Base();
+}
+
+public class Derived1 : Base
+{
+    public static new Derived1 Instance = new Derived1();
+}
+
+public class Derived2 : Derived1
+{
+}
+
+public delegate ref TResult RefFunc1<TArg, TResult>(TArg arg);
+
+public class Methods
+{
+    public static ref Derived1 M2(Base arg) => ref Derived1.Instance;
+
+    public static void Test(RefFunc1<Derived1, Base> arg) => System.Console.WriteLine(arg);
+    public static void Test(System.Func<Derived1, Base> arg) => System.Console.WriteLine(arg);
+}
+")
+            Dim comp2 = CreateVisualBasicCompilation(
+                Nothing,
+"Module M
+    Sub Main()
+        Methods.Test(Function(t)Base.Instance)
+    End Sub
+End Module",
+                referencedCompilations:={comp1},
+                compilationOptions:=TestOptions.DebugExe)
+
+            Dim verifier = CompileAndVerify(comp2, expectedOutput:="System.Func`2[Derived1,Base]")
+            verifier.VerifyDiagnostics()
+
+        End Sub
+
+        <Fact>
+        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
+        Public Sub DelegateToByRefFunctionWithBaseType()
+            Dim comp1 = CreateCSharpCompilation(
+"
+public delegate ref T D<T>();
+
+public class A<T>
+{
+#pragma warning disable 0649
+    private T _t;
+    public ref T F()
+    {
+        return ref _t;
+    }
+}
+public class B
+{
+    public static void F<T>(D<T> d, T t)
+    {
+        d() = t;
+    }
+}")
+            comp1.VerifyDiagnostics()
+            Dim comp2 = CreateVisualBasicCompilation(
+                Nothing,
+"Module M
+    Sub Main()
+        Dim o As New A(Of Object)()
+
+        B.F(Of String)(AddressOf o.F, String.Empty)
+        System.Console.Write(o.F())
+
+        B.F(Of String)(New D(of String)(AddressOf o.F), Nothing)
+        System.Console.Write(o.F())
+
+    End Sub
+End Module",
+                referencedCompilations:={comp1},
+                compilationOptions:=TestOptions.DebugExe)
+
+            comp2.AssertTheseDiagnostics(
+<expected>
+    BC31143: Method 'Public Overloads ByRef Function F() As Object' does not have a signature compatible with delegate 'Delegate ByRef Function D(Of String)() As String'.
+        B.F(Of String)(AddressOf o.F, String.Empty)
+                                 ~~~
+BC31143: Method 'Public Overloads ByRef Function F() As Object' does not have a signature compatible with delegate 'Delegate ByRef Function D(Of String)() As String'.
+        B.F(Of String)(New D(of String)(AddressOf o.F), Nothing)
+                                                  ~~~
+</expected>)
+        End Sub
+
+        <Fact>
+        <WorkItem(13206, "https://github.com/dotnet/roslyn/issues/13206")>
         Public Sub DelegateToByRefFunctionKeepingVsDropingByRef()
             Dim comp1 = CreateCSharpCompilation(
 "


### PR DESCRIPTION
Fix missing variance checks for ref returning methods/properties

Fixes:#17140
