### PR TITLE
Handle FileCodeModel eventing on the foreground thread

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelIncrementalAnalyzer.cs
@@ -70,31 +70,36 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             public void FireEvents(DocumentId documentId, CancellationToken cancellationToken)
             {
-                var project = _workspace.DeferredState.ProjectTracker.GetProject(documentId.ProjectId);
-                if (project == null)
+                _notificationService.RegisterNotification(() =>
                 {
-                    return;
-                }
+                    var project = _workspace.DeferredState.ProjectTracker.GetProject(documentId.ProjectId);
+                    if (project == null)
+                    {
+                        return false;
+                    }
 
-                var codeModelProvider = project as IProjectCodeModelProvider;
-                if (codeModelProvider == null)
-                {
-                    return;
-                }
+                    var codeModelProvider = project as IProjectCodeModelProvider;
+                    if (codeModelProvider == null)
+                    {
+                        return false;
+                    }
 
-                var filename = _workspace.GetFilePath(documentId);
-                if (filename == null)
-                {
-                    return;
-                }
+                    var filename = _workspace.GetFilePath(documentId);
+                    if (filename == null)
+                    {
+                        return false;
+                    }
 
-                if (!codeModelProvider.ProjectCodeModel.TryGetCachedFileCodeModel(filename, out var fileCodeModelHandle))
-                {
-                    return;
-                }
+                    if (!codeModelProvider.ProjectCodeModel.TryGetCachedFileCodeModel(filename, out var fileCodeModelHandle))
+                    {
+                        return false;
+                    }
 
-                var codeModel = fileCodeModelHandle.Object;
-                _notificationService.RegisterNotification(() => codeModel.FireEvents(), _listener.BeginAsyncOperation("CodeModelEvent"), cancellationToken);
+                    var codeModel = fileCodeModelHandle.Object;
+                    return codeModel.FireEvents();
+                },
+                _listener.BeginAsyncOperation("CodeModelEvent"),
+                cancellationToken);
             }
 
             #region unused


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=366045.

CodeModel events (fired when types or members are added or removed,
for example) are handled in a `SolutionCrawler` incremental analyzer.
Actually firing the events needs to happen on the foreground thread,
which we currently do. Some of the setup, including obtaining the
`FileCodeModel` instance, happens on a background thread.

It turns out the `FileCodeModel` must also be obtained on the
foreground thread but we don't enforce this very well. Most of the time
we go down this path the `FileCodeModel` instance has already been
created and cached; in this case we get lucky and don't go down any
problematic paths. However, if we _do_ need to create it then we may
also need to start pushing project data down to the workspace. That can
only happen on the foreground thread, and we *do* enforce it there.

This often manifests as a crash during solution close. Something has
caused the incremental analyzer to run on a background thread.
Meanwhile, the foreground thread is closing the solution, which means
we are no longer pushing project data to the workspace. If the
`FileCodeModel` has not already been cached we'll try to create a new
one and start pushing to the workspace--and then we blow up because
we're on the wrong thread.

Further, the `FileCodeModel.FireEvents()` method returns a bool indicating
whether or not it has more work to do. If it has more work, we need to
post that work back to the foreground thread. Of course, by the time that
subsequent work runs the project or solution may have closed, or the
document in question may no longer exist. So the setup work--mapping from
the `DocumentId` to the `Project` and file path--also need to happen on the
foreground thread.

The fix is to do _all_ the setup work on the foreground thread, and to do
it every time it runs. If the `FileCodeModel` has already been cached things continue to work as before.
If it hasn't, and we try to create it during shutdown then the request
to push to the workspace will fail gracefully. No `FileCodeModel` will
be created, and the incremental analyzer will just bail early.