### PR TITLE
Add test explorer service GUID to the rest of project files

### DIFF
--- a/src/Workspaces/CSharpTest/CSharpServicesTest.csproj
+++ b/src/Workspaces/CSharpTest/CSharpServicesTest.csproj
@@ -92,5 +92,8 @@
     <Compile Include="Formatting\FormattingTriviaTests.cs" />
     <Compile Include="CodeGeneration\AddImportsTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="..\..\..\build\Targets\Imports.targets" />
 </Project>


### PR DESCRIPTION
Replaces #17370
I see that the rest of the projects are already added in https://github.com/dotnet/roslyn/commit/047eb5cce266712ea415e30f71fe2a879544d266
cc @jasonmalinowski @jaredpar @tannergooding 
@dotnet/roslyn-infrastructure 