### PR TITLE
Flush console out before reading it

### DIFF
--- a/src/Scripting/CSharpTest/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest/InteractiveSessionTests.cs
@@ -475,7 +475,7 @@ Environment.ProcessorCount
         }
 
         [Fact]
-        public void CompilationChain_SubmissionSlotResize()
+        public async void CompilationChain_SubmissionSlotResize()
         {
             var state = CSharpScript.RunAsync("");
 
@@ -486,7 +486,7 @@ Environment.ProcessorCount
 
             using (var redirect = new OutputRedirect(CultureInfo.InvariantCulture))
             {
-                state.ContinueWith(@"System.Console.WriteLine(i);").Wait();
+                await state.ContinueWith(@"System.Console.WriteLine(i);");
                 Assert.Equal(1, int.Parse(redirect.Output));
             }
         }
@@ -822,7 +822,7 @@ x
 
         [WorkItem(5397, "DevDiv_Projects/Roslyn")]
         [Fact]
-        public void TopLevelLambda()
+        public async void TopLevelLambda()
         {
             var s = CSharpScript.RunAsync(@"
 using System;
@@ -835,7 +835,7 @@ TestDelegate testDelB = delegate (string s) { Console.WriteLine(s); };
 
             using (var redirect = new OutputRedirect(CultureInfo.InvariantCulture))
             {
-                s.ContinueWith(@"testDelB(""hello"");").Wait();
+                await s.ContinueWith(@"testDelB(""hello"");");
                 Assert.Equal("hello", redirect.Output.Trim());
             }
         }

--- a/src/Scripting/CoreTestUtilities/RedirectedOutput.cs
+++ b/src/Scripting/CoreTestUtilities/RedirectedOutput.cs
@@ -22,7 +22,14 @@ namespace Microsoft.CodeAnalysis.Scripting
             Console.SetOut(_newOut);
         }
 
-        public string Output => _newOut.ToString();
+        public string Output
+        {
+            get
+            {
+                _newOut.Flush();
+                return _newOut.ToString();
+            }
+        }
 
         void IDisposable.Dispose()
         {


### PR DESCRIPTION
This might fix some flakiness in scripting tests.

E.g. https://ci.dot.net/job/dotnet_roslyn/job/master/job/ubuntu_14_debug_prtest/92/