### PR TITLE
Port the Formatting tests to the new framework

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
@@ -1,0 +1,264 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpFormatting : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+
+        public CSharpFormatting(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory, nameof(CSharpFormatting))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void AlignOpenBraceWithMethodDeclaration()
+        {
+            SetUpEditor(@"
+$$class C
+{
+    void Main()
+     {
+    }
+}");
+
+            Editor.FormatDocument();
+            this.VerifyTextContains(@"
+class C
+{
+    void Main()
+    {
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatOnSemicolon()
+        {
+            SetUpEditor(@"
+public class C
+{
+    void Foo()
+    {
+        var x =        from a             in       new List<int>()
+    where x % 2 = 0
+                      select x   ;$$
+    }
+}");
+
+            this.SendKeys(VirtualKey.Backspace, ";");
+            this.VerifyTextContains(@"
+public class C
+{
+    void Foo()
+    {
+        var x = from a in new List<int>()
+                where x % 2 = 0
+                select x;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void FormatSelection()
+        {
+            SetUpEditor(@"
+public class C {
+    public void M( ) {$$
+        }
+}");
+
+            this.SelectTextInCurrentDocument("public void M( ) {");
+            Editor.FormatSelection();
+            this.VerifyTextContains(@"
+public class C {
+    public void M()
+    {
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void PasteCodeWithLambdaBody()
+        {
+            SetUpEditor(@"
+using System;
+class Program
+{
+    static void Main()
+    {
+        Action a = () =>
+        {
+            using (null)
+            {
+                $$
+            }
+        };
+    }
+}");
+            Editor.Paste(@"        Action b = () =>
+        {
+
+            };");
+
+            this.VerifyTextContains(@"
+using System;
+class Program
+{
+    static void Main()
+    {
+        Action a = () =>
+        {
+            using (null)
+            {
+                Action b = () =>
+                {
+
+                };
+            }
+        };
+    }
+}");
+            // Undo should only undo the formatting
+            Editor.Undo();
+            this.VerifyTextContains(@"
+using System;
+class Program
+{
+    static void Main()
+    {
+        Action a = () =>
+        {
+            using (null)
+            {
+                        Action b = () =>
+        {
+
+            };
+            }
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void PasteCodeWithLambdaBody2()
+        {
+            SetUpEditor(@"
+using System;
+class Program
+{
+    static void Main()
+    {
+        Action a = () =>
+        {
+            using (null)
+            {
+                $$
+            }
+        };
+    }
+}");
+            Editor.Paste(@"        Action<int> b = n =>
+        {
+            Console.Writeline(n);
+        };");
+
+            this.VerifyTextContains(@"
+using System;
+class Program
+{
+    static void Main()
+    {
+        Action a = () =>
+        {
+            using (null)
+            {
+                Action<int> b = n =>
+                {
+                    Console.Writeline(n);
+                };
+            }
+        };
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void PasteCodeWithLambdaBody3()
+        {
+            SetUpEditor(@"
+using System;
+class Program
+{
+    static void Main()
+    {
+        Action a = () =>
+        {
+            using (null)
+            {
+                $$
+            }
+        };
+    }
+}");
+            Editor.Paste(@"        D d = delegate(int x)
+{
+    return 2 * x;
+};");
+
+            this.VerifyTextContains(@"
+using System;
+class Program
+{
+    static void Main()
+    {
+        Action a = () =>
+        {
+            using (null)
+            {
+                D d = delegate (int x)
+                {
+                    return 2 * x;
+                };
+            }
+        };
+    }
+}");
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18065"),
+         Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void ShiftEnterWithIntelliSenseAndBraceMatching()
+        {
+            SetUpEditor(@"
+class Program
+{
+    object M(object bar)
+    {
+        return M$$
+    }
+}");
+            VisualStudio.Instance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            Editor.SendKeys("(ba", new KeyPress(VirtualKey.Enter, ShiftState.Shift), "// comment");
+            this.VerifyTextContains(@"
+class Program
+{
+    object M(object bar)
+    {
+        return M(bar);
+        // comment
+    }
+}");
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
-using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
 using Xunit;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -31,8 +30,8 @@ $$class C
     }
 }");
 
-            Editor.FormatDocument();
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.FormatDocument();
+            VisualStudio.Editor.Verify.TextContains(@"
 class C
 {
     void Main()
@@ -55,8 +54,8 @@ public class C
     }
 }");
 
-            this.SendKeys(VirtualKey.Backspace, ";");
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SendKeys(VirtualKey.Backspace, ";");
+            VisualStudio.Editor.Verify.TextContains(@"
 public class C
 {
     void Foo()
@@ -77,9 +76,9 @@ public class C {
         }
 }");
 
-            this.SelectTextInCurrentDocument("public void M( ) {");
-            Editor.FormatSelection();
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.SelectTextInCurrentDocument("public void M( ) {");
+            VisualStudio.Editor.FormatSelection();
+            VisualStudio.Editor.Verify.TextContains(@"
 public class C {
     public void M()
     {
@@ -105,12 +104,12 @@ class Program
         };
     }
 }");
-            Editor.Paste(@"        Action b = () =>
+            VisualStudio.Editor.Paste(@"        Action b = () =>
         {
 
             };");
 
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.Verify.TextContains(@"
 using System;
 class Program
 {
@@ -129,8 +128,8 @@ class Program
     }
 }");
             // Undo should only undo the formatting
-            Editor.Undo();
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.Undo();
+            VisualStudio.Editor.Verify.TextContains(@"
 using System;
 class Program
 {
@@ -168,12 +167,12 @@ class Program
         };
     }
 }");
-            Editor.Paste(@"        Action<int> b = n =>
+            VisualStudio.Editor.Paste(@"        Action<int> b = n =>
         {
             Console.Writeline(n);
         };");
 
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.Verify.TextContains(@"
 using System;
 class Program
 {
@@ -211,12 +210,12 @@ class Program
         };
     }
 }");
-            Editor.Paste(@"        D d = delegate(int x)
+            VisualStudio.Editor.Paste(@"        D d = delegate(int x)
 {
     return 2 * x;
 };");
 
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.Verify.TextContains(@"
 using System;
 class Program
 {
@@ -248,9 +247,9 @@ class Program
         return M$$
     }
 }");
-            VisualStudio.Instance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
-            Editor.SendKeys("(ba", new KeyPress(VirtualKey.Enter, ShiftState.Shift), "// comment");
-            this.VerifyTextContains(@"
+            VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            VisualStudio.Editor.SendKeys("(ba", new KeyPress(VirtualKey.Enter, ShiftState.Shift), "// comment");
+            VisualStudio.Editor.Verify.TextContains(@"
 class Program
 {
     object M(object bar)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicFormatting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicFormatting.cs
@@ -6,13 +6,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
-using Roslyn.VisualStudio.IntegrationTests.Extensions;
-using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
 using Xunit;
-
-// *************************************************************
-// ***** Turn on visible whitespace when editing this file *****
-// *************************************************************
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -39,8 +33,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 
             SetUpEditor(testCode);
 
-            Editor.FormatDocument();
-            this.VerifyTextContains(
+            VisualStudio.Editor.FormatDocument();
+            VisualStudio.Editor.Verify.TextContains(
 @"Module A
     Sub Main(args As String())
 
@@ -54,8 +48,8 @@ End Module");
             SetUpEditor(@"
 $$module A
 end module");
-            Editor.FormatDocument();
-            this.VerifyTextContains(@"
+            VisualStudio.Editor.FormatDocument();
+            VisualStudio.Editor.Verify.TextContains(@"
 Module A
 End Module");
         }
@@ -70,9 +64,9 @@ Module Program
         Return Main$$
     End Function
 End Module");
-            this.WaitForAsyncOperations(FeatureAttribute.Workspace);
-            Editor.SendKeys("(o", new KeyPress(VirtualKey.Enter, ShiftState.Shift), "'comment");
-            this.VerifyTextContains(@"
+            VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            VisualStudio.Editor.SendKeys("(o", new KeyPress(VirtualKey.Enter, ShiftState.Shift), "'comment");
+            VisualStudio.Editor.Verify.TextContains(@"
 Module Program
     Function Main(ooo As Object) As Object
         Return Main(ooo)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicFormatting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicFormatting.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
+using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.IntegrationTests.Extensions;
+using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
+using Xunit;
+
+// *************************************************************
+// ***** Turn on visible whitespace when editing this file *****
+// *************************************************************
+
+namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class BasicFormatting : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.VisualBasic;
+
+        public BasicFormatting(VisualStudioInstanceFactory instanceFactory)
+            : base(instanceFactory, nameof(BasicFormatting))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void VerifyFormattingIndent()
+        {
+            var testCode = new StringBuilder()
+                .AppendLine("$$Module A")
+                .AppendLine("    Sub Main(args As String())")
+                .AppendLine("    ")
+                .AppendLine("        End Sub")
+                .AppendLine("End Module")
+                .ToString();
+
+            SetUpEditor(testCode);
+
+            Editor.FormatDocument();
+            this.VerifyTextContains(
+@"Module A
+    Sub Main(args As String())
+
+    End Sub
+End Module");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void VerifyCaseCorrection()
+        {
+            SetUpEditor(@"
+$$module A
+end module");
+            Editor.FormatDocument();
+            this.VerifyTextContains(@"
+Module A
+End Module");
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18065"), 
+         Trait(Traits.Feature, Traits.Features.Formatting)]
+        public void ShiftEnterWithIntelliSenseAndBraceMatching()
+        {
+            SetUpEditor(@"
+Module Program
+    Function Main(ooo As Object) As Object
+        Return Main$$
+    End Function
+End Module");
+            this.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            Editor.SendKeys("(o", new KeyPress(VirtualKey.Enter, ShiftState.Shift), "'comment");
+            this.VerifyTextContains(@"
+Module Program
+    Function Main(ooo As Object) As Object
+        Return Main(ooo)
+        'comment
+    End Function
+End Module");
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="CSharp\CSharpEncapsulateField.cs" />
     <Compile Include="CSharp\CSharpF1Help.cs" />
     <Compile Include="CSharp\CSharpInteractiveBoxSelection.cs" />
+    <Compile Include="CSharp\CSharpFormatting.cs" />
     <Compile Include="CSharp\CSharpChangeSignatureDialog.cs" />
     <Compile Include="CSharp\CSharpClassification.cs" />
     <Compile Include="CSharp\CSharpErrorListCommon.cs" />
@@ -77,6 +78,7 @@
     <Compile Include="VisualBasic\BasicAutomaticBraceCompletion.cs" />
     <Compile Include="VisualBasic\BasicBuild.cs" />
     <Compile Include="VisualBasic\BasicClassification.cs" />
+    <Compile Include="VisualBasic\BasicFormatting.cs" />
     <Compile Include="VisualBasic\BasicGenerateEqualsAndGetHashCodeDialog.cs" />
     <Compile Include="VisualBasic\BasicGenerateConstructorDialog.cs" />
     <Compile Include="VisualBasic\BasicChangeSignatureDialog.cs" />

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -163,12 +163,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             => _editorInProc.DialogSendKeys(dialogAutomationName, keys);
 
         public void FormatDocument() {
-            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            VisualStudioInstance.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
             SendKeys(new KeyPress(VirtualKey.K, ShiftState.Ctrl), new KeyPress(VirtualKey.D, ShiftState.Ctrl));
         }
 
         public void FormatSelection() {
-            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            VisualStudioInstance.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
             SendKeys(new KeyPress(VirtualKey.K, ShiftState.Ctrl), new KeyPress(VirtualKey.F, ShiftState.Ctrl));
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -4,6 +4,8 @@ using System;
 using System.Linq;
 using System.Windows.Automation;
 using System.Collections.Generic;
+using System.Threading;
+using System.Windows;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
@@ -159,6 +161,26 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void DialogSendKeys(string dialogAutomationName, string keys)
             => _editorInProc.DialogSendKeys(dialogAutomationName, keys);
+
+        public void FormatDocument() {
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            SendKeys(new KeyPress(VirtualKey.K, ShiftState.Ctrl), new KeyPress(VirtualKey.D, ShiftState.Ctrl));
+        }
+
+        public void FormatSelection() {
+            VisualStudioInstance.VisualStudioWorkspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
+            SendKeys(new KeyPress(VirtualKey.K, ShiftState.Ctrl), new KeyPress(VirtualKey.F, ShiftState.Ctrl));
+        }
+
+        public void Paste(string text)
+        {
+            var thread = new Thread(() => Clipboard.SetText(text));
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            VisualStudioInstance.Dte.ExecuteCommand("Edit.Paste");
+        }
 
         public void Undo()
             => _editorInProc.Undo();


### PR DESCRIPTION
Original tests at https://github.com/dotnet/roslyn-internal/blob/master/Closed/Hosting/RoslynTaoActions/IntegrationTests/BasicFormatting.xml / https://github.com/dotnet/roslyn-internal/blob/master/Closed/Hosting/RoslynTaoActions/IntegrationTests/CSharpFormatting.xml