### PR TITLE
Adds support for  binding `ref readonly` style of `in` parameters.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -127,6 +127,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     allValue = false;
                                     break;
 
+                                case SyntaxKind.ReadOnlyKeyword:
+                                    Debug.Assert(refKind == RefKind.Ref || syntax.HasErrors);
+                                    goto case SyntaxKind.InKeyword;
+
                                 case SyntaxKind.InKeyword:
                                     refKind = RefKind.RefReadOnly;
                                     allValue = false;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -38,5 +38,65 @@ class Program
   IL_0001:  ret
 }");
         }
+
+        [Fact]
+        public void RefReturnArrayAccess1()
+        {
+            var text = @"
+class Program
+{
+    static ref readonly int M(ref readonly int x)
+    {
+        return ref x;
+    }
+}
+";
+
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false);
+
+            comp.VerifyIL("Program.M(ref readonly int)", @"
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  ret
+}");
+        }
+
+        [Fact]
+        public void BindingInvalidRefInCombination()
+        {
+            var text = @"
+class Program
+{
+    // should be a syntax error
+    // just make sure binder is ok with this
+    static ref readonly int M(in ref readonly int x)
+    {
+        return ref x;
+    }
+
+    // should be a syntax error
+    // just make sure binder is ok with this
+    static ref readonly int M1( ref in readonly int x)
+    {
+        return ref x;
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (6,34): error CS8205:  The parameter modifier 'ref' cannot be used with 'in' 
+                //     static ref readonly int M(in ref readonly int x)
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "ref").WithArguments("ref", "in").WithLocation(6, 34),
+                // (6,38): error CS8205:  The parameter modifier 'readonly' cannot be used with 'in' 
+                //     static ref readonly int M(in ref readonly int x)
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "readonly").WithArguments("readonly", "in").WithLocation(6, 38),
+                // (13,37): error CS8205:  The parameter modifier 'in' cannot be used with 'ref' 
+                //     static ref readonly int M1( ref in readonly int x)
+                Diagnostic(ErrorCode.ERR_BadParameterModifiers, "in").WithArguments("in", "ref").WithLocation(13, 37)
+            );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class CodeGenInParametersTests : CompilingTestBase
     {
         [Fact]
-        public void RefReturnArrayAccess()
+        public void RefReturnParamAccess()
         {
             var text = @"
 class Program
@@ -40,7 +40,7 @@ class Program
         }
 
         [Fact]
-        public void RefReturnArrayAccess1()
+        public void RefReturnParamAccess1()
         {
             var text = @"
 class Program

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5462,6 +5462,7 @@ public class C
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.ReadonlyReferences)]
         public void RefReadonlyReturn()
         {
             var sourceA =
@@ -5472,6 +5473,32 @@ public class C
     int _p;
     public ref readonly int P => ref _p;
     public ref readonly int this[in int i] => ref _p;
+}";
+            var compA = CreateCompilationWithMscorlib(sourceA);
+            compA.VerifyDiagnostics();
+            var refA = compA.EmitToImageReference();
+            // From C# symbols.
+            RefReadonlyReturnInternal(compA);
+
+            var compB = CreateVisualBasicCompilation(GetUniqueName(), "", referencedAssemblies: new[] { MscorlibRef, refA });
+            compB.VerifyDiagnostics();
+            // From VB symbols.
+            //PROTOTYPE(refReadonly): metadata emit and VB NYI
+            //RefReadonlyReturnInternal(compB);
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.ReadonlyReferences)]
+        public void RefReadonlyReturn1()
+        {
+            var sourceA =
+@"public delegate ref readonly int D();
+public class C
+{
+    public ref readonly int F(ref readonly int i) => ref i;
+    int _p;
+    public ref readonly int P => ref _p;
+    public ref readonly int this[ref readonly int i] => ref _p;
 }";
             var compA = CreateCompilationWithMscorlib(sourceA);
             compA.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -775,7 +775,7 @@ class C
 
         [Fact]
         [CompilerTrait(CompilerFeature.ReadonlyReferences)]
-        public void ReadonlyRefsInlambda()
+        public void RefReadonlysInlambda()
         {
             var source = @"
 class C
@@ -811,7 +811,7 @@ class C
 
         [Fact]
         [CompilerTrait(CompilerFeature.ReadonlyReferences)]
-        public void ReadonlyRefsInlambda1()
+        public void RefReadonlysInlambda1()
         {
             var source = @"
 class C

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -755,6 +755,26 @@ class C
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.ReadonlyReferences)]
+        public void RefReadonlyReturningDelegate1()
+        {
+            var source = @"delegate ref readonly int D(ref readonly int arg);";
+
+            var comp = CreateCompilationWithMscorlib45(source);
+            comp.VerifyDiagnostics();
+
+            var global = comp.GlobalNamespace;
+            var d = global.GetMembers("D")[0] as NamedTypeSymbol;
+            Assert.False(d.DelegateInvokeMethod.ReturnsByRef);
+            Assert.True(d.DelegateInvokeMethod.ReturnsByRefReadonly);
+            Assert.Equal(RefKind.RefReadOnly, d.DelegateInvokeMethod.RefKind);
+            Assert.Equal(RefKind.RefReadOnly, ((MethodSymbol)d.GetMembers("EndInvoke").Single()).RefKind);
+
+            Assert.Equal(RefKind.RefReadOnly, d.DelegateInvokeMethod.Parameters[0].RefKind);
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.ReadonlyReferences)]
         public void ReadonlyRefsInlambda()
         {
             var source = @"
@@ -767,6 +787,42 @@ class C
         DD<int> d1 = (in int a) => ref a;
 
         DD<int> d2 = delegate(in int a){return ref a;};
+    }
+}";
+            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular);
+            var compilation = CreateCompilationWithMscorlib45(new SyntaxTree[] { tree }).VerifyDiagnostics();
+
+            var model = compilation.GetSemanticModel(tree);
+
+            ExpressionSyntax lambdaSyntax = tree.GetCompilationUnitRoot().DescendantNodes().OfType<ParenthesizedLambdaExpressionSyntax>().Single();
+            var lambda = (LambdaSymbol)model.GetSymbolInfo(lambdaSyntax).Symbol;
+
+            Assert.False(lambda.ReturnsByRef);
+            Assert.True(lambda.ReturnsByRefReadonly);
+            Assert.Equal(lambda.Parameters[0].RefKind, RefKind.RefReadOnly);
+
+            lambdaSyntax = tree.GetCompilationUnitRoot().DescendantNodes().OfType<AnonymousMethodExpressionSyntax>().Single();
+            lambda = (LambdaSymbol)model.GetSymbolInfo(lambdaSyntax).Symbol;
+
+            Assert.False(lambda.ReturnsByRef);
+            Assert.True(lambda.ReturnsByRefReadonly);
+            Assert.Equal(lambda.Parameters[0].RefKind, RefKind.RefReadOnly);
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.ReadonlyReferences)]
+        public void ReadonlyRefsInlambda1()
+        {
+            var source = @"
+class C
+{
+    public delegate ref readonly T DD<T>(ref readonly T arg);
+
+    public static void Main()
+    {
+        DD<int> d1 = (ref readonly int a) => ref a;
+
+        DD<int> d2 = delegate(ref readonly int a){return ref a;};
     }
 }";
             var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
@@ -534,6 +534,7 @@ class C
         }
 
         [Fact]
+        [CompilerTrait(CompilerFeature.ReadonlyReferences)]
         public void ReadonlyRefReturningExpressionBodiedIndexer()
         {
             var comp = CreateCompilationWithMscorlib45(@"
@@ -541,6 +542,34 @@ class C
 {
     int field = 0;
     public ref readonly int this[in int arg] => ref field;
+}");
+            comp.VerifyDiagnostics();
+
+            var global = comp.GlobalNamespace;
+            var c = global.GetTypeMember("C");
+
+            var p = c.GetMember<SourcePropertySymbol>("this[]");
+            Assert.Null(p.SetMethod);
+            Assert.NotNull(p.GetMethod);
+            Assert.False(p.GetMethod.IsImplicitlyDeclared);
+            Assert.True(p.IsExpressionBodied);
+            Assert.Equal(RefKind.RefReadOnly, p.GetMethod.RefKind);
+            Assert.Equal(RefKind.RefReadOnly, p.GetMethod.Parameters[0].RefKind);
+            Assert.False(p.ReturnsByRef);
+            Assert.False(p.GetMethod.ReturnsByRef);
+            Assert.True(p.ReturnsByRefReadonly);
+            Assert.True(p.GetMethod.ReturnsByRefReadonly);
+        }
+
+        [Fact]
+        [CompilerTrait(CompilerFeature.ReadonlyReferences)]
+        public void ReadonlyRefReturningExpressionBodiedIndexer1()
+        {
+            var comp = CreateCompilationWithMscorlib45(@"
+class C
+{
+    int field = 0;
+    public ref readonly int this[ref readonly int arg] => ref field;
 }");
             comp.VerifyDiagnostics();
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
@@ -535,7 +535,7 @@ class C
 
         [Fact]
         [CompilerTrait(CompilerFeature.ReadonlyReferences)]
-        public void ReadonlyRefReturningExpressionBodiedIndexer()
+        public void RefReadonlyReturningExpressionBodiedIndexer()
         {
             var comp = CreateCompilationWithMscorlib45(@"
 class C
@@ -563,7 +563,7 @@ class C
 
         [Fact]
         [CompilerTrait(CompilerFeature.ReadonlyReferences)]
-        public void ReadonlyRefReturningExpressionBodiedIndexer1()
+        public void RefReadonlyReturningExpressionBodiedIndexer1()
         {
             var comp = CreateCompilationWithMscorlib45(@"
 class C


### PR DESCRIPTION
Adds support for  binding `ref readonly` style of `in` parameters.