### PR TITLE
Support 'Clearing' of the FAR windows if a language requests it.

### DIFF
--- a/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
+++ b/src/EditorFeatures/Core/Host/IStreamingFindReferencesPresenter.cs
@@ -28,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Editor.Host
         /// If false, the presenter will not group by definitions, and will show the definition
         /// items in isolation.</param>
         FindUsagesContext StartSearch(string title, bool supportsReferences);
+
+        /// <summary>
+        /// Clears all the items from the presenter.
+        /// </summary>
+        void ClearAll();
     }
 
     internal static class IStreamingFindUsagesPresenterExtensions

--- a/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockNavigableItemsPresenter.vb
+++ b/src/EditorFeatures/TestUtilities2/Utilities/GoToHelpers/MockNavigableItemsPresenter.vb
@@ -16,6 +16,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities.GoToHelpers
             _action = action
         End Sub
 
+        Public Sub ClearAll() Implements IStreamingFindUsagesPresenter.ClearAll
+            Throw New NotImplementedException()
+        End Sub
+
         Public Function StartSearch(title As String, alwaysShowDeclarations As Boolean) As FindUsagesContext Implements IStreamingFindUsagesPresenter.StartSearch
             _action()
             Return Context

--- a/src/VisualStudio/Core/Next/FindReferences/Contexts/WithReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Contexts/WithReferencesFindUsagesContext.cs
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
                 // Ok, we got a *reference* to some definition item.  This may have been
                 // a reference for some definition that we haven't created any declaration
-                // entries for (i.e. becuase it had DisplayIfNoReferences = false).  Because
+                // entries for (i.e. because it had DisplayIfNoReferences = false).  Because
                 // we've now found a reference, we want to make sure all its declaration
                 // entries are added.
                 await AddDeclarationEntriesAsync(definition).ConfigureAwait(false);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/17475

TypeScript would like this so that they don't have stale results showing when their projects load/unload.  This is very common for them as just touching an import can change the project configuration.