### PR TITLE
Ensure LanguageParser.ParseStatement doesn’t return null.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6488,7 +6488,7 @@ tryAgain:
         public StatementSyntax ParseStatement()
         {
             return ParseWithStackGuard(
-                ParseStatementCore,
+                () => ParseStatementCore() ?? ParseExpressionStatement(),
                 () => SyntaxFactory.EmptyStatement(SyntaxFactory.MissingToken(SyntaxKind.SemicolonToken)));
         }
 


### PR DESCRIPTION
Fixes #17458.
LanguageParser.ParseStatement can return null in case of an error. LanguageParser.ParseStatement is modified to recover from this situation by parsing an expression statement.

@dotnet/roslyn-compiler Please review.