### PR TITLE
Suggest names after types

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -205,11 +205,8 @@
     <Compile Include="CodeActions\EncapsulateField\EncapsulateFieldTests.cs" />
     <Compile Include="CodeActions\ExtractMethod\ExtractMethodTests.cs" />
     <Compile Include="CodeActions\GenerateDefaultConstructors\GenerateDefaultConstructorsTests.cs" />
-<<<<<<< HEAD
     <Compile Include="Diagnostics\UpgradeProject\UpgradeProjectTests.cs" />
-=======
     <Compile Include="Completion\CompletionProviders\DeclarationNameCompletionProviderTests_NameDeclarationInfoTests.cs" />
->>>>>>> Show names after types in intellisense
     <Compile Include="GenerateFromMembers\AddConstructorParametersFromMembers\AddConstructorParametersFromMembersTests.cs" />
     <Compile Include="GenerateFromMembers\GenerateConstructorFromMembers\GenerateConstructorFromMembersTests.cs" />
     <Compile Include="CodeActions\InlineTemporary\InlineTemporaryTests.cs" />

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -199,12 +199,17 @@
     <Compile Include="ConflictMarkerResolution\ConflictMarkerResolutionTests.cs" />
     <Compile Include="Completion\CompletionProviders\OverrideCompletionProviderTests_ExpressionBody.cs" />
     <Compile Include="Completion\CompletionProviders\TupleNameCompletionProviderTests.cs" />
+    <Compile Include="Completion\CompletionProviders\DeclarationNameCompletionProviderTests.cs" />
     <Compile Include="ConvertToInterpolatedString\ConvertConcatenationToInterpolatedStringTests.cs" />
     <Compile Include="ConvertToInterpolatedString\ConvertPlaceholderToInterpolatedStringTests.cs" />
     <Compile Include="CodeActions\EncapsulateField\EncapsulateFieldTests.cs" />
     <Compile Include="CodeActions\ExtractMethod\ExtractMethodTests.cs" />
     <Compile Include="CodeActions\GenerateDefaultConstructors\GenerateDefaultConstructorsTests.cs" />
+<<<<<<< HEAD
     <Compile Include="Diagnostics\UpgradeProject\UpgradeProjectTests.cs" />
+=======
+    <Compile Include="Completion\CompletionProviders\DeclarationNameCompletionProviderTests_NameDeclarationInfoTests.cs" />
+>>>>>>> Show names after types in intellisense
     <Compile Include="GenerateFromMembers\AddConstructorParametersFromMembers\AddConstructorParametersFromMembersTests.cs" />
     <Compile Include="GenerateFromMembers\GenerateConstructorFromMembers\GenerateConstructorFromMembersTests.cs" />
     <Compile Include="CodeActions\InlineTemporary\InlineTemporaryTests.cs" />
@@ -581,7 +586,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="DeclarationInfo\" />
+  </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -583,9 +583,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="DeclarationInfo\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -1,0 +1,474 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.NamingStyles;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Simplification;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+using static Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.SymbolSpecification;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSetSources
+{
+    public class DeclarationNameCompletionProviderTests : AbstractCSharpCompletionProviderTests
+    {
+        public DeclarationNameCompletionProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
+        {
+        }
+
+        internal override CompletionProvider CreateCompletionProvider()
+        {
+            return new DeclarationNameCompletionProvider();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void NameWithOnlyType1()
+        {
+            var markup = @"
+public class C
+{
+    C $$
+}
+";
+            await VerifyItemExistsAsync(markup, "C", glyph: (int)Glyph.PropertyPublic);
+            await VerifyItemExistsAsync(markup, "c", glyph: (int)Glyph.FieldPublic);
+            await VerifyItemExistsAsync(markup, "GetC", glyph: (int)Glyph.MethodPublic);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void AsyncTask()
+        {
+            var markup = @"
+public class C
+{
+    async Task $$
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void AsyncTaskOfT()
+        {
+            var markup = @"
+public class C
+{
+    async Task<C> $$
+}
+";
+            var workspace = WorkspaceFixture.GetWorkspace();
+            var oldOptions = workspace.Options;
+            try
+            {
+                var newOptions = oldOptions.WithChangedOption(new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp), AsyncMethodsEndWithAsync());
+                workspace.Options = newOptions;
+                await VerifyItemExistsAsync(markup, "GetCAsync");
+            }
+            finally
+            {
+                workspace.Options = oldOptions;
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void MethodDeclaration1()
+        {
+            var markup = @"
+public class C
+{
+    virtual C $$
+}
+";
+            await VerifyItemExistsAsync(markup, "GetC");
+            await VerifyItemIsAbsentAsync(markup, "C");
+            await VerifyItemIsAbsentAsync(markup, "c");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void WordBreaking1()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    CancellationToken $$
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken");
+            await VerifyItemExistsAsync(markup, "cancellation");
+            await VerifyItemExistsAsync(markup, "token");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void WordBreaking2()
+        {
+            var markup = @"
+interface I {}
+public class C
+{
+    I $$
+}
+";
+            await VerifyItemExistsAsync(markup, "I");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void WordBreaking3()
+        {
+            var markup = @"
+interface II {}
+public class C
+{
+    I $$
+}
+";
+            await VerifyItemExistsAsync(markup, "I");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void WordBreaking4()
+        {
+            var markup = @"
+interface IFoo {}
+public class C
+{
+    IFoo $$
+}
+";
+            await VerifyItemExistsAsync(markup, "Foo");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void WordBreaking5()
+        {
+            var markup = @"
+class AWonderfullyLongClassName {}
+public class C
+{
+    AWonderfullyLongClassName $$
+}
+";
+            await VerifyItemExistsAsync(markup, "A");
+            await VerifyItemExistsAsync(markup, "AWonderfully");
+            await VerifyItemExistsAsync(markup, "AWonderfullyLong");
+            await VerifyItemExistsAsync(markup, "AWonderfullyLongClass");
+            await VerifyItemExistsAsync(markup, "Name");
+            await VerifyItemExistsAsync(markup, "ClassName");
+            await VerifyItemExistsAsync(markup, "LongClassName");
+            await VerifyItemExistsAsync(markup, "WonderfullyLongClassName");
+            await VerifyItemExistsAsync(markup, "AWonderfullyLongClassName");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void Parameter1()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    void Foo(CancellationToken $$
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken", glyph: (int)Glyph.Parameter);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void Parameter2()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    void Foo(int x, CancellationToken c$$
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken", glyph: (int)Glyph.Parameter);
+        }
+
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void Parameter3()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    void Foo(CancellationToken c$$) {}
+}
+";
+            await VerifyItemExistsAsync(markup, "cancellationToken", glyph: (int)Glyph.Parameter);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForInt()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    int $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void NoSuggestionsForLong()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    long $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void NoSuggestionsForDouble()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    double $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForFloat()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    float $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForSbyte()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    sbyte $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForShort()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    short $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForUint()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    uint $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForUlong()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    ulong $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForUShort()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    ushort $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForBool()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    bool $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForByte()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    byte $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForChar()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    char $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void SuggestionsForString()
+        {
+            var markup = @"
+public class C
+{
+    string $$
+}
+";
+            await VerifyItemExistsAsync(markup, "v");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void ArrayElementTypeSuggested()
+        {
+            var markup = @"
+using System.Threading;
+public class C
+{
+    C[] $$
+}
+";
+            await VerifyItemExistsAsync(markup, "C");
+            await VerifyItemIsAbsentAsync(markup, "Array");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void NotTriggeredByVar()
+        {
+            var markup = @"
+public class C
+{
+    var $$
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void NptAfterVoid()
+        {
+            var markup = @"
+public class C
+{
+    void $$
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void AfterGeneric()
+        {
+            var markup = @"
+public class C
+{
+    System.Collections.Generic.IEnumerable<C> $$
+}
+";
+            await VerifyItemExistsAsync(markup, "C");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void NothingAfterVar()
+        {
+            var markup = @"
+public class C
+{
+    void foo()
+    {
+        var $$
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        private NamingStylePreferences AsyncMethodsEndWithAsync()
+        {
+            var symbolSpecification = new SymbolSpecification(
+                Guid.NewGuid(),
+                "Name",
+                ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Method)),
+                ImmutableArray.Create<Accessibility>(),
+                ImmutableArray.Create(new SymbolSpecification.ModifierKind(ModifierKindEnum.IsAsync)));
+
+            var namingStyle = new NamingStyle(Guid.NewGuid(),
+                name: "Name",
+                prefix: "",
+                suffix: "",
+                wordSeparator: "",
+                capitalizationScheme: Capitalization.PascalCase);
+                
+
+            var namingRule = new SerializableNamingRule();
+            namingRule.SymbolSpecificationID = symbolSpecification.ID;
+            namingRule.NamingStyleID = namingStyle.ID;
+            namingRule.EnforcementLevel = DiagnosticSeverity.Error;
+
+            var info = new NamingStylePreferences(
+                ImmutableArray.Create(symbolSpecification),
+                ImmutableArray.Create(namingStyle),
+                ImmutableArray.Create(namingRule));
+
+            return info;
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -45,18 +45,6 @@ public class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void AsyncTask()
-        {
-            var markup = @"
-public class C
-{
-    async Task $$
-}
-";
-            await VerifyNoItemsExistAsync(markup);
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void AsyncTaskOfT()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
@@ -13,7 +11,6 @@ using Microsoft.CodeAnalysis.NamingStyles;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Test.Utilities;
-using Roslyn.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.SymbolSpecification;
 
@@ -53,18 +50,19 @@ public class C
     async Task<C> $$
 }
 ";
-            var workspace = WorkspaceFixture.GetWorkspace();
-            var oldOptions = workspace.Options;
-            try
-            {
-                var newOptions = oldOptions.WithChangedOption(new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp), AsyncMethodsEndWithAsync());
-                workspace.Options = newOptions;
-                await VerifyItemExistsAsync(markup, "GetCAsync");
-            }
-            finally
-            {
-                workspace.Options = oldOptions;
-            }
+            await VerifyItemExistsAsync(markup, "GetCAsync");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void NonAsyncTaskOfT()
+        {
+            var markup = @"
+public class C
+{
+    Task<C> $$
+}
+";
+            await VerifyItemExistsAsync(markup, "GetCAsync");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -116,7 +114,7 @@ public class C
 interface II {}
 public class C
 {
-    I $$
+    II $$
 }
 ";
             await VerifyItemExistsAsync(markup, "I");
@@ -197,7 +195,7 @@ public class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForInt()
+        public async void NoSuggestionsForInt()
         {
             var markup = @"
 using System.Threading;
@@ -206,7 +204,7 @@ public class C
     int $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -219,7 +217,7 @@ public class C
     long $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -232,11 +230,11 @@ public class C
     double $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForFloat()
+        public async void NoSuggestionsForFloat()
         {
             var markup = @"
 using System.Threading;
@@ -245,11 +243,11 @@ public class C
     float $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForSbyte()
+        public async void NoSuggestionsForSbyte()
         {
             var markup = @"
 using System.Threading;
@@ -258,11 +256,11 @@ public class C
     sbyte $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForShort()
+        public async void NoSuggestionsForShort()
         {
             var markup = @"
 using System.Threading;
@@ -271,11 +269,11 @@ public class C
     short $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForUint()
+        public async void NoSuggestionsForUint()
         {
             var markup = @"
 using System.Threading;
@@ -284,11 +282,11 @@ public class C
     uint $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForUlong()
+        public async void NoSuggestionsForUlong()
         {
             var markup = @"
 using System.Threading;
@@ -297,7 +295,7 @@ public class C
     ulong $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -310,11 +308,11 @@ public class C
     ushort $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForBool()
+        public async void NoSuggestionsForBool()
         {
             var markup = @"
 using System.Threading;
@@ -323,11 +321,11 @@ public class C
     bool $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForByte()
+        public async void NoSuggestionsForByte()
         {
             var markup = @"
 using System.Threading;
@@ -336,11 +334,11 @@ public class C
     byte $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForChar()
+        public async void NoSuggestionsForChar()
         {
             var markup = @"
 using System.Threading;
@@ -349,11 +347,11 @@ public class C
     char $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void SuggestionsForString()
+        public async void NoSuggestionsForString()
         {
             var markup = @"
 public class C
@@ -361,7 +359,19 @@ public class C
     string $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "v");
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void NoSingleLetterClassNameSuggested()
+        {
+            var markup = @"
+public class C
+{
+    C $$
+}
+";
+            await VerifyNoItemsExistAsync(markup);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -427,36 +437,6 @@ public class C
 }
 ";
             await VerifyNoItemsExistAsync(markup);
-        }
-
-        private NamingStylePreferences AsyncMethodsEndWithAsync()
-        {
-            var symbolSpecification = new SymbolSpecification(
-                Guid.NewGuid(),
-                "Name",
-                ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Method)),
-                ImmutableArray.Create<Accessibility>(),
-                ImmutableArray.Create(new SymbolSpecification.ModifierKind(ModifierKindEnum.IsAsync)));
-
-            var namingStyle = new NamingStyle(Guid.NewGuid(),
-                name: "Name",
-                prefix: "",
-                suffix: "",
-                wordSeparator: "",
-                capitalizationScheme: Capitalization.PascalCase);
-                
-
-            var namingRule = new SerializableNamingRule();
-            namingRule.SymbolSpecificationID = symbolSpecification.ID;
-            namingRule.NamingStyleID = namingStyle.ID;
-            namingRule.EnforcementLevel = DiagnosticSeverity.Error;
-
-            var info = new NamingStylePreferences(
-                ImmutableArray.Create(symbolSpecification),
-                ImmutableArray.Create(namingStyle),
-                ImmutableArray.Create(namingRule));
-
-            return info;
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -31,20 +31,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSe
         public async void NameWithOnlyType1()
         {
             var markup = @"
-public class C
+public class MyClass
 {
-    C $$
+    MyClass $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "C", glyph: (int)Glyph.PropertyPublic);
-            await VerifyItemExistsAsync(markup, "c", glyph: (int)Glyph.FieldPublic);
-            await VerifyItemExistsAsync(markup, "GetC", glyph: (int)Glyph.MethodPublic);
+            await VerifyItemExistsAsync(markup, "MyClass", glyph: (int)Glyph.MethodPublic);
+            await VerifyItemExistsAsync(markup, "myClass", glyph: (int)Glyph.FieldPublic);
+            await VerifyItemExistsAsync(markup, "GetMyClass", glyph: (int)Glyph.MethodPublic);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void AsyncTaskOfT()
         {
             var markup = @"
+using System.Threading.Tasks;
 public class C
 {
     async Task<C> $$
@@ -53,7 +54,7 @@ public class C
             await VerifyItemExistsAsync(markup, "GetCAsync");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact(Skip = "not yet implemented"), Trait(Traits.Feature, Traits.Features.Completion)]
         public async void NonAsyncTaskOfT()
         {
             var markup = @"
@@ -104,7 +105,7 @@ public class C
     I $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "I");
+            await VerifyItemExistsAsync(markup, "GetI");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -117,7 +118,7 @@ public class C
     II $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "I");
+            await VerifyItemExistsAsync(markup, "GetI");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -137,21 +138,21 @@ public class C
         public async void WordBreaking5()
         {
             var markup = @"
-class AWonderfullyLongClassName {}
+class SomeWonderfullyLongClassName {}
 public class C
 {
-    AWonderfullyLongClassName $$
+    SomeWonderfullyLongClassName $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "A");
-            await VerifyItemExistsAsync(markup, "AWonderfully");
-            await VerifyItemExistsAsync(markup, "AWonderfullyLong");
-            await VerifyItemExistsAsync(markup, "AWonderfullyLongClass");
+            await VerifyItemExistsAsync(markup, "Some");
+            await VerifyItemExistsAsync(markup, "SomeWonderfully");
+            await VerifyItemExistsAsync(markup, "SomeWonderfullyLong");
+            await VerifyItemExistsAsync(markup, "SomeWonderfullyLongClass");
             await VerifyItemExistsAsync(markup, "Name");
             await VerifyItemExistsAsync(markup, "ClassName");
             await VerifyItemExistsAsync(markup, "LongClassName");
             await VerifyItemExistsAsync(markup, "WonderfullyLongClassName");
-            await VerifyItemExistsAsync(markup, "AWonderfullyLongClassName");
+            await VerifyItemExistsAsync(markup, "SomeWonderfullyLongClassName");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -371,7 +372,8 @@ public class C
     C $$
 }
 ";
-            await VerifyNoItemsExistAsync(markup);
+            await VerifyItemIsAbsentAsync(markup, "C");
+            await VerifyItemIsAbsentAsync(markup, "c");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -379,12 +381,12 @@ public class C
         {
             var markup = @"
 using System.Threading;
-public class C
+public class MyClass
 {
-    C[] $$
+    MyClass[] $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "C");
+            await VerifyItemExistsAsync(markup, "MyClass");
             await VerifyItemIsAbsentAsync(markup, "Array");
         }
 
@@ -421,7 +423,7 @@ public class C
     System.Collections.Generic.IEnumerable<C> $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "C");
+            await VerifyItemExistsAsync(markup, "GetC");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -403,7 +403,7 @@ public class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async void NptAfterVoid()
+        public async void NotAfterVoid()
         {
             var markup = @"
 public class C

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests_NameDeclarationInfoTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests_NameDeclarationInfoTests.cs
@@ -30,7 +30,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
             await VerifyNoModifiers(markup);
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
@@ -45,7 +45,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
             await VerifyNoModifiers(markup);
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.Public);
         }
 
@@ -60,7 +60,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
             await VerifyModifiers(markup, new DeclarationModifiers(isVirtual: true));
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.Public);
         }
 
@@ -75,7 +75,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
             await VerifyModifiers(markup, new DeclarationModifiers(isStatic: true));
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.Private);
         }
 
@@ -90,7 +90,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Field);
             await VerifyModifiers(markup, new DeclarationModifiers(isConst: true));
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.Private);
         }
 
@@ -108,7 +108,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Local);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
@@ -126,7 +126,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Local);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
@@ -144,7 +144,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Local);
             await VerifyModifiers(markup, new DeclarationModifiers(isReadOnly: true));
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
@@ -162,7 +162,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Local);
             await VerifyModifiers(markup, new DeclarationModifiers(isReadOnly: true));
-            await VerifyTypeName(markup, "global::System.Int32");
+            await VerifyTypeName(markup, "int");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
@@ -210,7 +210,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Parameter);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "global::System.String");
+            await VerifyTypeName(markup, "string");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
@@ -226,7 +226,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Parameter);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "global::System.String");
+            await VerifyTypeName(markup, "string");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
@@ -243,7 +243,7 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Parameter);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "global::System.Collections.Generic.List");
+            await VerifyTypeName(markup, "global::System.Collections.Generic.List<string>");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests_NameDeclarationInfoTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests_NameDeclarationInfoTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.DeclarationInfoTests
     {
         protected CSharpTestWorkspaceFixture fixture = new CSharpTestWorkspaceFixture();
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void AfterTypeInClass1()
         {
             var markup = @"
@@ -30,11 +30,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
             await VerifyNoModifiers(markup);
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void AfterTypeInClassWithAccessibility()
         {
             var markup = @"
@@ -45,11 +45,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
             await VerifyNoModifiers(markup);
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.Public);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void AfterTypeInClassVirtual()
         {
             var markup = @"
@@ -60,11 +60,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
             await VerifyModifiers(markup, new DeclarationModifiers(isVirtual: true));
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.Public);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void AfterTypeInClassStatic()
         {
             var markup = @"
@@ -75,11 +75,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
             await VerifyModifiers(markup, new DeclarationModifiers(isStatic: true));
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.Private);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void AfterTypeInClassConst()
         {
             var markup = @"
@@ -90,11 +90,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Field);
             await VerifyModifiers(markup, new DeclarationModifiers(isConst: true));
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.Private);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void VariableDeclaration1()
         {
             var markup = @"
@@ -108,11 +108,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Local);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void VariableDeclaration2()
         {
             var markup = @"
@@ -126,11 +126,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Local);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ReadonlyVariableDeclaration1()
         {
             var markup = @"
@@ -144,11 +144,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Local);
             await VerifyModifiers(markup, new DeclarationModifiers(isReadOnly: true));
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ReadonlyVariableDeclaration2()
         {
             var markup = @"
@@ -162,11 +162,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Local);
             await VerifyModifiers(markup, new DeclarationModifiers(isReadOnly: true));
-            await VerifyTypeName(markup, "Int32");
+            await VerifyTypeName(markup, "global::System.Int32");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void Parameter1()
         {
             var markup = @"
@@ -178,11 +178,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Parameter);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "C");
+            await VerifyTypeName(markup, "global::C");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void Parameter2()
         {
             var markup = @"
@@ -194,11 +194,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Parameter);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "C");
+            await VerifyTypeName(markup, "global::C");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ParameterAfterPredefinedType1()
         {
             var markup = @"
@@ -210,11 +210,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Parameter);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "String");
+            await VerifyTypeName(markup, "global::System.String");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ParameterAfterPredefinedType2()
         {
             var markup = @"
@@ -226,11 +226,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Parameter);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "String");
+            await VerifyTypeName(markup, "global::System.String");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ParameterAfterGeneric()
         {
             var markup = @"
@@ -243,11 +243,11 @@ class C
 ";
             await VerifySymbolKinds(markup, SymbolKind.Parameter);
             await VerifyModifiers(markup, new DeclarationModifiers());
-            await VerifyTypeName(markup, "List");
+            await VerifyTypeName(markup, "global::System.Collections.Generic.List");
             await VerifyAccessibility(markup, Accessibility.NotApplicable);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ClassTypeParameter1()
         {
             var markup = @"
@@ -258,7 +258,7 @@ class C<$$
             await VerifySymbolKinds(markup, SymbolKind.TypeParameter);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ClassTypeParameter2()
         {
             var markup = @"
@@ -269,7 +269,7 @@ class C<T1, $$
             await VerifySymbolKinds(markup, SymbolKind.TypeParameter);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ModifierExclusion1()
         {
             var markup = @"
@@ -281,7 +281,7 @@ class C
             await VerifySymbolKinds(markup, SymbolKind.Field);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ModifierExclusion2()
         {
             var markup = @"
@@ -293,7 +293,7 @@ class C
             await VerifySymbolKinds(markup, SymbolKind.Field);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ModifierExclusion3()
         {
             var markup = @"
@@ -305,7 +305,7 @@ class C
             await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ModifierExclusion4()
         {
             var markup = @"
@@ -317,7 +317,7 @@ class C
             await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ModifierExclusion5()
         {
             var markup = @"
@@ -329,7 +329,7 @@ class C
             await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ModifierExclusion6()
         {
             var markup = @"
@@ -341,7 +341,7 @@ class C
             await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ModifierExclusion7()
         {
             // Note that the async is not included in the incomplete member syntax
@@ -354,7 +354,7 @@ class C
             await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void ModifierExclusion8()
         {
             // Note that the async is not included in the incomplete member syntax
@@ -447,7 +447,7 @@ namespace ConsoleApp1
         private async Task VerifyTypeName(string markup, string typeName)
         {
             var result = await GetResultsAsync(markup);
-            Assert.Equal(typeName, result.Type.Name);
+            Assert.Equal(typeName, result.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
         }
 
         private async Task VerifyNoModifiers(string markup)

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests_NameDeclarationInfoTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests_NameDeclarationInfoTests.cs
@@ -1,0 +1,492 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Roslyn.Test.Utilities;
+using Xunit;
+using System.Collections.Immutable;
+using static Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationNameCompletionProvider;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.DeclarationInfoTests
+{
+    public class DeclarationNameCompletion_ContextTests
+    {
+        protected CSharpTestWorkspaceFixture fixture = new CSharpTestWorkspaceFixture();
+
+        [Fact]
+        public async void AfterTypeInClass1()
+        {
+            var markup = @"
+class C
+{
+    int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
+            await VerifyNoModifiers(markup);
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void AfterTypeInClassWithAccessibility()
+        {
+            var markup = @"
+class C
+{
+    public int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
+            await VerifyNoModifiers(markup);
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.Public);
+        }
+
+        [Fact]
+        public async void AfterTypeInClassVirtual()
+        {
+            var markup = @"
+class C
+{
+    public virtual int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
+            await VerifyModifiers(markup, new DeclarationModifiers(isVirtual: true));
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.Public);
+        }
+
+        [Fact]
+        public async void AfterTypeInClassStatic()
+        {
+            var markup = @"
+class C
+{
+    private static int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
+            await VerifyModifiers(markup, new DeclarationModifiers(isStatic: true));
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.Private);
+        }
+
+        [Fact]
+        public async void AfterTypeInClassConst()
+        {
+            var markup = @"
+class C
+{
+    private const int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Field);
+            await VerifyModifiers(markup, new DeclarationModifiers(isConst: true));
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.Private);
+        }
+
+        [Fact]
+        public async void VariableDeclaration1()
+        {
+            var markup = @"
+class C
+{
+    void foo()
+    {
+        int $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Local);
+            await VerifyModifiers(markup, new DeclarationModifiers());
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void VariableDeclaration2()
+        {
+            var markup = @"
+class C
+{
+    void foo()
+    {
+        int c1, $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Local);
+            await VerifyModifiers(markup, new DeclarationModifiers());
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void ReadonlyVariableDeclaration1()
+        {
+            var markup = @"
+class C
+{
+    void foo()
+    {
+        readonly int $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Local);
+            await VerifyModifiers(markup, new DeclarationModifiers(isReadOnly: true));
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void ReadonlyVariableDeclaration2()
+        {
+            var markup = @"
+class C
+{
+    void foo()
+    {
+        readonly int c1, $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Local);
+            await VerifyModifiers(markup, new DeclarationModifiers(isReadOnly: true));
+            await VerifyTypeName(markup, "Int32");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void Parameter1()
+        {
+            var markup = @"
+class C
+{
+    void foo(C $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Parameter);
+            await VerifyModifiers(markup, new DeclarationModifiers());
+            await VerifyTypeName(markup, "C");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void Parameter2()
+        {
+            var markup = @"
+class C
+{
+    void foo(C c1, C $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Parameter);
+            await VerifyModifiers(markup, new DeclarationModifiers());
+            await VerifyTypeName(markup, "C");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void ParameterAfterPredefinedType1()
+        {
+            var markup = @"
+class C
+{
+    void foo(string $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Parameter);
+            await VerifyModifiers(markup, new DeclarationModifiers());
+            await VerifyTypeName(markup, "String");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void ParameterAfterPredefinedType2()
+        {
+            var markup = @"
+class C
+{
+    void foo(C c1, string $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Parameter);
+            await VerifyModifiers(markup, new DeclarationModifiers());
+            await VerifyTypeName(markup, "String");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void ParameterAfterGeneric()
+        {
+            var markup = @"
+using System.Collections.Generic;
+class C
+{
+    void foo(C c1, List<string> $$
+    }
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Parameter);
+            await VerifyModifiers(markup, new DeclarationModifiers());
+            await VerifyTypeName(markup, "List");
+            await VerifyAccessibility(markup, Accessibility.NotApplicable);
+        }
+
+        [Fact]
+        public async void ClassTypeParameter1()
+        {
+            var markup = @"
+class C<$$
+{
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.TypeParameter);
+        }
+
+        [Fact]
+        public async void ClassTypeParameter2()
+        {
+            var markup = @"
+class C<T1, $$
+{
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.TypeParameter);
+        }
+
+        [Fact]
+        public async void ModifierExclusion1()
+        {
+            var markup = @"
+class C
+{
+    readonly int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Field);
+        }
+
+        [Fact]
+        public async void ModifierExclusion2()
+        {
+            var markup = @"
+class C
+{
+    const int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Field);
+        }
+
+        [Fact]
+        public async void ModifierExclusion3()
+        {
+            var markup = @"
+class C
+{
+    abstract int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
+        }
+
+        [Fact]
+        public async void ModifierExclusion4()
+        {
+            var markup = @"
+class C
+{
+    virtual int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
+        }
+
+        [Fact]
+        public async void ModifierExclusion5()
+        {
+            var markup = @"
+class C
+{
+    sealed int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
+        }
+
+        [Fact]
+        public async void ModifierExclusion6()
+        {
+            var markup = @"
+class C
+{
+    override int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Method, SymbolKind.Property);
+        }
+
+        [Fact]
+        public async void ModifierExclusion7()
+        {
+            // Note that the async is not included in the incomplete member syntax
+            var markup = @"
+class C
+{
+    async int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
+        }
+
+        [Fact]
+        public async void ModifierExclusion8()
+        {
+            // Note that the async is not included in the incomplete member syntax
+            var markup = @"
+class C
+{
+    partial int $$
+}
+";
+            await VerifySymbolKinds(markup, SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void LocalInsideMethod1()
+        {
+            var markup = @"
+namespace ConsoleApp1
+{
+    class ReallyLongClassName { }
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            ReallyLongClassName $$
+        }
+    }
+";
+            await VerifySymbolKinds(markup, SymbolKind.Local);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void LocalInsideMethod2()
+        {
+            var markup = @"
+namespace ConsoleApp1
+{
+    class ReallyLongClassName<T> { }
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            ReallyLongClassName<int> $$
+        }
+    }
+";
+            await VerifySymbolKinds(markup, SymbolKind.Local);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void LocalInsideMethodAfterPredefinedTypeKeyword()
+        {
+            var markup = @"
+namespace ConsoleApp1
+{
+    class ReallyLongClassName { }
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string $$
+        }
+    }
+";
+            await VerifySymbolKinds(markup, SymbolKind.Local);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void LocalInsideMethodAfterArray()
+        {
+            var markup = @"
+namespace ConsoleApp1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string[] $$
+        }
+    }
+";
+            await VerifySymbolKinds(markup, SymbolKind.Local);
+        }
+
+        private async Task VerifyNoType(string markup)
+        {
+            var result = await GetResultsAsync(markup);
+            Assert.Null(result.Type);
+        }
+
+        private async Task VerifyTypeName(string markup, string typeName)
+        {
+            var result = await GetResultsAsync(markup);
+            Assert.Equal(typeName, result.Type.Name);
+        }
+
+        private async Task VerifyNoModifiers(string markup)
+        {
+            var result = await GetResultsAsync(markup);
+            Assert.Equal(default(DeclarationModifiers), result.Modifiers);
+        }
+
+        private async Task VerifySymbolKinds(string markup, params SymbolKind[] expectedSymbolKinds)
+        {
+            var result = await GetResultsAsync(markup);
+            Assert.True(expectedSymbolKinds.SequenceEqual(result.PossibleSymbolKinds));
+        }
+
+        private async Task VerifyModifiers(string markup, DeclarationModifiers modifiers)
+        {
+            var result = await GetResultsAsync(markup);
+            Assert.Equal(modifiers, result.Modifiers);
+        }
+
+        private async Task VerifyAccessibility(string markup, Accessibility accessibility)
+        {
+            var result = await GetResultsAsync(markup);
+            Assert.Equal(accessibility, result.DeclaredAccessibility);
+        }
+
+        private async Task<NameDeclarationInfo> GetResultsAsync(string markup)
+        {
+            var (document, position) = ApplyChangesToFixture(markup);
+            var result = await NameDeclarationInfo.GetDeclarationInfo(document, position, CancellationToken.None);
+            return result;
+        }
+
+        private (Document, int) ApplyChangesToFixture(string markup)
+        {
+            string text;
+            int position;
+            MarkupTestFile.GetPosition(markup, out text, out position);
+            return (fixture.UpdateDocument(text, SourceCodeKind.Regular), position);
+        }
+    }
+}

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -2981,5 +2981,38 @@ class C
 
             End Using
         End Function
+
+        <WorkItem(16236, "https://github.com/dotnet/roslyn/issues/16236")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NameCompletionSorting() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+interface ISyntaxFactsService {}
+class C
+{
+    void M()
+    {
+        ISyntaxFactsService $$
+    }
+} </Document>)
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionSession()
+
+                Dim expectedOrder =
+                    {
+                        "syntaxFactsService",
+                        "syntaxFacts",
+                        "factsService",
+                        "syntax",
+                        "service"
+                    }
+
+                Dim items = state.CurrentCompletionPresenterSession.CompletionItems
+                Assert.Equal(expectedOrder.Count, items.Count)
+                For i = 0 To expectedOrder.Count - 1
+                    Assert.Equal(expectedOrder(i), items(i).DisplayText)
+                Next
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1029,7 +1029,7 @@ class Foo
                 Await state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
                 state.SendTypeChars(c.ToString())
                 Await state.WaitForAsynchronousOperationsAsync()
-                Assert.NotEqual("Numberos", state.CurrentCompletionPresenterSession.SelectedItem.DisplayText)
+                Assert.NotEqual("Numberos", state.CurrentCompletionPresenterSession?.SelectedItem?.DisplayText)
                 Assert.Contains(String.Format("Numeros num = Nu{0}", c), state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -738,7 +738,7 @@ partial class C
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem(displayText:="C", isHardSelected:=True)
                 state.SendTypeChars(" ")
-                Await state.AssertNoCompletionSession()
+                Await state.AssertCompletionSession()
             End Using
         End Function
 
@@ -1028,7 +1028,8 @@ class Foo
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem(displayText:="Numeros", isHardSelected:=True)
                 state.SendTypeChars(c.ToString())
-                Await state.AssertNoCompletionSession()
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.NotEqual("Numberos", state.CurrentCompletionPresenterSession.SelectedItem.DisplayText)
                 Assert.Contains(String.Format("Numeros num = Nu{0}", c), state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3007,11 +3007,7 @@ class C
                         "service"
                     }
 
-                Dim items = state.CurrentCompletionPresenterSession.CompletionItems
-                Assert.Equal(expectedOrder.Count, items.Count)
-                For i = 0 To expectedOrder.Count - 1
-                    Assert.Equal(expectedOrder(i), items(i).DisplayText)
-                Next
+                state.AssertItemsInOrder(expectedOrder)
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -236,14 +236,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                        Function(i) i.DisplayText = v))
         End Function
 
-        Public Function AssertItemsInOrder(expectedOrder As String()) As Boolean
+        Public Sub AssertItemsInOrder(expectedOrder As String())
             AssertNoAsynchronousOperationsRunning()
             Dim items = CurrentCompletionPresenterSession.CompletionItems
             Assert.Equal(expectedOrder.Count, items.Count)
             For i = 0 To expectedOrder.Count - 1
                 Assert.Equal(expectedOrder(i), items(i).DisplayText)
             Next
-        End Function
+        End Sub
 
         Public Async Function AssertSelectedCompletionItem(
                                Optional displayText As String = Nothing,

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -236,6 +236,15 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                        Function(i) i.DisplayText = v))
         End Function
 
+        Public Function AssertItemsInOrder(expectedOrder As String()) As Boolean
+            AssertNoAsynchronousOperationsRunning()
+            Dim items = CurrentCompletionPresenterSession.CompletionItems
+            Assert.Equal(expectedOrder.Count, items.Count)
+            For i = 0 To expectedOrder.Count - 1
+                Assert.Equal(expectedOrder(i), items(i).DisplayText)
+            Next
+        End Function
+
         Public Async Function AssertSelectedCompletionItem(
                                Optional displayText As String = Nothing,
                                Optional description As String = Nothing,

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -63,6 +63,9 @@
     <Compile Include="AddPackage\CSharpAddSpecificPackageCodeFixProvider.cs" />
     <Compile Include="AddParameter\CSharpAddParameterCodeFixProvider.cs" />
     <Compile Include="CodeFixes\RemoveUnusedVariable\RemoveUnusedVariableCodeFixProvider.cs" />
+    <Compile Include="Completion\CompletionProviders\DeclarationNameCompletionProvider.NameGenerator.cs" />
+    <Compile Include="Completion\CompletionProviders\DeclarationNameCompletionProvider.DeclarationInfo.cs" />
+    <Compile Include="Completion\CompletionProviders\DeclarationNameCompletionProvider_BuiltInStyles.cs" />
     <Compile Include="ConvertIfToSwitch\CSharpConvertIfToSwitchCodeRefactoringProvider.cs" />
     <Compile Include="ConvertIfToSwitch\CSharpConvertIfToSwitchCodeRefactoringProvider.Pattern.cs" />
     <Compile Include="ConvertNumericLiteral\CSharpConvertNumericLiteralCodeRefactoringProvider.cs" />
@@ -75,6 +78,7 @@
       <DependentUpon>CSharpFeaturesResources.resx</DependentUpon>
     </Compile>
     <Compile Include="DesignerAttributes\CSharpDesignerAttributeService.cs" />
+    <Compile Include="Completion\CompletionProviders\DeclarationNameCompletionProvider.cs" />
     <Compile Include="ImplementAbstractClass\CSharpImplementAbstractClassCodeFixProvider.cs" />
     <Compile Include="ImplementInterface\CSharpImplementInterfaceCodeFixProvider.cs" />
     <Compile Include="Structure\Providers\ArrowExpressionClauseStructureProvider.cs" />

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -657,6 +657,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;Name&gt;.
+        /// </summary>
+        internal static string Name {
+            get {
+                return ResourceManager.GetString("Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name can be simplified.
         /// </summary>
         internal static string Name_can_be_simplified {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -515,4 +515,7 @@
   <data name="Warning_Extracting_a_local_function_reference_may_produce_invalid_code" xml:space="preserve">
     <value>Warning: Extracting a local function reference may produce invalid code</value>
   </data>
+  <data name="Name" xml:space="preserve">
+    <value>&lt;Name&gt;</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
@@ -43,6 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
                 new PartialTypeCompletionProvider(),
                 new XmlDocCommentCompletionProvider(),
                 new TupleNameCompletionProvider()
+                ,new DeclarationNameCompletionProvider()
             );
 
         private readonly Workspace _workspace;

--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
                 new PartialMethodCompletionProvider(),
                 new PartialTypeCompletionProvider(),
                 new XmlDocCommentCompletionProvider(),
-                new TupleNameCompletionProvider()
-                ,new DeclarationNameCompletionProvider()
+                new TupleNameCompletionProvider(),
+                new DeclarationNameCompletionProvider()
             );
 
         private readonly Workspace _workspace;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.NamingStyles;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
+{
+    internal partial class DeclarationNameCompletionProvider
+    {
+        internal struct NameDeclarationInfo
+        {
+            public NameDeclarationInfo(ImmutableArray<SymbolKind> possibleSymbolKinds,
+                Accessibility accessibility, 
+                DeclarationModifiers declarationModifiers, ITypeSymbol type) 
+            {
+                PossibleSymbolKinds = possibleSymbolKinds;
+                DeclaredAccessibility = accessibility;
+                Modifiers = declarationModifiers;
+                Type = type;
+            }
+
+            public ImmutableArray<SymbolKind> PossibleSymbolKinds { get; }
+            public DeclarationModifiers Modifiers { get; }
+            public ITypeSymbol Type { get; }
+            public Accessibility DeclaredAccessibility { get; }
+
+            internal static async Task<NameDeclarationInfo> GetDeclarationInfo(Document document, int position, CancellationToken cancellationToken)
+            {
+                var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken).GetPreviousTokenIfTouchingWord(position);
+                var semanticModel = await document.GetSemanticModelForSpanAsync(new Text.TextSpan(token.SpanStart, 0), cancellationToken).ConfigureAwait(false);
+
+                NameDeclarationInfo result;
+                if (IsParameterDeclaration(token, semanticModel, position, cancellationToken, out result)
+                    || IsTypeParameterDeclaration(token, semanticModel, position, cancellationToken, out result)
+                    || IsVariableDeclaration(token, semanticModel, position, cancellationToken, out result)
+                    || IsIncompleteMemberDeclaration(token, semanticModel, position, cancellationToken, out result)
+                    || IsFieldDeclaration(token, semanticModel, position, cancellationToken, out result)
+                    || IsMethodDeclaration(token, semanticModel, position, cancellationToken, out result)
+                    || IsPropertyDeclaration(token, semanticModel, position, cancellationToken, out result)
+                    || IsPossibleVariableOrLocalMethodDeclaration(token, semanticModel, position, cancellationToken, out result))
+                {
+                    return result;
+                }
+
+                return default(NameDeclarationInfo);
+            }
+
+            private static bool IsPossibleVariableOrLocalMethodDeclaration(SyntaxToken token, SemanticModel semanticModel,
+                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            {
+                result = IsLastTokenOfType<ExpressionStatementSyntax>(
+                    token, semanticModel,
+                    e => e.Expression,
+                    unused => default(SyntaxTokenList),
+                    unused => ImmutableArray.Create(SymbolKind.Local),
+                    cancellationToken);
+                return result.Type != null;
+            }
+
+            private static bool IsPropertyDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            {
+                result = IsLastTokenOfType<PropertyDeclarationSyntax>(token, semanticModel, m => m.Type, m => m.Modifiers, GetPossibleDeclarations, cancellationToken);
+                return result.Type != null;
+            }
+
+            private static bool IsMethodDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            {
+                result = IsLastTokenOfType<MethodDeclarationSyntax>(token, semanticModel, m => m.ReturnType, m => m.Modifiers, GetPossibleDeclarations, cancellationToken);
+                return result.Type != null;
+            }
+
+            private static NameDeclarationInfo IsFollowingTypeOrComma<TSyntaxNode>(SyntaxToken token,
+                SemanticModel semanticModel,
+                Func<TSyntaxNode, SyntaxNode> typeSyntaxGetter,
+                Func<TSyntaxNode, SyntaxTokenList?> modifierGetter,
+                Func<DeclarationModifiers, ImmutableArray<SymbolKind>> possibleDeclarationComputer,
+                CancellationToken cancellationToken) where TSyntaxNode : SyntaxNode
+            {
+                if (!IsValidToken(token))
+                {
+                    return default(NameDeclarationInfo);
+                }
+
+                var target = token.GetAncestor<TSyntaxNode>();
+                if (target == null)
+                {
+                    return default(NameDeclarationInfo);
+                }
+
+                if (token.IsKind(SyntaxKind.CommaToken) && token.Parent != target)
+                {
+                    return default(NameDeclarationInfo);
+                }
+
+                var typeSyntax = typeSyntaxGetter(target);
+                var modifiers = modifierGetter(target);
+
+                if (modifiers == null)
+                {
+                    return default(NameDeclarationInfo);
+                }
+
+                return new NameDeclarationInfo(
+                    possibleDeclarationComputer(GetDeclarationModifiers(modifiers.Value)),
+                    GetAccessibility(modifiers.Value),
+                    GetDeclarationModifiers(modifiers.Value),
+                    semanticModel.GetTypeInfo(typeSyntax, cancellationToken).Type);
+            }
+
+            private static NameDeclarationInfo IsLastTokenOfType<TSyntaxNode>(SyntaxToken token, SemanticModel semanticModel,
+                Func<TSyntaxNode, SyntaxNode> typeSyntaxGetter,
+                Func<TSyntaxNode, SyntaxTokenList?> modifierGetter,
+                Func<DeclarationModifiers, ImmutableArray<SymbolKind>> possibleDeclarationComputer,
+                CancellationToken cancellationToken) where TSyntaxNode : SyntaxNode
+            {
+                if (!IsValidToken(token))
+                {
+                    return default(NameDeclarationInfo);
+                }
+
+                var target = token.GetAncestor<TSyntaxNode>();
+                if (target == null)
+                {
+                    return default(NameDeclarationInfo);
+                }
+
+                var typeSyntax = typeSyntaxGetter(target);
+                if (token != typeSyntax.GetLastToken())
+                {
+                    return default(NameDeclarationInfo);
+                }
+
+                var modifiers = modifierGetter(target);
+                if (modifiers == null)
+                {
+                    return default(NameDeclarationInfo);
+                }
+
+                return new NameDeclarationInfo(
+                    possibleDeclarationComputer(GetDeclarationModifiers(modifiers.Value)),
+                    GetAccessibility(modifiers.Value),
+                    GetDeclarationModifiers(modifiers.Value),
+                    semanticModel.GetTypeInfo(typeSyntax, cancellationToken).Type);
+            }
+
+            private static bool IsFieldDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            {
+                result = IsFollowingTypeOrComma<VariableDeclarationSyntax>(token, semanticModel,
+                    v => v.Type,
+                    v => v.IsParentKind(SyntaxKind.FieldDeclaration) ? ((FieldDeclarationSyntax)v.Parent).Modifiers : default(SyntaxTokenList?),
+                    GetPossibleDeclarations,
+                    cancellationToken);
+                return result.Type != null;
+            }
+
+            private static bool IsIncompleteMemberDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            {
+                result = IsLastTokenOfType<IncompleteMemberSyntax>(token, semanticModel,
+                    i => i.Type,
+                    i => i.Modifiers,
+                    GetPossibleDeclarations,
+                    cancellationToken);
+                return result.Type != null;
+            }
+
+            private static bool IsVariableDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            {
+                result = IsFollowingTypeOrComma<VariableDeclarationSyntax>(token, semanticModel,
+                     v => v.Type,
+                     v => v.IsParentKind(SyntaxKind.LocalDeclarationStatement) ? ((LocalDeclarationStatementSyntax)v.Parent).Modifiers : (SyntaxTokenList?)null,
+                     d => ImmutableArray.Create(SymbolKind.Local),
+                     cancellationToken);
+                return result.Type != null;
+            }
+
+            private static bool IsTypeParameterDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            {
+                if (token.IsKind(SyntaxKind.LessThanToken, SyntaxKind.CommaToken) &&
+                    token.Parent.IsKind(SyntaxKind.TypeParameterList))
+                {
+                    result = new NameDeclarationInfo(
+                        ImmutableArray.Create(SymbolKind.TypeParameter),
+                        Accessibility.NotApplicable,
+                        new DeclarationModifiers(),
+                        null);
+
+                    return true;
+                }
+
+                result = default(NameDeclarationInfo);
+                return false;
+            }
+
+            private static bool IsParameterDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            {
+                result = IsLastTokenOfType<ParameterSyntax>(
+                    token, semanticModel,
+                    p => p.Type,
+                    unused => default(SyntaxTokenList),
+                    unused => ImmutableArray.Create(SymbolKind.Parameter),
+                    cancellationToken);
+                return result.Type != null;
+            }
+
+            private static bool IsValidToken(SyntaxToken token) => 
+                token.IsKind(SyntaxKind.IdentifierToken, SyntaxKind.GreaterThanToken, SyntaxKind.CloseBracketToken) || token.Parent.IsKind(SyntaxKind.PredefinedType);
+
+            private static ImmutableArray<SymbolKind> GetPossibleDeclarations(DeclarationModifiers modifiers)
+            {
+                if (modifiers.IsConst || modifiers.IsReadOnly)
+                {
+                    return ImmutableArray.Create(SymbolKind.Field);
+                }
+
+                var possibleTypes = ImmutableArray.Create(SymbolKind.Field, SymbolKind.Method, SymbolKind.Property);
+                if (modifiers.IsAbstract || modifiers.IsVirtual || modifiers.IsSealed || modifiers.IsOverride)
+                {
+                    possibleTypes = possibleTypes.Remove(SymbolKind.Field);
+                }
+
+                if (modifiers.IsAsync || modifiers.IsPartial)
+                {
+                    possibleTypes = possibleTypes.Remove(SymbolKind.Property);
+                }
+
+                return possibleTypes;
+            }
+
+            private static DeclarationModifiers GetDeclarationModifiers(SyntaxTokenList modifiers)
+            {
+                var declarationModifiers = new DeclarationModifiers();
+                foreach (var modifer in modifiers)
+                {
+                    switch (modifer.Kind())
+                    {
+                        case SyntaxKind.StaticKeyword:
+                            declarationModifiers = declarationModifiers.WithIsStatic(true);
+                            continue;
+                        case SyntaxKind.AbstractKeyword:
+                            declarationModifiers = declarationModifiers.WithIsAbstract(true);
+                            continue;
+                        case SyntaxKind.NewKeyword:
+                            declarationModifiers = declarationModifiers.WithIsNew(true);
+                            continue;
+                        case SyntaxKind.UnsafeKeyword:
+                            declarationModifiers = declarationModifiers.WithIsUnsafe(true);
+                            continue;
+                        case SyntaxKind.ReadOnlyKeyword:
+                            declarationModifiers = declarationModifiers.WithIsReadOnly(true);
+                            continue;
+                        case SyntaxKind.VirtualKeyword:
+                            declarationModifiers = declarationModifiers.WithIsVirtual(true);
+                            continue;
+                        case SyntaxKind.OverrideKeyword:
+                            declarationModifiers = declarationModifiers.WithIsOverride(true);
+                            continue;
+                        case SyntaxKind.SealedKeyword:
+                            declarationModifiers = declarationModifiers.WithIsSealed(true);
+                            continue;
+                        case SyntaxKind.ConstKeyword:
+                            declarationModifiers = declarationModifiers.WithIsConst(true);
+                            continue;
+                        case SyntaxKind.AsyncKeyword:
+                            declarationModifiers = declarationModifiers.WithAsync(true);
+                            continue;
+                        case SyntaxKind.PartialKeyword:
+                            declarationModifiers = declarationModifiers.WithPartial(true);
+                            continue;
+                    }
+                }
+
+                return declarationModifiers;
+            }
+
+            private static Accessibility GetAccessibility(SyntaxTokenList modifiers)
+            {
+                for (int i = modifiers.Count - 1; i >= 0; i--)
+                {
+                    var modifier = modifiers[i];
+                    switch (modifier.Kind())
+                    {
+                        case SyntaxKind.PrivateKeyword:
+                            return Accessibility.Private;
+                        case SyntaxKind.PublicKeyword:
+                            return Accessibility.Public;
+                        case SyntaxKind.ProtectedKeyword:
+                            return Accessibility.Protected;
+                        case SyntaxKind.InternalKeyword:
+                            return Accessibility.Internal;
+                    }
+                }
+
+                return Accessibility.NotApplicable;
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
@@ -20,9 +20,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     {
         internal struct NameDeclarationInfo
         {
-            public NameDeclarationInfo(ImmutableArray<SymbolKind> possibleSymbolKinds,
+            public NameDeclarationInfo(
+                ImmutableArray<SymbolKind> possibleSymbolKinds,
                 Accessibility accessibility, 
-                DeclarationModifiers declarationModifiers, ITypeSymbol type) 
+                DeclarationModifiers declarationModifiers, 
+                ITypeSymbol type) 
             {
                 PossibleSymbolKinds = possibleSymbolKinds;
                 DeclaredAccessibility = accessibility;
@@ -57,27 +59,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return default(NameDeclarationInfo);
             }
 
-            private static bool IsPossibleVariableOrLocalMethodDeclaration(SyntaxToken token, SemanticModel semanticModel,
-                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            private static bool IsPossibleVariableOrLocalMethodDeclaration(
+                SyntaxToken token, SemanticModel semanticModel, int position, 
+                CancellationToken cancellationToken, out NameDeclarationInfo result)
             {
                 result = IsLastTokenOfType<ExpressionStatementSyntax>(
                     token, semanticModel,
                     e => e.Expression,
-                    unused => default(SyntaxTokenList),
-                    unused => ImmutableArray.Create(SymbolKind.Local),
+                    _ => default(SyntaxTokenList),
+                    _ => ImmutableArray.Create(SymbolKind.Local),
                     cancellationToken);
                 return result.Type != null;
             }
 
-            private static bool IsPropertyDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            private static bool IsPropertyDeclaration(SyntaxToken token, SemanticModel semanticModel, 
+                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
             {
-                result = IsLastTokenOfType<PropertyDeclarationSyntax>(token, semanticModel, m => m.Type, m => m.Modifiers, GetPossibleDeclarations, cancellationToken);
+                result = IsLastTokenOfType<PropertyDeclarationSyntax>(
+                    token, 
+                    semanticModel, 
+                    m => m.Type, 
+                    m => m.Modifiers, 
+                    GetPossibleDeclarations, 
+                    cancellationToken);
+
                 return result.Type != null;
             }
 
-            private static bool IsMethodDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            private static bool IsMethodDeclaration(SyntaxToken token, SemanticModel semanticModel, 
+                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
             {
-                result = IsLastTokenOfType<MethodDeclarationSyntax>(token, semanticModel, m => m.ReturnType, m => m.Modifiers, GetPossibleDeclarations, cancellationToken);
+                result = IsLastTokenOfType<MethodDeclarationSyntax>(
+                    token, 
+                    semanticModel, 
+                    m => m.ReturnType, 
+                    m => m.Modifiers,
+                    GetPossibleDeclarations, 
+                    cancellationToken);
+
                 return result.Type != null;
             }
 
@@ -119,7 +138,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     semanticModel.GetTypeInfo(typeSyntax, cancellationToken).Type);
             }
 
-            private static NameDeclarationInfo IsLastTokenOfType<TSyntaxNode>(SyntaxToken token, SemanticModel semanticModel,
+            private static NameDeclarationInfo IsLastTokenOfType<TSyntaxNode>(
+                SyntaxToken token, 
+                SemanticModel semanticModel,
                 Func<TSyntaxNode, SyntaxNode> typeSyntaxGetter,
                 Func<TSyntaxNode, SyntaxTokenList?> modifierGetter,
                 Func<DeclarationModifiers, ImmutableArray<SymbolKind>> possibleDeclarationComputer,
@@ -155,7 +176,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     semanticModel.GetTypeInfo(typeSyntax, cancellationToken).Type);
             }
 
-            private static bool IsFieldDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            private static bool IsFieldDeclaration(SyntaxToken token, SemanticModel semanticModel, 
+                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
             {
                 result = IsFollowingTypeOrComma<VariableDeclarationSyntax>(token, semanticModel,
                     v => v.Type,
@@ -165,7 +187,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return result.Type != null;
             }
 
-            private static bool IsIncompleteMemberDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            private static bool IsIncompleteMemberDeclaration(SyntaxToken token, SemanticModel semanticModel, 
+                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
             {
                 result = IsLastTokenOfType<IncompleteMemberSyntax>(token, semanticModel,
                     i => i.Type,
@@ -175,7 +198,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return result.Type != null;
             }
 
-            private static bool IsVariableDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            private static bool IsVariableDeclaration(SyntaxToken token, SemanticModel semanticModel, 
+                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
             {
                 result = IsFollowingTypeOrComma<VariableDeclarationSyntax>(token, semanticModel,
                      v => v.Type,
@@ -185,7 +209,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return result.Type != null;
             }
 
-            private static bool IsTypeParameterDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            private static bool IsTypeParameterDeclaration(SyntaxToken token, SemanticModel semanticModel, 
+                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
             {
                 if (token.IsKind(SyntaxKind.LessThanToken, SyntaxKind.CommaToken) &&
                     token.Parent.IsKind(SyntaxKind.TypeParameterList))
@@ -203,19 +228,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return false;
             }
 
-            private static bool IsParameterDeclaration(SyntaxToken token, SemanticModel semanticModel, int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
+            private static bool IsParameterDeclaration(SyntaxToken token, SemanticModel semanticModel, 
+                int position, CancellationToken cancellationToken, out NameDeclarationInfo result)
             {
                 result = IsLastTokenOfType<ParameterSyntax>(
                     token, semanticModel,
                     p => p.Type,
-                    unused => default(SyntaxTokenList),
-                    unused => ImmutableArray.Create(SymbolKind.Parameter),
+                    _ => default(SyntaxTokenList),
+                    _ => ImmutableArray.Create(SymbolKind.Parameter),
                     cancellationToken);
                 return result.Type != null;
             }
 
             private static bool IsValidToken(SyntaxToken token) => 
-                token.IsKind(SyntaxKind.IdentifierToken, SyntaxKind.GreaterThanToken, SyntaxKind.CloseBracketToken) || token.Parent.IsKind(SyntaxKind.PredefinedType);
+                token.IsKind(
+                    SyntaxKind.IdentifierToken, 
+                    SyntaxKind.GreaterThanToken, 
+                    SyntaxKind.CloseBracketToken) 
+                || token.Parent.IsKind(SyntaxKind.PredefinedType);
 
             private static ImmutableArray<SymbolKind> GetPossibleDeclarations(DeclarationModifiers modifiers)
             {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 Func<DeclarationModifiers, ImmutableArray<SymbolKind>> possibleDeclarationComputer,
                 CancellationToken cancellationToken) where TSyntaxNode : SyntaxNode
             {
-                if (!IsValidToken(token))
+                if (!IsPossibleTypeToken(token) && !token.IsKind(SyntaxKind.CommaToken))
                 {
                     return default(NameDeclarationInfo);
                 }
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 Func<DeclarationModifiers, ImmutableArray<SymbolKind>> possibleDeclarationComputer,
                 CancellationToken cancellationToken) where TSyntaxNode : SyntaxNode
             {
-                if (!IsValidToken(token))
+                if (!IsPossibleTypeToken(token))
                 {
                     return default(NameDeclarationInfo);
                 }
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return result.Type != null;
             }
 
-            private static bool IsValidToken(SyntaxToken token) => 
+            private static bool IsPossibleTypeToken(SyntaxToken token) => 
                 token.IsKind(
                     SyntaxKind.IdentifierToken, 
                     SyntaxKind.GreaterThanToken, 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
@@ -124,6 +124,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 }
 
                 var typeSyntax = typeSyntaxGetter(target);
+                if (typeSyntax == null)
+                {
+                    return default(NameDeclarationInfo);
+                }
+
                 var modifiers = modifierGetter(target);
 
                 if (modifiers == null)
@@ -158,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 }
 
                 var typeSyntax = typeSyntaxGetter(target);
-                if (token != typeSyntax.GetLastToken())
+                if (typeSyntax == null || token != typeSyntax.GetLastToken())
                 {
                     return default(NameDeclarationInfo);
                 }
@@ -181,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             {
                 result = IsFollowingTypeOrComma<VariableDeclarationSyntax>(token, semanticModel,
                     v => v.Type,
-                    v => v.IsParentKind(SyntaxKind.FieldDeclaration) ? ((FieldDeclarationSyntax)v.Parent).Modifiers : default(SyntaxTokenList?),
+                    v => v.Parent is FieldDeclarationSyntax f ? f.Modifiers : default(SyntaxTokenList?),
                     GetPossibleDeclarations,
                     cancellationToken);
                 return result.Type != null;
@@ -203,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             {
                 result = IsFollowingTypeOrComma<VariableDeclarationSyntax>(token, semanticModel,
                      v => v.Type,
-                     v => v.IsParentKind(SyntaxKind.LocalDeclarationStatement) ? ((LocalDeclarationStatementSyntax)v.Parent).Modifiers : (SyntaxTokenList?)null,
+                     v => v.Parent is LocalDeclarationStatementSyntax l ? l.Modifiers : default(SyntaxTokenList?),
                      d => ImmutableArray.Create(SymbolKind.Local),
                      cancellationToken);
                 return result.Type != null;
@@ -219,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         ImmutableArray.Create(SymbolKind.TypeParameter),
                         Accessibility.NotApplicable,
                         new DeclarationModifiers(),
-                        null);
+                        type: null);
 
                     return true;
                 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.NameGenerator.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.NameGenerator.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.NameGenerator.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.NameGenerator.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.NamingStyles;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Words = System.Collections.Generic.IEnumerable<string>;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
+{
+    internal partial class DeclarationNameCompletionProvider
+    {
+        internal class NameGenerator
+        {
+            static readonly NamingStyle s_interfacePrefix = new NamingStyles.NamingStyle(Guid.NewGuid(),
+                prefix: "I", capitalizationScheme: Capitalization.PascalCase);
+
+            internal static ImmutableArray<Words> GetBaseNames(ITypeSymbol type)
+            {
+                var baseName = TryRemoveInterfacePrefix(type);
+                var breaks = StringBreaker.BreakIntoWordParts(baseName);
+                return GetInterleavedPatterns(breaks, baseName);
+            }
+
+            private static ImmutableArray<Words> GetInterleavedPatterns(StringBreaks breaks, string baseName)
+            {
+                var result = ImmutableArray.CreateBuilder<Words>();
+                result.Add(GetWords(0, breaks.Count, breaks, baseName));
+
+                for (int length = breaks.Count - 1; length > 0; length--)
+                {
+                    // going forward
+                    result.Add(GetLongestForwardSubsequence(length, breaks, baseName));
+
+                    // going backward
+                    result.Add(GetLongestBackwardSubsequence(length, breaks, baseName));
+                }
+                return result.ToImmutable();
+            }
+
+            private static Words GetLongestBackwardSubsequence(int length, StringBreaks breaks, string baseName)
+            {
+                var start = breaks.Count - length;
+                return GetWords(start, breaks.Count, breaks, baseName);
+            }
+
+            private static Words GetLongestForwardSubsequence(int length, StringBreaks breaks, string baseName)
+            {
+                var end = length;
+                return GetWords(0, end, breaks, baseName);
+            }
+
+            private static Words GetWords(int start, int end, StringBreaks breaks, string baseName)
+            {
+                var result = ImmutableArray.Create<string>();
+                for (; start < end; start++)
+                {
+                    var @break = breaks[start];
+                    result = result.Add(baseName.Substring(@break.Start, @break.Length));
+                }
+
+                return result;
+            }
+
+            private static string TryRemoveInterfacePrefix(ITypeSymbol type)
+            {
+                var name = type.Name;
+                if (type.TypeKind == TypeKind.Interface && name.Length > 1)
+                {
+                    string unused;
+                    if (s_interfacePrefix.IsNameCompliant(name, out unused))
+                    {
+                        return name.Substring(1);
+                    }
+                }
+
+                return type.CreateParameterName();
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.NameGenerator.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.NameGenerator.cs
@@ -17,19 +17,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     {
         internal class NameGenerator
         {
-            static readonly NamingStyle s_interfacePrefix = new NamingStyles.NamingStyle(Guid.NewGuid(),
-                prefix: "I", capitalizationScheme: Capitalization.PascalCase);
-
-            internal static ImmutableArray<Words> GetBaseNames(ITypeSymbol type)
+            internal static ImmutableArray<IEnumerable<string>> GetBaseNames(ITypeSymbol type)
             {
                 var baseName = TryRemoveInterfacePrefix(type);
                 var breaks = StringBreaker.BreakIntoWordParts(baseName);
                 return GetInterleavedPatterns(breaks, baseName);
             }
 
-            private static ImmutableArray<Words> GetInterleavedPatterns(StringBreaks breaks, string baseName)
+            private static ImmutableArray<IEnumerable<string>> GetInterleavedPatterns(StringBreaks breaks, string baseName)
             {
-                var result = ImmutableArray.CreateBuilder<Words>();
+                var result = ArrayBuilder<IEnumerable<string>>.GetInstance();
                 result.Add(GetWords(0, breaks.Count, breaks, baseName));
 
                 for (int length = breaks.Count - 1; length > 0; length--)
@@ -72,13 +69,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 var name = type.Name;
                 if (type.TypeKind == TypeKind.Interface && name.Length > 1)
                 {
-                    string unused;
-                    if (s_interfacePrefix.IsNameCompliant(name, out unused))
+                    if (name[0] == 'I' && char.IsLower(name[1]))
                     {
                         return name.Substring(1);
                     }
                 }
-
                 return type.CreateParameterName();
             }
         }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             CancellationToken cancellationToken)
         {
             var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            var namingStyleOptions = options.GetOption(SimplificationOptions.NamingPreferences, LanguageNames.CSharp);
+            var namingStyleOptions = options.GetOption(SimplificationOptions.NamingPreferences);
             var rules = namingStyleOptions.CreateRules().NamingRules.Concat(s_BuiltInRules);
             var result = new Dictionary<string, SymbolKind>();
             foreach (var symbolKind in declarationInfo.PossibleSymbolKinds)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         private void AddBuilder(CompletionContext completionContext)
         {
-            completionContext.SuggestionModeItem = CommonCompletionItem.Create(CSharpFeaturesResources.Name);
+            completionContext.SuggestionModeItem = CommonCompletionItem.Create(CSharpFeaturesResources.Name, CompletionItemRules.Default);
         }
 
         private ITypeSymbol UnwrapType(ITypeSymbol type)
@@ -178,8 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         CompletionItem CreateCompletionItem(string name, Glyph glyph, string sortText)
         {
-            return CommonCompletionItem.Create(name, glyph, sortText: sortText,
-                rules: CompletionItemRules.Default);
+            return CommonCompletionItem.Create(name, CompletionItemRules.Default, glyph: glyph, sortText: sortText);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -68,7 +68,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return false;
             }
 
-            return type.SpecialType != SpecialType.System_Void;
+            if (type.SpecialType == SpecialType.System_Void)
+            {
+                return false;
+            }
+
+            return !type.IsSpecialType();
         }
 
         private Glyph GetGlyph(SymbolKind kind, Accessibility declaredAccessibility)
@@ -140,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 var taskOfTType = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
                 var valueTaskType = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
                 if (originalDefinition == taskOfTType
-                    || originalDefinition == valueTaskType )
+                    || originalDefinition == valueTaskType)
                 {
                     return UnwrapType(namedType.TypeArguments[0], compilation);
                 }
@@ -149,10 +154,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return type;
         }
 
-        private async Task <IEnumerable<(string, SymbolKind)>> GetRecommendedNamesAsync(
-            IEnumerable<IEnumerable<string>> baseNames, 
-            NameDeclarationInfo declarationInfo, 
-            CSharpSyntaxContext context, 
+        private async Task<IEnumerable<(string, SymbolKind)>> GetRecommendedNamesAsync(
+            IEnumerable<IEnumerable<string>> baseNames,
+            NameDeclarationInfo declarationInfo,
+            CSharpSyntaxContext context,
             Document document,
             CancellationToken cancellationToken)
         {
@@ -171,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         foreach (var baseName in baseNames)
                         {
                             var name = rule.NamingStyle.CreateName(baseName);
-                            if (!result.ContainsKey(name)) // Don't add multiple items for the same name
+                            if (name.Length > 1 && !result.ContainsKey(name)) // Don't add multiple items for the same name
                             {
                                 result.Add(name, symbolKind);
                             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.SymbolSpecification;
+using Words = System.Collections.Generic.IEnumerable<string>;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
+{
+    internal partial class DeclarationNameCompletionProvider : CommonCompletionProvider
+    {
+        internal override bool IsInsertionTrigger(SourceText text, int insertedCharacterPosition, OptionSet options)
+        {
+            return CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, insertedCharacterPosition, options);
+        }
+
+        public override async Task ProvideCompletionsAsync(CompletionContext completionContext)
+        {
+            var position = completionContext.Position;
+            var document = completionContext.Document;
+            var cancellationToken = completionContext.CancellationToken;
+            var semanticModel = await document.GetSemanticModelForSpanAsync(new Text.TextSpan(position, 0), cancellationToken).ConfigureAwait(false);
+
+            var context = CSharpSyntaxContext.CreateContext(document.Project.Solution.Workspace, semanticModel, position, cancellationToken);
+
+            var targetToken = context.TargetToken;
+            var nameInfo = await NameDeclarationInfo.GetDeclarationInfo(document, position, cancellationToken).ConfigureAwait(false);
+
+            if (!IsValidType(nameInfo.Type))
+            {
+                return;
+            }
+
+            var type = UnwrapType(nameInfo.Type);
+            var baseNames = NameGenerator.GetBaseNames(type);
+            int i = 0;
+            foreach (var (name, kind) in GetRecommendedNames(baseNames, nameInfo, context))
+            {
+                // We've produced items in the desired order, add a sort text to each item to prevent alphabetization
+                completionContext.AddItem(CreateCompletionItem(name, GetGlyph(kind, nameInfo.DeclaredAccessibility), i++.ToString("D8")));
+            }
+
+            AddBuilder(completionContext);
+        }
+
+        private bool IsValidType(ITypeSymbol type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (type.IsErrorType() && (type.Name == "var" || type.Name == string.Empty))
+            {
+                return false;
+            }
+
+            return type.SpecialType != SpecialType.System_Void;
+        }
+
+        private Glyph GetGlyph(SymbolKind kind, Accessibility declaredAccessibility)
+        {
+            Glyph publicIcon;
+            switch (kind)
+            {
+                case SymbolKind.Field:
+                    publicIcon = Glyph.FieldPublic;
+                    break;
+                case SymbolKind.Local:
+                    publicIcon = Glyph.Local;
+                    break;
+                case SymbolKind.Method:
+                    publicIcon = Glyph.MethodPublic;
+                    break;
+                case SymbolKind.Parameter:
+                    publicIcon = Glyph.Parameter;
+                    break;
+                case SymbolKind.Property:
+                    publicIcon = Glyph.PropertyPublic;
+                    break;
+                case SymbolKind.RangeVariable:
+                    publicIcon = Glyph.RangeVariable;
+                    break;
+                case SymbolKind.TypeParameter:
+                    publicIcon = Glyph.TypeParameter;
+                    break;
+                default:
+                    throw new ArgumentException();
+            }
+
+            switch (declaredAccessibility)
+            {
+                case Accessibility.Private:
+                    publicIcon += Glyph.ClassPrivate - Glyph.ClassPublic;
+                    break;
+
+                case Accessibility.Protected:
+                case Accessibility.ProtectedAndInternal:
+                case Accessibility.ProtectedOrInternal:
+                    publicIcon += Glyph.ClassProtected - Glyph.ClassPublic;
+                    break;
+
+                case Accessibility.Internal:
+                    publicIcon += Glyph.ClassInternal - Glyph.ClassPublic;
+                    break;
+            }
+
+            return publicIcon;
+        }
+
+        private void AddBuilder(CompletionContext completionContext)
+        {
+            completionContext.SuggestionModeItem = CommonCompletionItem.Create(CSharpFeaturesResources.Name);
+        }
+
+        private ITypeSymbol UnwrapType(ITypeSymbol type)
+        {
+            var nts = type as INamedTypeSymbol;
+            if (nts != null && nts.ConstructedFrom != null)
+            {
+                var constructedFrom = nts.ConstructedFrom;
+                switch (constructedFrom.SpecialType)
+                {
+                    case SpecialType.System_Collections_Generic_IEnumerable_T:
+                    case SpecialType.System_Collections_Generic_IList_T:
+                    case SpecialType.System_Collections_Generic_ICollection_T:
+                    case SpecialType.System_Collections_Generic_IReadOnlyList_T:
+                    case SpecialType.System_Collections_Generic_IReadOnlyCollection_T:
+                    case SpecialType.System_Nullable_T:
+                        return UnwrapType(nts.TypeArguments[0]);
+                }
+
+                if (constructedFrom.Name == "Task"
+                   && constructedFrom.ContainingNamespace?.Name == "Tasks"
+                   && constructedFrom.ContainingNamespace.ContainingNamespace?.Name == "Threading"
+                   && constructedFrom.ContainingNamespace.ContainingNamespace.ContainingNamespace?.Name == "System"
+                   && (constructedFrom.ContainingNamespace.ContainingNamespace.ContainingNamespace.ContainingNamespace?.IsGlobalNamespace ?? false))
+                {
+                    return UnwrapType(nts.TypeArguments[0]);
+                }
+            }
+
+            return type;
+        }
+
+        private IEnumerable<(string, SymbolKind)> GetRecommendedNames(IEnumerable<Words> baseNames, NameDeclarationInfo declarationInfo, CSharpSyntaxContext context)
+        {
+            var namingStyleOptions = context.Workspace.Options.GetOption(SimplificationOptions.NamingPreferences, LanguageNames.CSharp);
+            var rules = namingStyleOptions.CreateRules().NamingRules.Concat(s_BuiltInRules);
+            var result = new List<(string, SymbolKind)>();
+            foreach (var symbolKind in declarationInfo.PossibleSymbolKinds)
+            {
+                var kind = new SymbolKindOrTypeKind(symbolKind);
+                var modifiers = declarationInfo.Modifiers;
+                foreach (var rule in rules)
+                {
+                    if (rule.SymbolSpecification.AppliesTo(kind, declarationInfo.Modifiers, declarationInfo.DeclaredAccessibility))
+                    {
+                        foreach (var name in baseNames)
+                        {
+                            result.Add((rule.NamingStyle.CreateName(name), symbolKind));
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        CompletionItem CreateCompletionItem(string name, Glyph glyph, string sortText)
+        {
+            return CommonCompletionItem.Create(name, glyph, sortText: sortText,
+                rules: CompletionItemRules.Default);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider_BuiltInStyles.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider_BuiltInStyles.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Roslyn.Utilities;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider_BuiltInStyles.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider_BuiltInStyles.cs
@@ -10,11 +10,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
     internal partial class DeclarationNameCompletionProvider
     {
-        private static ImmutableArray<NamingRule> s_BuiltInRules = ImmutableArray.Create(
-            CreateCamelCaseFieldsAndParametersRule(),
-            CreateEndWithAsyncRule(),
-            CreateGetAsyncRule(),
-            CreateMethodStartsWithGetRule());
+        private static ImmutableArray<NamingRule> s_BuiltInRules;
+
+        static DeclarationNameCompletionProvider()
+        {
+            s_BuiltInRules = ImmutableArray.Create(
+                CreateCamelCaseFieldsAndParametersRule(),
+                CreateEndWithAsyncRule(),
+                CreateGetAsyncRule(),
+                CreateMethodStartsWithGetRule());
+        }
 
         private static NamingRule CreateGetAsyncRule()
         {
@@ -24,7 +29,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new SymbolSpecification(Guid.NewGuid(), "endswithasync", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
                 new NamingStyles.NamingStyle(Guid.NewGuid(), prefix: "Get", suffix: "Async"),
                 DiagnosticSeverity.Info);
-
         }
 
         private static NamingRule CreateCamelCaseFieldsAndParametersRule()
@@ -35,7 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new SymbolSpecification(Guid.NewGuid(), "camelcasefields", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
                 new NamingStyles.NamingStyle(Guid.NewGuid(), capitalizationScheme: Capitalization.CamelCase),
                 DiagnosticSeverity.Info);
-
         }
 
         private static NamingRule CreateEndWithAsyncRule()
@@ -46,7 +49,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 new SymbolSpecification(Guid.NewGuid(), "endswithasynct", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
                 new NamingStyles.NamingStyle(Guid.NewGuid(), suffix: "Async"),
                 DiagnosticSeverity.Info);
-
         }
 
         private static NamingRule CreateMethodStartsWithGetRule()

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider_BuiltInStyles.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider_BuiltInStyles.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles.SymbolSpecification;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
+{
+    internal partial class DeclarationNameCompletionProvider
+    {
+        private static ImmutableArray<NamingRule> s_BuiltInRules = ImmutableArray.Create(
+            CreateCamelCaseFieldsAndParametersRule(),
+            CreateEndWithAsyncRule(),
+            CreateGetAsyncRule(),
+            CreateMethodStartsWithGetRule());
+
+        private static NamingRule CreateGetAsyncRule()
+        {
+            var kinds = ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Method));
+            var modifiers = ImmutableArray.Create(new ModifierKind(ModifierKindEnum.IsAsync));
+            return new NamingRule(
+                new SymbolSpecification(Guid.NewGuid(), "endswithasync", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
+                new NamingStyles.NamingStyle(Guid.NewGuid(), prefix: "Get", suffix: "Async"),
+                DiagnosticSeverity.Info);
+
+        }
+
+        private static NamingRule CreateCamelCaseFieldsAndParametersRule()
+        {
+            var kinds = ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Field), new SymbolKindOrTypeKind(SymbolKind.Parameter), new SymbolKindOrTypeKind(SymbolKind.Local));
+            var modifiers = ImmutableArray.Create<ModifierKind>(new ModifierKind(ModifierKindEnum.Ignore));
+            return new NamingRule(
+                new SymbolSpecification(Guid.NewGuid(), "camelcasefields", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
+                new NamingStyles.NamingStyle(Guid.NewGuid(), capitalizationScheme: Capitalization.CamelCase),
+                DiagnosticSeverity.Info);
+
+        }
+
+        private static NamingRule CreateEndWithAsyncRule()
+        {
+            var kinds = ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Method));
+            var modifiers = ImmutableArray.Create(new ModifierKind(ModifierKindEnum.IsAsync));
+            return new NamingRule(
+                new SymbolSpecification(Guid.NewGuid(), "endswithasynct", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
+                new NamingStyles.NamingStyle(Guid.NewGuid(), suffix: "Async"),
+                DiagnosticSeverity.Info);
+
+        }
+
+        private static NamingRule CreateMethodStartsWithGetRule()
+        {
+            var kinds = ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Method));
+            var modifiers = ImmutableArray.Create<ModifierKind>(new ModifierKind(ModifierKindEnum.Ignore));
+            return new NamingRule(
+                new SymbolSpecification(Guid.NewGuid(), "startswithget", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
+                new NamingStyles.NamingStyle(Guid.NewGuid(), prefix: "Get"),
+                DiagnosticSeverity.Info);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider_BuiltInStyles.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider_BuiltInStyles.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         private static NamingRule CreateCamelCaseFieldsAndParametersRule()
         {
             var kinds = ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Field), new SymbolKindOrTypeKind(SymbolKind.Parameter), new SymbolKindOrTypeKind(SymbolKind.Local));
-            var modifiers = ImmutableArray.Create<ModifierKind>(new ModifierKind(ModifierKindEnum.Ignore));
+            var modifiers = ImmutableArray.Create<ModifierKind>();
             return new NamingRule(
                 new SymbolSpecification(Guid.NewGuid(), "camelcasefields", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
                 new NamingStyles.NamingStyle(Guid.NewGuid(), capitalizationScheme: Capitalization.CamelCase),
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         private static NamingRule CreateMethodStartsWithGetRule()
         {
             var kinds = ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Method));
-            var modifiers = ImmutableArray.Create<ModifierKind>(new ModifierKind(ModifierKindEnum.Ignore));
+            var modifiers = ImmutableArray.Create<ModifierKind>();
             return new NamingRule(
                 new SymbolSpecification(Guid.NewGuid(), "startswithget", kinds, ImmutableArray.Create<Accessibility>(), modifiers),
                 new NamingStyles.NamingStyle(Guid.NewGuid(), prefix: "Get"),

--- a/src/Workspaces/Core/Portable/Editing/DeclarationKind.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationKind.cs
@@ -33,6 +33,6 @@ namespace Microsoft.CodeAnalysis.Editing
         SetAccessor,
         AddAccessor,
         RemoveAccessor,
-        RaiseAccessor,
+        RaiseAccessor
     }
 }

--- a/src/Workspaces/Core/Portable/Editing/DeclarationKind.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationKind.cs
@@ -33,6 +33,6 @@ namespace Microsoft.CodeAnalysis.Editing
         SetAccessor,
         AddAccessor,
         RemoveAccessor,
-        RaiseAccessor
+        RaiseAccessor,
     }
 }

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
@@ -74,6 +74,67 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                    AnyMatches(this.ApplicableAccessibilityList, symbol);
         }
 
+        internal bool AppliesTo(SymbolKindOrTypeKind kind, DeclarationModifiers modifiers, Accessibility accessibility)
+        {
+            if (ApplicableSymbolKindList.Any() && !ApplicableSymbolKindList.Any(k => k.Equals(kind)))
+            {
+                return false;
+            }
+
+            if (!IgnoreModifiers(RequiredModifierList))
+            {
+                var collapsedModifiers = CollapseModifiers(RequiredModifierList);
+                if (modifiers != collapsedModifiers)
+                {
+                    return false;
+                }
+            }
+
+            if (ApplicableAccessibilityList.Any() && accessibility != Accessibility.NotApplicable && !ApplicableAccessibilityList.Any(k => k == accessibility))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool IgnoreModifiers(ImmutableArray<ModifierKind> requiredModifierList)
+        {
+            return requiredModifierList.Length == 1 && requiredModifierList[0].ModifierKindWrapper == ModifierKindEnum.Ignore;
+        }
+
+        private DeclarationModifiers CollapseModifiers(ImmutableArray<ModifierKind> requiredModifierList)
+        {
+            if (requiredModifierList == default(ImmutableArray<ModifierKind>))
+            {
+                return new DeclarationModifiers();
+            }
+
+            DeclarationModifiers result = new DeclarationModifiers();
+            foreach (var modifier in requiredModifierList)
+            {
+                switch (modifier.ModifierKindWrapper)
+                {
+                    case ModifierKindEnum.IsAbstract:
+                        result = result.WithIsAbstract(true);
+                        break;
+                    case ModifierKindEnum.IsStatic:
+                        result = result.WithIsStatic(true);
+                        break;
+                    case ModifierKindEnum.IsAsync:
+                        result = result.WithAsync(true);
+                        break;
+                    case ModifierKindEnum.IsReadOnly:
+                        result = result.WithIsReadOnly(true);
+                        break;
+                    case ModifierKindEnum.IsConst:
+                        result = result.WithIsConst(true);
+                        break;
+                }
+            }
+            return result;
+        }
+
         private bool AnyMatches<TSymbolMatcher>(ImmutableArray<TSymbolMatcher> matchers, ISymbol symbol)
             where TSymbolMatcher : ISymbolMatcher
         {
@@ -360,7 +421,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             IsStatic,
             IsAsync,
             IsReadOnly,
-            IsConst
+            IsConst,
+            Ignore // This matches any modifiers
         }
     }
 }

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/SymbolSpecification.cs
@@ -81,13 +81,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                 return false;
             }
 
-            if (!IgnoreModifiers(RequiredModifierList))
+            var collapsedModifiers = CollapseModifiers(RequiredModifierList);
+            if ((modifiers & collapsedModifiers) != collapsedModifiers)
             {
-                var collapsedModifiers = CollapseModifiers(RequiredModifierList);
-                if (modifiers != collapsedModifiers)
-                {
-                    return false;
-                }
+                return false;
             }
 
             if (ApplicableAccessibilityList.Any() && accessibility != Accessibility.NotApplicable && !ApplicableAccessibilityList.Any(k => k == accessibility))
@@ -96,11 +93,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             }
 
             return true;
-        }
-
-        private bool IgnoreModifiers(ImmutableArray<ModifierKind> requiredModifierList)
-        {
-            return requiredModifierList.Length == 1 && requiredModifierList[0].ModifierKindWrapper == ModifierKindEnum.Ignore;
         }
 
         private DeclarationModifiers CollapseModifiers(ImmutableArray<ModifierKind> requiredModifierList)
@@ -422,7 +414,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             IsAsync,
             IsReadOnly,
             IsConst,
-            Ignore // This matches any modifiers
         }
     }
 }


### PR DESCRIPTION
Adds a provider that suggests names when a name is required after a TypeSyntax. The provider determines what kinds of symbols could be declared after the type and uses the user's naming rules + some built in rules to suggest (with a builder) some possible names.

![image](https://cloud.githubusercontent.com/assets/3751401/24017756/7ead331e-0a4e-11e7-8caf-6074cac972d6.png)
![image](https://cloud.githubusercontent.com/assets/3751401/24017920/2f19cdf2-0a4f-11e7-837e-468ac00cf77d.png)
