### PR TITLE
Port the rename integration tests to the new framework.

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
@@ -1,0 +1,447 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
+using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.IntegrationTests.Extensions;
+using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpRename : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+
+        private InlineRenameDialog_OutOfProc InlineRenameDialog => VisualStudio.Instance.InlineRenameDialog;
+
+        public CSharpRename(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory, nameof(CSharpRename))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyLocalVariableRename()
+        {
+            var markup = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        int [|x|]$$ = 0;
+        [|x|] = 5;
+        TestMethod([|x|]);
+    }
+
+    static void TestMethod(int y)
+    {
+
+    }
+}";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        int y = 0;
+        y = 5;
+        TestMethod(y);
+    }
+
+    static void TestMethod(int y)
+    {
+
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyLocalVariableRenameWithCommentsUpdated()
+        {
+            // "variable" is intentionally misspelled as "varixable" and "this" is misspelled as
+            // "thix" below to ensure we don't change instances of "x" in comments that are part of
+            // larger words
+            var markup = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    /// <summary>
+    /// creates a varixable named [|x|] xx
+    /// </summary>
+    /// <param name=""args""></param>
+    static void Main(string[] args)
+    {
+        // thix varixable is named [|x|] xx
+        int [|x|]$$ = 0;
+        [|x|] = 5;
+        TestMethod([|x|]);
+    }
+
+    static void TestMethod(int y)
+    {
+        /*
+         * [|x|]
+         * xx
+         */
+    }
+}";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+            InlineRenameDialog.ToggleIncludeComments();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    /// <summary>
+    /// creates a varixable named y xx
+    /// </summary>
+    /// <param name=""args""></param>
+    static void Main(string[] args)
+    {
+        // thix varixable is named y xx
+        int y = 0;
+        y = 5;
+        TestMethod(y);
+    }
+
+    static void TestMethod(int y)
+    {
+        /*
+         * y
+         * xx
+         */
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyLocalVariableRenameWithStringsUpdated()
+        {
+            var markup = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        int [|x|]$$ = 0;
+        [|x|] = 5;
+        var s = ""[|x|] xx [|x|]"";
+        var sLiteral = 
+            @""
+            [|x|]
+            xx
+            [|x|]
+            "";
+        char c = 'x';
+        char cUnit = '\u0078';
+    }
+}";
+            SetUpEditor(markup);
+
+            InlineRenameDialog.Invoke();
+            InlineRenameDialog.ToggleIncludeStrings();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        int y = 0;
+        y = 5;
+        var s = ""y xx y"";
+        var sLiteral = 
+            @""
+            y
+            xx
+            y
+            "";
+        char c = 'x';
+        char cUnit = '\u0078';
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyOverloadsUpdated()
+        {
+            var markup = @"
+interface I
+{
+    void [|TestMethod|]$$(int y);
+    void [|TestMethod|](string y);
+}
+
+class B : I
+{
+    public virtual void [|TestMethod|](int y)
+    { }
+
+    public virtual void [|TestMethod|](string y)
+    { }
+}";
+            SetUpEditor(markup);
+
+            InlineRenameDialog.Invoke();
+            InlineRenameDialog.ToggleIncludeOverloads();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+interface I
+{
+    void y(int y);
+    void y(string y);
+}
+
+class B : I
+{
+    public virtual void y(int y)
+    { }
+
+    public virtual void y(string y)
+    { }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyMultiFileRename()
+        {
+            SetUpEditor(@"
+class $$Program
+{
+}");
+
+            VisualStudio.Instance.SolutionExplorer.AddFile(ProjectName, "Class2.cs", @"");
+            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class2.cs");
+
+            const string class2Markup = @"
+class SomeOtherClass
+{
+    void M()
+    {
+        [|Program|] p = new [|Program|]();
+    }
+}";
+            MarkupTestFile.GetSpans(class2Markup, out var code, out ImmutableArray<TextSpan> renameSpans);
+
+            Editor.SetText(code);
+            this.PlaceCaret("Program");
+
+            InlineRenameDialog.Invoke();
+
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+class SomeOtherClass
+{
+    void M()
+    {
+        y p = new y();
+    }
+}");
+
+            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class1.cs");
+            this.VerifyTextContains(@"
+class y
+{
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyRenameCancellation()
+        {
+            SetUpEditor(@"
+class $$Program
+{
+}");
+
+            VisualStudio.Instance.SolutionExplorer.AddFile(ProjectName, "Class2.cs", @"");
+            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class2.cs");
+            Editor.SetText(@"
+class SomeOtherClass
+{
+    void M()
+    {
+        Program p = new Program();
+    }
+}");
+            this.PlaceCaret("Program");
+
+            InlineRenameDialog.Invoke();
+
+            Editor.SendKeys(VirtualKey.Y);
+            this.VerifyTextContains(@"class SomeOtherClass
+{
+    void M()
+    {
+        y p = new y();
+    }
+}");
+
+            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class1.cs");
+            this.VerifyTextContains(@"
+class y
+{
+}");
+
+            Editor.SendKeys(VirtualKey.Escape);
+            this.WaitForAsyncOperations(FeatureAttribute.Rename);
+
+            this.VerifyTextContains(@"
+class Program
+{
+}");
+
+            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class2.cs");
+            this.VerifyTextContains(@"
+class SomeOtherClass
+{
+    void M()
+    {
+        Program p = new Program();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyCrossProjectRename()
+        {
+            SetUpEditor(@"
+$$class RenameRocks 
+{
+    static void Main(string[] args)
+    {
+        Class2 c = null;
+        c.ToString();
+    }
+}");
+
+            VisualStudio.Instance.SolutionExplorer.AddProject("Project2", WellKnownProjectTemplates.ClassLibrary, LanguageName);
+            VisualStudio.Instance.SolutionExplorer.AddProjectReference(fromProjectName: ProjectName, toProjectName: "Project2");
+
+            VisualStudio.Instance.SolutionExplorer.AddFile("Project2", "Class2.cs", @"");
+            VisualStudio.Instance.SolutionExplorer.OpenFile("Project2", "Class2.cs");
+
+
+            Editor.SetText(@"
+public class Class2 { static void Main(string [] args) { } }");
+
+            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class1.cs");
+            this.PlaceCaret("Class2");
+
+            InlineRenameDialog.Invoke();
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+
+            this.VerifyTextContains(@"
+class RenameRocks 
+{
+    static void Main(string[] args)
+    {
+        y c = null;
+        c.ToString();
+    }
+}");
+
+            VisualStudio.Instance.SolutionExplorer.OpenFile("Project2", "Class2.cs");
+            this.VerifyTextContains(@"
+public class y { static void Main(string [] args) { } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyRenameUndo()
+        {
+            VerifyCrossProjectRename();
+
+            Editor.SendKeys(Ctrl(VirtualKey.Z));
+
+            this.VerifyTextContains(@"
+public class Class2 { static void Main(string [] args) { } }");
+
+            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class1.cs");
+            this.VerifyTextContains(@"
+class RenameRocks 
+{
+    static void Main(string[] args)
+    {
+        Class2 c = null;
+        c.ToString();
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyRenameInStandaloneFiles()
+        {
+            VisualStudio.Instance.SolutionExplorer.CloseSolution();
+            VisualStudio.Instance.SolutionExplorer.AddStandaloneFile("StandaloneFile1.cs");
+            Editor.SetText(@"
+class Program
+{
+    void Foo()
+    {
+        var ids = 1;
+        ids = 2;
+    }
+}");
+            this.PlaceCaret("ids");
+
+            InlineRenameDialog.Invoke();
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+
+            this.VerifyTextContains(@"
+class Program
+{
+    void Foo()
+    {
+        var y = 1;
+        y = 2;
+    }
+}");
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -9,9 +8,8 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
-using Roslyn.VisualStudio.IntegrationTests.Extensions;
-using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
 using Xunit;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -20,7 +18,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        private InlineRenameDialog_OutOfProc InlineRenameDialog => VisualStudio.Instance.InlineRenameDialog;
+        private InlineRenameDialog_OutOfProc InlineRenameDialog => VisualStudio.InlineRenameDialog;
 
         public CSharpRename(VisualStudioInstanceFactory instanceFactory)
             : base(instanceFactory, nameof(CSharpRename))
@@ -53,11 +51,11 @@ class Program
             InlineRenameDialog.Invoke();
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -116,11 +114,11 @@ class Program
             InlineRenameDialog.ToggleIncludeComments();
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -176,11 +174,11 @@ class Program
             InlineRenameDialog.ToggleIncludeStrings();
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 class Program
 {
     static void Main(string[] args)
@@ -224,11 +222,11 @@ class B : I
             InlineRenameDialog.ToggleIncludeOverloads();
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 interface I
 {
     void y(int y);
@@ -252,9 +250,9 @@ class B : I
 class $$Program
 {
 }");
-
-            VisualStudio.Instance.SolutionExplorer.AddFile(ProjectName, "Class2.cs", @"");
-            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class2.cs");
+            var project = new ProjectUtils.Project(ProjectName);
+            VisualStudio.SolutionExplorer.AddFile(project, "Class2.cs", @"");
+            VisualStudio.SolutionExplorer.OpenFile(project, "Class2.cs");
 
             const string class2Markup = @"
 class SomeOtherClass
@@ -266,16 +264,16 @@ class SomeOtherClass
 }";
             MarkupTestFile.GetSpans(class2Markup, out var code, out ImmutableArray<TextSpan> renameSpans);
 
-            Editor.SetText(code);
-            this.PlaceCaret("Program");
+            VisualStudio.Editor.SetText(code);
+            VisualStudio.Editor.PlaceCaret("Program");
 
             InlineRenameDialog.Invoke();
 
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 class SomeOtherClass
 {
     void M()
@@ -284,8 +282,8 @@ class SomeOtherClass
     }
 }");
 
-            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class1.cs");
-            this.VerifyTextContains(@"
+            VisualStudio.SolutionExplorer.OpenFile(project, "Class1.cs");
+            VisualStudio.Editor.Verify.TextContains(@"
 class y
 {
 }");
@@ -299,9 +297,10 @@ class $$Program
 {
 }");
 
-            VisualStudio.Instance.SolutionExplorer.AddFile(ProjectName, "Class2.cs", @"");
-            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class2.cs");
-            Editor.SetText(@"
+            var project = new ProjectUtils.Project(ProjectName);
+            VisualStudio.SolutionExplorer.AddFile(project, "Class2.cs", @"");
+            VisualStudio.SolutionExplorer.OpenFile(project, "Class2.cs");
+            VisualStudio.Editor.SetText(@"
 class SomeOtherClass
 {
     void M()
@@ -309,12 +308,12 @@ class SomeOtherClass
         Program p = new Program();
     }
 }");
-            this.PlaceCaret("Program");
+            VisualStudio.Editor.PlaceCaret("Program");
 
             InlineRenameDialog.Invoke();
 
-            Editor.SendKeys(VirtualKey.Y);
-            this.VerifyTextContains(@"class SomeOtherClass
+            VisualStudio.Editor.SendKeys(VirtualKey.Y);
+            VisualStudio.Editor.Verify.TextContains(@"class SomeOtherClass
 {
     void M()
     {
@@ -322,22 +321,22 @@ class SomeOtherClass
     }
 }");
 
-            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class1.cs");
-            this.VerifyTextContains(@"
+            VisualStudio.SolutionExplorer.OpenFile(project, "Class1.cs");
+            VisualStudio.Editor.Verify.TextContains(@"
 class y
 {
 }");
 
-            Editor.SendKeys(VirtualKey.Escape);
-            this.WaitForAsyncOperations(FeatureAttribute.Rename);
+            VisualStudio.Editor.SendKeys(VirtualKey.Escape);
+            VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.Rename);
 
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.Verify.TextContains(@"
 class Program
 {
 }");
 
-            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class2.cs");
-            this.VerifyTextContains(@"
+            VisualStudio.SolutionExplorer.OpenFile(project, "Class2.cs");
+            VisualStudio.Editor.Verify.TextContains(@"
 class SomeOtherClass
 {
     void M()
@@ -359,24 +358,26 @@ $$class RenameRocks
         c.ToString();
     }
 }");
+            var project1 = new ProjectUtils.Project(ProjectName);
+            var project2 = new ProjectUtils.Project("Project2");
 
-            VisualStudio.Instance.SolutionExplorer.AddProject("Project2", WellKnownProjectTemplates.ClassLibrary, LanguageName);
-            VisualStudio.Instance.SolutionExplorer.AddProjectReference(fromProjectName: ProjectName, toProjectName: "Project2");
+            VisualStudio.SolutionExplorer.AddProject(project2, WellKnownProjectTemplates.ClassLibrary, LanguageName);
+            VisualStudio.SolutionExplorer.AddProjectReference(fromProjectName: project1, toProjectName: new ProjectUtils.ProjectReference("Project2"));
 
-            VisualStudio.Instance.SolutionExplorer.AddFile("Project2", "Class2.cs", @"");
-            VisualStudio.Instance.SolutionExplorer.OpenFile("Project2", "Class2.cs");
+            VisualStudio.SolutionExplorer.AddFile(project2, "Class2.cs", @"");
+            VisualStudio.SolutionExplorer.OpenFile(project2, "Class2.cs");
 
 
-            Editor.SetText(@"
+            VisualStudio.Editor.SetText(@"
 public class Class2 { static void Main(string [] args) { } }");
 
-            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class1.cs");
-            this.PlaceCaret("Class2");
+            VisualStudio.SolutionExplorer.OpenFile(project1, "Class1.cs");
+            VisualStudio.Editor.PlaceCaret("Class2");
 
             InlineRenameDialog.Invoke();
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
 
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.Verify.TextContains(@"
 class RenameRocks 
 {
     static void Main(string[] args)
@@ -386,8 +387,8 @@ class RenameRocks
     }
 }");
 
-            VisualStudio.Instance.SolutionExplorer.OpenFile("Project2", "Class2.cs");
-            this.VerifyTextContains(@"
+            VisualStudio.SolutionExplorer.OpenFile(project2, "Class2.cs");
+            VisualStudio.Editor.Verify.TextContains(@"
 public class y { static void Main(string [] args) { } }");
         }
 
@@ -396,13 +397,13 @@ public class y { static void Main(string [] args) { } }");
         {
             VerifyCrossProjectRename();
 
-            Editor.SendKeys(Ctrl(VirtualKey.Z));
+            VisualStudio.Editor.SendKeys(Ctrl(VirtualKey.Z));
 
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.Verify.TextContains(@"
 public class Class2 { static void Main(string [] args) { } }");
 
-            VisualStudio.Instance.SolutionExplorer.OpenFile(ProjectName, "Class1.cs");
-            this.VerifyTextContains(@"
+            VisualStudio.SolutionExplorer.OpenFile(new ProjectUtils.Project(ProjectName), "Class1.cs");
+            VisualStudio.Editor.Verify.TextContains(@"
 class RenameRocks 
 {
     static void Main(string[] args)
@@ -416,9 +417,9 @@ class RenameRocks
         [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
         public void VerifyRenameInStandaloneFiles()
         {
-            VisualStudio.Instance.SolutionExplorer.CloseSolution();
-            VisualStudio.Instance.SolutionExplorer.AddStandaloneFile("StandaloneFile1.cs");
-            Editor.SetText(@"
+            VisualStudio.SolutionExplorer.CloseSolution();
+            VisualStudio.SolutionExplorer.AddStandaloneFile("StandaloneFile1.cs");
+            VisualStudio.Editor.SetText(@"
 class Program
 {
     void Foo()
@@ -427,13 +428,13 @@ class Program
         ids = 2;
     }
 }");
-            this.PlaceCaret("ids");
+            VisualStudio.Editor.PlaceCaret("ids");
 
             InlineRenameDialog.Invoke();
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
 
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.Verify.TextContains(@"
 class Program
 {
     void Foo()

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
+using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class BasicRename : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.VisualBasic;
+
+        private InlineRenameDialog_OutOfProc InlineRenameDialog => VisualStudio.Instance.InlineRenameDialog;
+
+        public BasicRename(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory, nameof(BasicRename))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyLocalVariableRename()
+        {
+            var markup = @"
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim [|x|]$$ As Integer = 0
+        [|x|] = 5
+        TestMethod([|x|])
+    End Sub
+    Sub TestMethod(y As Integer)
+
+    End Sub
+End Module";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim y As Integer = 0
+        y = 5
+        TestMethod(y)
+    End Sub
+    Sub TestMethod(y As Integer)
+
+    End Sub
+End Module");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyLocalVariableRenameWithCommentsUpdated()
+        {
+            // "variable" is intentionally misspelled as "varixable" and "this" is misspelled as
+            // "thix" below to ensure we don't change instances of "x" in comments that are part of
+            // larger words
+            var markup = @"
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    ''' <summary>
+    ''' creates a varixable named [|x|] xx
+    ''' </summary>
+    ''' <param name=""args""></param>
+    Sub Main(args As String())
+        ' thix varixable is named [|x|] xx
+        Dim [|x|]$$ As Integer = 0
+        [|x|] = 5
+        TestMethod([|x|])
+End Module";
+            SetUpEditor(markup);
+            InlineRenameDialog.Invoke();
+            InlineRenameDialog.ToggleIncludeComments();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    ''' <summary>
+    ''' creates a varixable named y xx
+    ''' </summary>
+    ''' <param name=""args""></param>
+    Sub Main(args As String())
+        ' thix varixable is named y xx
+        Dim y As Integer = 0
+        y = 5
+        TestMethod(y)
+End Module");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyLocalVariableRenameWithStringsUpdated()
+        {
+            var markup = @"
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim [|x|]$$ As Integer = 0
+        [|x|] = 5
+        Dim s = ""[|x|] xx [|x|]""
+    End Sub
+End Module";
+            SetUpEditor(markup);
+
+            InlineRenameDialog.Invoke();
+            InlineRenameDialog.ToggleIncludeStrings();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim y As Integer = 0
+        y = 5
+        Dim s = ""y xx y""
+    End Sub
+End Module");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Rename)]
+        public void VerifyOverloadsUpdated()
+        {
+            var markup = @"
+Interface I
+    Sub [|TestMethod|]$$(y As Integer)
+    Sub [|TestMethod|](y As String)
+End Interface
+
+Public MustInherit Class A
+    Implements I
+    Public MustOverride Sub [|TestMethod|](y As Integer) Implements I.[|TestMethod|]
+    Public MustOverride Sub [|TestMethod|](y As String) Implements I.[|TestMethod|]
+End Class";
+            SetUpEditor(markup);
+
+            InlineRenameDialog.Invoke();
+            InlineRenameDialog.ToggleIncludeOverloads();
+
+            MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
+            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            AssertEx.SetEqual(renameSpans, tags);
+
+            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            this.VerifyTextContains(@"
+Interface I
+    Sub y(y As Integer)
+    Sub y(y As String)
+End Interface
+
+Public MustInherit Class A
+    Implements I
+    Public MustOverride Sub y(y As Integer) Implements I.y
+    Public MustOverride Sub y(y As String) Implements I.y
+End Class");
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
-using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
 using Xunit;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -17,7 +16,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        private InlineRenameDialog_OutOfProc InlineRenameDialog => VisualStudio.Instance.InlineRenameDialog;
+        private InlineRenameDialog_OutOfProc InlineRenameDialog => VisualStudio.InlineRenameDialog;
 
         public BasicRename(VisualStudioInstanceFactory instanceFactory)
             : base(instanceFactory, nameof(BasicRename))
@@ -46,11 +45,11 @@ End Module";
             InlineRenameDialog.Invoke();
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 Imports System
 Imports System.Collections.Generic
 Imports System.Linq
@@ -94,11 +93,11 @@ End Module";
             InlineRenameDialog.ToggleIncludeComments();
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 Imports System
 Imports System.Collections.Generic
 Imports System.Linq
@@ -137,11 +136,11 @@ End Module";
             InlineRenameDialog.ToggleIncludeStrings();
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 Imports System
 Imports System.Collections.Generic
 Imports System.Linq
@@ -175,11 +174,11 @@ End Class";
             InlineRenameDialog.ToggleIncludeOverloads();
 
             MarkupTestFile.GetSpans(markup, out var _, out ImmutableArray<TextSpan> renameSpans);
-            var tags = Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
+            var tags = VisualStudio.Editor.GetTagSpans(InlineRenameDialog.ValidRenameTag);
             AssertEx.SetEqual(renameSpans, tags);
 
-            Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Y, VirtualKey.Enter);
+            VisualStudio.Editor.Verify.TextContains(@"
 Interface I
     Sub y(y As Integer)
     Sub y(y As String)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="CSharp\CSharpQuickInfo.cs" />
     <Compile Include="CSharp\CSharpSendToInteractive.cs" />
     <Compile Include="CSharp\CSharpNavigateTo.cs" />
+    <Compile Include="CSharp\CSharpRename.cs" />
     <Compile Include="CSharp\CSharpSignatureHelp.cs" />
     <Compile Include="CSharp\CSharpSquigglesDesktop.cs" />
     <Compile Include="CSharp\CSharpSquigglesCommon.cs" />
@@ -92,6 +93,7 @@
     <Compile Include="VisualBasic\BasicNavigateTo.cs" />
     <Compile Include="VisualBasic\BasicGoToDefinition.cs" />
     <Compile Include="VisualBasic\BasicGenerateFromUsage.cs" />
+    <Compile Include="VisualBasic\BasicRename.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -515,7 +515,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 IVsMonitorUserContext monitorUserContext = GetGlobalService<SVsMonitorUserContext, IVsMonitorUserContext>();
                 Marshal.ThrowExceptionForHR(monitorUserContext.CreateEmptyContext(out var emptyUserContext));
                 Marshal.ThrowExceptionForHR(GetActiveVsTextView().GetCaretPos(out var line, out var column));
-                var span = new TextSpan()
+                var span = new TextManager.Interop.TextSpan()
                 {
                     iStartLine = line,
                     iStartIndex = column,

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -414,6 +414,37 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             }
         }
 
+        /// <summary>
+        /// Adds a new standalone file to the Miscellaneous Files workspace.
+        /// </summary>
+        /// <param name="fileName">The name of the file to add.</param>
+        public void AddStandaloneFile(string fileName)
+        {
+            string itemTemplate;
+
+            var extension = Path.GetExtension(fileName).ToLowerInvariant();
+            switch (extension)
+            {
+                case ".cs":
+                    itemTemplate = @"General\Visual C# Class";
+                    break;
+                case ".csx":
+                    itemTemplate = @"Script\Visual C# Script";
+                    break;
+                case ".vb":
+                    itemTemplate = @"General\Visual Basic Class";
+                    break;
+                case ".txt":
+                    itemTemplate = @"General\Text File";
+                    break;
+                default:
+                    throw new NotSupportedException($"File type '{extension}' is not yet supported.");
+            }
+
+            GetDTE().ItemOperations.NewFile(itemTemplate, fileName);
+        }
+            
+
         public void SetFileContents(string projectName, string relativeFilePath, string contents)
         {
             var project = GetProject(projectName);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -5,6 +5,10 @@ using System.Linq;
 using System.Windows.Automation;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
@@ -57,6 +61,24 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void MoveCaret(int position)
             => _editorInProc.MoveCaret(position);
+
+        public ImmutableArray<TextSpan> GetTagSpans(string tagId)
+        {
+            var tagInfo = _editorInProc.GetTagSpans(tagId).ToList();
+
+            // The spans are returned in an array:
+            //    [s1.Start, s1.Length, s2.Start, s2.Length, ...]
+            // Reconstruct the spans from their component parts
+
+            var builder = ArrayBuilder<TextSpan>.GetInstance();
+
+            for (int i = 0; i < tagInfo.Count; i += 2)
+            {
+                builder.Add(new TextSpan(tagInfo[i], tagInfo[i + 1]));
+            }
+
+            return builder.ToImmutableAndFree();
+        }
 
         public string GetCurrentCompletionItem()
         {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -1,19 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Windows.Automation;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
-using System.Collections.Immutable;
 
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InlineRenameDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InlineRenameDialog_OutOfProc.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
+{
+    public class InlineRenameDialog_OutOfProc : OutOfProcComponent
+    {
+        private const string ChangeSignatureDialogAutomationId = "InlineRenameDialog";
+
+        public string ValidRenameTag => "RoslynRenameValidTag";
+
+        public InlineRenameDialog_OutOfProc(VisualStudioInstance visualStudioInstance) 
+            : base(visualStudioInstance)
+        {
+        }
+
+        public void Invoke()
+        {
+            VisualStudioInstance.ExecuteCommand("Refactor.Rename");
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Rename);
+        }
+
+        public void ToggleIncludeComments()
+        {
+            VisualStudioInstance.Editor.SendKeys(new KeyPress(VirtualKey.C, ShiftState.Alt));
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Rename);
+        }
+
+        public void ToggleIncludeStrings()
+        {
+            VisualStudioInstance.Editor.SendKeys(new KeyPress(VirtualKey.S, ShiftState.Alt));
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Rename);
+        }
+
+        public void ToggleIncludeOverloads()
+        {
+            VisualStudioInstance.Editor.SendKeys(new KeyPress(VirtualKey.O, ShiftState.Alt));
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Rename);
+        }            
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InlineRenameDialog_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InlineRenameDialog_OutOfProc.cs
@@ -19,25 +19,25 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void Invoke()
         {
             VisualStudioInstance.ExecuteCommand("Refactor.Rename");
-            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Rename);
+            VisualStudioInstance.Workspace.WaitForAsyncOperations(FeatureAttribute.Rename);
         }
 
         public void ToggleIncludeComments()
         {
             VisualStudioInstance.Editor.SendKeys(new KeyPress(VirtualKey.C, ShiftState.Alt));
-            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Rename);
+            VisualStudioInstance.Workspace.WaitForAsyncOperations(FeatureAttribute.Rename);
         }
 
         public void ToggleIncludeStrings()
         {
             VisualStudioInstance.Editor.SendKeys(new KeyPress(VirtualKey.S, ShiftState.Alt));
-            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Rename);
+            VisualStudioInstance.Workspace.WaitForAsyncOperations(FeatureAttribute.Rename);
         }
 
         public void ToggleIncludeOverloads()
         {
             VisualStudioInstance.Editor.SendKeys(new KeyPress(VirtualKey.O, ShiftState.Alt));
-            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Rename);
+            VisualStudioInstance.Workspace.WaitForAsyncOperations(FeatureAttribute.Rename);
         }            
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -128,5 +128,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void EditProjectFile(ProjectUtils.Project project)
             => _inProc.EditProjectFile(project.Name);
+
+		public void AddStandaloneFile(string fileName)
+            => _inProc.AddStandaloneFile(fileName);
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -35,6 +35,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
         public GenerateTypeDialog_OutOfProc GenerateTypeDialog { get; }
 
+		public InlineRenameDialog_OutOfProc InlineRenameDialog { get; set; }
+		
         public PreviewChangesDialog_OutOfProc PreviewChangesDialog { get; }
 
         public SendKeys SendKeys { get; }
@@ -92,6 +94,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             ErrorList = new ErrorList_OutOfProc(this);
             FindReferencesWindow = new FindReferencesWindow_OutOfProc(this);
             GenerateTypeDialog = new GenerateTypeDialog_OutOfProc(this);
+			InlineRenameDialog = new InlineRenameDialog_OutOfProc(this);
             PreviewChangesDialog = new PreviewChangesDialog_OutOfProc(this);
             Shell = new Shell_OutOfProc(this);
             SolutionExplorer = new SolutionExplorer_OutOfProc(this);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -53,6 +53,7 @@
     <Compile Include="InProcess\Editor_InProc.cs" />
     <Compile Include="Interop\NativeMethods.cs" />
     <Compile Include="LightBulbHelper.cs" />
+    <Compile Include="OutOfProcess\InlineRenameDialog_OutOfProc.cs" />
     <Compile Include="OutOfProcess\ChangeSignatureDialog_OutOfProc.cs" />
     <Compile Include="OutOfProcess\Editor_OutOfProc.Verifier.cs" />
     <Compile Include="OutOfProcess\ErrorList_OutOfProc.Verifier.cs" />


### PR DESCRIPTION
Original tests at https://github.com/dotnet/roslyn-internal/blob/dev15.0.x/Closed/Hosting/RoslynTaoActions/IntegrationTests/CSharpRename.xml / https://github.com/dotnet/roslyn-internal/blob/dev15.0.x/Closed/Hosting/RoslynTaoActions/IntegrationTests/BasicRename.xml