### PR TITLE
add marker to see code lens perf easier

### DIFF
--- a/src/VisualStudio/Core/Next/CodeLens/RemoteCodeLensReferencesService.cs
+++ b/src/VisualStudio/Core/Next/CodeLens/RemoteCodeLensReferencesService.cs
@@ -7,10 +7,9 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeLens;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.Diagnostics;
-using Microsoft.VisualStudio.LanguageServices.Implementation.Extensions;
-using Microsoft.VisualStudio.LanguageServices.Remote;
 
 namespace Microsoft.VisualStudio.LanguageServices.CodeLens
 {
@@ -20,85 +19,97 @@ namespace Microsoft.VisualStudio.LanguageServices.CodeLens
         public async Task<ReferenceCount> GetReferenceCountAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode, int maxSearchResults,
             CancellationToken cancellationToken)
         {
-            if (syntaxNode == null)
+            using (Logger.LogBlock(FunctionId.CodeLens_GetReferenceCountAsync, cancellationToken))
             {
-                return null;
-            }
+                if (syntaxNode == null)
+                {
+                    return null;
+                }
 
-            var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().TryGetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
-            if (remoteHostClient == null)
-            {
-                // remote host is not running. this can happen if remote host is disabled.
-                return await CodeLensReferencesServiceFactory.Instance.GetReferenceCountAsync(solution, documentId, syntaxNode, maxSearchResults, cancellationToken).ConfigureAwait(false);
-            }
+                var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().TryGetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
+                if (remoteHostClient == null)
+                {
+                    // remote host is not running. this can happen if remote host is disabled.
+                    return await CodeLensReferencesServiceFactory.Instance.GetReferenceCountAsync(solution, documentId, syntaxNode, maxSearchResults, cancellationToken).ConfigureAwait(false);
+                }
 
-            // TODO: send telemetry on session
-            return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<ReferenceCount>(
-                solution, WellKnownServiceHubServices.CodeAnalysisService_GetReferenceCountAsync,
-                new object[] { new CodeLensArguments(documentId, syntaxNode), maxSearchResults }, cancellationToken).ConfigureAwait(false);
+                // TODO: send telemetry on session
+                return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<ReferenceCount>(
+                    solution, WellKnownServiceHubServices.CodeAnalysisService_GetReferenceCountAsync,
+                    new object[] { new CodeLensArguments(documentId, syntaxNode), maxSearchResults }, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public async Task<IEnumerable<ReferenceLocationDescriptor>> FindReferenceLocationsAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
-            if (syntaxNode == null)
+            using (Logger.LogBlock(FunctionId.CodeLens_FindReferenceLocationsAsync, cancellationToken))
             {
-                return null;
-            }
+                if (syntaxNode == null)
+                {
+                    return null;
+                }
 
-            var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().TryGetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
-            if (remoteHostClient == null)
-            {
-                // remote host is not running. this can happen if remote host is disabled.
-                return await CodeLensReferencesServiceFactory.Instance.FindReferenceLocationsAsync(solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
-            }
+                var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().TryGetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
+                if (remoteHostClient == null)
+                {
+                    // remote host is not running. this can happen if remote host is disabled.
+                    return await CodeLensReferencesServiceFactory.Instance.FindReferenceLocationsAsync(solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                }
 
-            // TODO: send telemetry on session
-            return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<IEnumerable<ReferenceLocationDescriptor>>(
-                solution, WellKnownServiceHubServices.CodeAnalysisService_FindReferenceLocationsAsync,
-                new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
+                // TODO: send telemetry on session
+                return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<IEnumerable<ReferenceLocationDescriptor>>(
+                    solution, WellKnownServiceHubServices.CodeAnalysisService_FindReferenceLocationsAsync,
+                    new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public async Task<IEnumerable<ReferenceMethodDescriptor>> FindReferenceMethodsAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
-            if (syntaxNode == null)
+            using (Logger.LogBlock(FunctionId.CodeLens_FindReferenceMethodsAsync, cancellationToken))
             {
-                return null;
-            }
+                if (syntaxNode == null)
+                {
+                    return null;
+                }
 
-            var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().TryGetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
-            if (remoteHostClient == null)
-            {
-                // remote host is not running. this can happen if remote host is disabled.
-                return await CodeLensReferencesServiceFactory.Instance.FindReferenceMethodsAsync(solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
-            }
+                var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().TryGetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
+                if (remoteHostClient == null)
+                {
+                    // remote host is not running. this can happen if remote host is disabled.
+                    return await CodeLensReferencesServiceFactory.Instance.FindReferenceMethodsAsync(solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                }
 
-            // TODO: send telemetry on session
-            return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<IEnumerable<ReferenceMethodDescriptor>>(
-                solution, WellKnownServiceHubServices.CodeAnalysisService_FindReferenceMethodsAsync,
-                new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
+                // TODO: send telemetry on session
+                return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<IEnumerable<ReferenceMethodDescriptor>>(
+                    solution, WellKnownServiceHubServices.CodeAnalysisService_FindReferenceMethodsAsync,
+                    new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public async Task<string> GetFullyQualifiedName(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
-            if (syntaxNode == null)
+            using (Logger.LogBlock(FunctionId.CodeLens_GetFullyQualifiedName, cancellationToken))
             {
-                return null;
-            }
+                if (syntaxNode == null)
+                {
+                    return null;
+                }
 
-            var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().TryGetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
-            if (remoteHostClient == null)
-            {
-                // remote host is not running. this can happen if remote host is disabled.
-                return await CodeLensReferencesServiceFactory.Instance.GetFullyQualifiedName(solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
-            }
+                var remoteHostClient = await solution.Workspace.Services.GetService<IRemoteHostClientService>().TryGetRemoteHostClientAsync(cancellationToken).ConfigureAwait(false);
+                if (remoteHostClient == null)
+                {
+                    // remote host is not running. this can happen if remote host is disabled.
+                    return await CodeLensReferencesServiceFactory.Instance.GetFullyQualifiedName(solution, documentId, syntaxNode, cancellationToken).ConfigureAwait(false);
+                }
 
-            // TODO: send telemetry on session
-            return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<string>(
-                solution, WellKnownServiceHubServices.CodeAnalysisService_GetFullyQualifiedName,
-                new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
+                // TODO: send telemetry on session
+                return await remoteHostClient.RunCodeAnalysisServiceOnRemoteHostAsync<string>(
+                    solution, WellKnownServiceHubServices.CodeAnalysisService_GetFullyQualifiedName,
+                    new CodeLensArguments(documentId, syntaxNode), cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -366,5 +366,9 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         RemoteHost_Connect,
         RemoteHost_Disconnect,
         CodeAnalysisService_GetTodoCommentsAsync,
+        CodeLens_GetReferenceCountAsync,
+        CodeLens_FindReferenceLocationsAsync,
+        CodeLens_FindReferenceMethodsAsync,
+        CodeLens_GetFullyQualifiedName,
     }
 }


### PR DESCRIPTION
this will let us to see perf in trace output or perfview when locally investigate code lens perf. but not in kusto, this code path is too busy to send to AI.