### PR TITLE
Don't require an invisible editor to be opened when we're locating nodes

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
             get
             {
-                var point = FileCodeModel.EnsureEditor(() => CodeModelService.GetStartPoint(LookupNode()));
+                var point = CodeModelService.GetStartPoint(LookupNode());
                 if (point == null)
                 {
                     return null;
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         public virtual EnvDTE.TextPoint GetStartPoint(EnvDTE.vsCMPart part)
         {
-            var point = FileCodeModel.EnsureEditor(() => CodeModelService.GetStartPoint(LookupNode(), part));
+            var point = CodeModelService.GetStartPoint(LookupNode(), part);
             if (point == null)
             {
                 return null;


### PR DESCRIPTION
We implement GetStartPoint in a two step process: locate the point
directly from the tree, and then take that point and get an
EnvDTE.TextPoint from it. The first step we were opening an invisible
editor for for no good reason, which was causing us to check out files
from source control. The second step does require an invisible editor
(since EnvDTE.TextPoint is implemented by the shims) but that we were
already opting out of an editable editor for.

Going through source control, we used to open an editor for the first
step because at the time we were grabbing tab settings which required
the editor to be open, but that's no longer the case.

*Review:* @dotnet/roslyn-ide