### PR TITLE
Explaining how branch names are converted in publish-assets.ps1

### DIFF
--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -43,6 +43,7 @@ try
         "dev15.0.x" { } 
         "dev15.1.x" { } 
         "master" { } 
+        # Note that slashes are replaced with underscores. So a feature branch would look like "features_refout"
         "dev_pilchie_Fix389698" { }
         default
         {

--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -40,7 +40,6 @@ try
         "dev15.0.x" { } 
         "dev15.1.x" { } 
         "master" { } 
-        "dev/pilchie/Fix389698" { }
         default
         {
             if (-not $test)

--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -35,16 +35,12 @@ try
     # We need to remove 'refs/heads/' from the beginning of the string
     $branchName = $branchName -Replace "^refs/heads/"
     
-    # We also need to replace all instances of '/' with '_'
-    $branchName = $branchName.Replace("/", "_")
-
     switch ($branchName)
     {
         "dev15.0.x" { } 
         "dev15.1.x" { } 
         "master" { } 
-        # Note that slashes are replaced with underscores. So a feature branch would look like "features_refout"
-        "dev_pilchie_Fix389698" { }
+        "dev/pilchie/Fix389698" { }
         default
         {
             if (-not $test)


### PR DESCRIPTION
Documenting a gotcha as follow-up for https://github.com/dotnet/roslyn/pull/18129

@jaredpar @jasonmalinowski for review.

@Pilchie Should branch "dev_pilchie_Fix389698" really appear in this file in `master`?
