### PR TITLE
Fix publish-assets.ps1 for refout feature branch

### DIFF
--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -43,7 +43,7 @@ try
         "dev15.0.x" { } 
         "master" { } 
         "post-dev15" { } 
-        "features/refout" { }
+        "features_refout" { }
         default
         {
             if (-not $test)


### PR DESCRIPTION
Apparently, the format I used in https://github.com/dotnet/roslyn/pull/18082 was incorrect.
The signed build produced: "Branch features_refout is not supported for publishing"

@jaredpar for review
@VSadov @dotnet/roslyn-compiler FYI
