### PR TITLE
Disabling flaking dialog tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpChangeSignatureDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpChangeSignatureDialog.cs
@@ -80,7 +80,8 @@ class C
 }");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/17680"),
+         Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public void VerifyRemoveParameter()
         {
             SetUpEditor(@"
@@ -124,7 +125,8 @@ class C
 }");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/17680"),
+         Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public void VerifyCrossLanguageGlobalUndo()
         {
             SetUpEditor(@"using VBProject;

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateTypeDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateTypeDialog.cs
@@ -101,7 +101,8 @@ End Class
 ");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/17680"), 
+         Trait(Traits.Feature, Traits.Features.CodeActionsGenerateType)]
         public void CheckFoldersPopulateComboBox()
         {
             VisualStudio.Instance.SolutionExplorer.AddFile(ProjectName, @"folder1\folder2\GenerateTypeTests.vb", open: true);


### PR DESCRIPTION
Related to https://github.com/dotnet/roslyn/issues/17680

Only disabling the specific failing ones for now. If more of them start
failing then I'll disable *all* of the dialog tests until we understand
the problem.