### PR TITLE
Test Runner Updates

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -18,6 +18,7 @@
     <IncludePattern Condition="'$(IncludePattern)' == '' AND '$(TestVsi)' != 'true'">*.UnitTests.dll</IncludePattern>
     <IncludePattern Condition="'$(IncludePattern)' == '' AND '$(TestVsi)' == 'true'">*.IntegrationTests.dll</IncludePattern>
     <OutputDirectory>Binaries\$(Configuration)</OutputDirectory>
+    <RunTestArgs>$(RunTestArgs) -log:&quot;$(OutputDirectory)\runtests.log&quot;</RunTestArgs>
     <CoreClrTestDirectory>$(OutputDirectory)\CoreClrTest</CoreClrTestDirectory>
     <MSBuildCommonProperties>
       RestorePackages=false;

--- a/src/Tools/Source/RunTests/Cache/AssemblyUtil.cs
+++ b/src/Tools/Source/RunTests/Cache/AssemblyUtil.cs
@@ -41,6 +41,9 @@ namespace RunTests.Cache
                 case "System.Runtime.Loader":
                     // This light up probing is done by the scripting layer. 
                     return true;
+                case "Microsoft.Diagnostics.Tracing.EventSource":
+                    // Part of ETW tracing and not used by suites at this time.
+                    return true;
                 case "Microsoft.VisualStudio.CodeAnalysis":
                 case "Microsoft.VisualStudio.CodeAnalysis.Sdk":
                 case "Microsoft.VisualStudio.TeamSystem.Common":

--- a/src/Tools/Source/RunTests/Cache/CachingTestExecutor.cs
+++ b/src/Tools/Source/RunTests/Cache/CachingTestExecutor.cs
@@ -38,7 +38,6 @@ namespace RunTests.Cache
             catch (Exception ex)
             {
                 var msg = $"Unable to calculate content file for {assemblyInfo.AssemblyPath}";
-                Console.WriteLine(msg);
                 Logger.LogError(ex, msg + Environment.NewLine + ex.Message);
                 contentFile = null;
 

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -100,14 +100,6 @@ namespace RunTests
                 Console.WriteLine(ex);
             }
 
-            // This is deliberately being checked in on a temporary basis.  Need to see how this data behaves in the commit
-            // queue and the easiest way is to dump to the console.  Once the commit queue behavior is verified this will
-            // be deleted.
-            if (Constants.IsJenkinsRun)
-            {
-                Logger.WriteTo(Console.Out);
-            }
-
             Logger.Clear();
         }
 

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -81,10 +81,23 @@ namespace RunTests
 
         private static void WriteLogFile(Options options)
         {
-            var fileName = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().CodeBase), "runtests.log");
-            using (var writer = new StreamWriter(fileName, append: false))
+            var logFilePath = options.LogFilePath;
+            if (string.IsNullOrEmpty(logFilePath))
             {
-                Logger.WriteTo(writer);
+                return;
+            }
+
+            try
+            {
+                using (var writer = new StreamWriter(logFilePath, append: false))
+                {
+                    Logger.WriteTo(writer);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error writing log file {logFilePath}");
+                Console.WriteLine(ex);
             }
 
             // This is deliberately being checked in on a temporary basis.  Need to see how this data behaves in the commit

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Linq;
 using RestSharp;
 using System.Collections.Immutable;
 using Newtonsoft.Json;
+using System.Reflection;
 
 namespace RunTests
 {
@@ -80,7 +81,7 @@ namespace RunTests
 
         private static void WriteLogFile(Options options)
         {
-            var fileName = Path.Combine(Path.GetDirectoryName(options.Assemblies.First()), "runtests.log");
+            var fileName = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().CodeBase), "runtests.log");
             using (var writer = new StreamWriter(fileName, append: false))
             {
                 Logger.WriteTo(writer);

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -121,16 +121,25 @@ namespace RunTests
             }
 
             Console.WriteLine("================");
+            var line = new StringBuilder();
             foreach (var testResult in testResults)
             {
+                line.Length = 0;
                 var color = testResult.Succeeded ? Console.ForegroundColor : ConsoleColor.Red;
-                var message = $"{testResult.DisplayName,-75} {(testResult.Succeeded ? "PASSED" : "FAILED")} {testResult.Elapsed}{(testResult.IsFromCache ? "*" : "")}";
+                line.Append($"{testResult.DisplayName,-75}");
+                line.Append($" {(testResult.Succeeded ? "PASSED" : "FAILED")}");
+                line.Append($" {testResult.Elapsed}");
+                line.Append($" {(testResult.IsFromCache ? "*" : "")}");
+                line.Append($" {(!string.IsNullOrEmpty(testResult.Diagnostics) ? "?" : "")}");
+
+                var message = line.ToString();
                 ConsoleUtil.WriteLine(color, message);
                 Logger.Log(message);
             }
             Console.WriteLine("================");
 
             // Print diagnostics out last so they are cleanly visible at the end of the test summary
+            Console.WriteLine("Extra run diagnostics for logging, did not impact run results");
             foreach (var testResult in testResults.Where(x => !string.IsNullOrEmpty(x.Diagnostics)))
             {
                 Console.WriteLine(testResult.Diagnostics);

--- a/src/Tools/Source/RunTests/project.json
+++ b/src/Tools/Source/RunTests/project.json
@@ -4,6 +4,7 @@
     "RestSharp": "105.2.3",
     "System.Collections.Immutable": "1.3.1",
     "System.Reflection.Metadata": "1.4.2",
+    "System.ValueTuple": "4.3.0"
   },
   "frameworks": {
     "net46": { }


### PR DESCRIPTION
Change summary:

- No longer print full diagnostic log in Jenkins (fixed the error it was helping with)
- Remove the output which Jenkins incorrectly listed as a failure cause
- Performance improvements building reference graph
- More informative diagnostics when finding missing references 
- Fix cache misses for most of the IDE layer