### PR TITLE
send servicehub log files along with NFW to help investigate HubClient.RequestServiceAsync issues.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -30,5 +30,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 description: description,
                 exceptionObject: exception);
         }
+
+        /// <summary>
+        /// Report Non-Fatal Watson
+        /// </summary>
+        /// <param name="description">any description you want to save with this watson report</param>
+        /// <param name="exception">Exception that triggered this non-fatal error</param>
+        /// <param name="callback">callback to include extra data with the NFW</param>
+        public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback)
+        {
+            TelemetryService.DefaultSession.PostFault(
+                eventName: FunctionId.NonFatalWatson.GetEventName(),
+                description: description,
+                exceptionObject: exception,
+                gatherEventDetails: callback);
+        }
     }
 }


### PR DESCRIPTION
this doesn't change any user experience. but will help us to have more info on figuring out why this happens

[Watson] clr20r3: CLR_EXCEPTION_System.InvalidOperationException_DETOURS_80131509_Microsoft.CodeAnalysis.Workspaces.dll!Roslyn.Utilities.Contract.FailWithReturn[[System.__Canon,_mscorlib]]
(https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems?id=386567&projectId=0bdbc590-a062-4c3f-b0f6-9383f67865ee&src=alerts&src-action=summary_id_link&fullScreen=true&_a=edit)

....

currently we identified 3 common cases that lead to the above problem. but we need more info to figure out the root cause of it.

this change let us send those info when this happens.

....

**Customer scenario**

VS suddenly crash while user is using solution with C#/VB projects.

**Bugs this fixes:** 

https://github.com/dotnet/roslyn/issues/17012

this doesn't actually fix the crash, but send more info to help us to fix the issue.

**Workarounds, if any**

turn off OOP through hidden registry key.

**Risk**

when customer hit the issue, now we send more info than before when sending NFW. but since NFW is throttled and not sent on every occurrences of the issue, most of time, should be okay. but when NFW is actually sent, it will take more time.

**Performance impact**

when NFW is actually sent, it will take more time to gather information.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

we have found these 3 common patterns that cause HubClient.RequestServiceAsync to fail. people are tracking each issues separately. but requires more info to track down to root cause. this PR is to gather more data to help investigating the issues below.

#1, “StreamJsonRpc.RemoteInvocationException: Request locate failed with message: Cannot find service module info file '*/codeAnalysisService.servicehub.service.json' in 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\ServiceHub\Services', using discovery services failed: VsixServiceDiscovery: ExternalSettingsManager::GetScopePaths failed to initialize PkgDefManager”
 
 
#2, “StreamJsonRpc.RemoteInvocationException: Request locate failed with message: Cannot find service module info file '*/codeAnalysisService.servicehub.service.json' in 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\ServiceHub\Services', using discovery services failed: VsixServiceDiscovery: connect ENOENT \\?\pipe\a5e4cfe06cbe4adead96a3d5ff65a88d at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)”
 
#3, StreamJsonRpc.RemoteInvocationException: Request locate failed with message: Cannot find service config file 'C:\Users\[UserName]\AppData\Local\Temp\dev50B1.tmp'. at Microsoft.ServiceHub.HostLib.AppDomainIsolationServiceManager.GetDomainKey(ServiceModuleInfo smi) at Microsoft.ServiceHub.HostLib.AppDomainIsolationServiceManager.StartService(ServiceModuleInfo smi) at Microsoft.ServiceHub.HostLib.Host.startService(ServiceModuleInfo smi) at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task) at StreamJsonRpc.JsonRpc.<InvokeCoreAsync>d__56`1.MoveNext() --- End of stack trace from previous location where exception was thrown --- at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification

currently, we have these bugs to track each issues.

388344
[Watson] crash32: HEAP_CORRUPTION_c0000374_heap_corruption!ServiceHub.Host.CLR.x86.exe
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/388344

388327
[Watson] crash32: HEAP_CORRUPTION_ACTIONABLE_BlockNotBusy_DOUBLE_FREE_c0000374_Microsoft.VisualStudio.Settings.15.0.dll!RegistryDetouring::InitializeRegRootHive
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/388327

387392 Lock the app config file in %temp% in volatile pkgdef merge case for the lifetime of VS instance
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/387392

**How was the bug found?**

Watson, customer report.