### PR TITLE
Enable debug information by default in CSI

### DIFF
--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -121,7 +121,6 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 return CommonCompiler.Failed;
             }
 
-
             var cancellationToken = new CancellationToken();
 
             if (_compiler.Arguments.InteractiveMode)

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             var script = Script.CreateInitialScript<int>(_scriptCompiler, code, options, globals.GetType(), assemblyLoaderOpt: null);
             try
             {
-                return script.RunAsync(globals, cancellationToken).Result.ReturnValue;
+                return script.RunAsync(globals, cancellationToken).GetAwaiter().GetResult().ReturnValue;
             }
             catch (CompilationErrorException e)
             {

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -108,7 +108,12 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 }
             }
 
+
+            // only emit symbols for non-interactive mode,
+            var emitDebugInformation = !_compiler.Arguments.InteractiveMode;
+
             var scriptPathOpt = sourceFiles.IsEmpty ? null : sourceFiles[0].Path;
+            var scriptOptions = GetScriptOptions(_compiler.Arguments, scriptPathOpt, _compiler.MessageProvider, diagnosticsInfos, emitDebugInformation);
 
             var errors = _compiler.Arguments.Errors.Concat(diagnosticsInfos.Select(Diagnostic.Create));
             if (_compiler.ReportErrors(errors, _console.Error, errorLogger))
@@ -116,9 +121,6 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 return CommonCompiler.Failed;
             }
 
-            // only emit symbols for non-interactive mode, and when encoding is known
-            var emitDebugInformation = !_compiler.Arguments.InteractiveMode && code.Encoding != null;
-            var scriptOptions = GetScriptOptions(_compiler.Arguments, scriptPathOpt, _compiler.MessageProvider, diagnosticsInfos, emitDebugInformation);
 
             var cancellationToken = new CancellationToken();
 

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             }
             else
             {
-                return RunScript(scriptOptions, code.ToString(), errorLogger, cancellationToken);
+                return RunScript(scriptOptions, code, errorLogger, cancellationToken);
             }
         }
 
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 namespaces: CommandLineHelpers.GetImports(arguments),
                 metadataResolver: metadataResolver,
                 sourceResolver: sourceResolver,
-                emitDebugInformation: false,
+                emitDebugInformation: true,
                 fileEncoding: null);
         }
 
@@ -173,12 +173,12 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             return new CommonCompiler.LoggingSourceFileResolver(arguments.SourcePaths, arguments.BaseDirectory, ImmutableArray<KeyValuePair<string, string>>.Empty, loggerOpt);
         }
 
-        private int RunScript(ScriptOptions options, string code, ErrorLogger errorLogger, CancellationToken cancellationToken)
+        private int RunScript(ScriptOptions options, SourceText code, ErrorLogger errorLogger, CancellationToken cancellationToken)
         {
             var globals = new CommandLineScriptGlobals(_console.Out, _objectFormatter);
             globals.Args.AddRange(_compiler.Arguments.ScriptArguments);
 
-            var script = Script.CreateInitialScript<int>(_scriptCompiler, SourceText.From(code), options, globals.GetType(), assemblyLoaderOpt: null);
+            var script = Script.CreateInitialScript<int>(_scriptCompiler, code, options, globals.GetType(), assemblyLoaderOpt: null);
             try
             {
                 return script.RunAsync(globals, cancellationToken).Result.ReturnValue;

--- a/src/Test/Utilities/Portable/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Portable/Assert/AssertEx.cs
@@ -392,6 +392,13 @@ namespace Roslyn.Test.Utilities
             Assert.Contains(expectedSubString, actualString, StringComparison.Ordinal);
         }
 
+        public static void AssertStartsWithToleratingWhitespaceDifferences(string expectedSubString, string actualString)
+        {
+            expectedSubString = NormalizeWhitespace(expectedSubString);
+            actualString = NormalizeWhitespace(actualString);
+            Assert.StartsWith(expectedSubString, actualString, StringComparison.Ordinal);
+        }
+
         internal static string NormalizeWhitespace(string input)
         {
             var output = new StringBuilder();


### PR DESCRIPTION
**Customer scenario**

Improves script debugging experience 
1) CSI now displays file path and line number for method stack frames defined in .csx files.
2) It is now possible to attach a debugger to csi.exe and step thru the .csx source.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn/issues/13482

**Workarounds, if any**

None.

**Risk**

Low

**How was the bug found?**

Dogfood, customer reports.

### Current

```
λ csi.exe error.csx
hello world
System.AggregateException: One or more errors occurred. ---> System.Exception: crash!!!
   at Submission#0.<<Initialize>>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
...
```

### With the PR

```
λ csi.exe error.csx
hello world
System.Exception: crash!!!
   at Submission#0.<<Initialize>>d__0.MoveNext() in X:\Documents\dev\csharp-scripting-demos\error.csx:line 3
--- End of stack trace from previous location where exception was thrown ---
...
```
