### PR TITLE
don't convert metadata reference to project reference. this workspace…

### DIFF
--- a/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
@@ -68,7 +68,6 @@ namespace Microsoft.CodeAnalysis.Remote
             lock (_gate)
             {
                 this.OnSolutionAdded(solutionInfo);
-                this.UpdateReferencesAfterAdd();
 
                 return this.CurrentSolution;
             }
@@ -91,8 +90,6 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var newSolution = this.SetCurrentSolution(solution);
                 this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.SolutionChanged, oldSolution, newSolution);
-
-                this.UpdateReferencesAfterAdd();
 
                 return this.CurrentSolution;
             }


### PR DESCRIPTION
… replicates workspace in host (VS), it is a bug that it tried to convert metadata reference to project reference.

also, this sometimes caused VS to crash since if a user had circular reference by metadata reference, by converting metadata reference to project reference, we are introducing circular p2p reference in solution, and workspace crash.