### PR TITLE
return null session if RemoteHost is not reachable

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -59,7 +59,7 @@ namespace Roslyn.Test.Utilities.Remote
 
         public AssetStorage AssetStorage => _inprocServices.AssetStorage;
 
-        protected override async Task<Session> CreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
+        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
@@ -132,6 +132,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // TODO: send telemetry on session
                 using (var session = await client.CreateCodeAnalysisServiceSessionAsync(solution, cancellationToken).ConfigureAwait(false))
                 {
+                    if (session == null)
+                    {
+                        // session is not available
+                        return DiagnosticAnalysisResultMap.Create(ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty, ImmutableDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo>.Empty);
+                    }
+
                     session.AddAdditionalAssets(optionAsset);
 
                     var result = await session.InvokeAsync(
@@ -194,11 +200,6 @@ This data should always be correct as we're never persisting the data between se
 
             private void ReportAnalyzerExceptions(Project project, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> exceptions)
             {
-                if (exceptions == null)
-                {
-                    return;
-                }
-
                 foreach (var kv in exceptions)
                 {
                     var analyzer = kv.Key;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
@@ -129,8 +129,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     analyzerDriver.AnalysisOptions.LogAnalyzerExecutionTime,
                     project.Id, optionAsset.Checksum, hostChecksums, analyzerMap.Keys.ToArray());
 
-                // TODO: send telemetry on session
-                using (var session = await client.CreateCodeAnalysisServiceSessionAsync(solution, cancellationToken).ConfigureAwait(false))
+                using (var session = await client.TryCreateCodeAnalysisServiceSessionAsync(solution, cancellationToken).ConfigureAwait(false))
                 {
                     if (session == null)
                     {

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -15,16 +16,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         {
             var solution = document.Project.Solution;
 
-            using (var session = await client.CreateCodeAnalysisServiceSessionAsync(
-                solution, cancellationToken).ConfigureAwait(false))
-            {
-                var serializableResults = await session.InvokeAsync<SerializableNavigateToSearchResult[]>(
-                    nameof(IRemoteNavigateToSearchService.SearchDocumentAsync),
-                    document.Id,
-                    searchPattern).ConfigureAwait(false);
+            var serializableResults = await client.RunCodeAnalysisServiceOnRemoteHostAsync<SerializableNavigateToSearchResult[]>(
+                solution, nameof(IRemoteNavigateToSearchService.SearchDocumentAsync),
+                new object[] { document.Id, searchPattern }, cancellationToken).ConfigureAwait(false);
 
-                return serializableResults.Select(r => r.Rehydrate(solution)).ToImmutableArray();
-            }
+            serializableResults = serializableResults ?? Array.Empty<SerializableNavigateToSearchResult>();
+            return serializableResults.Select(r => r.Rehydrate(solution)).ToImmutableArray();
         }
 
         private async Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInRemoteProcessAsync(
@@ -32,16 +29,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         {
             var solution = project.Solution;
 
-            using (var session = await client.CreateCodeAnalysisServiceSessionAsync(
-                solution, cancellationToken).ConfigureAwait(false))
-            {
-                var serializableResults = await session.InvokeAsync<SerializableNavigateToSearchResult[]>(
-                    nameof(IRemoteNavigateToSearchService.SearchProjectAsync),
-                    project.Id,
-                    searchPattern).ConfigureAwait(false);
+            var serializableResults = await client.RunCodeAnalysisServiceOnRemoteHostAsync<SerializableNavigateToSearchResult[]>(
+                solution, nameof(IRemoteNavigateToSearchService.SearchProjectAsync),
+                new object[] { project.Id, searchPattern }, cancellationToken).ConfigureAwait(false);
 
-                return serializableResults.Select(r => r.Rehydrate(solution)).ToImmutableArray();
-            }
+            serializableResults = serializableResults ?? Array.Empty<SerializableNavigateToSearchResult>();
+            return serializableResults.Select(r => r.Rehydrate(solution)).ToImmutableArray();
         }
 
         private static async Task<RemoteHostClient> GetRemoteHostClientAsync(Project project, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
@@ -120,12 +120,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 using (Logger.LogBlock(FunctionId.SolutionChecksumUpdater_SynchronizePrimaryWorkspace, cancellationToken))
                 {
                     var solution = _service.Workspace.CurrentSolution;
-                    using (var session = await remoteHostClient.CreateServiceSessionAsync(WellKnownRemoteHostServices.RemoteHostService, solution, cancellationToken).ConfigureAwait(false))
-                    {
-                        // ask remote host to sync initial asset
-                        var checksum = await solution.State.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
-                        await session.InvokeAsync(WellKnownRemoteHostServices.RemoteHostService_SynchronizePrimaryWorkspaceAsync, checksum).ConfigureAwait(false);
-                    }
+                    var checksum = await solution.State.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
+
+                    await remoteHostClient.RunOnRemoteHostAsync(
+                        WellKnownRemoteHostServices.RemoteHostService, solution,
+                        WellKnownRemoteHostServices.RemoteHostService_SynchronizePrimaryWorkspaceAsync, checksum, cancellationToken).ConfigureAwait(false);
                 }
             }
 

--- a/src/VisualStudio/Core/Next/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Next/CodeLens/RemoteCodeLensReferencesService.cs
@@ -33,10 +33,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
             }
 
             // TODO: send telemetry on session
-            using (var session = await remoteHostClient.CreateCodeAnalysisServiceSessionAsync(solution, cancellationToken).ConfigureAwait(false))
-            {
-                return await session.InvokeAsync<ReferenceCount>(WellKnownServiceHubServices.CodeAnalysisService_GetReferenceCountAsync, new CodeLensArguments(documentId, syntaxNode), maxSearchResults).ConfigureAwait(false);
-            }
+            return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<ReferenceCount>(
+                solution, WellKnownServiceHubServices.CodeAnalysisService_GetReferenceCountAsync,
+                new object[] { new CodeLensArguments(documentId, syntaxNode), maxSearchResults }, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<ReferenceLocationDescriptor>> FindReferenceLocationsAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
@@ -55,10 +54,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
             }
 
             // TODO: send telemetry on session
-            using (var session = await remoteHostClient.CreateCodeAnalysisServiceSessionAsync(solution, cancellationToken).ConfigureAwait(false))
-            {
-                return await session.InvokeAsync<IEnumerable<ReferenceLocationDescriptor>>(WellKnownServiceHubServices.CodeAnalysisService_FindReferenceLocationsAsync, new CodeLensArguments(documentId, syntaxNode)).ConfigureAwait(false);
-            }
+            return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<IEnumerable<ReferenceLocationDescriptor>>(
+                solution, WellKnownServiceHubServices.CodeAnalysisService_FindReferenceLocationsAsync,
+                new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<IEnumerable<ReferenceMethodDescriptor>> FindReferenceMethodsAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
@@ -77,10 +75,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
             }
 
             // TODO: send telemetry on session
-            using (var session = await remoteHostClient.CreateCodeAnalysisServiceSessionAsync(solution, cancellationToken).ConfigureAwait(false))
-            {
-                return await session.InvokeAsync<IEnumerable<ReferenceMethodDescriptor>>(WellKnownServiceHubServices.CodeAnalysisService_FindReferenceMethodsAsync, new CodeLensArguments(documentId, syntaxNode)).ConfigureAwait(false);
-            }
+            return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<IEnumerable<ReferenceMethodDescriptor>>(
+                solution, WellKnownServiceHubServices.CodeAnalysisService_FindReferenceMethodsAsync,
+                new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<string> GetFullyQualifiedName(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
@@ -99,10 +96,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
             }
 
             // TODO: send telemetry on session
-            using (var session = await remoteHostClient.CreateCodeAnalysisServiceSessionAsync(solution, cancellationToken).ConfigureAwait(false))
-            {
-                return await session.InvokeAsync<string>(WellKnownServiceHubServices.CodeAnalysisService_GetFullyQualifiedName, new CodeLensArguments(documentId, syntaxNode)).ConfigureAwait(false);
-            }
+            return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<string>(
+                solution, WellKnownServiceHubServices.CodeAnalysisService_GetFullyQualifiedName,
+                new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -59,6 +59,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                 using (var session = await _client.CreateServiceSessionAsync(WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution, CancellationToken.None).ConfigureAwait(false))
                 {
+                    if (session == null)
+                    {
+                        // failed to create session. remote host might not responding or gone. 
+                        return;
+                    }
+
                     await session.InvokeAsync(
                         WellKnownRemoteHostServices.RemoteHostService_PersistentStorageService_RegisterPrimarySolutionId,
                         solutionId).ConfigureAwait(false);
@@ -95,14 +101,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             private async Task UnregisterPrimarySolutionAsync(
                 SolutionId solutionId, bool synchronousShutdown)
             {
-                using (var session = await _client.CreateServiceSessionAsync(WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution, CancellationToken.None).ConfigureAwait(false))
-                {
-                    // ask remote host to sync initial asset
-                    await session.InvokeAsync(
-                        WellKnownRemoteHostServices.RemoteHostService_PersistentStorageService_UnregisterPrimarySolutionId,
-                        solutionId,
-                        synchronousShutdown).ConfigureAwait(false);
-                }
+                await _client.RunOnRemoteHostAsync(
+                    WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution,
+                    WellKnownRemoteHostServices.RemoteHostService_PersistentStorageService_UnregisterPrimarySolutionId,
+                        new object[] { solutionId, synchronousShutdown }, CancellationToken.None).ConfigureAwait(false);
             }
 
             public void ClearSolution() { }

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 _currentSolutionId = _workspace.CurrentSolution.Id;
                 var solutionId = _currentSolutionId;
 
-                using (var session = await _client.CreateServiceSessionAsync(WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution, CancellationToken.None).ConfigureAwait(false))
+                using (var session = await _client.TryCreateServiceSessionAsync(WellKnownRemoteHostServices.RemoteHostService, _workspace.CurrentSolution, CancellationToken.None).ConfigureAwait(false))
                 {
                     if (session == null)
                     {

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             _rpc.StartListening();
         }
 
-        protected override async Task<Session> CreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
+        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host for solution related information

--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -116,7 +116,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             var mock = new MockLogService();
             var client = await service.GetRemoteHostClientAsync(CancellationToken.None);
-            using (var session = await client.CreateServiceSessionAsync(WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine, mock, CancellationToken.None))
+            using (var session = await client.TryCreateServiceSessionAsync(WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine, mock, CancellationToken.None))
             {
                 await session.InvokeAsync(nameof(IRemoteSymbolSearchUpdateEngine.UpdateContinuouslyAsync), "emptySource", Path.GetTempPath());
             }

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -217,12 +217,10 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
         private static async Task UpdatePrimaryWorkspace(InProcRemoteHostClient client, Solution solution)
         {
-            using (var session = await client.CreateServiceSessionAsync(WellKnownRemoteHostServices.RemoteHostService, solution, CancellationToken.None))
-            {
-                await session.InvokeAsync(
-                    WellKnownRemoteHostServices.RemoteHostService_SynchronizePrimaryWorkspaceAsync,
-                    await solution.State.GetChecksumAsync(CancellationToken.None));
-            }
+            await client.RunOnRemoteHostAsync(
+                WellKnownRemoteHostServices.RemoteHostService, solution,
+                WellKnownRemoteHostServices.RemoteHostService_SynchronizePrimaryWorkspaceAsync,
+                await solution.State.GetChecksumAsync(CancellationToken.None), CancellationToken.None);
         }
 
         private static Solution Populate(Solution solution)

--- a/src/VisualStudio/Razor/RazorLangaugeServiceClient.cs
+++ b/src/VisualStudio/Razor/RazorLangaugeServiceClient.cs
@@ -24,6 +24,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
         public async Task<Session> CreateSessionAsync(Solution solution, object callbackTarget = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var innerSession = await _client.CreateServiceSessionAsync(RazorServiceName, solution, callbackTarget, cancellationToken).ConfigureAwait(false);
+            if (innerSession == null)
+            {
+                return null;
+            }
+
             return new Session(innerSession);
         }
 

--- a/src/VisualStudio/Razor/RazorLangaugeServiceClient.cs
+++ b/src/VisualStudio/Razor/RazorLangaugeServiceClient.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
 
         public async Task<Session> CreateSessionAsync(Solution solution, object callbackTarget = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var innerSession = await _client.CreateServiceSessionAsync(RazorServiceName, solution, callbackTarget, cancellationToken).ConfigureAwait(false);
+            var innerSession = await _client.TryCreateServiceSessionAsync(RazorServiceName, solution, callbackTarget, cancellationToken).ConfigureAwait(false);
             if (innerSession == null)
             {
                 return null;

--- a/src/Workspaces/Core/Desktop/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/Workspaces/Core/Desktop/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                 }
             }
 
-            private async Task<RemoteHostClient.Session> GetSessionAsync()
+            private async Task<RemoteHostClient.Session> TryGetSessionAsync()
             {
                 using (await _gate.DisposableWaitAsync(_cancellationToken).ConfigureAwait(false))
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                     // to be created on the remote side.  We only want one instance of that type.  The
                     // alternative is to make that type static variable on the remote side.  But that's
                     // much less clean and would make some of the state management much more complex.
-                    _sessionDoNotAccessDirectly = await _client.CreateServiceSessionAsync(
+                    _sessionDoNotAccessDirectly = await _client.TryCreateServiceSessionAsync(
                         WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine,
                         _logService,
                         _cancellationToken).ConfigureAwait(false);
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity)
             {
-                var session = await GetSessionAsync().ConfigureAwait(false);
+                var session = await TryGetSessionAsync().ConfigureAwait(false);
                 if (session == null)
                 {
                     // we couldn't get session. most likely remote host is gone
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string assemblyName)
             {
-                var session = await GetSessionAsync().ConfigureAwait(false);
+                var session = await TryGetSessionAsync().ConfigureAwait(false);
                 if (session == null)
                 {
                     // we couldn't get session. most likely remote host is gone
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity)
             {
-                var session = await GetSessionAsync().ConfigureAwait(false);
+                var session = await TryGetSessionAsync().ConfigureAwait(false);
                 if (session == null)
                 {
                     // we couldn't get session. most likely remote host is gone
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             public async Task UpdateContinuouslyAsync(
                 string sourceName, string localSettingsDirectory)
             {
-                var session = await GetSessionAsync().ConfigureAwait(false);
+                var session = await TryGetSessionAsync().ConfigureAwait(false);
                 if (session == null)
                 {
                     // we couldn't get session. most likely remote host is gone

--- a/src/Workspaces/Core/Desktop/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/Workspaces/Core/Desktop/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
 {
@@ -24,18 +25,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
                 var client = await workspace.GetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
                 if (client != null)
                 {
-                    // We create a single session and use it for the entire lifetime of this process.
-                    // That single session will be used to do all communication with the remote process.
-                    // This is because each session will cause a new instance of the RemoteSymbolSearchUpdateEngine
-                    // to be created on the remote side.  We only want one instance of that type.  The
-                    // alternative is to make that type static variable on the remote side.  But that's
-                    // much less clean and would make some of the state management much more complex.
-                    var session = await client.CreateServiceSessionAsync(
-                        WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine,
-                        logService,
-                        cancellationToken).ConfigureAwait(false);
-
-                    return new RemoteUpdateEngine(session);
+                    return new RemoteUpdateEngine(workspace, client, logService, cancellationToken);
                 }
             }
 
@@ -45,17 +35,86 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
         private class RemoteUpdateEngine : ISymbolSearchUpdateEngine
         {
-            private readonly RemoteHostClient.Session _session;
+            private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
 
-            public RemoteUpdateEngine(RemoteHostClient.Session session)
+            private readonly Workspace _workspace;
+            private readonly ISymbolSearchLogService _logService;
+            private readonly CancellationToken _cancellationToken;
+
+            private RemoteHostClient _client;
+            private RemoteHostClient.Session _sessionDoNotAccessDirectly;
+
+            public RemoteUpdateEngine(
+                Workspace workspace, RemoteHostClient client,
+                ISymbolSearchLogService logService, CancellationToken cancellationToken)
             {
-                _session = session;
+                _workspace = workspace;
+                _logService = logService;
+                _cancellationToken = cancellationToken;
+
+                // this engine is stateful service which maintaining a connection to remote host. so
+                // this feature is required to handle remote host recycle situation.
+                _client = client;
+                _client.ConnectionChanged += OnConnectionChanged;
+            }
+
+            private async void OnConnectionChanged(object sender, bool connected)
+            {
+                if (connected)
+                {
+                    return;
+                }
+
+                // to make things simpler, this is not cancellable. I believe this
+                // is okay since this handle rare cases where remote host is recycled or
+                // removed
+                using (await _gate.DisposableWaitAsync(CancellationToken.None).ConfigureAwait(false))
+                {
+                    _client.ConnectionChanged -= OnConnectionChanged;
+
+                    _sessionDoNotAccessDirectly?.Dispose();
+                    _sessionDoNotAccessDirectly = null;
+
+                    _client = await _workspace.GetRemoteHostClientAsync(CancellationToken.None).ConfigureAwait(false);
+                    _client.ConnectionChanged += OnConnectionChanged;
+                }
+            }
+
+            private async Task<RemoteHostClient.Session> GetSessionAsync()
+            {
+                using (await _gate.DisposableWaitAsync(_cancellationToken).ConfigureAwait(false))
+                {
+                    if (_sessionDoNotAccessDirectly != null)
+                    {
+                        return _sessionDoNotAccessDirectly;
+                    }
+
+                    // We create a single session and use it for the entire lifetime of this process.
+                    // That single session will be used to do all communication with the remote process.
+                    // This is because each session will cause a new instance of the RemoteSymbolSearchUpdateEngine
+                    // to be created on the remote side.  We only want one instance of that type.  The
+                    // alternative is to make that type static variable on the remote side.  But that's
+                    // much less clean and would make some of the state management much more complex.
+                    _sessionDoNotAccessDirectly = await _client.CreateServiceSessionAsync(
+                        WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine,
+                        _logService,
+                        _cancellationToken).ConfigureAwait(false);
+
+                    return _sessionDoNotAccessDirectly;
+                }
             }
 
             public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
                 string source, string name, int arity)
             {
-                var results = await _session.InvokeAsync<SerializablePackageWithTypeResult[]>(
+                var session = await GetSessionAsync().ConfigureAwait(false);
+                if (session == null)
+                {
+                    // we couldn't get session. most likely remote host is gone
+                    return ImmutableArray<PackageWithTypeResult>.Empty;
+                }
+
+                var results = await session.InvokeAsync<SerializablePackageWithTypeResult[]>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindPackagesWithTypeAsync),
                     source, name, arity).ConfigureAwait(false);
 
@@ -65,7 +124,14 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
                 string source, string assemblyName)
             {
-                var results = await _session.InvokeAsync<SerializablePackageWithAssemblyResult[]>(
+                var session = await GetSessionAsync().ConfigureAwait(false);
+                if (session == null)
+                {
+                    // we couldn't get session. most likely remote host is gone
+                    return ImmutableArray<PackageWithAssemblyResult>.Empty;
+                }
+
+                var results = await session.InvokeAsync<SerializablePackageWithAssemblyResult[]>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindPackagesWithAssemblyAsync),
                     source, assemblyName).ConfigureAwait(false);
 
@@ -75,19 +141,33 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
                 string name, int arity)
             {
-                var results = await _session.InvokeAsync<SerializableReferenceAssemblyWithTypeResult[]>(
+                var session = await GetSessionAsync().ConfigureAwait(false);
+                if (session == null)
+                {
+                    // we couldn't get session. most likely remote host is gone
+                    return ImmutableArray<ReferenceAssemblyWithTypeResult>.Empty;
+                }
+
+                var results = await session.InvokeAsync<SerializableReferenceAssemblyWithTypeResult[]>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindReferenceAssembliesWithTypeAsync),
                     name, arity).ConfigureAwait(false);
 
                 return results.Select(r => r.Rehydrate()).ToImmutableArray();
             }
 
-            public Task UpdateContinuouslyAsync(
+            public async Task UpdateContinuouslyAsync(
                 string sourceName, string localSettingsDirectory)
             {
-                return _session.InvokeAsync(
+                var session = await GetSessionAsync().ConfigureAwait(false);
+                if (session == null)
+                {
+                    // we couldn't get session. most likely remote host is gone
+                    return;
+                }
+
+                await session.InvokeAsync(
                     nameof(IRemoteSymbolSearchUpdateEngine.UpdateContinuouslyAsync),
-                    sourceName, localSettingsDirectory);
+                    sourceName, localSettingsDirectory).ConfigureAwait(false);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Remote.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Remote.cs
@@ -69,14 +69,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // the 'progress' parameter which will then upate the UI.
             var serverCallback = new ServerCallback(solution, progress, cancellationToken);
 
-            using (var session = await client.CreateCodeAnalysisServiceSessionAsync(
-                solution, serverCallback, cancellationToken).ConfigureAwait(false))
-            {
-                await session.InvokeAsync(
-                    nameof(IRemoteSymbolFinder.FindReferencesAsync),
-                    SerializableSymbolAndProjectId.Dehydrate(symbolAndProjectId),
-                    documents?.Select(d => d.Id).ToArray()).ConfigureAwait(false);
-            }
+            await client.RunCodeAnalysisServiceOnRemoteHostAsync(
+                solution, serverCallback,
+                nameof(IRemoteSymbolFinder.FindReferencesAsync),
+                new object[] { SerializableSymbolAndProjectId.Dehydrate(symbolAndProjectId), documents?.Select(d => d.Id).ToArray() },
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -24,21 +24,37 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public event EventHandler<bool> ConnectionChanged;
 
+        /// <summary>
+        /// Create <see cref="RemoteHostClient.Session"/> for the <paramref name="serviceName"/> if possible.
+        /// otherwise, return null.
+        /// </summary>
         public Task<Session> CreateServiceSessionAsync(string serviceName, CancellationToken cancellationToken)
         {
             return CreateServiceSessionAsync(serviceName, callbackTarget: null, cancellationToken: cancellationToken);
         }
 
+        /// <summary>
+        /// Create <see cref="RemoteHostClient.Session"/> for the <paramref name="serviceName"/> if possible.
+        /// otherwise, return null.
+        /// </summary>
         public Task<Session> CreateServiceSessionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
         {
             return CreateServiceSessionAsync(serviceName, snapshot: null, callbackTarget: callbackTarget, cancellationToken: cancellationToken);
         }
 
+        /// <summary>
+        /// Create <see cref="RemoteHostClient.Session"/> for the <paramref name="serviceName"/> if possible.
+        /// otherwise, return null.
+        /// </summary>
         public Task<Session> CreateServiceSessionAsync(string serviceName, Solution solution, CancellationToken cancellationToken)
         {
             return CreateServiceSessionAsync(serviceName, solution, callbackTarget: null, cancellationToken: cancellationToken);
         }
 
+        /// <summary>
+        /// Create <see cref="RemoteHostClient.Session"/> for the <paramref name="serviceName"/> if possible.
+        /// otherwise, return null.
+        /// </summary>
         public async Task<Session> CreateServiceSessionAsync(string serviceName, Solution solution, object callbackTarget, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(solution.Workspace == _workspace);
@@ -98,18 +114,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
             public abstract Task InvokeAsync(string targetName, params object[] arguments);
 
-            /// <summary>
-            /// All caller must guard itself from it returning default(T) which can happen if OOP is killed
-            /// unintentionally such as user killed OOP process.
-            /// </summary>
             public abstract Task<T> InvokeAsync<T>(string targetName, params object[] arguments);
 
             public abstract Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync);
 
-            /// <summary>
-            /// All caller must guard itself from it returning default(T) which can happen if OOP is killed
-            /// unintentionally such as user killed OOP process.
-            /// </summary>
             public abstract Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync);
 
             public void AddAdditionalAssets(CustomAsset asset)
@@ -148,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Remote
             protected override Task<Session> CreateServiceSessionAsync(
                 string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
             {
-                return Task.FromResult<Session>(new NoOpSession(snapshot, cancellationToken));
+                return SpecializedTasks.Default<Session>();
             }
 
             protected override void OnConnected()
@@ -159,34 +167,6 @@ namespace Microsoft.CodeAnalysis.Remote
             protected override void OnDisconnected()
             {
                 // do nothing
-            }
-
-            private class NoOpSession : Session
-            {
-                public NoOpSession(PinnedRemotableDataScope scope, CancellationToken cancellationToken) :
-                    base(scope, cancellationToken)
-                {
-                }
-
-                public override Task InvokeAsync(string targetName, params object[] arguments)
-                {
-                    return SpecializedTasks.EmptyTask;
-                }
-
-                public override Task<T> InvokeAsync<T>(string targetName, params object[] arguments)
-                {
-                    return SpecializedTasks.Default<T>();
-                }
-
-                public override Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync)
-                {
-                    return SpecializedTasks.EmptyTask;
-                }
-
-                public override Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync)
-                {
-                    return SpecializedTasks.Default<T>();
-                }
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -2,8 +2,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -27,6 +25,74 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             var clientService = workspace.Services.GetService<IRemoteHostClientService>();
             return clientService?.GetRemoteHostClientAsync(cancellationToken);
+        }
+
+        public static Task RunOnRemoteHostAsync(
+            this RemoteHostClient client, string serviceName, Solution solution, string targetName, object argument, CancellationToken cancellationToken)
+        {
+            return RunOnRemoteHostAsync(client, serviceName, solution, targetName, new object[] { argument }, cancellationToken);
+        }
+
+        public static Task RunOnRemoteHostAsync(
+            this RemoteHostClient client, string serviceName, Solution solution, string targetName, object[] arguments, CancellationToken cancellationToken)
+        {
+            object callbackTarget = null;
+            return RunOnRemoteHostAsync(client, serviceName, solution, callbackTarget, targetName, arguments, cancellationToken);
+        }
+
+        public static async Task RunOnRemoteHostAsync(
+            this RemoteHostClient client, string serviceName, Solution solution, object callbackTarget,
+            string targetName, object[] arguments, CancellationToken cancellationToken)
+        {
+            using (var session = await client.CreateServiceSessionAsync(serviceName, solution, callbackTarget, cancellationToken).ConfigureAwait(false))
+            {
+                if (session == null)
+                {
+                    // can't create Session. RemoteHost seems not responding for some reasons such as OOP gone.
+                    return;
+                }
+
+                await session.InvokeAsync(targetName, arguments).ConfigureAwait(false);
+            }
+        }
+
+        public static async Task<T> RunOnRemoteHostAsync<T>(
+            this RemoteHostClient client, string serviceName, Solution solution, string targetName, object[] arguments, CancellationToken cancellationToken)
+        {
+            using (var session = await client.CreateServiceSessionAsync(serviceName, solution, cancellationToken).ConfigureAwait(false))
+            {
+                if (session == null)
+                {
+                    // can't create Session. RemoteHost seems not responding for some reasons such as OOP gone.
+                    return default(T);
+                }
+
+                return await session.InvokeAsync<T>(targetName, arguments).ConfigureAwait(false);
+            }
+        }
+
+        public static Task RunCodeAnalysisServiceOnRemoteHostAsync(
+            this RemoteHostClient client, Solution solution, object callbackTarget, string targetName, object argument, CancellationToken cancellationToken)
+        {
+            return RunCodeAnalysisServiceOnRemoteHostAsync(client, solution, callbackTarget, targetName, new object[] { argument }, cancellationToken);
+        }
+
+        public static Task RunCodeAnalysisServiceOnRemoteHostAsync(
+            this RemoteHostClient client, Solution solution, object callbackTarget, string targetName, object[] arguments, CancellationToken cancellationToken)
+        {
+            return RunOnRemoteHostAsync(client, WellKnownServiceHubServices.CodeAnalysisService, solution, callbackTarget, targetName, arguments, cancellationToken);
+        }
+
+        public static Task<T> RunCodeAnalysisServiceOnRemoteHostAsync<T>(
+            this RemoteHostClient client, Solution solution, string targetName, object argument, CancellationToken cancellationToken)
+        {
+            return RunCodeAnalysisServiceOnRemoteHostAsync<T>(client, solution, targetName, new object[] { argument }, cancellationToken);
+        }
+
+        public static Task<T> RunCodeAnalysisServiceOnRemoteHostAsync<T>(
+            this RemoteHostClient client, Solution solution, string targetName, object[] arguments, CancellationToken cancellationToken)
+        {
+            return RunOnRemoteHostAsync<T>(client, WellKnownServiceHubServices.CodeAnalysisService, solution, targetName, arguments, cancellationToken);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,6 +8,7 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal static class RemoteHostClientExtensions
     {
+        [Obsolete]
         public static Task<RemoteHostClient.Session> CreateCodeAnalysisServiceSessionAsync(
             this RemoteHostClient client, Solution solution, CancellationToken cancellationToken)
         {
@@ -14,10 +16,24 @@ namespace Microsoft.CodeAnalysis.Remote
                 client, solution, callbackTarget: null, cancellationToken: cancellationToken);
         }
 
+        [Obsolete]
         public static Task<RemoteHostClient.Session> CreateCodeAnalysisServiceSessionAsync(
             this RemoteHostClient client, Solution solution, object callbackTarget, CancellationToken cancellationToken)
         {
-            return client.CreateServiceSessionAsync(
+            return TryCreateCodeAnalysisServiceSessionAsync(client, solution, callbackTarget, cancellationToken);
+        }
+
+        public static Task<RemoteHostClient.Session> TryCreateCodeAnalysisServiceSessionAsync(
+            this RemoteHostClient client, Solution solution, CancellationToken cancellationToken)
+        {
+            return TryCreateCodeAnalysisServiceSessionAsync(
+                client, solution, callbackTarget: null, cancellationToken: cancellationToken);
+        }
+
+        public static Task<RemoteHostClient.Session> TryCreateCodeAnalysisServiceSessionAsync(
+            this RemoteHostClient client, Solution solution, object callbackTarget, CancellationToken cancellationToken)
+        {
+            return client.TryCreateServiceSessionAsync(
                 WellKnownServiceHubServices.CodeAnalysisService, solution, callbackTarget, cancellationToken);
         }
 
@@ -44,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Remote
             this RemoteHostClient client, string serviceName, Solution solution, object callbackTarget,
             string targetName, object[] arguments, CancellationToken cancellationToken)
         {
-            using (var session = await client.CreateServiceSessionAsync(serviceName, solution, callbackTarget, cancellationToken).ConfigureAwait(false))
+            using (var session = await client.TryCreateServiceSessionAsync(serviceName, solution, callbackTarget, cancellationToken).ConfigureAwait(false))
             {
                 if (session == null)
                 {
@@ -56,10 +72,13 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
+        /// <summary>
+        /// Run given service on remote host. if it fails to run on remote host, it will return default(T)
+        /// </summary>
         public static async Task<T> RunOnRemoteHostAsync<T>(
             this RemoteHostClient client, string serviceName, Solution solution, string targetName, object[] arguments, CancellationToken cancellationToken)
         {
-            using (var session = await client.CreateServiceSessionAsync(serviceName, solution, cancellationToken).ConfigureAwait(false))
+            using (var session = await client.TryCreateServiceSessionAsync(serviceName, solution, cancellationToken).ConfigureAwait(false))
             {
                 if (session == null)
                 {
@@ -83,12 +102,18 @@ namespace Microsoft.CodeAnalysis.Remote
             return RunOnRemoteHostAsync(client, WellKnownServiceHubServices.CodeAnalysisService, solution, callbackTarget, targetName, arguments, cancellationToken);
         }
 
+        /// <summary>
+        /// Run given service on remote host. if it fails to run on remote host, it will return default(T)
+        /// </summary>
         public static Task<T> RunCodeAnalysisServiceOnRemoteHostAsync<T>(
             this RemoteHostClient client, Solution solution, string targetName, object argument, CancellationToken cancellationToken)
         {
             return RunCodeAnalysisServiceOnRemoteHostAsync<T>(client, solution, targetName, new object[] { argument }, cancellationToken);
         }
 
+        /// <summary>
+        /// Run given service on remote host. if it fails to run on remote host, it will return default(T)
+        /// </summary>
         public static Task<T> RunCodeAnalysisServiceOnRemoteHostAsync<T>(
             this RemoteHostClient client, Solution solution, string targetName, object[] arguments, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
following @rynowak 's suggestion.

when remote host is not available, CreateSession will return null instead of InvokeAsync returning null.

all consumer of OOP now should check whether it got session back before it does anything.

this is following up work for this PR - https://github.com/dotnet/roslyn/pull/17174

fix https://github.com/dotnet/roslyn/issues/17217