### PR TITLE
Have distinct LocalDeclarationKind for OutVariable, Deconstruction

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             nodeBinder: _enclosingBinder,
                             typeSyntax: node.Type,
                             identifierToken: designation.Identifier,
-                            kind: LocalDeclarationKind.DeclarationExpression,
+                            kind: node.IsOutVarDeclaration() ? LocalDeclarationKind.OutVariable : LocalDeclarationKind.DeclarationExpressionVariable,
                             nodeToBind: nodeToBind,
                             forbiddenZone: argumentListSyntax);
         }
@@ -481,7 +481,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                       nodeBinder: _enclosingBinder,
                                       closestTypeSyntax: closestTypeSyntax,
                                       identifierToken: designation.Identifier,
-                                      kind: LocalDeclarationKind.Deconstruction,
+                                      kind: LocalDeclarationKind.DeconstructionVariable,
                                       deconstruction: deconstruction);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             nodeBinder: _enclosingBinder,
                             typeSyntax: node.Type,
                             identifierToken: designation.Identifier,
-                            kind: LocalDeclarationKind.RegularVariable,
+                            kind: LocalDeclarationKind.OutVariable,
                             nodeToBind: nodeToBind,
                             forbiddenZone: argumentListSyntax);
         }
@@ -481,7 +481,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                       nodeBinder: _enclosingBinder,
                                       closestTypeSyntax: closestTypeSyntax,
                                       identifierToken: designation.Identifier,
-                                      kind: LocalDeclarationKind.RegularVariable,
+                                      kind: LocalDeclarationKind.Deconstruction,
                                       deconstruction: deconstruction);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             nodeBinder: _enclosingBinder,
                             typeSyntax: node.Type,
                             identifierToken: designation.Identifier,
-                            kind: LocalDeclarationKind.OutVariable,
+                            kind: LocalDeclarationKind.DeclarationExpression,
                             nodeToBind: nodeToBind,
                             forbiddenZone: argumentListSyntax);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/LocalDeclarationKind.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalDeclarationKind.cs
@@ -53,12 +53,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// User variable declared by a declaration expression in the left-hand-side of a deconstruction assignment.
         /// </summary>
-        Deconstruction,
+        DeconstructionVariable,
 
         /// <summary>
-        /// User variable declared by a declaration expression that is not a deconstruction. This occurs for an
-        /// out variable declaration, and as a result of error recovery in incorrect code.
+        /// User variable declared as an out argument.
         /// </summary>
-        DeclarationExpression,
+        OutVariable,
+
+        /// <summary>
+        /// User variable declared by a declaration expression in some unsupported context.
+        /// This occurs as a result of error recovery in incorrect code.
+        /// </summary>
+        DeclarationExpressionVariable,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/LocalDeclarationKind.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalDeclarationKind.cs
@@ -51,13 +51,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         PatternVariable,
 
         /// <summary>
-        /// User variable declared in the left-hand-side of a deconstruction assignment.
+        /// User variable declared by a declaration expression in the left-hand-side of a deconstruction assignment.
         /// </summary>
         Deconstruction,
 
         /// <summary>
-        /// User variable declared in an out argument.
+        /// User variable declared by a declaration expression that is not a deconstruction. This occurs for an
+        /// out variable declaration, and as a result of error recovery in incorrect code.
         /// </summary>
-        OutVariable,
+        DeclarationExpression,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/LocalDeclarationKind.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalDeclarationKind.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     /// <summary>
-    /// Specifies the syntax that a user defined variable comes from.
+    /// Specifies the syntactic construct that a user defined variable comes from.
     /// </summary>
     internal enum LocalDeclarationKind : byte
     {
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         None,
 
         /// <summary>
-        /// User defined local variable declared by <see cref="LocalDeclarationStatementSyntax"/> (including deconstruction-declaration), or by "out var" argument.
+        /// User defined local variable declared by <see cref="LocalDeclarationStatementSyntax"/>.
         /// </summary>
         RegularVariable,
 
@@ -49,5 +49,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// The variable that captures the result of a pattern matching operation like "i" in "expr is int i"
         /// </summary>
         PatternVariable,
+
+        /// <summary>
+        /// User variable declared in the left-hand-side of a deconstruction assignment.
+        /// </summary>
+        Deconstruction,
+
+        /// <summary>
+        /// User variable declared in an out argument.
+        /// </summary>
+        OutVariable,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         Debug.Assert(node is CatchDeclarationSyntax);
                         break;
 
-                    case LocalDeclarationKind.OutVariable:
+                    case LocalDeclarationKind.DeclarationExpression:
                     case LocalDeclarationKind.Deconstruction:
                     case LocalDeclarationKind.PatternVariable:
                         Debug.Assert(node is SingleVariableDesignationSyntax);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -411,7 +411,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 switch (_declarationKind)
                 {
                     case LocalDeclarationKind.RegularVariable:
-                        Debug.Assert(node is VariableDeclaratorSyntax || node is SingleVariableDesignationSyntax);
+                        Debug.Assert(node is VariableDeclaratorSyntax);
                         break;
 
                     case LocalDeclarationKind.Constant:
@@ -428,6 +428,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         Debug.Assert(node is CatchDeclarationSyntax);
                         break;
 
+                    case LocalDeclarationKind.OutVariable:
+                    case LocalDeclarationKind.Deconstruction:
                     case LocalDeclarationKind.PatternVariable:
                         Debug.Assert(node is SingleVariableDesignationSyntax);
                         break;
@@ -761,7 +763,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if ((object)this._type == null)
                 {
-                    AssertNoOutOrPatternVariable();
+                    AssertNoOutOrPatternVariableSyntax();
                     SetType(_nodeBinder.CreateErrorType("var"));
                 }
 
@@ -769,10 +771,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             [Conditional("DEBUG")]
-            private void AssertNoOutOrPatternVariable()
+            private void AssertNoOutOrPatternVariableSyntax()
             {
-                var parent = this._typeSyntax.Parent;
+                // The following assertion
+                //   Debug.Assert(DeclarationKind != LocalDeclarationKind.OutVariable && DeclarationKind != LocalDeclarationKind.PatternVariable);
+                // would not be correct because, for example, the declarations in the erroneous code `M(out (var x, var y))` are treated as out variables.
 
+                var parent = this._typeSyntax.Parent;
                 if (parent?.Kind() == SyntaxKind.DeclarationExpression && ((DeclarationExpressionSyntax)parent).IsOutVarDeclaration())
                 {
                     Debug.Assert(false);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -428,8 +428,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         Debug.Assert(node is CatchDeclarationSyntax);
                         break;
 
-                    case LocalDeclarationKind.DeclarationExpression:
-                    case LocalDeclarationKind.Deconstruction:
+                    case LocalDeclarationKind.OutVariable:
+                    case LocalDeclarationKind.DeclarationExpressionVariable:
+                    case LocalDeclarationKind.DeconstructionVariable:
                     case LocalDeclarationKind.PatternVariable:
                         Debug.Assert(node is SingleVariableDesignationSyntax);
                         break;
@@ -763,29 +764,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if ((object)this._type == null)
                 {
-                    AssertNoOutOrPatternVariableSyntax();
+                    Debug.Assert(this.DeclarationKind == LocalDeclarationKind.DeclarationExpressionVariable);
                     SetType(_nodeBinder.CreateErrorType("var"));
                 }
 
                 return this._type;
-            }
-
-            [Conditional("DEBUG")]
-            private void AssertNoOutOrPatternVariableSyntax()
-            {
-                // The following assertion
-                //   Debug.Assert(DeclarationKind != LocalDeclarationKind.OutVariable && DeclarationKind != LocalDeclarationKind.PatternVariable);
-                // would not be correct because, for example, the declarations in the erroneous code `M(out (var x, var y))` are treated as out variables.
-
-                var parent = this._typeSyntax.Parent;
-                if (parent?.Kind() == SyntaxKind.DeclarationExpression && ((DeclarationExpressionSyntax)parent).IsOutVarDeclaration())
-                {
-                    Debug.Assert(false);
-                }
-                else if (parent?.Kind() == SyntaxKind.DeclarationPattern)
-                {
-                    Debug.Assert(false);
-                }
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6057,8 +6057,8 @@ class C
             var x2Ref = GetReference(tree, "x2");
             Assert.Equal("string", model.GetTypeInfo(x2Ref).Type.ToDisplayString());
 
-            VerifyModelForDeconstruction(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
-            VerifyModelForDeconstruction(model, x2, LocalDeclarationKind.OutVariable, x2Ref);
+            VerifyModelForDeconstruction(model, x1, LocalDeclarationKind.DeclarationExpressionVariable, x1Ref);
+            VerifyModelForDeconstruction(model, x2, LocalDeclarationKind.DeclarationExpressionVariable, x2Ref);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -2491,7 +2491,7 @@ Deconstructing (1, hello)
 
         private static void VerifyModelForDeconstructionLocal(SemanticModel model, SingleVariableDesignationSyntax decl, params IdentifierNameSyntax[] references)
         {
-            VerifyModelForDeconstruction(model, decl, LocalDeclarationKind.RegularVariable, references);
+            VerifyModelForDeconstruction(model, decl, LocalDeclarationKind.Deconstruction, references);
         }
 
         private static void VerifyModelForLocal(SemanticModel model, SingleVariableDesignationSyntax decl, LocalDeclarationKind kind, params IdentifierNameSyntax[] references)
@@ -5933,7 +5933,7 @@ class Program
             var x2Ref = GetReference(tree, "x2");
             Assert.Equal("string[]", model.GetTypeInfo(x2Ref).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.RegularVariable, x1Ref);
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
             VerifyModelForLocal(model, x2, LocalDeclarationKind.PatternVariable, x2Ref);
         }
 
@@ -5967,7 +5967,7 @@ class Program
             var x1Ref = GetReference(tree, "x1");
             Assert.Equal("int", model.GetTypeInfo(x1Ref).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.RegularVariable, x1Ref);
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
         }
 
         [Fact]
@@ -6008,7 +6008,7 @@ class Program
             var x2Ref = GetReferences(tree, "x2");
             Assert.Equal("string[]", model.GetTypeInfo(x2Ref.First()).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.RegularVariable, x1Ref.ToArray());
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref.ToArray());
             VerifyModelForLocal(model, x2, LocalDeclarationKind.PatternVariable, x2Ref.ToArray());
         }
 
@@ -6057,8 +6057,8 @@ class C
             var x2Ref = GetReference(tree, "x2");
             Assert.Equal("string", model.GetTypeInfo(x2Ref).Type.ToDisplayString());
 
-            VerifyModelForDeconstructionLocal(model, x1, x1Ref);
-            VerifyModelForDeconstructionLocal(model, x2, x2Ref);
+            VerifyModelForDeconstruction(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
+            VerifyModelForDeconstruction(model, x2, LocalDeclarationKind.OutVariable, x2Ref);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -2491,7 +2491,7 @@ Deconstructing (1, hello)
 
         private static void VerifyModelForDeconstructionLocal(SemanticModel model, SingleVariableDesignationSyntax decl, params IdentifierNameSyntax[] references)
         {
-            VerifyModelForDeconstruction(model, decl, LocalDeclarationKind.Deconstruction, references);
+            VerifyModelForDeconstruction(model, decl, LocalDeclarationKind.DeconstructionVariable, references);
         }
 
         private static void VerifyModelForLocal(SemanticModel model, SingleVariableDesignationSyntax decl, LocalDeclarationKind kind, params IdentifierNameSyntax[] references)
@@ -5933,7 +5933,7 @@ class Program
             var x2Ref = GetReference(tree, "x2");
             Assert.Equal("string[]", model.GetTypeInfo(x2Ref).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.DeclarationExpression, x1Ref);
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
             VerifyModelForLocal(model, x2, LocalDeclarationKind.PatternVariable, x2Ref);
         }
 
@@ -5967,7 +5967,7 @@ class Program
             var x1Ref = GetReference(tree, "x1");
             Assert.Equal("int", model.GetTypeInfo(x1Ref).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.DeclarationExpression, x1Ref);
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
         }
 
         [Fact]
@@ -6008,7 +6008,7 @@ class Program
             var x2Ref = GetReferences(tree, "x2");
             Assert.Equal("string[]", model.GetTypeInfo(x2Ref.First()).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.DeclarationExpression, x1Ref.ToArray());
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref.ToArray());
             VerifyModelForLocal(model, x2, LocalDeclarationKind.PatternVariable, x2Ref.ToArray());
         }
 
@@ -6057,8 +6057,8 @@ class C
             var x2Ref = GetReference(tree, "x2");
             Assert.Equal("string", model.GetTypeInfo(x2Ref).Type.ToDisplayString());
 
-            VerifyModelForDeconstruction(model, x1, LocalDeclarationKind.DeclarationExpression, x1Ref);
-            VerifyModelForDeconstruction(model, x2, LocalDeclarationKind.DeclarationExpression, x2Ref);
+            VerifyModelForDeconstruction(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
+            VerifyModelForDeconstruction(model, x2, LocalDeclarationKind.OutVariable, x2Ref);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -5933,7 +5933,7 @@ class Program
             var x2Ref = GetReference(tree, "x2");
             Assert.Equal("string[]", model.GetTypeInfo(x2Ref).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.DeclarationExpression, x1Ref);
             VerifyModelForLocal(model, x2, LocalDeclarationKind.PatternVariable, x2Ref);
         }
 
@@ -5967,7 +5967,7 @@ class Program
             var x1Ref = GetReference(tree, "x1");
             Assert.Equal("int", model.GetTypeInfo(x1Ref).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.DeclarationExpression, x1Ref);
         }
 
         [Fact]
@@ -6008,7 +6008,7 @@ class Program
             var x2Ref = GetReferences(tree, "x2");
             Assert.Equal("string[]", model.GetTypeInfo(x2Ref.First()).Type.ToDisplayString());
 
-            VerifyModelForLocal(model, x1, LocalDeclarationKind.OutVariable, x1Ref.ToArray());
+            VerifyModelForLocal(model, x1, LocalDeclarationKind.DeclarationExpression, x1Ref.ToArray());
             VerifyModelForLocal(model, x2, LocalDeclarationKind.PatternVariable, x2Ref.ToArray());
         }
 
@@ -6057,8 +6057,8 @@ class C
             var x2Ref = GetReference(tree, "x2");
             Assert.Equal("string", model.GetTypeInfo(x2Ref).Type.ToDisplayString());
 
-            VerifyModelForDeconstruction(model, x1, LocalDeclarationKind.OutVariable, x1Ref);
-            VerifyModelForDeconstruction(model, x2, LocalDeclarationKind.OutVariable, x2Ref);
+            VerifyModelForDeconstruction(model, x1, LocalDeclarationKind.DeclarationExpression, x1Ref);
+            VerifyModelForDeconstruction(model, x2, LocalDeclarationKind.DeclarationExpression, x2Ref);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -2531,7 +2531,7 @@ class Program
                     if (node is DeclarationExpressionSyntax)
                     {
                         Assert.Equal(SymbolKind.Local, symbol.Kind);
-                        Assert.Equal(LocalDeclarationKind.Deconstruction, ((LocalSymbol)symbol).DeclarationKind);
+                        Assert.Equal(LocalDeclarationKind.DeconstructionVariable, ((LocalSymbol)symbol).DeclarationKind);
                     }
                     else
                     {
@@ -2545,7 +2545,7 @@ class Program
                     if (node is SingleVariableDesignationSyntax)
                     {
                         Assert.Equal(SymbolKind.Local, symbol.Kind);
-                        Assert.Equal(LocalDeclarationKind.Deconstruction, ((LocalSymbol)symbol).DeclarationKind);
+                        Assert.Equal(LocalDeclarationKind.DeconstructionVariable, ((LocalSymbol)symbol).DeclarationKind);
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -2495,8 +2495,9 @@ class C
         public void DeconstructionLocalsDeclaredNotUsed()
         {
             // Check that there are no *use sites* within this code for local variables.
-            // They are declared herein, but nowhere used. So they should not be returned
-            // by SemanticModel.GetSymbolInfo.
+            // They are not declared. So they should not be returned
+            // by SemanticModel.GetSymbolInfo. Similarly, check that all designation syntax
+            // forms declare deconstruction locals.
             string source = @"
 class Program
 {
@@ -2525,15 +2526,31 @@ class Program
             {
                 var si = model.GetSymbolInfo(node);
                 var symbol = si.Symbol;
-                if (symbol == null) continue;
-
-                if (node is DeclarationExpressionSyntax)
+                if ((object)symbol != null)
                 {
-                    Assert.Equal(SymbolKind.Local, symbol.Kind);
+                    if (node is DeclarationExpressionSyntax)
+                    {
+                        Assert.Equal(SymbolKind.Local, symbol.Kind);
+                        Assert.Equal(LocalDeclarationKind.Deconstruction, ((LocalSymbol)symbol).DeclarationKind);
+                    }
+                    else
+                    {
+                        Assert.NotEqual(SymbolKind.Local, symbol.Kind);
+                    }
                 }
-                else
+
+                symbol = model.GetDeclaredSymbol(node);
+                if ((object)symbol != null)
                 {
-                    Assert.NotEqual(SymbolKind.Local, symbol.Kind);
+                    if (node is SingleVariableDesignationSyntax)
+                    {
+                        Assert.Equal(SymbolKind.Local, symbol.Kind);
+                        Assert.Equal(LocalDeclarationKind.Deconstruction, ((LocalSymbol)symbol).DeclarationKind);
+                    }
+                    else
+                    {
+                        Assert.NotEqual(SymbolKind.Local, symbol.Kind);
+                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -961,7 +961,7 @@ public class Cls
             Assert.NotNull(symbol);
             Assert.Equal(decl.Identifier().ValueText, symbol.Name);
             Assert.Equal(variableDeclaratorSyntax, symbol.DeclaringSyntaxReferences.Single().GetSyntax());
-            Assert.Equal(LocalDeclarationKind.OutVariable, ((LocalSymbol)symbol).DeclarationKind);
+            Assert.Equal(LocalDeclarationKind.DeclarationExpression, ((LocalSymbol)symbol).DeclarationKind);
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)variableDeclaratorSyntax));
 
             var other = model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single();
@@ -1089,7 +1089,7 @@ public class Cls
             var symbol = model.GetDeclaredSymbol(variableDesignationSyntax);
             Assert.Equal(decl.Identifier().ValueText, symbol.Name);
             Assert.Equal(variableDesignationSyntax, symbol.DeclaringSyntaxReferences.Single().GetSyntax());
-            Assert.Equal(LocalDeclarationKind.OutVariable, ((LocalSymbol)symbol).DeclarationKind);
+            Assert.Equal(LocalDeclarationKind.DeclarationExpression, ((LocalSymbol)symbol).DeclarationKind);
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)variableDesignationSyntax));
             Assert.NotEqual(symbol, model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single());
             Assert.True(model.LookupNames(decl.SpanStart).Contains(decl.Identifier().ValueText));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -215,11 +215,11 @@ public class Cls
 
             var x1Decl = GetDeclaration(tree, "x1");
             var x1Ref = GetReference(tree, "x1");
-            VerifyModelForOutVarWithoutDataFlow(model, x1Decl, x1Ref);
+            VerifyModelForDeclarationVarWithoutDataFlow(model, x1Decl, x1Ref);
 
             var x2Decl = GetDeclaration(tree, "x2");
             var x2Ref = GetReference(tree, "x2");
-            VerifyModelForOutVarWithoutDataFlow(model, x2Decl, x2Ref);
+            VerifyModelForDeclarationVarWithoutDataFlow(model, x2Decl, x2Ref);
         }
 
         [Fact]
@@ -271,11 +271,11 @@ public class Cls
 
             var x1Decl = GetDeclaration(tree, "x1");
             var x1Ref = GetReference(tree, "x1");
-            VerifyModelForOutVarWithoutDataFlow(model, x1Decl, x1Ref);
+            VerifyModelForDeclarationVarWithoutDataFlow(model, x1Decl, x1Ref);
 
             var x2Decl = GetDeclaration(tree, "x2");
             var x2Ref = GetReference(tree, "x2");
-            VerifyModelForOutVarWithoutDataFlow(model, x2Decl, x2Ref);
+            VerifyModelForDeclarationVarWithoutDataFlow(model, x2Decl, x2Ref);
         }
 
         [Fact]
@@ -337,15 +337,15 @@ public class Cls
 
             var x1Decl = GetDeclaration(tree, "x1");
             var x1Ref = GetReference(tree, "x1");
-            VerifyModelForOutVarWithoutDataFlow(model, x1Decl, x1Ref);
+            VerifyModelForDeclarationVarWithoutDataFlow(model, x1Decl, x1Ref);
 
             var x2Decl = GetDeclaration(tree, "x2");
             var x2Ref = GetReference(tree, "x2");
-            VerifyModelForOutVarWithoutDataFlow(model, x2Decl, x2Ref);
+            VerifyModelForDeclarationVarWithoutDataFlow(model, x2Decl, x2Ref);
 
             var x3Decl = GetDeclaration(tree, "x3");
             var x3Ref = GetReference(tree, "x3");
-            VerifyModelForOutVarWithoutDataFlow(model, x3Decl, x3Ref);
+            VerifyModelForDeclarationVarWithoutDataFlow(model, x3Decl, x3Ref);
         }
 
         [Fact]
@@ -927,6 +927,11 @@ public class Cls
             VerifyModelForOutVar(model, decl, isDelegateCreation: false, isExecutableCode: true, isShadowed: false, verifyDataFlow: false, references: references);
         }
 
+        private static void VerifyModelForDeclarationVarWithoutDataFlow(SemanticModel model, DeclarationExpressionSyntax decl, params IdentifierNameSyntax[] references)
+        {
+            VerifyModelForOutVar(model, decl, isDelegateCreation: false, isExecutableCode: true, isShadowed: false, verifyDataFlow: false, expectedLocalKind: LocalDeclarationKind.DeclarationExpressionVariable, references: references);
+        }
+
         private static void VerifyModelForOutVar(SemanticModel model, DeclarationExpressionSyntax decl, params IdentifierNameSyntax[] references)
         {
             VerifyModelForOutVar(model, decl, isDelegateCreation: false, isExecutableCode: true, isShadowed: false, verifyDataFlow: true, references: references);
@@ -954,6 +959,7 @@ public class Cls
             bool isExecutableCode,
             bool isShadowed,
             bool verifyDataFlow = true,
+            LocalDeclarationKind expectedLocalKind = LocalDeclarationKind.OutVariable,
             params IdentifierNameSyntax[] references)
         {
             var variableDeclaratorSyntax = GetVariableDesignation(decl);
@@ -961,7 +967,7 @@ public class Cls
             Assert.NotNull(symbol);
             Assert.Equal(decl.Identifier().ValueText, symbol.Name);
             Assert.Equal(variableDeclaratorSyntax, symbol.DeclaringSyntaxReferences.Single().GetSyntax());
-            Assert.Equal(LocalDeclarationKind.DeclarationExpression, ((LocalSymbol)symbol).DeclarationKind);
+            Assert.Equal(expectedLocalKind, ((LocalSymbol)symbol).DeclarationKind);
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)variableDeclaratorSyntax));
 
             var other = model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single();
@@ -1089,7 +1095,7 @@ public class Cls
             var symbol = model.GetDeclaredSymbol(variableDesignationSyntax);
             Assert.Equal(decl.Identifier().ValueText, symbol.Name);
             Assert.Equal(variableDesignationSyntax, symbol.DeclaringSyntaxReferences.Single().GetSyntax());
-            Assert.Equal(LocalDeclarationKind.DeclarationExpression, ((LocalSymbol)symbol).DeclarationKind);
+            Assert.Equal(LocalDeclarationKind.OutVariable, ((LocalSymbol)symbol).DeclarationKind);
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)variableDesignationSyntax));
             Assert.NotEqual(symbol, model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single());
             Assert.True(model.LookupNames(decl.SpanStart).Contains(decl.Identifier().ValueText));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -961,7 +961,7 @@ public class Cls
             Assert.NotNull(symbol);
             Assert.Equal(decl.Identifier().ValueText, symbol.Name);
             Assert.Equal(variableDeclaratorSyntax, symbol.DeclaringSyntaxReferences.Single().GetSyntax());
-            Assert.Equal(LocalDeclarationKind.RegularVariable, ((LocalSymbol)symbol).DeclarationKind);
+            Assert.Equal(LocalDeclarationKind.OutVariable, ((LocalSymbol)symbol).DeclarationKind);
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)variableDeclaratorSyntax));
 
             var other = model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single();
@@ -1089,7 +1089,7 @@ public class Cls
             var symbol = model.GetDeclaredSymbol(variableDesignationSyntax);
             Assert.Equal(decl.Identifier().ValueText, symbol.Name);
             Assert.Equal(variableDesignationSyntax, symbol.DeclaringSyntaxReferences.Single().GetSyntax());
-            Assert.Equal(LocalDeclarationKind.RegularVariable, ((LocalSymbol)symbol).DeclarationKind);
+            Assert.Equal(LocalDeclarationKind.OutVariable, ((LocalSymbol)symbol).DeclarationKind);
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)variableDesignationSyntax));
             Assert.NotEqual(symbol, model.LookupSymbols(decl.SpanStart, name: decl.Identifier().ValueText).Single());
             Assert.True(model.LookupNames(decl.SpanStart).Contains(decl.Identifier().ValueText));


### PR DESCRIPTION
Fixes #13898 
@dotnet/roslyn-compiler May I please have a couple of reviews of this change?