### PR TITLE
Ensure proper tracking/cleanup of _bufferToDocumentInCurrentContextMa…

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -78,19 +78,24 @@ namespace Roslyn.Utilities
             return new OneOrMany<T>(builder.ToImmutableAndFree());
         }
 
-        public OneOrMany<T> InsertAt(T one, int index)
+        public bool Contains(T item)
         {
-            var builder = ArrayBuilder<T>.GetInstance();
-            if (_many.IsDefault)
+            Debug.Assert(item != null);
+            if (Count == 1)
             {
-                builder.Add(_one);
+                return item.Equals(_one);
             }
-            else
+
+            var iter = GetEnumerator();
+            while (iter.MoveNext())
             {
-                builder.AddRange(_many);
+                if (item.Equals(iter.Current))
+                {
+                    return true;
+                }
             }
-            builder.Insert(index, one);
-            return new OneOrMany<T>(builder.ToImmutableAndFree());
+
+            return false;
         }
 
         public OneOrMany<T> RemoveAll(T item)
@@ -118,45 +123,9 @@ namespace Roslyn.Utilities
             return builder.Count == Count ? this : new OneOrMany<T>(builder.ToImmutableAndFree());
         }
 
-        public OneOrMany<T> RemoveDuplicates()
-        {
-            var builder = ArrayBuilder<T>.GetInstance();
-            if (_many.IsDefault)
-            {
-                builder.Add(_one);
-            }
-            else
-            {
-                builder.AddRange(_many);
-            }
-
-            builder.RemoveDuplicates();
-            return builder.Count == Count ? this : new OneOrMany<T>(builder.ToImmutableAndFree());
-        }
-
         public Enumerator GetEnumerator()
         {
             return new Enumerator(this);
-        }
-
-        public bool Contains(T item)
-        {
-            Debug.Assert(item != null);
-            if (Count == 1)
-            {
-                return item.Equals(_one);
-            }
-
-            var iter = GetEnumerator();
-            while(iter.MoveNext())
-            {
-                if (item.Equals(iter.Current))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         internal struct Enumerator

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -117,6 +117,9 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs">
       <Link>InternalUtilities\ExceptionUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\OneOrMany.cs">
+      <Link>InternalUtilities\OneOrMany.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs">
       <Link>InternalUtilities\PlatformInformation.cs</Link>
     </Compile>


### PR DESCRIPTION
…p when closing shared documents

Current implementation was leaking entries in this map for shared document buffers when the shared document was closed. The primary reason was that we were only tracking the active document ID corresponding to a given text container. Hence, on document close for a specific document ID, we could not determine if we still need to track the text container for other related document IDs or not. This leak in turn was causing stale entries in the map to be returned when the shared document was re-opened.

Fix is to track all the related documents that have been opened with a specific text container, and remove the textContainer tracking entry in _bufferToDocumentInCurrentContextMap when all the attached document IDs have been closed.

Fixes https://github.com/dotnet/roslyn/issues/5343. I verified that this fixes the repro for both shared projects and cross-targeting dotnet core projects.