### PR TITLE
IOperation SyntaxNode check

### DIFF
--- a/src/Compilers/Test/Utilities/CSharp/CSharpCompilerTestUtilities.csproj
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpCompilerTestUtilities.csproj
@@ -29,6 +29,7 @@
     <Compile Include="CompilationTestUtils.cs" />
     <Compile Include="CompilingTestBase.cs" />
     <Compile Include="CSharpTestBase.cs" />
+    <Compile Include="CSharpSyntaxNodeGetOperationWalker.cs" />
     <Compile Include="CSharpTrackingDiagnosticAnalyzer.cs" />
     <Compile Include="DiagnosticExtensions.cs" />
     <Compile Include="DiagnosticTestUtilities.cs" />

--- a/src/Compilers/Test/Utilities/CSharp/CSharpSyntaxNodeGetOperationWalker.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpSyntaxNodeGetOperationWalker.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
+{
+    public sealed class CSharpSyntaxNodeGetOperationWalker
+        : SyntaxNodeGetOperationWalker
+    {
+        protected override bool IsSyntaxNodeKindExcluded(SyntaxNode node)
+        {
+            return node is CompilationUnitSyntax
+                || node is UsingDirectiveSyntax 
+                || node is NamespaceDeclarationSyntax
+                || node is ClassDeclarationSyntax;
+        }
+    }
+}

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicCompilerTestUtilities.vbproj
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicCompilerTestUtilities.vbproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicTestBase.vb" />
+    <Compile Include="BasicSyntaxNodeGetOperationWalker.vb" />
     <Compile Include="BasicTrackingDiagnosticAnalyzer.vb" />
     <Compile Include="CompilationTestUtils.vb" />
     <Compile Include="DiagnosticExtensions.vb" />

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicSyntaxNodeGetOperationWalker.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicSyntaxNodeGetOperationWalker.vb
@@ -1,0 +1,14 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Test.Utilities
+
+Public NotInheritable Class BasicSyntaxNodeGetOperationWalker
+    Inherits SyntaxNodeGetOperationWalker
+
+    Protected Overrides Function IsSyntaxNodeKindExcluded(node As SyntaxNode) As Boolean
+        Return TypeOf node Is ImportsStatementSyntax OrElse
+               TypeOf node Is NamespaceBlockSyntax OrElse
+               TypeOf node Is CompilationUnitSyntax OrElse
+               TypeOf node Is ModuleBlockSyntax
+    End Function
+End Class

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -66,11 +66,6 @@ Friend Module CompilationUtils
         Dim metadataReferences = If(references Is Nothing, {MscorlibRef}, {MscorlibRef}.Concat(references))
         assemblyName = If(assemblyName, GetUniqueName())
 
-#If Test_IOperation_Interface Then
-        Dim compilationForOperationWalking = VisualBasicCompilation.Create(assemblyName, sourceTrees, metadataReferences, options)
-        WalkOperationTrees(compilationForOperationWalking)
-#End If
-
         Return VisualBasicCompilation.Create(assemblyName, sourceTrees, metadataReferences, options)
     End Function
 
@@ -307,11 +302,6 @@ Friend Module CompilationUtils
             End If
         End If
 
-#If Test_IOperation_Interface Then
-        Dim compilationForOperationWalking = VisualBasicCompilation.Create(If(assemblyName, GetUniqueName()), sourceTrees, references, options)
-        WalkOperationTrees(compilationForOperationWalking)
-#End If
-
         Return VisualBasicCompilation.Create(If(assemblyName, GetUniqueName()), sourceTrees, references, options)
     End Function
 
@@ -341,27 +331,6 @@ Friend Module CompilationUtils
         DirectCast(c.Assembly, SourceAssemblySymbol).m_lazyIdentity = identity
         Return c
     End Function
-
-#If Test_IOperation_Interface Then
-    Private Sub WalkOperationTrees(compilation As VisualBasicCompilation)
-        Dim operationWalker = TestOperationWalker.GetInstance()
-
-        For Each tree In compilation.SyntaxTrees
-            Dim semanticModel = compilation.GetSemanticModel(tree)
-            Dim root = tree.GetRoot()
-
-            ' need to check other operation root as well (property, etc)
-            For Each methodNode As MethodBlockBaseSyntax In root.DescendantNodesAndSelf().OfType(Of MethodBlockBaseSyntax)
-                ' Have to iterate through statements because a bug:
-                ' https://github.com/dotnet/roslyn/issues/8919
-                For Each statement In methodNode.Statements
-                    Dim operation = semanticModel.GetOperation(statement)
-                    operationWalker.Visit(operation)
-                Next
-            Next
-        Next
-    End Sub
-#End If
 
     ''' <summary>
     ''' 

--- a/src/Test/Utilities/Portable/Compilation/SyntaxNodelGetOperationWalker.cs
+++ b/src/Test/Utilities/Portable/Compilation/SyntaxNodelGetOperationWalker.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.Utilities
+{
+    public abstract class SyntaxNodeGetOperationWalker : SyntaxWalker
+    {
+        public SemanticModel SemanticModel { get; set; }
+
+        // syntax nodes with null or OperationKind.None operation
+        public List<(SyntaxNode node, IOperation operation)> SyntaxNodesWithNoOperation { get; }
+
+        public SyntaxNodeGetOperationWalker()
+        {
+            SyntaxNodesWithNoOperation = new List<(SyntaxNode, IOperation)>();
+        }
+
+        public override void Visit(SyntaxNode node)
+        {
+            Debug.Assert(SemanticModel.SyntaxTree == node.SyntaxTree);
+
+            if (!IsSyntaxNodeKindExcluded(node))
+            {
+                var operation = SemanticModel.GetOperationInternal(node);
+                if (operation == null || operation.Kind == OperationKind.None)
+                {
+                    SyntaxNodesWithNoOperation.Add((node, operation));
+                }
+            }
+
+            base.Visit(node);
+        }
+
+        protected override void VisitToken(SyntaxToken token)
+        {
+            // No need to check tokens.
+        }
+
+        protected abstract bool IsSyntaxNodeKindExcluded(SyntaxNode node);
+
+        public void Report()
+        {
+            if (SyntaxNodesWithNoOperation.Any())
+            {
+                var sb = new StringBuilder();
+                foreach ((var node, var operation) in SyntaxNodesWithNoOperation)
+                {
+                    var operationType = operation == null ? "null" : operation.GetType().Name;
+                    sb.AppendLine($"{node.GetType().Name} : Operation - {operationType}");
+                    sb.AppendLine($"{node.ToString()}");
+                    sb.AppendLine("------------------------------------------");
+                }
+                Assert.True(false, sb.ToString());
+            }
+        }        
+
+        public static void CheckSyntaxTrees(SyntaxNodeGetOperationWalker walker, Compilation compilation)
+        {
+            if (walker == null || compilation == null)
+            {
+                return;
+            }
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                walker.SemanticModel = compilation.GetSemanticModel(tree);
+                walker.Visit(tree.GetRoot());
+            }
+            walker.Report();
+        }
+    }
+}

--- a/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.Semantics;
 using Xunit;
 
@@ -20,14 +23,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 s_instance = new TestOperationWalker();
             }
             return s_instance;
-        }
-
-#if Test_IOperation_None_Kind
+        }        
         internal override void VisitNoneOperation(IOperation operation)
         {
             Assert.True(false, "Encountered an IOperation with `Kind == OperationKind.None` while walking the operation tree.");
         }
-#endif
 
         public override void Visit(IOperation operation)
         {
@@ -536,6 +536,49 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public override void VisitInvalidExpression(IInvalidExpression operation)
         { 
             base.VisitInvalidExpression(operation);
+        }
+
+        public static void CheckOperationTrees(CSharpCompilation compilation)
+        {
+            var operationWalker = GetInstance();
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                var semanticModel = compilation.GetSemanticModel(tree);
+                var root = tree.GetRoot();
+
+                // TODO: check other operation root as well (property, etc.)
+                foreach (var methodNode in root.DescendantNodesAndSelf().OfType<CSharp.Syntax.BaseMethodDeclarationSyntax>())
+                {
+                    var bodyNode = methodNode.Body;
+                    if (bodyNode != null)
+                    {
+                        var operation = semanticModel.GetOperation(bodyNode);
+                        operationWalker.Visit(operation);
+                    }
+                }
+            }
+        }
+
+        public static void CheckOperationTrees(VisualBasicCompilation compilation)
+        {
+            var operationWalker = GetInstance();
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                var semanticModel = compilation.GetSemanticModel(tree);
+                var root = tree.GetRoot();
+
+                // TODO: check other operation root as well (property, etc.)
+                foreach (var methodNode in root.DescendantNodesAndSelf().OfType<VisualBasic.Syntax.MethodBlockBaseSyntax>())
+                {
+                    // Have to iterate through statements because a bug:
+                    // https://github.com/dotnet/roslyn/issues/8919
+                    foreach(var statement in methodNode.Statements)
+                    {
+                        var operation = semanticModel.GetOperation(statement);
+                        operationWalker.Visit(operation);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
@@ -538,7 +538,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             base.VisitInvalidExpression(operation);
         }
 
-        public static void CheckOperationTrees(CSharpCompilation compilation)
+        public static void CheckCSharpOperationTrees(CSharpCompilation compilation)
         {
             var operationWalker = GetInstance();
             foreach (var tree in compilation.SyntaxTrees)
@@ -552,14 +552,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     var bodyNode = methodNode.Body;
                     if (bodyNode != null)
                     {
-                        var operation = semanticModel.GetOperation(bodyNode);
+                        var operation = semanticModel.GetOperationInternal(bodyNode);
                         operationWalker.Visit(operation);
                     }
                 }
             }
         }
 
-        public static void CheckOperationTrees(VisualBasicCompilation compilation)
+        public static void CheckBasicOperationTrees(VisualBasicCompilation compilation)
         {
             var operationWalker = GetInstance();
             foreach (var tree in compilation.SyntaxTrees)
@@ -574,7 +574,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     // https://github.com/dotnet/roslyn/issues/8919
                     foreach(var statement in methodNode.Statements)
                     {
-                        var operation = semanticModel.GetOperation(statement);
+                        var operation = semanticModel.GetOperationInternal(statement);
                         operationWalker.Visit(operation);
                     }
                 }

--- a/src/Test/Utilities/Portable/TestUtilities.csproj
+++ b/src/Test/Utilities/Portable/TestUtilities.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Compilation\IRuntimeEnvironment.cs" />
     <Compile Include="Compilation\OperationTreeVerifier.cs" />
     <Compile Include="Compilation\TestOperationWalker.cs" />
+    <Compile Include="Compilation\SyntaxNodelGetOperationWalker.cs" />
     <Compile Include="Compilation\VersionTestHelpers.cs" />
     <Compile Include="ConditionalFactAttribute.cs" />
     <Compile Include="Diagnostics\BoxingOperationAnalyzer.cs" />


### PR DESCRIPTION
Hook up part of the compiler tests with `SyntaxNodeGetOperationWalker`, which traverses syntax trees and  examines return value of SemanticModel.GetOpertaion on each `SyntaxNode`. The walker reports null and None kind operations at the end. 

Also refactored and hooked up existing `TestOperationWalker`, which traverses operation tree (currently only on method bodies), accesses each operation and looks for exceptions and None operation.

#17913 
@dotnet/analyzer-ioperation 