### PR TITLE
Move to GitLink 3.0

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--Generated file, do not directly edit.  Run "RepoUtil change" to regenerate-->
   <PropertyGroup>
-    <GitLinkVersion>2.3.0</GitLinkVersion>
+    <GitLinkVersion>3.0.0-unstable0085</GitLinkVersion>
     <ManagedEsentVersion>1.9.4</ManagedEsentVersion>
     <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>
     <MicroBuildCoreSentinelVersion>1.0.0</MicroBuildCoreSentinelVersion>

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -17,7 +17,7 @@
     "RoslynTools.Microsoft.LocateVS": "0.2.4-beta",
     "RoslynTools.Microsoft.SignTool": "0.3.0-beta",
     "RoslynTools.Microsoft.VSIXExpInstaller": "0.2.4-beta",
-    "GitLink": "2.3.0"
+    "GitLink": "3.0.0-unstable0085"
   },
   "frameworks": {
     "net461": {}

--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -55,7 +55,6 @@
         "Exes\\vbccore\\vbc.exe",
         "Exes\\vbi\\vbi.exe",
         "Exes\\vbicore\\vbi.exe",
-        "Exes\\Pdb2Xml\\Microsoft.DiaSymReader.PortablePdb.dll",
         "Exes\\Pdb2Xml\\Pdb2Xml.exe",
         "Vsix\\CompilerExtension\\Roslyn.Compilers.Extension.dll",
         "Vsix\\Templates\\Roslyn.Templates.dll",

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -1,0 +1,41 @@
+# Collection of powershell build utility functions that we use across our scripts.
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+# Declare a number of useful variables for other scripts to use
+[string]$repoDir = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+[string]$binariesDir = Join-Path $repoDir "Binaries"
+[string]$scriptDir = $PSScriptRoot
+
+function Create-Directory([string]$dir) {
+    New-Item $dir -ItemType Directory -ErrorAction SilentlyContinue | out-null
+}
+
+# Return the version of the NuGet package as used in this repo
+function Get-PackageVersion([string]$name) {
+    $deps = Join-Path $repoDir "build\Targets\Dependencies.props"
+    $nodeName = "$($name)Version"
+    $x = [xml](Get-Content -raw $deps)
+    $node = $x.Project.PropertyGroup[$nodeName]
+    if ($node -eq $null) { 
+        throw "Cannot find package $name in Dependencies.props"
+    }
+
+    return $node.InnerText
+}
+
+# Locate the directory where our NuGet packages will be deployed.  Needs to be kept in sync
+# with the logic in Version.props
+function Get-PackagesDir {
+    $d = $null
+    if ($env:NUGET_PACKAGES -ne $null) {
+        $d = $env:NUGET_PACKAGES
+    }
+    else {
+        $d = Join-Path $env:UserProfile ".nuget\packages\"
+    }
+
+    Create-Directory $d
+    return $d
+}

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -832,6 +832,7 @@ Public Class BuildDevDivInsertionFiles
         add("Exes\VBCSCompiler\VBCSCompiler.exe.config")
         add("Exes\InteractiveHost\InteractiveHost.exe.config")
         add("Exes\csi\csi.rsp")
+        add("Exes\Pdb2Xml\Microsoft.DiaSymReader.PortablePdb.dll")
         add("Vsix\Roslyn.Deployment.Full.Next\remoteSymbolSearchUpdateEngine.servicehub.service.json")
         add("Vsix\Roslyn.Deployment.Full.Next\snapshotService.servicehub.service.json")
         add("Vsix\VisualStudioInteractiveComponents\CSharpInteractive.rsp")

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -26,12 +26,12 @@
 
     <MSBuild Projects="$(RepoRoot)Roslyn.sln" BuildInParallel="true" Properties="DeployExtension=false" />
 
-    <Exec Command="$(NuGetPackageRoot)\GitLink\$(GitLinkVersion)\lib\net45\GitLink.exe $(RepoRoot) -u https://github.com/dotnet/roslyn -f Roslyn.sln -c $(Configuration)" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)..\..\..\build\scripts\create-perftests.ps1 &quot;$(BinariesPath)&quot;" />
 
     <MSBuild Projects="$(RepoRoot)src\Setup\SetupStep1.proj" Properties="DeployExtension=false" />
 
+    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)run-gitlink.ps1 &quot;$(Configuration)&quot;" />
     <Exec Command="$(NuGetPackageRoot)\RoslynTools.Microsoft.SignTool\$(RoslynToolsMicrosoftSignToolVersion)\tools\SignTool.exe $(SignRoslynArgs) &quot;$(BinariesPath)&quot;" WorkingDirectory="$(RepoRoot)" />
 
     <MSBuild Projects="$(RepoRoot)src\NuGet\NuGet.proj" />

--- a/src/Tools/MicroBuild/run-gitlink.ps1
+++ b/src/Tools/MicroBuild/run-gitlink.ps1
@@ -1,0 +1,41 @@
+# Run GitLink on the binaries that we are producing.
+
+param([string]$config = "Release")
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+try {
+    . (Join-Path $PSScriptRoot "..\..\..\build\scripts\build-utils.ps1")
+
+    $configDir = Join-Path $binariesDir $config
+    $gitlinkVersion = Get-PackageVersion "GitLink"
+    $gitlink = Join-Path (Get-PackagesDir) "GitLink\$gitlinkVersion\build\GitLink.exe"
+
+    Write-Host "Running GitLink"
+
+    $config = Join-Path $repoDir "build\config\SignToolData.json"
+    $j = ConvertFrom-Json (Get-Content -raw $config)
+    foreach ($entry in $j.sign) {
+        foreach ($v in $entry.values) { 
+            $ext = [IO.Path]::GetExtension($v)
+            if (($ext -eq ".dll") -or ($ext -eq ".exe")) {
+                $name = [IO.Path]::ChangeExtension($v, ".pdb")
+                $pdbPath = Join-Path $configDir $name
+                Write-Host "`t$pdbPath"
+
+                $output = & $gitlink -u "https://github.com/dotnet/roslyn" $pdbPath
+                if (-not $?) {
+                    Write-Host "Error!!!"
+                    Write-Host $output
+                    exit 1
+                }
+            }
+        }
+    }
+
+    exit 0
+}
+catch [exception] {
+    write-host $_.Exception
+    exit 1
+}


### PR DESCRIPTION
This makes two changes:

1. Move us to GitLink 3.0
1. Add source link info to all binaries we sign