### PR TITLE
Enable a default implementation of an interface method to be provided as part of its declaration.

### DIFF
--- a/docs/features/DefaultInterfaceImplementation.md
+++ b/docs/features/DefaultInterfaceImplementation.md
@@ -28,7 +28,4 @@ class Test1 : I1
 ```
 
 
-**Things to follow-up on:**
-- Tests MethodImplementation_02, MethodImplementation_03 and MethodImplementation_04 in src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs reflect the current decision of LDM to continue reporting errors in scenarios like those. Need to get another confirmation regarding that, as well as address concerns expressed by @gafter around the wording used by the errors.
-- None of the tests are running PEVerify or verify expected behavior by running the compiled code because, at the moment, we cannot target runtime that supports the feature. The tests should be adjusted once they are able to target a runtime with required support.
-- The feature is currently targeting 7.1 language version, that might not be the final plan.
+**Open issues and work items** are tracked in https://github.com/dotnet/roslyn/issues/17952.

--- a/docs/features/DefaultInterfaceImplementation.md
+++ b/docs/features/DefaultInterfaceImplementation.md
@@ -1,0 +1,6 @@
+Default Interface Implementation
+=========================
+
+The *Default Interface Implementation* feature enables a default implementation of an interface member to be provided as part of the interface declaration. 
+
+Here is a link to the proposal https://github.com/dotnet/csharplang/blob/master/proposals/default-interface-methods.md. 

--- a/docs/features/DefaultInterfaceImplementation.md
+++ b/docs/features/DefaultInterfaceImplementation.md
@@ -4,3 +4,31 @@ Default Interface Implementation
 The *Default Interface Implementation* feature enables a default implementation of an interface member to be provided as part of the interface declaration. 
 
 Here is a link to the proposal https://github.com/dotnet/csharplang/blob/master/proposals/default-interface-methods.md. 
+
+**What is supported:**
+- Supplying an implementation along with declaration of a regular interface method and recognizing that implementation as default implementation for the method when a type implements the interface. 
+Here is an example:
+```
+public interface I1
+{
+    void M1() 
+    {
+        System.Console.WriteLine("Default implementation of M1 is called!!!");
+    }
+}
+
+class Test1 : I1
+{
+    static void Main()
+    {
+        I1 x = new Test1();
+        x.M1();
+    }
+}
+```
+
+
+**Things to follow-up on:**
+- Tests MethodImplementation_02, MethodImplementation_03 and MethodImplementation_04 in src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs reflect the current decision of LDM to continue reporting errors in scenarios like those. Need to get another confirmation regarding that, as well as address concerns expressed by @gafter around the wording used by the errors.
+- None of the tests are running PEVerify or verify expected behavior by running the compiled code because, at the moment, we cannot target runtime that supports the feature. The tests should be adjusted once they are able to target a runtime with required support.
+- The feature is currently targeting 7.1 language version, that might not be the final plan.

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8441,6 +8441,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Target runtime doesn&apos;t support default interface implementation..
+        /// </summary>
+        internal static string ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation {
+            get {
+                return ResourceManager.GetString("ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; cannot implement interface member &apos;{1}&apos; in type &apos;{2}&apos; because the target runtime doesn&apos;t support default interface implementation..
+        /// </summary>
+        internal static string ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember {
+            get {
+                return ResourceManager.GetString("ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The type &apos;{1}&apos; exists in both &apos;{0}&apos; and &apos;{2}&apos;.
         /// </summary>
         internal static string ERR_SameFullNameAggAgg {
@@ -9806,6 +9824,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_CSCHelp {
             get {
                 return ResourceManager.GetString("IDS_CSCHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to default interface implementation.
+        /// </summary>
+        internal static string IDS_DefaultInterfaceImplementation {
+            get {
+                return ResourceManager.GetString("IDS_DefaultInterfaceImplementation", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5035,4 +5035,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_FeatureNotAvailableInVersion7_1" xml:space="preserve">
     <value>Feature '{0}' is not available in C# 7.1.  Please use language version {1} or greater.</value>
   </data>
+  <data name="IDS_DefaultInterfaceImplementation" xml:space="preserve">
+    <value>default interface implementation</value>
+  </data>
+  <data name="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation" xml:space="preserve">
+    <value>Target runtime doesn't support default interface implementation.</value>
+  </data>
+  <data name="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember" xml:space="preserve">
+    <value>'{0}' cannot implement interface member '{1}' in type '{2}' because the target runtime doesn't support default interface implementation.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1469,5 +1469,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_Merge_conflict_marker_encountered = 8300,
         ERR_InvalidPreprocessingSymbol = 8301,
         ERR_FeatureNotAvailableInVersion7_1 = 8302,
+
+        ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation = 8401,
+        ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember = 8402,
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1470,7 +1470,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InvalidPreprocessingSymbol = 8301,
         ERR_FeatureNotAvailableInVersion7_1 = 8302,
 
-        ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation = 8401,
-        ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember = 8402,
+        ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation = 8501,
+        ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember = 8502,
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -127,6 +127,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureExpressionBodiedAccessor = MessageBase + 12715,
         IDS_FeatureExpressionBodiedDeOrConstructor = MessageBase + 12716,
         IDS_ThrowExpression = MessageBase + 12717,
+
+        IDS_DefaultInterfaceImplementation = MessageBase + 12718,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -183,6 +185,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Checks are in the LanguageParser unless otherwise noted.
             switch (feature)
             {
+                // C# 7.1 features.
+                case MessageID.IDS_DefaultInterfaceImplementation:
+                    return LanguageVersion.CSharp7_1;
+
                 // C# 7 features.
                 case MessageID.IDS_FeatureBinaryLiteral:
                 case MessageID.IDS_FeatureDigitSeparator:

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -404,6 +404,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// Figure out if runtime supports default interface implementation.
+        /// The setter is provided for test purposes only.
+        /// </summary>
+        internal virtual bool RuntimeSupportsDefaultInterfaceImplementation
+        {
+            get => CorLibrary.RuntimeSupportsDefaultInterfaceImplementation;
+            set => CorLibrary.RuntimeSupportsDefaultInterfaceImplementation = value;
+        }
+
+        /// <summary>
         /// Return an array of assemblies involved in canonical type resolution of
         /// NoPia local types defined within this assembly. In other words, all 
         /// references used by previous compilation referencing this assembly.

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -404,8 +404,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Figure out if runtime supports default interface implementation.
-        /// The setter is provided for test purposes only.
+        /// Figure out if the target runtime supports default interface implementation.
+        /// The setter is provided for test purposes only, use it carefully as symbol reuse/sharing
+        /// can cause the value to have effect on multiple compilations at the same time.
         /// </summary>
         internal virtual bool RuntimeSupportsDefaultInterfaceImplementation
         {

--- a/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
@@ -21,11 +21,43 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         /// <remarks></remarks>
         private NamedTypeSymbol[] _lazySpecialTypes;
+        private ThreeState _lazyRuntimeSupportsDefaultInterfaceImplementation = ThreeState.Unknown;
 
         /// <summary>
         /// How many Cor types have we cached so far.
         /// </summary>
         private int _cachedSpecialTypes;
+
+        internal override bool RuntimeSupportsDefaultInterfaceImplementation
+        {
+            get
+            {
+                if ((object)CorLibrary == this)
+                {
+                    if (!_lazyRuntimeSupportsDefaultInterfaceImplementation.HasValue())
+                    {
+                        // PROTOTYPE(DefaultInterfaceImplementation): Implement real detection if the feature is supported by the runtime
+                        // For now we assume that it is supported by default
+                        _lazyRuntimeSupportsDefaultInterfaceImplementation = ThreeState.True;
+                    }
+
+                    return _lazyRuntimeSupportsDefaultInterfaceImplementation.Value();
+                }
+
+                return base.RuntimeSupportsDefaultInterfaceImplementation;
+            }
+            set
+            {
+                if ((object)CorLibrary == this)
+                {
+                    Debug.Assert(!_lazyRuntimeSupportsDefaultInterfaceImplementation.HasValue());
+                    _lazyRuntimeSupportsDefaultInterfaceImplementation = value.ToThreeState();
+                    return;
+                }
+
+                base.RuntimeSupportsDefaultInterfaceImplementation = value;
+            }
+        }
 
         /// <summary>
         /// Lookup declaration for predefined CorLib type in this Assembly.

--- a/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -58,6 +59,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return _lazySpecialTypes[(int)type];
+        }
+
+        internal override bool RuntimeSupportsDefaultInterfaceImplementation
+        {
+            get
+            {
+                // For now we assume that it is not supported by default
+                Debug.Assert((object)CorLibrary == this);
+                return false;
+            }
+            set
+            {
+                Debug.Assert((object)CorLibrary == this);
+                throw ExceptionUtilities.Unreachable;
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -1558,13 +1558,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Checks to see if a body is legal given the current modifiers.
         /// If it is not, a diagnostic is added with the current type.
         /// </summary>
-        protected void CheckModifiersForBody(SyntaxNode syntax, Location location, DiagnosticBag diagnostics)
+        protected void CheckModifiersForBody(SyntaxNode declarationSyntax, Location location, DiagnosticBag diagnostics)
         {
             if (_containingType.IsInterface)
             {
                 if (!this.IsAccessor())
                 {
-                    Binder.CheckFeatureAvailability(syntax, MessageID.IDS_DefaultInterfaceImplementation, diagnostics, location);
+                    Binder.CheckFeatureAvailability(declarationSyntax, MessageID.IDS_DefaultInterfaceImplementation, diagnostics, location);
 
                     if (!ContainingAssembly.RuntimeSupportsDefaultInterfaceImplementation)
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -1558,11 +1558,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Checks to see if a body is legal given the current modifiers.
         /// If it is not, a diagnostic is added with the current type.
         /// </summary>
-        protected void CheckModifiersForBody(Location location, DiagnosticBag diagnostics)
+        protected void CheckModifiersForBody(SyntaxNode syntax, Location location, DiagnosticBag diagnostics)
         {
             if (_containingType.IsInterface)
             {
-                diagnostics.Add(ErrorCode.ERR_InterfaceMemberHasBody, location, this);
+                if (!this.IsAccessor())
+                {
+                    Binder.CheckFeatureAvailability(syntax, MessageID.IDS_DefaultInterfaceImplementation, diagnostics, location);
+
+                    if (!ContainingAssembly.RuntimeSupportsDefaultInterfaceImplementation)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, location);
+                    }
+                }
+                else
+                {
+                    diagnostics.Add(ErrorCode.ERR_InterfaceMemberHasBody, location, this);
+                }
             }
             else if (IsExtern && !IsAbstract)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.MakeFlags(MethodKind.PropertyGet, declarationModifiers, returnsVoid: false, isExtensionMethod: false,
                 isMetadataVirtualIgnoringModifiers: explicitInterfaceImplementations.Any());
 
-            CheckModifiersForBody(location, diagnostics);
+            CheckModifiersForBody(syntax, location, diagnostics);
 
             var info = ModifierUtils.CheckAccessibility(this.DeclarationModifiers);
             if (info != null)
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (hasBody || hasExpressionBody)
             {
-                CheckModifiersForBody(location, diagnostics);
+                CheckModifiersForBody(syntax, location, diagnostics);
             }
 
             var info = ModifierUtils.CheckAccessibility(this.DeclarationModifiers);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -861,7 +861,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 CheckForImplementationOfCorrespondingPropertyOrEvent((MethodSymbol)interfaceMember, implementingType, implementingTypeIsFromSomeCompilation, ref implicitImpl);
             }
 
-            if ((object)implicitImpl == null && (object)closestMismatch == null)
+            if ((object)implicitImpl == null)
             {
                 // Check for default interface implementations
                 if (!interfaceMember.IsAbstract)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -861,7 +861,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 CheckForImplementationOfCorrespondingPropertyOrEvent((MethodSymbol)interfaceMember, implementingType, implementingTypeIsFromSomeCompilation, ref implicitImpl);
             }
 
-            if ((object)implicitImpl == null)
+            if ((object)implicitImpl == null && seenTypeDeclaringInterface)
             {
                 // Check for default interface implementations
                 if (!interfaceMember.IsAbstract)

--- a/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
+++ b/src/Compilers/CSharp/Test/Symbol/CSharpCompilerSymbolTest.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Symbols\CorLibrary\Choosing.cs" />
     <Compile Include="Symbols\CorLibrary\CorTypes.cs" />
     <Compile Include="Symbols\CustomModifiersTests.cs" />
+    <Compile Include="Symbols\DefaultInterfaceImplementationTests.cs" />
     <Compile Include="Symbols\DestructorTests.cs" />
     <Compile Include="Symbols\EnumTests.cs" />
     <Compile Include="Symbols\ErrorTypeSymbolTests.cs" />

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -207,6 +207,9 @@ public interface I1
 class Test1 : I1
 {}
 ";
+
+            // Avoid sharing mscorlib symbols with other tests since we are about to change
+            // RuntimeSupportsDefaultInterfaceImplementation property for it.
             var mscorLibRef = MscorlibRefWithoutSharingCachedSymbols;
             var compilation1 = CreateCompilation(source1, new [] { mscorLibRef }, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
@@ -222,7 +225,7 @@ class Test1 : I1
             Assert.Same(m1, test1.FindImplementationForInterfaceMember(m1));
 
             compilation1.VerifyDiagnostics(
-                // (4,10): error CS8401: Target runtime doesn't support default interface implementation.
+                // (4,10): error CS8501: Target runtime doesn't support default interface implementation.
                 //     void M1() 
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, "M1").WithLocation(4, 10)
                 );
@@ -244,7 +247,7 @@ class Test2 : I1
             Assert.Same(m1, test2.FindImplementationForInterfaceMember(m1));
 
             compilation3.VerifyDiagnostics(
-                // (2,15): error CS8402: 'I1.M1()' cannot implement interface member 'I1.M1()' in type 'Test2' because the target runtime doesn't support default interface implementation.
+                // (2,15): error CS8502: 'I1.M1()' cannot implement interface member 'I1.M1()' in type 'Test2' because the target runtime doesn't support default interface implementation.
                 // class Test2 : I1
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember, "I1").WithArguments("I1.M1()", "I1.M1()", "Test2").WithLocation(2, 15)
                 );
@@ -284,7 +287,7 @@ class Test1 : I1
                 // (4,10): error CS8107: Feature 'default interface implementation' is not available in C# 7.  Please use language version 7.1 or greater.
                 //     void M1() 
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "M1").WithArguments("default interface implementation", "7.1").WithLocation(4, 10),
-                // (4,10): error CS8401: Target runtime doesn't support default interface implementation.
+                // (4,10): error CS8501: Target runtime doesn't support default interface implementation.
                 //     void M1() 
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, "M1").WithLocation(4, 10)
                 );
@@ -306,7 +309,7 @@ class Test2 : I1
             Assert.Same(m1, test2.FindImplementationForInterfaceMember(m1));
 
             compilation3.VerifyDiagnostics(
-                // (2,15): error CS8402: 'I1.M1()' cannot implement interface member 'I1.M1()' in type 'Test2' because the target runtime doesn't support default interface implementation.
+                // (2,15): error CS8502: 'I1.M1()' cannot implement interface member 'I1.M1()' in type 'Test2' because the target runtime doesn't support default interface implementation.
                 // class Test2 : I1
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember, "I1").WithArguments("I1.M1()", "I1.M1()", "Test2").WithLocation(2, 15)
                 );
@@ -390,7 +393,7 @@ public interface I1
             Assert.True(m1.IsVirtual);
 
             compilation1.VerifyDiagnostics(
-                // (4,8): error CS8401: Target runtime doesn't support default interface implementation.
+                // (4,8): error CS8501: Target runtime doesn't support default interface implementation.
                 //     I1 M1() 
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, "M1").WithLocation(4, 8)
                 );

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -1,0 +1,445 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
+{
+    public class DefaultInterfaceImplementationTests : CSharpTestBase
+    {
+        [Fact]
+        public void MethodImplementation_01()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    void M1() 
+    {
+        System.Console.WriteLine(""M1"");
+    }
+}
+
+class Test1 : I1
+{}
+";
+            var compilation1 = CreateCompilationWithMscorlib(source1, options:TestOptions.DebugDll, 
+                                                             parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+            Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+
+            var m1 = compilation1.GetMember<MethodSymbol>("I1.M1");
+
+            Assert.False(m1.IsAbstract);
+            Assert.True(m1.IsVirtual);
+
+            var test1 = compilation1.GetTypeByMetadataName("Test1");
+
+            Assert.Same(m1, test1.FindImplementationForInterfaceMember(m1));
+
+            compilation1.VerifyDiagnostics();
+            Assert.True(m1.IsMetadataVirtual());
+
+            CompileAndVerify(compilation1, verify:false,  
+                symbolValidator: (m) =>
+                {
+                    var result = (PEMethodSymbol)m.GlobalNamespace.GetTypeMember("I1").GetMember("M1");
+
+                    Assert.True(m1.IsMetadataVirtual());
+                    Assert.False(m1.IsAbstract);
+                    Assert.True(m1.IsVirtual);
+
+                    int rva;
+                    ((PEModuleSymbol)m).Module.GetMethodDefPropsOrThrow(result.Handle, out _, out _, out _, out rva);
+                    Assert.NotEqual(0, rva);
+                });
+
+            var source2 =
+@"
+class Test2 : I1
+{}
+";
+
+            var compilation2 = CreateCompilationWithMscorlib(source2, new[] { compilation1.ToMetadataReference() }, options: TestOptions.DebugDll);
+            Assert.True(compilation2.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            m1 = compilation2.GetMember<MethodSymbol>("I1.M1");
+            var test2 = compilation2.GetTypeByMetadataName("Test2");
+
+            Assert.Same(m1, test2.FindImplementationForInterfaceMember(m1));
+
+            compilation2.VerifyDiagnostics();
+            CompileAndVerify(compilation2, verify: false);
+
+            var compilation3 = CreateCompilationWithMscorlib(source2, new[] { compilation1.EmitToImageReference() }, options: TestOptions.DebugDll);
+            Assert.True(compilation3.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            m1 = compilation3.GetMember<MethodSymbol>("I1.M1");
+            test2 = compilation3.GetTypeByMetadataName("Test2");
+
+            Assert.Same(m1, test2.FindImplementationForInterfaceMember(m1));
+
+            compilation3.VerifyDiagnostics();
+            CompileAndVerify(compilation3, verify: false);
+        }
+
+        [Fact]
+        public void MethodImplementation_02()
+        {
+            var source1 =
+@"
+interface I1
+{
+    void M1() {}
+    void M2() {}
+}
+
+class Base
+{
+    void M1() { }
+}
+
+class Derived : Base, I1
+{
+    void M2() { }
+}
+
+class Test : I1 {}
+";
+            var compilation1 = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugDll,
+                                                             parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+            Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            compilation1.VerifyDiagnostics(
+                // (13,23): error CS0737: 'Derived' does not implement interface member 'I1.M2()'. 'Derived.M2()' cannot implement an interface member because it is not public.
+                // class Derived : Base, I1
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberNotPublic, "I1").WithArguments("Derived", "I1.M2()", "Derived.M2()").WithLocation(13, 23),
+                // (13,23): error CS0737: 'Derived' does not implement interface member 'I1.M1()'. 'Base.M1()' cannot implement an interface member because it is not public.
+                // class Derived : Base, I1
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberNotPublic, "I1").WithArguments("Derived", "I1.M1()", "Base.M1()").WithLocation(13, 23)
+                );
+        }
+
+        [Fact]
+        public void MethodImplementation_03()
+        {
+            var source1 =
+@"
+interface I1
+{
+    void M1() {}
+}
+
+class Test1 : I1
+{
+    public static void M1() { }
+}
+
+class Test2 : I1 {}
+";
+            var compilation1 = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugDll,
+                                                             parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+            Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            compilation1.VerifyDiagnostics(
+                // (7,15): error CS0736: 'Test1' does not implement interface member 'I1.M1()'. 'Test1.M1()' cannot implement an interface member because it is static.
+                // class Test1 : I1
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberStatic, "I1").WithArguments("Test1", "I1.M1()", "Test1.M1()").WithLocation(7, 15)
+                );
+        }
+
+        [Fact]
+        public void MethodImplementation_04()
+        {
+            var source1 =
+@"
+interface I1
+{
+    void M1() {}
+    int M2() => 1; 
+}
+
+class Test1 : I1
+{
+    public int M1() { return 0; }
+    public ref int M2() { throw null; }
+}
+
+class Test2 : I1 {}
+";
+            var compilation1 = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugDll,
+                                                             parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+            Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            compilation1.VerifyDiagnostics(
+                // (8,15): error CS8152: 'Test1' does not implement interface member 'I1.M2()'. 'Test1.M2()' cannot implement 'I1.M2()' because it does not return by value
+                // class Test1 : I1
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberWrongRefReturn, "I1").WithArguments("Test1", "I1.M2()", "Test1.M2()", "value").WithLocation(8, 15),
+                // (8,15): error CS0738: 'Test1' does not implement interface member 'I1.M1()'. 'Test1.M1()' cannot implement 'I1.M1()' because it does not have the matching return type of 'void'.
+                // class Test1 : I1
+                Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberWrongReturnType, "I1").WithArguments("Test1", "I1.M1()", "Test1.M1()", "void").WithLocation(8, 15)
+                );
+        }
+
+        private static MetadataReference MscorlibRefWithoutSharingCachedSymbols
+        {
+            get
+            {
+                return ((AssemblyMetadata)((MetadataImageReference)MscorlibRef).GetMetadata()).CopyWithoutSharingCachedSymbols().
+                    GetReference(display: "mscorlib.v4_0_30319.dll");
+            }
+        }
+
+        [Fact]
+        public void MethodImplementation_05()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    void M1() 
+    {
+        System.Console.WriteLine(""M1"");
+    }
+}
+
+class Test1 : I1
+{}
+";
+            var mscorLibRef = MscorlibRefWithoutSharingCachedSymbols;
+            var compilation1 = CreateCompilation(source1, new [] { mscorLibRef }, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+            compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation = false;
+
+            var m1 = compilation1.GetMember<MethodSymbol>("I1.M1");
+
+            Assert.False(m1.IsAbstract);
+            Assert.True(m1.IsVirtual);
+
+            var test1 = compilation1.GetTypeByMetadataName("Test1");
+
+            Assert.Same(m1, test1.FindImplementationForInterfaceMember(m1));
+
+            compilation1.VerifyDiagnostics(
+                // (4,10): error CS8401: Target runtime doesn't support default interface implementation.
+                //     void M1() 
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, "M1").WithLocation(4, 10)
+                );
+
+            Assert.True(m1.IsMetadataVirtual());
+
+            var source2 =
+@"
+class Test2 : I1
+{}
+";
+
+            var compilation3 = CreateCompilation(source2, new[] { mscorLibRef, compilation1.ToMetadataReference() }, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+            Assert.False(compilation3.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            m1 = compilation3.GetMember<MethodSymbol>("I1.M1");
+            var test2 = compilation3.GetTypeByMetadataName("Test2");
+
+            Assert.Same(m1, test2.FindImplementationForInterfaceMember(m1));
+
+            compilation3.VerifyDiagnostics(
+                // (2,15): error CS8402: 'I1.M1()' cannot implement interface member 'I1.M1()' in type 'Test2' because the target runtime doesn't support default interface implementation.
+                // class Test2 : I1
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember, "I1").WithArguments("I1.M1()", "I1.M1()", "Test2").WithLocation(2, 15)
+                );
+        }
+
+        [Fact]
+        public void MethodImplementation_06()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    void M1() 
+    {
+        System.Console.WriteLine(""M1"");
+    }
+}
+
+class Test1 : I1
+{}
+";
+            var mscorLibRef = MscorlibRefWithoutSharingCachedSymbols;
+            var compilation1 = CreateCompilation(source1, new[] { mscorLibRef }, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation = false;
+
+            var m1 = compilation1.GetMember<MethodSymbol>("I1.M1");
+
+            Assert.False(m1.IsAbstract);
+            Assert.True(m1.IsVirtual);
+
+            var test1 = compilation1.GetTypeByMetadataName("Test1");
+
+            Assert.Same(m1, test1.FindImplementationForInterfaceMember(m1));
+
+            compilation1.VerifyDiagnostics(
+                // (4,10): error CS8107: Feature 'default interface implementation' is not available in C# 7.  Please use language version 7.1 or greater.
+                //     void M1() 
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "M1").WithArguments("default interface implementation", "7.1").WithLocation(4, 10),
+                // (4,10): error CS8401: Target runtime doesn't support default interface implementation.
+                //     void M1() 
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, "M1").WithLocation(4, 10)
+                );
+
+            Assert.True(m1.IsMetadataVirtual());
+
+            var source2 =
+@"
+class Test2 : I1
+{}
+";
+
+            var compilation3 = CreateCompilation(source2, new[] { mscorLibRef, compilation1.ToMetadataReference() }, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            Assert.False(compilation3.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            m1 = compilation3.GetMember<MethodSymbol>("I1.M1");
+            var test2 = compilation3.GetTypeByMetadataName("Test2");
+
+            Assert.Same(m1, test2.FindImplementationForInterfaceMember(m1));
+
+            compilation3.VerifyDiagnostics(
+                // (2,15): error CS8402: 'I1.M1()' cannot implement interface member 'I1.M1()' in type 'Test2' because the target runtime doesn't support default interface implementation.
+                // class Test2 : I1
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember, "I1").WithArguments("I1.M1()", "I1.M1()", "Test2").WithLocation(2, 15)
+                );
+        }
+
+        [Fact]
+        public void MethodImplementation_07()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    void M1() 
+    {
+        System.Console.WriteLine(""M1"");
+    }
+}
+
+class Test1 : I1
+{}
+";
+            var compilation1 = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+
+            var m1 = compilation1.GetMember<MethodSymbol>("I1.M1");
+
+            Assert.False(m1.IsAbstract);
+            Assert.True(m1.IsVirtual);
+
+            var test1 = compilation1.GetTypeByMetadataName("Test1");
+
+            Assert.Same(m1, test1.FindImplementationForInterfaceMember(m1));
+
+            compilation1.VerifyDiagnostics(
+                // (4,10): error CS8107: Feature 'default interface implementation' is not available in C# 7.  Please use language version 7.1 or greater.
+                //     void M1() 
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "M1").WithArguments("default interface implementation", "7.1").WithLocation(4, 10)
+                );
+
+            Assert.True(m1.IsMetadataVirtual());
+
+            var source2 =
+@"
+class Test2 : I1
+{}
+";
+
+            var compilation2 = CreateCompilationWithMscorlib(source2, new[] { compilation1.ToMetadataReference() }, options: TestOptions.DebugDll,
+                                                            parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            Assert.True(compilation2.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+            m1 = compilation2.GetMember<MethodSymbol>("I1.M1");
+            var test2 = compilation2.GetTypeByMetadataName("Test2");
+
+            Assert.Same(m1, test2.FindImplementationForInterfaceMember(m1));
+
+            compilation2.VerifyDiagnostics();
+            CompileAndVerify(compilation2, verify: false);
+        }
+
+        [Fact]
+        public void MethodImplementation_08()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    I1 M1() 
+    {
+        throw null;
+    }
+}
+";
+            var compilation1 = CreateCompilation(source1, new[] { SystemCoreRef }, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
+            Assert.False(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+
+            var m1 = compilation1.GetMember<MethodSymbol>("I1.M1");
+
+            Assert.False(m1.IsAbstract);
+            Assert.True(m1.IsVirtual);
+
+            compilation1.VerifyDiagnostics(
+                // (4,8): error CS8401: Target runtime doesn't support default interface implementation.
+                //     I1 M1() 
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, "M1").WithLocation(4, 8)
+                );
+
+            Assert.True(m1.IsMetadataVirtual());
+
+            Assert.Throws<System.InvalidOperationException>(() => compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation = false);
+        }
+
+        [Fact]
+        public void MethodImplementation_09()
+        {
+            var source1 =
+@"
+public interface I1
+{
+    static void M1() 
+    {
+        System.Console.WriteLine(""M1"");
+    }
+}
+
+class Test1 : I1
+{}
+";
+            var compilation1 = CreateCompilationWithMscorlib(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
+            Assert.True(compilation1.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
+
+            var m1 = compilation1.GetMember<MethodSymbol>("I1.M1");
+
+            Assert.False(m1.IsAbstract);
+            Assert.True(m1.IsVirtual);
+            Assert.False(m1.IsStatic);
+
+            var test1 = compilation1.GetTypeByMetadataName("Test1");
+
+            Assert.Same(m1, test1.FindImplementationForInterfaceMember(m1));
+
+            compilation1.VerifyDiagnostics(
+                // (4,17): error CS0106: The modifier 'static' is not valid for this item
+                //     static void M1() 
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "M1").WithArguments("static").WithLocation(4, 17),
+                // (4,17): error CS8107: Feature 'default interface implementation' is not available in C# 7.  Please use language version 7.1 or greater.
+                //     static void M1() 
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "M1").WithArguments("default interface implementation", "7.1").WithLocation(4, 17)
+                );
+
+            Assert.True(m1.IsMetadataVirtual());
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedMethodTests.cs
@@ -85,9 +85,10 @@ interface C
     int M() => 1;
 }");
             comp.VerifyDiagnostics(
-    // (4,9): error CS0531: 'C.M()': interface members cannot have a definition
-    //     int M() => 1;
-    Diagnostic(ErrorCode.ERR_InterfaceMemberHasBody, "M").WithArguments("C.M()").WithLocation(4, 9));
+                // (4,9): error CS8107: Feature 'default interface implementation' is not available in C# 7.  Please use language version 7.1 or greater.
+                //     int M() => 1;
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "M").WithArguments("default interface implementation", "7.1").WithLocation(4, 9)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -8803,11 +8803,11 @@ struct S6<T>
 ";
             var comp = DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
                 new ErrorDescription { Code = (int)ErrorCode.ERR_SemicolonExpected, Line = 14, Column = 39 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_InterfaceMemberHasBody, Line = 5, Column = 13 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_InterfaceMemberHasBody, Line = 6, Column = 14 },
+                new ErrorDescription { Code = (int)ErrorCode.ERR_FeatureNotAvailableInVersion7, Line = 5, Column = 13 },
+                new ErrorDescription { Code = (int)ErrorCode.ERR_FeatureNotAvailableInVersion7, Line = 6, Column = 14 },
                 new ErrorDescription { Code = (int)ErrorCode.ERR_InterfaceMemberHasBody, Line = 7, Column = 20 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_InterfaceMemberHasBody, Line = 12, Column = 11 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_InterfaceMemberHasBody, Line = 13, Column = 14 },
+                new ErrorDescription { Code = (int)ErrorCode.ERR_FeatureNotAvailableInVersion7, Line = 12, Column = 11 },
+                new ErrorDescription { Code = (int)ErrorCode.ERR_FeatureNotAvailableInVersion7, Line = 13, Column = 14 },
                 new ErrorDescription { Code = (int)ErrorCode.ERR_InterfaceMemberHasBody, Line = 14, Column = 15 },
                 new ErrorDescription { Code = (int)ErrorCode.ERR_InterfaceMemberHasBody, Line = 14, Column = 41 });
 

--- a/src/Compilers/Core/Portable/MetadataReference/AssemblyMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/AssemblyMetadata.cs
@@ -70,10 +70,14 @@ namespace Microsoft.CodeAnalysis
         internal readonly WeakList<IAssemblySymbol> CachedSymbols = new WeakList<IAssemblySymbol>();
 
         // creates a copy
-        private AssemblyMetadata(AssemblyMetadata other)
+        private AssemblyMetadata(AssemblyMetadata other, bool shareCachedSymbols)
             : base(isImageOwner: false, id: other.Id)
         {
-            this.CachedSymbols = other.CachedSymbols;
+            if (shareCachedSymbols)
+            {
+                this.CachedSymbols = other.CachedSymbols;
+            }
+
             _lazyData = other._lazyData;
             _moduleFactoryOpt = other._moduleFactoryOpt;
             _initialModules = other._initialModules;
@@ -250,7 +254,12 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         internal new AssemblyMetadata Copy()
         {
-            return new AssemblyMetadata(this);
+            return new AssemblyMetadata(this, shareCachedSymbols: true);
+        }
+
+        internal AssemblyMetadata CopyWithoutSharingCachedSymbols()
+        {
+            return new AssemblyMetadata(this, shareCachedSymbols: false);
         }
 
         protected override Metadata CommonCopy()

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -6637,7 +6637,47 @@ class Class : IInterface
 
         [WorkItem(15387, "https://github.com/dotnet/roslyn/issues/15387")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
-        public async Task TestDoNotReorderComImportMembers()
+        public async Task TestDoNotReorderComImportMembers_01()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System.Runtime.InteropServices;
+
+[ComImport]
+interface IComInterface
+{
+    void MOverload();
+    void X();
+    void MOverload(int i);
+    int Prop { get; }
+}
+
+class Class : [|IComInterface|]
+{
+}",
+@"using System.Runtime.InteropServices;
+
+[ComImport]
+interface IComInterface
+{
+    void MOverload();
+    void X();
+    void MOverload(int i);
+    int Prop { get; }
+}
+
+class Class : IComInterface
+{
+    public void MOverload() { throw new System.NotImplementedException(); }
+    public void X() { throw new System.NotImplementedException(); }
+    public void MOverload(int i) { throw new System.NotImplementedException(); }
+    public int Prop => throw new System.NotImplementedException();
+}");
+        }
+
+        [WorkItem(15387, "https://github.com/dotnet/roslyn/issues/15387")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TestDoNotReorderComImportMembers_02()
         {
             await TestInRegularAndScriptAsync(
 @"
@@ -6668,9 +6708,6 @@ interface IComInterface
 
 class Class : IComInterface
 {
-    public void MOverload() { throw new System.NotImplementedException(); }
-    public void X() { throw new System.NotImplementedException(); }
-    public void MOverload(int i) { throw new System.NotImplementedException(); }
     public int Prop => throw new System.NotImplementedException();
 }");
         }


### PR DESCRIPTION
@dotnet/roslyn-compiler Please review.