### PR TITLE
Have Code DOM tests check for ComDefaultInterface

### DIFF
--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAccessorFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAccessorFunctionTests.vb
@@ -66,14 +66,7 @@ class C
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "FunctionKind", "Type", "Parameters", "Access", "IsOverloaded",
-                 "IsShared", "MustImplement", "Overloads", "Attributes", "DocComment", "Comment",
-                 "CanOverride", "OverrideKind", "IsGeneric"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeFunction2)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeAttributeTests.vb
@@ -1039,12 +1039,7 @@ class C
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Value", "Target", "Arguments"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeAttribute2)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeClassTests.vb
@@ -3930,15 +3930,7 @@ class $$C
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
-                 "DocComment", "Comment", "DerivedTypes", "ImplementedInterfaces", "IsAbstract",
-                 "ClassKind", "PartialClasses", "DataTypeKind", "Parts", "InheritanceKind", "IsGeneric",
-                 "IsShared"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeClass2)(code)
         End Sub
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeDelegateTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeDelegateTests.vb
@@ -375,14 +375,7 @@ delegate void D();
 delegate void $$D();
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind",
-                 "IsCodeType", "InfoLocation", "Children", "Language", "StartPoint",
-                 "EndPoint", "ExtenderNames", "ExtenderCATID", "Parent", "Namespace",
-                 "Bases", "Members", "Access", "Attributes", "DocComment", "Comment",
-                 "DerivedTypes", "BaseClass", "Type", "Parameters", "IsGeneric"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeDelegate2)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEnumTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEnumTests.vb
@@ -577,13 +577,7 @@ enum $$E
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
-                 "DocComment", "Comment", "DerivedTypes"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE.CodeEnum)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEventTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeEventTests.vb
@@ -963,13 +963,7 @@ class C
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Access", "Attributes", "DocComment", "Comment", "Adder",
-                 "Remover", "Thrower", "IsPropertyStyleEvent", "Type", "OverrideKind", "IsShared"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeEvent)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeFunctionTests.vb
@@ -2671,14 +2671,7 @@ class C
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "FunctionKind", "Type", "Parameters", "Access", "IsOverloaded",
-                 "IsShared", "MustImplement", "Overloads", "Attributes", "DocComment", "Comment",
-                 "CanOverride", "OverrideKind", "IsGeneric"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeFunction2)(code)
         End Sub
 
         Private Function GetExtensionMethodExtender(codeElement As EnvDTE80.CodeFunction2) As ICSExtensionMethodExtender

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeImportTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeImportTests.vb
@@ -81,12 +81,7 @@ namespace Bar
 using $$System;
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Namespace", "Alias", "Parent"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeImport)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeInterfaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeInterfaceTests.vb
@@ -421,13 +421,7 @@ interface $$I
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
-                 "DocComment", "Comment", "DerivedTypes", "IsGeneric", "DataTypeKind", "Parts"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeInterface2)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeNamespaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeNamespaceTests.vb
@@ -459,12 +459,7 @@ namespace $$N
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Members", "DocComment", "Comment"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE.CodeNamespace)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -1254,12 +1254,7 @@ class C
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Type", "Attributes", "DocComment", "ParameterKind", "DefaultValue"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeParameter2)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
@@ -1674,14 +1674,7 @@ class C
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Type", "Getter", "Setter", "Access", "Attributes",
-                 "DocComment", "Comment", "Parameters", "IsGeneric", "OverrideKind", "IsShared",
-                 "IsDefault", "Parent2", "ReadWrite"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeProperty2)(code)
         End Sub
 
         Private Function GetAutoImplementedPropertyExtender(codeElement As EnvDTE80.CodeProperty2) As ICSAutoImplementedPropertyExtender

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeStructTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeStructTests.vb
@@ -525,14 +525,7 @@ struct $$S
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "Namespace", "Bases", "Members", "Access", "Attributes",
-                 "DocComment", "Comment", "DerivedTypes", "ImplementedInterfaces", "IsAbstract",
-                 "IsGeneric", "DataTypeKind", "Parts"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeStruct2)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeVariableTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeVariableTests.vb
@@ -2016,13 +2016,7 @@ class S
 }
 </Code>
 
-            Dim expectedPropertyNames =
-                {"DTE", "Collection", "Name", "FullName", "ProjectItem", "Kind", "IsCodeType",
-                 "InfoLocation", "Children", "Language", "StartPoint", "EndPoint", "ExtenderNames",
-                 "ExtenderCATID", "Parent", "InitExpression", "Type", "Access", "IsConstant", "Attributes",
-                 "DocComment", "Comment", "IsShared", "ConstKind", "IsGeneric"}
-
-            TestPropertyDescriptors(code, expectedPropertyNames)
+            TestPropertyDescriptors(Of EnvDTE80.CodeVariable2)(code)
         End Sub
 
         Protected Overrides ReadOnly Property LanguageName As String


### PR DESCRIPTION
The Code DOM tests which verify the behavior of
TypeDescriptor.GetProperties relied on certain type libraries being
registered machine wide, EnvDTE in particular.  This is not true when
running our tests on bare Windows machines.

Changed these tests to instead directly validate the ComDefaultInterface
value for the types.  This is what ultimately controls the values
returned by GetProperties and hence is a sufficient test.