### PR TITLE
ExpressionVariableFinder should properly handle misplaces DeclarationExpressions with ParenthesizedVariableDesignation.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -759,7 +759,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol fieldType = field.GetFieldType(this.FieldsBeingBound);
                 Debug.Assert(declType == fieldType);
-                return new BoundFieldAccess(designation,
+                return new BoundFieldAccess(syntax,
                                             receiver,
                                             field,
                                             constantValueOpt: null,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -742,8 +742,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 case SyntaxKind.DiscardDesignation:
                     {
-                        var discarded = (DiscardDesignationSyntax)node;
-                        return BindDiscardExpression(discarded, declType);
+                        return BindDiscardExpression(syntax, declType);
                     }
                 case SyntaxKind.ParenthesizedVariableDesignation:
                     {
@@ -764,7 +763,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             default(ImmutableArray<string>),
                             Compilation,
                             shouldCheckConstraints: false);
-                        return new BoundTupleLiteral(node, default(ImmutableArray<string>), subExpressions, tupleType);
+                        return new BoundTupleLiteral(syntax, default(ImmutableArray<string>), subExpressions, tupleType);
                     }
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.Kind());

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1869,7 +1869,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return expr;
 
                 case BoundKind.DiscardExpression:
-                    Debug.Assert(valueKind == BindValueKind.Assignment || valueKind == BindValueKind.RefOrOut);
+                    Debug.Assert(valueKind == BindValueKind.Assignment || valueKind == BindValueKind.RefOrOut ||
+                                 diagnostics.HasAnyResolvedErrors());
                     return expr;
             }
 


### PR DESCRIPTION
Fixes #17572.
This change also ensures consistent SemanticModel behavior between valid and invalid usages of DeclarationExpressions.

@dotnet/roslyn-compiler Please review.