### PR TITLE
Improved handling of variable scopes for IDE0018 (inline declaration)

### DIFF
--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -1368,7 +1368,7 @@ class C
 
         [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
-        public async Task TestNotInShortCircuitExpression()
+        public async Task TestNotInShortCircuitExpression1()
         {
             await TestMissingAsync(
 @"
@@ -1379,6 +1379,30 @@ class C
     static void Main(string[] args)
     {
         string [|token|] = null;
+        bool condition = false && GetValue(out token);
+        Console.WriteLine(token);
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestNotInShortCircuitExpression2()
+        {
+            await TestMissingAsync(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|];
         bool condition = false && GetValue(out token);
         Console.WriteLine(token);
     }
@@ -1684,7 +1708,7 @@ class C
 
         [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
-        public async Task TestInShortCircuitExpression()
+        public async Task TestInShortCircuitExpression1()
         {
             await TestInRegularAndScript1Async(
 @"
@@ -1695,6 +1719,44 @@ class C
     static void Main(string[] args)
     {
         string [|token|] = null;
+        bool condition = false && GetValue(out token);
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}",
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        bool condition = false && GetValue(out string token);
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestInShortCircuitExpression2()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|];
         bool condition = false && GetValue(out token);
     }
 

--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -1309,6 +1309,114 @@ class C
 }");
         }
 
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestNotInUsing()
+        {
+            await TestMissingAsync(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|];
+        using (GetDisposableAndValue(out token))
+        {
+        }
+
+        Console.WriteLine(token);
+    }
+
+    private static IDisposable GetDisposableAndValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestNotInExceptionFilter()
+        {
+            await TestMissingAsync(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|];
+        try
+        {
+        }
+        catch when (GetValue(out token))
+        {
+        }
+
+        Console.WriteLine(token);
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestNotInShortCircuitExpression()
+        {
+            await TestMissingAsync(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|] = null;
+        bool condition = false && GetValue(out token);
+        Console.WriteLine(token);
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestNotInFixed()
+        {
+            await TestMissingAsync(
+@"
+using System;
+
+class C
+{
+    static unsafe void Main(string[] args)
+    {
+        string [|token|];
+        fixed (int* p = GetValue(out token))
+        {
+        }
+
+        Console.WriteLine(token);
+    }
+
+    private static int[] GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
         [WorkItem(17624, "https://github.com/dotnet/roslyn/issues/17624")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
         public async Task TestInLoops1()
@@ -1478,6 +1586,176 @@ class C
     }
 
     private static bool TryExtractTokenFromEmail(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestInUsing()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|];
+        using (GetDisposableAndValue(out token))
+        {
+        }
+    }
+
+    private static IDisposable GetDisposableAndValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}",
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        using (GetDisposableAndValue(out string token))
+        {
+        }
+    }
+
+    private static IDisposable GetDisposableAndValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestInExceptionFilter()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|];
+        try
+        {
+        }
+        catch when (GetValue(out token))
+        {
+        }
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}",
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        try
+        {
+        }
+        catch when (GetValue(out string token))
+        {
+        }
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestInShortCircuitExpression()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|] = null;
+        bool condition = false && GetValue(out token);
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}",
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        bool condition = false && GetValue(out string token);
+    }
+
+    private static bool GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [WorkItem(18076, "https://github.com/dotnet/roslyn/issues/18076")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task TestInFixed()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        string [|token|];
+        fixed (int* p = GetValue(out token))
+        {
+        }
+    }
+
+    private static int[] GetValue(out string token)
+    {
+        throw new NotImplementedException();
+    }
+}",
+@"
+using System;
+
+class C
+{
+    static void Main(string[] args)
+    {
+        fixed (int* p = GetValue(out string token))
+        {
+        }
+    }
+
+    private static int[] GetValue(out string token)
     {
         throw new NotImplementedException();
     }

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -250,12 +250,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             // In this case, inlining the 'i' would cause it to longer be definitely
             // assigned in the WriteLine invocation.
 
-            if (localDeclarator.Initializer == null)
-            {
-                // Don't need to examine this unless the variable has an initializer.
-                return false;
-            }
-
             // Find all the current read-references to the local.
             var query = from t in enclosingBlock.DescendantTokens()
                         where t.Kind() == SyntaxKind.IdentifierToken

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -324,11 +324,17 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                     return current;
                 }
 
-                // Any loop construct defines a scope for out-variables.
+                // Any loop construct defines a scope for out-variables, as well as each of the following:
+                // * Using statements
+                // * Fixed statements
+                // * Try statements (specifically for exception filters)
                 if (current.Kind() == SyntaxKind.WhileStatement ||
                     current.Kind() == SyntaxKind.DoStatement ||
                     current.Kind() == SyntaxKind.ForStatement ||
-                    current.Kind() == SyntaxKind.ForEachStatement)
+                    current.Kind() == SyntaxKind.ForEachStatement ||
+                    current.Kind() == SyntaxKind.UsingStatement ||
+                    current.Kind() == SyntaxKind.FixedStatement ||
+                    current.Kind() == SyntaxKind.TryStatement)
                 {
                     return current;
                 }


### PR DESCRIPTION
Fixes #18076

This pull request corrects the following errors and usability issues related to IDE0018:

* `using` statements are not being treated as a variable scope
* `fixed` statements are not being treated as a variable scope
* `try` statements are not being treated as a variable scope (specifically in the case of exception filters)
* Definite assignment analysis is disabled for variables without an initializer, resulting in suggestions getting reported which cause more problems than good

@dotnet/roslyn-ide for review