### PR TITLE
Ensure script compilations properly inherit return type from first compilation

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -510,7 +510,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _options,
                 this.ExternalReferences,
                 info?.PreviousScriptCompilation,
-                info?.ReturnType,
+                info?.ReturnTypeOpt,
                 info?.GlobalsType,
                 info != null,
                 _referenceManager,

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpScriptCompilationInfo.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpScriptCompilationInfo.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override Compilation CommonPreviousScriptCompilation => PreviousScriptCompilation;
 
         public CSharpScriptCompilationInfo WithPreviousScriptCompilation(CSharpCompilation compilation) =>
-            (compilation == PreviousScriptCompilation) ? this : new CSharpScriptCompilationInfo(compilation, ReturnType, GlobalsType);
+            (compilation == PreviousScriptCompilation) ? this : new CSharpScriptCompilationInfo(compilation, ReturnTypeOpt, GlobalsType);
 
         internal override ScriptCompilationInfo CommonWithPreviousScriptCompilation(Compilation compilation) =>
             WithPreviousScriptCompilation((CSharpCompilation)compilation);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -1583,6 +1583,7 @@ class A
         }
 
         [WorkItem(8506, "https://github.com/dotnet/roslyn/issues/8506")]
+        [WorkItem(17403, "https://github.com/dotnet/roslyn/issues/17403")]
         [Fact]
         public void CrossCorlibSystemObjectReturnType_Script()
         {
@@ -1592,21 +1593,42 @@ class A
             //
             // In the original bug, Xamarin iOS, Android, and Mac Mobile profile corlibs were
             // realistic cross-compilation targets.
-            var compilation = CSharpCompilation.CreateScriptCompilation(
-                "submission-assembly",
-                references: new [] { MinAsyncCorlibRef },
+
+            void AssertCompilationCorlib(CSharpCompilation compilation)
+            {
+                Assert.True(compilation.IsSubmission);
+
+                var taskOfT = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
+                var taskOfObject = taskOfT.Construct(compilation.ObjectType);
+                var entryPoint = compilation.GetEntryPoint(default(CancellationToken));
+
+                Assert.Same(compilation.ObjectType.ContainingAssembly, taskOfT.ContainingAssembly);
+                Assert.Same(compilation.ObjectType.ContainingAssembly, taskOfObject.ContainingAssembly);
+                Assert.Equal(taskOfObject, entryPoint.ReturnType);
+            }
+
+            var firstCompilation = CSharpCompilation.CreateScriptCompilation(
+                "submission-assembly-1",
+                references: new[] { MinAsyncCorlibRef },
                 syntaxTree: Parse("true", options: TestOptions.Script)
             ).VerifyDiagnostics();
 
-            Assert.True(compilation.IsSubmission);
+            AssertCompilationCorlib(firstCompilation);
 
-            var taskOfT = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
-            var taskOfObject = taskOfT.Construct(compilation.ObjectType);
-            var entryPoint = compilation.GetEntryPoint(default(CancellationToken));
+            var secondCompilation = CSharpCompilation.CreateScriptCompilation(
+                "submission-assembly-2",
+                previousScriptCompilation: firstCompilation,
+                syntaxTree: Parse("false", options: TestOptions.Script))
+                .WithScriptCompilationInfo(new CSharpScriptCompilationInfo(firstCompilation, null, null))
+                .VerifyDiagnostics();
 
-            Assert.Same(compilation.ObjectType.ContainingAssembly, taskOfT.ContainingAssembly);
-            Assert.Same(compilation.ObjectType.ContainingAssembly, taskOfObject.ContainingAssembly);
-            Assert.Equal(taskOfObject, entryPoint.ReturnType);
+            AssertCompilationCorlib(secondCompilation);
+
+            Assert.Same(firstCompilation.ObjectType, secondCompilation.ObjectType);
+
+            Assert.Null(new CSharpScriptCompilationInfo(null, null, null)
+                .WithPreviousScriptCompilation(firstCompilation)
+                .ReturnTypeOpt);
         }
 
         [WorkItem(3719, "https://github.com/dotnet/roslyn/issues/3719")]

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -669,7 +669,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 _embeddedTrees,
                 _declarationTable,
                 info?.PreviousScriptCompilation,
-                info?.ReturnType,
+                info?.ReturnTypeOpt,
                 info?.GlobalsType,
                 info IsNot Nothing,
                 _referenceManager,

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicScriptCompilationInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicScriptCompilationInfo.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
 
         Public Shadows Function WithPreviousScriptCompilation(compilation As VisualBasicCompilation) As VisualBasicScriptCompilationInfo
-            Return If(compilation Is PreviousScriptCompilation, Me, New VisualBasicScriptCompilationInfo(compilation, ReturnType, GlobalsType))
+            Return If(compilation Is PreviousScriptCompilation, Me, New VisualBasicScriptCompilationInfo(compilation, ReturnTypeOpt, GlobalsType))
         End Function
 
         Friend Overrides Function CommonWithPreviousScriptCompilation(compilation As Compilation) As ScriptCompilationInfo


### PR DESCRIPTION
This fixes #17403 which prevents Xamarin Workbooks from moving to the upstream Roslyn 2.0 NuGet. Related to, and expands upon, #8507 _(Compilation: use System.Object from target corlib)_.

### Before

<img width="628" alt="screen shot 2017-02-26 at 3 44 52 pm" src="https://cloud.githubusercontent.com/assets/49539/23343577/cee69cf6-fc3b-11e6-9537-0c6ff8bd1f23.png">

### After

<img width="628" alt="screen shot 2017-02-26 at 3 51 05 pm" src="https://cloud.githubusercontent.com/assets/49539/23343580/d6d61748-fc3b-11e6-9c25-b0f2c7695e21.png">

