### PR TITLE
Implemented  ref conditional operator (aka: ternary ref)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3509,39 +3509,36 @@ namespace Microsoft.CodeAnalysis.CSharp
                     type = bestType;
                     hasErrors = true;
                 }
-                else
+                else if (isRef)
                 {
-                    if (isRef)
+                    if (!Conversions.HasIdentityConversion(trueType, falseType))
                     {
-                        if (!Conversions.HasIdentityConversion(trueType, falseType))
-                        {
-                            diagnostics.Add(ErrorCode.ERR_RefConditionalDifferentTypes, falseExpr.Syntax.Location, trueType);
-                            type = CreateErrorType();
-                            hasErrors = true;
-                        }
-                        else
-                        {
-                            Debug.Assert(Conversions.HasIdentityConversion(trueType, bestType));
-                            Debug.Assert(Conversions.HasIdentityConversion(falseType, bestType));
-                            type = bestType;
-                        }
+                        diagnostics.Add(ErrorCode.ERR_RefConditionalDifferentTypes, falseExpr.Syntax.Location, trueType);
+                        type = CreateErrorType();
+                        hasErrors = true;
                     }
                     else
                     {
-                        trueExpr = GenerateConversionForAssignment(bestType, trueExpr, diagnostics);
-                        falseExpr = GenerateConversionForAssignment(bestType, falseExpr, diagnostics);
+                        Debug.Assert(Conversions.HasIdentityConversion(trueType, bestType));
+                        Debug.Assert(Conversions.HasIdentityConversion(falseType, bestType));
+                        type = bestType;
+                    }
+                }
+                else
+                {
+                    trueExpr = GenerateConversionForAssignment(bestType, trueExpr, diagnostics);
+                    falseExpr = GenerateConversionForAssignment(bestType, falseExpr, diagnostics);
 
-                        if (trueExpr.HasAnyErrors || falseExpr.HasAnyErrors)
-                        {
-                            // If one of the conversions went wrong (e.g. return type of method group being converted
-                            // didn't match), then we don't want to use bestType because it's not accurate.
-                            type = CreateErrorType();
-                            hasErrors = true;
-                        }
-                        else
-                        {
-                            type = bestType;
-                        }
+                    if (trueExpr.HasAnyErrors || falseExpr.HasAnyErrors)
+                    {
+                        // If one of the conversions went wrong (e.g. return type of method group being converted
+                        // didn't match), then we don't want to use bestType because it's not accurate.
+                        type = CreateErrorType();
+                        hasErrors = true;
+                    }
+                    else
+                    {
+                        type = bestType;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -3419,9 +3419,30 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         private BoundExpression BindConditionalOperator(ConditionalExpressionSyntax node, DiagnosticBag diagnostics)
         {
+            var whenTrue = node.WhenTrue.SkipRef(out var whenTrueRefKind);
+            var whenFalse = node.WhenFalse.SkipRef(out var whenFalseRefKind);
+
+            var isRef = whenTrueRefKind == RefKind.Ref  && whenFalseRefKind == RefKind.Ref;
+
+            if (!isRef)
+            {
+                if (whenFalseRefKind == RefKind.Ref)
+                {
+                    diagnostics.Add(ErrorCode.ERR_RefConditionalNeedsTwoRefs, whenFalse.GetFirstToken().GetLocation());
+                }
+
+                if (whenTrueRefKind == RefKind.Ref)
+                {
+                    diagnostics.Add(ErrorCode.ERR_RefConditionalNeedsTwoRefs, whenTrue.GetFirstToken().GetLocation());
+                }
+           }
+
             BoundExpression condition = BindBooleanExpression(node.Condition, diagnostics);
-            BoundExpression trueExpr = BindValue(node.WhenTrue, diagnostics, BindValueKind.RValue);
-            BoundExpression falseExpr = BindValue(node.WhenFalse, diagnostics, BindValueKind.RValue);
+
+            var valKind = isRef ? BindValueKind.RefOrOut : BindValueKind.RValue;
+
+            BoundExpression trueExpr = BindValue(whenTrue, diagnostics, valKind);
+            BoundExpression falseExpr = BindValue(whenFalse, diagnostics, valKind);
 
             TypeSymbol trueType = trueExpr.Type;
             TypeSymbol falseType = falseExpr.Type;
@@ -3490,19 +3511,37 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    trueExpr = GenerateConversionForAssignment(bestType, trueExpr, diagnostics);
-                    falseExpr = GenerateConversionForAssignment(bestType, falseExpr, diagnostics);
-
-                    if (trueExpr.HasAnyErrors || falseExpr.HasAnyErrors)
+                    if (isRef)
                     {
-                        // If one of the conversions went wrong (e.g. return type of method group being converted
-                        // didn't match), then we don't want to use bestType because it's not accurate.
-                        type = CreateErrorType();
-                        hasErrors = true;
+                        if (!Conversions.HasIdentityConversion(trueType, falseType))
+                        {
+                            diagnostics.Add(ErrorCode.ERR_RefConditionalDifferentTypes, falseExpr.Syntax.Location, trueType);
+                            type = CreateErrorType();
+                            hasErrors = true;
+                        }
+                        else
+                        {
+                            Debug.Assert(Conversions.HasIdentityConversion(trueType, bestType));
+                            Debug.Assert(Conversions.HasIdentityConversion(falseType, bestType));
+                            type = bestType;
+                        }
                     }
                     else
                     {
-                        type = bestType;
+                        trueExpr = GenerateConversionForAssignment(bestType, trueExpr, diagnostics);
+                        falseExpr = GenerateConversionForAssignment(bestType, falseExpr, diagnostics);
+
+                        if (trueExpr.HasAnyErrors || falseExpr.HasAnyErrors)
+                        {
+                            // If one of the conversions went wrong (e.g. return type of method group being converted
+                            // didn't match), then we don't want to use bestType because it's not accurate.
+                            type = CreateErrorType();
+                            hasErrors = true;
+                        }
+                        else
+                        {
+                            type = bestType;
+                        }
                     }
                 }
             }
@@ -3515,7 +3554,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors = constantValue != null && constantValue.IsBad;
             }
 
-            return new BoundConditionalOperator(node, condition, trueExpr, falseExpr, constantValue, type, hasErrors);
+            return new BoundConditionalOperator(node, isRef, condition, trueExpr, falseExpr, constantValue, type, hasErrors);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1521,6 +1521,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
+            var conditional = expr as BoundConditionalOperator;
+            if (conditional != null)
+            {
+                if (kind == BindValueKind.RefReturn)
+                {
+                    var returnable = CheckIsVariable(conditional.Consequence.Syntax, conditional.Consequence, kind, checkingReceiver:false, diagnostics: diagnostics) &
+                        CheckIsVariable(conditional.Alternative.Syntax, conditional.Alternative, kind, checkingReceiver:false, diagnostics: diagnostics);
+
+                    return returnable;
+                }
+                else if (conditional.IsByref)
+                {
+                    return true;
+                }
+                else
+                {
+                    Error(diagnostics, GetStandardLvalueError(kind), node);
+                }
+
+                return false;
+            }
+
             // Local constants are never variables. Local variables are sometimes
             // not to be treated as variables, if they are fixed, declared in a using, 
             // or declared in a foreach.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1531,7 +1531,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     return returnable;
                 }
-                else if (conditional.IsByref)
+                else if (conditional.IsByRef)
                 {
                     return true;
                 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -426,7 +426,7 @@
   <Node Name="BoundConditionalOperator" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-
+    <Field Name="IsByref" Type="bool"/>
     <Field Name="Condition" Type="BoundExpression"/>
     <Field Name="Consequence" Type="BoundExpression"/>
     <Field Name="Alternative" Type="BoundExpression"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -426,7 +426,7 @@
   <Node Name="BoundConditionalOperator" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-    <Field Name="IsByref" Type="bool"/>
+    <Field Name="IsByRef" Type="bool"/>
     <Field Name="Condition" Type="BoundExpression"/>
     <Field Name="Consequence" Type="BoundExpression"/>
     <Field Name="Alternative" Type="BoundExpression"/>

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2258,6 +2258,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;await&apos; cannot be used in an expression containing a ref conditional operator.
+        /// </summary>
+        internal static string ERR_ByRefConditionalAndAwait {
+            get {
+                return ResourceManager.GetString("ERR_ByRefConditionalAndAwait", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A declaration of a by-reference variable must have an initializer.
         /// </summary>
         internal static string ERR_ByReferenceVariableMustBeInitialized {
@@ -7906,6 +7915,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_RefAssignmentMustHaveIdentityConversion {
             get {
                 return ResourceManager.GetString("ERR_RefAssignmentMustHaveIdentityConversion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The expression must be of type &apos;{0}&apos; to match the alternative ref value.
+        /// </summary>
+        internal static string ERR_RefConditionalDifferentTypes {
+            get {
+                return ResourceManager.GetString("ERR_RefConditionalDifferentTypes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Both or none of conditional operator expressions can be ref values.
+        /// </summary>
+        internal static string ERR_RefConditionalNeedsTwoRefs {
+            get {
+                return ResourceManager.GetString("ERR_RefConditionalNeedsTwoRefs", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2260,9 +2260,9 @@ namespace Microsoft.CodeAnalysis.CSharp {
         /// <summary>
         ///   Looks up a localized string similar to &apos;await&apos; cannot be used in an expression containing a ref conditional operator.
         /// </summary>
-        internal static string ERR_ByRefConditionalAndAwait {
+        internal static string ERR_RefConditionalAndAwait {
             get {
-                return ResourceManager.GetString("ERR_ByRefConditionalAndAwait", resourceCulture);
+                return ResourceManager.GetString("ERR_RefConditionalAndAwait", resourceCulture);
             }
         }
         
@@ -7928,7 +7928,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Both or none of conditional operator expressions can be ref values.
+        ///   Looks up a localized string similar to Both conditional operator values must be ref values or neither may be a ref value.
         /// </summary>
         internal static string ERR_RefConditionalNeedsTwoRefs {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4834,6 +4834,15 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_RefReturningCallAndAwait" xml:space="preserve">
     <value>'await' cannot be used in an expression containing a call to '{0}' because it returns by reference</value>
   </data>
+  <data name="ERR_ByRefConditionalAndAwait" xml:space="preserve">
+    <value>'await' cannot be used in an expression containing a ref conditional operator</value>
+  </data>
+  <data name="ERR_RefConditionalNeedsTwoRefs" xml:space="preserve">
+    <value>Both or none of conditional operator expressions can be ref values</value>
+  </data>
+  <data name="ERR_RefConditionalDifferentTypes" xml:space="preserve">
+    <value>The expression must be of type '{0}' to match the alternative ref value</value>
+  </data>
   <data name="ERR_ExpressionTreeContainsLocalFunction" xml:space="preserve">
     <value>An expression tree may not contain a reference to a local function</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4834,11 +4834,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_RefReturningCallAndAwait" xml:space="preserve">
     <value>'await' cannot be used in an expression containing a call to '{0}' because it returns by reference</value>
   </data>
-  <data name="ERR_ByRefConditionalAndAwait" xml:space="preserve">
+  <data name="ERR_RefConditionalAndAwait" xml:space="preserve">
     <value>'await' cannot be used in an expression containing a ref conditional operator</value>
   </data>
   <data name="ERR_RefConditionalNeedsTwoRefs" xml:space="preserve">
-    <value>Both or none of conditional operator expressions can be ref values</value>
+    <value>Both conditional operator values must be ref values or neither may be a ref value</value>
   </data>
   <data name="ERR_RefConditionalDifferentTypes" xml:space="preserve">
     <value>The expression must be of type '{0}' to match the alternative ref value</value>

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 case BoundKind.ConditionalOperator:
                     var conditional = (BoundConditionalOperator)expression;
-                    if (!conditional.IsByref)
+                    if (!conditional.IsByRef)
                     {
                         goto default;
                     }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2162,6 +2162,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     }
                     break;
 
+                case BoundKind.ConditionalOperator:
+                    {
+                        var left = (BoundConditionalOperator)assignmentTarget;
+                        Debug.Assert(left.IsByref);
+
+                        var temp = EmitAddress(left, AddressKind.Writeable);
+                        Debug.Assert(temp == null, "taking ref of this should not create a temp");
+
+                        lhsUsesStack = true;
+                    }
+                    break;
+
                 case BoundKind.PointerIndirectionOperator:
                     {
                         var left = (BoundPointerIndirectionOperator)assignmentTarget;
@@ -2334,6 +2346,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 case BoundKind.Dup:
                     Debug.Assert(((BoundDup)expression).RefKind != RefKind.None);
+                    EmitIndirectStore(expression.Type, expression.Syntax);
+                    break;
+
+                case BoundKind.ConditionalOperator:
+                    Debug.Assert(((BoundConditionalOperator)expression).IsByref);
                     EmitIndirectStore(expression.Type, expression.Syntax);
                     break;
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2165,7 +2165,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 case BoundKind.ConditionalOperator:
                     {
                         var left = (BoundConditionalOperator)assignmentTarget;
-                        Debug.Assert(left.IsByref);
+                        Debug.Assert(left.IsByRef);
 
                         var temp = EmitAddress(left, AddressKind.Writeable);
                         Debug.Assert(temp == null, "taking ref of this should not create a temp");
@@ -2350,7 +2350,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     break;
 
                 case BoundKind.ConditionalOperator:
-                    Debug.Assert(((BoundConditionalOperator)expression).IsByref);
+                    Debug.Assert(((BoundConditionalOperator)expression).IsByRef);
                     EmitIndirectStore(expression.Type, expression.Syntax);
                     break;
 

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1001,6 +1001,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     Debug.Assert(((BoundCall)lhs).Method.RefKind == RefKind.Ref, "only ref returning methods are assignable");
                     return true;
 
+                case BoundKind.ConditionalOperator:
+                    Debug.Assert(((BoundConditionalOperator)lhs).IsByref, "only ref ternaries are assignable");
+                    return true;
+
                 case BoundKind.AssignmentOperator:
                     Debug.Assert(((BoundAssignmentOperator)lhs).RefKind == RefKind.Ref, "only ref assignments are assignable");
                     return true;
@@ -1239,21 +1243,23 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)
         {
             var origStack = StackDepth();
-            BoundExpression condition = (BoundExpression)this.Visit(node.Condition);
+            BoundExpression condition = (BoundExpression)this.VisitExpression(node.Condition, ExprContext.Value);
 
             var cookie = GetStackStateCookie();  // implicit goto here
 
+            var context = node.IsByref ? ExprContext.Address : ExprContext.Value;
+
             SetStackDepth(origStack);  // consequence is evaluated with original stack
-            BoundExpression consequence = (BoundExpression)this.Visit(node.Consequence);
+            BoundExpression consequence = (BoundExpression)this.VisitExpression(node.Consequence, context);
 
             EnsureStackState(cookie);   // implicit label here
 
             SetStackDepth(origStack);  // alternative is evaluated with original stack
-            BoundExpression alternative = (BoundExpression)this.Visit(node.Alternative);
+            BoundExpression alternative = (BoundExpression)this.VisitExpression(node.Alternative, context);
 
             EnsureStackState(cookie);   // implicit label here
 
-            return node.Update(condition, consequence, alternative, node.ConstantValueOpt, node.Type);
+            return node.Update(node.IsByref, condition, consequence, alternative, node.ConstantValueOpt, node.Type);
         }
 
         public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     return true;
 
                 case BoundKind.ConditionalOperator:
-                    Debug.Assert(((BoundConditionalOperator)lhs).IsByref, "only ref ternaries are assignable");
+                    Debug.Assert(((BoundConditionalOperator)lhs).IsByRef, "only ref ternaries are assignable");
                     return true;
 
                 case BoundKind.AssignmentOperator:
@@ -1243,23 +1243,23 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)
         {
             var origStack = StackDepth();
-            BoundExpression condition = (BoundExpression)this.VisitExpression(node.Condition, ExprContext.Value);
+            BoundExpression condition = this.VisitExpression(node.Condition, ExprContext.Value);
 
             var cookie = GetStackStateCookie();  // implicit goto here
 
-            var context = node.IsByref ? ExprContext.Address : ExprContext.Value;
+            var context = node.IsByRef ? ExprContext.Address : ExprContext.Value;
 
             SetStackDepth(origStack);  // consequence is evaluated with original stack
-            BoundExpression consequence = (BoundExpression)this.VisitExpression(node.Consequence, context);
+            BoundExpression consequence = this.VisitExpression(node.Consequence, context);
 
             EnsureStackState(cookie);   // implicit label here
 
             SetStackDepth(origStack);  // alternative is evaluated with original stack
-            BoundExpression alternative = (BoundExpression)this.VisitExpression(node.Alternative, context);
+            BoundExpression alternative = this.VisitExpression(node.Alternative, context);
 
             EnsureStackState(cookie);   // implicit label here
 
-            return node.Update(node.IsByref, condition, consequence, alternative, node.ConstantValueOpt, node.Type);
+            return node.Update(node.IsByRef, condition, consequence, alternative, node.ConstantValueOpt, node.Type);
         }
 
         public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1458,7 +1458,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_BadParameterModifiers = 8205,
 
-        ERR_ByRefConditionalAndAwait = 8301,
+        //PROTOTYPE(ReadonlyRefs): make err IDs contiguous before merging to master. 
+        //                         For now it is more convenient to have a gap to avoid conflicts with other added errors
+        ERR_RefConditionalAndAwait = 8301,
         ERR_RefConditionalNeedsTwoRefs = 8302,
         ERR_RefConditionalDifferentTypes = 8332,
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1457,5 +1457,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         #endregion more stragglers for C# 7
 
         ERR_BadParameterModifiers = 8205,
+
+        ERR_ByRefConditionalAndAwait = 8301,
+        ERR_RefConditionalNeedsTwoRefs = 8302,
+        ERR_RefConditionalDifferentTypes = 8332,
+
     }
 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2331,7 +2331,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public sealed override BoundNode VisitConditionalOperator(BoundConditionalOperator node)
         {
-            if (node.IsByref)
+            if (node.IsByRef)
             {
                 return VisitRefConditionalOperator(node);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -404,6 +404,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         goto default;
 
+                    case BoundKind.ConditionalOperator:
+                        var conditional = (BoundConditionalOperator)expression;
+                        if (refKind != RefKind.None)
+                        {
+                            Debug.Assert(conditional.IsByref);
+                            _F.Diagnostics.Add(ErrorCode.ERR_ByRefConditionalAndAwait, _F.Syntax.Location);
+                            refKind = RefKind.None; // Switch the RefKind to avoid asserting later in the pipeline
+                        }
+                        goto default;
+
                     case BoundKind.Literal:
                     case BoundKind.TypeExpression:
                         return expression;
@@ -807,7 +817,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (consequenceBuilder == null && alternativeBuilder == null)
             {
-                return UpdateExpression(conditionBuilder, node.Update(condition, consequence, alternative, node.ConstantValueOpt, node.Type));
+                return UpdateExpression(conditionBuilder, node.Update(node.IsByref, condition, consequence, alternative, node.ConstantValueOpt, node.Type));
             }
 
             if (conditionBuilder == null) conditionBuilder = new BoundSpillSequenceBuilder();

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -408,8 +408,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var conditional = (BoundConditionalOperator)expression;
                         if (refKind != RefKind.None)
                         {
-                            Debug.Assert(conditional.IsByref);
-                            _F.Diagnostics.Add(ErrorCode.ERR_ByRefConditionalAndAwait, _F.Syntax.Location);
+                            Debug.Assert(conditional.IsByRef);
+                            _F.Diagnostics.Add(ErrorCode.ERR_RefConditionalAndAwait, _F.Syntax.Location);
                             refKind = RefKind.None; // Switch the RefKind to avoid asserting later in the pipeline
                         }
                         goto default;
@@ -817,7 +817,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (consequenceBuilder == null && alternativeBuilder == null)
             {
-                return UpdateExpression(conditionBuilder, node.Update(node.IsByref, condition, consequence, alternative, node.ConstantValueOpt, node.Type));
+                return UpdateExpression(conditionBuilder, node.Update(node.IsByRef, condition, consequence, alternative, node.ConstantValueOpt, node.Type));
             }
 
             if (conditionBuilder == null) conditionBuilder = new BoundSpillSequenceBuilder();

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -1468,7 +1468,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 MakeBinaryOperator(syntax, kind, conditional.Alternative, right, type, method),
                                 ConstantValue.NotAvailable,
                                 type,
-                                false),
+                                isRef: false),
                             type);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -97,7 +97,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: boundTemp,
                 rewrittenAlternative: andOperatorCall,
                 constantValueOpt: null,
-                rewrittenType: type);
+                rewrittenType: type,
+                isRef: false);
 
             // temp = x; T.false(temp) ? temp : T.&(temp, y)
             return new BoundSequence(
@@ -966,7 +967,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: boolType);
+                rewrittenType: boolType,
+                isRef: false);
 
             // tempx = x; 
             // tempy = y;
@@ -1108,7 +1110,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     rewrittenConsequence: unliftedOp,
                     rewrittenAlternative: MakeLiteral(syntax, ConstantValue.Create(operatorKind == BinaryOperatorKind.Equal), boolType),
                     constantValueOpt: null,
-                    rewrittenType: boolType);
+                    rewrittenType: boolType,
+                    isRef: false);
             }
             else
             {
@@ -1125,7 +1128,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: boolType);
+                rewrittenType: boolType,
+                isRef: false);
 
             return new BoundSequence(
                 syntax: syntax,
@@ -1313,7 +1317,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: type);
+                rewrittenType: type,
+                isRef: false);
 
             return new BoundSequence(
                 syntax: syntax,
@@ -1462,7 +1467,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 MakeBinaryOperator(syntax, kind, conditional.Consequence, right, type, method),
                                 MakeBinaryOperator(syntax, kind, conditional.Alternative, right, type, method),
                                 ConstantValue.NotAvailable,
-                                type),
+                                type,
+                                false),
                             type);
                     }
                 }
@@ -1532,7 +1538,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     rewrittenConsequence: kind == BinaryOperatorKind.LiftedBoolAnd ? nullBool : newNullBool,
                     rewrittenAlternative: kind == BinaryOperatorKind.LiftedBoolAnd ? newNullBool : nullBool,
                     constantValueOpt: null,
-                    rewrittenType: alwaysNull.Type);
+                    rewrittenType: alwaysNull.Type,
+                    isRef: false);
             }
 
             // Now we optimize the case where one operand is null and the other is not. We generate
@@ -1558,7 +1565,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: alwaysNull.Type);
+                rewrittenType: alwaysNull.Type,
+                isRef: false);
             return new BoundSequence(
                 syntax: syntax,
                 locals: ImmutableArray.Create<LocalSymbol>(boundTemp.LocalSymbol),
@@ -1618,7 +1626,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: newNullBool.Type);
+                rewrittenType: newNullBool.Type,
+                isRef: false);
             return new BoundSequence(
                 syntax: syntax,
                 locals: ImmutableArray.Create<LocalSymbol>(boundTempX.LocalSymbol, boundTempY.LocalSymbol),
@@ -1702,7 +1711,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: alternative.Type);
+                rewrittenType: alternative.Type,
+                isRef: false);
 
             return new BoundSequence(
                 syntax: syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -535,6 +535,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(((BoundCall)originalLHS).Method.RefKind != RefKind.None);
                     break;
 
+                case BoundKind.ConditionalOperator:
+                    Debug.Assert(((BoundConditionalOperator)originalLHS).IsByref);
+                    break;
+
                 case BoundKind.AssignmentOperator:
                     Debug.Assert(((BoundAssignmentOperator)originalLHS).RefKind != RefKind.None);
                     break;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
 
                 case BoundKind.ConditionalOperator:
-                    Debug.Assert(((BoundConditionalOperator)originalLHS).IsByref);
+                    Debug.Assert(((BoundConditionalOperator)originalLHS).IsByRef);
                     break;
 
                 case BoundKind.AssignmentOperator:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             _factory.Default(nodeType),
                             null,
                             nodeType,
-                            false);
+                            isRef: false);
 
                         if (temp != null)
                         {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -178,7 +178,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             consequence,
                             _factory.Default(nodeType),
                             null,
-                            nodeType);
+                            nodeType,
+                            false);
 
                         if (temp != null)
                         {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (rewrittenCondition.ConstantValue == null)
             {
-                return node.Update(node.IsByref, rewrittenCondition, rewrittenConsequence, rewrittenAlternative, node.ConstantValueOpt, node.Type);
+                return node.Update(node.IsByRef, rewrittenCondition, rewrittenConsequence, rewrittenAlternative, node.ConstantValueOpt, node.Type);
             }
 
             return RewriteConditionalOperator(
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenAlternative,
                 node.ConstantValueOpt,
                 node.Type,
-                node.IsByref);
+                node.IsByRef);
         }
 
         private static BoundExpression RewriteConditionalOperator(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (rewrittenCondition.ConstantValue == null)
             {
-                return node.Update(rewrittenCondition, rewrittenConsequence, rewrittenAlternative, node.ConstantValueOpt, node.Type);
+                return node.Update(node.IsByref, rewrittenCondition, rewrittenConsequence, rewrittenAlternative, node.ConstantValueOpt, node.Type);
             }
 
             return RewriteConditionalOperator(
@@ -33,7 +33,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence,
                 rewrittenAlternative,
                 node.ConstantValueOpt,
-                node.Type);
+                node.Type,
+                node.IsByref);
         }
 
         private static BoundExpression RewriteConditionalOperator(
@@ -42,7 +43,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rewrittenConsequence,
             BoundExpression rewrittenAlternative,
             ConstantValue constantValueOpt,
-            TypeSymbol rewrittenType)
+            TypeSymbol rewrittenType,
+            bool isRef)
         {
             // NOTE: This optimization assumes that a constant has no side effects. In the future we 
             // might wish to represent nodes that are known to the optimizer as having constant
@@ -62,6 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return new BoundConditionalOperator(
                     syntax,
+                    isRef,
                     rewrittenCondition,
                     rewrittenConsequence,
                     rewrittenAlternative,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -969,7 +969,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 MakeConversionNode(null, syntax, conditional.Alternative, conversion, @checked, explicitCastInCode: false, constantValueOpt: ConstantValue.NotAvailable, rewrittenType: type),
                                 ConstantValue.NotAvailable,
                                 type,
-                                false),
+                                isRef: false),
                             type);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -841,7 +841,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: type);
+                rewrittenType: type,
+                isRef: false);
 
             return new BoundSequence(
                 syntax: syntax,
@@ -967,7 +968,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 MakeConversionNode(null, syntax, conditional.Consequence, conversion, @checked, explicitCastInCode: false, constantValueOpt: ConstantValue.NotAvailable, rewrittenType: type),
                                 MakeConversionNode(null, syntax, conditional.Alternative, conversion, @checked, explicitCastInCode: false, constantValueOpt: ConstantValue.NotAvailable, rewrittenType: type),
                                 ConstantValue.NotAvailable,
-                                type),
+                                type,
+                                false),
                             type);
                     }
                 }
@@ -1080,7 +1082,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: rewrittenType);
+                rewrittenType: rewrittenType,
+                isRef: false);
 
             // temp = operand
             // temp.HasValue ? new R?(op_Whatever(temp.GetValueOrDefault())) : default(R?)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             //(((temp = array) != null && temp.Length != 0) ? loc = &temp[0] : loc = null)
             BoundStatement localInit = factory.ExpressionStatement(
-                new BoundConditionalOperator(factory.Syntax, condition, consequenceAssignment, alternativeAssignment, ConstantValue.NotAvailable, localType));
+                new BoundConditionalOperator(factory.Syntax,false, condition, consequenceAssignment, alternativeAssignment, ConstantValue.NotAvailable, localType));
 
             return InstrumentLocalDeclarationIfNecessary(localDecl, localSymbol, localInit);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -125,7 +125,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: convertedLeft,
                 rewrittenAlternative: rewrittenRight,
                 constantValueOpt: null,
-                rewrittenType: rewrittenResultType);
+                rewrittenType: rewrittenResultType,
+                isRef: false);
 
             Debug.Assert(conditionalExpression.ConstantValue == null); // we shouldn't have hit this else case otherwise
             Debug.Assert(conditionalExpression.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamicAndTupleNames));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 MakeUnaryOperator(operatorKind, syntax, method, conditional.Alternative, type),
                                 ConstantValue.NotAvailable,
                                 type,
-                                false),
+                                isRef: false),
                             type);
                     }
                 }
@@ -808,7 +808,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression alternative = new BoundDefaultOperator(syntax, null, operand.Type);
 
             // x.HasValue ? new decimal?(op_Inc(x.GetValueOrDefault())) : default(decimal?)
-            return RewriteConditionalOperator(syntax, condition, consequence, alternative, ConstantValue.NotAvailable, operand.Type, false);
+            return RewriteConditionalOperator(syntax, condition, consequence, alternative, ConstantValue.NotAvailable, operand.Type, isRef: false);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -210,7 +210,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: type);
+                rewrittenType: type,
+                isRef: false);
 
             // temp = operand; 
             // temp.HasValue ? 
@@ -322,7 +323,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 MakeUnaryOperator(operatorKind, syntax, method, conditional.Consequence, type),
                                 MakeUnaryOperator(operatorKind, syntax, method, conditional.Alternative, type),
                                 ConstantValue.NotAvailable,
-                                type),
+                                type,
+                                false),
                             type);
                     }
                 }
@@ -647,7 +649,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenConsequence: consequence,
                 rewrittenAlternative: alternative,
                 constantValueOpt: null,
-                rewrittenType: type);
+                rewrittenType: type,
+                isRef: false);
 
             // temp = operand; 
             // temp.HasValue ? 
@@ -805,7 +808,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression alternative = new BoundDefaultOperator(syntax, null, operand.Type);
 
             // x.HasValue ? new decimal?(op_Inc(x.GetValueOrDefault())) : default(decimal?)
-            return RewriteConditionalOperator(syntax, condition, consequence, alternative, ConstantValue.NotAvailable, operand.Type);
+            return RewriteConditionalOperator(syntax, condition, consequence, alternative, ConstantValue.NotAvailable, operand.Type, false);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -566,8 +566,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var conditional = (BoundConditionalOperator)expr;
                     if (isRef)
                     {
-                        Debug.Assert(conditional.IsByref);
-                        F.Diagnostics.Add(ErrorCode.ERR_ByRefConditionalAndAwait, F.Syntax.Location);
+                        Debug.Assert(conditional.IsByRef);
+                        F.Diagnostics.Add(ErrorCode.ERR_RefConditionalAndAwait, F.Syntax.Location);
                         isRef = false; // Switch to ByVal to avoid asserting later in the pipeline
                     }
                     goto default;

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -552,6 +552,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.DefaultOperator:
                     return expr;
 
+                case BoundKind.Call:
+                    var call = (BoundCall)expr;
+                    if (isRef)
+                    {
+                        Debug.Assert(call.Method.RefKind != RefKind.None);
+                        F.Diagnostics.Add(ErrorCode.ERR_RefReturningCallAndAwait, F.Syntax.Location, call.Method);
+                        isRef = false; // Switch to ByVal to avoid asserting later in the pipeline
+                    }
+                    goto default;
+
+                case BoundKind.ConditionalOperator:
+                    var conditional = (BoundConditionalOperator)expr;
+                    if (isRef)
+                    {
+                        Debug.Assert(conditional.IsByref);
+                        F.Diagnostics.Add(ErrorCode.ERR_ByRefConditionalAndAwait, F.Syntax.Location);
+                        isRef = false; // Switch to ByVal to avoid asserting later in the pipeline
+                    }
+                    goto default;
+
                 default:
                     if (expr.ConstantValue != null)
                     {

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -653,7 +653,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundExpression Conditional(BoundExpression condition, BoundExpression consequence, BoundExpression alternative, TypeSymbol type)
         {
-            return new BoundConditionalOperator(Syntax, condition, consequence, alternative, default(ConstantValue), type) { WasCompilerGenerated = true };
+            return new BoundConditionalOperator(Syntax, false, condition, consequence, alternative, default(ConstantValue), type) { WasCompilerGenerated = true };
         }
 
         public BoundExpression ComplexConditionalReceiver(BoundExpression valueTypeReceiver, BoundExpression referenceTypeReceiver)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9507,9 +9507,9 @@ tryAgain:
             if (tk == SyntaxKind.QuestionToken && precedence <= Precedence.Ternary)
             {
                 var questionToken = this.EatToken();
-                var colonLeft = this.ParseExpressionCore();
+                var colonLeft = this.ParsePossibleRefExpression();
                 var colon = this.EatToken(SyntaxKind.ColonToken);
-                var colonRight = this.ParseExpressionCore();
+                var colonRight = this.ParsePossibleRefExpression();
                 leftOperand = _syntaxFactory.ConditionalExpression(leftOperand, questionToken, colonLeft, colon, colonRight);
             }
 

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -74,6 +74,7 @@
     <Compile Include="CodeGen\CodeGenInParametersTests.cs" />
     <Compile Include="CodeGen\CodeGenCapturing.cs" />
     <Compile Include="CodeGen\CodeGenRefReadonlyReturnTests.cs" />
+    <Compile Include="CodeGen\CodeGenRefConditionalOperatorTests.cs" />
     <Compile Include="Emit\BinaryCompatibility.cs" />
     <Compile Include="Emit\DesktopStrongNameProviderTests.cs" />
     <Compile Include="Attributes\InternalsVisibleToAndStrongNameTests.cs" />

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
@@ -700,7 +700,7 @@ class C
         }
 
         [Fact]
-        public void TestRefConditionlalUnsafeToReturn3()
+        public void TestRefConditionalUnsafeToReturn3()
         {
             var source = @"
 class C
@@ -782,7 +782,7 @@ class C
         }
 
         [Fact]
-        public void TestRefConditionlalDifferentTypes1()
+        public void TestRefConditionalDifferentTypes1()
         {
             var source = @"
 class C
@@ -808,7 +808,7 @@ class C
         }
 
         [Fact]
-        public void TestRefConditionlalDifferentTypes2()
+        public void TestRefConditionalDifferentTypes2()
         {
             var source = @"
 class C
@@ -833,7 +833,7 @@ class C
         }
 
         [Fact]
-        public void TestRefConditionlalDifferentTypes3()
+        public void TestRefConditionalDifferentTypes3()
         {
             var source = @"
 class C
@@ -871,7 +871,7 @@ class C
         }
 
         [Fact]
-        public void TestRefConditionlalDifferentTypes4()
+        public void TestRefConditionalDifferentTypes4()
         {
             var source = @"
 class C

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefConditionalOperatorTests.cs
@@ -1,0 +1,799 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    public class CodeGenRefConditionalOperatorTests : CSharpTestBase
+    {
+        [Fact]
+        public void TestRefConditionalOperatorInRefReturn()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.Write(Test1(true));
+        System.Console.Write(Test2(false));
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+
+    static ref int Test1(bool b)
+    {
+        return ref b ? ref val1 : ref val2;
+    }
+
+    static ref int Test2(bool b) => ref b ? ref val1 : ref val2;
+
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "3344");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Test1", @"
+{
+  // Code size       15 (0xf)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  brtrue.s   IL_0009
+  IL_0003:  ldsflda    ""int C.val2""
+  IL_0008:  ret
+  IL_0009:  ldsflda    ""int C.val1""
+  IL_000e:  ret
+}
+");
+
+            comp.VerifyIL("C.Test2", @"
+{
+  // Code size       15 (0xf)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  brtrue.s   IL_0009
+  IL_0003:  ldsflda    ""int C.val2""
+  IL_0008:  ret
+  IL_0009:  ldsflda    ""int C.val1""
+  IL_000e:  ret
+}
+");
+
+        }
+
+        [Fact]
+        public void TestRefConditionalOperatorInRefArgument()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+        System.Console.Write(
+                            M1(ref b? 
+                                   ref val1: 
+                                   ref val2));
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+
+    static ref int M1(ref int arg) => ref arg;
+
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "44", verify: false);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       27 (0x1b)
+  .maxstack  1
+  IL_0000:  ldc.i4.0
+  IL_0001:  brtrue.s   IL_000a
+  IL_0003:  ldsflda    ""int C.val2""
+  IL_0008:  br.s       IL_000f
+  IL_000a:  ldsflda    ""int C.val1""
+  IL_000f:  call       ""ref int C.M1(ref int)""
+  IL_0014:  ldind.i4
+  IL_0015:  call       ""void System.Console.Write(int)""
+  IL_001a:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRefConditionalOperatoAsValue()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+
+        System.Console.Write(b? ref val1: ref val2);
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "44", verify: false);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       21 (0x15)
+  .maxstack  1
+  IL_0000:  ldc.i4.0
+  IL_0001:  brtrue.s   IL_000a
+  IL_0003:  ldsfld     ""int C.val2""
+  IL_0008:  br.s       IL_000f
+  IL_000a:  ldsfld     ""int C.val1""
+  IL_000f:  call       ""void System.Console.Write(int)""
+  IL_0014:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRefConditionalOperatorAssignmentTarget()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+
+        (b? ref val1: ref val2) = 55;
+
+        System.Console.Write(val2);
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "55", verify: false);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       29 (0x1d)
+  .maxstack  2
+  IL_0000:  ldc.i4.0
+  IL_0001:  brtrue.s   IL_000a
+  IL_0003:  ldsflda    ""int C.val2""
+  IL_0008:  br.s       IL_000f
+  IL_000a:  ldsflda    ""int C.val1""
+  IL_000f:  ldc.i4.s   55
+  IL_0011:  stind.i4
+  IL_0012:  ldsfld     ""int C.val2""
+  IL_0017:  call       ""void System.Console.Write(int)""
+  IL_001c:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRefConditionalOperatorAssignmentTargetUsed()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+         System.Console.Write((b? ref val1: ref val2) = 55);
+
+        System.Console.Write(val2);
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "5555", verify: false);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       37 (0x25)
+  .maxstack  3
+  .locals init (int V_0)
+  IL_0000:  ldc.i4.0
+  IL_0001:  brtrue.s   IL_000a
+  IL_0003:  ldsflda    ""int C.val2""
+  IL_0008:  br.s       IL_000f
+  IL_000a:  ldsflda    ""int C.val1""
+  IL_000f:  ldc.i4.s   55
+  IL_0011:  dup
+  IL_0012:  stloc.0
+  IL_0013:  stind.i4
+  IL_0014:  ldloc.0
+  IL_0015:  call       ""void System.Console.Write(int)""
+  IL_001a:  ldsfld     ""int C.val2""
+  IL_001f:  call       ""void System.Console.Write(int)""
+  IL_0024:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRefConditionalOperatorIncrement()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+        (b? ref val1: ref M1(ref val2)) ++;
+        (b? ref val1: ref M1(ref val2)) += 22;
+
+        System.Console.Write(val2);
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+
+    static ref int M1(ref int arg) => ref arg;
+
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "67", verify: false);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       62 (0x3e)
+  .maxstack  4
+  IL_0000:  ldc.i4.0
+  IL_0001:  dup
+  IL_0002:  brtrue.s   IL_0010
+  IL_0004:  ldsflda    ""int C.val2""
+  IL_0009:  call       ""ref int C.M1(ref int)""
+  IL_000e:  br.s       IL_0015
+  IL_0010:  ldsflda    ""int C.val1""
+  IL_0015:  dup
+  IL_0016:  ldind.i4
+  IL_0017:  ldc.i4.1
+  IL_0018:  add
+  IL_0019:  stind.i4
+  IL_001a:  brtrue.s   IL_0028
+  IL_001c:  ldsflda    ""int C.val2""
+  IL_0021:  call       ""ref int C.M1(ref int)""
+  IL_0026:  br.s       IL_002d
+  IL_0028:  ldsflda    ""int C.val1""
+  IL_002d:  dup
+  IL_002e:  ldind.i4
+  IL_002f:  ldc.i4.s   22
+  IL_0031:  add
+  IL_0032:  stind.i4
+  IL_0033:  ldsfld     ""int C.val2""
+  IL_0038:  call       ""void System.Console.Write(int)""
+  IL_003d:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRefConditionalOperatorIncrementUsed()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+        System.Console.Write((b? ref val1: ref val2) ++);
+        System.Console.Write((b? ref val1: ref val2) += 22);
+
+        System.Console.Write(val2);
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "446767", verify: false);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       68 (0x44)
+  .maxstack  4
+  .locals init (int V_0)
+  IL_0000:  ldc.i4.0
+  IL_0001:  dup
+  IL_0002:  brtrue.s   IL_000b
+  IL_0004:  ldsflda    ""int C.val2""
+  IL_0009:  br.s       IL_0010
+  IL_000b:  ldsflda    ""int C.val1""
+  IL_0010:  dup
+  IL_0011:  ldind.i4
+  IL_0012:  stloc.0
+  IL_0013:  ldloc.0
+  IL_0014:  ldc.i4.1
+  IL_0015:  add
+  IL_0016:  stind.i4
+  IL_0017:  ldloc.0
+  IL_0018:  call       ""void System.Console.Write(int)""
+  IL_001d:  brtrue.s   IL_0026
+  IL_001f:  ldsflda    ""int C.val2""
+  IL_0024:  br.s       IL_002b
+  IL_0026:  ldsflda    ""int C.val1""
+  IL_002b:  dup
+  IL_002c:  ldind.i4
+  IL_002d:  ldc.i4.s   22
+  IL_002f:  add
+  IL_0030:  dup
+  IL_0031:  stloc.0
+  IL_0032:  stind.i4
+  IL_0033:  ldloc.0
+  IL_0034:  call       ""void System.Console.Write(int)""
+  IL_0039:  ldsfld     ""int C.val2""
+  IL_003e:  call       ""void System.Console.Write(int)""
+  IL_0043:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRefConditionalOperatorInRefAssignment()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = true;
+        int x = 1;
+        int y = 2;
+
+        ref var local = ref b ? ref x : ref y;
+
+        System.Console.WriteLine(local);
+    }
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "1");
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  2
+  .locals init (int V_0, //x
+                int V_1) //y
+  IL_0000:  ldc.i4.1
+  IL_0001:  ldc.i4.1
+  IL_0002:  stloc.0
+  IL_0003:  ldc.i4.2
+  IL_0004:  stloc.1
+  IL_0005:  brtrue.s   IL_000b
+  IL_0007:  ldloca.s   V_1
+  IL_0009:  br.s       IL_000d
+  IL_000b:  ldloca.s   V_0
+  IL_000d:  ldind.i4
+  IL_000e:  call       ""void System.Console.WriteLine(int)""
+  IL_0013:  ret
+}
+");
+        }
+
+        // elvis target reg and generic
+
+        [Fact]
+        public void TestRefConditionalAsyncIncrement()
+        {
+            var source = @"
+using System.Threading.Tasks;
+
+class C
+{
+    static void Main()
+    {
+        Test().Wait();
+        System.Console.Write(val1);
+    }
+
+    static async Task<int> Test()
+    {
+        bool b = true;
+
+        (b? ref val1: ref val2) += await One();
+
+        return 1;
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+
+    static ref int M1() => ref val1;
+
+    static async Task<int> One()
+    {
+        await Task.Yield();
+
+        return 1;
+    }
+
+}";
+            var comp = CreateCompilationWithMscorlib45(source,options: TestOptions.ReleaseExe);
+  
+            comp.VerifyEmitDiagnostics(
+                // (16,10): error CS8208: 'await' cannot be used in an expression containing a ref conditional operator
+                //         (b? ref val1: ref val2) += await One();
+                Diagnostic(ErrorCode.ERR_ByRefConditionalAndAwait, "b? ref val1: ref val2").WithLocation(16, 10)
+                );
+        }
+
+        [Fact]
+        public void TestRefConditionalAsyncAssign()
+        {
+            var source = @"
+using System.Threading.Tasks;
+
+class C
+{
+    static void Main()
+    {
+        Test().Wait();
+        System.Console.Write(val1);
+    }
+
+    static async Task<int> Test()
+    {
+        bool b = true;
+
+        (b? ref val1: ref val2) = await One();
+
+        return 1;
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+
+    static ref int M1() => ref val1;
+
+    static async Task<int> One()
+    {
+        await Task.Yield();
+
+        return 1;
+    }
+
+}";
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (16,35): error CS8208: 'await' cannot be used in an expression containing a ref conditional operator
+                //         (b? ref val1: ref val2) = await One();
+                Diagnostic(ErrorCode.ERR_ByRefConditionalAndAwait, "await One()").WithLocation(16, 35)
+               );
+        }
+
+        [Fact]
+        public void TestRefConditionaOneRef()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+
+        System.Console.Write(b? val1: ref val2);
+        System.Console.Write(b? ref val1: val2);
+    }
+
+    static int val1 = 33;
+    static int val2 = 44;
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (8,43): error CS8302: Both or none of conditional operator expressions can be ref values
+                //         System.Console.Write(b? val1: ref val2);
+                Diagnostic(ErrorCode.ERR_RefConditionalNeedsTwoRefs, "val2").WithLocation(8, 43),
+                // (9,37): error CS8302: Both or none of conditional operator expressions can be ref values
+                //         System.Console.Write(b? ref val1: val2);
+                Diagnostic(ErrorCode.ERR_RefConditionalNeedsTwoRefs, "val1").WithLocation(9, 37)
+               );
+        }
+
+        [Fact]
+        public void TestRefConditionaRValue()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+
+        (b? ref val1: ref 42) = 1;
+
+        ref var local = ref b? ref val1: ref 42;
+
+    }
+
+    static int val1 = 33;
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (8,27): error CS1510: A ref or out value must be an assignable variable
+                //         (b? ref val1: ref 42) = 1;
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "42").WithLocation(8, 27),
+                // (10,46): error CS1510: A ref or out value must be an assignable variable
+                //         ref var local = ref b? ref val1: ref 42;
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "42").WithLocation(10, 46)
+               );
+        }
+
+        [Fact]
+        public void TestRefConditionalUnsafeToReturn1()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+
+    }
+
+    ref int Test()
+    {
+        int local1 = 1;
+        int local2 = 2;
+        bool b = true;
+
+        return ref b? ref local1: ref local2;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (15,27): error CS8168: Cannot return local 'local1' by reference because it is not a ref local
+                //         return ref b? ref local1: ref local2;
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "local1").WithArguments("local1").WithLocation(15, 27),
+                // (15,39): error CS8168: Cannot return local 'local2' by reference because it is not a ref local
+                //         return ref b? ref local1: ref local2;
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "local2").WithArguments("local2").WithLocation(15, 39)
+
+               );
+        }
+
+        [Fact]
+        public void TestRefConditionalUnsafeToReturn2()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+
+    }
+
+    ref int Test()
+    {
+        int local2 = 1;
+        bool b = true;
+
+        return ref b? ref val1: ref local2;
+    }
+
+    static int val1 = 33;
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (14,37): error CS8168: Cannot return local 'local2' by reference because it is not a ref local
+                //         return ref b? ref val1: ref local2;
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "local2").WithArguments("local2").WithLocation(14, 37)
+               );
+        }
+
+        [Fact]
+        public void TestRefConditionlaUnsafeToReturn3()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+
+    }
+
+    ref int Test()
+    {
+        S1 local2 = default(S1);
+        bool b = true;
+
+        return ref (b? ref val1: ref local2).x;
+    }
+
+    static S1 val1;
+
+    struct S1
+    {
+        public int x;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (14,38): error CS8168: Cannot return local 'local2' by reference because it is not a ref local
+                //         return ref (b? ref val1: ref local2).x;
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "local2").WithArguments("local2").WithLocation(14, 38)
+               );
+        }
+
+        [Fact]
+        public void TestRefConditionalSafeToReturn1()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        Test() ++;
+        System.Console.WriteLine(val1.x);
+    }
+
+    static ref int Test()
+    {
+        bool b = true;
+
+        return ref (b? ref val1: ref val2).x;
+    }
+
+    static S1 val1;
+    static S1 val2;
+
+    struct S1
+    {
+        public int x;
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "1", verify: false);
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Test", @"
+{
+  // Code size       21 (0x15)
+  .maxstack  1
+  IL_0000:  ldc.i4.1
+  IL_0001:  brtrue.s   IL_000a
+  IL_0003:  ldsflda    ""C.S1 C.val2""
+  IL_0008:  br.s       IL_000f
+  IL_000a:  ldsflda    ""C.S1 C.val1""
+  IL_000f:  ldflda     ""int C.S1.x""
+  IL_0014:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRefConditionlaDifferentTypes1()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+
+        System.Console.Write(b? ref val1: ref val2);
+    }
+
+    static int val1 = 33;
+    static short val2 = 44;
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (8,47): error CS8332: The expression must be of type 'int' to match the alternative ref value
+                //         System.Console.Write(b? ref val1: ref val2);
+                Diagnostic(ErrorCode.ERR_RefConditionalDifferentTypes, "val2").WithArguments("int").WithLocation(8, 47)
+               );
+        }
+
+        [Fact]
+        public void TestRefConditionlaDifferentTypes2()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = false;
+
+        System.Console.Write(b? ref val1: ref ()=>1);
+    }
+
+    static System.Func<int> val1 = null;
+}
+";
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (8,47): error CS1510: A ref or out value must be an assignable variable
+                //         System.Console.Write(b? ref val1: ref ()=>1);
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "()=>1").WithLocation(8, 47)
+               );
+        }
+
+        [Fact]
+        public void TestRefConditionlaDifferentTypes3()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = true;
+
+        ref var x = ref b? ref val1: ref val2;
+        System.Console.Write(x.Alice);
+    }
+
+    static (int Alice, int) val1 = (1,2);
+    static (int Alice, int Bob) val2 = (3,4);
+}
+";
+
+            var comp = CompileAndVerify(source, additionalRefs: new[] { SystemRuntimeFacadeRef, ValueTupleRef }, expectedOutput: "1");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       26 (0x1a)
+  .maxstack  1
+  IL_0000:  ldc.i4.1
+  IL_0001:  brtrue.s   IL_000a
+  IL_0003:  ldsflda    ""(int Alice, int Bob) C.val2""
+  IL_0008:  br.s       IL_000f
+  IL_000a:  ldsflda    ""(int Alice, int) C.val1""
+  IL_000f:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0014:  call       ""void System.Console.Write(int)""
+  IL_0019:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TestRefConditionlaDifferentTypes4()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        bool b = true;
+
+        ref var x = ref b? ref val1: ref val2;
+        System.Console.Write(x.Bob);
+    }
+
+    static (int Alice, int) val1 = (1,2);
+    static (int Alice, int Bob) val2 = (3,4);
+}
+";
+
+            var comp = CreateCompilationWithMscorlib45(source, references: new[] { SystemRuntimeFacadeRef, ValueTupleRef }, options: TestOptions.ReleaseExe);
+
+            comp.VerifyEmitDiagnostics(
+                // (9,32): error CS1061: '(int Alice, int)' does not contain a definition for 'Bob' and no extension method 'Bob' accepting a first argument of type '(int Alice, int)' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Console.Write(x.Bob);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "Bob").WithArguments("(int Alice, int)", "Bob").WithLocation(9, 32)
+               );
+        }
+
+    }
+}


### PR DESCRIPTION
Implements ternary ref expression as in proposal 
https://github.com/dotnet/roslyn/issues/16473


The syntax is basically:

```cs
     // assign selectively
     (arr != null ? ref arr[0]: ref otherArr[0]) = 42;

     // increment selectively
     (arr != null ? ref arr[0]: ref otherArr[0]) += 42;

     // return by reference
     // parens are optional
     return ref  (arr != null ? ref arr[0]: ref otherArr[0]);

     // pass by reference
     // parens are optional
     foo(ref  (arr != null ? ref arr[0]: ref otherArr[0]));
```