### PR TITLE
NuGet packaging updates for 2.0.0 NuGet packages

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -15,7 +15,7 @@
     <MicrosoftBuildTasksCoreVersion>15.1.0-preview-000458-02</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildTasksCore14Version>14.3.0</MicrosoftBuildTasksCore14Version>
     <MicrosoftCodeAnalysisAnalyzersVersion>1.1.0</MicrosoftCodeAnalysisAnalyzersVersion>
-    <MicrosoftCodeAnalysisElfieVersion>0.10.6-rc2</MicrosoftCodeAnalysisElfieVersion>
+    <MicrosoftCodeAnalysisElfieVersion>0.10.6</MicrosoftCodeAnalysisElfieVersion>
     <MicrosoftCompositionVersion>1.0.27</MicrosoftCompositionVersion>
     <MicrosoftCSharpVersion>4.3.0</MicrosoftCSharpVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -129,6 +129,7 @@ var PreReleaseOnlyPackages = new HashSet<string>
     "Microsoft.CodeAnalysis.Remote.ServiceHub",
     "Microsoft.CodeAnalysis.Remote.Workspaces",
     "Microsoft.CodeAnalysis.Test.Resources.Proprietary",
+    "Microsoft.VisualStudio.IntegrationTest.Utilities",
     "Microsoft.VisualStudio.LanguageServices.Next",
     "Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient",
 };

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -172,6 +172,26 @@ void ReportError(string message)
     Console.ForegroundColor = color;
 }
 
+string GetPackageVersion(string packageName)
+{
+    // HACK: since Microsoft.Net.Compilers 2.0.0 was uploaded by accident and later deleted, we must bump the minor.
+    // We will do this to both the regular Microsoft.Net.Compilers package and also the netcore package to keep them
+    // in sync.
+    if (BuildVersion.StartsWith("2.0.") && packageName.StartsWith("Microsoft.Net.Compilers", StringComparison.OrdinalIgnoreCase))
+    {
+        string[] buildVersionParts = BuildVersion.Split('-');
+        string[] buildVersionBaseParts = buildVersionParts[0].Split('.');
+        
+        buildVersionBaseParts[buildVersionBaseParts.Length - 1] =
+            (int.Parse(buildVersionBaseParts[buildVersionBaseParts.Length - 1]) + 1).ToString();
+
+        buildVersionParts[0] = string.Join(".", buildVersionBaseParts);
+        return string.Join("-", buildVersionParts);
+    }
+
+    return BuildVersion;
+}
+
 int PackFiles(string[] nuspecFiles, string licenseUrl)
 {
     var commonProperties = new Dictionary<string, string>()
@@ -213,8 +233,10 @@ int PackFiles(string[] nuspecFiles, string licenseUrl)
 
         if (!IsCoreBuild)
         {
+            string packageArgs = commonArgs.Replace($"-prop version=\"{BuildVersion}\"", $"-prop version=\"{GetPackageVersion(Path.GetFileNameWithoutExtension(file))}\"");
+
             p.StartInfo.FileName = Path.GetFullPath(Path.Combine(SolutionRoot, "nuget.exe"));
-            p.StartInfo.Arguments = $@"pack {file} {commonArgs}";
+            p.StartInfo.Arguments = $@"pack {file} {packageArgs}";
         }
         else
         {
@@ -267,7 +289,7 @@ XElement MakePackageElement(string packageName, string version)
 
 IEnumerable<XElement> MakeRoslynPackageElements(string[] roslynPackageNames)
 {
-    return roslynPackageNames.Select(packageName => MakePackageElement(packageName, BuildVersion));
+    return roslynPackageNames.Select(packageName => MakePackageElement(packageName, GetPackageVersion(packageName)));
 }
 
 void GeneratePublishingConfig(string fileName, IEnumerable<XElement> packages)

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -15,9 +15,9 @@
   </Target>
 
   <Target Name="Clean">
-    <MSBuild Projects="@(Project)" Targets="Clean" BuildInParallel="false" />
+    <RemoveDir Directories="$(OutDir)NuGet" />
   </Target>
-  <Target Name="Rebuild">
-    <MSBuild Projects="@(Project)" Targets="Rebuild" BuildInParallel="false" />
+
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build">
   </Target>
 </Project>

--- a/src/Setup/DevDivPackages/Roslyn/project.json
+++ b/src/Setup/DevDivPackages/Roslyn/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.DiaSymReader": "1.1.0",
     "Microsoft.DiaSymReader.Native": "1.5.0-beta1",
-    "Microsoft.CodeAnalysis.Elfie": "0.10.6-rc2",
+    "Microsoft.CodeAnalysis.Elfie": "0.10.6",
     "System.Collections.Immutable": "1.3.1",
     "System.Reflection.Metadata": "1.4.2",
     "ManagedEsent": "1.9.4",

--- a/src/VisualStudio/Core/Def/project.json
+++ b/src/VisualStudio/Core/Def/project.json
@@ -3,7 +3,6 @@
     "EnvDTE": "8.0.0",
     "EnvDTE80": "8.0.0",
     "ManagedEsent": "1.9.4",
-    "Microsoft.CodeAnalysis.Elfie": "0.10.6-rc2",
     "Microsoft.VisualStudio.Telemetry": "15.0.722-masterBFDFE2B0",
     "Microsoft.VisualStudio.RemoteControl": "14.0.249-master2E2DC10C",
     "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",

--- a/src/Workspaces/Core/Desktop/project.json
+++ b/src/Workspaces/Core/Desktop/project.json
@@ -3,7 +3,7 @@
     "ManagedEsent": "1.9.4",
     "Microsoft.Build": "15.1.0-preview-000458-02",
     "Microsoft.Build.Tasks.Core": "15.1.0-preview-000458-02",
-    "Microsoft.CodeAnalysis.Elfie": "0.10.6-rc2",
+    "Microsoft.CodeAnalysis.Elfie": "0.10.6",
     "Microsoft.VisualStudio.RemoteControl": "14.0.249-master2E2DC10C"
   },
   "frameworks": {

--- a/src/Workspaces/CoreTest/project.json
+++ b/src/Workspaces/CoreTest/project.json
@@ -3,7 +3,6 @@
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",
     "xunit.runner.visualstudio": "2.2.0-beta4-build1194",
-    "Microsoft.CodeAnalysis.Elfie": "0.10.6-rc2",
     "Microsoft.Tpl.Dataflow": "4.5.24",
     "Microsoft.Build.Runtime": "15.1.0-preview-000458-02",
   },


### PR DESCRIPTION
Fixes two issues. This will fix future builds going forward, and we'll do a manual rerun of the script for 2.0.0.

- The Elfie package was still a pre-release version, so we bump it. The new package is the exact same contents as 0.10.6-rc2 but just repacked.
- We need to bump our Microsoft.Net.Compilers package since we accidentally uploaded a 2.0.0 package a long time ago.

*Review;* @dotnet/roslyn-ide, @CyrusNajmabadi, @jinujoseph, @jaredpar (for verifying I'm doing this right)