### PR TITLE
Add "#error version" to C# and udpate UpgradeProject to support 7.1

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2852,7 +2852,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Compiler version: &apos;{0}&apos;. Language version: &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Compiler version: &apos;{0}&apos;. Language version: {1}..
         /// </summary>
         internal static string ERR_CompilerAndLanguageVersion {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2852,6 +2852,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Compiler version: &apos;{0}&apos;. Language version: &apos;{1}&apos;..
+        /// </summary>
+        internal static string ERR_CompilerAndLanguageVersion {
+            get {
+                return ResourceManager.GetString("ERR_CompilerAndLanguageVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An expression tree lambda may not contain a COM call with ref omitted on arguments.
         /// </summary>
         internal static string ERR_ComRefCallInExpressionTree {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5042,6 +5042,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>A value of type 'void' may not be assigned.</value>
   </data>
   <data name="ERR_CompilerAndLanguageVersion" xml:space="preserve">
-    <value>Compiler version: '{0}'. Language version: '{1}'.</value>
+    <value>Compiler version: '{0}'. Language version: {1}.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5041,4 +5041,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_VoidAssignment" xml:space="preserve">
     <value>A value of type 'void' may not be assigned.</value>
   </data>
+  <data name="ERR_CompilerAndLanguageVersion" xml:space="preserve">
+    <value>Compiler version: '{0}'. Language version: '{1}'.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1471,5 +1471,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InvalidPreprocessingSymbol = 8301,
         ERR_FeatureNotAvailableInVersion7_1 = 8302,
         ERR_LanguageVersionCannotHaveLeadingZeroes = 8303,
+        ERR_CompilerAndLanguageVersion = 8304,
     }
 }

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -327,7 +327,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         if (errorText.StartsWith(versionMarker, StringComparison.Ordinal) &&
                             LanguageVersionFacts.TryParse(errorText.Substring(versionMarker.Length), out var languageVersion))
                         {
-                            ErrorCode error = languageVersion.GetErrorCode();
+                            ErrorCode error = this.Options.LanguageVersion.GetErrorCode();
                             eod = this.AddError(eod, triviaOffset, triviaWidth, error, "version", new CSharpRequiredLanguageVersion(languageVersion));
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -316,15 +316,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     if (errorText.Equals("version", StringComparison.Ordinal))
                     {
-                        Assembly assembly = typeof(DirectiveParser).GetTypeInfo().Assembly;
+                        Assembly assembly = typeof(CSharpCompiler).GetTypeInfo().Assembly;
                         string version = CommonCompiler.GetAssemblyFileVersion(assembly);
                         eod = this.AddError(eod, triviaOffset, triviaWidth, ErrorCode.ERR_CompilerAndLanguageVersion, version,
                             this.Options.SpecifiedLanguageVersion.ToDisplayString());
                     }
-                    else if (LanguageVersionFacts.TryParse(errorText, out var languageVersion))
+                    else
                     {
-                        ErrorCode error = languageVersion.GetErrorCode();
-                        eod = this.AddError(eod, triviaOffset, triviaWidth, error, "version", new CSharpRequiredLanguageVersion(languageVersion));
+                        const string versionMarker = "version:";
+                        if (errorText.StartsWith(versionMarker, StringComparison.Ordinal) &&
+                            LanguageVersionFacts.TryParse(errorText.Substring(versionMarker.Length), out var languageVersion))
+                        {
+                            ErrorCode error = languageVersion.GetErrorCode();
+                            eod = this.AddError(eod, triviaOffset, triviaWidth, error, "version", new CSharpRequiredLanguageVersion(languageVersion));
+                        }
                     }
                 }
             }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1307,6 +1307,7 @@ d.cs
             // - update the "UpgradeProject" codefixer
             // - update the IDE drop-down for selecting Language Version
             // - don't fix the canary test until you update all the tests that include it
+            // - update the command-line documentation (CommandLine.md)
             Assert.Equal(LanguageVersion.CSharp7_1, LanguageVersion.Latest.MapSpecifiedToEffectiveVersion());
             Assert.Equal(LanguageVersion.CSharp7, LanguageVersion.Default.MapSpecifiedToEffectiveVersion());
         }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -185,7 +185,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                         {
                             Assert.Equal(exp.Text, ((DefineDirectiveTriviaSyntax)dt).Name.ValueText); // Text
                         }
-
+                        break;
+                    case SyntaxKind.ErrorDirectiveTrivia:
+                        if (null != exp.Text)
+                        {
+                            Assert.Equal(exp.Text, ((ErrorDirectiveTriviaSyntax)dt).EndOfDirectiveToken.ToFullString());
+                        }
+                        break;
+                    case SyntaxKind.LoadDirectiveTrivia:
+                        if (null != exp.Text)
+                        {
+                            Assert.Equal(exp.Text, ((LoadDirectiveTriviaSyntax)dt).File.ValueText);
+                        }
+                        break;
+                    case SyntaxKind.UndefDirectiveTrivia:
+                        if (null != exp.Text)
+                        {
+                            Assert.Equal(exp.Text, ((UndefDirectiveTriviaSyntax)dt).Name.ValueText);
+                        }
+                        break;
+                    case SyntaxKind.ReferenceDirectiveTrivia:
+                        if (null != exp.Text)
+                        {
+                            Assert.Equal(exp.Text, ((ReferenceDirectiveTriviaSyntax)dt).File.ValueText);
+                        }
                         break;
                     case SyntaxKind.LineDirectiveTrivia:
                         var ld = dt as LineDirectiveTriviaSyntax;
@@ -220,7 +243,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                             Assert.NotEqual(SyntaxKind.None, ld.File.Kind());
                             Assert.Equal(exp.Text, ld.File.Value);
                         }
-
+                        break;
+                    default:
+                        if (null != exp.Text)
+                        {
+                            Assert.True(false, String.Format("You are expecting some text in the directive, but this method doesn't know how to verify it for `{0}`.", exp.Kind));
+                        }
                         break;
                 } // switch
             }
@@ -2563,7 +2591,7 @@ class A { }
             var node = Parse(text);
             TestRoundTripping(node, text, false);
             VerifyErrorCode(node, (int)ErrorCode.ERR_EndOfPPLineExpected);
-            VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.UndefDirectiveTrivia, Status = NodeStatus.IsActive, Text = "FOO(" });
+            VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.UndefDirectiveTrivia, Status = NodeStatus.IsActive, Text = "FOO" });
         }
 
         [Fact]
@@ -2587,7 +2615,7 @@ class A { }
             var node = Parse(text);
             TestRoundTripping(node, text, false);
             VerifyErrorCode(node, (int)ErrorCode.ERR_IdentifierExpected);
-            VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.UndefDirectiveTrivia, Status = NodeStatus.IsActive, Text = "1234" });
+            VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.UndefDirectiveTrivia, Status = NodeStatus.IsActive, Text = "" });
         }
 
         [Fact]
@@ -2998,7 +3026,7 @@ class A { }
             {
                 Kind = SyntaxKind.ErrorDirectiveTrivia,
                 Status = NodeStatus.IsActive,
-                Text = "7.1"
+                Text = "version:7.1"
             });
 
             node.GetDiagnostics().Verify(
@@ -3021,7 +3049,7 @@ class A { }
             {
                 Kind = SyntaxKind.ErrorDirectiveTrivia,
                 Status = NodeStatus.IsActive,
-                Text = "A.B"
+                Text = "version:A.B"
             });
 
             node.GetDiagnostics().Verify(

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -3032,10 +3032,10 @@ class A { }
             node.GetDiagnostics().Verify(
                 // (1,8): error CS1029: #error: 'version:7.1'
                 // #error version:7.1
-                Diagnostic(ErrorCode.ERR_ErrorDirective, "version:7.1").WithArguments("version:7.1").WithLocation(1, 8),
-                // (1,8): error CS8302: Feature 'version' is not available in C# 7.1. Please use language version 7.1 or greater.
+                Diagnostic(ErrorCode.ERR_ErrorDirective, "version:7.1").WithArguments("version:7.1"),
+                // (1,8): error CS8025: Feature 'version' is not available in C# 4. Please use language version 7.1 or greater.
                 // #error version:7.1
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "version:7.1").WithArguments("version", "7.1").WithLocation(1, 8)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion4, "version:7.1").WithArguments("version", "7.1").WithLocation(1, 8)
                 );
         }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -128,18 +128,15 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal virtual string GetAssemblyFileVersion()
         {
-            if (_clientDirectory != null)
-            {
-                Assembly assembly = Type.GetTypeInfo().Assembly;
-                var name = $"{assembly.GetName().Name}.dll";
-                var filePath = Path.Combine(_clientDirectory, name);
-                var fileVersionInfo = FileVersionInfo.GetVersionInfo(filePath);
-                string hash = ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash);
+            Assembly assembly = Type.GetTypeInfo().Assembly;
+            return GetAssemblyFileVersion(assembly);
+        }
 
-                return $"{fileVersionInfo.FileVersion} ({hash})";
-            }
-
-            return "";
+        internal static string GetAssemblyFileVersion(Assembly assembly)
+        {
+            string assemblyVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+            string hash = ExtractShortCommitHash(assembly.GetCustomAttribute<CommitHashAttribute>()?.Hash);
+            return $"{assemblyVersion} ({hash})";
         }
 
         internal static string ExtractShortCommitHash(string hash)

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -85,6 +85,19 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
+        public async Task UpgradeProjectFromCSharp7_1ToLatest()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class Program
+{
+#error version:[|7.1|]
+}",
+                LanguageVersion.Latest,
+                new CSharpParseOptions(LanguageVersion.CSharp7_1));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
         public async Task UpgradeProjectFromCSharp7ToCSharp7_1()
         {
             await TestLanguageVersionUpgradedAsync(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.Async
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
-        public async Task UpgradeProjectToDefault()
+        public async Task UpgradeProjectFromCSharp6ToDefault()
         {
             await TestLanguageVersionUpgradedAsync(
 @"
@@ -55,7 +55,7 @@ class Program
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
-        public async Task UpgradeProjectToCSharp7()
+        public async Task UpgradeProjectFromCSharp6ToCSharp7()
         {
             await TestLanguageVersionUpgradedAsync(
 @"
@@ -68,6 +68,33 @@ class Program
 }",
                 LanguageVersion.CSharp7,
                 new CSharpParseOptions(LanguageVersion.CSharp6),
+                index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
+        public async Task UpgradeProjectFromCSharp7ToLatest()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class Program
+{
+#error [|7.1|]
+}",
+                LanguageVersion.Latest,
+                new CSharpParseOptions(LanguageVersion.CSharp7));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUpgradeProject)]
+        public async Task UpgradeProjectFromCSharp7ToCSharp7_1()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class Program
+{
+#error [|7.1|]
+}",
+                LanguageVersion.CSharp7_1,
+                new CSharpParseOptions(LanguageVersion.CSharp7),
                 index: 1);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -78,7 +78,7 @@ class Program
 @"
 class Program
 {
-#error [|7.1|]
+#error version:[|7.1|]
 }",
                 LanguageVersion.Latest,
                 new CSharpParseOptions(LanguageVersion.CSharp7));
@@ -91,7 +91,7 @@ class Program
 @"
 class Program
 {
-#error [|7.1|]
+#error [|version:7.1|]
 }",
                 LanguageVersion.CSharp7_1,
                 new CSharpParseOptions(LanguageVersion.CSharp7),

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractUserDiagnosticTest.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -69,7 +70,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
         protected Document GetDocumentAndAnnotatedSpan(TestWorkspace workspace, out string annotation, out TextSpan span)
         {
-            var hostDocument = workspace.Documents.Single(d => d.AnnotatedSpans.Any());
+            var annotatedDocuments = workspace.Documents.Where(d => d.AnnotatedSpans.Any());
+            Debug.Assert(!annotatedDocuments.IsEmpty(), "No annotated span found");
+            var hostDocument = annotatedDocuments.Single();
             var annotatedSpan = hostDocument.AnnotatedSpans.Single();
             annotation = annotatedSpan.Key;
             span = annotatedSpan.Value.Single();

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -22,9 +22,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
         private const string CS8025 = nameof(CS8025); // error CS8025: Feature is not available in C# 4. Please use language version X or greater.
         private const string CS8026 = nameof(CS8026); // error CS8026: Feature is not available in C# 5. Please use language version X or greater.
         private const string CS8059 = nameof(CS8059); // error CS8059: Feature is not available in C# 6. Please use language version X or greater.
+        private const string CS8302 = nameof(CS8302); // error CS8302: Feature is not available in C# 7.0. Please use language version X or greater.
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059);
+            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8302);
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;
         public override string UpgradeAllProjectsResource => CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0;

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -22,10 +22,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
         private const string CS8025 = nameof(CS8025); // error CS8025: Feature is not available in C# 4. Please use language version X or greater.
         private const string CS8026 = nameof(CS8026); // error CS8026: Feature is not available in C# 5. Please use language version X or greater.
         private const string CS8059 = nameof(CS8059); // error CS8059: Feature is not available in C# 6. Please use language version X or greater.
-        private const string CS8302 = nameof(CS8302); // error CS8302: Feature is not available in C# 7.0. Please use language version X or greater.
+        private const string CS8107 = nameof(CS8107); // error CS8059: Feature is not available in C# 7.0. Please use language version X or greater.
+        private const string CS8302 = nameof(CS8302); // error CS8302: Feature is not available in C# 7.1. Please use language version X or greater.
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8302);
+            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302);
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;
         public override string UpgradeAllProjectsResource => CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0;

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ParseTreeDescription.vb
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/XML/ParseTreeDescription.vb
@@ -138,7 +138,7 @@ Public Class ParseTree
             Return Enumerations(enumString)
         End If
 
-        ReportError(referencingElement, "{0} is not a valid field type", enumString)
+        ReportError(referencingElement, "{0} is not a valid field type. You should add a node-kind entry in the syntax.xml.", enumString)
         Return Nothing
     End Function
 


### PR DESCRIPTION
This is a re-worked version of PR #17957. In particular, it introduces no new syntax nodes.

This change solves two problems:
1. print out the compiler version as a diagnostic for troubleshooting purpose (with `#error version`)
2. generate a "please use version 7.1" diagnostic even when the compiler supports no 7.1 features yet (with `#error 7.1`)

This is only supported in C# for now. I can file a separate issue for VB if needed.

Adds ability to print the compiler version as diagnostic (#17859)
Updates the UpgradeProject fixer as follow-up on #17894

@gafter @cston @tmat @CyrusNajmabadi for review. Thanks