### PR TITLE
Enabling the integration tests to run by default.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -197,7 +197,7 @@ set TMP=%TEMP%
         }
       }
 
-      def triggerPhraseOnly = true
+      def triggerPhraseOnly = false
       def triggerPhraseExtra = ""
       Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-dev15-rc')
       Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')


### PR DESCRIPTION
FYI. @jasonmalinowski, @dotnet/roslyn-infrastructure 

If we are really pushing to convert all of the tests over, these should be running on every PR by default.

I am currently aware of one bit of flakiness in the runs. That is, they sometimes fail with: `error MSB4018: The "FindInstalledExtension" task failed unexpectedly.`

This seems to be flakiness with `/p:DeployExtension=true` and could be worked around by always doing `/p:DeployExtension=false` and manually deploying the VSIX post-build via `VSIXExpInstaller`.