### PR TITLE
Ensure LanguageParser.ParseStatementCore doesn’t return null.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6518,7 +6518,15 @@ tryAgain:
                 // it as either a declaration or as an "await X();" statement that is in a non-async
                 // method. 
 
-                return ParsePossibleDeclarationOrBadAwaitStatement();
+                result = ParsePossibleDeclarationOrBadAwaitStatement();
+                if (result != null)
+                {
+                    return result;
+                }
+
+                // We failed to parse the statement as a declaration, let's recover
+                // by parsing as an expression statement.
+                return ParseExpressionStatement();
             }
             finally
             {


### PR DESCRIPTION
Fixes #17458.
Heuristics around local functions can cause both ParseStatementNoDeclaration and ParsePossibleDeclarationOrBadAwaitStatement to return null in case of an error. LanguageParser.ParseStatementCore is modified to recover from this situation by parsing an expression statement.