### PR TITLE
Properly highlight written references differently in FindRefs

### DIFF
--- a/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
+++ b/src/EditorFeatures/Core/FindUsages/AbstractFindUsagesService.ProgressAdapter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.FindUsages
 
             public Task OnReferenceFoundAsync(Document document, TextSpan span)
                 => _context.OnReferenceFoundAsync(new SourceReferenceItem(
-                    _definition, new DocumentSpan(document, span)));
+                    _definition, new DocumentSpan(document, span), isWrittenTo: false));
 
             public Task ReportProgressAsync(int current, int maximum)
                 => _context.ReportProgressAsync(current, maximum);

--- a/src/EditorFeatures/Core/Implementation/Preview/PreviewReferenceHighlightingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Preview/PreviewReferenceHighlightingTaggerProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.Composition;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Editor.Shared.Preview;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.VisualStudio.Text.Editor;
@@ -23,6 +25,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
         [ImportingConstructor]
         public PreviewReferenceHighlightingTaggerProvider() :
             base(PredefinedPreviewTaggerKeys.ReferenceHighlightingSpansKey, ReferenceHighlightTag.Instance)
+        {
+        }
+    }
+
+    [Export(typeof(ITaggerProvider))]
+    [TagType(typeof(NavigableHighlightTag))]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [ContentType(ContentTypeNames.XamlContentType)]
+    [TextViewRole(TextViewRoles.PreviewRole)]
+    internal class PreviewWrittenReferenceHighlightingTaggerProvider
+        : AbstractPreviewTaggerProvider<NavigableHighlightTag>
+    {
+        [ImportingConstructor]
+        public PreviewWrittenReferenceHighlightingTaggerProvider() :
+            base(PredefinedPreviewTaggerKeys.WrittenReferenceHighlightingSpansKey, WrittenReferenceHighlightTag.Instance)
         {
         }
     }

--- a/src/EditorFeatures/Core/Shared/Preview/PredefinedPreviewTaggerKeys.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PredefinedPreviewTaggerKeys.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
     {
         public static readonly object DefinitionHighlightingSpansKey = new object();
         public static readonly object ReferenceHighlightingSpansKey = new object();
+        public static readonly object WrittenReferenceHighlightingSpansKey = new object();
         public static readonly object ConflictSpansKey = new object();
         public static readonly object WarningSpansKey = new object();
         public static readonly object SuppressDiagnosticsSpansKey = new object();

--- a/src/Features/Core/Portable/FindUsages/IDefinitionsAndReferencesFactory.cs
+++ b/src/Features/Core/Portable/FindUsages/IDefinitionsAndReferencesFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
             var uniqueLocations = new HashSet<DocumentSpan>();
 
             // Order the symbols by precedence, then create the appropriate
-            // definition item per symbol and all refernece items for its
+            // definition item per symbol and all reference items for its
             // reference locations.
             foreach (var referencedSymbol in referencedSymbols.OrderBy(GetPrecedence))
             {
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
         }
 
         /// <summary>
-        /// Reference locations are deduplicated across the entire find references result set
+        /// Reference locations are de-duplicated across the entire find references result set
         /// Order the definitions so that references to multiple definitions appear under the
         /// desired definition (e.g. constructor references should prefer the constructor method
         /// over the type definition). Note that this does not change the order in which
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
 
             var sourceLocations = ArrayBuilder<DocumentSpan>.GetInstance();
 
-            // If it's a namespace, don't create any normal lcoation.  Namespaces
+            // If it's a namespace, don't create any normal location.  Namespaces
             // come from many different sources, but we'll only show a single 
             // root definition node for it.  That node won't be navigable.
             if (definition.Kind != SymbolKind.Namespace)
@@ -244,8 +244,10 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 return null;
             }
 
-            return new SourceReferenceItem(definitionItem, 
-                new DocumentSpan(referenceLocation.Document, location.SourceSpan));
+            return new SourceReferenceItem(
+                definitionItem, 
+                new DocumentSpan(referenceLocation.Document, location.SourceSpan),
+                referenceLocation.IsWrittenTo);
         }
 
         private static SymbolDisplayFormat GetFormat(ISymbol definition)

--- a/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
+++ b/src/Features/Core/Portable/FindUsages/SourceReferenceItem.cs
@@ -5,7 +5,7 @@ using System;
 namespace Microsoft.CodeAnalysis.FindUsages
 {
     /// <summary>
-    /// Information about a symbol's reference that can be used for diplay and 
+    /// Information about a symbol's reference that can be used for display and 
     /// navigation in an editor.
     /// </summary>
     internal sealed class SourceReferenceItem
@@ -20,10 +20,16 @@ namespace Microsoft.CodeAnalysis.FindUsages
         /// </summary>
         public DocumentSpan SourceSpan { get; }
 
-        public SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan)
+        /// <summary>
+        /// If this reference is a location where the definition is written to.
+        /// </summary>
+        public bool IsWrittenTo { get; }
+
+        public SourceReferenceItem(DefinitionItem definition, DocumentSpan sourceSpan, bool isWrittenTo)
         {
             Definition = definition;
             SourceSpan = sourceSpan;
+            IsWrittenTo = isWrittenTo;
         }
     }
 }

--- a/src/VisualStudio/Core/Next/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Contexts/AbstractTableDataSourceFindUsagesContext.cs
@@ -263,7 +263,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             protected async Task<Entry> CreateDocumentSpanEntryAsync(
                 RoslynDefinitionBucket definitionBucket,
                 DocumentSpan documentSpan,
-                bool isDefinitionLocation)
+                HighlightSpanKind spanKind)
             {
                 var document = documentSpan.Document;
                 var (guid, sourceText) = await GetGuidAndSourceTextAsync(document).ConfigureAwait(false);
@@ -274,7 +274,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 var taggedLineParts = await GetTaggedTextForDocumentRegionAsync(document, narrowSpan, lineSpan).ConfigureAwait(false);
 
                 return new DocumentSpanEntry(
-                    this, definitionBucket, documentSpan, isDefinitionLocation,
+                    this, definitionBucket, documentSpan, spanKind,
                     guid, sourceText, taggedLineParts);
             }
 

--- a/src/VisualStudio/Core/Next/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Contexts/WithoutReferencesFindUsagesContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.VisualStudio.Shell.FindAllReferences;
 using Roslyn.Utilities;
@@ -57,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     foreach (var sourceSpan in definition.SourceSpans)
                     {
                         var entry = await CreateDocumentSpanEntryAsync(
-                            definitionBucket, sourceSpan, isDefinitionLocation: true).ConfigureAwait(false);
+                            definitionBucket, sourceSpan, HighlightSpanKind.Definition).ConfigureAwait(false);
                         entries.Add(entry);
                     }
                 }

--- a/src/VisualStudio/Core/Next/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -25,7 +25,6 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
             private readonly DocumentSpan _documentSpan;
             private readonly object _boxedProjectGuid;
-
             protected readonly SourceText _sourceText;
 
             protected AbstractDocumentSpanEntry(

--- a/src/VisualStudio/Core/Next/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -68,18 +68,12 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 return null;
             }
 
-            public sealed override bool TryCreateColumnContent(string columnName, out FrameworkElement content)
+            public override bool TryCreateColumnContent(string columnName, out FrameworkElement content)
             {
                 if (columnName == StandardTableColumnDefinitions2.LineText)
                 {
                     var inlines = CreateLineTextInlines();
                     var textBlock = inlines.ToTextBlock(Presenter.TypeMap, wrap: false);
-
-                    var toolTipFactory = CreateDisposableToolTipFactory();
-                    if (toolTipFactory != null)
-                    {
-                        LazyToolTip.AttachTo(textBlock, toolTipFactory);
-                    }
 
                     content = textBlock;
                     return true;
@@ -90,8 +84,6 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             }
 
             protected abstract IList<Inline> CreateLineTextInlines();
-
-            protected virtual Func<DisposableToolTip> CreateDisposableToolTipFactory() => null;
         }
     }
 }

--- a/src/VisualStudio/Core/Next/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -3,12 +3,19 @@
 using System;
 using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Documents;
+using System.Windows.Media;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Preview;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
+using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 {
@@ -25,6 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 
             private readonly DocumentSpan _documentSpan;
             private readonly object _boxedProjectGuid;
+
             protected readonly SourceText _sourceText;
 
             protected AbstractDocumentSpanEntry(
@@ -75,6 +83,12 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     var inlines = CreateLineTextInlines();
                     var textBlock = inlines.ToTextBlock(Presenter.TypeMap, wrap: false);
 
+                    var toolTipFactory = CreateDisposableToolTipFactory();
+                    if (toolTipFactory != null)
+                    {
+                        LazyToolTip.AttachTo(textBlock, toolTipFactory);
+                    }
+
                     content = textBlock;
                     return true;
                 }
@@ -84,6 +98,8 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
             }
 
             protected abstract IList<Inline> CreateLineTextInlines();
+
+            protected virtual Func<DisposableToolTip> CreateDisposableToolTipFactory() => null;
         }
     }
 }

--- a/src/VisualStudio/Core/Next/FindReferences/Entries/AbstractDocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Entries/AbstractDocumentSpanEntry.cs
@@ -3,19 +3,12 @@
 using System;
 using System.Collections.Generic;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Documents;
-using System.Windows.Media;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Preview;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
-using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.FindUsages
 {


### PR DESCRIPTION
Looks like this: 

![image](https://cloud.githubusercontent.com/assets/4564579/23777983/d14a4204-04ec-11e7-8a6b-794f6aa57834.png)

(of course, with whatever color you've actually chosen for written references).