### PR TITLE
Do not run editor commands if designer file is opened be default

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
@@ -36,18 +36,24 @@ namespace Roslyn.VisualStudio.IntegrationTests
         {
         }
 
-        protected AbstractEditorTest(VisualStudioInstanceFactory instanceFactory, string solutionName, string projectTemplate, bool clearEditor = true)
+        protected AbstractEditorTest(
+            VisualStudioInstanceFactory instanceFactory,
+            string solutionName,
+            string projectTemplate)
            : base(instanceFactory)
         {
             VisualStudio.Instance.SolutionExplorer.CreateSolution(solutionName);
             VisualStudio.Instance.SolutionExplorer.AddProject(ProjectName, projectTemplate, LanguageName);
 
             VisualStudioWorkspaceOutOfProc = VisualStudio.Instance.VisualStudioWorkspace;
-            VisualStudioWorkspaceOutOfProc.SetUseSuggestionMode(false);
-
             Editor = VisualStudio.Instance.Editor;
-            if (clearEditor)
+
+            // Winforms and XAML do not open text files on creation
+            // so these editor tasks will not work if that is the project template being used.
+            if (projectTemplate != WellKnownProjectTemplates.WinFormsApplication &&
+                projectTemplate != WellKnownProjectTemplates.WpfApplication)
             {
+                VisualStudioWorkspaceOutOfProc.SetUseSuggestionMode(false);
                 ClearEditor();
             }
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpWinForms.cs
@@ -13,7 +13,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         protected override string LanguageName => LanguageNames.CSharp;
 
         public CSharpWinForms(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpWinForms), WellKnownProjectTemplates.WinFormsApplication, clearEditor: false)
+            : base(instanceFactory, nameof(CSharpWinForms), WellKnownProjectTemplates.WinFormsApplication)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicWinForms.cs
@@ -14,7 +14,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
         protected override string LanguageName => LanguageNames.VisualBasic;
 
         public BasicWinForms(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicWinForms), WellKnownProjectTemplates.WinFormsApplication, clearEditor: false)
+            : base(instanceFactory, nameof(BasicWinForms), WellKnownProjectTemplates.WinFormsApplication)
         {
         }
 
@@ -49,7 +49,7 @@ End Class");
         [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void Add_Control()
         {
-            OpenFileWithDesigner(ProjectName, "Form1.cs");
+            OpenFileWithDesigner(ProjectName, "Form1.vb");
             AddWinFormButton("SomeButton");
             CloseFile(ProjectName, "Form1.vb", saveFile: true);
             OpenFile(ProjectName, "Form1.Designer.vb");
@@ -60,7 +60,7 @@ End Class");
         [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void Change_Control_Property()
         {
-            OpenFileWithDesigner(ProjectName, "Form1.cs");
+            OpenFileWithDesigner(ProjectName, "Form1.vb");
             AddWinFormButton("SomeButton");
             EditWinFormButtonProperty(buttonName: "SomeButton", propertyName: "Text", propertyValue: "NewButtonText");
             CloseFile(ProjectName, "Form1.vb", saveFile: true);
@@ -71,7 +71,7 @@ End Class");
         [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void Change_Control_Property_In_Code()
         {
-            OpenFileWithDesigner(ProjectName, "Form1.cs");
+            OpenFileWithDesigner(ProjectName, "Form1.vb");
             AddWinFormButton("SomeButton");
             EditWinFormButtonProperty(buttonName: "SomeButton", propertyName: "Text", propertyValue: "ButtonTextGoesHere");
             var expectedPropertyValue = "ButtonTextGoesHere";
@@ -96,7 +96,7 @@ End Class");
         [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void Add_Click_Handler()
         {
-            OpenFileWithDesigner(ProjectName, "Form1.cs");
+            OpenFileWithDesigner(ProjectName, "Form1.vb");
             AddWinFormButton("SomeButton");
             EditWinFormsButtonEvent(buttonName: "SomeButton", eventName: "Click", eventHandlerName: "ExecuteWhenButtonClicked");
             OpenFile(ProjectName, "Form1.vb");
@@ -107,7 +107,7 @@ End Class");
         [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void Rename_Control()
         {
-            OpenFileWithDesigner(ProjectName, "Form1.cs");
+            OpenFileWithDesigner(ProjectName, "Form1.vb");
             AddWinFormButton("SomeButton");
             // Add some control properties and events
             EditWinFormButtonProperty(buttonName: "SomeButton", propertyName: "Text", propertyValue: "ButtonTextValue");
@@ -134,7 +134,7 @@ End Class");
         [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void Remove_Event_Handler()
         {
-            OpenFileWithDesigner(ProjectName, "Form1.cs");
+            OpenFileWithDesigner(ProjectName, "Form1.vb");
             AddWinFormButton("SomeButton");
             EditWinFormsButtonEvent(buttonName: "SomeButton", eventName: "Click", eventHandlerName: "FooHandler");
             //  Remove the event handler
@@ -148,7 +148,7 @@ End Class");
         [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void Change_Accessibility()
         {
-            OpenFileWithDesigner(ProjectName, "Form1.cs");
+            OpenFileWithDesigner(ProjectName, "Form1.vb");
             AddWinFormButton("SomeButton");
             EditWinFormButtonProperty(
                 buttonName: "SomeButton",
@@ -163,7 +163,7 @@ End Class");
         [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void Delete_Control()
         {
-            OpenFileWithDesigner(ProjectName, "Form1.cs");
+            OpenFileWithDesigner(ProjectName, "Form1.vb");
             AddWinFormButton("SomeButton");
             DeleteWinFormButton("SomeButton");
             VerifyNoBuildErrors();


### PR DESCRIPTION
Toggle completion mode command is not available if the focused window is a designer and not a test file. We now only run editor specific commands if the template opens a text file. re-running the tests I also found a typo in the tests.