### PR TITLE
made error report not NRE under test hardness

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService.cs
@@ -33,6 +33,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 hostDiagnosticUpdateSource,
                 registrationService, new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.DiagnosticService))
         {
+            // diagnosticAnalyzerProviderService and hostDiagnosticUpdateSource can only be null in test hardness otherwise, it should
+            // never be null
         }
 
         public IAsynchronousOperationListener Listener => _listener;

--- a/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/HostAnalyzerManager.cs
@@ -528,7 +528,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     documentId: null,
                     diagnostics: ImmutableArray.Create<DiagnosticData>(diagnostic));
 
-                _hostUpdateSource.RaiseDiagnosticsUpdated(args);
+                // this can be null in test. but in product code, this should never be null.
+                _hostUpdateSource?.RaiseDiagnosticsUpdated(args);
             }
         }
     }


### PR DESCRIPTION
some MEF importing fields can be null in unit test. which should never be null in product code unless MEF is messed up.

fix https://github.com/dotnet/roslyn/issues/14623