### PR TITLE
Updating the VisualStudioInstanceFactory to ensure that the instance is in a clean state for each test we run.

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -9,9 +9,10 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using EnvDTE;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Interop;
 using Microsoft.VisualStudio.Setup.Configuration;
-using Xunit.Sdk;
+using Process = System.Diagnostics.Process;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 {
@@ -95,10 +96,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             ThrowExceptionIfAlreadyHasActiveContext();
 
-            if (ShouldStartNewInstance(requiredPackageIds))
-            {
-                StartNewInstance(requiredPackageIds);
-            }
+            bool shouldStartNewInstance = ShouldStartNewInstance(requiredPackageIds);
+            UpdateCurrentlyRunningInstance(requiredPackageIds, shouldStartNewInstance);
 
             return new VisualStudioInstanceContext(_currentlyRunningInstance, this);
         }
@@ -139,18 +138,39 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// <summary>
         /// Starts up a new <see cref="VisualStudioInstance"/>, shutting down any instances that are already running.
         /// </summary>
-        private void StartNewInstance(ImmutableHashSet<string> requiredPackageIds)
+        private void UpdateCurrentlyRunningInstance(ImmutableHashSet<string> requiredPackageIds, bool shouldStartNewInstance)
         {
-            var instance = LocateVisualStudioInstance(requiredPackageIds) as ISetupInstance2;
+            Process hostProcess;
+            DTE dte;
 
-            _supportedPackageIds = ImmutableHashSet.CreateRange(instance.GetPackages().Select((supportedPackage) => supportedPackage.GetId()));
-            _installationPath = instance.GetInstallationPath();
+            if (shouldStartNewInstance)
+            {
+                // We are starting a new instance, so ensure we close the currently running instance, if it exists
+                _currentlyRunningInstance?.Close();
 
-            var process = StartNewVisualStudioProcess(_installationPath);
-            // We wait until the DTE instance is up before we're good
-            var dte = IntegrationHelper.WaitForNotNullAsync(() => IntegrationHelper.TryLocateDteForProcess(process)).Result;
+                var instance = LocateVisualStudioInstance(requiredPackageIds) as ISetupInstance2;
+                _supportedPackageIds = ImmutableHashSet.CreateRange(instance.GetPackages().Select((supportedPackage) => supportedPackage.GetId()));
+                _installationPath = instance.GetInstallationPath();
 
-            _currentlyRunningInstance = new VisualStudioInstance(process, dte);
+                hostProcess = StartNewVisualStudioProcess(_installationPath);
+                // We wait until the DTE instance is up before we're good
+                dte = IntegrationHelper.WaitForNotNullAsync(() => IntegrationHelper.TryLocateDteForProcess(hostProcess)).Result;
+            }
+            else
+            {
+                // We are going to reuse the currently running instance, so ensure that we grab the host Process and Dte
+                // before cleaning up any hooks or remoting services created by the previous instance. We will then
+                // create a new VisualStudioInstance from the previous to ensure that everything is in a 'clean' state.
+
+                Debug.Assert(_currentlyRunningInstance != null);
+
+                hostProcess = _currentlyRunningInstance.HostProcess;
+                dte = _currentlyRunningInstance.Dte;
+
+                _currentlyRunningInstance.Close(exitHostProcess: false);
+            }
+
+            _currentlyRunningInstance = new VisualStudioInstance(hostProcess, dte);
         }
 
         private static ISetupConfiguration GetSetupConfiguration()


### PR DESCRIPTION
FYI. @dotnet/roslyn-infrastructure 

This ensures that the VS instance is in a clean state for each test run by tearing down any remoting services that were setup by the previous test.