### PR TITLE
Make refout tests more resilient to environment differences

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -8915,11 +8915,11 @@ class C {
         public void RefOut()
         {
             var dir = Temp.CreateDirectory();
-            dir.CreateDirectory("ref");
+            var refDir = dir.CreateDirectory("ref");
 
             var src = dir.CreateFile("a.cs");
             src.WriteAllText(@"
-class C
+public class C
 {
     /// <summary>Main method</summary>
     public static void Main()
@@ -8977,10 +8977,43 @@ class C
                 new[] { "CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute" }
                 );
 
-            output = ProcessUtilities.RunAndGetOutput(refDll, startFolder: dir.ToString(), expectedRetCode: -532462766);
+            VerifyNullReferenceException(refDir, "a.dll");
 
             // Clean up temp files
             CleanupAllGeneratedFiles(dir.Path);
+        }
+
+        /// <summary>
+        /// Calls C.Main() on the program and verifies that a null reference exception is thrown.
+        /// </summary>
+        internal static void VerifyNullReferenceException(TempDirectory dir, string programName)
+        {
+            var src = dir.CreateFile("verifier.cs");
+            src.WriteAllText(@"
+class Verifier
+{
+    public static void Main()
+    {
+        try
+        {
+            C.Main();
+        }
+        catch(System.NullReferenceException)
+        {
+            System.Console.Write(""Got expected exception"");
+        }
+    }
+}");
+
+            var outWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var csc = new MockCSharpCompiler(null, dir.Path,
+                new[] { "/nologo", "/out:verifier.exe", $"/reference:{programName}", "verifier.cs" });
+
+            int exitCode = csc.Run(outWriter);
+            Assert.Equal(0, exitCode);
+            string dirPath = dir.ToString();
+            string output = ProcessUtilities.RunAndGetOutput(Path.Combine(dirPath, "verifier.exe"), startFolder: dirPath, expectedRetCode: 0);
+            Assert.Equal("Got expected exception", output);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -8965,7 +8965,7 @@ public class C
             var output = ProcessUtilities.RunAndGetOutput(exe, startFolder: dir.Path);
             Assert.Equal("Hello", output.Trim());
 
-            var refDll = Path.Combine(dir.Path, Path.Combine("ref", "a.dll"));
+            var refDll = Path.Combine(refDir.Path, "a.dll");
             Assert.True(File.Exists(refDll));
 
             // The types and members that are included needs further refinement.
@@ -8981,12 +8981,13 @@ public class C
 
             // Clean up temp files
             CleanupAllGeneratedFiles(dir.Path);
+            CleanupAllGeneratedFiles(refDir.Path);
         }
 
         /// <summary>
         /// Calls C.Main() on the program and verifies that a null reference exception is thrown.
         /// </summary>
-        internal static void VerifyNullReferenceException(TempDirectory dir, string programName)
+        private static void VerifyNullReferenceException(TempDirectory dir, string programName)
         {
             var src = dir.CreateFile("verifier.cs");
             src.WriteAllText(@"

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -8069,7 +8069,7 @@ a
             Dim output = ProcessUtilities.RunAndGetOutput(exe, startFolder:=dir.Path)
             Assert.Equal("Hello", output.Trim())
 
-            Dim refDll = Path.Combine(dir.Path, Path.Combine("ref", "a.dll"))
+            Dim refDll = Path.Combine(refDir.Path, "a.dll")
             Assert.True(File.Exists(refDll))
 
             ' The types and members that are included needs further refinement.
@@ -8085,6 +8085,7 @@ a
 
             ' Clean up temp files
             CleanupAllGeneratedFiles(dir.Path)
+            CleanupAllGeneratedFiles(refDir.Path)
         End Sub
 
         ''' <summary>


### PR DESCRIPTION
The original tests would fail on official build machines. Those tests attempt to run the ref assembly, and expect it to fail (a NullReferenceException should be thrown). But how the process fails depends on the environment, so that is no reliable.
The new design is to run a verifier program, which references the ref assembly and catches/reports the exception instead.

@cston @jaredpar @dotnet/roslyn-compiler for review. 