### PR TITLE
Search entire DLLs directory for perf tests

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -116,7 +116,7 @@ if defined TestPerfRun (
 
     call :TerminateBuildProcesses || goto :BuildFailed
 
-    .\Binaries\%BuildConfiguration%\Exes\Perf.Runner\Roslyn.Test.Performance.Runner.exe  --search-directory=".\\Binaries\\%BuildConfiguration%\\Dlls\\Perf.Tests\\" --no-trace-upload !EXTRA_PERF_RUNNER_ARGS! || goto :BuildFailed
+    .\Binaries\%BuildConfiguration%\Exes\Perf.Runner\Roslyn.Test.Performance.Runner.exe  --search-directory=".\\Binaries\\%BuildConfiguration%\\Dlls\\" --no-trace-upload !EXTRA_PERF_RUNNER_ARGS! || goto :BuildFailed
     exit /b 0
 )
 


### PR DESCRIPTION
@TyOverby this is necessary now that closedperfopenpullrequest.cmd invokes run_perf.ps1 directly