### PR TITLE
Fix missing  ValueKind check when binding array initializers

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2286,9 +2286,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (destinationType.Kind == SymbolKind.ArrayType)
             {
-                return BindArrayCreationWithInitializer(diagnostics, null,
+                var arrayCreation = BindArrayCreationWithInitializer(diagnostics, null,
                     (InitializerExpressionSyntax)node, (ArrayTypeSymbol)destinationType,
                     ImmutableArray<BoundExpression>.Empty);
+
+                return CheckValue(arrayCreation, valueKind, diagnostics);
             }
 
             return BindUnexpectedArrayInitializer((InitializerExpressionSyntax)node, diagnostics, ErrorCode.ERR_ArrayInitToNonArrayType);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -688,8 +688,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (initializer.Kind() == SyntaxKind.ArrayInitializerExpression)
             {
-                return BindUnexpectedArrayInitializer((InitializerExpressionSyntax)initializer,
+                var result = BindUnexpectedArrayInitializer((InitializerExpressionSyntax)initializer,
                     diagnostics, ErrorCode.ERR_ImplicitlyTypedVariableAssignedArrayInitializer, errorSyntax);
+
+                return CheckValue(result, valueKind, diagnostics);
             }
 
             BoundExpression expression = BindValue(initializer, diagnostics, valueKind);
@@ -2284,16 +2286,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BindValue(node, diagnostics, valueKind);
             }
 
+            BoundExpression result;
             if (destinationType.Kind == SymbolKind.ArrayType)
             {
-                var arrayCreation = BindArrayCreationWithInitializer(diagnostics, null,
+                result = BindArrayCreationWithInitializer(diagnostics, null,
                     (InitializerExpressionSyntax)node, (ArrayTypeSymbol)destinationType,
                     ImmutableArray<BoundExpression>.Empty);
-
-                return CheckValue(arrayCreation, valueKind, diagnostics);
+            }
+            else
+            {
+                result = BindUnexpectedArrayInitializer((InitializerExpressionSyntax)node, diagnostics, ErrorCode.ERR_ArrayInitToNonArrayType);
             }
 
-            return BindUnexpectedArrayInitializer((InitializerExpressionSyntax)node, diagnostics, ErrorCode.ERR_ArrayInitToNonArrayType);
+            return CheckValue(result, valueKind, diagnostics);
         }
 
         protected virtual SourceLocalSymbol LookupLocal(SyntaxToken nameToken)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -1716,9 +1716,9 @@ public class C
 }
 ";
 
-            var c = CreateCompilationWithMscorlib45AndCSruntime(source);
+            var c = CreateCompilationWithMscorlib(source);
 
-            c.VerifyEmitDiagnostics(
+            c.VerifyDiagnostics(
                 // (8,27): error CS1510: A ref or out value must be an assignable variable
                 //         ref int[] a = ref {1,2,3};
                 Diagnostic(ErrorCode.ERR_RefLvalueExpected, "{1,2,3}").WithLocation(8, 27)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -1712,6 +1712,12 @@ public class C
     {
         ref int[] a = ref {1,2,3};
         Console.WriteLine(a[0]);
+
+        ref var b = ref {4, 5, 6};
+        Console.WriteLine(b[0]);
+
+        ref object c = ref {1,2,3};
+        Console.WriteLine(c);
     }        
 }
 ";
@@ -1721,7 +1727,13 @@ public class C
             c.VerifyDiagnostics(
                 // (8,27): error CS1510: A ref or out value must be an assignable variable
                 //         ref int[] a = ref {1,2,3};
-                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "{1,2,3}").WithLocation(8, 27)
+                Diagnostic(ErrorCode.ERR_RefLvalueExpected, "{1,2,3}"),
+                // (11,17): error CS0820: Cannot initialize an implicitly-typed variable with an array initializer
+                //         ref var b = ref {4, 5, 6};
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedArrayInitializer, "b = ref {4, 5, 6}").WithLocation(11, 17),
+                // (14,28): error CS0622: Can only use array initializer expressions to assign to array types. Try using a new expression instead.
+                //         ref object c = ref {1,2,3};
+                Diagnostic(ErrorCode.ERR_ArrayInitToNonArrayType, "{1,2,3}").WithLocation(14, 28)
             );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -1716,7 +1716,7 @@ public class C
         ref var b = ref {4, 5, 6};
         Console.WriteLine(b[0]);
 
-        ref object c = ref {1,2,3};
+        ref object c = ref {7,8,9};
         Console.WriteLine(c);
     }        
 }
@@ -1732,8 +1732,8 @@ public class C
                 //         ref var b = ref {4, 5, 6};
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedVariableAssignedArrayInitializer, "b = ref {4, 5, 6}").WithLocation(11, 17),
                 // (14,28): error CS0622: Can only use array initializer expressions to assign to array types. Try using a new expression instead.
-                //         ref object c = ref {1,2,3};
-                Diagnostic(ErrorCode.ERR_ArrayInitToNonArrayType, "{1,2,3}").WithLocation(14, 28)
+                //         ref object c = ref {7,8,9};
+                Diagnostic(ErrorCode.ERR_ArrayInitToNonArrayType, "{7,8,9}").WithLocation(14, 28)
             );
         }
     }


### PR DESCRIPTION
FIxes:https://github.com/dotnet/roslyn/issues/17453

Array initializers like `{1,2,3}` are not lvalues and as such should give an error when used in ref assignments, but the check was missing.

I think introduction of RefExpressionSyntax made the scenario possible. 
Previously it was a syntax error since expression could not start with `{`, so the missing check was not causing trouble.