### PR TITLE
Check duplicate constraints with tuple name differences

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -4,6 +4,8 @@ Changes since VS2017 (C# 7)
 - https://github.com/dotnet/roslyn/issues/17089
 In C# 7, the compiler accepted a pattern of the form `dynamic identifier`, e.g. `if (e is dynamic x)`. This was accepted only if the expression `e` was statically of type `dynamic`. The compiler now rejects the use of the type `dynamic` for a pattern variable declaration, as no object's runtime type is `dynamic`.
 
-- https://github.com/dotnet/roslyn/issues/17674 In C# 7, the compiler accepted an assignment statement of the form `_ = M();` where M is a `void` method. The compiler now rejects that.
+- https://github.com/dotnet/roslyn/issues/17674 In C# 7.0, the compiler accepted an assignment statement of the form `_ = M();` where M is a `void` method. The compiler now rejects that.
 
 - https://github.com/dotnet/roslyn/issues/17173 Before C# 7.1, `csc` would accept leading zeroes in the `/langversion` option. Now it should reject it. Example: `csc.exe source.cs /langversion:07`.
+
+- https://github.com/dotnet/roslyn/issues/17994 In C# 7.0, duplicate constraints differing only in tuple element names would not produce an error. The compiler now rejects that.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Constraints.cs
@@ -154,6 +154,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 Error(diagnostics, ErrorCode.ERR_DuplicateBound, syntax, type, name);
                                 continue;
                             }
+                            else if (constraintTypes.Any((t1, t2) => t1.Equals(t2, TypeCompareKind.IgnoreTupleNames), type))
+                            {
+                                Error(diagnostics, ErrorCode.ERR_DuplicateBoundWithDifferentTupleNames, syntax, type, name);
+                                continue;
+                            }
 
                             if (type.TypeKind == TypeKind.Class)
                             {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3500,6 +3500,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Duplicate constraint &apos;{0}&apos; for type parameter &apos;{1}&apos;, with differences in tuple element names only..
+        /// </summary>
+        internal static string ERR_DuplicateBoundWithDifferentTupleNames {
+            get {
+                return ResourceManager.GetString("ERR_DuplicateBoundWithDifferentTupleNames", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The switch statement contains multiple cases with the label value &apos;{0}&apos;.
         /// </summary>
         internal static string ERR_DuplicateCaseLabel {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1173,6 +1173,9 @@
   <data name="ERR_DuplicateBound" xml:space="preserve">
     <value>Duplicate constraint '{0}' for type parameter '{1}'</value>
   </data>
+  <data name="ERR_DuplicateBoundWithDifferentTupleNames" xml:space="preserve">
+    <value>Duplicate constraint '{0}' for type parameter '{1}', with differences in tuple element names only.</value>
+  </data>
   <data name="ERR_ClassBoundNotFirst" xml:space="preserve">
     <value>The class type constraint '{0}' must come before any other constraints</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1471,5 +1471,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InvalidPreprocessingSymbol = 8301,
         ERR_FeatureNotAvailableInVersion7_1 = 8302,
         ERR_LanguageVersionCannotHaveLeadingZeroes = 8303,
+        ERR_DuplicateBoundWithDifferentTupleNames = 8304,
     }
 }

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis
             }
             return false;
         }
+
         public static bool Any<T, TArg>(this ArrayBuilder<T> builder, Func<T, TArg, bool> predicate, TArg arg)
         {
             foreach (var item in builder)

--- a/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ArrayBuilderExtensions.cs
@@ -18,6 +18,17 @@ namespace Microsoft.CodeAnalysis
             }
             return false;
         }
+        public static bool Any<T, TArg>(this ArrayBuilder<T> builder, Func<T, TArg, bool> predicate, TArg arg)
+        {
+            foreach (var item in builder)
+            {
+                if (predicate(item, arg))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
 
         public static bool All<T>(this ArrayBuilder<T> builder, Func<T, bool> predicate)
         {

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -19174,6 +19174,71 @@ End Class
         End Sub
 
         <Fact()>
+        <WorkItem(17994, "https://github.com/dotnet/roslyn/issues/17994")>
+        Public Sub TupleNameMatchInDuplicateConstraint()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Interface I1(Of T)
+End Interface
+
+Class C(Of U As {I1(Of (a As Integer, b As Integer)), I1(Of (a As Integer, b As Integer))})
+End Class
+]]></file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+            compilation.AssertTheseDiagnostics(<errors>
+BC32071: Constraint type 'I1(Of (a As Integer, b As Integer))' already specified for this type parameter.
+Class C(Of U As {I1(Of (a As Integer, b As Integer)), I1(Of (a As Integer, b As Integer))})
+                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                               </errors>)
+
+        End Sub
+
+        <Fact()>
+        <WorkItem(17994, "https://github.com/dotnet/roslyn/issues/17994")>
+        Public Sub TupleNameDifferencesInDuplicateConstraint()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Interface I1(Of T)
+End Interface
+
+Class C(Of U As {I1(Of (a As Integer, b As Integer)), I1(Of (notA As Integer, notB As Integer))})
+End Class
+]]></file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+            compilation.AssertTheseDiagnostics(<errors>
+BC32071: Constraint type 'I1(Of (notA As Integer, notB As Integer))' already specified for this type parameter.
+Class C(Of U As {I1(Of (a As Integer, b As Integer)), I1(Of (notA As Integer, notB As Integer))})
+                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                               </errors>)
+
+        End Sub
+
+        <Fact()>
+        <WorkItem(17994, "https://github.com/dotnet/roslyn/issues/17994")>
+        Public Sub TupleNameDifferencesInIndirectDuplicateConstraint()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Interface I1(Of T)
+End Interface
+Interface I2(Of T)
+    Inherits I1(Of T)
+End Interface
+
+Class C(Of U As {I1(Of (a As Integer, b As Integer)), I2(Of (notA As Integer, notB As Integer))})
+End Class
+]]></file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+            compilation.AssertTheseDiagnostics()
+
+        End Sub
+
+        <Fact()>
         <WorkItem(14841, "https://github.com/dotnet/roslyn/issues/14841")>
         Public Sub CanReImplementInterfaceWithDifferentTupleNames()
             Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(


### PR DESCRIPTION
The current check for duplicates in constraints does a full type comparison, so no error is reported.
This PR checks for duplicate constraints ignoring tuple names.

```C#
interface I<T> { T Get(); }
class C<U> where U : I<(int a, int b)>, I<(int notA, int notB)> // this is currently allowed, and would become an error
{
    void M(U u)
    {
        var mystery = u.Get(); // this is currently (int notA, int notB)
    }
}
```

The problem does not exist in VB.
I started a discussion with compat council to review this back compat break (from 7.0).

@dotnet/roslyn-compiler for review.

Fixes https://github.com/dotnet/roslyn/issues/17994