### PR TITLE
Update list of branches to allow publishing on

### DIFF
--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -40,8 +40,10 @@ try
 
     switch ($branchName)
     {
-        "dev15-rc3" { } 
+        "dev15.0.x" { } 
+        "dev15.1.x" { } 
         "master" { } 
+        "dev16" { } 
         default
         {
             if (-not $test)


### PR DESCRIPTION
@dotnet/roslyn-infrastructure @jasonmalinowski @jaredpar For approval.

It seems this fails the signed build if the branch name is not in the list of approved branches.

Note -- this is not a code change.