### PR TITLE
Document.TryGetSyntaxTree can return immediately if SyntaxTree was ca…

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis
             if (_syntaxTreeResultTask != null)
             {
                 syntaxTree = _syntaxTreeResultTask.Result;
+                return true;
             }
 
             if (!DocumentState.TryGetSyntaxTree(out syntaxTree))


### PR DESCRIPTION
…ched.

If the SyntaxTree was cached, i.e. _syntaxTreeResultTask != null, we can immediately return true. No further action is neccessary.