### PR TITLE
Add unit tests for IVariableDeclaration and IVariableDeclarationStatement

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -71,6 +71,7 @@
     <Compile Include="FlowAnalysis\RegionAnalysisTests.cs" />
     <Compile Include="FlowAnalysis\StructTests.cs" />
     <Compile Include="FlowAnalysis\TryLockUsingStatementTests.cs" />
+    <Compile Include="IOperation\IOperationTests_IVariableDeclaration.cs" />
     <Compile Include="Semantics\FuzzTests.cs" />
     <Compile Include="Semantics\OverloadResolutionPerfTests.cs" />
     <Compile Include="Semantics\PatternMatchingTests_Global.cs" />

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
@@ -472,7 +472,7 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
 
         #region Using Statements
 
-        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void UsingStatementDeclaration()
         {
             string source = @"
@@ -491,11 +491,9 @@ class Program : IDisposable
 }
 ";
             string expectedOperationTree = @"
-IUsingStatement (OperationKind.UsingStatement)
-  IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
-    IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
-      Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
-  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
 ";
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
@@ -251,6 +251,45 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
+        [Fact]
+        public void InvalidArrayDeclaration()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int[2, 3] a/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32[,] a (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact]
+        public void InvalidArrayMultipleDeclaration()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int[2, 3] a, b/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32[,] a (OperationKind.VariableDeclaration)
+  IVariableDeclaration: System.Int32[,] b (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
         #endregion
 
         #region Fixed Statements

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
@@ -48,7 +48,7 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
             VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree);
         }
 
-        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18061"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void FixedStatementDeclaration()
         {
             string source = @"
@@ -69,18 +69,16 @@ class Program
 }
 ";
             string expectedOperationTree = @"
-IFixedStatement (OperationKind.FixedStatement)
-  IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
-    IVariableDeclaration: System.Int32* p (OperationKind.VariableDeclaration)
-      Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
-          IFieldReferenceExpression: System.Int32 Program.i1 (OperationKind.FieldReferenceExpression, Type: System.Int32)
-            Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
-  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32* p (OperationKind.VariableDeclaration)
+    Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
+        IFieldReferenceExpression: System.Int32 Program.i1 (OperationKind.FieldReferenceExpression, Type: System.Int32)
+          Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
 ";
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
-        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18061"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void FixedStatementMultipleDeclaration()
         {
             string source = @"
@@ -101,17 +99,15 @@ class Program
 }
 ";
             string expectedOperationTree = @"
-IFixedStatement (OperationKind.FixedStatement)
-  IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
-    IVariableDeclaration: System.Int32* p1 (OperationKind.VariableDeclaration)
-      Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
-          IFieldReferenceExpression: System.Int32 Program.i1 (OperationKind.FieldReferenceExpression, Type: System.Int32)
-            Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
-    IVariableDeclaration: System.Int32* p2 (OperationKind.VariableDeclaration)
-      Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
-          IFieldReferenceExpression: System.Int32 Program.i2 (OperationKind.FieldReferenceExpression, Type: System.Int32)
-            Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
-  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32* p1 (OperationKind.VariableDeclaration)
+    Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
+        IFieldReferenceExpression: System.Int32 Program.i1 (OperationKind.FieldReferenceExpression, Type: System.Int32)
+          Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
+  IVariableDeclaration: System.Int32* p2 (OperationKind.VariableDeclaration)
+    Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
+        IFieldReferenceExpression: System.Int32 Program.i2 (OperationKind.FieldReferenceExpression, Type: System.Int32)
+          Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
 ";
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
@@ -144,7 +140,7 @@ IUsingStatement (OperationKind.UsingStatement)
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
-        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void UsingStatementMultipleDeclarations()
         {
             string source = @"
@@ -163,18 +159,16 @@ class Program : IDisposable
 }
 ";
             string expectedOperationTree = @"
-IUsingStatement (OperationKind.UsingStatement)
-  IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
-    IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
-      Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
-    IVariableDeclaration: Program p2 (OperationKind.VariableDeclaration)
-      Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
-  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
+  IVariableDeclaration: Program p2 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
 ";
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
-        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void ForLoopDeclaration()
         {
             string source = @"
@@ -192,24 +186,14 @@ class Program
 }
 ";
             string expectedOperationTree = @"
-IForLoopStatement (LoopKind.For) (OperationKind.LoopStatement)
-  Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean)
-      Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
-      Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
-  Local_1: System.Int32 i
-  Before: IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
-      IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
-        Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
-  AtLoopBottom: IExpressionStatement (OperationKind.ExpressionStatement)
-      IIncrementExpression (UnaryOperandKind.IntegerPostfixIncrement) (BinaryOperationKind.IntegerAdd) (OperationKind.IncrementExpression, Type: System.Int32)
-        Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
-        Right: ILiteralExpression (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
-  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
 ";
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
-        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void ForLoopMultipleDeclarations()
         {
             string source = @"
@@ -226,22 +210,11 @@ class Program
 }
 ";
             string expectedOperationTree = @"
-IForLoopStatement (LoopKind.For) (OperationKind.LoopStatement)
-  Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean)
-      Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
-      Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
-  Local_1: System.Int32 i
-  Local_2: System.Int32 j
-  Before: IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
-      IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
-        Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
-      IVariableDeclaration: System.Int32 j (OperationKind.VariableDeclaration)
-        Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
-  AtLoopBottom: IExpressionStatement (OperationKind.ExpressionStatement)
-      IIncrementExpression (UnaryOperandKind.IntegerPostfixIncrement) (BinaryOperationKind.IntegerAdd) (OperationKind.IncrementExpression, Type: System.Int32)
-        Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
-        Right: ILiteralExpression (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
-  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
+  IVariableDeclaration: System.Int32 j (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
 ";
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
@@ -1,0 +1,297 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public partial class IOperationTests : SemanticModelTestBase
+    {
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void SimpleVariableDeclaration()
+        {
+            string source = @"
+class Program
+{
+    int P1 { get; set; }
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i1;/*</bind>*/
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void MultipleDeclarations()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i1, i2;/*</bind>*/
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void FixedStatementDeclaration()
+        {
+            string source = @"
+class Program
+{
+    int i1;
+    static void Main(string[] args)
+    {
+        var reference = new Program();
+        unsafe
+        {
+            fixed (/*<bind>*/int* p = &reference.i1/*</bind>*/)
+            {
+
+            }
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IFixedStatement (OperationKind.FixedStatement)
+  IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+    IVariableDeclaration: System.Int32* p (OperationKind.VariableDeclaration)
+      Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
+          IFieldReferenceExpression: System.Int32 Program.i1 (OperationKind.FieldReferenceExpression, Type: System.Int32)
+            Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
+  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void FixedStatementMultipleDeclaration()
+        {
+            string source = @"
+class Program
+{
+    int i1, i2;
+    static void Main(string[] args)
+    {
+        var reference = new Program();
+        unsafe
+        {
+            fixed (/*<bind>*/int* p1 = &reference.i1, p2 = &reference.i2/*</bind>*/)
+            {
+
+            }
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IFixedStatement (OperationKind.FixedStatement)
+  IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+    IVariableDeclaration: System.Int32* p1 (OperationKind.VariableDeclaration)
+      Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
+          IFieldReferenceExpression: System.Int32 Program.i1 (OperationKind.FieldReferenceExpression, Type: System.Int32)
+            Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
+    IVariableDeclaration: System.Int32* p2 (OperationKind.VariableDeclaration)
+      Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
+          IFieldReferenceExpression: System.Int32 Program.i2 (OperationKind.FieldReferenceExpression, Type: System.Int32)
+            Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
+  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementDeclaration()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1 = new Program()/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() {}
+}
+";
+            string expectedOperationTree = @"
+IUsingStatement (OperationKind.UsingStatement)
+  IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+    IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+      Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
+  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementMultipleDeclarations()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1 = new Program(), p2 = new Program()/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() {}
+}
+";
+            string expectedOperationTree = @"
+IUsingStatement (OperationKind.UsingStatement)
+  IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+    IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+      Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
+    IVariableDeclaration: Program p2 (OperationKind.VariableDeclaration)
+      Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
+  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopDeclaration()
+        {
+            string source = @"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i = 0/*</bind>*/; i < 0; i++)
+        {
+
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IForLoopStatement (LoopKind.For) (OperationKind.LoopStatement)
+  Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean)
+      Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+      Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
+  Local_1: System.Int32 i
+  Before: IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+      IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+        Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
+  AtLoopBottom: IExpressionStatement (OperationKind.ExpressionStatement)
+      IIncrementExpression (UnaryOperandKind.IntegerPostfixIncrement) (BinaryOperationKind.IntegerAdd) (OperationKind.IncrementExpression, Type: System.Int32)
+        Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+        Right: ILiteralExpression (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopMultipleDeclarations()
+        {
+            string source = @"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i = 0, j = 0/*</bind>*/; i < 0; i++)
+        {
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IForLoopStatement (LoopKind.For) (OperationKind.LoopStatement)
+  Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThan) (OperationKind.BinaryOperatorExpression, Type: System.Boolean)
+      Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+      Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
+  Local_1: System.Int32 i
+  Local_2: System.Int32 j
+  Before: IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+      IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+        Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
+      IVariableDeclaration: System.Int32 j (OperationKind.VariableDeclaration)
+        Initializer: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
+  AtLoopBottom: IExpressionStatement (OperationKind.ExpressionStatement)
+      IIncrementExpression (UnaryOperandKind.IntegerPostfixIncrement) (BinaryOperationKind.IntegerAdd) (OperationKind.IncrementExpression, Type: System.Int32)
+        Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+        Right: ILiteralExpression (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalDeclaration()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/const int i1 = 1;/*</bind>*/
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+";
+            VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalMultipleDeclarations()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/const int i1 = 1, i2 = 2;/*</bind>*/
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2)
+";
+            VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
@@ -8,13 +8,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public partial class IOperationTests : SemanticModelTestBase
     {
+        #region Variable Declarations
+
         [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void SingleVariableDeclaration()
         {
             string source = @"
 class Program
 {
-    int P1 { get; set; }
     static void Main(string[] args)
     {
         /*<bind>*/int i1;/*</bind>*/
@@ -26,6 +27,47 @@ IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationSt
   IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
 ";
             VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void SingleVariableDeclarationWithInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i1 = 1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void SingleVariableDeclarationWithInvalidInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i1 = /*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
         [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
@@ -47,6 +89,171 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
 ";
             VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree);
         }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void MultipleDeclarationsWithInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i1 = 2, i2 = 2/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void MultipleDeclarationsWithInvalidInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i1 = , i2 = 2/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void InvalidMultipleVariableDeclaration()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i,/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+  IVariableDeclaration: System.Int32  (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void SingleVariableDeclarationExpressionInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i = GetInt()/*</bind>*/;
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void MutlipleVariableDeclarationsExpressionInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        /*<bind>*/int i = GetInt(), j = GetInt()/*</bind>*/;
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+  IVariableDeclaration: System.Int32 j (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact]
+        public void SingleVariableDeclarationLocalReferenceInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        int i = 1;
+        /*<bind>*/int i1 = i/*</bind>*/;
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact]
+        public void MultipleDeclarationsLocalReferenceInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        int i = 1;
+        /*<bind>*/int i1 = i, i2 = i1/*</bind>*/;
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Int32)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        #endregion
+
+        #region Fixed Statements
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18061"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void FixedStatementDeclaration()
@@ -112,6 +319,159 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18061"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void FixedStatementInvalidAssignment()
+        {
+            string source = @"
+class Program
+{
+    int i1;
+    static void Main(string[] args)
+    {
+        var reference = new Program();
+        unsafe
+        {
+            /*<bind>*/fixed (/*<bind>*/int* p = /*</bind>*/)
+            {
+
+            }/*</bind>*/
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32* p (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32*, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<FixedStatementSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18061"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void FixedStatementMultipleDeclarationsInvalidInitializers()
+        {
+            string source = @"
+class Program
+{
+    int i1, i2;
+    static void Main(string[] args)
+    {
+        var reference = new Program();
+        unsafe
+        {
+            fixed (/*<bind>*/int* p1 = , p2 = /*</bind>*/)
+            {
+
+            }
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32* p1 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32*, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: System.Int32* p2 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32*, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18061"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void FixedStatementNoInitializer()
+        {
+            string source = @"
+class Program
+{
+    int i1;
+    static void Main(string[] args)
+    {
+        var reference = new Program();
+        unsafe
+        {
+            /*<bind>*/fixed (/*<bind>*/int* p/*</bind>*/)
+            {
+
+            }/*</bind>*/
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32* p (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<FixedStatementSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18061"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void FixedStatementMultipleDeclarationsNoInitializers()
+        {
+            string source = @"
+class Program
+{
+    int i1, i2;
+    static void Main(string[] args)
+    {
+        var reference = new Program();
+        unsafe
+        {
+            fixed (/*<bind>*/int* p1, p2/*</bind>*/)
+            {
+
+            }
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32* p1 (OperationKind.VariableDeclaration)
+  IVariableDeclaration: System.Int32* p2 (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18061"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void FixedStatementInvalidMulipleDeclarations()
+        {
+            string source = @"
+class Program
+{
+    int i1, i2;
+    static void Main(string[] args)
+    {
+        var reference = new Program();
+        unsafe
+        {
+            fixed (/*<bind>*/int* p1 = &reference.i1,/*</bind>*/)
+            {
+
+            }
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32* p1 (OperationKind.VariableDeclaration)
+    Initializer: IAddressOfExpression (OperationKind.AddressOfExpression, Type: System.Int32*)
+        IFieldReferenceExpression: System.Int32 Program.i1 (OperationKind.FieldReferenceExpression, Type: System.Int32)
+          Instance Receiver: ILocalReferenceExpression: reference (OperationKind.LocalReferenceExpression, Type: Program)
+  IVariableDeclaration: System.Int32*  (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        #endregion
+
+        #region Using Statements
+
         [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void UsingStatementDeclaration()
         {
@@ -168,12 +528,265 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
-        public void ForLoopDeclaration()
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementInvalidInitializer()
         {
             string source = @"
 using System;
 
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1 =/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: Program, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementMultipleDeclarationsInvalidInitializers()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1 =, p2 =/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: Program, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: Program p2 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: Program, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementNoInitializer()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementMultipleDeclarationsNoInitializers()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1, p2/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+  IVariableDeclaration: Program p2 (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementInvalidMultipleDeclarations()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1 = new Program(),/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Program..ctor()) (OperationKind.ObjectCreationExpression, Type: Program)
+  IVariableDeclaration: Program  (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementExpressionInitializer()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1 = GetProgram()/*</bind>*/)
+        {
+        }
+    }
+
+    static Program GetProgram() => new Program();
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static Program Program.GetProgram()) (OperationKind.InvocationExpression, Type: Program)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementMultipleDeclarationsExpressionInitializers()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        using (/*<bind>*/Program p1 = GetProgram(), p2 = GetProgram()/*</bind>*/)
+        {
+        }
+    }
+
+    static Program GetProgram() => new Program();
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: Program p1 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static Program Program.GetProgram()) (OperationKind.InvocationExpression, Type: Program)
+  IVariableDeclaration: Program p2 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static Program Program.GetProgram()) (OperationKind.InvocationExpression, Type: Program)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementLocalReferenceInitializer()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        Program p1 = new Program();
+        using (/*<bind>*/Program p2 = p1/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: Program p2 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: p1 (OperationKind.LocalReferenceExpression, Type: Program)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18062"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void UsingStatementMultipleDeclarationsLocalReferenceInitializers()
+        {
+            string source = @"
+using System;
+
+class Program : IDisposable
+{
+    static void Main(string[] args)
+    {
+        Program p1 = new Program();
+        using (/*<bind>*/Program p2 = p1, p3 = p1/*</bind>*/)
+        {
+        }
+    }
+
+    public void Dispose() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: Program p2 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: p1 (OperationKind.LocalReferenceExpression, Type: Program)
+  IVariableDeclaration: Program p3 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: p1 (OperationKind.LocalReferenceExpression, Type: Program)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        #endregion
+
+        #region For Loops
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopDeclaration()
+        {
+            string source = @"
 class Program
 {
     static void Main(string[] args)
@@ -197,8 +810,6 @@ IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationSt
         public void ForLoopMultipleDeclarations()
         {
             string source = @"
-using System;
-
 class Program
 {
     static void Main(string[] args)
@@ -219,13 +830,191 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
             VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
         }
 
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopInvalidInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i =/*</bind>*/; i < 0; i++)
+        {
+
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopMultipleDeclarationsInvalidInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i =, j =/*</bind>*/; i < 0; i++)
+        {
+
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: System.Int32 j (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopNoInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i/*</bind>*/; i < 0; i++)
+        {
+
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopMultipleDeclarationsNoInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i, j/*</bind>*/; i < 0; i++)
+        {
+
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+  IVariableDeclaration: System.Int32 j (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+
+
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopInvalidMultipleDeclarations()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i =,/*</bind>*/; i < 0; i++)
+        {
+
+        }
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: System.Int32  (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopExpressionInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i = GetInt()/*</bind>*/; i < 0; i++)
+        {
+
+        }
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18063"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ForLoopMultipleDeclarationsExpressionInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        for (/*<bind>*/int i = GetInt(), j = GetInt()/*</bind>*/; i < 0; i++)
+        {
+
+        }
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+  IVariableDeclaration: System.Int32 j (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+
+        #endregion
+
+        #region Const Local Declarations
+
         [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
         public void ConstLocalDeclaration()
         {
             string source = @"
-using System;
-using System.Collections.Generic;
-
 class Program
 {
     static void Main(string[] args)
@@ -266,5 +1055,205 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
 ";
             VerifyOperationTreeForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree);
         }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalDeclarationInvalidInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const /*<bind>*/int i1 = /*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalMultipleDeclarationsInvalidInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const /*<bind>*/int i1 = , i2 = /*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalDeclarationNoInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const /*<bind>*/int i1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalMutlipleDeclarationsNoInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const /*<bind>*/int i1, i2/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalInvalidMultipleDeclarations()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const /*<bind>*/int i1,/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+  IVariableDeclaration: System.Int32  (OperationKind.VariableDeclaration)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalDeclarationExpressionInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const /*<bind>*/int i1 = GetInt()/*</bind>*/;
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalMultipleDeclarationsExpressionInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const /*<bind>*/int i1 = GetInt(), i2 = GetInt()/*</bind>*/;
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static System.Int32 Program.GetInt()) (OperationKind.InvocationExpression, Type: System.Int32)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalDeclarationLocalReferenceInitializer()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const int i = 1;
+        const /*<bind>*/int i1 = i/*</bind>*/;
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32, Constant: 1)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
+        public void ConstLocalMultipleDeclarationsLocalReferenceInitializers()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        const int i = 1;
+        const /*<bind>*/int i1 = i, i2 = i1/*</bind>*/;
+    }
+
+    static int GetInt() => 1;
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: System.Int32 i1 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32, Constant: 1)
+  IVariableDeclaration: System.Int32 i2 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Int32, Constant: 1)
+";
+            VerifyOperationTreeForTest<VariableDeclarationSyntax>(source, expectedOperationTree);
+        }
+
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public partial class IOperationTests : SemanticModelTestBase
     {
         [Fact, WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")]
-        public void SimpleVariableDeclaration()
+        public void SingleVariableDeclaration()
         {
             string source = @"
 class Program

--- a/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
@@ -109,6 +109,7 @@
     <Compile Include="FlowAnalysis\RegionAnalysisTestsWithStaticLocals.vb" />
     <Compile Include="FlowAnalysis\StructureAnalysisTests.vb" />
     <Compile Include="FlowAnalysis\TryLockUsingStatementTests.vb" />
+    <Compile Include="IOperation\IOperationTests_IVariableDeclaration.vb" />
     <Compile Include="Resource.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
@@ -774,8 +774,6 @@ IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationSt
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
         End Sub
 
-
-
         <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub StaticMulipleDeclarationAsNew()
             Dim source = <![CDATA[

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
@@ -1,0 +1,346 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
+    Partial Public Class IOperationTests
+        Inherits SemanticModelTestBase
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub SingleVariableDeclaration()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1 As Integer'BIND:"Dim i1 As Integer"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub MultipleVariableDeclarations()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1 As Integer, i2 As Integer, b1 As Boolean'BIND:"Dim i1 As Integer, i2 As Integer, b1 As Boolean"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (3 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+  IVariableDeclaration: b1 As System.Boolean (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub DimAsNew()
+            Dim source = <![CDATA[
+Module Program
+    Class C
+    End Class
+    Sub Main(args As String())
+        Dim p1 As New C'BIND:"Dim p1 As New C"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: p1 As Program.C (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub Program.C..ctor()) (OperationKind.ObjectCreationExpression, Type: Program.C)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub MultipleDimAsNew()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim i1, i2 As New Integer'BIND:"Dim i1, i2 As New Integer"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub MixedDimAsNewAndEqualsDeclarations()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim i1, i2 As New Integer, b1 As Boolean = False'BIND:"Dim i1, i2 As New Integer, b1 As Boolean = False"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (3 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+  IVariableDeclaration: b1 As System.Boolean (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: False) (OperationKind.LiteralExpression, Type: System.Boolean, Constant: False)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17913"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub UsingStatementDeclarationAsNew()
+            Dim source = <![CDATA[
+Module Program
+    Class C
+        Implements IDisposable
+        Public Sub Dispose() Implements IDisposable.Dispose
+        End Sub
+    End Class
+    Sub Main(args As String())
+        Using c1 As New C'BIND:"Dim c1 As New C"
+            Console.WriteLine(c1)
+        End Using
+    End Sub
+End Module
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IUsingStatement (OperationKind.UsingStatement)
+  IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+    IVariableDeclaration: c1 As Program.C (OperationKind.VariableDeclaration)
+      Initializer: IObjectCreationExpression (Constructor: Sub Program.C..ctor()) (OperationKind.ObjectCreationExpression, Type: Program.C)
+  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17913"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub UsingStatementDeclaration()
+            Dim source = <![CDATA[
+Module Program
+    Class C
+        Implements IDisposable
+        Public Sub Dispose() Implements IDisposable.Dispose
+        End Sub
+    End Class
+    Sub Main(args As String())
+        Using c1 As C = New C'BIND:"c1 As C = New C"
+            Console.WriteLine(c1)
+        End Using
+    End Sub
+End Module
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IUsingStatement (OperationKind.UsingStatement)
+  IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+    IVariableDeclaration: c1 As Program.C (OperationKind.VariableDeclaration)
+      Initializer: IObjectCreationExpression (Constructor: Sub Program.C..ctor()) (OperationKind.ObjectCreationExpression, Type: Program.C)
+  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstDeclaration()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 As Integer = 1'BIND:"Const i1 As Integer = 1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstMultipleDeclaration()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Const i1 = 1, i2 = 2'BIND:"Const i1 = 1, i2 = 2"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticDeclaration()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Static i1 As Integer'BIND:"Static i1 As Integer"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticMultipleDeclarations()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Static i1, i2 As Integer'BIND:"Static i1, i2 As Integer"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticAsNewDeclaration()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Static i1 As New Integer'BIND:"Static i1 As New Integer"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticMulipleDeclarationAsNew()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Static i1, i2 As New Integer'BIND:"Static i1, i2 As New Integer"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticMixedAsNewAndEqualsDeclaration()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Static i1, i2 As New Integer, b1 As Boolean = False'BIND:"Static i1, i2 As New Integer, b1 As Boolean = False"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (3 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub System.Int32..ctor()) (OperationKind.ObjectCreationExpression, Type: System.Int32)
+  IVariableDeclaration: b1 As System.Boolean (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: False) (OperationKind.LiteralExpression, Type: System.Boolean, Constant: False)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+    End Class
+End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
@@ -1,11 +1,14 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.CodeAnalysis.Semantics
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
     Partial Public Class IOperationTests
         Inherits SemanticModelTestBase
+#Region "Dim Declarations"
+
         <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub SingleVariableDeclaration()
             Dim source = <![CDATA[
@@ -45,6 +48,188 @@ IVariableDeclarationStatement (3 variables) (OperationKind.VariableDeclarationSt
         End Sub
 
         <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub SingleVariableDeclarationNoType()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim i1'BIND:"Dim i1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub MultipleVariableDeclarationNoTypes()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim i1, i2'BIND:"Dim i1, i2"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration)
+  IVariableDeclaration: i2 As System.Object (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub InvalidMultipleVariableDeclaration()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim i1 As Integer,'BIND:"Dim i1 As Integer,"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+  IVariableDeclaration:  As System.Object (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub InvalidMultipleVariableDeclarationsNoType()
+            Dim source = <![CDATA[
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim i1,'BIND:"Dim i1,"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration)
+  IVariableDeclaration:  As System.Object (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub SingleVariableDeclarationLocalReferenceInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1 = 1
+        Dim i2 = i1'BIND:"Dim i2 = i1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub MultipleVariableDeclarationLocalReferenceInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1 = 1
+        Dim i2 = i1, i3 = i1'BIND:"Dim i2 = i1, i3 = i1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Int32)
+  IVariableDeclaration: i3 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub SingleVariableDeclarationExpressionInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1 = ReturnInt()'BIND:"Dim i1 = ReturnInt()"
+    End Sub
+
+    Function ReturnInt() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static Function Program.ReturnInt() As System.Int32) (OperationKind.InvocationExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub MultipleVariableDeclarationExpressionInitializers()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1 = ReturnInt(), i2 = ReturnInt()'BIND:"Dim i1 = ReturnInt(), i2 = ReturnInt()"
+    End Sub
+
+    Function ReturnInt() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static Function Program.ReturnInt() As System.Int32) (OperationKind.InvocationExpression, Type: System.Int32)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: IInvocationExpression (static Function Program.ReturnInt() As System.Int32) (OperationKind.InvocationExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub DimAsNew()
             Dim source = <![CDATA[
 Module Program
@@ -68,10 +253,6 @@ IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationSt
         <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub MultipleDimAsNew()
             Dim source = <![CDATA[
-Imports System
-Imports System.Collections.Generic
-Imports System.Linq
-
 Module Program
     Sub Main(args As String())
         Dim i1, i2 As New Integer'BIND:"Dim i1, i2 As New Integer"
@@ -91,14 +272,49 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
         End Sub
 
 
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub DimAsNewNoObject()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1 As New'BIND:"Dim i1 As New"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As ? (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub MultipleDimAsNewNoObject()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1, i2 As New'BIND:"Dim i1, i2 As New"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As ? (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: i2 As ? (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
 
         <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub MixedDimAsNewAndEqualsDeclarations()
             Dim source = <![CDATA[
-Imports System
-Imports System.Collections.Generic
-Imports System.Linq
-
 Module Program
     Sub Main(args As String())
         Dim i1, i2 As New Integer, b1 As Boolean = False'BIND:"Dim i1, i2 As New Integer, b1 As Boolean = False"
@@ -119,7 +335,40 @@ IVariableDeclarationStatement (3 variables) (OperationKind.VariableDeclarationSt
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
         End Sub
 
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub DimAsNewMultipleDeclarationsSameInitializerInstance()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim i1, i2 As New Integer'BIND:"Dim i1, i2 As New Integer"
+    End Sub
+End Module
+    ]]>.Value
 
+            Dim fileName = "a.vb"
+            Dim syntaxTree = Parse(source, fileName)
+            Dim compilation = CreateCompilationWithMscorlib(syntaxTree)
+
+            Dim node As SyntaxNode = CompilationUtils.FindBindingText(Of LocalDeclarationStatementSyntax)(compilation, fileName)
+            Assert.NotNull(node)
+
+            Dim tree = (From t In compilation.SyntaxTrees Where t.FilePath = fileName).Single()
+            Dim semanticModel = compilation.GetSemanticModel(tree)
+            Dim operation = CType(semanticModel.GetOperationInternal(node), IVariableDeclarationStatement)
+
+            Assert.Equal(2, operation.Variables.Count())
+            Dim var1 = operation.Variables(0)
+            Dim var2 = operation.Variables(1)
+
+            Assert.NotNull(var1.InitialValue)
+            Assert.NotNull(var2.InitialValue)
+
+            Assert.Same(var1.InitialValue, var2.InitialValue)
+        End Sub
+
+#End Region
+
+#Region "Using Statements"
 
         <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17917"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub UsingStatementDeclarationAsNew()
@@ -131,7 +380,7 @@ Module Program
         End Sub
     End Class
     Sub Main(args As String())
-        Using c1 As New C'BIND:"Dim c1 As New C"
+        Using c1 As New C'BIND:"c1 As New C"
             Console.WriteLine(c1)
         End Using
     End Sub
@@ -146,6 +395,7 @@ IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationSt
 
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
         End Sub
+
 
         <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17917"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub UsingStatementDeclaration()
@@ -172,6 +422,10 @@ IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationSt
 
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
         End Sub
+
+#End Region
+
+#Region "Const Declarations"
 
         <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub ConstDeclaration()
@@ -216,6 +470,241 @@ IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationSt
 
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
         End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstAsNew()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 As New Integer'BIND:"Const i1 As New Integer"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstAsNewMultipleDeclarations()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1, i2 As New Integer'BIND:"Const i1, i2 As New Integer"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstSingleDeclarationNoType()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 = 1'BIND:"Const i1 = 1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstMultipleDeclarationsNoTypes()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 = 1, i2 = 2'BIND:"Const i1 = 1, i2 = 2"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstSingleDeclarationLocalReferenceInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 = 1
+        Const i2 = i1'BIND:"Const i2 = i1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Int32, Constant: 1)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstMultipleDeclarationsLocalReferenceInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 = 1
+        Const i2 = i1, i3 = i1'BIND:"Const i2 = i1, i3 = i1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i2 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Int32, Constant: 1)
+  IVariableDeclaration: i3 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Int32, Constant: 1)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstSingleDeclarationExpressionInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 = Int1()'BIND:"Const i1 = Int1()"
+    End Sub
+
+    Function Int1() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstMultipleDeclarationsExpressionInitializers()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 = Int1(), i2 = Int1()'BIND:"Const i1 = Int1(), i2 = Int1()"
+    End Sub
+
+    Function Int1() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: i2 As System.Object (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstDimAsNewNoInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 As New'BIND:"Const i1 As New"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As ? (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstDimAsNewMultipleDeclarationsNoInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1, i2 As New'BIND:"Const i1, i2 As New"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As ? (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: i2 As ? (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub ConstInvalidMultipleDeclaration()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Const i1 = 1,'BIND:"Const i1 = 1,"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As System.Int32 (OperationKind.VariableDeclaration)
+    Initializer: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+  IVariableDeclaration:  As System.Object (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+#End Region
+
+#Region "Static Declarations"
 
         <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub StaticDeclaration()
@@ -338,5 +827,260 @@ IVariableDeclarationStatement (3 variables) (OperationKind.VariableDeclarationSt
 
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
         End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticSingleDeclarationNoType()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 = 1'BIND:"Static i1 = 1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object)
+        ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticMultipleDeclarationsNoTypes()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 = 1, i2 = 2'BIND:"Static i1 = 1, i2 = 2"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object)
+        ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+  IVariableDeclaration: i2 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object)
+        ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticSingleDeclarationLocalReferenceInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 = 1
+        Static i2 = i1'BIND:"Static i2 = i1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i2 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Object)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticMultipleDeclarationsLocalReferenceInitializers()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 = 1
+        Static i2 = i1, i3 = i1'BIND:"Static i2 = i1, i3 = i1"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i2 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Object)
+  IVariableDeclaration: i3 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: System.Object)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticSingleDeclarationExpressionInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 = Int1()'BIND:"Static i1 = Int1()"
+    End Sub
+
+    Function Int1() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object)
+        IInvocationExpression (static Function Program.Int1() As System.Int32) (OperationKind.InvocationExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticMultipleDeclarationsExpressionInitializers()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 = Int1(), i2 = Int1()'BIND:"Static i1 = Int1(), i2 = Int1()"
+    End Sub
+
+    Function Int1() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object)
+        IInvocationExpression (static Function Program.Int1() As System.Int32) (OperationKind.InvocationExpression, Type: System.Int32)
+  IVariableDeclaration: i2 As System.Object (OperationKind.VariableDeclaration)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object)
+        IInvocationExpression (static Function Program.Int1() As System.Int32) (OperationKind.InvocationExpression, Type: System.Int32)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticAsNewSingleDeclarationInvalidInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 As'BIND:"Static i1 As"
+    End Sub
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As ? (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticAsNewMultipleDeclarationInvalidInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1, i2 As'BIND:"Static i1, i2 As"
+    End Sub
+
+    Function Int1() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As ? (OperationKind.VariableDeclaration)
+  IVariableDeclaration: i2 As ? (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticSingleDeclarationInvalidInitializer()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 ='BIND:"Static i1 ="
+    End Sub
+
+    Function Int1() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticMultipleDeclarationsInvalidInitializers()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1 =, i2 ='BIND:"Static i1 =, i2 ="
+    End Sub
+
+    Function Int1() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement, IsInvalid)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+  IVariableDeclaration: i2 As System.Object (OperationKind.VariableDeclaration, IsInvalid)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object, IsInvalid)
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+
+
+        <Fact(), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        Public Sub StaticInvalidMultipleDeclaration()
+            Dim source = <![CDATA[
+Module Program
+    Sub Main(args As String())
+        Static i1,'BIND:"Static i1,"
+    End Sub
+
+    Function Int1() As Integer
+        Return 1
+    End Function
+End Module
+    ]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (2 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: i1 As System.Object (OperationKind.VariableDeclaration)
+  IVariableDeclaration:  As System.Object (OperationKind.VariableDeclaration)
+]]>.Value
+
+            VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
+        End Sub
+
+#End Region
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
@@ -139,11 +139,9 @@ End Module
 ]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IUsingStatement (OperationKind.UsingStatement)
-  IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
-    IVariableDeclaration: c1 As Program.C (OperationKind.VariableDeclaration)
-      Initializer: IObjectCreationExpression (Constructor: Sub Program.C..ctor()) (OperationKind.ObjectCreationExpression, Type: Program.C)
-  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: c1 As Program.C (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub Program.C..ctor()) (OperationKind.ObjectCreationExpression, Type: Program.C)
 ]]>.Value
 
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
@@ -167,11 +165,9 @@ End Module
 ]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IUsingStatement (OperationKind.UsingStatement)
-  IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
-    IVariableDeclaration: c1 As Program.C (OperationKind.VariableDeclaration)
-      Initializer: IObjectCreationExpression (Constructor: Sub Program.C..ctor()) (OperationKind.ObjectCreationExpression, Type: Program.C)
-  IBlockStatement (0 statements) (OperationKind.BlockStatement)
+IVariableDeclarationStatement (1 variables) (OperationKind.VariableDeclarationStatement)
+  IVariableDeclaration: c1 As Program.C (OperationKind.VariableDeclaration)
+    Initializer: IObjectCreationExpression (Constructor: Sub Program.C..ctor()) (OperationKind.ObjectCreationExpression, Type: Program.C)
 ]]>.Value
 
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IVariableDeclaration.vb
@@ -121,7 +121,7 @@ IVariableDeclarationStatement (3 variables) (OperationKind.VariableDeclarationSt
 
 
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17913"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17917"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub UsingStatementDeclarationAsNew()
             Dim source = <![CDATA[
 Module Program
@@ -149,7 +149,7 @@ IUsingStatement (OperationKind.UsingStatement)
             VerifyOperationTreeForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17913"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/17917"), WorkItem(17599, "https://github.com/dotnet/roslyn/issues/17599")>
         Public Sub UsingStatementDeclaration()
             Dim source = <![CDATA[
 Module Program


### PR DESCRIPTION
Fixes #17599. This adds unit tests for `IVariableDeclaration` and `IVariableDeclarationStatement`. This covers the following statements:
**C#**:
* Basic declarations
* Multiple variable declarations
* Declarations in `fixed` statements
* Declarations in `using` statements
* Declarations in `for` loops
* Local `const` declarations

**VB**:
* Basic `Dim` statements
* Multiple `Dim` statements
* `Dim As New` statements
* Mixed `Dim` and `Dim As New` statements
* `Using` statements
    * Skipped due to #17917 
* Local `Const` declarations
* Local `Static` declarations

Skipped in both languages are `foreach`, as it does not create an `IVariableDeclaration` or `IVariableDeclarationStatement`. `For` is skipped in VB, as it also does not create an `IVariableDeclaration` or `IVariableDeclarationStatement`. 

Tagging @dotnet/analyzer-ioperation @AlekseyTs for review.