### PR TITLE
don't convert metadata reference to project reference. this workspace…

### DIFF
--- a/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
@@ -25,6 +25,12 @@ namespace Microsoft.CodeAnalysis.Remote
             Options = Options.WithChangedOption(CacheOptions.RecoverableTreeLengthThreshold, 0);
         }
 
+        // constructor for testing
+        public RemoteWorkspace(string workspaceKind)
+            : base(RoslynServices.HostServices, workspaceKind: workspaceKind)
+        {
+        }
+
         // this workspace doesn't allow modification by calling TryApplyChanges.
         // consumer of solution is still free to fork solution as they want, they just can't apply those changes
         // back to primary workspace. only solution service can update primary workspace

--- a/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
@@ -57,7 +57,6 @@ namespace Microsoft.CodeAnalysis.Remote
             lock (_gate)
             {
                 this.OnSolutionAdded(solutionInfo);
-                this.UpdateReferencesAfterAdd();
 
                 return this.CurrentSolution;
             }
@@ -80,8 +79,6 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var newSolution = this.SetCurrentSolution(solution);
                 this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.SolutionChanged, oldSolution, newSolution);
-
-                this.UpdateReferencesAfterAdd();
 
                 return this.CurrentSolution;
             }


### PR DESCRIPTION
… replicates workspace in host (VS), it is a bug that it tried to convert metadata reference to project reference.

also, this sometimes caused VS to crash since if a user had circular reference by metadata reference, by converting metadata reference to project reference, we are introducing circular p2p reference in solution, and workspace crash.


**Customer scenario**

(C#/VB) users who have a solution that has circular references through metadata references

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/17717
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=394983

**Workarounds, if any**

Don't have circular references. or have circular references but don't reference the metadata from output path of a project.

**Risk**
Low

**Performance impact**

none

**Is this a regression from a previous update?**

No

**Root cause analysis:**

let's say a solution has project P1 and P2. and P1 has p2p reference to P2 and output its dll to P1.dll. and p2 has metadata reference to P1.dll. basically, the solution has circular reference through metadata reference. when this solution is opened in OOP, OOP will try to convert metadata reference to p2p reference. this causes the workspace to have circular p2p reference and it throws an unexpected exception and at the end, cause VS to crash.

**How was the bug found?**

Watson report



