### PR TITLE
Check GetConstantValue and GetConversion on target-typed default

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return CreateUserDefinedConversion(syntax, source, conversion, isCast, destination, diagnostics);
             }
 
-            if (conversion.Kind == ConversionKind.NullLiteral && source.Kind == BoundKind.DefaultLiteral)
+            if (conversion.Kind == ConversionKind.DefaultOrNullLiteral && source.Kind == BoundKind.DefaultLiteral)
             {
                 return CreateDefaultLiteralConversion(syntax, (BoundDefaultLiteral)source, conversion, isCast, destination, diagnostics, wasCompilerGenerated);
             }
@@ -908,7 +908,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return sourceConstantValue;
                     }
 
-                case ConversionKind.NullLiteral:
+                case ConversionKind.DefaultOrNullLiteral:
                     return sourceConstantValue;
 
                 case ConversionKind.ImplicitConstant:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -658,7 +658,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static BoundExpression BindDefaultLiteral(DefaultLiteralSyntax node)
         {
-            return new BoundDefaultLiteral(node, ConstantValue.DefaultLiteral, type: null);
+            return new BoundDefaultLiteral(node, constantValueOpt: null, type: null);
         }
 
         private BoundExpression BindTupleExpression(TupleExpressionSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2628,7 +2628,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
-            if (operand.ConstantValue == ConstantValue.DefaultLiteral)
+            if (operand.Kind == BoundKind.DefaultLiteral && operand.ConstantValue == null)
             {
                 Error(diagnostics, ErrorCode.ERR_DefaultNotValid, node, targetType);
                 return new BoundIsOperator(node, operand, typeExpression, Conversion.NoConversion, resultType, hasErrors: true);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2936,7 +2936,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.IntegerToPointer:
                 case ConversionKind.NullToPointer:
                 case ConversionKind.AnonymousFunction:
-                case ConversionKind.NullLiteral:
+                case ConversionKind.DefaultOrNullLiteral:
                 case ConversionKind.MethodGroup:
                     // We've either replaced Dynamic with Object, or already bailed out with an error.
                     throw ExceptionUtilities.UnexpectedValue(conversionKind);
@@ -3022,7 +3022,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // We do not want to warn for the case "null as TYPE" where the null
                 // is a literal, because the user might be saying it to cause overload resolution
                 // to pick a particular method
-                return new BoundAsOperator(node, operand, typeExpression, Conversion.NullLiteral, resultType);
+                return new BoundAsOperator(node, operand, typeExpression, Conversion.DefaultOrNullLiteral, resultType);
             }
 
             if (operand.Kind == BoundKind.MethodGroup)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -216,10 +216,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case ConversionKind.Identity:
                     case ConversionKind.ImplicitReference:
                     case ConversionKind.Unboxing:
-                    case ConversionKind.DefaultOrNullLiteral:
                     case ConversionKind.ImplicitNullable:
                         // these are the conversions allowed by a pattern match
                         break;
+                    case ConversionKind.DefaultOrNullLiteral:
+                        throw ExceptionUtilities.UnexpectedValue(conversion.Kind);
                     //case ConversionKind.ExplicitNumeric:  // we do not perform numeric conversions of the operand
                     //case ConversionKind.ImplicitConstant:
                     //case ConversionKind.ImplicitNumeric:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case ConversionKind.Identity:
                     case ConversionKind.ImplicitReference:
                     case ConversionKind.Unboxing:
-                    case ConversionKind.NullLiteral:
+                    case ConversionKind.DefaultOrNullLiteral:
                     case ConversionKind.ImplicitNullable:
                         // these are the conversions allowed by a pattern match
                         break;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1028,7 +1028,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     Debug.Assert(initializerOpt.Kind == BoundKind.Conversion &&
                         (((BoundConversion)initializerOpt).Operand.IsLiteralNull() ||
-                            ((BoundConversion)initializerOpt).Operand.IsLiteralDefault()),
+                            ((BoundConversion)initializerOpt).Operand.Kind == BoundKind.DefaultLiteral),
                         "All other typeless expressions should have conversion errors");
 
                     // CONSIDER: this is a very confusing error message, but it's what Dev10 reports.

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -396,19 +396,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics.Add(ErrorCode.ERR_NullNotValid, _syntax.Expression.Location);
                     return false;
                 }
-                else if (collectionExpr.ConstantValue.IsDefaultLiteral)
-                {
-                    diagnostics.Add(ErrorCode.ERR_DefaultNotValid, _syntax.Expression.Location);
-                    return false;
-                }
             }
 
             if ((object)collectionExprType == null) // There's no way to enumerate something without a type.
             {
-                // The null literal was caught above, so anything else with a null type is a method group or anonymous function
-                diagnostics.Add(ErrorCode.ERR_AnonMethGrpInForEach, _syntax.Expression.Location, collectionExpr.Display);
-                // CONSIDER: dev10 also reports ERR_ForEachMissingMember (i.e. failed pattern match).
-
+                if (collectionExpr.Kind == BoundKind.DefaultLiteral && (object)collectionExpr.Type == null)
+                {
+                    diagnostics.Add(ErrorCode.ERR_DefaultNotValid, _syntax.Expression.Location);
+                }
+                else
+                {
+                    // The null and default literals were caught above, so anything else with a null type is a method group or anonymous function
+                    diagnostics.Add(ErrorCode.ERR_AnonMethGrpInForEach, _syntax.Expression.Location, collectionExpr.Display);
+                    // CONSIDER: dev10 also reports ERR_ForEachMissingMember (i.e. failed pattern match).
+                }
                 return false;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -198,7 +198,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Conversion AnonymousFunction => new Conversion(ConversionKind.AnonymousFunction);
         internal static Conversion Boxing => new Conversion(ConversionKind.Boxing);
         internal static Conversion NullLiteral => new Conversion(ConversionKind.NullLiteral);
-        internal static Conversion DefaultLiteral => new Conversion(ConversionKind.DefaultLiteral);
         internal static Conversion NullToPointer => new Conversion(ConversionKind.NullToPointer);
         internal static Conversion PointerToVoid => new Conversion(ConversionKind.PointerToVoid);
         internal static Conversion PointerToPointer => new Conversion(ConversionKind.PointerToPointer);

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -550,12 +550,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Returns true if the conversion is an implicit null or default literal conversion.
-        /// For clarity, use <see cref="IsDefaultOrNullLiteral"/> instead.
         /// </summary>
         /// <remarks>
         /// Null or default literal conversions are described in section 6.1.5 of the C# language specification.
         /// </remarks>
-        [Obsolete]
         public bool IsNullLiteral
         {
             get
@@ -563,21 +561,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return Kind == ConversionKind.DefaultOrNullLiteral;
             }
         }
-
-        /// <summary>
-        /// Returns true if the conversion is an implicit null or default literal conversion.
-        /// </summary>
-        /// <remarks>
-        /// Null or default literal conversions are described in section 6.1.5 of the C# language specification.
-        /// </remarks>
-        public bool IsDefaultOrNullLiteral
-        {
-            get
-            {
-                return Kind == ConversionKind.DefaultOrNullLiteral;
-            }
-        }
-
 
         /// <summary>
         /// Returns true if the conversion is an implicit dynamic conversion. 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitEnumeration:
                 case ConversionKind.AnonymousFunction: 
                 case ConversionKind.Boxing: 
-                case ConversionKind.NullLiteral: 
+                case ConversionKind.DefaultOrNullLiteral: 
                 case ConversionKind.NullToPointer: 
                 case ConversionKind.PointerToVoid: 
                 case ConversionKind.PointerToPointer: 
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Conversion ImplicitEnumeration => new Conversion(ConversionKind.ImplicitEnumeration);
         internal static Conversion AnonymousFunction => new Conversion(ConversionKind.AnonymousFunction);
         internal static Conversion Boxing => new Conversion(ConversionKind.Boxing);
-        internal static Conversion NullLiteral => new Conversion(ConversionKind.NullLiteral);
+        internal static Conversion DefaultOrNullLiteral => new Conversion(ConversionKind.DefaultOrNullLiteral);
         internal static Conversion NullToPointer => new Conversion(ConversionKind.NullToPointer);
         internal static Conversion PointerToVoid => new Conversion(ConversionKind.PointerToVoid);
         internal static Conversion PointerToPointer => new Conversion(ConversionKind.PointerToPointer);
@@ -549,18 +549,35 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Returns true if the conversion is an implicit null literal conversion.
+        /// Returns true if the conversion is an implicit null or default literal conversion.
+        /// For clarity, use <see cref="IsDefaultOrNullLiteral"/> instead.
         /// </summary>
         /// <remarks>
-        /// Null literal conversions are described in section 6.1.5 of the C# language specification.
+        /// Null or default literal conversions are described in section 6.1.5 of the C# language specification.
         /// </remarks>
+        [Obsolete]
         public bool IsNullLiteral
         {
             get
             {
-                return Kind == ConversionKind.NullLiteral;
+                return Kind == ConversionKind.DefaultOrNullLiteral;
             }
         }
+
+        /// <summary>
+        /// Returns true if the conversion is an implicit null or default literal conversion.
+        /// </summary>
+        /// <remarks>
+        /// Null or default literal conversions are described in section 6.1.5 of the C# language specification.
+        /// </remarks>
+        public bool IsDefaultOrNullLiteral
+        {
+            get
+            {
+                return Kind == ConversionKind.DefaultOrNullLiteral;
+            }
+        }
+
 
         /// <summary>
         /// Returns true if the conversion is an implicit dynamic conversion. 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ExplicitTupleLiteral,
         ExplicitTuple,
         ImplicitNullable,
-        NullLiteral,
+        DefaultOrNullLiteral,
         ImplicitReference,
         Boxing,
         PointerToVoid,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -41,6 +41,5 @@ namespace Microsoft.CodeAnalysis.CSharp
         // implement them for compatibility with the native compiler.
         IntPtr,
         InterpolatedString, // a conversion from an interpolated string to IFormattable or FormattableString
-        DefaultLiteral,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
@@ -40,7 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.PointerToVoid:
                 case ConversionKind.NullToPointer:
                 case ConversionKind.InterpolatedString:
-                case ConversionKind.DefaultLiteral:
                     return true;
 
                 case ConversionKind.ExplicitNumeric:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKindExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitTuple:
                 case ConversionKind.ImplicitEnumeration:
                 case ConversionKind.ImplicitNullable:
-                case ConversionKind.NullLiteral:
+                case ConversionKind.DefaultOrNullLiteral:
                 case ConversionKind.ImplicitReference:
                 case ConversionKind.Boxing:
                 case ConversionKind.ImplicitDynamic:

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -807,19 +807,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     break;
 
+                case BoundKind.DefaultLiteral:
+                    var defaultExpression = (BoundDefaultLiteral)sourceExpression;
+                    if ((object)defaultExpression.Type == null)
+                    {
+                        return Conversion.NullLiteral;
+                    }
+                    break;
+
                 case BoundKind.TupleLiteral:
                     var tupleConversion = ClassifyImplicitTupleLiteralConversion((BoundTupleLiteral)sourceExpression, destination, ref useSiteDiagnostics);
                     if (tupleConversion.Exists)
                     {
                         return tupleConversion;
-                    }
-                    break;
-
-                case BoundKind.DefaultLiteral:
-                    var defaultExpression = (BoundDefaultLiteral)sourceExpression;
-                    if ((object)defaultExpression.Type == null)
-                    {
-                        return Conversion.DefaultLiteral;
                     }
                     break;
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -811,7 +811,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var defaultExpression = (BoundDefaultLiteral)sourceExpression;
                     if ((object)defaultExpression.Type == null)
                     {
-                        return Conversion.NullLiteral;
+                        return Conversion.DefaultOrNullLiteral;
                     }
                     break;
 
@@ -865,7 +865,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // The spec defines a "null literal conversion" specifically as a conversion from
                 // null to nullable type.
-                return Conversion.NullLiteral;
+                return Conversion.DefaultOrNullLiteral;
             }
 
             // SPEC: An implicit conversion exists from the null literal to any reference type. 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -594,7 +594,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.PointerToVoid:
 
                 // Added to spec in Roslyn timeframe.
-                case ConversionKind.NullLiteral:
+                case ConversionKind.DefaultOrNullLiteral:
                 case ConversionKind.NullToPointer:
 
                 // Added for C# 7.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -594,7 +594,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.PointerToVoid:
 
                 // Added to spec in Roslyn timeframe.
-                case ConversionKind.DefaultOrNullLiteral:
+                case ConversionKind.DefaultOrNullLiteral: // updated to include "default" in C# 7.1
                 case ConversionKind.NullToPointer:
 
                 // Added for C# 7.

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/UserDefinedImplicitConversions.cs
@@ -606,9 +606,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ExplicitTuple:
                     return false;
 
-                case ConversionKind.DefaultLiteral:
-                    return true;
-
                 default:
                     throw ExceptionUtilities.UnexpectedValue(kind);
             }

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -735,7 +735,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case CSharp.ConversionKind.ImplicitConstant:
                     case CSharp.ConversionKind.IntegerToPointer:
                     case CSharp.ConversionKind.IntPtr:
-                    case CSharp.ConversionKind.NullLiteral:
+                    case CSharp.ConversionKind.DefaultOrNullLiteral:
                     case CSharp.ConversionKind.NullToPointer:
                     case CSharp.ConversionKind.PointerToInteger:
                     case CSharp.ConversionKind.PointerToPointer:

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2989,9 +2989,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 case BoundKind.Conversion:
                     var conversion = (BoundConversion)expr;
                     var conversionKind = conversion.ConversionKind;
+                    Debug.Assert(conversionKind != ConversionKind.DefaultOrNullLiteral);
+
                     if (conversionKind.IsImplicitConversion() &&
-                        conversionKind != ConversionKind.MethodGroup &&
-                        conversionKind != ConversionKind.DefaultOrNullLiteral)
+                        conversionKind != ConversionKind.MethodGroup)
                     {
                         return StackMergeType(conversion.Operand);
                     }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2991,7 +2991,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     var conversionKind = conversion.ConversionKind;
                     if (conversionKind.IsImplicitConversion() &&
                         conversionKind != ConversionKind.MethodGroup &&
-                        conversionKind != ConversionKind.NullLiteral)
+                        conversionKind != ConversionKind.DefaultOrNullLiteral)
                     {
                         return StackMergeType(conversion.Operand);
                     }

--- a/src/Compilers/CSharp/Portable/Lowering/Extensions.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Extensions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (conversion.ConversionKind)
                 {
                     case ConversionKind.NullLiteral:
-                        // Any "null literal conversion" is a conversion from the literal null to
+                        // Any "null literal conversion" is a conversion from the literals null/default to
                         // a nullable value type; obviously it never has a value.
                         return true;
                     case ConversionKind.ImplicitNullable:

--- a/src/Compilers/CSharp/Portable/Lowering/Extensions.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Extensions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var conversion = (BoundConversion)expr;
                 switch (conversion.ConversionKind)
                 {
-                    case ConversionKind.NullLiteral:
+                    case ConversionKind.DefaultOrNullLiteral:
                         // Any "null literal conversion" is a conversion from the literals null/default to
                         // a nullable value type; obviously it never has a value.
                         return true;

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -644,7 +644,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return Convert(e1, intermediate, node.Type, node.Checked, false);
                     }
                 case ConversionKind.DefaultOrNullLiteral:
-                    // TODO REVIEW
+                    // PROTOTYPE(default): how do we reach this code with `default` and does it need to be fixed to handle it?
                     return Convert(Constant(_bound.Null(_objectType)), _objectType, node.Type, false, node.ExplicitCastInCode);
                 default:
                     return Convert(Visit(node.Operand), node.Operand.Type, node.Type, node.Checked, node.ExplicitCastInCode);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var conversion = (BoundConversion)operand;
                 if (!conversion.ConversionKind.IsUserDefinedConversion() &&
                     conversion.ConversionKind.IsImplicitConversion() &&
-                    conversion.ConversionKind != ConversionKind.NullLiteral &&
+                    conversion.ConversionKind != ConversionKind.DefaultOrNullLiteral &&
                     conversion.Type.StrippedType().IsEnumType())
                 {
                     operand = conversion.Operand;
@@ -643,7 +643,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var e1 = Convert(Visit(node.Operand), node.Operand.Type, intermediate, node.Checked, false);
                         return Convert(e1, intermediate, node.Type, node.Checked, false);
                     }
-                case ConversionKind.NullLiteral:
+                case ConversionKind.DefaultOrNullLiteral:
                     // TODO REVIEW
                     return Convert(Constant(_bound.Null(_objectType)), _objectType, node.Type, false, node.ExplicitCastInCode);
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -644,6 +644,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return Convert(e1, intermediate, node.Type, node.Checked, false);
                     }
                 case ConversionKind.NullLiteral:
+                    // TODO REVIEW
                     return Convert(Constant(_bound.Null(_objectType)), _objectType, node.Type, false, node.ExplicitCastInCode);
                 default:
                     return Convert(Visit(node.Operand), node.Operand.Type, node.Type, node.Checked, node.ExplicitCastInCode);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -299,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 case ConversionKind.AnonymousFunction:
                                 case ConversionKind.ImplicitConstant:
                                 case ConversionKind.MethodGroup:
-                                case ConversionKind.NullLiteral:
+                                case ConversionKind.DefaultOrNullLiteral:
                                     return true;
 
                                 case ConversionKind.Boxing:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -188,7 +188,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case ConversionKind.NullLiteral:
-                case ConversionKind.DefaultLiteral:
                     if (!_inExpressionLambda || !explicitCastInCode)
                     {
                         return new BoundDefaultLiteral(syntax, rewrittenType);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     break;
 
-                case ConversionKind.NullLiteral:
+                case ConversionKind.DefaultOrNullLiteral:
                     if (!_inExpressionLambda || !explicitCastInCode)
                     {
                         return new BoundDefaultLiteral(syntax, rewrittenType);

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -5,7 +5,6 @@
 *REMOVED*override sealed Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.ToString() -> string
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.CSharpParseOptions(Microsoft.CodeAnalysis.CSharp.LanguageVersion languageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Default, Microsoft.CodeAnalysis.DocumentationMode documentationMode = Microsoft.CodeAnalysis.DocumentationMode.Parse, Microsoft.CodeAnalysis.SourceCodeKind kind = Microsoft.CodeAnalysis.SourceCodeKind.Regular, System.Collections.Generic.IEnumerable<string> preprocessorSymbols = null) -> void
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.SpecifiedLanguageVersion.get -> Microsoft.CodeAnalysis.CSharp.LanguageVersion
-Microsoft.CodeAnalysis.CSharp.Conversion.IsDefaultOrNullLiteral.get -> bool
 Microsoft.CodeAnalysis.CSharp.Conversion.IsTupleConversion.get -> bool
 Microsoft.CodeAnalysis.CSharp.Conversion.IsTupleLiteralConversion.get -> bool
 Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7 = 7 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@
 *REMOVED*override sealed Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.ToString() -> string
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.CSharpParseOptions(Microsoft.CodeAnalysis.CSharp.LanguageVersion languageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Default, Microsoft.CodeAnalysis.DocumentationMode documentationMode = Microsoft.CodeAnalysis.DocumentationMode.Parse, Microsoft.CodeAnalysis.SourceCodeKind kind = Microsoft.CodeAnalysis.SourceCodeKind.Regular, System.Collections.Generic.IEnumerable<string> preprocessorSymbols = null) -> void
 Microsoft.CodeAnalysis.CSharp.CSharpParseOptions.SpecifiedLanguageVersion.get -> Microsoft.CodeAnalysis.CSharp.LanguageVersion
+Microsoft.CodeAnalysis.CSharp.Conversion.IsDefaultOrNullLiteral.get -> bool
 Microsoft.CodeAnalysis.CSharp.Conversion.IsTupleConversion.get -> bool
 Microsoft.CodeAnalysis.CSharp.Conversion.IsTupleLiteralConversion.get -> bool
 Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7 = 7 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -4971,6 +4971,49 @@ namespace ConsoleApplication1
                 expectedOutput: expectedOutput);
         }
 
+        [Fact]
+        public void EnumEqualityWithDefault()
+        {
+            string source =
+@"
+using System;
+using System.Linq.Expressions;
+
+namespace ConsoleApplication1
+{
+    enum YesNo
+    {
+        Yes,
+        No
+    }
+
+    class MyType
+    {
+        public string Name { get; set; }
+        public YesNo? YesNo { get; set; }
+
+        public int? Age { get; set; }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+
+            Expression<Func<MyType, bool>> expr = (MyType x) => x.YesNo == (YesNo?)default;
+            Console.WriteLine(expr.Dump());
+        }
+    }
+
+}";
+            string expectedOutput = "Equal(Convert(MemberAccess(Parameter(x Type:ConsoleApplication1.MyType).YesNo Type:System.Nullable`1[ConsoleApplication1.YesNo]) Lifted LiftedToNull Type:System.Nullable`1[System.Int32]) Convert(Convert(Constant(null Type:System.Object) Lifted LiftedToNull Type:System.Nullable`1[ConsoleApplication1.YesNo]) Lifted LiftedToNull Type:System.Nullable`1[System.Int32]) Lifted Type:System.Boolean)";
+            CompileAndVerify(
+                new[] { source, ExpressionTestLibrary },
+                new[] { ExpressionAssemblyRef },
+                expectedOutput: expectedOutput,
+                parseOptions: TestOptions.ExperimentalParseOptions);
+        }
+
         [WorkItem(546618, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546618")]
         [Fact]
         public void TildeNullableEnum()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -325,6 +325,7 @@ class C
             Assert.Null(model.GetTypeInfo(def).Type);
             Assert.Equal("System.Int32", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
             Assert.Null(model.GetSymbolInfo(def).Symbol);
+            Assert.Equal("", model.GetConstantValue(def).Value.ToString()); // crash
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -57,6 +57,7 @@ class C
             Assert.Equal("System.Int32", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
             Assert.Null(model.GetSymbolInfo(def).Symbol);
             Assert.Equal("0", model.GetConstantValue(def).Value.ToString());
+            Assert.True(model.GetConversion(def).IsNullLiteral);
         }
 
         [Fact]
@@ -126,6 +127,7 @@ struct S
             Assert.Equal("S", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
             Assert.Null(model.GetSymbolInfo(def).Symbol);
             Assert.False(model.GetConstantValue(def).HasValue);
+            Assert.True(model.GetConversion(def).IsNullLiteral);
         }
 
         [Fact]
@@ -153,6 +155,7 @@ class C
             Assert.Equal("T", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
             Assert.Null(model.GetSymbolInfo(def).Symbol);
             Assert.False(model.GetConstantValue(def).HasValue);
+            Assert.True(model.GetConversion(def).IsNullLiteral);
         }
 
         [Fact]
@@ -862,6 +865,7 @@ class Program
             Assert.Equal("System.Int32?", model.GetTypeInfo(def).Type.ToTestDisplayString());
             Assert.Equal("System.Int32?", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
             Assert.Null(model.GetSymbolInfo(def).Symbol);
+            Assert.True(model.GetConversion(def).IsNullLiteral);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -865,6 +865,7 @@ class Program
             Assert.Equal("System.Int32?", model.GetTypeInfo(def).Type.ToTestDisplayString());
             Assert.Equal("System.Int32?", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
             Assert.Null(model.GetSymbolInfo(def).Symbol);
+            Assert.False(model.GetConstantValue(def).HasValue);
             Assert.True(model.GetConversion(def).IsNullLiteral);
         }
 
@@ -1067,11 +1068,19 @@ class C
             Assert.Equal("System.Int16", model.GetTypeInfo(def).Type.ToTestDisplayString());
             Assert.Null(model.GetSymbolInfo(def).Symbol);
             Assert.Null(model.GetDeclaredSymbol(def));
+            Assert.Equal("System.Int16", model.GetTypeInfo(def).ConvertedType.ToTestDisplayString());
+            Assert.Null(model.GetSymbolInfo(def).Symbol);
+            Assert.Equal((short)0, model.GetConstantValue(def).Value);
+            Assert.True(model.GetConversion(def).IsIdentity);
 
-            var conversion = nodes.OfType<CastExpressionSyntax>().Single();
-            var conversionTypeInfo = model.GetTypeInfo(conversion);
+            var conversionSyntax = nodes.OfType<CastExpressionSyntax>().Single();
+            var conversionTypeInfo = model.GetTypeInfo(conversionSyntax);
             Assert.Equal("System.Int16", conversionTypeInfo.Type.ToTestDisplayString());
             Assert.Equal("System.Int32", conversionTypeInfo.ConvertedType.ToTestDisplayString());
+            Assert.Equal((short)0, model.GetConstantValue(conversionSyntax).Value);
+            Conversion conversion = model.GetConversion(conversionSyntax);
+            Assert.True(conversion.IsNumeric);
+            Assert.True(conversion.IsImplicit);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -952,13 +952,17 @@ class C
         {
             System.Console.Write(""0"");
         }
+        if (default == x)
+        {
+            System.Console.Write(""1"");
+        }
     }
 }
 ";
 
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.ExperimentalParseOptions, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "0");
+            CompileAndVerify(comp, expectedOutput: "01");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -529,7 +529,7 @@ enum E { zero, one }
 
             // sbyte? nullable = null;
             var v1 = (mainStats[0] as LocalDeclarationStatementSyntax).Declaration.Variables;
-            ConversionTestHelper(model, v1[0].Initializer.Value, ConversionKind.NullLiteral, ConversionKind.NoConversion);
+            ConversionTestHelper(model, v1[0].Initializer.Value, ConversionKind.DefaultOrNullLiteral, ConversionKind.NoConversion);
             // uint? nullable01 = 100;
             var v2 = (mainStats[1] as LocalDeclarationStatementSyntax).Declaration.Variables;
             ConversionTestHelper(model, v2[0].Initializer.Value, ConversionKind.ImplicitNullable, ConversionKind.ExplicitNullable);
@@ -680,7 +680,7 @@ class C {
                     Assert.False(conv.IsExplicit);
                     Assert.True(conv.IsNullable);
                     break;
-                case ConversionKind.NullLiteral:
+                case ConversionKind.DefaultOrNullLiteral:
                     Assert.True(conv.Exists);
                     Assert.True(conv.IsImplicit);
                     Assert.False(conv.IsExplicit);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -684,7 +684,7 @@ class C {
                     Assert.True(conv.Exists);
                     Assert.True(conv.IsImplicit);
                     Assert.False(conv.IsExplicit);
-                    Assert.True(conv.IsNullLiteral);
+                    Assert.True(conv.IsDefaultOrNullLiteral);
                     break;
                 case ConversionKind.ImplicitReference:
                     Assert.True(conv.Exists);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -684,7 +684,7 @@ class C {
                     Assert.True(conv.Exists);
                     Assert.True(conv.IsImplicit);
                     Assert.False(conv.IsExplicit);
-                    Assert.True(conv.IsDefaultOrNullLiteral);
+                    Assert.True(conv.IsNullLiteral);
                     break;
                 case ConversionKind.ImplicitReference:
                     Assert.True(conv.Exists);

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis
         String,
         Decimal,
         DateTime,
-        DefaultLiteral,
     }
 
     internal abstract partial class ConstantValue : IEquatable<ConstantValue>

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -80,7 +80,6 @@ namespace Microsoft.CodeAnalysis
 
         public static ConstantValue Bad { get { return ConstantValueBad.Instance; } }
         public static ConstantValue Null { get { return ConstantValueNull.Instance; } }
-        public static ConstantValue DefaultLiteral { get { return ConstantValueDefault.DefaultLiteralConstant; } }
         public static ConstantValue Nothing { get { return Null; } }
         // Null, Nothing and Unset are all ConstantValueNull. Null and Nothing are equivalent and represent the null and
         // nothing constants in C# and VB.  Unset indicates an uninitialized ConstantValue.
@@ -654,14 +653,6 @@ namespace Microsoft.CodeAnalysis
             get
             {
                 return ReferenceEquals(this, Null);
-            }
-        }
-
-        public bool IsDefaultLiteral
-        {
-            get
-            {
-                return ReferenceEquals(this, DefaultLiteral);
             }
         }
 

--- a/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
+++ b/src/Compilers/Core/Portable/ConstantValueSpecialized.cs
@@ -269,7 +269,6 @@ namespace Microsoft.CodeAnalysis
             public static readonly ConstantValueDefault Decimal = new ConstantValueDecimalZero();
             public static readonly ConstantValueDefault DateTime = new ConstantValueDefault(ConstantValueTypeDiscriminator.DateTime);
             public static readonly ConstantValueDefault Boolean = new ConstantValueDefault(ConstantValueTypeDiscriminator.Boolean);
-            public static readonly ConstantValueDefault DefaultLiteralConstant = new ConstantValueDefault(ConstantValueTypeDiscriminator.DefaultLiteral);
 
             protected ConstantValueDefault(ConstantValueTypeDiscriminator discriminator)
                 : base(discriminator)

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -525,7 +525,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                 // Case :
                 // 3. object y = (NullableValueType)null;
-                if ((!castToOuterType.IsBoxing || expressionToCastType.IsDefaultOrNullLiteral) &&
+                if ((!castToOuterType.IsBoxing || expressionToCastType.IsNullLiteral) &&
                     castToOuterType.IsImplicit &&
                     expressionToCastType.IsImplicit &&
                     expressionToOuterType.IsImplicit)

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -525,7 +525,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                 // Case :
                 // 3. object y = (NullableValueType)null;
-                if ((!castToOuterType.IsBoxing || expressionToCastType.IsNullLiteral) &&
+                if ((!castToOuterType.IsBoxing || expressionToCastType.IsDefaultOrNullLiteral) &&
                     castToOuterType.IsImplicit &&
                     expressionToCastType.IsImplicit &&
                     expressionToOuterType.IsImplicit)


### PR DESCRIPTION
I noticed two more semantic model APIs that need coverage.

`GetConstantValue` should behave as it does on `default(...)`.
In the current implementation, when the type of the `default` literal is inferred, the bound node remains the same (typeless and without a constant value) and  it is wrapped with a bound conversion. I'd like to get your feedback on that.

Relates to umbrella item for "default" (https://github.com/dotnet/roslyn/issues/13602)
@dotnet/roslyn-compiler for review.