### PR TITLE
[PR For Personal Review Only] 'me' parameter specifier for VB

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Delegates.vb
@@ -936,6 +936,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 flag = flag And (Not SourceParameterFlags.Optional)
             End If
 
+            If (flag And SourceParameterFlags.Me) = SourceParameterFlags.Me Then
+                Dim location = token.GetLocation()
+                diagnostics.Add(ERRID.ERR_MeIllegal1, location, GetDelegateOrEventKeywordText(container))
+                flag = flag And (Not SourceParameterFlags.Me)
+            End If
+
+
             Return flag
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
@@ -238,6 +238,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Case SyntaxKind.ByValKeyword : foundFlag = SourceParameterFlags.ByVal
                     Case SyntaxKind.OptionalKeyword : foundFlag = SourceParameterFlags.Optional
                     Case SyntaxKind.ParamArrayKeyword : foundFlag = SourceParameterFlags.ParamArray
+                    Case SyntaxKind.MeKeyword : foundFlag = SourceParameterFlags.Me
                 End Select
 
                 ' Report errors with the modifier
@@ -899,6 +900,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 flag = flag And (Not SourceParameterFlags.Optional)
             End If
 
+            'If (flag And SourceParameterFlags.Me) <> 0 Then
+            '    diagnostics.Add(ERRID.ERR_MeIllegal1, token.GetLocation(), container.GetKindText())
+            '    flag = flag And (Not SourceParameterFlags.Me)
+            'End If
+
             Return flag
         End Function
 
@@ -950,7 +956,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If flag = SourceParameterFlags.ByRef Then
                 Dim location = token.GetLocation()
                 diagnostics.Add(ERRID.ERR_ByRefIllegal1, location, container.GetKindText(), token.ToString())
-                Return flag And (Not SourceParameterFlags.ByRef)
+                flag = flag And (Not SourceParameterFlags.ByRef)
+            End If
+
+            If flag = SourceParameterFlags.Me Then
+                Dim location = token.GetLocation()
+                diagnostics.Add(ERRID.ERR_MeIllegal1, location, container.GetKindText(), token.ToString())
+                flag = flag And (Not SourceParameterFlags.Me)
             End If
             Return flag
         End Function
@@ -1023,7 +1035,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     End If
                 End If
+                If (flagsOfPreviousParameters And SourceParameterFlags.Me) <> 0 AndAlso i > 0 AndAlso
+                    Not reportedError Then
 
+                    ReportDiagnostic(diagBag, paramSyntax, ERRID.ERR_MeParamMustBeFirst)
+                    reportedError = True
+
+                End If
                 If (flagsOfPreviousParameters And SourceParameterFlags.ParamArray) <> 0 AndAlso
                     Not reportedError Then
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Utils.vb
@@ -1017,7 +1017,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim flags As SourceParameterFlags = Nothing
 
                 flags = DecodeParameterModifiers(container, paramSyntax.Modifiers, checkModifier, diagBag)
-
+                ' Check validatity of 'Optional' parameter usage
                 If (flagsOfPreviousParameters And SourceParameterFlags.Optional) = SourceParameterFlags.Optional Then
                     If (flags And SourceParameterFlags.ParamArray) = SourceParameterFlags.ParamArray AndAlso
                         Not reportedError Then
@@ -1040,16 +1040,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 '    (arg0 As T, Me arg1 As T)  Error
                 '    (Me arg0 As T, Me arg1 as T)  Error
                 If (flags And SourceParameterFlags.Me) <> 0 Then
-                    If i > 0 AndAlso Not reportedError Then
-                        ReportDiagnostic(diagBag, paramSyntax, ERRID.ERR_MeParamMustBeFirst)
-                        reportedError = True
-                    ElseIf container.ContainingType.IsInterface AndAlso Not reportedError Then
+                    If Not container.ContainingType.IsModuleType AndAlso Not reportedError Then
                         ReportDiagnostic(diagBag, paramSyntax, ERRID.ERR_MeIllegal1)
                         reportedError = True
-                    End If
-                ElseIf (flagsOfPreviousParameters And SourceParameterFlags.Me) <> 0 Then
-                    If (flags And SourceParameterFlags.Me) = SourceParameterFlags.Me AndAlso
-                        Not reportedError Then
+                    ElseIf i > 0 AndAlso Not reportedError Then
+                        ReportDiagnostic(diagBag, paramSyntax, ERRID.ERR_MeParamMustBeFirst)
+                        reportedError = True
+                    ElseIf (flagsOfPreviousParameters And SourceParameterFlags.Me) <> 0 AndAlso Not reportedError Then
                         ReportDiagnostic(diagBag, paramSyntax, ERRID.ERR_MeIllegal1)
                         reportedError = True
                     End If

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1725,8 +1725,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_BadAssemblyName = 37283
 
         ERR_Merge_conflict_marker_encountered = 37284
+        ' 'Me' Parameter Errors
         ERR_MultipleMeParameterSpecifiers = 37285
         ERR_MeIllegal1 = 37286
+        ERR_MeParamMustBeFirst = 37287
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000
@@ -2001,6 +2003,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         FEATURE_BinaryLiterals
         FEATURE_Tuples
         FEATURE_IOperation
-        ERR_MeParamMustBeFirst
+
     End Enum
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1726,7 +1726,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ERR_Merge_conflict_marker_encountered = 37284
         ERR_MultipleMeParameterSpecifiers = 37285
-
+        ERR_MeIllegal1 = 37286
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000
@@ -2001,5 +2001,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         FEATURE_BinaryLiterals
         FEATURE_Tuples
         FEATURE_IOperation
+        ERR_MeParamMustBeFirst
     End Enum
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1725,6 +1725,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_BadAssemblyName = 37283
 
         ERR_Merge_conflict_marker_encountered = 37284
+        ERR_MultipleMeParameterSpecifiers = 37285
+
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -4656,6 +4656,13 @@ checkNullable:
                         End If
                         specifier = ParameterSpecifiers.ParamArray
 
+                    Case SyntaxKind.MeKeyword
+                        keyword = DirectCast(CurrentToken, KeywordSyntax)
+                        If (specifiers And ParameterSpecifiers.Me) <> 0 Then
+                            keyword = ReportSyntaxError(keyword, ERRID.ERR_MultipleMeParameterSpecifiers)
+                        End If
+                        specifier = ParameterSpecifiers.Me
+
                     Case Else
                         Dim result = keywords.ToList
                         Me._pool.Free(keywords)
@@ -6216,6 +6223,7 @@ checkNullable:
         [ByVal] = &H2
         [Optional] = &H4
         [ParamArray] = &H8
+        [Me] = &H10
     End Enum
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
@@ -260,7 +260,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 diagnostics.Add(ERRID.ERR_EventMethodOptionalParamIllegal1, location, token.ToString())
                 flag = flag And (Not SourceParameterFlags.ParamArray)
             End If
-
+            If (flag And SourceParameterFlags.Me) <> 0 Then
+                Dim location = token.GetLocation()
+                diagnostics.Add(ERRID.ERR_MeIllegal1, location, token.ToString())
+                flag = flag And (Not SourceParameterFlags.Me)
+            End If
             Return flag
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomEventAccessorSymbol.vb
@@ -275,7 +275,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 diagnostics.Add(ERRID.ERR_EventAddRemoveByrefParamIllegal, location, token.ToString())
                 flag = flag And (Not SourceParameterFlags.ByRef)
             End If
-
+            If (flag And SourceParameterFlags.Me) <> 0 Then
+                Dim location = token.GetLocation()
+                diagnostics.Add(ERRID.ERR_MeIllegal1, location, token.ToString())
+                flag = flag And (Not SourceParameterFlags.Me)
+            End If
             Return CheckEventMethodParameterModifier(container, token, flag, diagnostics)
         End Function
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceComplexParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceComplexParameterSymbol.vb
@@ -208,7 +208,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return (_flags And SourceParameterFlags.Optional) <> 0
             End Get
         End Property
-
+        Public Overrides ReadOnly Property IsMe As Boolean
+            Get
+                Return (_flags And SourceParameterFlags.Me) <> 0
+            End Get
+        End Property
         Public Overrides ReadOnly Property IsParamArray As Boolean
             Get
                 If (_flags And SourceParameterFlags.ParamArray) <> 0 Then
@@ -349,7 +353,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ' Attributes and default values are computed lazily and need access to the parameter's syntax.
             ' If the parameter syntax includes either of these get a syntax reference and pass it to the parameter symbol.
-            If (syntax.AttributeLists.Count <> 0 OrElse syntax.Default IsNot Nothing) Then
+            If (syntax.AttributeLists.Count <> 0 OrElse syntax.Default IsNot Nothing OrElse ((flags And SourceParameterFlags.Me) <> 0)) Then
                 syntaxRef = binder.GetSyntaxReference(syntax)
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -479,6 +479,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         [ByRef] = 1 << 1
         [Optional] = 1 << 2
         [ParamArray] = 1 << 3
+        [Me] = 1 << 4
     End Enum
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
@@ -461,6 +461,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 diagnostics.Add(ERRID.ERR_SetHasToBeByVal1, location, token.ToString())
                 Return flag And SourceParameterFlags.ByVal
             End If
+            If (flag And SourceParameterFlags.Me) <> 0 Then
+                Dim location = token.GetLocation()
+                diagnostics.Add(ERRID.ERR_MeIllegal1, location, token.ToString())
+                flag = flag And (Not SourceParameterFlags.Me)
+            End If
             Return SourceParameterFlags.ByVal
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
@@ -459,14 +459,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If flag <> SourceParameterFlags.ByVal Then
                 Dim location = token.GetLocation()
                 diagnostics.Add(ERRID.ERR_SetHasToBeByVal1, location, token.ToString())
-                Return flag And SourceParameterFlags.ByVal
+                flag = flag And SourceParameterFlags.ByVal
             End If
             If (flag And SourceParameterFlags.Me) <> 0 Then
                 Dim location = token.GetLocation()
                 diagnostics.Add(ERRID.ERR_MeIllegal1, location, token.ToString())
                 flag = flag And (Not SourceParameterFlags.Me)
             End If
-            Return SourceParameterFlags.ByVal
+            Return flag
         End Function
 
         Friend Overrides Function GetBoundMethodBody(compilationState As TypeCompilationState, diagnostics As DiagnosticBag, Optional ByRef methodBodyBinder As Binder = Nothing) As BoundBlock

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/UnboundLambdaParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/UnboundLambdaParameterSymbol.vb
@@ -73,7 +73,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' 'Lambda' parameters cannot be declared 'Optional'.
                 Binder.ReportDiagnostic(diagBag, GetModifierToken(syntax.Modifiers, SyntaxKind.OptionalKeyword), ERRID.ERR_OptionalIllegal1, StringConstants.Lambda)
             End If
-
+            If (flags And SourceParameterFlags.Me) <> 0 Then
+                ' 'Lambda' parameters cannot be declared 'Me'.
+                Binder.ReportDiagnostic(diagBag, GetModifierToken(syntax.Modifiers, SyntaxKind.MeKeyword), ERRID.ERR_MeIllegal1, StringConstants.Lambda)
+            End If
             If syntax.AttributeLists.Node IsNot Nothing Then
                 Binder.ReportDiagnostic(diagBag, syntax.AttributeLists.Node, ERRID.ERR_LambdasCannotHaveAttributes)
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethod.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethod.vb
@@ -62,6 +62,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If origParameter.IsOptional Then
                 flags = flags Or SourceParameterFlags.Optional
             End If
+            If origParameter.IsMe Then
+                flags = flags Or SourceParameterFlags.Me
+            End If
 
             Return SourceComplexParameterSymbol.Create(
                     newContainer,

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -6883,7 +6883,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to &apos;Me&apos; not valid here..
+        '''  Looks up a localized string similar to {0} parameters cannot be declared &apos;Me&apos;..
         '''</summary>
         Friend ReadOnly Property ERR_MeIllegal1() As String
             Get

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -7369,6 +7369,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Multiple &apos;Me&apos; parameter specifiers..
+        '''</summary>
+        Friend ReadOnly Property ERR_MultipleMeParameterSpecifiers() As String
+            Get
+                Return ResourceManager.GetString("ERR_MultipleMeParameterSpecifiers", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to &apos;New&apos; constraint cannot be specified multiple times for the same type parameter..
         '''</summary>
         Friend ReadOnly Property ERR_MultipleNewConstraints() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -6883,6 +6883,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to &apos;Me&apos; not valid here..
+        '''</summary>
+        Friend ReadOnly Property ERR_MeIllegal1() As String
+            Get
+                Return ResourceManager.GetString("ERR_MeIllegal1", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to {0} &apos;{1}&apos; conflicts with a member implicitly declared for {2} &apos;{3}&apos; in {4} &apos;{5}&apos;..
         '''</summary>
         Friend ReadOnly Property ERR_MemberClashesWithSynth6() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -6910,6 +6910,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to &apos;Me&apos; Parameter must be first..
+        '''</summary>
+        Friend ReadOnly Property ERR_MeParamMustBeFirst() As String
+            Get
+                Return ResourceManager.GetString("ERR_MeParamMustBeFirst", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Merge conflict marker encountered.
         '''</summary>
         Friend ReadOnly Property ERR_Merge_conflict_marker_encountered() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5473,4 +5473,7 @@
   <data name="ERR_MeIllegal1" xml:space="preserve">
     <value>'Me' not valid here.</value>
   </data>
+  <data name="ERR_MeParamMustBeFirst" xml:space="preserve">
+    <value>'Me' Parameter must be first.</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5467,4 +5467,7 @@
   <data name="ERR_Merge_conflict_marker_encountered" xml:space="preserve">
     <value>Merge conflict marker encountered</value>
   </data>
+  <data name="ERR_MultipleMeParameterSpecifiers" xml:space="preserve">
+    <value>Multiple 'Me' parameter specifiers.</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5471,7 +5471,7 @@
     <value>Multiple 'Me' parameter specifiers.</value>
   </data>
   <data name="ERR_MeIllegal1" xml:space="preserve">
-    <value>'Me' not valid here.</value>
+    <value>{0} parameters cannot be declared 'Me'.</value>
   </data>
   <data name="ERR_MeParamMustBeFirst" xml:space="preserve">
     <value>'Me' Parameter must be first.</value>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5470,4 +5470,7 @@
   <data name="ERR_MultipleMeParameterSpecifiers" xml:space="preserve">
     <value>Multiple 'Me' parameter specifiers.</value>
   </data>
+  <data name="ERR_MeIllegal1" xml:space="preserve">
+    <value>'Me' not valid here.</value>
+  </data>
 </root>


### PR DESCRIPTION
# PR For Personal Review Only
## 'Me' Parameter Specifier for VB

- [ ] Definition
Same semantic usage rules as the attribute  `<System.RunTime.CompilerServices.Extension()>`
Must be on first parameter, and only first parameter. 
- [x] Parser Support
- [ ] Semantics / Binder Support
- [ ] Synthesis of the method attribute `<System.RunTime.CompilerServices.Extension()>` 
- [ ] Unit Tests
- [ ] Error Messages *(needs reworking)*

**Example**

```vbnet
Public Module Exts
  Public Function IsEven(Me Value As Integer) As Boolean
    Return Value Mod 2 = 0
  End Function

  Public Function IsOdd(Me Value As Integer) As Boolean
    Return Value Mod 2 = 1
  End Function

End Module
```
will be functionally equivalent to have then `<System.RunTime.CompilerServices.Extension()>` attribute on the method.

```vbnet
Public Module Exts
  <System.RunTime.CompilerServices.Extension()>
  Public Function IsEven(Value As Integer) As Boolean
    Return Value Mod 2 = 0
  End Function

  <System.RunTime.CompilerServices.Extension()>
  Public Function IsOdd(Value As Integer) As Boolean
    Return Value Mod 2 = 1
  End Function

End Module
```