### PR TITLE
Add helper methods to Verify operation tree for annonated text within…

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Semantics;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public partial class IOperationTests : CompilingTestBase
+    public partial class IOperationTests : SemanticModelTestBase
     {
         [Fact]
         [WorkItem(382240, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=382240")]

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ISymbolInitializer.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ISymbolInitializer.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public partial class IOperationTests : CompilingTestBase
+    public partial class IOperationTests : SemanticModelTestBase
     {
         [Fact, WorkItem(17595, "https://github.com/dotnet/roslyn/issues/17595")]
         public void NoInitializers()

--- a/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/SemanticModelTestBase.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -151,4 +152,32 @@ Public MustInherit Class SemanticModelTestBase : Inherits BasicTestBase
             ).Where(Function(s) anyArity OrElse DirectCast(s, Symbol).GetArity() = arity.Value).ToList()
     End Function
 
+    Friend Function GetOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, fileName As String, Optional which As Integer = 0) As String
+        Dim node As SyntaxNode = CompilationUtils.FindBindingText(Of TSyntaxNode)(compilation, fileName, which)
+        If node Is Nothing Then
+            Return Nothing
+        End If
+
+        Dim tree = (From t In compilation.SyntaxTrees Where t.FilePath = fileName).Single()
+        Dim semanticModel = compilation.GetSemanticModel(tree)
+        Dim operation = semanticModel.GetOperationInternal(node)
+        Return If(operation IsNot Nothing, OperationTreeVerifier.GetOperationTree(operation), Nothing)
+    End Function
+
+    Friend Function GetOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0) As String
+        Dim fileName = "a.vb"
+        Dim syntaxTree = Parse(testSrc, fileName, parseOptions)
+        Dim compilation = CreateCompilationWithMscorlib(syntaxTree)
+        Return GetOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, which)
+    End Function
+
+    Friend Sub VerifyOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(compilation As VisualBasicCompilation, fileName As String, expectedOperationTree As String, Optional which As Integer = 0)
+        Dim actualOperationTree = GetOperationTreeForTest(Of TSyntaxNode)(compilation, fileName, which)
+        OperationTreeVerifier.Verify(expectedOperationTree, actualOperationTree)
+    End Sub
+
+    Friend Sub VerifyOperationTreeForTest(Of TSyntaxNode As SyntaxNode)(testSrc As String, expectedOperationTree As String, Optional parseOptions As VisualBasicParseOptions = Nothing, Optional which As Integer = 0)
+        Dim actualOperationTree = GetOperationTreeForTest(Of TSyntaxNode)(testSrc, parseOptions, which)
+        OperationTreeVerifier.Verify(expectedOperationTree, actualOperationTree)
+    End Sub
 End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests.vb
@@ -8,7 +8,7 @@ Imports Roslyn.Test.Utilities
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
     Partial Public Class IOperationTests
-        Inherits BasicTestBase
+        Inherits SemanticModelTestBase
 
         <Fact>
         Public Sub InvalidUserDefinedOperators()

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_ISymbolInitializer.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_ISymbolInitializer.vb
@@ -8,7 +8,7 @@ Imports Roslyn.Test.Utilities
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
     Partial Public Class IOperationTests
-        Inherits BasicTestBase
+        Inherits SemanticModelTestBase
 
         <Fact, WorkItem(17595, "https://github.com/dotnet/roslyn/issues/17595")>
         Public Sub NoInitializers()

--- a/src/Test/Utilities/Portable/Compilation/CompilationExtensions.cs
+++ b/src/Test/Utilities/Portable/Compilation/CompilationExtensions.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var actualTextBuilder = new StringBuilder();
             SemanticModel model = compilation.GetSemanticModel(node.SyntaxTree);
             AppendOperationTree(model, node, actualTextBuilder);
-            VerifyOperationTree(expectedOperationTree, actualTextBuilder.ToString());
+            OperationTreeVerifier.Verify(expectedOperationTree, actualTextBuilder.ToString());
         }
 
         internal static void VerifyOperationTree(this Compilation compilation, string expectedOperationTree, bool skipImplicitlyDeclaredSymbols = false)
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 actualTextBuilder.Append(Environment.NewLine);
             }
 
-            VerifyOperationTree(expectedOperationTree, actualTextBuilder.ToString());
+            OperationTreeVerifier.Verify(expectedOperationTree, actualTextBuilder.ToString());
         }
 
         private static void AppendOperationTree(SemanticModel model, SyntaxNode node, StringBuilder actualTextBuilder, int initialIndent = 0)
@@ -233,15 +233,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             {
                 actualTextBuilder.Append($"  SemanticModel.GetOperation() returned NULL for node with text: '{node.ToString()}'");
             }
-        }
-
-        private static void VerifyOperationTree(string expectedOperationTree, string actualOperationTree)
-        {
-            char[] newLineChars = Environment.NewLine.ToCharArray();
-            string actual = actualOperationTree.Trim(newLineChars);
-            expectedOperationTree = expectedOperationTree.Trim(newLineChars);
-            expectedOperationTree = Regex.Replace(expectedOperationTree, "([^\r])\n", "$1" + Environment.NewLine);
-            AssertEx.AreEqual(expectedOperationTree, actual);
         }
 
         internal static bool CanHaveExecutableCodeBlock(ISymbol symbol)

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -219,7 +219,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         internal override void VisitNoneOperation(IOperation operation)
         {
-            Assert.True(false, "Encountered an IOperation with `Kind == OperationKind.None` while walking the operation tree.");
+            LogString("IOperation: ");
+            LogCommonPropertiesAndNewLine(operation);
         }
 
         public override void VisitBlockStatement(IBlockStatement operation)

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -5,8 +5,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.Semantics;
 using Microsoft.CodeAnalysis.Test.Extensions;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
@@ -40,6 +42,15 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var walker = new OperationTreeVerifier(operation, initialIndent);
             walker.Visit(operation);
             return walker._builder.ToString();
+        }
+
+        public static void Verify(string expectedOperationTree, string actualOperationTree)
+        {
+            char[] newLineChars = Environment.NewLine.ToCharArray();
+            string actual = actualOperationTree.Trim(newLineChars);
+            expectedOperationTree = expectedOperationTree.Trim(newLineChars);
+            expectedOperationTree = Regex.Replace(expectedOperationTree, "([^\r])\n", "$1" + Environment.NewLine);
+            AssertEx.AreEqual(expectedOperationTree, actual);
         }
 
         #region Logging helpers

--- a/src/Test/Utilities/Portable/Extensions/SemanticModelExtensions.cs
+++ b/src/Test/Utilities/Portable/Extensions/SemanticModelExtensions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CodeAnalysis.Test.Extensions
     {
         public static IOperation GetOperationInternal(this SemanticModel model, SyntaxNode node)
         {
+            // Invoke the GetOperationInternal API to by-pass the IOperation feature flag check.
             return model.GetOperationInternal(node);
         }
     }

--- a/src/Test/Utilities/Portable/Extensions/SemanticModelExtensions.cs
+++ b/src/Test/Utilities/Portable/Extensions/SemanticModelExtensions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Test.Extensions
+{
+    public static class SemanticModelExtensions
+    {
+        public static IOperation GetOperationInternal(this SemanticModel model, SyntaxNode node)
+        {
+            return model.GetOperationInternal(node);
+        }
+    }
+}

--- a/src/Test/Utilities/Portable/TestUtilities.csproj
+++ b/src/Test/Utilities/Portable/TestUtilities.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Diagnostics\TrackingDiagnosticAnalyzer.cs" />
     <Compile Include="ExceptionHelper.cs" />
     <Compile Include="CompilerTraitAttribute.cs" />
+    <Compile Include="Extensions\SemanticModelExtensions.cs" />
     <Compile Include="Extensions\SymbolExtensions.cs" />
     <Compile Include="FX\ConsoleOutput.cs" />
     <Compile Include="FX\CultureHelpers.cs" />


### PR DESCRIPTION
… a source file.

These APIs will be used in autogenerated unit test for Operation tree verification.