### PR TITLE
Add C# and VB QuickInfo integration tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
@@ -155,6 +155,12 @@ namespace Roslyn.VisualStudio.IntegrationTests
             WaitForAsyncOperations(FeatureAttribute.SignatureHelp);
         }
 
+        protected void InvokeQuickInfo()
+        {
+            ExecuteCommand(WellKnownCommandNames.Edit_QuickInfo);
+            WaitForAsyncOperations(FeatureAttribute.QuickInfo);
+        }
+
         protected void InvokeCodeActionList()
         {
             WaitForAsyncOperations(FeatureAttribute.SolutionCrawler);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpQuickInfo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpQuickInfo.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpQuickInfo : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+
+        public CSharpQuickInfo(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory, nameof(CSharpQuickInfo))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void QuickInfo_MetadataDocumentation()
+        {
+            SetUpEditor(@"
+///<summary>Hello!</summary>
+class Program
+{
+    static void Main(string$$[] args)
+    {
+    }
+}");
+            InvokeQuickInfo();
+            Assert.Equal(
+                "class\u200e System\u200e.String\r\nRepresents text as a sequence of UTF-16 code units.To browse the .NET Framework source code for this type, see the Reference Source.",
+                Editor.GetQuickInfo());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void QuickInfo_Documentation()
+        {
+            SetUpEditor(@"
+///<summary>Hello!</summary>
+class Program$$
+{
+    static void Main(string[] args)
+    {
+    }
+}");
+            InvokeQuickInfo();
+            Assert.Equal("class\u200e Program\r\nHello!", Editor.GetQuickInfo());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void International()
+        {
+            SetUpEditor(@"
+/// <summary>
+/// This is an XML doc comment defined in code.
+/// </summary>
+class العربية123
+{
+    static void Main()
+    {
+         العربية123$$ foo;
+    }
+}");
+            InvokeQuickInfo();
+            Assert.Equal(@"class" + '\u200e' + @" العربية123
+This is an XML doc comment defined in code.", Editor.GetQuickInfo());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void SectionOrdering()
+        {
+            SetUpEditor(@"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    /// <exception cref=""Exception""></exception>
+    async Task <int> M()
+    {
+                return await M$$();
+            }
+        }");
+
+            InvokeQuickInfo();
+            var expected = "\u200e(awaitable\u200e)\u200e Task\u200e<int\u200e>\u200e C\u200e.M\u200e(\u200e)\u000d\u000a\u000d\u000aUsage:\u000d\u000a  int\u200e x\u200e \u200e=\u200e await\u200e M\u200e(\u200e\u200e)\u200e;\u000d\u000a\u000d\u000aExceptions:\u200e\u000d\u000a\u200e  Exception";
+            Assert.Equal(expected, Editor.GetQuickInfo());
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicQuickInfo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicQuickInfo.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class BasicQuickInfo : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.VisualBasic;
+
+        public BasicQuickInfo(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory, nameof(BasicQuickInfo))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void QuickInfo1()
+        {
+            SetUpEditor(@"
+''' <summary>Hello!</summary>
+Class Program
+    Sub Main(ByVal args As String$$())
+    End Sub
+End Class");
+            InvokeQuickInfo();
+            Assert.Equal("Class\u200e System.String\r\nRepresents text as a sequence of UTF-16 code units.To browse the .NET Framework source code for this type, see the Reference Source.",
+                Editor.GetQuickInfo());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public void International()
+        {
+            SetUpEditor(@"
+''' <summary>
+''' This is an XML doc comment defined in code.
+''' </summary>
+Class العربية123
+    Shared Sub Foo()
+         Dim foo as العربية123$$
+    End Sub
+End Class");
+            InvokeQuickInfo();
+            Assert.Equal(@"Class" + '\u200e' + @" TestProj.العربية123
+This is an XML doc comment defined in code.", Editor.GetQuickInfo());
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="CSharp\CSharpInteractive.cs" />
     <Compile Include="AbstractEditorTest.cs" />
     <Compile Include="CSharp\CSharpInteractiveCommands.cs" />
+    <Compile Include="CSharp\CSharpQuickInfo.cs" />
     <Compile Include="CSharp\CSharpSignatureHelp.cs" />
     <Compile Include="CSharp\CSharpWinForms.cs" />
     <Compile Include="CSharp\CSharpAddMissingReference.cs" />
@@ -49,6 +50,7 @@
     <Compile Include="VisualBasic\BasicIntelliSense.cs" />
     <Compile Include="VisualBasic\BasicSignatureHelp.cs" />
     <Compile Include="VisualBasic\BasicWinForms.cs" />
+    <Compile Include="VisualBasic\BasicQuickInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -328,15 +328,29 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public Signature GetCurrentSignature()
             => ExecuteOnActiveView(view =>
             {
-                var broken = GetComponentModelService<ISignatureHelpBroker>();
+                var broker = GetComponentModelService<ISignatureHelpBroker>();
 
-                var sessions = broken.GetSessions(view);
+                var sessions = broker.GetSessions(view);
                 if (sessions.Count != 1)
                 {
                     throw new InvalidOperationException($"Expected exactly one session in the signature help, but found {sessions.Count}");
                 }
 
                 return new Signature(sessions[0].SelectedSignature);
+            });
+
+        public string GetQuickInfo()
+            => ExecuteOnActiveView(view =>
+            {
+                var broker = GetComponentModelService<IQuickInfoBroker>();
+
+                var sessions = broker.GetSessions(view);
+                if (sessions.Count != 1)
+                {
+                    throw new InvalidOperationException($"Expected exactly one QuickInfo session, but found {sessions.Count}");
+                }
+
+                return QuickInfoToStringConverter.GetStringFromBulkContent(sessions[0].QuickInfoContent);
             });
 
         public bool IsCaretOnScreen()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/QuickInfoToStringConverter.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/QuickInfoToStringConverter.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using Microsoft.VisualStudio.Language.Intellisense;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
+{
+    public static class QuickInfoToStringConverter
+    {
+        public static string GetStringFromBulkContent(BulkObservableCollection<object> content)
+        {
+            return string.Join(Environment.NewLine, content.Select(item => GetStringFromItem(item) ?? string.Empty));
+        }
+
+        private static string GetStringFromItem(object item)
+        {
+            var displayPanel = item as StackPanel;
+            if (displayPanel != null)
+            {
+                return displayPanel.ToString();
+            }
+
+            string itemString = item as string;
+            if (itemString != null)
+            {
+                return itemString;
+            }
+
+            TextBlock textBlock = item as TextBlock;
+            if (textBlock != null)
+            {
+                return GetStringFromTextBlock(textBlock);
+            }
+
+            var textBuffer = item as ITextBuffer;
+            if (textBuffer != null)
+            {
+                return textBuffer.CurrentSnapshot.GetText();
+            }
+
+            return null;
+        }
+
+        private static string GetStringFromTextBlock(TextBlock textBlock)
+        {
+            if (!string.IsNullOrEmpty(textBlock.Text))
+            {
+                return textBlock.Text;
+            }
+
+            var sb = new StringBuilder();
+            BuildStringFromInlineCollection(textBlock.Inlines, sb);
+            return sb.ToString();
+        }
+
+        private static void BuildStringFromInlineCollection(InlineCollection inlines, StringBuilder sb)
+        {
+            foreach (var inline in inlines)
+            {
+                if (inline != null)
+                {
+                    string inlineText = GetStringFromInline(inline);
+                    if (!string.IsNullOrEmpty(inlineText))
+                    {
+                        sb.Append(inlineText);
+                    }
+                }
+            }
+        }
+
+        private static string GetStringFromInline(Inline currentInline)
+        {
+            var lineBreak = currentInline as LineBreak;
+            if (lineBreak != null)
+            {
+                return Environment.NewLine;
+            }
+
+            var run = currentInline as Run;
+            if (run == null)
+            {
+                return null;
+            }
+
+            return run.Text;
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -86,6 +86,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             return _inProc.GetCurrentSignature();
         }
 
+        public string GetQuickInfo()
+        {
+            WaitForQuickInfo();
+            return _inProc.GetQuickInfo();
+        }
+
         public void ShowLightBulb()
             => _inProc.ShowLightBulb();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/OutOfProcComponent.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/OutOfProcComponent.cs
@@ -26,5 +26,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         protected void WaitForSignatureHelp()
             => VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.SignatureHelp);
+
+        protected void WaitForQuickInfo()
+        {
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.DiagnosticService);
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.ErrorSquiggles);
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.QuickInfo);
+        }
+
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -35,6 +35,7 @@
     <Compile Include="DialogHelpers.cs" />
     <Compile Include="InProcess\FindReferencesWindow_InProc.cs" />
     <Compile Include="InProcess\InProcComponent.cs" />
+    <Compile Include="InProcess\QuickInfoToStringConverter.cs" />
     <Compile Include="InProcess\Shell_InProc.cs" />
     <Compile Include="InProcess\SolutionExplorer_InProc.cs" />
     <Compile Include="InProcess\VisualStudio_InProc.cs" />

--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
@@ -6,6 +6,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
     {
         public const string Edit_ListMembers = "Edit.ListMembers";
         public const string Edit_ParameterInfo = "Edit.ParameterInfo";
+        public const string Edit_QuickInfo = "Edit.QuickInfo";
         public const string Edit_ToggleCompletionMode = "Edit.ToggleCompletionMode";
 
         public const string Test_IntegrationTestService_Start = "Test.IntegrationTestService.Start";


### PR DESCRIPTION
Tag @dotnet/roslyn-ide for review
Will remove the XML-based test in a subsequent PR