### PR TITLE
Take a screenshot when an Assert fails

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 
 namespace Roslyn.VisualStudio.IntegrationTests
 {
+    [CaptureTestName]
     public abstract class AbstractIntegrationTest : IDisposable
     {
         protected readonly VisualStudioInstanceContext VisualStudio;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/CaptureTestNameAttribute.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/CaptureTestNameAttribute.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities
+{
+    /// <summary>
+    /// Captures the name of the test currently being run by xUnit.
+    /// This should only be applied to test methods or classes that are guaranteed
+    /// to run serially, not in parallel, as it assumes tests are run one at a time.
+    /// </summary>
+    public class CaptureTestNameAttribute : BeforeAfterTestAttribute
+    {
+        /// <summary>
+        /// The name of the currently running test, or null if no test is running.
+        /// The format is test_class_name.method_name.
+        /// </summary>
+        public static string CurrentName { get; set; }
+
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            CurrentName = methodUnderTest.DeclaringType.Name + "." + methodUnderTest.Name;
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            CurrentName = null;
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -17,6 +17,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         private const string User32 = "User32.dll";
         private const string SetupConfigurationNative = "x86\\Microsoft.VisualStudio.Setup.Configuration.Native.dll";
 
+        #region Microsoft.VisualStudio.Setup.Configuration.Native.dll
+
         public const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
 
         [DllImport(SetupConfigurationNative, BestFitMapping = false, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, EntryPoint = "GetSetupConfiguration", ExactSpelling = true, PreserveSig = true, SetLastError = false, ThrowOnUnmappableChar = false)]
@@ -24,6 +26,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
             [Out, MarshalAs(UnmanagedType.Interface)] out ISetupConfiguration setupConfiguration,
             [In] IntPtr pReserved
         );
+
+        #endregion
+
+        #region gdi32.dll
 
         [DllImport(Gdi32)]
         public static extern bool BitBlt(IntPtr hdcDest, int xDest, int yDest, int wDest, int hDest, IntPtr hdcSource, int xSrc, int ySrc, CopyPixelOperation rop);
@@ -46,14 +52,26 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         [DllImport(Gdi32)]
         public static extern IntPtr SelectObject(IntPtr hdc, IntPtr bmp);
 
+        #endregion
+
+        #region kernel32.dll
+
         [DllImport(Kernel32)]
         public static extern uint GetCurrentThreadId();
+
+        #endregion
+
+        #region ole32.dll
 
         [DllImport(Ole32, PreserveSig = false)]
         public static extern void CreateBindCtx(int reserved, [MarshalAs(UnmanagedType.Interface)] out IBindCtx bindContext);
 
         [DllImport(Ole32, PreserveSig = false)]
         public static extern void GetRunningObjectTable(int reserved, [MarshalAs(UnmanagedType.Interface)] out IRunningObjectTable runningObjectTable);
+
+        #endregion
+
+        #region user32.dll
 
         public static readonly int SizeOf_INPUT = Marshal.SizeOf<INPUT>();
 
@@ -221,5 +239,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 
         [DllImport(User32, CharSet = CharSet.Unicode)]
         public static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+        #endregion
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -11,7 +11,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 {
     internal static class NativeMethods
     {
-        private const string Gdi32 = "gdi32.dll";
         private const string Kernel32 = "kernel32.dll";
         private const string Ole32 = "ole32.dll";
         private const string User32 = "User32.dll";
@@ -26,31 +25,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
             [Out, MarshalAs(UnmanagedType.Interface)] out ISetupConfiguration setupConfiguration,
             [In] IntPtr pReserved
         );
-
-        #endregion
-
-        #region gdi32.dll
-
-        [DllImport(Gdi32)]
-        public static extern bool BitBlt(IntPtr hdcDest, int xDest, int yDest, int wDest, int hDest, IntPtr hdcSource, int xSrc, int ySrc, CopyPixelOperation rop);
-
-        [DllImport(Gdi32)]
-        public static extern IntPtr CreateCompatibleBitmap(IntPtr hdc, int nWidth, int nHeight);
-
-        [DllImport(Gdi32)]
-        public static extern IntPtr CreateCompatibleDC(IntPtr hdc);
-
-        [DllImport(Gdi32)]
-        public static extern IntPtr DeleteDC(IntPtr hdc);
-
-        [DllImport(Gdi32)]
-        public static extern IntPtr DeleteObject(IntPtr hdc);
-
-        [DllImport(Gdi32)]
-        public static extern bool ReleaseDC(IntPtr hWnd, IntPtr hDc);
-
-        [DllImport(Gdi32)]
-        public static extern IntPtr SelectObject(IntPtr hdc, IntPtr bmp);
 
         #endregion
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Interop/NativeMethods.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -10,6 +11,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 {
     internal static class NativeMethods
     {
+        private const string Gdi32 = "gdi32.dll";
         private const string Kernel32 = "kernel32.dll";
         private const string Ole32 = "ole32.dll";
         private const string User32 = "User32.dll";
@@ -22,6 +24,27 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
             [Out, MarshalAs(UnmanagedType.Interface)] out ISetupConfiguration setupConfiguration,
             [In] IntPtr pReserved
         );
+
+        [DllImport(Gdi32)]
+        public static extern bool BitBlt(IntPtr hdcDest, int xDest, int yDest, int wDest, int hDest, IntPtr hdcSource, int xSrc, int ySrc, CopyPixelOperation rop);
+
+        [DllImport(Gdi32)]
+        public static extern IntPtr CreateCompatibleBitmap(IntPtr hdc, int nWidth, int nHeight);
+
+        [DllImport(Gdi32)]
+        public static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+        [DllImport(Gdi32)]
+        public static extern IntPtr DeleteDC(IntPtr hdc);
+
+        [DllImport(Gdi32)]
+        public static extern IntPtr DeleteObject(IntPtr hdc);
+
+        [DllImport(Gdi32)]
+        public static extern bool ReleaseDC(IntPtr hWnd, IntPtr hDc);
+
+        [DllImport(Gdi32)]
+        public static extern IntPtr SelectObject(IntPtr hdc, IntPtr bmp);
 
         [DllImport(Kernel32)]
         public static extern uint GetCurrentThreadId();
@@ -145,6 +168,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
         public static extern IntPtr GetAncestor(IntPtr hWnd, uint gaFlags);
 
         [DllImport(User32)]
+        public static extern IntPtr GetDesktopWindow();
+
+        [DllImport(User32)]
         public static extern IntPtr GetForegroundWindow();
 
         [DllImport(User32, SetLastError = true)]
@@ -152,6 +178,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Interop
 
         [DllImport(User32, SetLastError = true)]
         public static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);
+
+        [DllImport(User32)]
+        public static extern IntPtr GetWindowDC(IntPtr hWnd);
 
         [DllImport(User32)]
         public static extern uint GetWindowThreadProcessId(IntPtr hWnd, [Optional] IntPtr lpdwProcessId);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/ScreenshotService.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/ScreenshotService.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Windows.Forms;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Interop;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities
+{
+    internal class ScreenshotService
+    {
+        /// <summary>
+        /// Takes a picture of the screen and saves it to the location specified by
+        /// <paramref name="fullPath"/>. Files are always saved in PNG format, regardless of the
+        /// file extension.
+        /// </summary>
+        public static void TakeScreenshot(string fullPath)
+        {
+            using (var bitmap = CaptureFullScreen())
+            {
+                bitmap.Save(fullPath, ImageFormat.Png);
+            }
+        }
+
+        /// <summary>
+        /// Captures the full screen including the mouse cursor.
+        /// </summary>
+        /// <returns>A <see cref="Bitmap"/> containing the screen capture of the desktop.</returns>
+        private static Bitmap CaptureFullScreen()
+        {
+            IntPtr desktop = IntPtr.Zero;
+            IntPtr srcDC = IntPtr.Zero;
+            IntPtr destDC = IntPtr.Zero;
+            IntPtr bmp = IntPtr.Zero;
+
+            try
+            {
+                Size size = Screen.PrimaryScreen.Bounds.Size;
+                desktop = NativeMethods.GetDesktopWindow();
+                srcDC = NativeMethods.GetWindowDC(desktop);
+                destDC = NativeMethods.CreateCompatibleDC(srcDC);
+                bmp = NativeMethods.CreateCompatibleBitmap(srcDC, size.Width, size.Height);
+                var oldBmp = NativeMethods.SelectObject(destDC, bmp);
+                var b = NativeMethods.BitBlt(destDC, 0, 0, size.Width, size.Height, srcDC, 0, 0, CopyPixelOperation.SourceCopy | CopyPixelOperation.CaptureBlt);
+
+                var bitmap = Bitmap.FromHbitmap(bmp);
+                NativeMethods.SelectObject(destDC, oldBmp);
+
+                return bitmap;
+            }
+            finally
+            {
+                if (bmp != IntPtr.Zero)
+                {
+                    NativeMethods.DeleteObject(bmp);
+                }
+
+                if (destDC != IntPtr.Zero)
+                {
+                    NativeMethods.DeleteDC(destDC);
+                }
+
+                if (srcDC != IntPtr.Zero)
+                {
+                    NativeMethods.ReleaseDC(desktop, srcDC);
+                }
+            }
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -40,6 +40,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 throw new PlatformNotSupportedException("The Visual Studio Integration Test Framework is only supported on Visual Studio 15.0 and later.");
             }
 
+        }
+
+        public VisualStudioInstanceFactory()
+        {
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolveHandler;
             AppDomain.CurrentDomain.FirstChanceException += FirstChanceExceptionHandler;
         }
@@ -52,7 +56,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 {
                     var assemblyPath = typeof(VisualStudioInstanceFactory).Assembly.Location;
                     var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
-                    var fileName = $"{eventArgs.Exception.GetType().Name}-{DateTime.Now:HH.mm.ss}.png";
+                    var testName = CaptureTestNameAttribute.CurrentName ?? "Unknown";
+                    var fileName = $"{testName}-{eventArgs.Exception.GetType().Name}-{DateTime.Now:HH.mm.ss}.png";
 
                     var fullPath = Path.Combine(assemblyDirectory, "xUnitResults", "Screenshots", fileName);
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Debug.WriteLine(e);
                 // Per the AppDomain.FirstChanceException contract we must catch and deal with all exceptions that arise in the handler.
                 // Otherwise, we are likely to end up with recursive calls into this method until we overflow the stack.
             }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -43,6 +43,7 @@
     <Compile Include="OutOfProcess\OutOfProcComponent.cs" />
     <Compile Include="OutOfProcess\SolutionExplorer_OutOfProc.cs" />
     <Compile Include="InProcess\VisualStudioWorkspace_InProc.cs" />
+    <Compile Include="ScreenshotService.cs" />
     <Compile Include="TestUtilities.cs" />
     <Compile Include="WellKnownCommandNames.cs" />
     <Compile Include="VisualStudioInstance.cs" />
@@ -66,7 +67,9 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="UIAutomationClient" />
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -23,6 +23,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CaptureTestNameAttribute.cs" />
     <Compile Include="Common\Comparison.cs" />
     <Compile Include="Common\Parameter.cs" />
     <Compile Include="Common\Signature.cs" />


### PR DESCRIPTION
While porting the Find References integration tests I ran into a situation where the test passed locally, but failed in Jenkins. A screenshot would have made it easier to diagnose the issue, but we currently have no support for that--so I've added it here.

Basically, any time an `XunitException` is thrown in the test code we'll capture the screen and save it to a file under xUnitResults\Screenshots.