### PR TITLE
added support for metadata xml doc comment

### DIFF
--- a/src/Workspaces/Core/Desktop/Execution/DesktopReferenceSerializationServiceFactory.cs
+++ b/src/Workspaces/Core/Desktop/Execution/DesktopReferenceSerializationServiceFactory.cs
@@ -25,7 +25,9 @@ namespace Microsoft.CodeAnalysis.Execution
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
-            return new Service(workspaceServices.GetService<ITemporaryStorageService>());
+            return new Service(
+                workspaceServices.GetService<ITemporaryStorageService>(),
+                workspaceServices.GetService<IDocumentationProviderService>());
         }
 
         private sealed class Service : AbstractReferenceSerializationService
@@ -34,7 +36,8 @@ namespace Microsoft.CodeAnalysis.Execution
             // typical low number, high volumn data cache.
             private static readonly ConcurrentDictionary<Encoding, byte[]> s_encodingCache = new ConcurrentDictionary<Encoding, byte[]>(concurrencyLevel: 2, capacity: 5);
 
-            public Service(ITemporaryStorageService service) : base(service)
+            public Service(ITemporaryStorageService service, IDocumentationProviderService documentationService) :
+                base(service, documentationService)
             {
             }
 

--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Execution
         private readonly IDocumentationProviderService _documentationService;
 
         protected AbstractReferenceSerializationService(
-            ITemporaryStorageService storageService, 
+            ITemporaryStorageService storageService,
             IDocumentationProviderService documentationService)
         {
             _storageService = storageService;
@@ -265,9 +265,11 @@ namespace Microsoft.CodeAnalysis.Execution
                 // an alternative approach of this is synching content of xml doc comment to remote host as well
                 // so that we can put xml doc comment as part of snapshot. but until we believe that is necessary,
                 // it will go with simpler approach
+                var documentProvider = filePath != null && _documentationService != null ?
+                    _documentationService.GetDocumentationProvider(filePath) : XmlDocumentationProvider.Default;
+
                 return new SerializedMetadataReference(
-                    properties, filePath, tuple.Value.metadata, tuple.Value.storages,
-                    _documentationService?.GetDocumentationProvider(filePath) ?? XmlDocumentationProvider.Default);
+                    properties, filePath, tuple.Value.metadata, tuple.Value.storages, documentProvider);
             }
 
             throw ExceptionUtilities.UnexpectedValue(kind);

--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -28,10 +28,14 @@ namespace Microsoft.CodeAnalysis.Execution
         private static readonly ConditionalWeakTable<Metadata, object> s_lifetimeMap = new ConditionalWeakTable<Metadata, object>();
 
         private readonly ITemporaryStorageService _storageService;
+        private readonly IDocumentationProviderService _documentationService;
 
-        protected AbstractReferenceSerializationService(ITemporaryStorageService storageService)
+        protected AbstractReferenceSerializationService(
+            ITemporaryStorageService storageService, 
+            IDocumentationProviderService documentationService)
         {
             _storageService = storageService;
+            _documentationService = documentationService;
         }
 
         public virtual void WriteTo(Encoding encoding, ObjectWriter writer, CancellationToken cancellationToken)
@@ -254,11 +258,16 @@ namespace Microsoft.CodeAnalysis.Execution
                     return new MissingMetadataReference(properties, filePath, XmlDocumentationProvider.Default);
                 }
 
-                // TODO: deal with xml document provider properly
-                //       should we shadow copy xml doc comment?
+                // for now, we will use IDocumentationProviderService to get DocumentationProvider for metadata
+                // references. if the service is not available, then use Default (NoOp) provider.
+                // since xml doc comment is not part of solution snapshot, (like xml reference resolver or strong name
+                // provider) this provider can also potentially provide content that is different than one in the host. 
+                // an alternative approach of this is synching content of xml doc comment to remote host as well
+                // so that we can put xml doc comment as part of snapshot. but until we believe that is necessary,
+                // it will go with simpler approach
                 return new SerializedMetadataReference(
                     properties, filePath, tuple.Value.metadata, tuple.Value.storages,
-                    XmlDocumentationProvider.Default);
+                    _documentationService?.GetDocumentationProvider(filePath) ?? XmlDocumentationProvider.Default);
             }
 
             throw ExceptionUtilities.UnexpectedValue(kind);
@@ -672,7 +681,6 @@ namespace Microsoft.CodeAnalysis.Execution
                 Metadata metadata, ImmutableArray<ITemporaryStreamStorage> storagesOpt, DocumentationProvider initialDocumentation) :
                 base(properties, fullPath, initialDocumentation)
             {
-                // TODO: doc comment provider is a bit wierd.
                 _metadata = metadata;
                 _storagesOpt = storagesOpt;
 
@@ -681,8 +689,8 @@ namespace Microsoft.CodeAnalysis.Execution
 
             protected override DocumentationProvider CreateDocumentationProvider()
             {
-                // TODO: properly implement this
-                return null;
+                // this uses documentation provider given at the constructor
+                throw ExceptionUtilities.Unreachable;
             }
 
             protected override Metadata GetMetadataImpl()

--- a/src/Workspaces/Core/Portable/Execution/ReferenceSerializationServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Execution/ReferenceSerializationServiceFactory.cs
@@ -18,12 +18,15 @@ namespace Microsoft.CodeAnalysis.Execution
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
-            return new Service(workspaceServices.GetService<ITemporaryStorageService>());
+            return new Service(
+                workspaceServices.GetService<ITemporaryStorageService>(),
+                workspaceServices.GetService<IDocumentationProviderService>());
         }
 
         private sealed class Service : AbstractReferenceSerializationService
         {
-            public Service(ITemporaryStorageService service) : base(service)
+            public Service(ITemporaryStorageService service, IDocumentationProviderService documentationService) :
+                base(service, documentationService)
             {
             }
 


### PR DESCRIPTION
this was one of missing feature in OOP that was in backlog to support. @rynowak wanted this for Razor running in OOP. so added the support.