### PR TITLE
Add support for deconstruction into field-like events.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -120,8 +120,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private BoundPropertyAccess TransformPropertyAccess(BoundPropertyAccess prop, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
+        private BoundExpression TransformPropertyOrEventReceiver(Symbol propertyOrEvent, BoundExpression receiverOpt, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
         {
+            Debug.Assert(propertyOrEvent.Kind == SymbolKind.Property || propertyOrEvent.Kind == SymbolKind.Event);
+
             // We need to stash away the receiver so that it does not get evaluated twice.
             // If the receiver is classified as a value of reference type then we can simply say
             //
@@ -141,14 +143,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             // assume that was the case.
 
             // If the property is static or if the receiver is of kind "Base" or "this", then we can just generate prop = prop + value
-            if (prop.ReceiverOpt == null || prop.PropertySymbol.IsStatic || !CanChangeValueBetweenReads(prop.ReceiverOpt))
+            if (receiverOpt == null || propertyOrEvent.IsStatic || !CanChangeValueBetweenReads(receiverOpt))
             {
-                return prop;
+                return receiverOpt;
             }
 
-            Debug.Assert(prop.ReceiverOpt.Kind != BoundKind.TypeExpression);
+            Debug.Assert(receiverOpt.Kind != BoundKind.TypeExpression);
 
-            BoundExpression rewrittenReceiver = VisitExpression(prop.ReceiverOpt);
+            BoundExpression rewrittenReceiver = VisitExpression(receiverOpt);
 
             BoundAssignmentOperator assignmentToTemp;
 
@@ -165,9 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             stores.Add(assignmentToTemp);
             temps.Add(receiverTemp.LocalSymbol);
 
-            // CONSIDER: this is a temporary object that will be rewritten away before this lowering completes.
-            // Mitigation: this will only produce short-lived garbage for compound assignments and increments/decrements of properties.
-            return new BoundPropertyAccess(prop.Syntax, receiverTemp, prop.PropertySymbol, prop.ResultKind, prop.Type);
+            return receiverTemp;
         }
 
         private BoundDynamicMemberAccess TransformDynamicMemberAccess(BoundDynamicMemberAccess memberAccess, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
@@ -318,8 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             argumentRefKinds = GetRefKindsOrNull(refKinds);
             refKinds.Free();
 
-            // CONSIDER: this is a temporary object that will be rewritten away before this lowering completes.
-            // Mitigation: this will only produce short-lived garbage for compound assignments and increments/decrements of indexers.
+            // This is a temporary object that will be rewritten away before the lowering completes.
             return new BoundIndexerAccess(
                 syntax,
                 transformedReceiver,
@@ -332,15 +331,31 @@ namespace Microsoft.CodeAnalysis.CSharp
                 indexerAccess.Type);
         }
 
-        private BoundFieldAccess TransformReferenceTypeFieldAccess(BoundFieldAccess fieldAccess, BoundExpression receiver, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
+        /// <summary>
+        /// Returns true if the <paramref name="receiver"/> was lowered and transformed.
+        /// The <paramref name="receiver"/> is not changed if this function returns false. 
+        /// </summary>
+        private bool TransformCompoundAssignmentFieldOrEventAccessReceiver(Symbol fieldOrEvent, ref BoundExpression receiver, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
         {
+            Debug.Assert(fieldOrEvent.Kind == SymbolKind.Field || fieldOrEvent.Kind == SymbolKind.Event);
+
+            //If the receiver is static or is the receiver is of kind "Base" or "this", then we can just generate field = field + value
+            if (fieldOrEvent.IsStatic || !CanChangeValueBetweenReads(receiver))
+            {
+                return true;
+            }
+            else if (!receiver.Type.IsReferenceType)
+            {
+                return false;
+            }
+
             Debug.Assert(receiver.Type.IsReferenceType);
             Debug.Assert(receiver.Kind != BoundKind.TypeExpression);
             BoundExpression rewrittenReceiver = VisitExpression(receiver);
 
             if (rewrittenReceiver.Type.IsTypeParameter())
             {
-                var memberContainingType = fieldAccess.FieldSymbol.ContainingType;
+                var memberContainingType = fieldOrEvent.ContainingType;
 
                 // From the verifier prospective type parameters do not contain fields or methods.
                 // the instance must be "boxed" to access the field
@@ -352,7 +367,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiverTemp = _factory.StoreToTemp(rewrittenReceiver, out assignmentToTemp);
             stores.Add(assignmentToTemp);
             temps.Add(receiverTemp.LocalSymbol);
-            return new BoundFieldAccess(fieldAccess.Syntax, receiverTemp, fieldAccess.FieldSymbol, null);
+            receiver = receiverTemp;
+            return true;
         }
 
         private BoundDynamicIndexerAccess TransformDynamicIndexerAccess(BoundDynamicIndexerAccess indexerAccess, ArrayBuilder<BoundExpression> stores, ArrayBuilder<LocalSymbol> temps)
@@ -452,7 +468,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var propertyAccess = (BoundPropertyAccess)originalLHS;
                         if (propertyAccess.PropertySymbol.RefKind == RefKind.None)
                         {
-                            return TransformPropertyAccess(propertyAccess, stores, temps);
+                            // This is a temporary object that will be rewritten away before the lowering completes.
+                            return propertyAccess.Update(TransformPropertyOrEventReceiver(propertyAccess.PropertySymbol, propertyAccess.ReceiverOpt, stores, temps),
+                                                         propertyAccess.PropertySymbol, propertyAccess.ResultKind, propertyAccess.Type);
                         }
                     }
                     break;
@@ -479,14 +497,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var fieldAccess = (BoundFieldAccess)originalLHS;
                         BoundExpression receiverOpt = fieldAccess.ReceiverOpt;
 
-                        //If the receiver is static or is the receiver is of kind "Base" or "this", then we can just generate field = field + value
-                        if (fieldAccess.FieldSymbol.IsStatic || !CanChangeValueBetweenReads(receiverOpt))
+                        if (TransformCompoundAssignmentFieldOrEventAccessReceiver(fieldAccess.FieldSymbol, ref receiverOpt, stores, temps))
                         {
-                            return fieldAccess;
-                        }
-                        else if (receiverOpt.Type.IsReferenceType)
-                        {
-                            return TransformReferenceTypeFieldAccess(fieldAccess, receiverOpt, stores, temps);
+                            return MakeFieldAccess(fieldAccess.Syntax, receiverOpt, fieldAccess.FieldSymbol, fieldAccess.ConstantValueOpt, fieldAccess.ResultKind, fieldAccess.Type, fieldAccess);
                         }
                     }
                     break;
@@ -542,6 +555,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.PointerElementAccess:
                 case BoundKind.PointerIndirectionOperator:
                 case BoundKind.RefValueOperator:
+                    break;
+
+                case BoundKind.EventAccess:
+                    {
+                        var eventAccess = (BoundEventAccess)originalLHS;
+                        Debug.Assert(eventAccess.IsUsableAsField);
+                        BoundExpression receiverOpt = eventAccess.ReceiverOpt;
+
+                        if (eventAccess.EventSymbol.IsWindowsRuntimeEvent)
+                        {
+                            // This is a temporary object that will be rewritten away before the lowering completes.
+                            return eventAccess.Update(TransformPropertyOrEventReceiver(eventAccess.EventSymbol, eventAccess.ReceiverOpt, stores, temps),
+                                                      eventAccess.EventSymbol, eventAccess.IsUsableAsField, eventAccess.ResultKind, eventAccess.Type);
+                        }
+
+                        if (TransformCompoundAssignmentFieldOrEventAccessReceiver(eventAccess.EventSymbol, ref receiverOpt, stores, temps))
+                        {
+                            return MakeEventAccess(eventAccess.Syntax, receiverOpt, eventAccess.EventSymbol, eventAccess.ConstantValue, eventAccess.ResultKind, eventAccess.Type);
+                        }
+                    }
                     break;
 
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundSequence(syntax, tempSymbols, sideEffects.ToImmutableAndFree(), marshalCall, marshalCall.Type);
         }
 
-        private BoundExpression VisitWindowsRuntimeEventFieldAssignmentOperator(SyntaxNode syntax, BoundEventAccess left, BoundExpression right)
+        private BoundExpression VisitWindowsRuntimeEventFieldAssignmentOperator(SyntaxNode syntax, BoundEventAccess left, BoundExpression rewrittenRight)
         {
             Debug.Assert(left.IsUsableAsField);
 
@@ -181,7 +181,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(eventSymbol.IsWindowsRuntimeEvent);
 
             BoundExpression rewrittenReceiverOpt = left.ReceiverOpt == null ? null : VisitExpression(left.ReceiverOpt);
-            BoundExpression rewrittenRight = VisitExpression(right);
 
             const bool isDynamic = false;
             return RewriteWindowsRuntimeEventAssignmentOperator(


### PR DESCRIPTION
Fixes #16962.

@dotnet/roslyn-compiler, @jcouv Please review.