### PR TITLE
Update to publish dev15.0.x

### DIFF
--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -40,7 +40,7 @@ try
 
     switch ($branchName)
     {
-        "dev15-rc3" { } 
+        "dev15.0.x" { } 
         "master" { } 
         default
         {


### PR DESCRIPTION
This is just two branches that are currently configured to be building 2.0 and 2.1 packages. This is just a smaller version of #17291 that avoids the NuGet versioning problem.

FYI to @Pilchie, and @dotnet/roslyn-infrastructure.