### PR TITLE
Add runtime reference to MS.VS.Debugger.Metadata

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/FunctionResolver/project.json
+++ b/src/ExpressionEvaluator/Core/Source/FunctionResolver/project.json
@@ -3,7 +3,11 @@
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "System.Collections.Immutable": "1.3.1",
     "System.Reflection.Metadata": "1.4.2",
-    "Microsoft.VisualStudio.Debugger.Engine": "15.0.26201-alpha"
+    "Microsoft.VisualStudio.Debugger.Engine": "15.0.26201-alpha",
+    "Microsoft.VisualStudio.Debugger.Metadata": {
+        "version": "15.0.26201-alpha",
+        "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.3": {

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/project.json
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/project.json
@@ -1,6 +1,10 @@
 {
   "dependencies": {
-    "Microsoft.VisualStudio.Debugger.Engine": "15.0.26201-alpha"
+    "Microsoft.VisualStudio.Debugger.Engine": "15.0.26201-alpha",
+    "Microsoft.VisualStudio.Debugger.Metadata": {
+        "version": "15.0.26201-alpha",
+        "exclude": "compile"
+    }
   },
   "frameworks": {
     "netstandard1.3": {


### PR DESCRIPTION
These EE projects tranisively reference MS.VS.Debugger.Metadata but it
is not referenced.  Hence it was not a part of the project output and as
a result test libraries did not participate in caching.

Adding this reference directly as compile + runtime created a lot of
compilation errors due to the following:

- The DLL contains a namespace named Microsoft.MetadataReader
- The projects make heavy use of System.Reflection.MetadataReader
- The project namespace is Microsoft.*

Once a compile reference was added to MS.VS.Debugger.Metadata it caused
MetadataReader to prefer the namespace over the type.  This is fixable
by adding a lot of using directives into ~5 source files but that seemed
fairly disruptive hence I went with this approach.