### PR TITLE
Modify Symbol Display for readonly references from "ref readonly" to "in"

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6344,7 +6344,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 RefKind refKind = analyzedArguments.RefKind(i);
                 if (refKind != RefKind.None)
                 {
-                    Error(diagnostics, ErrorCode.ERR_BadArgExtraRef, analyzedArguments.Argument(i).Syntax, i + 1, refKind.ToDisplayString());
+                    Error(diagnostics, ErrorCode.ERR_BadArgExtraRef, analyzedArguments.Argument(i).Syntax, i + 1, refKind.ToArgumentDisplayString());
                     return true;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1593,7 +1593,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // Parameter {0} must be declared with the '{1}' keyword
                         Error(diagnostics, ErrorCode.ERR_BadParamRef, anonymousFunction.ParameterLocation(i),
-                            i + 1, delegateRefKind.ToDisplayString());
+                            i + 1, delegateRefKind.ToParameterDisplayString());
                     }
                 }
                 return;
@@ -1646,12 +1646,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (delegateRefKind == RefKind.None)
                         {
                             // Parameter {0} should not be declared with the '{1}' keyword
-                            Error(diagnostics, ErrorCode.ERR_BadParamExtraRef, lambdaParameterLocation, i + 1, lambdaRefKind.ToDisplayString());
+                            Error(diagnostics, ErrorCode.ERR_BadParamExtraRef, lambdaParameterLocation, i + 1, lambdaRefKind.ToParameterDisplayString());
                         }
                         else
                         {
                             // Parameter {0} must be declared with the '{1}' keyword
-                            Error(diagnostics, ErrorCode.ERR_BadParamRef, lambdaParameterLocation, i + 1, delegateRefKind.ToDisplayString());
+                            Error(diagnostics, ErrorCode.ERR_BadParamRef, lambdaParameterLocation, i + 1, delegateRefKind.ToParameterDisplayString());
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -973,7 +973,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         sourceLocation,
                         symbols,
                         arg + 1,
-                        refParm.ToArgumentDisplayString());
+                        refParm.ToParameterDisplayString());
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -963,7 +963,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         sourceLocation,
                         symbols,
                         arg + 1,
-                        refArg.ToDisplayString());
+                        refArg.ToArgumentDisplayString());
                 }
                 else
                 {
@@ -973,7 +973,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         sourceLocation,
                         symbols,
                         arg + 1,
-                        refParm.ToDisplayString());
+                        refParm.ToArgumentDisplayString());
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (includeType)
             {
-                AddRefKindIfRequired(symbol.RefKind);
+                AddParameterRefKindIfRequired(symbol.RefKind);
                 AddCustomModifiersIfRequired(symbol.RefCustomModifiers, leadingSpace: false, trailingSpace: true);
 
                 if (symbol.IsParams && format.ParameterOptions.IncludesOption(SymbolDisplayParameterOptions.IncludeParamsRefOut))
@@ -728,7 +728,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void AddRefKindIfRequired(RefKind refKind)
+        private void AddParameterRefKindIfRequired(RefKind refKind)
         {
             if (format.ParameterOptions.IncludesOption(SymbolDisplayParameterOptions.IncludeParamsRefOut))
             {
@@ -743,9 +743,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         AddSpace();
                         break;
                     case RefKind.RefReadOnly:
-                        AddKeyword(SyntaxKind.RefKeyword);
-                        AddSpace();
-                        AddKeyword(SyntaxKind.ReadOnlyKeyword);
+                        AddKeyword(SyntaxKind.InKeyword);
                         AddSpace();
                         break;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1549,7 +1549,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     // '{0}' cannot define an overloaded {1} that differs only on parameter modifiers '{2}' and '{3}'
                     var methodKind = method1.MethodKind == MethodKind.Constructor ? MessageID.IDS_SK_CONSTRUCTOR : MessageID.IDS_SK_METHOD;
-                    diagnostics.Add(ErrorCode.ERR_OverloadRefKind, method1.Locations[0], this, methodKind.Localize(), refKind1.ToDisplayString(), refKind2.ToDisplayString());
+                    diagnostics.Add(ErrorCode.ERR_OverloadRefKind, method1.Locations[0], this, methodKind.Localize(), refKind1.ToParameterDisplayString(), refKind2.ToParameterDisplayString());
 
                     return;
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -121,25 +121,24 @@ class Program
 
             var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (6,9): error CS8408: Cannot assign to variable 'ref readonly int' because it is a readonly variable
+                // (6,9): error CS8408: Cannot assign to variable 'in int' because it is a readonly variable
                 //         arg1 = 1;
-                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "arg1").WithArguments("variable", "ref readonly int").WithLocation(6, 9),
-                // (7,9): error CS8409: Cannot assign to a member of variable 'ref readonly (int Alice, int Bob)' because it is a readonly variable
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "arg1").WithArguments("variable", "in int").WithLocation(6, 9),
+                // (7,9): error CS8409: Cannot assign to a member of variable 'in (int Alice, int Bob)' because it is a readonly variable
                 //         arg2.Alice = 2;
-                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField2, "arg2.Alice").WithArguments("variable", "ref readonly (int Alice, int Bob)").WithLocation(7, 9),
-                // (9,9): error CS8408: Cannot assign to variable 'ref readonly int' because it is a readonly variable
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField2, "arg2.Alice").WithArguments("variable", "in (int Alice, int Bob)").WithLocation(7, 9),
+                // (9,9): error CS8408: Cannot assign to variable 'in int' because it is a readonly variable
                 //         arg1 ++;
-                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "arg1").WithArguments("variable", "ref readonly int").WithLocation(9, 9),
-                // (10,9): error CS8409: Cannot assign to a member of variable 'ref readonly (int Alice, int Bob)' because it is a readonly variable
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "arg1").WithArguments("variable", "in int").WithLocation(9, 9),
+                // (10,9): error CS8409: Cannot assign to a member of variable 'in (int Alice, int Bob)' because it is a readonly variable
                 //         arg2.Alice --;
-                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField2, "arg2.Alice").WithArguments("variable", "ref readonly (int Alice, int Bob)").WithLocation(10, 9),
-                // (12,9): error CS8408: Cannot assign to variable 'ref readonly int' because it is a readonly variable
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField2, "arg2.Alice").WithArguments("variable", "in (int Alice, int Bob)").WithLocation(10, 9),
+                // (12,9): error CS8408: Cannot assign to variable 'in int' because it is a readonly variable
                 //         arg1 += 1;
-                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "arg1").WithArguments("variable", "ref readonly int").WithLocation(12, 9),
-                // (13,9): error CS8409: Cannot assign to a member of variable 'ref readonly (int Alice, int Bob)' because it is a readonly variable
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "arg1").WithArguments("variable", "in int"),
+                // (13,9): error CS8409: Cannot assign to a member of variable 'in (int Alice, int Bob)' because it is a readonly variable
                 //         arg2.Alice -= 2;
-                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField2, "arg2.Alice").WithArguments("variable", "ref readonly (int Alice, int Bob)").WithLocation(13, 9)
-            );
+                Diagnostic(ErrorCode.ERR_AssignReadonlyNotField2, "arg2.Alice").WithArguments("variable", "in (int Alice, int Bob)"));
         }
 
         [Fact]
@@ -158,13 +157,12 @@ class Program
 
             var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (6,25): error CS8406: Cannot use variable 'ref readonly int' as a ref or out value because it is a readonly variable
+                // (6,25): error CS8406: Cannot use variable 'in int' as a ref or out value because it is a readonly variable
                 //         ref var y = ref arg1;
-                Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "arg1").WithArguments("variable", "ref readonly int").WithLocation(6, 25),
-                // (7,25): error CS8407: Members of variable 'ref readonly (int Alice, int Bob)' cannot be used as a ref or out value because it is a readonly variable
+                Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "arg1").WithArguments("variable", "in int"),
+                // (7,25): error CS8407: Members of variable 'in (int Alice, int Bob)' cannot be used as a ref or out value because it is a readonly variable
                 //         ref int a = ref arg2.Alice;
-                Diagnostic(ErrorCode.ERR_RefReadonlyNotField2, "arg2.Alice").WithArguments("variable", "ref readonly (int Alice, int Bob)").WithLocation(7, 25)
-            );
+                Diagnostic(ErrorCode.ERR_RefReadonlyNotField2, "arg2.Alice").WithArguments("variable", "in (int Alice, int Bob)"));
         }
 
         [Fact]
@@ -230,13 +228,12 @@ class Program
 
             var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (10,24): error CS8406: Cannot use variable 'ref readonly int' as a ref or out value because it is a readonly variable
+                // (10,24): error CS8406: Cannot use variable 'in int' as a ref or out value because it is a readonly variable
                 //             return ref arg1;
-                Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "arg1").WithArguments("variable", "ref readonly int").WithLocation(10, 24),
-                // (14,24): error CS8407: Members of variable 'ref readonly (int Alice, int Bob)' cannot be used as a ref or out value because it is a readonly variable
+                Diagnostic(ErrorCode.ERR_RefReadonlyNotField, "arg1").WithArguments("variable", "in int"),
+                // (14,24): error CS8407: Members of variable 'in (int Alice, int Bob)' cannot be used as a ref or out value because it is a readonly variable
                 //             return ref arg2.Alice;
-                Diagnostic(ErrorCode.ERR_RefReadonlyNotField2, "arg2.Alice").WithArguments("variable", "ref readonly (int Alice, int Bob)").WithLocation(14, 24)
-            );
+                Diagnostic(ErrorCode.ERR_RefReadonlyNotField2, "arg2.Alice").WithArguments("variable", "in (int Alice, int Bob)"));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -30,7 +30,7 @@ class Program
 
             var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false);
 
-            comp.VerifyIL("Program.M(ref readonly int)", @"
+            comp.VerifyIL("Program.M(in int)", @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -54,7 +54,7 @@ class Program
 
             var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false);
 
-            comp.VerifyIL("Program.M(ref readonly int)", @"
+            comp.VerifyIL("Program.M(in int)", @"
 {
   // Code size        2 (0x2)
   .maxstack  1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AmbiguousOverrideTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AmbiguousOverrideTests.cs
@@ -1334,9 +1334,9 @@ abstract class TestClass
 }";
 
             var comp = CreateCompilationWithMscorlib(text).VerifyDiagnostics(
-                // (5,17): error CS0663: 'TestClass' cannot define an overloaded method that differs only on parameter modifiers 'ref readonly' and 'ref'
+                // (5,17): error CS0663: 'TestClass' cannot define an overloaded method that differs only on parameter modifiers 'in' and 'ref'
                 //     public void Method(ref readonly int x) { }
-                Diagnostic(ErrorCode.ERR_OverloadRefKind, "Method").WithArguments("TestClass", "method", "ref readonly", "ref").WithLocation(5, 17));
+                Diagnostic(ErrorCode.ERR_OverloadRefKind, "Method").WithArguments("TestClass", "method", "in", "ref").WithLocation(5, 17));
         }
 
         [Fact]
@@ -1351,9 +1351,9 @@ abstract class TestClass
 }";
 
             var comp = CreateCompilationWithMscorlib(text).VerifyDiagnostics(
-                // (5,17): error CS0663: 'TestClass' cannot define an overloaded method that differs only on parameter modifiers 'ref readonly' and 'out'
+                // (5,17): error CS0663: 'TestClass' cannot define an overloaded method that differs only on parameter modifiers 'in' and 'out'
                 //     public void Method(ref readonly int x) { }
-                Diagnostic(ErrorCode.ERR_OverloadRefKind, "Method").WithArguments("TestClass", "method", "ref readonly", "out").WithLocation(5, 17));
+                Diagnostic(ErrorCode.ERR_OverloadRefKind, "Method").WithArguments("TestClass", "method", "in", "out").WithLocation(5, 17));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -5538,13 +5538,11 @@ public class C
             // Method without IncludeRef.
             Verify(
                 SymbolDisplay.ToDisplayParts(method, formatWithoutRef),
-                "int F(ref readonly int)",
+                "int F(in int)",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.MethodName,
                 SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.Keyword,
-                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
@@ -5568,13 +5566,11 @@ public class C
             // Indexer without IncludeRef.
             Verify(
                 SymbolDisplay.ToDisplayParts(indexer, formatWithoutRef),
-                "int this[ref readonly int] { get; }",
+                "int this[in int] { get; }",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.Keyword,
-                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
@@ -5600,7 +5596,7 @@ public class C
             // Method with IncludeRef.
             Verify(
                 SymbolDisplay.ToDisplayParts(method, formatWithRef),
-                "ref readonly int F(ref readonly int)",
+                "ref readonly int F(in int)",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
@@ -5609,8 +5605,6 @@ public class C
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.MethodName,
                 SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.Keyword,
-                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
@@ -5638,7 +5632,7 @@ public class C
             // Indexer with IncludeRef.
             Verify(
                 SymbolDisplay.ToDisplayParts(indexer, formatWithRef),
-                "ref readonly int this[ref readonly int] { get; }",
+                "ref readonly int this[in int] { get; }",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
@@ -5647,8 +5641,6 @@ public class C
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.Keyword,
-                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
@@ -5678,17 +5670,14 @@ public class C
             // Method without IncludeType, with IncludeRef.
             Verify(
                 SymbolDisplay.ToDisplayParts(method, formatWithoutTypeWithRef),
-                "F(ref readonly int)",
+                "F(in int)",
                 SymbolDisplayPartKind.MethodName,
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Punctuation);
         }
-
 
         [WorkItem(5002, "https://github.com/dotnet/roslyn/issues/5002")]
         [Fact]
@@ -5849,7 +5838,7 @@ class C
                 semanticModel.GetDeclaredSymbol(local));
 
             Verify(localSymbol.ToDisplayParts(SymbolDisplayFormat.TestFormat),
-                "System.Threading.Tasks.Task<System.Int32> Local(ref readonly System.Int32* x, out System.Char? c)",
+                "System.Threading.Tasks.Task<System.Int32> Local(in System.Int32* x, out System.Char? c)",
                 SymbolDisplayPartKind.NamespaceName, // System
                 SymbolDisplayPartKind.Punctuation, // .
                 SymbolDisplayPartKind.NamespaceName, // Threading
@@ -5865,9 +5854,7 @@ class C
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.MethodName, // Local
                 SymbolDisplayPartKind.Punctuation, // (
-                SymbolDisplayPartKind.Keyword, // ref
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.Keyword, // readonly
+                SymbolDisplayPartKind.Keyword, // in
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.NamespaceName, // System
                 SymbolDisplayPartKind.Punctuation, // .

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceOverriddenOrHiddenMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceOverriddenOrHiddenMembersTests.cs
@@ -835,9 +835,9 @@ interface B : A
 }";
 
             var comp = CreateCompilationWithMscorlib(code).VerifyDiagnostics(
-                // (8,10): warning CS0108: 'B.M(ref readonly int)' hides inherited member 'A.M(ref readonly int)'. Use the new keyword if hiding was intended.
+                // (8,10): warning CS0108: 'B.M(in int)' hides inherited member 'A.M(in int)'. Use the new keyword if hiding was intended.
                 //     void M(ref readonly int x);
-                Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("B.M(ref readonly int)", "A.M(ref readonly int)").WithLocation(8, 10));
+                Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("B.M(in int)", "A.M(in int)").WithLocation(8, 10));
 
             var aMethod = comp.GetMember<MethodSymbol>("A.M");
             var bMethod = comp.GetMember<MethodSymbol>("B.M");
@@ -1169,9 +1169,9 @@ class B : A
 }";
 
             var comp = CreateCompilationWithMscorlib(code).VerifyDiagnostics(
-                // (6,11): error CS0535: 'B' does not implement interface member 'A.M(ref readonly int)'
+                // (6,11): error CS0535: 'B' does not implement interface member 'A.M(in int)'
                 // class B : A
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "A").WithArguments("B", "A.M(ref readonly int)").WithLocation(6, 11));
+                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "A").WithArguments("B", "A.M(in int)").WithLocation(6, 11));
         }
 
         [Fact]
@@ -1214,9 +1214,9 @@ class ChildClass : BaseInterface
 }";
 
             var comp = CreateCompilationWithMscorlib(text).VerifyDiagnostics(
-                // (7,20): error CS0535: 'ChildClass' does not implement interface member 'BaseInterface.Method2(ref readonly int)'
+                // (7,20): error CS0535: 'ChildClass' does not implement interface member 'BaseInterface.Method2(in int)'
                 // class ChildClass : BaseInterface
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "BaseInterface").WithArguments("ChildClass", "BaseInterface.Method2(ref readonly int)").WithLocation(7, 20),
+                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "BaseInterface").WithArguments("ChildClass", "BaseInterface.Method2(in int)").WithLocation(7, 20),
                 // (7,20): error CS0535: 'ChildClass' does not implement interface member 'BaseInterface.Method1(ref int)'
                 // class ChildClass : BaseInterface
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "BaseInterface").WithArguments("ChildClass", "BaseInterface.Method1(ref int)").WithLocation(7, 20));
@@ -1348,9 +1348,9 @@ class B : A
 }";
 
             var comp = CreateCompilationWithMscorlib(code).VerifyDiagnostics(
-                // (6,11): error CS0535: 'B' does not implement interface member 'A.this[ref readonly int]'
+                // (6,11): error CS0535: 'B' does not implement interface member 'A.this[in int]'
                 // class B : A
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "A").WithArguments("B", "A.this[ref readonly int]").WithLocation(6, 11));
+                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "A").WithArguments("B", "A.this[in int]").WithLocation(6, 11));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
@@ -3999,9 +3999,9 @@ class B : A
 }";
 
             var comp = CreateCompilationWithMscorlib(code).VerifyDiagnostics(
-                // (8,17): warning CS0108: 'B.M(ref readonly int)' hides inherited member 'A.M(ref readonly int)'. Use the new keyword if hiding was intended.
+                // (8,17): warning CS0108: 'B.M(in int)' hides inherited member 'A.M(in int)'. Use the new keyword if hiding was intended.
                 //     public void M(ref readonly int x) { }
-                Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("B.M(ref readonly int)", "A.M(ref readonly int)").WithLocation(8, 17));
+                Diagnostic(ErrorCode.WRN_NewRequired, "M").WithArguments("B.M(in int)", "A.M(in int)").WithLocation(8, 17));
 
             var aMethod = comp.GetMember<MethodSymbol>("A.M");
             var bMethod = comp.GetMember<MethodSymbol>("B.M");
@@ -4450,9 +4450,9 @@ class ChildClass : BaseClass
                 // (10,26): error CS0115: 'ChildClass.Method2(ref int)': no suitable method found to override
                 //     public override void Method2(ref int x) { }
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Method2").WithArguments("ChildClass.Method2(ref int)").WithLocation(10, 26),
-                // (9,26): error CS0115: 'ChildClass.Method1(ref readonly int)': no suitable method found to override
+                // (9,26): error CS0115: 'ChildClass.Method1(in int)': no suitable method found to override
                 //     public override void Method1(ref readonly int x) { }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Method1").WithArguments("ChildClass.Method1(ref readonly int)").WithLocation(9, 26));
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "Method1").WithArguments("ChildClass.Method1(in int)").WithLocation(9, 26));
         }
 
         [Fact]
@@ -4584,9 +4584,9 @@ class B : A
                 // (8,25): error CS0115: 'B.this[int]': no suitable method found to override
                 //     public override int this[int p] { get { return p; } }
                 Diagnostic(ErrorCode.ERR_OverrideNotExpected, "this").WithArguments("B.this[int]").WithLocation(8, 25),
-                // (6,7): error CS0534: 'B' does not implement inherited abstract member 'A.this[ref readonly int].get'
+                // (6,7): error CS0534: 'B' does not implement inherited abstract member 'A.this[in int].get'
                 // class B : A
-                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "B").WithArguments("B", "A.this[ref readonly int].get").WithLocation(6, 7));
+                Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "B").WithArguments("B", "A.this[in int].get").WithLocation(6, 7));
         }
 
         [Fact]
@@ -4604,9 +4604,9 @@ class B : A
 }";
 
             var comp = CreateCompilationWithMscorlib(code).VerifyDiagnostics(
-                // (8,25): error CS0115: 'B.this[ref readonly int]': no suitable method found to override
+                // (8,25): error CS0115: 'B.this[in int]': no suitable method found to override
                 //     public override int this[ref readonly int p] { get { return p; } }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "this").WithArguments("B.this[ref readonly int]").WithLocation(8, 25),
+                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "this").WithArguments("B.this[in int]").WithLocation(8, 25),
                 // (6,7): error CS0534: 'B' does not implement inherited abstract member 'A.this[int].get'
                 // class B : A
                 Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "B").WithArguments("B", "A.this[int].get").WithLocation(6, 7));

--- a/src/Compilers/Core/Portable/Symbols/RefKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/RefKind.cs
@@ -32,16 +32,6 @@ namespace Microsoft.CodeAnalysis
 
     internal static class RefKindExtensions
     {
-        internal static string ToReturnTypeDisplayString(this RefKind kind)
-        {
-            switch (kind)
-            {
-                case RefKind.Ref: return "ref";
-                case RefKind.RefReadOnly: return "ref readonly";
-                default: throw new ArgumentException($"Invalid RefKind for return types: {kind}");
-            }
-        }
-
         internal static string ToParameterDisplayString(this RefKind kind)
         {
             switch (kind)

--- a/src/Compilers/Core/Portable/Symbols/RefKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/RefKind.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Text;
+using System;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -32,14 +32,34 @@ namespace Microsoft.CodeAnalysis
 
     internal static class RefKindExtensions
     {
-        internal static string ToDisplayString(this RefKind kind)
+        internal static string ToReturnTypeDisplayString(this RefKind kind)
+        {
+            switch (kind)
+            {
+                case RefKind.Ref: return "ref";
+                case RefKind.RefReadOnly: return "ref readonly";
+                default: throw new ArgumentException($"Invalid RefKind for return types: {kind}");
+            }
+        }
+
+        internal static string ToParameterDisplayString(this RefKind kind)
         {
             switch (kind)
             {
                 case RefKind.Out: return "out";
                 case RefKind.Ref: return "ref";
-                case RefKind.RefReadOnly: return "ref readonly";
-                default: return null;
+                case RefKind.RefReadOnly: return "in";
+                default: throw new ArgumentException($"Invalid RefKind for parameters: {kind}");
+            }
+        }
+
+        internal static string ToArgumentDisplayString(this RefKind kind)
+        {
+            switch (kind)
+            {
+                case RefKind.Out: return "out";
+                case RefKind.Ref: return "ref";
+                default: throw new ArgumentException($"Invalid RefKind for arguments: {kind}");
             }
         }
 


### PR DESCRIPTION
@VSadov @dotnet/roslyn-compiler  ready for review.