### PR TITLE
Ensure LocalRewriter doesn’t crash when it has to deal with ErrorMethodSymbol.

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     argsToParamsOpt: default(ImmutableArray<int>),
                     resultKind: LookupResultKind.Viable,
                     type: method.ReturnType,
-                    hasErrors: false
+                    hasErrors: method.OriginalDefinition is ErrorMethodSymbol
                 )
             { WasCompilerGenerated = true };
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -814,7 +814,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (expression.Type.IsNullableType())
             {
-                return BoundCall.Synthesized(syntax, expression, GetNullableMethod(syntax, expression.Type, SpecialMember.System_Nullable_T_GetValueOrDefault));
+                return BoundCall.Synthesized(syntax, expression, UnsafeGetNullableMethod(syntax, expression.Type, SpecialMember.System_Nullable_T_GetValueOrDefault));
             }
 
             return expression;
@@ -839,7 +839,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression MakeNullableHasValue(SyntaxNode syntax, BoundExpression expression)
         {
-            return BoundCall.Synthesized(syntax, expression, GetNullableMethod(syntax, expression.Type, SpecialMember.System_Nullable_T_get_HasValue));
+            return BoundCall.Synthesized(syntax, expression, UnsafeGetNullableMethod(syntax, expression.Type, SpecialMember.System_Nullable_T_get_HasValue));
         }
 
         private BoundExpression LowerLiftedBuiltInComparisonOperator(
@@ -1194,7 +1194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // new R?(tempX.GetValueOrDefault() OP tempY.GetValueOrDefault)
             return new BoundObjectCreationExpression(
                 syntax,
-                GetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor),
+                UnsafeGetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor),
                 unliftedOp);
         }
 
@@ -1480,9 +1480,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return new BoundDefaultOperator(syntax, null, nullableBoolType);
             }
+
             return new BoundObjectCreationExpression(
                 syntax,
-                GetNullableMethod(syntax, nullableBoolType, SpecialMember.System_Nullable_T__ctor),
+                UnsafeGetNullableMethod(syntax, nullableBoolType, SpecialMember.System_Nullable_T__ctor),
                 MakeBooleanConstant(syntax, value.GetValueOrDefault()));
         }
 
@@ -1662,8 +1663,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TypeSymbol boolType = _compilation.GetSpecialType(SpecialType.System_Boolean);
 
-            MethodSymbol getValueOrDefaultX = GetNullableMethod(syntax, boundTempX.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
-            MethodSymbol getValueOrDefaultY = GetNullableMethod(syntax, boundTempY.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
+            MethodSymbol getValueOrDefaultX = UnsafeGetNullableMethod(syntax, boundTempX.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
+            MethodSymbol getValueOrDefaultY = UnsafeGetNullableMethod(syntax, boundTempY.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
 
             // tempx.GetValueOrDefault()
             BoundExpression callX_GetValueOrDefault = BoundCall.Synthesized(syntax, boundTempX, getValueOrDefaultX);
@@ -1712,11 +1713,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                 type: conditionalExpression.Type);
         }
 
-        private MethodSymbol GetNullableMethod(SyntaxNode syntax, TypeSymbol nullableType, SpecialMember member)
+        /// <summary>
+        /// This function provides a false sense of security, it is likely going to surprise you when the requested member is missing.
+        /// Recommendation: Do not use, use <see cref="TryGetNullableMethod"/> instead! 
+        /// If used, a unit-test with a missing member is absolutely a must have.
+        /// </summary>
+        private MethodSymbol UnsafeGetNullableMethod(SyntaxNode syntax, TypeSymbol nullableType, SpecialMember member)
         {
             var nullableType2 = nullableType as NamedTypeSymbol;
             Debug.Assert((object)nullableType2 != null);
-            return GetSpecialTypeMethod(syntax, member).AsMember(nullableType2);
+            return UnsafeGetSpecialTypeMethod(syntax, member).AsMember(nullableType2);
+        }
+
+        private bool TryGetNullableMethod(SyntaxNode syntax, TypeSymbol nullableType, SpecialMember member, out MethodSymbol result)
+        {
+            var nullableType2 = (NamedTypeSymbol)nullableType;
+            if (TryGetSpecialTypeMethod(syntax, member, out result))
+            {
+                result = result.AsMember(nullableType2);
+                return true;
+            }
+
+            return false;
         }
 
         private BoundExpression RewriteNullableNullEquality(
@@ -1816,7 +1834,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return oldNode.Update(operatorKind, loweredLeft, loweredRight, oldNode.ConstantValueOpt, oldNode.MethodOpt, oldNode.ResultKind, type);
             }
 
-            var method = GetSpecialTypeMethod(syntax, member);
+            var method = UnsafeGetSpecialTypeMethod(syntax, member);
             Debug.Assert((object)method != null);
 
             return BoundCall.Synthesized(syntax, null, method, loweredLeft, loweredRight);
@@ -1839,7 +1857,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                method = GetSpecialTypeMethod(syntax, member);
+                method = UnsafeGetSpecialTypeMethod(syntax, member);
             }
 
             Debug.Assert((object)method != null);
@@ -1877,7 +1895,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // call Operator (left, right)
-            var method = GetSpecialTypeMethod(syntax, member);
+            var method = UnsafeGetSpecialTypeMethod(syntax, member);
             Debug.Assert((object)method != null);
 
             return BoundCall.Synthesized(syntax, null, method, loweredLeft, loweredRight);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -911,7 +911,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // wrap it in a nullable ctor.
                     defaultValue = new BoundObjectCreationExpression(
                         syntax,
-                        GetNullableMethod(syntax, parameterType, SpecialMember.System_Nullable_T__ctor),
+                        UnsafeGetNullableMethod(syntax, parameterType, SpecialMember.System_Nullable_T__ctor),
                         defaultValue);
                 }
                 else
@@ -1019,7 +1019,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Finally, wrap it in a nullable ctor.
                 defaultValue = new BoundObjectCreationExpression(
                     syntax,
-                    GetNullableMethod(syntax, parameterType, SpecialMember.System_Nullable_T__ctor),
+                    UnsafeGetNullableMethod(syntax, parameterType, SpecialMember.System_Nullable_T__ctor),
                     defaultValue);
             }
             else if (defaultConstantValue.IsNull || defaultConstantValue.IsBad)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         node.Syntax,
                         loweredReceiver,
                         receiverType.IsNullableType() ?
-                                 GetNullableMethod(node.Syntax, loweredReceiver.Type, SpecialMember.System_Nullable_T_get_HasValue) :
+                                 UnsafeGetNullableMethod(node.Syntax, loweredReceiver.Type, SpecialMember.System_Nullable_T_get_HasValue) :
                                  null,
                         loweredAccessExpression,
                         null,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -739,7 +739,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // SPEC: by a wrapping from T to T?.
 
                 BoundExpression rewrittenConversion = MakeConversionNode(syntax, rewrittenOperand, conversion.UnderlyingConversions[0], rewrittenType.GetNullableUnderlyingType(), @checked);
-                MethodSymbol ctor = GetNullableMethod(syntax, rewrittenType, SpecialMember.System_Nullable_T__ctor);
+                MethodSymbol ctor = UnsafeGetNullableMethod(syntax, rewrittenType, SpecialMember.System_Nullable_T__ctor);
                 return new BoundObjectCreationExpression(syntax, ctor, rewrittenConversion);
             }
             else
@@ -756,7 +756,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // (If the source is known to be possibly null then we need to keep the call to get Value 
                     // in place so that it throws at runtime.)
-                    MethodSymbol get_Value = GetNullableMethod(syntax, rewrittenOperandType, SpecialMember.System_Nullable_T_get_Value);
+                    MethodSymbol get_Value = UnsafeGetNullableMethod(syntax, rewrittenOperandType, SpecialMember.System_Nullable_T_get_Value);
                     value = BoundCall.Synthesized(syntax, rewrittenOperand, get_Value);
                 }
                 
@@ -835,11 +835,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundAssignmentOperator tempAssignment;
             var boundTemp = _factory.StoreToTemp(operand, out tempAssignment);
-            MethodSymbol getValueOrDefault = GetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
+            MethodSymbol getValueOrDefault;
+                
+            if (!TryGetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_GetValueOrDefault, out getValueOrDefault))
+            {
+                return BadExpression(syntax, type, operand);
+            }
+
             BoundExpression condition = MakeNullableHasValue(syntax, boundTemp);
             BoundExpression consequence = new BoundObjectCreationExpression(
                 syntax,
-                GetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor),
+                UnsafeGetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor),
                 MakeConversionNode(
                     syntax,
                     BoundCall.Synthesized(syntax, boundTemp, getValueOrDefault),
@@ -914,7 +920,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return new BoundObjectCreationExpression(
                     syntax,
-                    GetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor),
+                    UnsafeGetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor),
                     MakeConversionNode(
                         syntax,
                         nonNullValue,
@@ -1019,7 +1025,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (call.Method.ReturnType.IsNonNullableValueType())
             {
                 Debug.Assert(resultType.IsNullableType() && resultType.GetNullableUnderlyingType() == call.Method.ReturnType);
-                MethodSymbol ctor = GetNullableMethod(call.Syntax, resultType, SpecialMember.System_Nullable_T__ctor);
+                MethodSymbol ctor = UnsafeGetNullableMethod(call.Syntax, resultType, SpecialMember.System_Nullable_T__ctor);
                 return new BoundObjectCreationExpression(call.Syntax, ctor, call);
             }
 
@@ -1034,7 +1040,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (_inExpressionLambda)
             {
-                Conversion conv = MakeConversion(syntax, conversion, rewrittenOperand.Type, rewrittenType);
+                Conversion conv = TryMakeConversion(syntax, conversion, rewrittenOperand.Type, rewrittenType);
                 return BoundConversion.Synthesized(syntax, rewrittenOperand, conv, false, true, default(ConstantValue), rewrittenType);
             }
 
@@ -1068,7 +1074,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundAssignmentOperator tempAssignment;
             BoundLocal boundTemp = _factory.StoreToTemp(rewrittenOperand, out tempAssignment);
-            MethodSymbol getValueOrDefault = GetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
+            MethodSymbol getValueOrDefault = UnsafeGetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
 
             // temp.HasValue
             BoundExpression condition = MakeNullableHasValue(syntax, boundTemp);
@@ -1121,7 +1127,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol target = rewrittenType;
 
             SpecialMember member = GetIntPtrConversionMethod(source: rewrittenOperand.Type, target: rewrittenType);
-            MethodSymbol method = GetSpecialTypeMethod(syntax, member);
+            MethodSymbol method;
+
+            if (!TryGetSpecialTypeMethod(syntax, member, out method))
+            {
+                return BadExpression(syntax, rewrittenType, rewrittenOperand);
+            }
+
             Debug.Assert(!method.ReturnsVoid);
             Debug.Assert(method.ParameterCount == 1);
 
@@ -1339,7 +1351,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private Conversion MakeConversion(SyntaxNode syntax, Conversion conversion, TypeSymbol fromType, TypeSymbol toType)
+        /// <summary>
+        /// Reports diagnostics and returns Conversion.NoConversion in case of missing runtime helpers.
+        /// </summary>
+        private Conversion TryMakeConversion(SyntaxNode syntax, Conversion conversion, TypeSymbol fromType, TypeSymbol toType)
         {
             switch (conversion.Kind)
             {
@@ -1347,8 +1362,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.ImplicitUserDefined:
                     {
                         var meth = conversion.Method;
-                        Conversion fromConversion = MakeConversion(syntax, conversion.UserDefinedFromConversion, fromType, meth.Parameters[0].Type);
-                        Conversion toConversion = MakeConversion(syntax, conversion.UserDefinedToConversion, meth.ReturnType, toType);
+                        Conversion fromConversion = TryMakeConversion(syntax, conversion.UserDefinedFromConversion, fromType, meth.Parameters[0].Type);
+                        if (!fromConversion.Exists)
+                        {
+                            return Conversion.NoConversion;
+                        }
+
+                        Conversion toConversion = TryMakeConversion(syntax, conversion.UserDefinedToConversion, meth.ReturnType, toType);
+                        if (!toConversion.Exists)
+                        {
+                            return Conversion.NoConversion;
+                        }
+
                         if (fromConversion == conversion.UserDefinedFromConversion && toConversion == conversion.UserDefinedToConversion)
                         {
                             return conversion;
@@ -1364,8 +1389,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ConversionKind.IntPtr:
                     {
                         SpecialMember member = GetIntPtrConversionMethod(fromType, toType);
-                        MethodSymbol method = GetSpecialTypeMethod(syntax, member);
-                        return MakeUserDefinedConversion(syntax, method, fromType, toType, conversion.IsImplicit);
+                        MethodSymbol method;
+                        if (!TryGetSpecialTypeMethod(syntax, member, out method))
+                        {
+                            return Conversion.NoConversion;
+                        }
+
+                        return TryMakeUserDefinedConversion(syntax, method, fromType, toType, conversion.IsImplicit);
                     }
                 case ConversionKind.ImplicitNumeric:
                 case ConversionKind.ExplicitNumeric:
@@ -1373,8 +1403,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (fromType.SpecialType == SpecialType.System_Decimal || toType.SpecialType == SpecialType.System_Decimal)
                     {
                         SpecialMember member = DecimalConversionMethod(fromType, toType);
-                        MethodSymbol method = GetSpecialTypeMethod(syntax, member);
-                        return MakeUserDefinedConversion(syntax, method, fromType, toType, conversion.IsImplicit);
+                        MethodSymbol method;
+                        if (!TryGetSpecialTypeMethod(syntax, member, out method))
+                        {
+                            return Conversion.NoConversion;
+                        }
+
+                        return TryMakeUserDefinedConversion(syntax, method, fromType, toType, conversion.IsImplicit);
                     }
                     return conversion;
                 case ConversionKind.ImplicitEnumeration:
@@ -1383,14 +1418,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (fromType.SpecialType == SpecialType.System_Decimal)
                     {
                         SpecialMember member = DecimalConversionMethod(fromType, toType.GetEnumUnderlyingType());
-                        MethodSymbol method = GetSpecialTypeMethod(syntax, member);
-                        return MakeUserDefinedConversion(syntax, method, fromType, toType, conversion.IsImplicit);
+                        MethodSymbol method;
+                        if (!TryGetSpecialTypeMethod(syntax, member, out method))
+                        {
+                            return Conversion.NoConversion;
+                        }
+
+                        return TryMakeUserDefinedConversion(syntax, method, fromType, toType, conversion.IsImplicit);
                     }
                     else if (toType.SpecialType == SpecialType.System_Decimal)
                     {
                         SpecialMember member = DecimalConversionMethod(fromType.GetEnumUnderlyingType(), toType);
-                        MethodSymbol method = GetSpecialTypeMethod(syntax, member);
-                        return MakeUserDefinedConversion(syntax, method, fromType, toType, conversion.IsImplicit);
+                        MethodSymbol method;
+                        if (!TryGetSpecialTypeMethod(syntax, member, out method))
+                        {
+                            return Conversion.NoConversion;
+                        }
+
+                        return TryMakeUserDefinedConversion(syntax, method, fromType, toType, conversion.IsImplicit);
                     }
                     return conversion;
                 default:
@@ -1398,18 +1443,34 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private Conversion MakeConversion(SyntaxNode syntax, TypeSymbol fromType, TypeSymbol toType)
+        /// <summary>
+        /// Reports diagnostics and returns Conversion.NoConversion in case of missing runtime helpers.
+        /// </summary>
+        private Conversion TryMakeConversion(SyntaxNode syntax, TypeSymbol fromType, TypeSymbol toType)
         {
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-            var result = MakeConversion(syntax, _compilation.Conversions.ClassifyConversionFromType(fromType, toType, ref useSiteDiagnostics), fromType, toType);
+            var result = TryMakeConversion(syntax, _compilation.Conversions.ClassifyConversionFromType(fromType, toType, ref useSiteDiagnostics), fromType, toType);
             _diagnostics.Add(syntax, useSiteDiagnostics);
             return result;
         }
 
-        private Conversion MakeUserDefinedConversion(SyntaxNode syntax, MethodSymbol meth, TypeSymbol fromType, TypeSymbol toType, bool isImplicit = true)
+        /// <summary>
+        /// Reports diagnostics and returns Conversion.NoConversion in case of missing runtime helpers.
+        /// </summary>
+        private Conversion TryMakeUserDefinedConversion(SyntaxNode syntax, MethodSymbol meth, TypeSymbol fromType, TypeSymbol toType, bool isImplicit = true)
         {
-            Conversion fromConversion = MakeConversion(syntax, fromType, meth.Parameters[0].Type);
-            Conversion toConversion = MakeConversion(syntax, meth.ReturnType, toType);
+            Conversion fromConversion = TryMakeConversion(syntax, fromType, meth.Parameters[0].Type);
+            if (!fromConversion.Exists)
+            {
+                return Conversion.NoConversion;
+            }
+
+            Conversion toConversion = TryMakeConversion(syntax, meth.ReturnType, toType);
+            if (!toConversion.Exists)
+            {
+                return Conversion.NoConversion;
+            }
+
             // TODO: distinguish between normal and lifted conversions here
             var analysis = UserDefinedConversionAnalysis.Normal(meth, fromConversion, toConversion, fromType, toType);
             var result = UserDefinedConversionResult.Valid(ImmutableArray.Create<UserDefinedConversionAnalysis>(analysis), 0);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ForEachStatement.cs
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement initializer = new BoundStatementList(forEachSyntax,
                 statements: ImmutableArray.Create<BoundStatement>(stringVarDecl, positionVariableDecl));
 
-            MethodSymbol method = GetSpecialTypeMethod(forEachSyntax, SpecialMember.System_String__Length);
+            MethodSymbol method = UnsafeGetSpecialTypeMethod(forEachSyntax, SpecialMember.System_String__Length);
             BoundExpression stringLength = BoundCall.Synthesized(
                     syntax: forEachSyntax,
                     receiverOpt: boundStringVar,
@@ -436,7 +436,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node.ElementConversion.IsValid);
 
             // (V)s.Chars[p]
-            MethodSymbol chars = GetSpecialTypeMethod(forEachSyntax, SpecialMember.System_String__Chars);
+            MethodSymbol chars = UnsafeGetSpecialTypeMethod(forEachSyntax, SpecialMember.System_String__Chars);
             BoundExpression iterationVarInitValue = MakeConversionNode(
                 syntax: forEachSyntax,
                 rewrittenOperand: BoundCall.Synthesized(
@@ -697,8 +697,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol boolType = _compilation.GetSpecialType(SpecialType.System_Boolean);
 
             // Values we'll use every iteration
-            MethodSymbol getLowerBoundMethod = GetSpecialTypeMethod(forEachSyntax, SpecialMember.System_Array__GetLowerBound);
-            MethodSymbol getUpperBoundMethod = GetSpecialTypeMethod(forEachSyntax, SpecialMember.System_Array__GetUpperBound);
+            MethodSymbol getLowerBoundMethod = UnsafeGetSpecialTypeMethod(forEachSyntax, SpecialMember.System_Array__GetLowerBound);
+            MethodSymbol getUpperBoundMethod = UnsafeGetSpecialTypeMethod(forEachSyntax, SpecialMember.System_Array__GetUpperBound);
 
             BoundExpression rewrittenExpression = (BoundExpression)Visit(collectionExpression);
             BoundStatement rewrittenBody = (BoundStatement)Visit(node.Body);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -35,7 +35,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (_inExpressionLambda)
             {
                 TypeSymbol strippedLeftType = rewrittenLeft.Type.StrippedType();
-                Conversion rewrittenConversion = MakeConversion(syntax, leftConversion, strippedLeftType, rewrittenResultType);
+                Conversion rewrittenConversion = TryMakeConversion(syntax, leftConversion, strippedLeftType, rewrittenResultType);
+                if (!rewrittenConversion.Exists)
+                {
+                    return BadExpression(syntax, rewrittenResultType, rewrittenLeft, rewrittenRight);
+                }
+
                 return new BoundNullCoalescingOperator(syntax, rewrittenLeft, rewrittenRight, rewrittenConversion, rewrittenResultType);
             }
 
@@ -116,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // MakeConversion(temp, rewrittenResultType)
             BoundExpression convertedLeft = GetConvertedLeftForNullCoalescingOperator(boundTemp, leftConversion, rewrittenResultType);
-            Debug.Assert(convertedLeft.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamicAndTupleNames));
+            Debug.Assert(convertedLeft.HasErrors || convertedLeft.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             // (temp != null) ? MakeConversion(temp, LeftConversion) : RightOperand
             BoundExpression conditionalExpression = RewriteConditionalOperator(
@@ -156,7 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (rewrittenLeftType != rewrittenResultType && rewrittenLeftType.IsNullableType())
             {
                 TypeSymbol strippedLeftType = rewrittenLeftType.GetNullableUnderlyingType();
-                MethodSymbol getValueOrDefault = GetNullableMethod(rewrittenLeft.Syntax, rewrittenLeftType, SpecialMember.System_Nullable_T_GetValueOrDefault);
+                MethodSymbol getValueOrDefault = UnsafeGetNullableMethod(rewrittenLeft.Syntax, rewrittenLeftType, SpecialMember.System_Nullable_T_GetValueOrDefault);
                 rewrittenLeft = BoundCall.Synthesized(rewrittenLeft.Syntax, rewrittenLeft, getValueOrDefault);
                 if (strippedLeftType == rewrittenResultType)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
@@ -501,7 +501,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (underlyingSwitchType.SpecialType == SpecialType.System_String)
                 {
                     _localRewriter.EnsureStringHashFunction(rewrittenSections, _factory.Syntax);
-                    stringEquality = _localRewriter.GetSpecialTypeMethod(_factory.Syntax, SpecialMember.System_String__op_Equality);
+                    stringEquality = _localRewriter.UnsafeGetSpecialTypeMethod(_factory.Syntax, SpecialMember.System_String__op_Equality);
                 }
 
                 // The BoundSwitchStatement requires a constant target when there are no sections, so we accomodate that here.

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Patterns.cs
@@ -179,9 +179,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 //     t = e as T?;
                 //     return t.HasValue;
                 // }
+
+                // At the moment this code path has no test coverage https://github.com/dotnet/roslyn/issues/17548.
                 return _factory.Call(
                     _factory.AssignmentExpression(loweredTarget, _factory.As(loweredInput, type)),
-                    GetNullableMethod(syntax, type, SpecialMember.System_Nullable_T_get_HasValue));
+                    UnsafeGetNullableMethod(syntax, type, SpecialMember.System_Nullable_T_get_HasValue));
             }
             else if (type.IsValueType)
             {
@@ -207,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var asg1 = _factory.AssignmentExpression(_factory.Local(tmp), tmpType == loweredInput.Type ? loweredInput : _factory.As(loweredInput, tmpType));
                 var value = _factory.Call(
                     _factory.Local(tmp),
-                    GetNullableMethod(syntax, tmpType, SpecialMember.System_Nullable_T_GetValueOrDefault));
+                    UnsafeGetNullableMethod(syntax, tmpType, SpecialMember.System_Nullable_T_GetValueOrDefault));
                 var asg2 = _factory.AssignmentExpression(loweredTarget, value);
                 var result = MakeNullableHasValue(syntax, _factory.Local(tmp));
                 return _factory.MakeSequence(tmp, asg1, asg2, result);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringConcat.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringConcat.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return _factory.Coalesce(loweredOperand, _factory.Literal(""));
             }
 
-            var method = GetSpecialTypeMethod(syntax, SpecialMember.System_String__ConcatObject);
+            var method = UnsafeGetSpecialTypeMethod(syntax, SpecialMember.System_String__ConcatObject);
             Debug.Assert((object)method != null);
 
             return (BoundExpression)BoundCall.Synthesized(syntax, null, method, loweredOperand);
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 SpecialMember.System_String__ConcatStringString :
                 SpecialMember.System_String__ConcatObjectObject;
 
-            var method = GetSpecialTypeMethod(syntax, member);
+            var method = UnsafeGetSpecialTypeMethod(syntax, member);
             Debug.Assert((object)method != null);
 
             return (BoundExpression)BoundCall.Synthesized(syntax, null, method, loweredLeft, loweredRight);
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 SpecialMember.System_String__ConcatStringStringString :
                 SpecialMember.System_String__ConcatObjectObjectObject;
 
-            var method = GetSpecialTypeMethod(syntax, member);
+            var method = UnsafeGetSpecialTypeMethod(syntax, member);
             Debug.Assert((object)method != null);
 
             return BoundCall.Synthesized(syntax, null, method, ImmutableArray.Create(loweredFirst, loweredSecond, loweredThird));
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression RewriteStringConcatenationManyExprs(SyntaxNode syntax, ImmutableArray<BoundExpression> loweredArgs)
         {
             Debug.Assert(loweredArgs.Length > 3);
-            Debug.Assert(loweredArgs.All(a => a.Type.SpecialType == SpecialType.System_Object || a.Type.SpecialType == SpecialType.System_String));
+            Debug.Assert(loweredArgs.All(a => a.HasErrors || a.Type.SpecialType == SpecialType.System_Object || a.Type.SpecialType == SpecialType.System_String));
 
             bool isObject = false;
             TypeSymbol elementType = null;
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!isObject && loweredArgs.Length == 4)
             {
                 SpecialMember member = SpecialMember.System_String__ConcatStringStringStringString;
-                var method = GetSpecialTypeMethod(syntax, member);
+                var method = UnsafeGetSpecialTypeMethod(syntax, member);
                 Debug.Assert((object)method != null);
 
                 return (BoundExpression)BoundCall.Synthesized(syntax, null, method, loweredArgs);
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     SpecialMember.System_String__ConcatObjectArray :
                     SpecialMember.System_String__ConcatStringArray;
 
-                var method = GetSpecialTypeMethod(syntax, member);
+                var method = UnsafeGetSpecialTypeMethod(syntax, member);
                 Debug.Assert((object)method != null);
 
                 var array = _factory.ArrayOrEmpty(elementType, loweredArgs);
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 SpecialMember.System_String__ConcatStringString :
                 SpecialMember.System_String__ConcatObjectObject;
 
-            var method = GetSpecialTypeMethod(syntax, member);
+            var method = UnsafeGetSpecialTypeMethod(syntax, member);
             Debug.Assert((object)method != null);
 
             return new BoundBinaryOperator(syntax, operatorKind, loweredLeft, loweredRight, default(ConstantValue), method, default(LookupResultKind), type);
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // If so, we can synthesize a ToString call to avoid boxing.
                         if (ConcatExprCanBeOptimizedWithToString(operand.Type))
                         {
-                            var toString = GetSpecialTypeMethod(syntax, SpecialMember.System_Object__ToString);
+                            var toString = UnsafeGetSpecialTypeMethod(syntax, SpecialMember.System_Object__ToString);
 
                             var type = (NamedTypeSymbol)operand.Type;
                             var toStringMembers = type.GetMembers(toString.Name);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (rewrittenExpression.Type.SpecialType == SpecialType.System_String)
             {
                 EnsureStringHashFunction(rewrittenSections, syntax);
-                stringEquality = GetSpecialTypeMethod(syntax, SpecialMember.System_String__op_Equality);
+                stringEquality = UnsafeGetSpecialTypeMethod(syntax, SpecialMember.System_String__op_Equality);
             }
 
             return oldNode.Update(
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Rewrite the switch statement using nullable expression's underlying value as the switch expression.
 
             // rewrittenExpression.GetValueOrDefault()
-            MethodSymbol getValueOrDefault = GetNullableMethod(syntax, exprNullableType, SpecialMember.System_Nullable_T_GetValueOrDefault);
+            MethodSymbol getValueOrDefault = UnsafeGetNullableMethod(syntax, exprNullableType, SpecialMember.System_Nullable_T_GetValueOrDefault);
             BoundCall callGetValueOrDefault = BoundCall.Synthesized(exprSyntax, rewrittenExpression, getValueOrDefault);
             rewrittenExpression = callGetValueOrDefault;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UnaryOperator.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundAssignmentOperator tempAssignment;
             BoundLocal boundTemp = _factory.StoreToTemp(loweredOperand, out tempAssignment);
-            MethodSymbol getValueOrDefault = GetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
+            MethodSymbol getValueOrDefault = UnsafeGetNullableMethod(syntax, boundTemp.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
 
             // temp.HasValue
             BoundExpression condition = MakeNullableHasValue(syntax, boundTemp);
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression GetLiftedUnaryOperatorConsequence(UnaryOperatorKind kind, SyntaxNode syntax, MethodSymbol method, TypeSymbol type, BoundExpression nonNullOperand)
         {
-            MethodSymbol ctor = GetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor);
+            MethodSymbol ctor = UnsafeGetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor);
 
             // OP(temp.GetValueOrDefault())
             BoundExpression unliftedOp = MakeUnaryOperator(
@@ -620,8 +620,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundAssignmentOperator tempAssignment;
             BoundLocal boundTemp = _factory.StoreToTemp(rewrittenArgument, out tempAssignment);
 
-            MethodSymbol getValueOrDefault = GetNullableMethod(syntax, type, SpecialMember.System_Nullable_T_GetValueOrDefault);
-            MethodSymbol ctor = GetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor);
+            MethodSymbol getValueOrDefault = UnsafeGetNullableMethod(syntax, type, SpecialMember.System_Nullable_T_GetValueOrDefault);
+            MethodSymbol ctor = UnsafeGetNullableMethod(syntax, type, SpecialMember.System_Nullable_T__ctor);
 
             // temp.HasValue
             BoundExpression condition = MakeNullableHasValue(node.Syntax, boundTemp);
@@ -699,7 +699,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (binaryOperatorKind.IsLifted())
             {
                 binaryOperandType = _compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(binaryOperandType);
-                MethodSymbol ctor = GetNullableMethod(node.Syntax, binaryOperandType, SpecialMember.System_Nullable_T__ctor);
+                MethodSymbol ctor = UnsafeGetNullableMethod(node.Syntax, binaryOperandType, SpecialMember.System_Nullable_T__ctor);
                 boundOne = new BoundObjectCreationExpression(node.Syntax, ctor, boundOne);
             }
 
@@ -790,8 +790,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // This method assumes that operand is already a temporary and so there is no need to copy it again.
             MethodSymbol method = GetDecimalIncDecOperator(oper);
-            MethodSymbol getValueOrDefault = GetNullableMethod(syntax, operand.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
-            MethodSymbol ctor = GetNullableMethod(syntax, operand.Type, SpecialMember.System_Nullable_T__ctor);
+            MethodSymbol getValueOrDefault = UnsafeGetNullableMethod(syntax, operand.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
+            MethodSymbol ctor = UnsafeGetNullableMethod(syntax, operand.Type, SpecialMember.System_Nullable_T__ctor);
 
             // x.HasValue
             BoundExpression condition = MakeNullableHasValue(syntax, operand);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (isNullableValueType)
             {
-                MethodSymbol getValueOrDefault = GetNullableMethod(syntax, local.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
+                MethodSymbol getValueOrDefault = UnsafeGetNullableMethod(syntax, local.Type, SpecialMember.System_Nullable_T_GetValueOrDefault);
                 // local.GetValueOrDefault()
                 disposedExpression = BoundCall.Synthesized(syntax, local, getValueOrDefault);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -637,7 +637,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundCall(
                 Syntax, receiver, method, args,
                 ImmutableArray<String>.Empty, ImmutableArray<RefKind>.Empty, false, false, false,
-                default(ImmutableArray<int>), LookupResultKind.Viable, method.ReturnType)
+                default(ImmutableArray<int>), LookupResultKind.Viable, method.ReturnType,
+                hasErrors:method.OriginalDefinition is ErrorMethodSymbol)
             { WasCompilerGenerated = true };
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -868,5 +868,1559 @@ namespace System
                 Assert.NotNull(symbol);
             }
         }
+
+        [Fact, WorkItem(377890, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=377890")]
+        public void System_IntPtr__op_Explicit_FromInt32()
+        {
+            string source = @"
+using System;
+
+public class MyClass
+{
+    static void Main()
+    {
+        ((IntPtr)0).GetHashCode();
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source);
+            comp.MakeMemberMissing(SpecialMember.System_IntPtr__op_Explicit_FromInt32);
+            comp.VerifyEmitDiagnostics(
+                // (8,10): error CS0656: Missing compiler required member 'System.IntPtr.op_Explicit'
+                //         ((IntPtr)0).GetHashCode();
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(IntPtr)0").WithArguments("System.IntPtr", "op_Explicit").WithLocation(8, 10)
+                );
+        }
+
+        [Fact]
+        public void System_Delegate__Combine()
+        {
+            var source =
+@"
+using System;
+using System.Threading.Tasks;
+
+namespace RoslynAsyncDelegate
+{
+    class Program
+    {
+        static EventHandler MyEvent;
+
+        static void Main(string[] args)
+        {
+           MyEvent += async delegate { await Task.Delay(0); };
+        }
+    }
+}
+
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            compilation.MakeMemberMissing(SpecialMember.System_Delegate__Combine);
+            compilation.VerifyEmitDiagnostics(
+                // (13,12): error CS0656: Missing compiler required member 'System.Delegate.Combine'
+                //            MyEvent += async delegate { await Task.Delay(0); };
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "MyEvent += async delegate { await Task.Delay(0); }").WithArguments("System.Delegate", "Combine").WithLocation(13, 12)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_01()
+        {
+            string source = @"
+using System;
+
+public struct S
+{
+    public static implicit operator int(S n) // 1 native compiler
+    {
+        Console.WriteLine(1);
+        return 0;
+    }
+
+    public static implicit operator int?(S n) // 2 Roslyn compiler
+    {
+        Console.WriteLine(2);
+        return null;
+    }
+
+    public static void Main()
+    {
+        int? qa = 5;
+        S b = default(S);
+        var sum = qa + b;
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (20,19): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         int? qa = 5;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "5").WithArguments("System.Nullable`1", ".ctor").WithLocation(20, 19),
+                // (22,19): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         var sum = qa + b;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "qa + b").WithArguments("System.Nullable`1", ".ctor").WithLocation(22, 19)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_01()
+        {
+            string source = @"
+using System;
+
+public struct S
+{
+    public static implicit operator int(S n) // 1 native compiler
+    {
+        Console.WriteLine(1);
+        return 0;
+    }
+
+    public static implicit operator int?(S n) // 2 Roslyn compiler
+    {
+        Console.WriteLine(2);
+        return null;
+    }
+
+    public static void Main()
+    {
+        int? qa = 5;
+        S b = default(S);
+        var sum = qa + b;
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (22,19): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         var sum = qa + b;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "qa + b").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(22, 19),
+                // (22,19): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         var sum = qa + b;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "qa + b").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(22, 19)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_get_HasValue_01()
+        {
+            string source = @"
+using System;
+
+public struct S
+{
+    public static implicit operator int(S n) // 1 native compiler
+    {
+        Console.WriteLine(1);
+        return 0;
+    }
+
+    public static implicit operator int?(S n) // 2 Roslyn compiler
+    {
+        Console.WriteLine(2);
+        return null;
+    }
+
+    public static void Main()
+    {
+        int? qa = 5;
+        S b = default(S);
+        var sum = qa + b;
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_get_HasValue);
+            compilation.VerifyEmitDiagnostics(
+                // (22,19): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
+                //         var sum = qa + b;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "qa + b").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(22, 19),
+                // (22,19): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
+                //         var sum = qa + b;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "qa + b").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(22, 19)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_02()
+        {
+            string source = @"
+using System;
+namespace Test
+{
+    static class Program
+    {
+        static void Main()
+        {
+            int? i = 123;
+            C c = (C)i;
+        }
+    }
+
+    public class C
+    {
+        public readonly int v;
+        public C(int v) { this.v = v; }
+        public static implicit operator C(int v)
+        {
+            Console.Write(v);
+            return new C(v);
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (10,19): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //             C c = (C)i;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(C)i").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(10, 19)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_get_Value()
+        {
+            var source =
+@"
+using System;
+
+class C
+{
+    static void Test()
+    {
+        byte? b = 0;
+        IntPtr p = (IntPtr)b;
+        Console.WriteLine(p);
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_get_Value);
+            compilation.VerifyEmitDiagnostics(
+                // (9,28): error CS0656: Missing compiler required member 'System.Nullable`1.get_Value'
+                //         IntPtr p = (IntPtr)b;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "b").WithArguments("System.Nullable`1", "get_Value").WithLocation(9, 28)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_02()
+        {
+            var source =
+@"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        Console.WriteLine((IntPtr?)M_int());
+        Console.WriteLine((IntPtr?)M_int(42));
+        Console.WriteLine((IntPtr?)M_long());
+        Console.WriteLine((IntPtr?)M_long(300));
+    }
+
+    static int? M_int(int? p = null) { return p; } 
+    static long? M_long(long? p = null) { return p; } 
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (8,27): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         Console.WriteLine((IntPtr?)M_int());
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(IntPtr?)M_int()").WithArguments("System.Nullable`1", ".ctor").WithLocation(8, 27),
+                // (9,42): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         Console.WriteLine((IntPtr?)M_int(42));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "42").WithArguments("System.Nullable`1", ".ctor").WithLocation(9, 42),
+                // (9,27): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         Console.WriteLine((IntPtr?)M_int(42));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(IntPtr?)M_int(42)").WithArguments("System.Nullable`1", ".ctor").WithLocation(9, 27),
+                // (10,27): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         Console.WriteLine((IntPtr?)M_long());
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(IntPtr?)M_long()").WithArguments("System.Nullable`1", ".ctor").WithLocation(10, 27),
+                // (11,43): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         Console.WriteLine((IntPtr?)M_long(300));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "300").WithArguments("System.Nullable`1", ".ctor").WithLocation(11, 43),
+                // (11,27): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         Console.WriteLine((IntPtr?)M_long(300));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(IntPtr?)M_long(300)").WithArguments("System.Nullable`1", ".ctor").WithLocation(11, 27)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_03()
+        {
+            var source =
+@"
+
+using System;
+
+class Class1
+{
+    static void Main()
+    {
+        MyClass b = (int?)1;
+    }
+}
+
+class MyClass
+{
+    public static implicit operator MyClass(decimal Value)
+    {
+        return new MyClass();
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (9,21): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         MyClass b = (int?)1;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(int?)1").WithArguments("System.Nullable`1", ".ctor").WithLocation(9, 21),
+                // (9,21): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         MyClass b = (int?)1;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(int?)1").WithArguments("System.Nullable`1", ".ctor").WithLocation(9, 21)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_04()
+        {
+            var source1 = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+public static class Test
+{
+    public static void Generic<T>([Optional][DecimalConstant(0, 0, 0, 0, 50)] T x)
+    {
+        Console.WriteLine(x == null ? ""null"" : x.ToString());
+    }
+
+    public static void Decimal([Optional][DecimalConstant(0, 0, 0, 0, 50)] Decimal x)
+    {
+        Console.WriteLine(x.ToString());
+    }
+
+    public static void NullableDecimal([Optional][DecimalConstant(0, 0, 0, 0, 50)] Decimal? x)
+    {
+        Console.WriteLine(x == null ? ""null"" : x.ToString());
+    }
+
+    public static void Object([Optional][DecimalConstant(0, 0, 0, 0, 50)] object x)
+    {
+        Console.WriteLine(x == null ? ""null"" : x.ToString());
+    }
+
+    public static void String([Optional][DecimalConstant(0, 0, 0, 0, 50)] string x)
+    {
+        Console.WriteLine(x == null ? ""null"" : x.ToString());
+    }
+
+    public static void Int32([Optional][DecimalConstant(0, 0, 0, 0, 50)] int x)
+    {
+        Console.WriteLine(x.ToString());
+    }
+
+    public static void IComparable([Optional][DecimalConstant(0, 0, 0, 0, 50)] IComparable x)
+    {
+        Console.WriteLine(x == null ? ""null"" : x.ToString());
+    }
+
+    public static void ValueType([Optional][DecimalConstant(0, 0, 0, 0, 50)] ValueType x)
+    {
+        Console.WriteLine(x == null ? ""null"" : x.ToString());
+    }
+}
+";
+
+            var source2 = @"
+class Program
+{
+    public static void Main()
+    {
+        // Respects default value
+        Test.Generic<decimal>();    
+        Test.Generic<decimal?>();   
+        Test.Generic<object>();             
+        Test.Decimal();                    
+        Test.NullableDecimal();            
+        Test.Object();                      
+        Test.IComparable();                 
+        Test.ValueType();                   
+        Test.Int32();                       
+
+        // Null, since not convertible
+        Test.Generic<string>();             
+        Test.String();                      
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source1 + source2);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (55,9): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         Test.Generic<decimal?>();   
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "Test.Generic<decimal?>()").WithArguments("System.Nullable`1", ".ctor").WithLocation(55, 9),
+                // (58,9): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         Test.NullableDecimal();            
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "Test.NullableDecimal()").WithArguments("System.Nullable`1", ".ctor").WithLocation(58, 9)
+                );
+        }
+
+        [Fact]
+        public void System_String__ConcatObjectObject()
+        {
+            var source =
+@"
+
+using System;
+
+class Class1
+{
+    static void Main()
+    {
+    }
+}
+
+class MyClass
+{
+    public static implicit operator MyClass(decimal Value)
+    {
+        Console.WriteLine(""Value is: "" + Value);
+        return new MyClass();
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_String__ConcatObjectObject);
+            compilation.VerifyEmitDiagnostics(
+                // (16,27): error CS0656: Missing compiler required member 'System.String.Concat'
+                //         Console.WriteLine("Value is: " + Value);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"""Value is: "" + Value").WithArguments("System.String", "Concat").WithLocation(16, 27)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_04()
+        {
+            var source =
+@"
+
+using System;
+
+class Class1
+{
+    static void Main()
+    {
+        int? a = 1;
+        a.ToString();
+        MyClass b = a;
+        b.ToString();
+    }
+}
+
+class MyClass
+{
+    public static implicit operator MyClass(decimal Value)
+    {
+        return new MyClass();
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (11,21): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         MyClass b = a;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "a").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(11, 21),
+                // (11,21): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         MyClass b = a;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "a").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(11, 21)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_get_HasValue_02()
+        {
+            var source =
+@"
+
+using System;
+
+class Class1
+{
+    static void Main()
+    {
+        int? a = 1;
+        a.ToString();
+        MyClass b = a;
+        b.ToString();
+    }
+}
+
+class MyClass
+{
+    public static implicit operator MyClass(decimal Value)
+    {
+        Console.WriteLine(""Value is: "" + Value);
+        return new MyClass();
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_get_HasValue);
+            compilation.VerifyEmitDiagnostics(
+                // (11,21): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
+                //         MyClass b = a;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "a").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(11, 21)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_03()
+        {
+            string source = @"using System;
+
+namespace Test
+{
+    static class Program
+    {
+        static void Main()
+        {
+            S.v = 0;
+            S? S2 = 123;                  // not lifted, int=>int?, int?=>S, S=>S?
+            Console.WriteLine(S.v == 123);
+        }
+    }
+
+    public struct S
+    {
+        public static int v;
+        // s == null, return v = -1
+        public static implicit operator S(int? s)
+        {
+            Console.Write(""Imp S::int? -> S "");
+            S ss = new S();
+            S.v = s ?? -1;
+            return ss;
+        }
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (23,19): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //             S.v = s ?? -1;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "s").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(23, 19)
+                );
+        }
+
+        [Fact]
+        public void System_String__ConcatStringStringString()
+        {
+            string source = @"
+using System;
+struct S
+{
+    private string str;
+    public S(char chr) { this.str = chr.ToString(); }
+    public S(string str) { this.str = str; }
+    public static S operator + (S x, S y) { return new S('(' + x.str + '+' + y.str + ')'); }
+}
+
+class C
+{
+    static void Main()
+    {
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_String__ConcatStringStringString);
+            compilation.VerifyEmitDiagnostics(
+                // (8,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator + (S x, S y) { return new S('(' + x.str + '+' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '+'").WithArguments("System.String", "Concat").WithLocation(8, 58)
+                );
+        }
+
+        [Fact]
+        public void System_String__ConcatStringStringStringString()
+        {
+            string source = @"
+using System;
+struct S
+{
+    private string str;
+    public S(char chr) { this.str = chr.ToString(); }
+    public S(string str) { this.str = str; }
+    public static S operator + (S x, S y) { return new S('(' + x.str + '+' + y.str + ')'); }
+}
+
+class C
+{
+    static void Main()
+    {
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_String__ConcatStringStringStringString);
+            compilation.VerifyEmitDiagnostics(
+                // (8,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator + (S x, S y) { return new S('(' + x.str + '+' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '+' + y.str").WithArguments("System.String", "Concat").WithLocation(8, 58)
+                );
+        }
+
+        [Fact]
+        public void System_String__ConcatStringArray()
+        {
+            string source = @"
+using System;
+struct S
+{
+    private string str;
+    public S(char chr) { this.str = chr.ToString(); }
+    public S(string str) { this.str = str; }
+    public static S operator + (S x, S y) { return new S('(' + x.str + '+' + y.str + ')'); }
+    public static S operator - (S x, S y) { return new S('(' + x.str + '-' + y.str + ')'); }
+    public static S operator % (S x, S y) { return new S('(' + x.str + '%' + y.str + ')'); }
+    public static S operator / (S x, S y) { return new S('(' + x.str + '/' + y.str + ')'); }
+    public static S operator * (S x, S y) { return new S('(' + x.str + '*' + y.str + ')'); }
+    public static S operator & (S x, S y) { return new S('(' + x.str + '&' + y.str + ')'); }
+    public static S operator | (S x, S y) { return new S('(' + x.str + '|' + y.str + ')'); }
+    public static S operator ^ (S x, S y) { return new S('(' + x.str + '^' + y.str + ')'); }
+    public static S operator << (S x, int y) { return new S('(' + x.str + '<' + '<' + y.ToString() + ')'); }
+    public static S operator >> (S x, int y) { return new S('(' + x.str + '>' + '>' + y.ToString() + ')'); }
+    public static S operator >= (S x, S y) { return new S('(' + x.str + '>' + '=' + y.str + ')'); }
+    public static S operator <= (S x, S y) { return new S('(' + x.str + '<' + '=' + y.str + ')'); }
+    public static S operator > (S x, S y) { return new S('(' + x.str + '>' + y.str + ')'); }
+    public static S operator < (S x, S y) { return new S('(' + x.str + '<' + y.str + ')'); }
+    public override string ToString() { return this.str; }
+}
+
+class C
+{
+    static void Main()
+    {
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_String__ConcatStringArray);
+            compilation.VerifyEmitDiagnostics(
+                // (8,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator + (S x, S y) { return new S('(' + x.str + '+' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '+' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(8, 58),
+                // (9,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator - (S x, S y) { return new S('(' + x.str + '-' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '-' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(9, 58),
+                // (10,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator % (S x, S y) { return new S('(' + x.str + '%' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '%' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(10, 58),
+                // (11,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator / (S x, S y) { return new S('(' + x.str + '/' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '/' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(11, 58),
+                // (12,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator * (S x, S y) { return new S('(' + x.str + '*' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '*' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(12, 58),
+                // (13,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator & (S x, S y) { return new S('(' + x.str + '&' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '&' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(13, 58),
+                // (14,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator | (S x, S y) { return new S('(' + x.str + '|' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '|' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(14, 58),
+                // (15,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator ^ (S x, S y) { return new S('(' + x.str + '^' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '^' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(15, 58),
+                // (16,61): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator << (S x, int y) { return new S('(' + x.str + '<' + '<' + y.ToString() + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '<' + '<' + y.ToString() + ')'").WithArguments("System.String", "Concat").WithLocation(16, 61),
+                // (17,61): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator >> (S x, int y) { return new S('(' + x.str + '>' + '>' + y.ToString() + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '>' + '>' + y.ToString() + ')'").WithArguments("System.String", "Concat").WithLocation(17, 61),
+                // (18,59): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator >= (S x, S y) { return new S('(' + x.str + '>' + '=' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '>' + '=' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(18, 59),
+                // (19,59): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator <= (S x, S y) { return new S('(' + x.str + '<' + '=' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '<' + '=' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(19, 59),
+                // (20,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator > (S x, S y) { return new S('(' + x.str + '>' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '>' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(20, 58),
+                // (21,58): error CS0656: Missing compiler required member 'System.String.Concat'
+                //     public static S operator < (S x, S y) { return new S('(' + x.str + '<' + y.str + ')'); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "'(' + x.str + '<' + y.str + ')'").WithArguments("System.String", "Concat").WithLocation(21, 58)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_05()
+        {
+            string source =
+@"
+struct S
+{
+    public static int operator +(S s) { return 1; }
+    public static void Main()
+    {
+        S s = new S();
+        S? sq = s;
+        var j = +sq;
+        System.Console.WriteLine(j);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (9,17): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         var j = +sq;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "+sq").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(9, 17)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_05()
+        {
+            string source =
+@"
+struct S
+{
+    public static int operator +(S s) { return 1; }
+    public static void Main()
+    {
+        S s = new S();
+        S? sq = s;
+        var j = +sq;
+        System.Console.WriteLine(j);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (8,17): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         S? sq = s;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "s").WithArguments("System.Nullable`1", ".ctor").WithLocation(8, 17),
+                // (9,17): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         var j = +sq;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "+sq").WithArguments("System.Nullable`1", ".ctor").WithLocation(9, 17)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_06()
+        {
+            string source =
+@"
+class C
+{
+  public readonly int? i;
+  public C(int? i) { this.i = i; }
+  public static implicit operator int?(C c) { return c.i; }
+  public static implicit operator C(int? s) { return new C(s); }
+  static void Main()
+  {
+    C c = new C(null);
+    c++;
+    System.Console.WriteLine(object.ReferenceEquals(c, null) ? 1 : 0);
+  }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (11,5): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //     c++;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "c++").WithArguments("System.Nullable`1", ".ctor").WithLocation(11, 5),
+                // (11,5): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //     c++;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "c++").WithArguments("System.Nullable`1", ".ctor").WithLocation(11, 5)
+                );
+        }
+
+        [Fact]
+        public void System_Decimal__op_Multiply()
+        {
+            string source = @"
+using System;
+class Program
+{       
+    static void Main()
+    {
+        Func<decimal?, decimal?> lambda = a => { return checked(a * a); };
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Decimal__op_Multiply);
+            compilation.VerifyEmitDiagnostics(
+                // (7,65): error CS0656: Missing compiler required member 'System.Decimal.op_Multiply'
+                //         Func<decimal?, decimal?> lambda = a => { return checked(a * a); };
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "a * a").WithArguments("System.Decimal", "op_Multiply").WithLocation(7, 65)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_06()
+        {
+            string source = @"
+using System;
+
+struct S : IDisposable
+{
+    public void Dispose()
+    {
+        Console.WriteLine(123);
+    }
+
+    static void Main()
+    {
+        using (S? r = new S())
+        {
+            Console.Write(r);
+        }
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (13,9): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         using (S? r = new S())
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"using (S? r = new S())
+        {
+            Console.Write(r);
+        }").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(13, 9)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_07()
+        {
+            string source = @"
+using System;
+class C
+{
+  static void Main()
+  {
+    decimal q = 10;
+    decimal? x = 10;
+
+    T(2, (x++).Value == (q++));
+  }
+
+  static void T(int line, bool b)
+  {
+  }
+}";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (10,11): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //     T(2, (x++).Value == (q++));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x++").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(10, 11)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_07()
+        {
+            string source = @"
+using System;
+class C
+{
+  static void Main()
+  {
+    decimal q = 10;
+    decimal? x = 10;
+
+    T(2, (x++).Value == (q++));
+  }
+
+  static void T(int line, bool b)
+  {
+  }
+}";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (8,18): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //     decimal? x = 10;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "10").WithArguments("System.Nullable`1", ".ctor").WithLocation(8, 18),
+                // (10,11): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //     T(2, (x++).Value == (q++));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x++").WithArguments("System.Nullable`1", ".ctor").WithLocation(10, 11),
+                // (10,11): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //     T(2, (x++).Value == (q++));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x++").WithArguments("System.Nullable`1", ".ctor").WithLocation(10, 11)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_08()
+        {
+            string source = @"
+using System;
+struct S
+{
+  public int x;
+  public S(int x) { this.x = x; }
+  public static S operator ++(S s) { return new S(s.x + 1); }
+  public static S operator --(S s) { return new S(s.x - 1); }
+}
+
+class C
+{
+  static void Main()
+  {
+    S? n = new S(1);
+    S s = new S(1);
+
+    T(2, (n++).Value.x == (s++).x);
+  }
+
+  static void T(int line, bool b)
+  {
+  }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (18,11): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //     T(2, (n++).Value.x == (s++).x);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "n++").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(18, 11)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_08()
+        {
+            string source = @"
+using System;
+struct S
+{
+  public int x;
+  public S(int x) { this.x = x; }
+  public static S operator ++(S s) { return new S(s.x + 1); }
+  public static S operator --(S s) { return new S(s.x - 1); }
+}
+
+class C
+{
+  static void Main()
+  {
+    S? n = new S(1);
+    S s = new S(1);
+
+    T(2, (n++).Value.x == (s++).x);
+  }
+
+  static void T(int line, bool b)
+  {
+  }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (15,12): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //     S? n = new S(1);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "new S(1)").WithArguments("System.Nullable`1", ".ctor").WithLocation(15, 12),
+                // (18,11): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //     T(2, (n++).Value.x == (s++).x);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "n++").WithArguments("System.Nullable`1", ".ctor").WithLocation(18, 11)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_09()
+        {
+            string source = @"
+using System;
+class C
+{
+    
+    static void T(int x, bool? b) {}
+
+    static void Main()
+    {
+        bool bt = true;
+        bool? bnt = bt;
+
+        T(1, true & bnt);
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (11,21): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         bool? bnt = bt;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "bt").WithArguments("System.Nullable`1", ".ctor").WithLocation(11, 21),
+                // (13,14): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         T(1, true & bnt);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "true").WithArguments("System.Nullable`1", ".ctor").WithLocation(13, 14),
+                // (13,14): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         T(1, true & bnt);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "true & bnt").WithArguments("System.Nullable`1", ".ctor").WithLocation(13, 14)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_09()
+        {
+            string source = @"
+using System;
+class C
+{
+    
+    static void T(int x, bool? b) {}
+
+    static void Main()
+    {
+        bool bt = true;
+        bool? bnt = bt;
+
+        T(13, bnt & bnt);
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (13,15): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         T(13, bnt & bnt);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "bnt & bnt").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(13, 15),
+                // (13,15): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         T(13, bnt & bnt);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "bnt & bnt").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(13, 15)
+                );
+        }
+
+        [Fact]
+        public void System_String__op_Equality_01()
+        {
+            string source = @"
+using System;
+struct SZ
+{
+    public string str;
+    public SZ(string str) { this.str = str; }
+    public SZ(char c) { this.str = c.ToString(); }
+    public static bool operator ==(SZ sz1, SZ sz2) { return sz1.str == sz2.str; }
+    public static bool operator !=(SZ sz1, SZ sz2) { return sz1.str != sz2.str; }
+    public override bool Equals(object x) { return true; }
+    public override int GetHashCode() { return 0; }
+}
+class C
+{
+    static void Main()
+    {
+    }
+}
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_String__op_Equality);
+            compilation.VerifyEmitDiagnostics(
+                // (8,61): error CS0656: Missing compiler required member 'System.String.op_Equality'
+                //     public static bool operator ==(SZ sz1, SZ sz2) { return sz1.str == sz2.str; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "sz1.str == sz2.str").WithArguments("System.String", "op_Equality").WithLocation(8, 61)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_get_HasValue_03()
+        {
+            var source = @"
+using System;
+
+static class LiveList
+{
+    struct WhereInfo<TSource>
+    {
+        public int Key { get; set; }
+    }
+
+    static void Where<TSource>()
+    {
+        Action subscribe = () =>
+        {
+            WhereInfo<TSource>? previous = null;
+
+            var previousKey = previous?.Key;
+        };
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_get_HasValue);
+            compilation.VerifyEmitDiagnostics(
+                // (17,31): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
+                //             var previousKey = previous?.Key;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "previous?.Key").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(17, 31)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_10()
+        {
+            var source =
+@"using System;
+public class X
+{
+    public static void Main()
+    {
+        var s = nameof(Main);
+        if (s is string t) Console.WriteLine(""1. {0}"", t);
+        s = null;
+        Console.WriteLine(""2. {0}"", s is string w ? w : nameof(X));
+        int? x = 12;
+        {if (x is var y) Console.WriteLine(""3. {0}"", y);}
+        {if (x is int y) Console.WriteLine(""4. {0}"", y);}
+        x = null;
+        {if (x is var y) Console.WriteLine(""5. {0}"", y);}
+        {if (x is int y) Console.WriteLine(""6. {0}"", y);}
+        Console.WriteLine(""7. {0}"", (x is bool is bool));
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (16,38): warning CS0184: The given expression is never of the provided ('bool') type
+                //         Console.WriteLine("7. {0}", (x is bool is bool));
+                Diagnostic(ErrorCode.WRN_IsAlwaysFalse, "x is bool").WithArguments("bool").WithLocation(16, 38),
+                // (16,38): warning CS0183: The given expression is always of the provided ('bool') type
+                //         Console.WriteLine("7. {0}", (x is bool is bool));
+                Diagnostic(ErrorCode.WRN_IsAlwaysTrue, "x is bool is bool").WithArguments("bool").WithLocation(16, 38),
+                // (12,19): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         {if (x is int y) Console.WriteLine("4. {0}", y);}
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int y").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(12, 19),
+                // (15,19): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //         {if (x is int y) Console.WriteLine("6. {0}", y);}
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int y").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(15, 19)
+                );
+        }
+
+        [Fact]
+        public void System_String__op_Equality_02()
+        {
+            var source =
+@"
+using System;
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    public static void M(object o)
+    {
+        switch (o)
+        {
+            case ""hmm"":
+                Console.WriteLine(""hmm""); break;
+            case null:
+                Console.WriteLine(""null""); break;
+            case 1:
+                Console.WriteLine(""int 1""); break;
+            case ((byte)1):
+                Console.WriteLine(""byte 1""); break;
+            case ((short)1):
+                Console.WriteLine(""short 1""); break;
+            case ""bar"":
+                Console.WriteLine(""bar""); break;
+            case object t when t != o:
+                Console.WriteLine(""impossible""); break;
+            case 2:
+                Console.WriteLine(""int 2""); break;
+            case ((byte)2):
+                Console.WriteLine(""byte 2""); break;
+            case ((short)2):
+                Console.WriteLine(""short 2""); break;
+            case ""baz"":
+                Console.WriteLine(""baz""); break;
+            default:
+                Console.WriteLine(""other "" + o); break;
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_String__op_Equality);
+            compilation.VerifyEmitDiagnostics(
+                // (11,9): error CS0656: Missing compiler required member 'System.String.op_Equality'
+                //         switch (o)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"switch (o)
+        {
+            case ""hmm"":
+                Console.WriteLine(""hmm""); break;
+            case null:
+                Console.WriteLine(""null""); break;
+            case 1:
+                Console.WriteLine(""int 1""); break;
+            case ((byte)1):
+                Console.WriteLine(""byte 1""); break;
+            case ((short)1):
+                Console.WriteLine(""short 1""); break;
+            case ""bar"":
+                Console.WriteLine(""bar""); break;
+            case object t when t != o:
+                Console.WriteLine(""impossible""); break;
+            case 2:
+                Console.WriteLine(""int 2""); break;
+            case ((byte)2):
+                Console.WriteLine(""byte 2""); break;
+            case ((short)2):
+                Console.WriteLine(""short 2""); break;
+            case ""baz"":
+                Console.WriteLine(""baz""); break;
+            default:
+                Console.WriteLine(""other "" + o); break;
+        }").WithArguments("System.String", "op_Equality").WithLocation(11, 9),
+                // (11,9): error CS0656: Missing compiler required member 'System.String.op_Equality'
+                //         switch (o)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"switch (o)
+        {
+            case ""hmm"":
+                Console.WriteLine(""hmm""); break;
+            case null:
+                Console.WriteLine(""null""); break;
+            case 1:
+                Console.WriteLine(""int 1""); break;
+            case ((byte)1):
+                Console.WriteLine(""byte 1""); break;
+            case ((short)1):
+                Console.WriteLine(""short 1""); break;
+            case ""bar"":
+                Console.WriteLine(""bar""); break;
+            case object t when t != o:
+                Console.WriteLine(""impossible""); break;
+            case 2:
+                Console.WriteLine(""int 2""); break;
+            case ((byte)2):
+                Console.WriteLine(""byte 2""); break;
+            case ((short)2):
+                Console.WriteLine(""short 2""); break;
+            case ""baz"":
+                Console.WriteLine(""baz""); break;
+            default:
+                Console.WriteLine(""other "" + o); break;
+        }").WithArguments("System.String", "op_Equality").WithLocation(11, 9)
+                );
+        }
+
+        [Fact]
+        public void System_String__Chars()
+        {
+            var source =
+@"using System;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        bool hasB = false;
+        foreach (var c in ""ab"")
+        {
+           switch (c)
+           {
+              case char b when IsB(b):
+                 hasB = true;
+                 break;
+
+              default:
+                 hasB = false;
+                 break;
+           }
+        }
+        Console.WriteLine(hasB);
+    }
+
+    public static bool IsB(char value)
+    {
+        return value == 'b';
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_String__Chars);
+            compilation.VerifyEmitDiagnostics(
+                // (8,9): error CS0656: Missing compiler required member 'System.String.get_Chars'
+                //         foreach (var c in "ab")
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"foreach (var c in ""ab"")
+        {
+           switch (c)
+           {
+              case char b when IsB(b):
+                 hasB = true;
+                 break;
+
+              default:
+                 hasB = false;
+                 break;
+           }
+        }").WithArguments("System.String", "get_Chars").WithLocation(8, 9)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T_GetValueOrDefault_11()
+        {
+            var source =
+@"using System;
+class Program
+{
+  static void Main(string[] args)
+  {
+  }
+  static void M(X? x)
+  {
+    switch (x)
+    {
+      case null:
+        Console.WriteLine(""null"");
+        break;
+      case 1:
+        Console.WriteLine(1);
+        break;
+    }
+  }
+}
+struct X
+{
+    public static implicit operator int? (X x)
+    {
+        return 1;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T_GetValueOrDefault);
+            compilation.VerifyEmitDiagnostics(
+                // (9,13): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //     switch (x)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(9, 13),
+                // (9,5): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //     switch (x)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"switch (x)
+    {
+      case null:
+        Console.WriteLine(""null"");
+        break;
+      case 1:
+        Console.WriteLine(1);
+        break;
+    }").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(9, 5)
+                );
+        }
+
+        [Fact]
+        public void System_String__ConcatObject()
+        {
+            var source = @"
+using System;
+
+public class Test
+{
+    private static string S = ""F"";
+    private static object O = ""O"";
+
+    static void Main()
+    {
+        Console.WriteLine(O + null);
+        Console.WriteLine(S + null);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_String__ConcatObject);
+            compilation.VerifyEmitDiagnostics(
+                // (11,27): error CS0656: Missing compiler required member 'System.String.Concat'
+                //         Console.WriteLine(O + null);
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "O + null").WithArguments("System.String", "Concat").WithLocation(11, 27)
+                );
+        }
+
+        [Fact]
+        public void System_Object__ToString()
+        {
+            var source = @"
+using System;
+
+public class Test
+{
+    static void Main()
+    {
+        char c = 'c';
+        Console.WriteLine(c + ""3"");
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Object__ToString);
+            compilation.VerifyEmitDiagnostics(
+                // (9,27): error CS0656: Missing compiler required member 'System.Object.ToString'
+                //         Console.WriteLine(c + "3");
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"c + ""3""").WithArguments("System.Object", "ToString").WithLocation(9, 27)
+                );
+        }
+
+        [Fact]
+        public void System_String__ConcatStringString()
+        {
+            var source = @"
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+class Test
+{
+    public static void Main()
+    {
+        Expression<Func<string, string, string>> testExpr = (x, y) => x + y;
+        var result = testExpr.Compile()(""Hello "", ""World!"");
+        Console.WriteLine(result);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef });
+            compilation.MakeMemberMissing(SpecialMember.System_String__ConcatStringString);
+            compilation.VerifyEmitDiagnostics(
+                // (10,71): error CS0656: Missing compiler required member 'System.String.Concat'
+                //         Expression<Func<string, string, string>> testExpr = (x, y) => x + y;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x + y").WithArguments("System.String", "Concat").WithLocation(10, 71)
+                );
+        }
+
+        [Fact]
+        public void System_Array__GetLowerBound()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        double[,] values = {
+            { 1.2, 2.3, 3.4, 4.5 },
+            { 5.6, 6.7, 7.8, 8.9 },
+        };
+
+        foreach (var x in values)
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Array__GetLowerBound);
+            compilation.VerifyEmitDiagnostics(
+                // (11,9): error CS0656: Missing compiler required member 'System.Array.GetLowerBound'
+                //         foreach (var x in values)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"foreach (var x in values)
+        {
+            System.Console.WriteLine(x);
+        }").WithArguments("System.Array", "GetLowerBound").WithLocation(11, 9)
+                );
+        }
+
+        [Fact]
+        public void System_Array__GetUpperBound()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        double[,] values = {
+            { 1.2, 2.3, 3.4, 4.5 },
+            { 5.6, 6.7, 7.8, 8.9 },
+        };
+
+        foreach (var x in values)
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.MakeMemberMissing(SpecialMember.System_Array__GetUpperBound);
+            compilation.VerifyEmitDiagnostics(
+                // (11,9): error CS0656: Missing compiler required member 'System.Array.GetUpperBound'
+                //         foreach (var x in values)
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"foreach (var x in values)
+        {
+            System.Console.WriteLine(x);
+        }").WithArguments("System.Array", "GetUpperBound").WithLocation(11, 9)
+                );
+        }
+
+        [Fact]
+        public void System_Decimal__op_Implicit_FromInt32()
+        {
+            var source =
+@"using System;
+using System.Linq.Expressions;
+
+public struct SampStruct
+{
+    public static implicit operator int(SampStruct ss1)
+    {
+        return 1;
+    }
+}
+
+public class Test
+{
+    static void Main()
+    {
+        Expression<Func<SampStruct?, decimal, decimal>> testExpr = (x, y) => x ?? y;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef });
+            compilation.MakeMemberMissing(SpecialMember.System_Decimal__op_Implicit_FromInt32);
+            compilation.VerifyEmitDiagnostics(
+                // (16,78): error CS0656: Missing compiler required member 'System.Decimal.op_Implicit'
+                //         Expression<Func<SampStruct?, decimal, decimal>> testExpr = (x, y) => x ?? y;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "x ?? y").WithArguments("System.Decimal", "op_Implicit").WithLocation(16, 78)
+                );
+        }
+
+        [Fact]
+        public void System_Nullable_T__ctor_10()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System;
+
+class Test {
+    static void LogCallerLineNumber5([CallerLineNumber] int? lineNumber   = 5) { Console.WriteLine(""line: "" + lineNumber); }
+
+    public static void Main() {
+        LogCallerLineNumber5();
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemRef });
+            compilation.MakeMemberMissing(SpecialMember.System_Nullable_T__ctor);
+            compilation.VerifyEmitDiagnostics(
+                // (10,9): error CS0656: Missing compiler required member 'System.Nullable`1..ctor'
+                //         LogCallerLineNumber5();
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "LogCallerLineNumber5()").WithArguments("System.Nullable`1", ".ctor").WithLocation(10, 9)
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=377890.

@dotnet/roslyn-compiler Please review.