### PR TITLE
Getting diagnostics and location of a token without a syntax tree should not crash

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
-        public void GetTokenDiagnositcsWithoutSyntaxTree_WithDiagnositcs()
+        public void GetTokenDiagnosticsWithoutSyntaxTree_WithDiagnostics()
         {
             var tokens = SyntaxFactory.ParseTokens("1l").ToList();
             Assert.Equal(2, tokens.Count); // { "1l", "EOF" }
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
-        public void GetTokenDiagnositcsWithoutSyntaxTree_WithoutDiagnositcs()
+        public void GetTokenDiagnosticsWithoutSyntaxTree_WithoutDiagnostics()
         {
             var tokens = SyntaxFactory.ParseTokens("1L").ToList();
             Assert.Equal(2, tokens.Count); // { "1L", "EOF" }
@@ -411,20 +411,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
-        public void GetExpressionDiagnositcsWithoutSyntaxTree_WithDiagnositcs()
+        public void GetTokenDiagnosticsWithSyntaxTree_WithDiagnostics()
         {
-            var tokens = SyntaxFactory.ParseTokens("1l").ToList();
-            Assert.Equal(2, tokens.Count); // { "1l", "EOF" }
+            var expression = (LiteralExpressionSyntax)SyntaxFactory.ParseExpression("1l");
+            Assert.Equal("1l", expression.Token.Text);
+            Assert.NotNull(expression.Token.SyntaxTree);
 
-            var literal = tokens.First();
-            Assert.Equal("1l", literal.Text);
+            var expectedLocation = Location.Create(expression.Token.SyntaxTree, TextSpan.FromBounds(0, 2));
+            Assert.Equal(expectedLocation, expression.Token.GetLocation());
 
-            var expression = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, literal);
-
-            var expectedLocation = Location.Create(expression.SyntaxTree, TextSpan.FromBounds(0, 2));
-            Assert.Equal(expectedLocation, expression.GetLocation());
-
-            expression.GetDiagnostics().Verify(
+            expression.Token.GetDiagnostics().Verify(
                 // (1,2): warning CS0078: The 'l' suffix is easily confused with the digit '1' -- use 'L' for clarity
                 // 1l
                 Diagnostic(ErrorCode.WRN_LowercaseEllSuffix, "l").WithLocation(1, 2));
@@ -432,20 +428,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
-        public void GetExpressionDiagnositcsWithoutSyntaxTree_WithoutDiagnositcs()
+        public void GetTokenDiagnosticsWithSyntaxTree_WithoutDiagnostics()
         {
-            var tokens = SyntaxFactory.ParseTokens("1L").ToList();
-            Assert.Equal(2, tokens.Count); // { "1L", "EOF" }
+            var expression = (LiteralExpressionSyntax)SyntaxFactory.ParseExpression("1L");
+            Assert.Equal("1L", expression.Token.Text);
+            Assert.NotNull(expression.Token.SyntaxTree);
 
-            var literal = tokens.First();
-            Assert.Equal("1L", literal.Text);
+            var expectedLocation = Location.Create(expression.Token.SyntaxTree, TextSpan.FromBounds(0, 2));
+            Assert.Equal(expectedLocation, expression.Token.GetLocation());
 
-            var expression = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, literal);
-
-            var expectedLocation = Location.Create(expression.SyntaxTree, TextSpan.FromBounds(0, 2));
-            Assert.Equal(expectedLocation, expression.GetLocation());
-
-            expression.GetDiagnostics().Verify();
+            expression.Token.GetDiagnostics().Verify();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -381,7 +381,37 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         [Fact]
         [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
-        public void GetTokenDiagnositcsWithoutSyntaxTree()
+        public void GetTokenDiagnositcsWithoutSyntaxTree_WithDiagnositcs()
+        {
+            var tokens = SyntaxFactory.ParseTokens("1l").ToList();
+            Assert.Equal(2, tokens.Count); // { "1l", "EOF" }
+
+            var literal = tokens.First();
+            Assert.Equal("1l", literal.Text);
+            Assert.Equal(Location.None, literal.GetLocation());
+
+            literal.GetDiagnostics().Verify(
+                // warning CS0078: The 'l' suffix is easily confused with the digit '1' -- use 'L' for clarity
+                Diagnostic(ErrorCode.WRN_LowercaseEllSuffix));
+        }
+
+        [Fact]
+        [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
+        public void GetTokenDiagnositcsWithoutSyntaxTree_WithoutDiagnositcs()
+        {
+            var tokens = SyntaxFactory.ParseTokens("1L").ToList();
+            Assert.Equal(2, tokens.Count); // { "1L", "EOF" }
+
+            var literal = tokens.First();
+            Assert.Equal("1L", literal.Text);
+            Assert.Equal(Location.None, literal.GetLocation());
+
+            literal.GetDiagnostics().Verify();
+        }
+
+        [Fact]
+        [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
+        public void GetExpressionDiagnositcsWithoutSyntaxTree_WithDiagnositcs()
         {
             var tokens = SyntaxFactory.ParseTokens("1l").ToList();
             Assert.Equal(2, tokens.Count); // { "1l", "EOF" }
@@ -389,11 +419,42 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var literal = tokens.First();
             Assert.Equal("1l", literal.Text);
 
-            Assert.Equal(Location.None, literal.GetLocation());
+            var expression = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, literal);
 
-            literal.GetDiagnostics().Verify(
-                // warning CS0078: The 'l' suffix is easily confused with the digit '1' -- use 'L' for clarity
-                Diagnostic(ErrorCode.WRN_LowercaseEllSuffix));
+            var expectedLocation = Location.Create(expression.SyntaxTree, TextSpan.FromBounds(0, 2));
+            Assert.Equal(expectedLocation, expression.GetLocation());
+
+            expression.GetDiagnostics().Verify(
+                // (1,2): warning CS0078: The 'l' suffix is easily confused with the digit '1' -- use 'L' for clarity
+                // 1l
+                Diagnostic(ErrorCode.WRN_LowercaseEllSuffix, "l").WithLocation(1, 2));
+        }
+
+        [Fact]
+        [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
+        public void GetExpressionDiagnositcsWithoutSyntaxTree_WithoutDiagnositcs()
+        {
+            var tokens = SyntaxFactory.ParseTokens("1L").ToList();
+            Assert.Equal(2, tokens.Count); // { "1L", "EOF" }
+
+            var literal = tokens.First();
+            Assert.Equal("1L", literal.Text);
+
+            var expression = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, literal);
+
+            var expectedLocation = Location.Create(expression.SyntaxTree, TextSpan.FromBounds(0, 2));
+            Assert.Equal(expectedLocation, expression.GetLocation());
+
+            expression.GetDiagnostics().Verify();
+        }
+
+        [Fact]
+        [WorkItem(17067, "https://github.com/dotnet/roslyn/issues/17067")]
+        public void GetDiagnosticsFromNullToken()
+        {
+            var token = new SyntaxToken(null);
+            Assert.Equal(Location.None, token.GetLocation());
+            token.GetDiagnostics().Verify();
         }
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public struct SyntaxToken : IEquatable<SyntaxToken>
     {
-        private static readonly Func<DiagnosticInfo, Diagnostic> CreateDiagnosticWithoutLocation = Diagnostic.Create;
+        private static readonly Func<DiagnosticInfo, Diagnostic> s_createDiagnosticWithoutLocation = Diagnostic.Create;
 
         internal static readonly Func<SyntaxToken, bool> NonZeroWidth = t => t.Width > 0;
         internal static readonly Func<SyntaxToken, bool> Any = t => true;
@@ -663,7 +663,7 @@ namespace Microsoft.CodeAnalysis
 
                 return diagnostics.Length == 0
                     ? SpecializedCollections.EmptyEnumerable<Diagnostic>()
-                    : diagnostics.Select(CreateDiagnosticWithoutLocation);
+                    : diagnostics.Select(s_createDiagnosticWithoutLocation);
             }
 
             return tree.GetDiagnostics(this);

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -20,9 +20,10 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
     public struct SyntaxToken : IEquatable<SyntaxToken>
     {
+        private static readonly Func<DiagnosticInfo, Diagnostic> CreateDiagnosticWithoutLocation = Diagnostic.Create;
+
         internal static readonly Func<SyntaxToken, bool> NonZeroWidth = t => t.Width > 0;
         internal static readonly Func<SyntaxToken, bool> Any = t => true;
-        internal static readonly Func<DiagnosticInfo, Diagnostic> CreateDiagnosticWithoutLocation = Diagnostic.Create;
 
         internal SyntaxToken(SyntaxNode parent, GreenNode token, int position, int index)
         {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -634,9 +634,12 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public Location GetLocation()
         {
-            return Node != null
-                ? this.SyntaxTree.GetLocation(this.Span)
-                : Location.None;
+            if (this.Node == null || this.SyntaxTree == null)
+            {
+                return Location.None;
+            }
+
+            return this.SyntaxTree.GetLocation(this.Span);
         }
 
         /// <summary>
@@ -646,9 +649,18 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public IEnumerable<Diagnostic> GetDiagnostics()
         {
-            return Node != null
-                ? this.SyntaxTree.GetDiagnostics(this)
-                : SpecializedCollections.EmptyEnumerable<Diagnostic>();
+            if (this.Node == null)
+            {
+                return SpecializedCollections.EmptyEnumerable<Diagnostic>();
+            }
+
+            if (this.SyntaxTree == null)
+            {
+                // If the parent or it's syntax tree are null, return diagnostics without a location.
+                return this.Node.GetDiagnostics().Select(Diagnostic.Create);
+            }
+
+            return this.SyntaxTree.GetDiagnostics(this);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #17067 
cc @AlekseyTs @gafter @dotnet/roslyn-compiler 

`this.SyntaxTree` is calculated from `Parent?.SyntaxTree`. So if `SyntaxTree` is null, this means that the parent (a `SyntaxNode`) is null, or doesn't belong to a tree. In that bug's case, the node is null.
Please let me know if there is another API surface area that the bug may have missed.