### PR TITLE
Fix /skipCommitPrinting by adding missing %

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -64,7 +64,7 @@ if defined testBuildCorrectness (
 )
 
 REM Output the commit that we're building, for reference in Jenkins logs
-if not "%SkipCommitPrinting" == "1" (
+if not "%SkipCommitPrinting%" == "1" (
     echo Building this commit:
     git show --no-patch --pretty=raw HEAD
 )


### PR DESCRIPTION
When trying to build on Windows without Git, `cibuild.cmd` doesn't pick up `/skipCommitPrinting` correctly, causing `git show` to always be called. Fixes the `if` by adding the closing `%`.

/cc @ellismg 