### PR TITLE
Don't offer backing-fields in Generate-Equals/GetHashCode.

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersTests.cs
@@ -936,5 +936,32 @@ class Program
 chosenSymbols: new string[] { },
 ignoreTrivia: false);
         }
+
+        [WorkItem(17643, "https://github.com/dotnet/roslyn/issues/17643")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TestWithDialogNoBackingFields()
+        {
+            await TestWithPickMembersDialogAsync(
+@"
+class Program
+{
+    public int F { get; set; }
+    [||]
+}",
+@"
+class Program
+{
+    public int F { get; set; }
+
+    public override bool Equals(object obj)
+    {
+        var program = obj as Program;
+        return program != null &&
+               F == program.F;
+    }
+}",
+chosenSymbols: null,
+ignoreTrivia: false);
+        }
     }
 }

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -125,7 +125,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 => _memberNames = memberNames;
 
             public PickMembersResult PickMembers(string title, ImmutableArray<ISymbol> members)
-                => new PickMembersResult(_memberNames.SelectAsArray(n => members.Single(m => m.Name == n)));
+                => new PickMembersResult(_memberNames.IsDefault
+                    ? members
+                    : _memberNames.SelectAsArray(n => members.Single(m => m.Name == n)));
         }
 
         internal Task TestWithPickMembersDialogAsync(
@@ -137,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             CodeActionPriority? priority = null,
             TestParameters parameters = default(TestParameters))
         {
-            var pickMembersService = new TestPickMembersService(chosenSymbols.AsImmutableOrEmpty());
+            var pickMembersService = new TestPickMembersService(chosenSymbols.AsImmutableOrNull());
             return TestInRegularAndScript1Async(
                 initialMarkup, expectedMarkup,
                 index, ignoreTrivia, priority,

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/GenerateEqualsAndGetHashCodeFromMembersCodeRefactoringProvider.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
 
             // Find all the possible instance fields/properties.  If there are any, then
             // show a dialog to the user to select the ones they want.
-            var viableMembers = containingType.GetMembers().WhereAsArray(IsInstanceFieldOrProperty);
+            var viableMembers = containingType.GetMembers().WhereAsArray(IsViableInstanceFieldOrProperty);
             if (viableMembers.Length == 0)
             {
                 return;
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             {
                 var info = await this.GetSelectedMemberInfoAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
                 if (info != null &&
-                    info.SelectedMembers.All(IsInstanceFieldOrProperty))
+                    info.SelectedMembers.All(IsViableInstanceFieldOrProperty))
                 {
                     if (info.ContainingType != null && info.ContainingType.TypeKind != TypeKind.Interface)
                     {

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
@@ -73,27 +73,27 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
 
         // Can use non const fields and properties with setters in them.
         protected static bool IsWritableInstanceFieldOrProperty(ISymbol symbol)
-            => IsInstanceFieldOrProperty(symbol) &&
+            => IsViableInstanceFieldOrProperty(symbol) &&
                IsWritableFieldOrProperty(symbol);
 
         private static bool IsWritableFieldOrProperty(ISymbol symbol)
         {
             switch (symbol)
             {
-                case IFieldSymbol field: return !field.IsConst && field.AssociatedSymbol == null;
+                case IFieldSymbol field: return !field.IsConst && IsViableField(field);
                 case IPropertySymbol property: return property.IsWritableInConstructor();
                 default: return false;
             }
         }
 
-        protected static bool IsInstanceFieldOrProperty(ISymbol symbol)
-            => !symbol.IsStatic && (IsField(symbol) || IsProperty(symbol));
+        protected static bool IsViableInstanceFieldOrProperty(ISymbol symbol)
+            => !symbol.IsStatic && (IsViableField(symbol) || IsViableProperty(symbol));
 
-        private static bool IsProperty(ISymbol symbol)
+        private static bool IsViableProperty(ISymbol symbol)
             => symbol.Kind == SymbolKind.Property;
 
-        private static bool IsField(ISymbol symbol)
-            => symbol.Kind == SymbolKind.Field;
+        private static bool IsViableField(ISymbol symbol)
+            => symbol is IFieldSymbol field && field.AssociatedSymbol == null;
 
         protected ImmutableArray<IParameterSymbol> DetermineParameters(
             ImmutableArray<ISymbol> selectedMembers)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/17643