### PR TITLE
Warn when using static member on derived type

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -5971,6 +5971,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     resultKind = LookupResultKind.StaticInstanceMismatch;
                     return true;
                 }
+
+                if (receiver != null && symbol.ContainingType != receiver.Type)
+                {
+                    Error(diagnostics, ErrorCode.WRN_StaticMemberAccessThroughDerivedType, node, symbol, receiver.Type);
+                }
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -995,6 +995,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                                              receiver,
                                              diagnostics);
                 }
+                else
+                {
+                    if ((object)receiver != null && method.ContainingType != receiver.Type)
+                    {
+                        Error(diagnostics, ErrorCode.WRN_StaticMemberAccessThroughDerivedType, node, method, receiver.Type);
+                    }
+                }
 
                 return new BoundCall(node, receiver, method, args, argNames, argRefKinds, isDelegateCall: false,
                             expanded: expanded, invokedAsExtensionMethod: invokedAsExtensionMethod,

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -13553,6 +13553,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A reference to static member &apos;{0}&apos; was made through the derived type &apos;{1}&apos;..
+        /// </summary>
+        internal static string WRN_StaticMemberAccessThroughDerivedType {
+            get {
+                return ResourceManager.GetString("WRN_StaticMemberAccessThroughDerivedType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Source file has exceeded the limit of 16,707,565 lines representable in the PDB; debug information will be incorrect.
         /// </summary>
         internal static string WRN_TooManyLinesForDebugger {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5014,4 +5014,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TypeForwardedToMultipleAssemblies" xml:space="preserve">
     <value>Module '{0}' in assembly '{1}' is forwarding the type '{2}' to multiple assemblies: '{3}' and '{4}'.</value>
   </data>
+  <data name="WRN_StaticMemberAccessThroughDerivedType" xml:space="preserve">
+    <value>A reference to static member '{0}' was made through the derived type '{1}'.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1457,6 +1457,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AttributesInLocalFuncDecl = 8205,
         ERR_TypeForwardedToMultipleAssemblies = 8206,
         ERR_ExpressionTreeContainsDiscard = 8207,
+        WRN_StaticMemberAccessThroughDerivedType = 8208,
         #endregion more stragglers for C# 7
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -223,6 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_MainIgnored:
                 case ErrorCode.WRN_UnqualifiedNestedTypeInCref:
                 case ErrorCode.WRN_NoRuntimeMetadataVersion:
+                case ErrorCode.WRN_StaticMemberAccessThroughDerivedType:
                     return 2;
                 case ErrorCode.WRN_IsAlwaysTrue:
                 case ErrorCode.WRN_IsAlwaysFalse:

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -235,6 +235,7 @@ class X
                         case ErrorCode.WRN_NubExprIsConstBool2:
                         case ErrorCode.WRN_UnqualifiedNestedTypeInCref:
                         case ErrorCode.WRN_NoRuntimeMetadataVersion:
+                        case ErrorCode.WRN_StaticMemberAccessThroughDerivedType:
                             Assert.Equal(2, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_PdbLocalNameTooLong:


### PR DESCRIPTION
Resolves #13882.

New warning code used: CS8208.