### PR TITLE
Updating BuildAndTest.proj to manually deploy integration test dependencies.

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -23,14 +23,7 @@
     <MSBuildCommonProperties>
       RestorePackages=false;
       TreatWarningsAsErrors=true;
-    </MSBuildCommonProperties>
-    <MSBuildCommonProperties Condition="'$(TestVsi)' != 'true'">
-      $(MSBuildCommonProperties);
       DeployExtension=false;
-    </MSBuildCommonProperties>
-    <MSBuildCommonProperties Condition="'$(TestVsi)' == 'true'">
-      $(MSBuildCommonProperties);
-      DeployExtension=true;
     </MSBuildCommonProperties>
   </PropertyGroup>
 
@@ -102,9 +95,20 @@
       <CoreRunArgs>$(CoreClrTestDirectory)\xunit.console.netcore.exe @(CoreTestAssemblies, ' ') -parallel all -xml $(CoreClrTestDirectory)\xUnitResults\TestResults.xml</CoreRunArgs>
       <RunTestsExe>Binaries\$(Configuration)\Exes\RunTests\RunTests.exe</RunTestsExe>
       <RunTestsArgs>$(NuGetPackageRoot)\xunit.runner.console\$(xunitrunnerconsoleVersion)\tools $(RunTestArgs) @(TestAssemblies, ' ')</RunTestsArgs>
+      <VsixExpInstallerExe>$(NuGetPackageRoot)\roslyntools.microsoft.vsixexpinstaller\$(RoslynToolsMicrosoftVSIXExpInstallerVersion)\tools\VsixExpInstaller.exe</VsixExpInstallerExe>
+      <VsixExpInstallerArgs>/rootSuffix:RoslynDev /vsInstallDir:"$([System.IO.Path]::GetFullPath('$(MSBuildBinPath)\..\..\..'))"</VsixExpInstallerArgs>
     </PropertyGroup>
 
     <Exec Condition="'$(TestVsi)' != 'true' AND '$(SkipCoreClr)' != 'true'" Command="&quot;$(CoreRunExe)&quot; $(CoreRunArgs)" />
+
+    <!-- Manually deploy any VSIX required by our integration tests (https://github.com/dotnet/roslyn/issues/17456) -->
+    <Exec Condition="'$(TestVsi)' == 'true'" Command="&quot;$(VsixExpInstallerExe)&quot; $(VsixExpInstallerArgs) $(OutputDirectory)\Vsix\CompilerExtension\Roslyn.Compilers.Extension.vsix" />
+    <Exec Condition="'$(TestVsi)' == 'true'" Command="&quot;$(VsixExpInstallerExe)&quot; $(VsixExpInstallerArgs) $(OutputDirectory)\Vsix\VisualStudioSetup\Roslyn.VisualStudio.Setup.vsix" />
+    <Exec Condition="'$(TestVsi)' == 'true'" Command="&quot;$(VsixExpInstallerExe)&quot; $(VsixExpInstallerArgs) $(OutputDirectory)\Vsix\VisualStudioSetup.Next\Roslyn.VisualStudio.Setup.Next.vsix" />
+    <Exec Condition="'$(TestVsi)' == 'true'" Command="&quot;$(VsixExpInstallerExe)&quot; $(VsixExpInstallerArgs) $(OutputDirectory)\Vsix\VisualStudioInteractiveComponents\Roslyn.VisualStudio.InteractiveComponents.vsix" />
+    <Exec Condition="'$(TestVsi)' == 'true'" Command="&quot;$(VsixExpInstallerExe)&quot; $(VsixExpInstallerArgs) $(OutputDirectory)\Vsix\ExpressionEvaluatorPackage\ExpressionEvaluatorPackage.vsix" />
+    <Exec Condition="'$(TestVsi)' == 'true'" Command="&quot;$(VsixExpInstallerExe)&quot; $(VsixExpInstallerArgs) $(OutputDirectory)\Vsix\VisualStudioDiagnosticsWindow\Roslyn.VisualStudio.DiagnosticsWindow.vsix" />
+    <Exec Condition="'$(TestVsi)' == 'true'" Command="&quot;$(VsixExpInstallerExe)&quot; $(VsixExpInstallerArgs) $(OutputDirectory)\Vsix\VisualStudioIntegrationTestSetup\Microsoft.VisualStudio.IntegrationTest.Setup.vsix" />
 
     <Exec Command="&quot;$(RunTestsExe)&quot; $(RunTestsArgs)" />
 


### PR DESCRIPTION
FYI. @jasonmalinowski, @jaredpar, @dotnet/roslyn-infrastructure 

This should hopefully help cut down the deployment issues for the open vs integration tests.