### PR TITLE
Creating AddDefine code refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -195,6 +195,7 @@
     <Compile Include="CodeActions\AbstractCSharpCodeActionTest.cs" />
     <Compile Include="CodeActions\ConvertIfToSwitch\ConvertIfToSwitchTests.cs" />
     <Compile Include="CodeActions\ConvertNumericLiteral\ConvertNumericLiteralTests.cs" />
+    <Compile Include="CodeActions\AddDefine\AddDefineTests.cs" />
     <Compile Include="CodeActions\UseNamedArguments\UseNamedArgumentsTests.cs" />
     <Compile Include="ConflictMarkerResolution\ConflictMarkerResolutionTests.cs" />
     <Compile Include="Completion\CompletionProviders\OverrideCompletionProviderTests_ExpressionBody.cs" />

--- a/src/EditorFeatures/CSharpTest/CodeActions/AddDefine/AddDefineTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/AddDefine/AddDefineTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddDefine;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.AddDefine
+{
+    public class AddDefineTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new AddDefineCodeRefactoringProvider();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task OnlySimplePragma()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+class C
+{
+#if [||]TEST == 1
+#endif
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task OnlyPragma()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+class C
+{
+    int x[||];
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task OnlyEmptySelection()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+class C
+{
+#if [|TEST|]
+#endif
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task OnlyInactiveCondition()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+#define TEST
+class C
+{
+#if [|TEST|]
+#endif
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task OnlyIfPragma()
+        {
+            await TestMissingInRegularAndScriptAsync(@"
+#define [||]TEST
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task CursorBeforeIf()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    void M()
+    {
+[||]#if TEST
+        System.Console.WriteLine();
+#endif
+    }
+}", @"
+#define TEST
+class C
+{
+    void M()
+    {
+#if [||]TEST
+        System.Console.WriteLine();
+#endif
+    }
+}", ignoreTrivia: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task CursorMiddleIf()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    void M()
+    {
+#if [||]TEST
+        System.Console.WriteLine();
+#endif
+    }
+}", @"
+#define TEST
+class C
+{
+    void M()
+    {
+#if [||]TEST
+        System.Console.WriteLine();
+#endif
+    }
+}", ignoreTrivia: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task CursorAfterIf()
+        {
+            await TestInRegularAndScriptAsync(@"
+class C
+{
+    void M()
+    {
+#if TEST[||]
+        System.Console.WriteLine();
+#endif
+    }
+}", @"
+#define TEST
+class C
+{
+    void M()
+    {
+#if [||]TEST
+        System.Console.WriteLine();
+#endif
+    }
+}", ignoreTrivia: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddDefine)]
+        public async Task InitialCommentRemains()
+        {
+            await TestInRegularAndScriptAsync(@"
+// copyright
+class C
+{
+    void M()
+    {
+#if [||]TEST
+        System.Console.WriteLine();
+#endif
+    }
+}", @"
+// copyright
+#define TEST
+class C
+{
+    void M()
+    {
+#if [||]TEST
+        System.Console.WriteLine();
+#endif
+    }
+}", ignoreTrivia: false);
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,7 +55,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             TestWorkspace workspace)
         {
             var document = GetDocument(workspace);
-            var span = workspace.Documents.Single(d => !d.IsLinkFile && d.SelectedSpans.Count == 1).SelectedSpans.Single();
+            var documents = workspace.Documents.SingleOrDefault(d => !d.IsLinkFile && d.SelectedSpans.Count == 1);
+            Debug.Assert(documents != null, "There must be exactly one selection, marked with [|...|]");
+            var span = documents.SelectedSpans.Single();
             var actions = ArrayBuilder<CodeAction>.GetInstance();
             var context = new CodeRefactoringContext(document, span, actions.Add, CancellationToken.None);
             await provider.ComputeRefactoringsAsync(context);

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -31,6 +31,7 @@ namespace Roslyn.Test.Utilities
             public const string CodeActionsAddDocCommentNodes = "CodeActions.AddDocCommentParamNodes";
             public const string CodeActionsAddAwait = "CodeActions.AddAwait";
             public const string CodeActionsAddBraces = "CodeActions.AddBraces";
+            public const string CodeActionsAddDefine = "CodeActions.AddDefine";
             public const string CodeActionsAddImport = "CodeActions.AddImport";
             public const string CodeActionsAddMissingReference = "CodeActions.AddMissingReference";
             public const string CodeActionsAddParameter = "CodeActions.AddParameter";

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -63,6 +63,7 @@
     <Compile Include="AddPackage\CSharpAddSpecificPackageCodeFixProvider.cs" />
     <Compile Include="AddParameter\CSharpAddParameterCodeFixProvider.cs" />
     <Compile Include="CodeFixes\RemoveUnusedVariable\RemoveUnusedVariableCodeFixProvider.cs" />
+    <Compile Include="CodeRefactorings\AddDefine\AddDefineCodeRefactoringProvider.cs" />
     <Compile Include="ConvertIfToSwitch\CSharpConvertIfToSwitchCodeRefactoringProvider.cs" />
     <Compile Include="ConvertIfToSwitch\CSharpConvertIfToSwitchCodeRefactoringProvider.Pattern.cs" />
     <Compile Include="ConvertNumericLiteral\CSharpConvertNumericLiteralCodeRefactoringProvider.cs" />

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -71,11 +71,11 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add define pragma.
+        ///   Looks up a localized string similar to Add #define {0}.
         /// </summary>
-        internal static string Add_define_pragma {
+        internal static string Add_define_0 {
             get {
-                return ResourceManager.GetString("Add_define_pragma", resourceCulture);
+                return ResourceManager.GetString("Add_define_0", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -71,6 +71,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add define pragma.
+        /// </summary>
+        internal static string Add_define_pragma {
+            get {
+                return ResourceManager.GetString("Add_define_pragma", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add &apos;this.&apos;.
         /// </summary>
         internal static string Add_this {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -126,8 +126,8 @@
   <data name="Invert_if_statement" xml:space="preserve">
     <value>Invert if statement</value>
   </data>
-  <data name="Add_define_pragma" xml:space="preserve">
-    <value>Add define pragma</value>
+  <data name="Add_define_0" xml:space="preserve">
+    <value>Add #define {0}</value>
   </data>
   <data name="Simplify_lambda_expression" xml:space="preserve">
     <value>Simplify lambda expression</value>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -126,6 +126,9 @@
   <data name="Invert_if_statement" xml:space="preserve">
     <value>Invert if statement</value>
   </data>
+  <data name="Add_define_pragma" xml:space="preserve">
+    <value>Add define pragma</value>
+  </data>
   <data name="Simplify_lambda_expression" xml:space="preserve">
     <value>Simplify lambda expression</value>
   </data>

--- a/src/Features/CSharp/Portable/CodeRefactorings/AddDefine/AddDefineCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/AddDefine/AddDefineCodeRefactoringProvider.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddDefine
+{
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.AddDefine), Shared]
+    internal partial class AddDefineCodeRefactoringProvider : CodeRefactoringProvider
+    {
+        public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+        {
+            var document = context.Document;
+            var textSpan = context.Span;
+            var cancellationToken = context.CancellationToken;
+
+            if (!textSpan.IsEmpty ||
+                document.Project.Solution.Workspace.Kind == WorkspaceKind.MiscellaneousFiles)
+            {
+                return;
+            }
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var trivia = root.FindTrivia(textSpan.Start);
+            if (!trivia.HasStructure)
+            {
+                return;
+            }
+
+            var structure = trivia.GetStructure();
+            if (structure.Kind() != SyntaxKind.IfDirectiveTrivia)
+            {
+                return;
+            }
+
+            var ifPragma = (IfDirectiveTriviaSyntax)structure;
+            if (ifPragma == null ||
+                ifPragma.ConditionValue ||
+                ifPragma.Condition.Kind() != SyntaxKind.IdentifierName)
+            {
+                return;
+            }
+
+            context.RegisterRefactoring(
+                new AddDefineCodeAction(
+                    CSharpFeaturesResources.Add_define_pragma,
+                    (c) => AddDefineAsync(document, ifPragma, c)));
+        }
+
+        private async Task<Document> AddDefineAsync(Document document, IfDirectiveTriviaSyntax ifPragma,
+            CancellationToken cancellationToken)
+        {
+            var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            var root = tree.GetRoot();
+            var firstUsing = root.ChildNodes().FirstOrDefault();
+
+            var define = SyntaxFactory.Trivia(SyntaxFactory.DefineDirectiveTrivia(
+                ((IdentifierNameSyntax)ifPragma.Condition).Identifier
+                    .WithLeadingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, " "))
+                    .WithTrailingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.EndOfLineTrivia, "\r\n")), false));
+            var newLeadingTrivia = new SyntaxTriviaList();
+            newLeadingTrivia = newLeadingTrivia.AddRange(firstUsing.GetLeadingTrivia());
+            newLeadingTrivia = newLeadingTrivia.Add(define);
+
+            var result = root.ReplaceNode(firstUsing, firstUsing.WithLeadingTrivia(newLeadingTrivia));
+            return document.WithSyntaxRoot(result);
+        }
+
+        private class AddDefineCodeAction : CodeAction.DocumentChangeAction
+        {
+            public AddDefineCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument) :
+                base(title, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/PredefinedCodeRefactoringProviderNames.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
     internal static class PredefinedCodeRefactoringProviderNames
     {
         public const string AddConstructorParametersFromMembers = "Add Parameters From Members Code Action Provider";
+        public const string AddDefine = "Add Define Code Action Provider";
         public const string ChangeSignature = "Change Signature Code Action Provider";
         public const string EncapsulateField = "Encapsulate Field";
         public const string ExtractInterface = "Extract Interface Code Action Provider";


### PR DESCRIPTION
This code refactoring adds a `#define <identifier>` when triggered on an inactive `#if <identifier>`.

@dotnet/roslyn-ide for review.
If this looks good, I'll do the same for VB.