### PR TITLE
Format expression-bodied everything on typing ';'

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -3121,6 +3121,59 @@ class Program{
         }
 
         [WpfFact]
+        [WorkItem(17257, "https://github.com/dotnet/roslyn/issues/17257")]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public void FormattingRangeForConstructor()
+        {
+            var code = @"class C
+{public C()=>f=1;$$
+}";
+
+            var expected = @"class C
+{
+    public C() => f = 1;
+}";
+
+            AutoFormatToken(code, expected);
+        }
+
+        [WpfFact]
+        [WorkItem(17257, "https://github.com/dotnet/roslyn/issues/17257")]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public void FormattingRangeForDestructor()
+        {
+            var code = @"class C
+{~C()=>f=1;$$
+}";
+
+            var expected = @"class C
+{
+    ~C() => f = 1;
+}";
+
+            AutoFormatToken(code, expected);
+        }
+
+        [WpfFact]
+        [WorkItem(17257, "https://github.com/dotnet/roslyn/issues/17257")]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public void FormattingRangeForOperator()
+        {
+            var code = @"class C
+{public static C operator +(C left, C right)=>field=1;$$
+    static int field;
+}";
+
+            var expected = @"class C
+{
+    public static C operator +(C left, C right) => field = 1;
+    static int field;
+}";
+
+            AutoFormatToken(code, expected);
+        }
+
+        [WpfFact]
         [WorkItem(954386, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/954386")]
         [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
         public void FormattingRangeForFirstMemberOfNamespace()

--- a/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
@@ -122,7 +122,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 (parent is FieldDeclarationSyntax) ||
                 (parent is EventFieldDeclarationSyntax) ||
                 (parent is MethodDeclarationSyntax) ||
-                (parent is PropertyDeclarationSyntax))
+                (parent is PropertyDeclarationSyntax) ||
+                (parent is ConstructorDeclarationSyntax) ||
+                (parent is DestructorDeclarationSyntax) ||
+                (parent is OperatorDeclarationSyntax))
             {
                 return ValueTuple.Create(GetAppropriatePreviousToken(parent.GetFirstToken(), canTokenBeFirstInABlock: true), parent.GetLastToken());
             }


### PR DESCRIPTION
This extends the behavior to constructors, destructors, and operators.
Fixes #17257 

@CyrusNajmabadi Can you please review this? Do I need a second reviewer?
