### PR TITLE
Update diagnostic usage for langversion in C#

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1232,7 +1232,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid option &apos;{0}&apos; for /langversion; must be ISO-1, ISO-2, Default or an integer in range 1 to 6..
+        ///   Looks up a localized string similar to Invalid option &apos;{0}&apos; for /langversion; must be ISO-1, ISO-2, Default or an integer in range 1 to 7..
         /// </summary>
         internal static string ERR_BadCompatMode {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2687,7 +2687,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>This warning occurs if the assembly attributes AssemblyKeyFileAttribute or AssemblyKeyNameAttribute found in source conflict with the /keyfile or /keycontainer command line option or key file name or key container specified in the Project Properties.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Invalid option '{0}' for /langversion; must be ISO-1, ISO-2, Default or an integer in range 1 to 6.</value>
+    <value>Invalid option '{0}' for /langversion; must be ISO-1, ISO-2, Default or an integer in range 1 to 7.</value>
   </data>
   <data name="ERR_DelegateOnConditional" xml:space="preserve">
     <value>Cannot create delegate with '{0}' because it or a method it overrides has a Conditional attribute</value>

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1320,6 +1320,10 @@ d.cs
             parsedArgs = DefaultParse(new[] { "/langversion: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/langversion:"));
             Assert.Equal(defaultVersion, parsedArgs.ParseOptions.LanguageVersion);
+
+            // When new language versions are added, this test will fail. Remember to update the diagnostics message (ERR_BadCompatMode).
+            Assert.Equal(LanguageVersion.CSharp7, LanguageVersion.Latest.MapSpecifiedToEffectiveVersion());
+            Assert.Equal(LanguageVersion.CSharp7, LanguageVersion.Default.MapSpecifiedToEffectiveVersion());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1320,7 +1320,11 @@ d.cs
             parsedArgs = DefaultParse(new[] { "/langversion: ", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(Diagnostic(ErrorCode.ERR_SwitchNeedsString).WithArguments("<text>", "/langversion:"));
             Assert.Equal(defaultVersion, parsedArgs.ParseOptions.LanguageVersion);
+        }
 
+        [Fact]
+        public void RememberToUpdateDiagnosticsWhenUpdatingLangVersion()
+        {
             // When new language versions are added, this test will fail. Remember to update the diagnostics message (ERR_BadCompatMode).
             Assert.Equal(LanguageVersion.CSharp7, LanguageVersion.Latest.MapSpecifiedToEffectiveVersion());
             Assert.Equal(LanguageVersion.CSharp7, LanguageVersion.Default.MapSpecifiedToEffectiveVersion());


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/17147

With this fix, invoking `csc /langversion:1234` displays:
```
Microsoft (R) Visual C# Compiler version 42.42.42.42424
Copyright (C) Microsoft Corporation. All rights reserved.

error CS1617: Invalid option '1234' for /langversion; must be ISO-1, ISO-2, Default or an integer in range 1 to 7.
warning CS2008: No source files specified.
error CS1562: Outputs without source must have the /out option specified
```