### PR TITLE
made host analyzer not to load assembly to find out analyzer referenc…

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/IReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/IReferenceSerializationService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Execution
 
         void WriteTo(Encoding encoding, ObjectWriter writer, CancellationToken cancellationToken);
         void WriteTo(MetadataReference reference, ObjectWriter writer, CancellationToken cancellationToken);
-        void WriteTo(AnalyzerReference reference, ObjectWriter writer, CancellationToken cancellationToken);
+        void WriteTo(AnalyzerReference reference, ObjectWriter writer, bool usePathFromAssembly, CancellationToken cancellationToken);
 
         Encoding ReadEncodingFrom(ObjectReader reader, CancellationToken cancellationToken);
         MetadataReference ReadMetadataReferenceFrom(ObjectReader reader, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/Execution/Serializer.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                         return;
 
                     case WellKnownSynchronizationKinds.AnalyzerReference:
-                        SerializeAnalyzerReference((AnalyzerReference)value, writer, cancellationToken);
+                        SerializeAnalyzerReference((AnalyzerReference)value, writer, usePathFromAssembly: true, cancellationToken: cancellationToken);
                         return;
 
                     case WellKnownSynchronizationKinds.SourceText:

--- a/src/Workspaces/Core/Portable/Execution/Serializer_Asset.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer_Asset.cs
@@ -139,10 +139,10 @@ namespace Microsoft.CodeAnalysis.Serialization
             return _hostSerializationService.ReadMetadataReferenceFrom(reader, cancellationToken);
         }
 
-        public void SerializeAnalyzerReference(AnalyzerReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        public void SerializeAnalyzerReference(AnalyzerReference reference, ObjectWriter writer, bool usePathFromAssembly, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            _hostSerializationService.WriteTo(reference, writer, cancellationToken);
+            _hostSerializationService.WriteTo(reference, writer, usePathFromAssembly, cancellationToken);
         }
 
         private AnalyzerReference DeserializeAnalyzerReference(ObjectReader reader, CancellationToken cancellationToken)


### PR DESCRIPTION
…e dll location

unlike analyzers through nuget which is per project and on demand, host analyzer is context less so it will load dlls that belong to any language such as typescript, xaml, F# and more blindly. this change should prevent it from happening.