### PR TITLE
Fix parenthesis simplification around binary expressions

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4157,5 +4157,31 @@ public class KVP<T1, T2>
 
             await TestAsync(code, expected, index: 0);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [WorkItem(11958, "https://github.com/dotnet/roslyn/issues/11958")]
+        public async Task EnsureParenthesesInStringConcatenation()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        int [||]i = 1 + 2;
+        string s = ""a"" + i;
+    }
+}";
+
+            var expected = @"
+class C
+{
+    void M()
+    {
+        string s = ""a"" + (1 + 2);
+    }
+}";
+
+            await TestAsync(code, expected, index: 0, compareTokens: false);
+        }
     }
 }

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -6,6 +6,300 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Simplification
     Public Class ParenthesisSimplificationTests
         Inherits AbstractSimplificationTests
 
+#Region "VB"
+        <WorkItem(2211, "https://github.com/dotnet/roslyn/issues/2211")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_DontRemoveParensAroundConditionalAccessExpressionIfParentIsMemberAccessExpression() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System
+Imports System.Collections.Generic
+
+Module Program
+    Sub Main()
+        Dim x = New List(Of Integer)
+        Dim i = {|Simplify:({|Simplify:CType(x?.Count, Integer?)|})|}.GetValueOrDefault()
+    End Sub
+End Module
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System
+Imports System.Collections.Generic
+
+Module Program
+    Sub Main()
+        Dim x = New List(Of Integer)
+        Dim i = (x?.Count).GetValueOrDefault()
+    End Sub
+End Module
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_RemoveParenthesesAroundEmptyXmlElement() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = {|Simplify:(&lt;xml/&gt;)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = &lt;xml/&gt;
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_RemoveParenthesesAroundEmptyXmlElementInInvocation() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System.Xml.Linq
+
+Class C
+    Sub M(xml as XElement)
+        Dim x = M({|Simplify:(&lt;xml/&gt;)|})
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System.Xml.Linq
+
+Class C
+    Sub M(xml as XElement)
+        Dim x = M(&lt;xml/&gt;)
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_RemoveParenthesesAroundXmlElement() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = {|Simplify:(&lt;xml&gt;&lt;/xml&gt;)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = &lt;xml&gt;&lt;/xml&gt;
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_RemoveParenthesesAroundXmlElementInInvocation() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System.Xml.Linq
+
+Class C
+    Sub M(xml as XElement)
+        Dim x = M({|Simplify:(&lt;xml&gt;&lt;/xml&gt;)|})
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System.Xml.Linq
+
+Class C
+    Sub M(xml as XElement)
+        Dim x = M(&lt;xml&gt;&lt;/xml&gt;)
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundEmptyXmlElementWhenPreviousTokenIsLessThan() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = 1 &lt; {|Simplify:(&lt;xml/&gt;)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = 1 &lt; (&lt;xml/&gt;)
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundEmptyXmlElementWhenPreviousTokenIsGreaterThan() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = 1 &gt; {|Simplify:(&lt;xml/&gt;)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = 1 &gt; (&lt;xml/&gt;)
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundXmlElementWhenPreviousTokenIsLessThan() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = 1 &lt; {|Simplify:(&lt;xml&gt;&lt;/xml&gt;)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = 1 &lt; (&lt;xml&gt;&lt;/xml&gt;)
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundXmlElementWhenPreviousTokenIsGreaterThan() As Task
+            Dim input =
+<Workspace>
+    <Project Language="Visual Basic" CommonReferences="true">
+        <Document>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = 1 &gt; {|Simplify:(&lt;xml&gt;&lt;/xml&gt;)|}
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+Imports System.Xml.Linq
+
+Class C
+    Sub M()
+        Dim x = 1 &gt; (&lt;xml&gt;&lt;/xml&gt;)
+    End Sub
+End Class
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+#End Region
+
 #Region "VB Array Literal tests"
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
@@ -857,6 +1151,46 @@ class C
 
         End Function
 
+        <WorkItem(2211, "https://github.com/dotnet/roslyn/issues/2211")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_DontRemoveParensAroundConditionalAccessExpressionIfParentIsMemberAccessExpression() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main()
+    {
+        var x = new List&lt;int&gt;();
+        int i = {|Simplify:({|Simplify:(int?)x?.Count|})|}.GetValueOrDefault();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main()
+    {
+        var x = new List&lt;int&gt;();
+        int i = (x?.Count).GetValueOrDefault();
+    }
+}
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
 #End Region
 
 #Region "C# Binary Expressions"
@@ -1050,24 +1384,19 @@ class Program
 
             Await TestAsync(input, expected)
         End Function
-#End Region
 
-        <WorkItem(2211, "https://github.com/dotnet/roslyn/issues/2211")>
+        <WorkItem(11958, "https://github.com/dotnet/roslyn/issues/11958")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestCSharp_DontRemoveParensAroundConditionalAccessExpressionIfParentIsMemberAccessExpression() As Task
+        Public Async Function TestCSharp_SimplifyInStringConcatenationIfItWouldNotChangeMeaning1() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
         <Document>
-using System;
-using System.Collections.Generic;
-
-class Program
+class C
 {
-    static void Main()
+    void M()
     {
-        var x = new List&lt;int&gt;();
-        int i = {|Simplify:({|Simplify:(int?)x?.Count|})|}.GetValueOrDefault();
+        var x = "" + {|Simplify:(1)|};
     }
 }
         </Document>
@@ -1076,15 +1405,11 @@ class Program
 
             Dim expected =
 <code>
-using System;
-using System.Collections.Generic;
-
-class Program
+class C
 {
-    static void Main()
+    void M()
     {
-        var x = new List&lt;int&gt;();
-        int i = (x?.Count).GetValueOrDefault();
+        var x = "" + 1;
     }
 }
 </code>
@@ -1092,296 +1417,106 @@ class Program
             Await TestAsync(input, expected)
         End Function
 
-        <WorkItem(2211, "https://github.com/dotnet/roslyn/issues/2211")>
+        <WorkItem(11958, "https://github.com/dotnet/roslyn/issues/11958")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_DontRemoveParensAroundConditionalAccessExpressionIfParentIsMemberAccessExpression() As Task
+        Public Async Function TestCSharp_SimplifyInStringConcatenationIfItWouldNotChangeMeaning2() As Task
             Dim input =
 <Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
+    <Project Language="C#" CommonReferences="true">
         <Document>
-Imports System
-Imports System.Collections.Generic
-
-Module Program
-    Sub Main()
-        Dim x = New List(Of Integer)
-        Dim i = {|Simplify:({|Simplify:CType(x?.Count, Integer?)|})|}.GetValueOrDefault()
-    End Sub
-End Module
+class C
+{
+    void M()
+    {
+        var x = "a" + {|Simplify:("b" + "c")|};
+    }
+}
         </Document>
     </Project>
 </Workspace>
 
             Dim expected =
 <code>
-Imports System
-Imports System.Collections.Generic
-
-Module Program
-    Sub Main()
-        Dim x = New List(Of Integer)
-        Dim i = (x?.Count).GetValueOrDefault()
-    End Sub
-End Module
+class C
+{
+    void M()
+    {
+        var x = "a" + "b" + "c";
+    }
+}
 </code>
 
             Await TestAsync(input, expected)
         End Function
 
-        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <WorkItem(11958, "https://github.com/dotnet/roslyn/issues/11958")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_RemoveParenthesesAroundEmptyXmlElement() As Task
+        Public Async Function TestCSharp_DontSimplifyIfItWouldChangeStringConcatenation() As Task
             Dim input =
 <Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
+    <Project Language="C#" CommonReferences="true">
         <Document>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = {|Simplify:(&lt;xml/&gt;)|}
-    End Sub
-End Class
+class C
+{
+    void M()
+    {
+        var x = "" + {|Simplify:(1 + 2)|};
+    }
+}
         </Document>
     </Project>
 </Workspace>
 
             Dim expected =
 <code>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = &lt;xml/&gt;
-    End Sub
-End Class
+class C
+{
+    void M()
+    {
+        var x = "" + (1 + 2);
+    }
+}
 </code>
 
             Await TestAsync(input, expected)
         End Function
 
-        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
+        <WorkItem(11958, "https://github.com/dotnet/roslyn/issues/11958")>
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_RemoveParenthesesAroundEmptyXmlElementInInvocation() As Task
+        Public Async Function TestCSharp_DontSimplifyIfOperatorOverloadsWouldNoLongerByCalled() As Task
             Dim input =
 <Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
+    <Project Language="C#" CommonReferences="true">
         <Document>
-Imports System.Xml.Linq
+class C
+{
+    public static string operator +(C left, C right) => "";
 
-Class C
-    Sub M(xml as XElement)
-        Dim x = M({|Simplify:(&lt;xml/&gt;)|})
-    End Sub
-End Class
+    void M()
+    {
+        var x = "" + {|Simplify:(new C() + new C())|};
+    }
+}
         </Document>
     </Project>
 </Workspace>
 
             Dim expected =
 <code>
-Imports System.Xml.Linq
+class C
+{
+    public static string operator +(C left, C right) => "";
 
-Class C
-    Sub M(xml as XElement)
-        Dim x = M(&lt;xml/&gt;)
-    End Sub
-End Class
+    void M()
+    {
+        var x = "" + (new C() + new C());
+    }
+}
 </code>
 
             Await TestAsync(input, expected)
         End Function
+#End Region
 
-        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_RemoveParenthesesAroundXmlElement() As Task
-            Dim input =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = {|Simplify:(&lt;xml&gt;&lt;/xml&gt;)|}
-    End Sub
-End Class
-        </Document>
-    </Project>
-</Workspace>
-
-            Dim expected =
-<code>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = &lt;xml&gt;&lt;/xml&gt;
-    End Sub
-End Class
-</code>
-
-            Await TestAsync(input, expected)
-        End Function
-
-        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_RemoveParenthesesAroundXmlElementInInvocation() As Task
-            Dim input =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-Imports System.Xml.Linq
-
-Class C
-    Sub M(xml as XElement)
-        Dim x = M({|Simplify:(&lt;xml&gt;&lt;/xml&gt;)|})
-    End Sub
-End Class
-        </Document>
-    </Project>
-</Workspace>
-
-            Dim expected =
-<code>
-Imports System.Xml.Linq
-
-Class C
-    Sub M(xml as XElement)
-        Dim x = M(&lt;xml&gt;&lt;/xml&gt;)
-    End Sub
-End Class
-</code>
-
-            Await TestAsync(input, expected)
-        End Function
-
-        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundEmptyXmlElementWhenPreviousTokenIsLessThan() As Task
-            Dim input =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = 1 &lt; {|Simplify:(&lt;xml/&gt;)|}
-    End Sub
-End Class
-        </Document>
-    </Project>
-</Workspace>
-
-            Dim expected =
-<code>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = 1 &lt; (&lt;xml/&gt;)
-    End Sub
-End Class
-</code>
-
-            Await TestAsync(input, expected)
-        End Function
-
-        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundEmptyXmlElementWhenPreviousTokenIsGreaterThan() As Task
-            Dim input =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = 1 &gt; {|Simplify:(&lt;xml/&gt;)|}
-    End Sub
-End Class
-        </Document>
-    </Project>
-</Workspace>
-
-            Dim expected =
-<code>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = 1 &gt; (&lt;xml/&gt;)
-    End Sub
-End Class
-</code>
-
-            Await TestAsync(input, expected)
-        End Function
-
-        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundXmlElementWhenPreviousTokenIsLessThan() As Task
-            Dim input =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = 1 &lt; {|Simplify:(&lt;xml&gt;&lt;/xml&gt;)|}
-    End Sub
-End Class
-        </Document>
-    </Project>
-</Workspace>
-
-            Dim expected =
-<code>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = 1 &lt; (&lt;xml&gt;&lt;/xml&gt;)
-    End Sub
-End Class
-</code>
-
-            Await TestAsync(input, expected)
-        End Function
-
-        <WorkItem(4490, "https://github.com/dotnet/roslyn/issues/4490")>
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
-        Public Async Function TestVisualBasic_DontRemoveParenthesesAroundXmlElementWhenPreviousTokenIsGreaterThan() As Task
-            Dim input =
-<Workspace>
-    <Project Language="Visual Basic" CommonReferences="true">
-        <Document>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = 1 &gt; {|Simplify:(&lt;xml&gt;&lt;/xml&gt;)|}
-    End Sub
-End Class
-        </Document>
-    </Project>
-</Workspace>
-
-            Dim expected =
-<code>
-Imports System.Xml.Linq
-
-Class C
-    Sub M()
-        Dim x = 1 &gt; (&lt;xml&gt;&lt;/xml&gt;)
-    End Sub
-End Class
-</code>
-
-            Await TestAsync(input, expected)
-        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -1516,6 +1516,59 @@ class C
 
             Await TestAsync(input, expected)
         End Function
+
+        <WorkItem(11958, "https://github.com/dotnet/roslyn/issues/11958")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_SimplifyIfBinaryExpressionTypeIsIdentityConversion() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    int Add(int a, int b, int c) => a + {|Simplify:(b + c)|};
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+class C
+{
+    int Add(int a, int b, int c) => a + b + c;
+}
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <WorkItem(11958, "https://github.com/dotnet/roslyn/issues/11958")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_SimplifyIfBinaryExpressionTypeIsImplicitNumericConversion() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class C
+{
+    int Add(int a, short b, short c) => a + {|Simplify:(b + c)|};
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+class C
+{
+    int Add(int a, short b, short c) => a + b + c;
+}
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
 #End Region
 
     End Class

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -252,8 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return false;
                 }
 
-                var parentBinaryExpression = parentExpression as BinaryExpressionSyntax;
-                if (parentBinaryExpression != null)
+                if (parentExpression is BinaryExpressionSyntax parentBinaryExpression)
                 {
                     // If both the expression and its parent are binary expressions and their kinds
                     // are the same, check to see if they are commutative (e.g. + or *).
@@ -269,7 +268,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                         // necessary -- even if they could be removed depending on whether the parenthesized expression
                         // appears on the left or right side of the parent binary expression.
 
-                        // First, does the parenthesized binary expression result in an operator overload being called?
+                        // First, does the binary expression result in an operator overload being called?
                         var symbolInfo = semanticModel.GetSymbolInfo(binaryExpression);
                         if (symbolInfo.Symbol != null)
                         {
@@ -280,8 +279,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                             }
                         }
 
-                        // Second, check the type and converted type of the parenthesized expression. Are they the same?
-                        var typeInfo = semanticModel.GetTypeInfo(node);
+                        // Second, check the type and converted type of the binary expression. Are they the same?
+                        var typeInfo = semanticModel.GetTypeInfo(binaryExpression);
                         if (typeInfo.Type != null && typeInfo.ConvertedType != null)
                         {
                             if (!typeInfo.Type.Equals(typeInfo.ConvertedType))
@@ -303,8 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     return parentBinaryExpression.Right == node;
                 }
 
-                var parentAssignmentExpression = parentExpression as AssignmentExpressionSyntax;
-                if (parentAssignmentExpression != null)
+                if (parentExpression is AssignmentExpressionSyntax parentAssignmentExpression)
                 {
                     // Assignment expressions are right associative; removing parens from the LHS changes the association.
                     return parentAssignmentExpression.Left == node;
@@ -362,8 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 //   {x < (x), x > (1 + 2)}
                 //   {x < x, (x) > (1 + 2)}
 
-                var binaryExpression = node.Parent as BinaryExpressionSyntax;
-                if (binaryExpression != null &&
+                if (node.Parent is BinaryExpressionSyntax binaryExpression &&
                     binaryExpression.IsKind(SyntaxKind.LessThanExpression, SyntaxKind.GreaterThanExpression) &&
                     (binaryExpression.IsParentKind(SyntaxKind.Argument) || binaryExpression.Parent is InitializerExpressionSyntax))
                 {
@@ -434,8 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             if (node.IsParentKind(SyntaxKind.Argument))
             {
                 var argument = (ArgumentSyntax)node.Parent;
-                var argumentList = argument.Parent as ArgumentListSyntax;
-                if (argumentList != null)
+                if (argument.Parent is ArgumentListSyntax argumentList)
                 {
                     var argumentIndex = argumentList.Arguments.IndexOf(argument);
                     if (argumentIndex > 0)
@@ -444,9 +440,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     }
                 }
             }
-            else if (node.Parent is InitializerExpressionSyntax)
+            else if (node.Parent is InitializerExpressionSyntax initializer)
             {
-                var initializer = (InitializerExpressionSyntax)node.Parent;
                 var expressionIndex = initializer.Expressions.IndexOf(node);
                 if (expressionIndex > 0)
                 {
@@ -474,8 +469,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             if (node.IsParentKind(SyntaxKind.Argument))
             {
                 var argument = (ArgumentSyntax)node.Parent;
-                var argumentList = argument.Parent as ArgumentListSyntax;
-                if (argumentList != null)
+                if (argument.Parent is ArgumentListSyntax argumentList)
                 {
                     var argumentIndex = argumentList.Arguments.IndexOf(argument);
                     if (argumentIndex >= 0 && argumentIndex < argumentList.Arguments.Count - 1)
@@ -484,9 +478,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                     }
                 }
             }
-            else if (node.Parent is InitializerExpressionSyntax)
+            else if (node.Parent is InitializerExpressionSyntax initializer)
             {
-                var initializer = (InitializerExpressionSyntax)node.Parent;
                 var expressionIndex = initializer.Expressions.IndexOf(node);
                 if (expressionIndex >= 0 && expressionIndex < initializer.Expressions.Count - 1)
                 {

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpParenthesesReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpParenthesesReducer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             OptionSet optionSet,
             CancellationToken cancellationToken)
         {
-            if (node.CanRemoveParentheses())
+            if (node.CanRemoveParentheses(semanticModel))
             {
                 // TODO(DustinCa): We should not be skipping elastic trivia below.
                 // However, the formatter seems to mess up trailing trivia in some


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11958

This change adds a couple of semantic checks when determining whether parentheses can be removed from around a addition or multiplication expression contained within another addition or multiplication expression. For example, `a + (b + c)` or `a * (b * c)`. Essentially, we're now a bit more conservative and will only remove parentheses if the following semantic rules hold true:

1. The inner binary expression must not result in a user-defined operator being called.
2. The type and converted type of binary expression must match.

This ensures that we don't incorrectly remove parentheses in several cases, such as the following string concatenation example.

```C#
var x = "Hello, world: " + (19 + 23);
```

cc @dotnet/roslyn-ide 