### PR TITLE
Update the required frameworks in the description

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -5,8 +5,7 @@
     <description>
     .Net Compilers package. Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
 
-Supported Platforms:
-- .NET Framework 4.5
+    This package can be used to compile code targeting any platform, but can only be run using the desktop .NET 4.6+ Full Framework.
     </description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>


### PR DESCRIPTION
The description of this package is vague and incorrect. We now require .NET 4.6, not
.NET 4.5, and that is only a build-time requirement, not a deploy requirement.

/cc @jasonmalinowski @jaredpar @dotnet/roslyn-infrastructure 