### PR TITLE
Add 7.1 support to UpgradeProject, add #version directive

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2852,6 +2852,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Compiler version: &apos;{0}&apos;. Language version: &apos;{1}&apos;..
+        /// </summary>
+        internal static string ERR_CompilerAndLanguageVersion {
+            get {
+                return ResourceManager.GetString("ERR_CompilerAndLanguageVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An expression tree lambda may not contain a COM call with ref omitted on arguments.
         /// </summary>
         internal static string ERR_ComRefCallInExpressionTree {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5041,4 +5041,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_VoidAssignment" xml:space="preserve">
     <value>A value of type 'void' may not be assigned.</value>
   </data>
+  <data name="ERR_CompilerAndLanguageVersion" xml:space="preserve">
+    <value>Compiler version: '{0}'. Language version: '{1}'.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1471,5 +1471,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InvalidPreprocessingSymbol = 8301,
         ERR_FeatureNotAvailableInVersion7_1 = 8302,
         ERR_LanguageVersionCannotHaveLeadingZeroes = 8303,
+        ERR_CompilerAndLanguageVersion = 8304,
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -128,18 +128,15 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal virtual string GetAssemblyFileVersion()
         {
-            if (_clientDirectory != null)
-            {
-                Assembly assembly = Type.GetTypeInfo().Assembly;
-                var name = $"{assembly.GetName().Name}.dll";
-                var filePath = Path.Combine(_clientDirectory, name);
-                var fileVersionInfo = FileVersionInfo.GetVersionInfo(filePath);
-                string hash = ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash);
+            Assembly assembly = Type.GetTypeInfo().Assembly;
+            return GetAssemblyFileVersion(assembly);
+        }
 
-                return $"{fileVersionInfo.FileVersion} ({hash})";
-            }
-
-            return "";
+        internal static string GetAssemblyFileVersion(Assembly assembly)
+        {
+            string assemblyVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+            string hash = ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash);
+            return $"{assemblyVersion} ({hash})";
         }
 
         internal static string ExtractShortCommitHash(string hash)

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Async
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
-        public async Task UpgradeProjectToDefault()
+        public async Task UpgradeProjectFromCSharp6ToDefault()
         {
             await TestLanguageVersionUpgradedAsync(
 @"
@@ -55,7 +55,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
-        public async Task UpgradeProjectToCSharp7()
+        public async Task UpgradeProjectFromCSharp6ToCSharp7()
         {
             await TestLanguageVersionUpgradedAsync(
 @"
@@ -68,6 +68,33 @@ class Program
 }",
                 LanguageVersion.CSharp7,
                 new CSharpParseOptions(LanguageVersion.CSharp6),
+                index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
+        public async Task UpgradeProjectFromCSharp7ToLatest()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class Program
+{
+#error [|7.1|]
+}",
+                LanguageVersion.Latest,
+                new CSharpParseOptions(LanguageVersion.CSharp7));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
+        public async Task UpgradeProjectFromCSharp7ToCSharp7_1()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class Program
+{
+#error [|7.1|]
+}",
+                LanguageVersion.CSharp7_1,
+                new CSharpParseOptions(LanguageVersion.CSharp7),
                 index: 1);
         }
 

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -69,7 +70,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
         protected Document GetDocumentAndAnnotatedSpan(TestWorkspace workspace, out string annotation, out TextSpan span)
         {
-            var hostDocument = workspace.Documents.Single(d => d.AnnotatedSpans.Any());
+            var annotatedDocuments = workspace.Documents.Where(d => d.AnnotatedSpans.Any());
+            Debug.Assert(!annotatedDocuments.IsEmpty(), "No annotated span found");
+            var hostDocument = annotatedDocuments.Single();
             var annotatedSpan = hostDocument.AnnotatedSpans.Single();
             annotation = annotatedSpan.Key;
             span = annotatedSpan.Value.Single();

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -22,9 +22,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
         private const string CS8025 = nameof(CS8025); // error CS8025: Feature is not available in C# 4. Please use language version X or greater.
         private const string CS8026 = nameof(CS8026); // error CS8026: Feature is not available in C# 5. Please use language version X or greater.
         private const string CS8059 = nameof(CS8059); // error CS8059: Feature is not available in C# 6. Please use language version X or greater.
+        private const string CS8302 = nameof(CS8302); // error CS8302: Feature is not available in C# 7.0. Please use language version X or greater.
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059);
+            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8302);
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;
         public override string UpgradeAllProjectsResource => CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0;

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ParseTreeDescription.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ParseTreeDescription.vb
@@ -138,7 +138,7 @@ Public Class ParseTree
             Return Enumerations(enumString)
         End If
 
-        ReportError(referencingElement, "{0} is not a valid field type", enumString)
+        ReportError(referencingElement, "{0} is not a valid field type. You should add a node-kind entry in the syntax.xml.", enumString)
         Return Nothing
     End Function
 


### PR DESCRIPTION

Adds #version (https://github.com/dotnet/roslyn/issues/17859)
Updates the UpgradeProject fixer as follow-up on https://github.com/dotnet/roslyn/pull/17894