### PR TITLE
Fix IsCurrentContext for newly opened source files for CPS projects

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
@@ -713,19 +713,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
             else
             {
-                NewBufferOpened(docCookie, textBuffer, documentKeyOpt, IsCurrentContext(docCookie, documentKeyOpt));
+                NewBufferOpened(docCookie, textBuffer, documentKeyOpt, IsCurrentContext(documentKeyOpt));
             }
         }
 
-        private bool IsCurrentContext(uint docCookie, DocumentKey documentKey)
+        private bool IsCurrentContext(DocumentKey documentKey)
         {
             AssertIsForeground();
-            _runningDocumentTable.GetDocumentHierarchyItem(docCookie, out var hierarchy, out var itemid);
-
-            // If it belongs to a Shared Code or ASP.NET 5 project, then find the correct host project
-            var hostProject = LinkedFileUtilities.GetContextHostProject(hierarchy, _projectContainer);
-
-            return documentKey.HostProject == hostProject;
+            var document = documentKey.HostProject.GetCurrentDocumentFromPath(documentKey.Moniker);
+            return document != null && LinkedFileUtilities.IsCurrentContextHierarchy(document, _runningDocumentTable);
         }
 
         public IDisposable ProvideDocumentIdHint(string filePath, DocumentId documentId)


### PR DESCRIPTION
Current implementation of this method directly uses the document hierarchy from the running document table. For CPS projects, we create a wrapper hierarchy on top of the underlying project hierarchy, and pass this into the Roslyn's AbstractProject. This wrapper hieararchy implements the properties related to shared hierarchy (see [here](http://index/?query=UnConfiguredProjectH&rightProject=Microsoft.VisualStudio.ProjectSystem.Managed.VS&file=ProjectSystem%5CVS%5CLanguageServices%5CUnconfiguredProjectHostObject.cs&line=51)), and needs to be used for determining the current context. Current implementation of IsCurrentContext doesn't go via this hierarchy and hence causes the below bug. [LinkedFileUtilities.IsCurrentContextHierarchy](http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/Implementation/ProjectSystem/LinkedFileUtilities.cs,a3d3388af3d5074f) helper already handles this correctly and is used by the fix.

Fixes https://github.com/dotnet/roslyn-project-system/issues/1613