### PR TITLE
Capture better dumps when the contents of linked files don't match

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -109,6 +109,7 @@
     <Compile Include="FindUsages\IFindUsagesService.cs" />
     <Compile Include="FindUsages\SimpleFindUsagesContext.cs" />
     <Compile Include="Implementation\InlineRename\Dashboard\DashboardAutomationPeer.cs" />
+    <Compile Include="Implementation\Intellisense\QuickInfo\Providers\LinkedFileDiscrepancyException.cs" />
     <Compile Include="Implementation\Structure\BlockTagState.cs" />
     <Compile Include="Tags\ExportImageMonikerServiceAttribute.cs" />
     <Compile Include="Implementation\NavigateTo\AbstractNavigateToItemDisplay.cs" />

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -137,13 +137,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                     return linkedToken;
                 }
             }
-            catch (Exception e)
+            catch (Exception thrownException)
             {
                 // We are seeing linked files with different spans cause FindToken to crash.
                 // Capturing more information for https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299
                 var originalText = await originalDocument.GetTextAsync().ConfigureAwait(false);
                 var linkedText = await linkedDocument.GetTextAsync().ConfigureAwait(false);
-                FatalError.Report(e);
+
+                var linkedFileException = new LinkedFileDiscrepancyException(thrownException, originalText.ToString(), linkedText.ToString());
+                FatalError.Report(linkedFileException);
             }
 
             return default(SyntaxToken);

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/LinkedFileDiscrepancyException.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/LinkedFileDiscrepancyException.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
+{
+    // Used to aid the investigation of https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299
+    internal class LinkedFileDiscrepancyException : Exception
+    {
+        private readonly string _originalText;
+        private readonly string _linkedText;
+
+        public LinkedFileDiscrepancyException(Exception innerException, string originalText, string linkedText)
+            : base("The contents of linked files do not match.", innerException)
+        {
+            _originalText = originalText;
+            _linkedText = linkedText;
+        }
+    }
+}


### PR DESCRIPTION
In order to gather more information on
https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299, we created
https://github.com/dotnet/roslyn/pull/16918 to capture the text of the
linked documents that aren't in sync. However, we tried to do so by
putting their text in local variables that were optimized away in dumps.

This change introduces a custom exception object that holds onto the
text of the conflicting documents and reports that exception.

Ask Mode Template
==========
**Customer scenario** We don't quite know. The customer has linked files (very common in cross-targeting) in their project and when they type in a file Visual Studio crashes occasionally.

**Bugs this fixes:** This change fixes no bugs, but helps us understand https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299.

**Workarounds, if any**: Unknown.

**Risk**: Very low, we just report a new exception when this failure happens. The new code is in a `catch` block that is going to intentionally crash anyway.

**Performance impact**: Essentially none. We create a couple new objects during the process of crashing.

**Is this a regression from a previous update?**: No.

**Root cause analysis:** Unknown.

**How did we miss it?** The previous attempt to gather data for this issue was unintentionally ineffective.

**How was the bug found?** We investigated the dumps and found that the previous attempt was ineffective.