### PR TITLE
Forbid a void assignment to a discard.

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -3,3 +3,6 @@ Changes since VS2017 (C# 7)
 
 - https://github.com/dotnet/roslyn/issues/17089
 In C# 7, the compiler accepted a pattern of the form `dynamic identifier`, e.g. `if (e is dynamic x)`. This was accepted only if the expression `e` was statically of type `dynamic`. The compiler now rejects the use of the type `dynamic` for a pattern variable declaration, as no object's runtime type is `dynamic`.
+
+- https://github.com/dotnet/roslyn/issues/17674 In C# 7, the compiler accepted an assignment statement of the form `_ = M();` where M is a `void` method. The compiler now rejects that.
+

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1718,22 +1718,26 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (op1.Kind == BoundKind.DiscardExpression)
             {
-                op1 = InferTypeForDiscard((BoundDiscardExpression)op1, op2, diagnostics);
+                op1 = InferTypeForDiscardAssignment((BoundDiscardExpression)op1, op2, diagnostics);
             }
 
             return BindAssignment(node, op1, op2, diagnostics);
         }
 
-        private BoundExpression InferTypeForDiscard(BoundDiscardExpression op1, BoundExpression op2, DiagnosticBag diagnostics)
+        private BoundExpression InferTypeForDiscardAssignment(BoundDiscardExpression op1, BoundExpression op2, DiagnosticBag diagnostics)
         {
-            if (op2.Type == null)
+            var inferredType = op2.Type;
+            if (inferredType == null)
             {
                 return op1.FailInference(this, diagnostics);
             }
-            else
+
+            if (inferredType.SpecialType == SpecialType.System_Void)
             {
-                return op1.SetInferredType(op2.Type);
+                diagnostics.Add(ErrorCode.ERR_VoidAssignment, op1.Syntax.Location);
             }
+
+            return op1.SetInferredType(inferredType);
         }
 
         private BoundAssignmentOperator BindAssignment(SyntaxNode node, BoundExpression op1, BoundExpression op2, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9566,6 +9566,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A value of type &apos;void&apos; may not be assigned..
+        /// </summary>
+        internal static string ERR_VoidAssignment {
+            get {
+                return ResourceManager.GetString("ERR_VoidAssignment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The operation in question is undefined on void pointers.
         /// </summary>
         internal static string ERR_VoidError {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5035,4 +5035,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>Feature '{0}' is not available in C# 7.1.  Please use language version {1} or greater.</value>
   </data>
+  <data name="ERR_VoidAssignment" xml:space="preserve">
+    <value>A value of type 'void' may not be assigned.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1464,6 +1464,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_TypeForwardedToMultipleAssemblies = 8206,
         ERR_ExpressionTreeContainsDiscard = 8207,
         ERR_PatternDynamicType = 8208,
+        ERR_VoidAssignment = 8209,
         #endregion more stragglers for C# 7
 
         ERR_Merge_conflict_marker_encountered = 8300,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -23347,5 +23347,25 @@ namespace ConsoleApplication1
                 Diagnostic(ErrorCode.ERR_ExpressionTreeContainsThrowExpression, "throw null").WithLocation(16, 49)
                 );
         }
+
+        [Fact, WorkItem(17674, "https://github.com/dotnet/roslyn/issues/17674")]
+        public void VoidDiscardAssignment()
+        {
+            var text = @"
+class Program
+{
+    public static void Main(string[] args)
+    {
+        _ = M();
+    }
+    static void M() { }
+}
+";
+            CreateCompilationWithMscorlibAndSystemCore(text).VerifyDiagnostics(
+                // (6,9): error CS8209: A value of type 'void' may not be assigned.
+                //         _ = M();
+                Diagnostic(ErrorCode.ERR_VoidAssignment, "_").WithLocation(6, 9)
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes #17674 

Note that this is under review of @dotnet/roslyn-compat-council and integration will be held until a final approval.

@dotnet/roslyn-compiler Please review.
