### PR TITLE
Update the Roslyn package version to 2.0.1

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -10,7 +10,7 @@
     <!-- This is the assembly version of Roslyn from the .NET assembly perspective. It should only be revved during significant point releases. -->
     <RoslynAssemblyVersionBase Condition="'$(RoslynAssemblyVersion)' == ''">2.0.0</RoslynAssemblyVersionBase>
     <!-- This is the file version of Roslyn, as placed in the PE header. It should be revved during point releases, and is also what provides the basis for our NuGet package versioning. -->
-    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.0.0</RoslynFileVersionBase>
+    <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.0.1</RoslynFileVersionBase>
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>


### PR DESCRIPTION
We leave the assembly version at 2.0.0 since that's what we do for patch releases.

This is a preemptive update for any updates we might have to ship out of here. FYI to @dotnet/roslyn-infrastructure and @MattGertz.