### PR TITLE
Pick the right project for P2P refs in lightweight solution load and cross-targeting

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -761,14 +761,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 projectContext.AddAdditionalFile(sourceFile.Path);
             }
 
+            var metadataReferences = commandLineArguments.ResolveMetadataReferences(project.CurrentCompilationOptions.MetadataReferenceResolver).AsImmutable();
             var addedProjectReferences = new HashSet<string>();
             foreach (var projectReferencePath in projectInfo.ReferencedProjectFilePaths)
             {
-                // NOTE: ImmutableProjects might contain projects for other languages like
-                // Xaml, or Typescript where the project file ends up being identical.
-                var referencedProject = ImmutableProjects.SingleOrDefault(
-                    p => (p.Language == LanguageNames.CSharp || p.Language == LanguageNames.VisualBasic)
-                         && StringComparer.OrdinalIgnoreCase.Equals(p.ProjectFilePath, projectReferencePath));
+                var referencedProject = TryFindExistingProjectForProjectReference(projectReferencePath, metadataReferences);
                 if (referencedProject == null)
                 {
                     referencedProject = GetOrCreateProjectFromArgumentsAndReferences(
@@ -809,15 +806,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
-            foreach (var reference in commandLineArguments.ResolveMetadataReferences(project.CurrentCompilationOptions.MetadataReferenceResolver))
+            foreach (var reference in metadataReferences)
             {
-                // Some references may fail to be resolved - if they are, we'll still pass them
-                // through, in case they come into existence later (they may be built by other 
-                // parts of the build system).
-                var unresolvedReference = reference as UnresolvedMetadataReference;
-                var path = unresolvedReference == null
-                    ? ((PortableExecutableReference)reference).FilePath
-                    : unresolvedReference.Reference;
+                var path = GetReferencePath(reference);
                 if (targetPathsToProjectPaths.TryGetValue(path, out var possibleProjectReference) &&
                     addedProjectReferences.Contains(possibleProjectReference))
                 {
@@ -842,6 +833,47 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             return (AbstractProject)projectContext;
+        }
+
+        private AbstractProject TryFindExistingProjectForProjectReference(string projectReferencePath, ImmutableArray<MetadataReference> metadataReferences)
+        {
+            // NOTE: ImmutableProjects might contain projects for other languages like
+            // Xaml, or Typescript where the project file ends up being identical.
+            AbstractProject candidate = null;
+            foreach (var existingProject in ImmutableProjects)
+            {
+                if (existingProject.Language != LanguageNames.CSharp && existingProject.Language != LanguageNames.VisualBasic)
+                {
+                    continue;
+                }
+
+                if (!StringComparer.OrdinalIgnoreCase.Equals(existingProject.ProjectFilePath, projectReferencePath))
+                {
+                    continue;
+                }
+
+                // There might be multiple projects that have the same project file path and language in the case of
+                // cross-targeted .NET Core project.  To support that, we'll try to find the one with the output path
+                // that matches one of the metadata references we're trying to add.  If we don't find any, then we'll
+                // settle one with a matching project file path.
+                candidate = candidate ?? existingProject;
+                if (metadataReferences.Contains(mr => StringComparer.OrdinalIgnoreCase.Equals(GetReferencePath(mr), existingProject.BinOutputPath)))
+                {
+                    return existingProject;
+                }
+            }
+
+            return candidate;
+        }
+
+        private static string GetReferencePath(MetadataReference mr)
+        {
+            // Some references may fail to be resolved - if they are, we'll still pass them
+            // through, in case they come into existence later (they may be built by other 
+            // parts of the build system).
+            return mr is UnresolvedMetadataReference umr
+                ? umr.Reference
+                : ((PortableExecutableReference)mr).FilePath;
         }
 
         private static string GetLanguageOfProject(string projectFilename)


### PR DESCRIPTION
If a project being loaded in lightweight solution load references a CPS project
that does cross-targeting, we may crash trying to hook up P2P references,
because we were looking for a single project matching the project file name, and
language.  In the case of cross-targeting though, we create a project for each
TFM, and the .Single call would blow up.

To fix this, we now continue looking through projects until we find one with an
output path that matches our reference.

Fixes #17570.

**Ask Mode Template**
Customer and Scenario Info

Who is impacted by this bug: Customers using .NET Core with cross-targeting, Desktop projects, and lightweight solution load.
What is the customer scenario and impact of the bug: Sometime not long after opening the solution, VS may crash.  This is timing dependent, and most likely to happen on the first open after LSL is enabled.
What is the workaround: Disable LSL
How was the bug found: Watson - 57 hits in RTW, 1460 altogether, Customer report from AArnott
If this fix is for a regression - what had regressed, when was the regression introduced, and why was the regression originally missed: This is not a regression.
​What is a Customer Rea​dy description of change should we need to document this: VS no longer crashes in lightweight solution load if a .NET Framework project references a cross-targeted .NET Core project.
Bug Fix Details

Overview of the fix: Instead of assuming that there is only a single IntelliSense project for a give project file path, find the one that matches the reference by output path if there is one.
Which VS products, SKUs, or components need the fix: All Skus - Roslyn insertion
What branch does the fix go into: D15Rel
What feature areas are impacted by the fix: Solution Load, LSL, .NET Core projects.
What is the risk of the code change: Low, the original path is preserved, but instead of crashing if there are multiple entries, we try to pick the best one, falling back to the first if there is no best match.
Does this change have impact on anything else (e.g. setup, perf, stress, ux, visual freeze, go live, breaking change, samples, etc): We now walk the list of references of each project 
How is this fix rolling forward in the next major release / sprintly train (e.g. Dev15):​ Regular merges in Roslyn repo.
​Validation
What testing/validation was done on the fix, and what were the results:
Forced a repro by adding a delay to the code, and stepped through ensure it behaves as expected.  
Vendor team buddy tested the fix.
Val build running
Will provide to Andrew to validate in his scenario.
(Binary/Component Insertions only) have you validated that your insertion does not regress DDRIT / RPS: Pending completion of VAL build, but chance is low, given DDRIT/RPS doesn't cover LSL scenarios.
Which engineering partner teams have signed off on the fix: 
Who code reviewed the fix: JasonMal