### PR TITLE
Move several jenkins legs to Windows only images

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -34,6 +34,7 @@
     <RoslynToolsMicrosoftLocateVSVersion>0.2.4-beta</RoslynToolsMicrosoftLocateVSVersion>
     <RoslynToolsMicrosoftSignToolVersion>0.3.0-beta</RoslynToolsMicrosoftSignToolVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.2.4-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
+    <RoslynToolsReferenceAssembliesVersion>0.1.1</RoslynToolsReferenceAssembliesVersion>
     <SystemAppContextVersion>4.3.0</SystemAppContextVersion>
     <SystemCollectionsVersion>4.3.0</SystemCollectionsVersion>
     <SystemCollectionsConcurrentVersion>4.3.0</SystemCollectionsConcurrentVersion>

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -17,6 +17,7 @@
     "RoslynTools.Microsoft.LocateVS": "0.2.4-beta",
     "RoslynTools.Microsoft.SignTool": "0.3.0-beta",
     "RoslynTools.Microsoft.VSIXExpInstaller": "0.2.4-beta",
+    "RoslynTools.ReferenceAssemblies": "0.1.1",
     "GitLink": "3.0.0-unstable0085"
   },
   "frameworks": {

--- a/build/scripts/cibuild.ps1
+++ b/build/scripts/cibuild.ps1
@@ -54,8 +54,8 @@ try {
     }
 
     $buildConfiguration = if ($release) { "Release" } else { "Debug" }
-    $msbuildDir = Get-MSBuildDir
-    $msbuild = Join-Path $msbuildDir "msbuild.exe"
+    $msbuild = Ensure-MSBuild
+    $msbuildDir = Split-Path -parent $msbuild
     $configDir = Join-Path $binariesDIr $buildConfiguration
 
     if (-not $skipRestore) { 

--- a/build/scripts/deploy-msbuild.ps1
+++ b/build/scripts/deploy-msbuild.ps1
@@ -1,0 +1,50 @@
+# This script will ensure that the MSBuild toolset of the specified 
+# version is downloaded and deployed to Binaries\Toolset\MSBuild
+#
+# This is a no-op if it is already present at the appropriate version
+
+[CmdletBinding(PositionalBinding=$false)]
+param ($version = "0.1.7-alpha")
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+try {
+    
+    . (Join-Path $PSScriptRoot "build-utils.ps1")
+    $toolsDir = Join-Path $binariesDir "Toolset"
+    $scratchDir = Join-Path $toolsDir "Scratch"
+
+    Create-Directory $toolsDir
+    Create-Directory $scratchDir
+    pushd $toolsDir
+
+    $scratchFile = Join-Path $scratchDir "msbuild.txt"
+    $scratchVersion = Get-Content -raw $scratchFile -ErrorAction SilentlyContinue
+    if ($scratchVersion -eq ($version + [Environment]::NewLine)) { 
+        exit 0
+    }
+
+    $tempFileName = "msbuild-$version.zip"
+    $tempFile = Join-Path $scratchDir $tempFileName
+    if (-not (Test-Path $tempFile)) { 
+        $url = "https://jdashstorage.blob.core.windows.net/msbuild/msbuild-$version.zip" 
+        $webClient = New-Object -TypeName "System.Net.WebClient"
+        $webClient.DownloadFile($url, $tempFile)
+    }
+    
+    Remove-Item -re (Join-Path $toolsDir "msbuild") -ErrorAction SilentlyContinue
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [IO.Compression.ZipFile]::ExtractToDirectory($tempFile, $toolsDir)
+
+    $version | Out-File $scratchFile 
+    exit 0
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    exit 1
+}
+finally {
+    popd
+}

--- a/build/scripts/test-machine-setup.ps1
+++ b/build/scripts/test-machine-setup.ps1
@@ -14,8 +14,12 @@ try {
     . (Join-Path $PSScriptRoot "build-utils.ps1")
     Write-Host "Calling Get-MSBuildKindAndDir"
     Get-MSBuildKindAndDir
+    Write-Host "Calling Get-MSBuildKindAndDir -xcopy"
+    Get-MSBuildKindAndDir -xcopy
     Write-Host "Calling Get-MSBuildDir"
     Get-MSBuildDir
+    Write-Host "Calling Get-MSBuildDir -xcopy"
+    Get-MSBuildDir -xcopy
     
     try {
         Write-Host "Calling Get-VisualStudioDir"
@@ -24,7 +28,23 @@ try {
     catch { 
         Write-Host "Unable to find Visual Studio (expected on a machine without VS)"
         Write-Host $_
+        Write-Host $_.Exception
     }
+
+    try { 
+
+        $vswhere = Ensure-BasicTool "vswhere" "1.0.50"
+        Write-Host "VSWhere is $vswhere"
+    }
+    catch { 
+        Write-Host "Error gettin vswhere"
+        Write-Host $_
+        Write-Host $_.Exception
+    }
+
+    Write-Host "Enumerate packages dir"
+    $d = Get-PackagesDir
+    Get-ChildItem $d
 
 }
 catch {

--- a/docs/infrastructure/msbuild.md
+++ b/docs/infrastructure/msbuild.md
@@ -1,0 +1,10 @@
+# MSBuild usage
+
+This repo must support the ability to build with a number of different MSBuild configurations:
+
+- MSBuild via Visual Studio: this happens when developers open Roslyn.sln in Visual Studio and execute the build action.  This uses desktop MSBuild to drive the solution. 
+- MSBuild via CLI: the cross platform portions of the repo are built via the CLI.  This is a subset of the code contained in Roslyn.sln. 
+- MSBuild xcopy: an xcopyable version of MSBuild that is used to run many of our Jenkins legs.  It allows Roslyn to build and run tests on a completely fresh Windows image (no pre-reqs).  The [xcopy-msbuild](https://github.com/jaredpar/xcopy-msbuild) project is responsible for building this image. 
+- BuildTools: this is a collection of tools produced by [dotnet/buildtools](https://github.com/dotnet/buildtools) which build a number of dotnet repos. 
+
+This places a small burden on our repo to keep our build props / targets files simple to avoid any odd conflicts.  This is rarely an issue at this point.

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -70,7 +70,7 @@ string GetExistingPackageVersion(string name)
     return null;
 }
 
-var IsCoreBuild = Directory.Exists(ToolsetPath);
+var IsCoreBuild = File.Exists(Path.Combine(ToolsetPath, "corerun"));
 
 #endregion
 

--- a/src/Test/Perf/tests/Perf.Tests.csproj
+++ b/src/Test/Perf/tests/Perf.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Roslyn.Test.Performance.Tests</RootNamespace>
     <AssemblyName>Roslyn.Test.Performance.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Nonshipping>true</Nonshipping>
   </PropertyGroup>

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -15,14 +15,14 @@
   <!-- Non-official builds / local testing have different defaults -->
   <PropertyGroup Condition="'$(OfficialBuild)' != 'true'">
     <BranchName Condition="'$(BranchName)' == ''">master</BranchName>
-    <SignRoslynArgs>-test</SignRoslynArgs>
+    <SignRoslynArgs>-test -msbuildPath "$(MSBuildBinPath)\msbuild.exe"</SignRoslynArgs>
     <PublishAssetsArgs>-test</PublishAssetsArgs>
     <CopyInsertionFileArgs>-test</CopyInsertionFileArgs>
     <SetupStep2Properties>FinalizeValidate=false;ManifestPublishUrl=https://vsdrop.corp.microsoft.com/file/v1/Products/DevDiv/dotnet/roslyn/master/20160729.6</SetupStep2Properties>
   </PropertyGroup>
 
   <Target Name="Build">
-    <Exec Command="powershell -noprofile -executionPolicy ByPass -file build\scripts\restore.ps1 -clean -msbuildDir &quot;$(MSBuildBinPath)&quot;" WorkingDirectory="$(RepoRoot)" />
+    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(RepoRoot)build\scripts\restore.ps1 -msbuildDir &quot;$(MSBuildBinPath)&quot;" />
 
     <MSBuild Projects="$(RepoRoot)Roslyn.sln" BuildInParallel="true" Properties="DeployExtension=false" />
 

--- a/src/Tools/MicroBuild/cibuild.cmd
+++ b/src/Tools/MicroBuild/cibuild.cmd
@@ -1,17 +1,1 @@
-@setlocal enabledelayedexpansion
-
-pushd %~dp0
-
-REM Ensure we are in a known-clean state before running the build
-call "..\..\..\build\scripts\LoadNuGetInfo.cmd" || goto :BuildFailed
-call "%NugetExe%" locals all -clear || goto :BuildFailed
-
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat" || goto :BuildFailed
-msbuild /nodereuse:false /p:Configuration=Release /p:SkipTest=true Build.proj || goto :BuildFailed
-popd
-
-exit /b 0
-
-:BuildFailed
-echo Build failed with ERRORLEVEL %ERRORLEVEL%
-exit /b 1
+powershell -noprofile -executionPolicy RemoteSigned -file "%~dp0\cibuild.ps1" %*

--- a/src/Tools/MicroBuild/cibuild.ps1
+++ b/src/Tools/MicroBuild/cibuild.ps1
@@ -1,0 +1,39 @@
+
+[CmdletBinding(PositionalBinding=$false)]
+param ()
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+# Kill any instances VBCSCompiler.exe to release locked files, ignoring stderr if process is not open
+# This prevents future CI runs from failing while trying to delete those files.
+# Kill any instances of msbuild.exe to ensure that we never reuse nodes (e.g. if a non-roslyn CI run
+# left some floating around).
+function Terminate-BuildProcesses() {
+    Get-Process msbuild -ErrorAction SilentlyContinue | kill 
+    Get-Process vbcscompiler -ErrorAction SilentlyContinue | kill
+}
+
+try {
+    . (Join-Path $PSScriptRoot "..\..\..\build\scripts\build-utils.ps1")
+    Push-Location $PSScriptRoot
+
+    $nuget = Ensure-NuGet
+    Exec { & $nuget locals all -clear }
+
+    $msbuild = Ensure-MSBuild
+    & $msbuild /nodereuse:false /p:Configuration=Release /p:SkipTest=true Build.proj 
+    if (-not $?) { 
+        throw "Build failed"
+    }
+
+    exit 0
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    exit 1
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
This moves many of our Jenkins legs to be Windows only images (no Visual Studio).  The key part of enabling this change is setting up our repo to use an xcopy version of MSBuild.   In general our repo scripts will prefer machine installs of MSBuild but when unable to find one will use an xcopy version. 

Right now the MSBuild toolset is deployed via a zip file.  There are suggestions about using NuGet and I did look into that (see [this change](https://github.com/jaredpar/roslyn/commit/bec74a0f3e50251fe05c8dc23d2fbedf31c64048)).  Using a NuGet package is simple enough.  

The problem is that it's ~66MB in size due to the inclusion of framework reference assemblies.   In practice it didn't seem  NuGet was well setup to handle that size of a package.  Still open to using NuGet here.  I also considered breaking apart the reference assemblies and msbuild toolset into different packages but I'm not sure that will help much. 
