### PR TITLE
Update VSLangProj in Open to 7.0.3300

### DIFF
--- a/src/Setup/Templates/project.json
+++ b/src/Setup/Templates/project.json
@@ -14,7 +14,7 @@
     "System.Collections.Immutable": "1.1.36",
     "System.Reflection.Metadata": "1.0.21",
     "Microsoft.VisualStudio.TemplateWizardInterface": "8.0.0.0-alpha",
-    "VSLangProj": "7.0.3300-alpha"
+    "VSLangProj": "7.0.3300"
   },
   "frameworks": {
     "net46": { }

--- a/src/VisualStudio/Core/Def/project.json
+++ b/src/VisualStudio/Core/Def/project.json
@@ -39,7 +39,7 @@
     "Microsoft.DiaSymReader": "1.1.0",
     "Microsoft.MSXML": "8.0.0.0-alpha",
     "Microsoft.Build": "15.1.0-preview-000458-02",
-    "VSLangProj": "7.0.3300-alpha",
+    "VSLangProj": "7.0.3300",
     "VSLangProj80": "8.0.0.0-alpha",
     "VSLangProj140": "14.3.25407-alpha",
     "VsWebsite.Interop": "8.0.0.0-alpha",


### PR DESCRIPTION
The change I made earlier for EnvDTE turned out not to be sufficient to merge the PR for UpgradeProject code fixer (https://github.com/dotnet/roslyn/pull/17435).

Recently created VSLangProj2 package depends on VSLangProj (>= 7.0.3300).

@jaredpar @dotnet/roslyn-infrastructure for review.