### PR TITLE
Don't offer to use an object/collection initializer if it would break code that crosses pp-directives.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -769,5 +769,60 @@ class C
     }
 }");
         }
+
+        [WorkItem(17953, "https://github.com/dotnet/roslyn/issues/17953")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestMissingAcrossPreprocessorDirective()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System.Collections.Generic;
+
+public class Foo
+{
+    public void M()
+    {
+        var items = new [||]List<object>();
+#if true
+        items.Add(1);
+#endif
+    }
+}");
+        }
+
+        [WorkItem(17953, "https://github.com/dotnet/roslyn/issues/17953")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestAvailableInsidePreprocessorDirective()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System.Collections.Generic;
+
+public class Foo
+{
+    public void M()
+    {
+#if true
+        var items = new [||]List<object>();
+        items.Add(1);
+#endif
+    }
+}",
+@"
+using System.Collections.Generic;
+
+public class Foo
+{
+    public void M()
+    {
+#if true
+        var items = new List<object>
+        {
+            1
+        };
+#endif
+    }
+}", ignoreTrivia: false);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -481,5 +481,60 @@ class C
     }
 }");
         }
+
+        [WorkItem(17953, "https://github.com/dotnet/roslyn/issues/17953")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestMissingAcrossPreprocessorDirective()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+public class Foo
+{
+    public void M()
+    {
+        var foo = [||]new Foo();
+#if true
+        foo.Value = "";
+#endif
+    }
+
+    public string Value { get; set; }
+}");
+        }
+
+        [WorkItem(17953, "https://github.com/dotnet/roslyn/issues/17953")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestAvailableInsidePreprocessorDirective()
+        {
+            await TestInRegularAndScript1Async(
+@"
+public class Foo
+{
+    public void M()
+    {
+#if true
+        var foo = [||]new Foo();
+        foo.Value = "";
+#endif
+    }
+
+    public string Value { get; set; }
+}",
+@"
+public class Foo
+{
+    public void M()
+    {
+#if true
+        var foo = new Foo
+        {
+            Value = "";
+        };
+#endif
+    }
+
+    public string Value { get; set; }
+}", ignoreTrivia: false);
+        }
     }
 }

--- a/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -98,6 +98,14 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 return;
             }
 
+            var containingStatement = objectCreationExpression.FirstAncestorOrSelf<TStatementSyntax>();
+            var nodes = ImmutableArray.Create<SyntaxNode>(containingStatement).AddRange(matches.Value);
+            var syntaxFacts = GetSyntaxFactsService();
+            if (syntaxFacts.ContainsInterleavedDirective(nodes, cancellationToken))
+            {
+                return;
+            }
+
             var locations = ImmutableArray.Create(objectCreationExpression.GetLocation());
 
             var severity = option.Notification.Value;

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -74,6 +75,13 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
             var result = analyzer.Analyze();
 
             if (result == null || result.Value.Length == 0)
+            {
+                return;
+            }
+
+            var containingStatement = objectCreationExpression.FirstAncestorOrSelf<TStatementSyntax>();
+            var nodes = ImmutableArray.Create<SyntaxNode>(containingStatement).AddRange(result.Value.Select(m => m.Statement));
+            if (syntaxFacts.ContainsInterleavedDirective(nodes, cancellationToken))
             {
                 return;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -311,9 +311,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         }
 
         public static bool IsAnyLambdaOrAnonymousMethod(this SyntaxNode node)
-        {
-            return node.IsAnyLambda() || node.IsKind(SyntaxKind.AnonymousMethodExpression);
-        }
+            => node.IsAnyLambda() || node.IsKind(SyntaxKind.AnonymousMethodExpression);
 
         /// <summary>
         /// Returns true if the passed in node contains an interleaved pp directive.
@@ -352,28 +350,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         /// constructs (like #if/#endif or #region/#endregion), but the grouping construct isn't
         /// entirely contained within the span of the node.
         /// </summary>
+        public static bool ContainsInterleavedDirective(this SyntaxNode syntaxNode, CancellationToken cancellationToken)
+            => CSharpSyntaxFactsService.Instance.ContainsInterleavedDirective(syntaxNode, cancellationToken);
+
         public static bool ContainsInterleavedDirective(
-            this SyntaxNode syntaxNode,
-            CancellationToken cancellationToken)
-        {
-            // Check if this node contains a start, middle or end pp construct whose matching construct is
-            // not contained within this node.  If so, this node must be pinned and cannot move.
-
-            var span = syntaxNode.Span;
-            foreach (var token in syntaxNode.DescendantTokens())
-            {
-                if (ContainsInterleavedDirective(span, token, cancellationToken))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool ContainsInterleavedDirective(
+            this SyntaxToken token,
             TextSpan textSpan,
-            SyntaxToken token,
             CancellationToken cancellationToken)
         {
             return

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1989,5 +1989,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public ImmutableArray<SyntaxNode> GetSelectedMembers(SyntaxNode root, TextSpan textSpan)
             => ImmutableArray<SyntaxNode>.CastUp(root.GetMembersInSpan(textSpan));
+
+        protected override bool ContainsInterleavedDirective(TextSpan span, SyntaxToken token, CancellationToken cancellationToken)
+            => token.ContainsInterleavedDirective(span, cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/AbstractSyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/AbstractSyntaxFactsService.cs
@@ -1,9 +1,13 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServices
@@ -206,5 +210,45 @@ namespace Microsoft.CodeAnalysis.LanguageServices
 
             return ImmutableArray.CreateRange(leadingTrivia.Take(index));
         }
+
+        public bool ContainsInterleavedDirective(
+            ImmutableArray<SyntaxNode> nodes, CancellationToken cancellationToken)
+        {
+            if (nodes.Length > 0)
+            {
+                var span = TextSpan.FromBounds(nodes.First().Span.Start, nodes.Last().Span.End);
+
+                foreach (var node in nodes)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (ContainsInterleavedDirective(span, node, cancellationToken))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool ContainsInterleavedDirective(SyntaxNode node, CancellationToken cancellationToken)
+            => ContainsInterleavedDirective(node.Span, node, cancellationToken);
+
+        private bool ContainsInterleavedDirective(
+            TextSpan span, SyntaxNode node, CancellationToken cancellationToken)
+        {
+            foreach (var token in node.DescendantTokens())
+            {
+                if (ContainsInterleavedDirective(span, token, cancellationToken))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        protected abstract bool ContainsInterleavedDirective(TextSpan span, SyntaxToken token, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -281,6 +281,9 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         SyntaxNode GetNextExecutableStatement(SyntaxNode statement);
 
         ImmutableArray<SyntaxTrivia> GetFileBanner(SyntaxNode root);
+
+        bool ContainsInterleavedDirective(SyntaxNode node, CancellationToken cancellationToken);
+        bool ContainsInterleavedDirective(ImmutableArray<SyntaxNode> nodes, CancellationToken cancellationToken);
     }
 
     [Flags]

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxNodeExtensions.vb
@@ -340,20 +340,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         ''' </summary>
         <Extension()>
         Public Function ContainsInterleavedDirective(node As SyntaxNode, cancellationToken As CancellationToken) As Boolean
-            ' Check if this node contains a start or end pp construct whose
-            ' matching construct is not contained within this node.  If so, 
-            ' this node must be pinned and cannot move.
-            '
-            ' Also, keep track of those spans so that if we see #else/#elif we
-            ' can tell if they belong to a pp span that is entirely within the
-            ' node.
-            Dim span = node.Span
-            Return node.DescendantTokens().Any(Function(token) ContainsInterleavedDirective(span, token, cancellationToken))
+            Return VisualBasicSyntaxFactsService.Instance.ContainsInterleavedDirective(node, cancellationToken)
         End Function
 
-        Private Function ContainsInterleavedDirective(
-            textSpan As TextSpan,
+        <Extension>
+        Public Function ContainsInterleavedDirective(
             token As SyntaxToken,
+            textSpan As TextSpan,
             cancellationToken As CancellationToken) As Boolean
 
             Return ContainsInterleavedDirective(textSpan, token.LeadingTrivia, cancellationToken) OrElse

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1755,5 +1755,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Function ISyntaxFactsService_GetFileBanner(root As SyntaxNode) As ImmutableArray(Of SyntaxTrivia) Implements ISyntaxFactsService.GetFileBanner
             Return GetFileBanner(root)
         End Function
+
+        Protected Overrides Function ContainsInterleavedDirective(span As TextSpan, token As SyntaxToken, cancellationToken As CancellationToken) As Boolean
+            Return token.ContainsInterleavedDirective(span, cancellationToken)
+        End Function
+
+        Private Function ISyntaxFactsService_ContainsInterleavedDirective(node As SyntaxNode, cancellationToken As CancellationToken) As Boolean Implements ISyntaxFactsService.ContainsInterleavedDirective
+            Return ContainsInterleavedDirective(node, cancellationToken)
+        End Function
+
+        Private Function ISyntaxFactsService_ContainsInterleavedDirective1(nodes As ImmutableArray(Of SyntaxNode), cancellationToken As CancellationToken) As Boolean Implements ISyntaxFactsService.ContainsInterleavedDirective
+            Return ContainsInterleavedDirective(nodes, cancellationToken)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/17953