### PR TITLE
Add test projects services tags

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CSharpExpressionCompilerTest.csproj
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CSharpExpressionCompilerTest.csproj
@@ -106,5 +106,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/FunctionResolverTest.csproj
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/FunctionResolverTest.csproj
@@ -81,5 +81,8 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/BasicExpressionCompilerTest.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/BasicExpressionCompilerTest.vbproj
@@ -95,5 +95,8 @@
   <ItemGroup>
     <Folder Include="My Project\" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="..\..\..\..\..\build\Targets\Imports.targets" />
 </Project>


### PR DESCRIPTION
@dotnet/roslyn-infrastructure 

VS 2017 keeps adding these tags to project files. A quick [search](http://stackoverflow.com/questions/18614342/what-is-service-include-in-a-csproj-file-for) indicates that this is how VS identifies test projects. The guid exists on [other projects](https://github.com/dotnet/roslyn/search?utf8=%E2%9C%93&q=82A7F48D-3B50-4B1E-B82E-3ADA8210C358) in the code base. Should these be added as well?