### PR TITLE
Port go to implementation tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.CSharp
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class CSharpGoToImplementation : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.CSharp;
+
+        public CSharpGoToImplementation(VisualStudioInstanceFactory instanceFactory)
+                    : base(instanceFactory, nameof(CSharpGoToImplementation))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
+        public void SimpleGoToImplementation()
+        {
+            AddFile("FileImplementation.cs");
+            OpenFile(ProjectName, "FileImplementation.cs");
+            Editor.SetText(
+@"class Implementation : IFoo
+{
+}");
+            AddFile("FileInterface.cs");
+            OpenFile(ProjectName, "FileInterface.cs");
+            Editor.SetText(
+@"interface IFoo 
+{
+}");
+            PlaceCaret("interface IFoo");
+            Editor.GoToImplementation();
+            VerifyTextContains(@"class Implementation$$", assertCaretPosition: true);
+            Assert.False(VisualStudio.Instance.Shell.IsActiveTabProvisional());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
+        public void GoToImplementationOpensProvisionalTabIfDocumentNotOpen()
+        {
+            AddFile("FileImplementation.cs");
+            OpenFile(ProjectName, "FileImplementation.cs");
+            Editor.SetText(
+@"class Implementation : IBar
+{
+}");
+            CloseFile(ProjectName, "FileImplementation.cs");
+            AddFile("FileInterface.cs");
+            OpenFile(ProjectName, "FileInterface.cs");
+            Editor.SetText(
+@"interface IBar
+{
+}");
+            PlaceCaret("interface IBar");
+            Editor.GoToImplementation();
+            VerifyTextContains(@"class Implementation$$", assertCaretPosition: true);
+            Assert.True(VisualStudio.Instance.Shell.IsActiveTabProvisional());
+        }
+
+
+        // TODO: Enable this once the GoToDefinition tests are merged
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/15740"),
+         Trait(Traits.Feature, Traits.Features.GoToImplementation)]
+        public void GoToImplementationFromMetadataAsSource()
+        {
+            AddFile("FileImplementation.cs");
+            OpenFile(ProjectName, "FileImplementation.cs");
+            Editor.SetText(
+@"using System;
+
+class Implementation : IDisposable
+{
+  public void SomeMethod()
+  {
+    IDisposable d;
+  }
+}");
+            PlaceCaret("IDisposable d");
+
+            // Uncomment this line once the GoToDefinition tests are merged
+            // Editor.GoToDefinition();
+            Editor.GoToImplementation();
+            VerifyTextContains(@"class Implementation : IDisposable", assertCaretPosition: true);
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
-using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
-using Roslyn.VisualStudio.IntegrationTests.Extensions.SolutionExplorer;
 using Xunit;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
@@ -25,45 +22,45 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         public void SimpleGoToImplementation()
         {
             var project = new ProjectUtils.Project(ProjectName);
-            this.AddFile("FileImplementation.cs", project);
-            this.OpenFile("FileImplementation.cs", project);
-            Editor.SetText(
+            VisualStudio.SolutionExplorer.AddFile(project, "FileImplementation.cs");
+            VisualStudio.SolutionExplorer.OpenFile(project, "FileImplementation.cs");
+            VisualStudio.Editor.SetText(
 @"class Implementation : IFoo
 {
 }");
-            this.AddFile("FileInterface.cs", project);
-            this.OpenFile("FileInterface.cs", project);
-            Editor.SetText(
+            VisualStudio.SolutionExplorer.AddFile(project, "FileInterface.cs");
+            VisualStudio.SolutionExplorer.OpenFile(project, "FileInterface.cs");
+            VisualStudio.Editor.SetText(
 @"interface IFoo 
 {
 }");
-            this.PlaceCaret("interface IFoo");
-            Editor.GoToImplementation();
-            this.VerifyTextContains(@"class Implementation$$", assertCaretPosition: true);
-            Assert.False(VisualStudio.Instance.Shell.IsActiveTabProvisional());
+            VisualStudio.Editor.PlaceCaret("interface IFoo");
+            VisualStudio.Editor.GoToImplementation();
+            VisualStudio.Editor.Verify.TextContains(@"class Implementation$$", assertCaretPosition: true);
+            Assert.False(VisualStudio.Shell.IsActiveTabProvisional());
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
         public void GoToImplementationOpensProvisionalTabIfDocumentNotOpen()
         {
             var project = new ProjectUtils.Project(ProjectName);
-            this.AddFile("FileImplementation.cs", project);
-            this.OpenFile("FileImplementation.cs", project);
-            Editor.SetText(
+            VisualStudio.SolutionExplorer.AddFile(project, "FileImplementation.cs");
+            VisualStudio.SolutionExplorer.OpenFile(project, "FileImplementation.cs");
+            VisualStudio.Editor.SetText(
 @"class Implementation : IBar
 {
 }");
-            this.CloseFile("FileImplementation.cs", project);
-            this.AddFile("FileInterface.cs", project);
-            this.OpenFile("FileInterface.cs", project);
-            Editor.SetText(
+            VisualStudio.SolutionExplorer.CloseFile(project, "FileImplementation.cs", saveFile: true);
+            VisualStudio.SolutionExplorer.AddFile(project, "FileInterface.cs");
+            VisualStudio.SolutionExplorer.OpenFile(project, "FileInterface.cs");
+            VisualStudio.Editor.SetText(
 @"interface IBar
 {
 }");
-            this.PlaceCaret("interface IBar");
-            Editor.GoToImplementation();
-            this.VerifyTextContains(@"class Implementation$$", assertCaretPosition: true);
-            Assert.True(VisualStudio.Instance.Shell.IsActiveTabProvisional());
+            VisualStudio.Editor.PlaceCaret("interface IBar");
+            VisualStudio.Editor.GoToImplementation();
+            VisualStudio.Editor.Verify.TextContains(@"class Implementation$$", assertCaretPosition: true);
+            Assert.True(VisualStudio.Shell.IsActiveTabProvisional());
         }
 
 
@@ -72,9 +69,9 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         public void GoToImplementationFromMetadataAsSource()
         {
             var project = new ProjectUtils.Project(ProjectName);
-            this.AddFile("FileImplementation.cs", project);
-            this.OpenFile("FileImplementation.cs", project);
-            Editor.SetText(
+            VisualStudio.SolutionExplorer.AddFile(project, "FileImplementation.cs");
+            VisualStudio.SolutionExplorer.OpenFile(project, "FileImplementation.cs");
+            VisualStudio.Editor.SetText(
 @"using System;
 
 class Implementation : IDisposable
@@ -84,10 +81,10 @@ class Implementation : IDisposable
         IDisposable d;
     }
 }");
-            this.PlaceCaret("IDisposable d", charsOffset: -1);
-            Editor.GoToDefinition();
-            Editor.GoToImplementation();
-            this.VerifyTextContains(@"class Implementation$$ : IDisposable", assertCaretPosition: true);
+            VisualStudio.Editor.PlaceCaret("IDisposable d", charsOffset: -1);
+            VisualStudio.Editor.GoToDefinition();
+            VisualStudio.Editor.GoToImplementation();
+            VisualStudio.Editor.Verify.TextContains(@"class Implementation$$ : IDisposable", assertCaretPosition: true);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
@@ -4,7 +4,10 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
+using Roslyn.VisualStudio.IntegrationTests.Extensions.SolutionExplorer;
 using Xunit;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -21,43 +24,45 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
         public void SimpleGoToImplementation()
         {
-            AddFile("FileImplementation.cs");
-            OpenFile(ProjectName, "FileImplementation.cs");
+            var project = new ProjectUtils.Project(ProjectName);
+            this.AddFile("FileImplementation.cs", project);
+            this.OpenFile("FileImplementation.cs", project);
             Editor.SetText(
 @"class Implementation : IFoo
 {
 }");
-            AddFile("FileInterface.cs");
-            OpenFile(ProjectName, "FileInterface.cs");
+            this.AddFile("FileInterface.cs", project);
+            this.OpenFile("FileInterface.cs", project);
             Editor.SetText(
 @"interface IFoo 
 {
 }");
-            PlaceCaret("interface IFoo");
+            this.PlaceCaret("interface IFoo");
             Editor.GoToImplementation();
-            VerifyTextContains(@"class Implementation$$", assertCaretPosition: true);
+            this.VerifyTextContains(@"class Implementation$$", assertCaretPosition: true);
             Assert.False(VisualStudio.Instance.Shell.IsActiveTabProvisional());
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
         public void GoToImplementationOpensProvisionalTabIfDocumentNotOpen()
         {
-            AddFile("FileImplementation.cs");
-            OpenFile(ProjectName, "FileImplementation.cs");
+            var project = new ProjectUtils.Project(ProjectName);
+            this.AddFile("FileImplementation.cs", project);
+            this.OpenFile("FileImplementation.cs", project);
             Editor.SetText(
 @"class Implementation : IBar
 {
 }");
-            CloseFile(ProjectName, "FileImplementation.cs");
-            AddFile("FileInterface.cs");
-            OpenFile(ProjectName, "FileInterface.cs");
+            this.CloseFile("FileImplementation.cs", project);
+            this.AddFile("FileInterface.cs", project);
+            this.OpenFile("FileInterface.cs", project);
             Editor.SetText(
 @"interface IBar
 {
 }");
-            PlaceCaret("interface IBar");
+            this.PlaceCaret("interface IBar");
             Editor.GoToImplementation();
-            VerifyTextContains(@"class Implementation$$", assertCaretPosition: true);
+            this.VerifyTextContains(@"class Implementation$$", assertCaretPosition: true);
             Assert.True(VisualStudio.Instance.Shell.IsActiveTabProvisional());
         }
 
@@ -66,8 +71,9 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
         public void GoToImplementationFromMetadataAsSource()
         {
-            AddFile("FileImplementation.cs");
-            OpenFile(ProjectName, "FileImplementation.cs");
+            var project = new ProjectUtils.Project(ProjectName);
+            this.AddFile("FileImplementation.cs", project);
+            this.OpenFile("FileImplementation.cs", project);
             Editor.SetText(
 @"using System;
 
@@ -78,10 +84,10 @@ class Implementation : IDisposable
         IDisposable d;
     }
 }");
-            PlaceCaret("IDisposable d", charsOffset: -1);
+            this.PlaceCaret("IDisposable d", charsOffset: -1);
             Editor.GoToDefinition();
             Editor.GoToImplementation();
-            VerifyTextContains(@"class Implementation$$ : IDisposable", assertCaretPosition: true);
+            this.VerifyTextContains(@"class Implementation$$ : IDisposable", assertCaretPosition: true);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
@@ -62,8 +63,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 
 
         // TODO: Enable this once the GoToDefinition tests are merged
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/15740"),
-         Trait(Traits.Feature, Traits.Features.GoToImplementation)]
+        [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
         public void GoToImplementationFromMetadataAsSource()
         {
             AddFile("FileImplementation.cs");
@@ -73,17 +73,15 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 
 class Implementation : IDisposable
 {
-  public void SomeMethod()
-  {
-    IDisposable d;
-  }
+    public void SomeMethod()
+    {
+        IDisposable d;
+    }
 }");
-            PlaceCaret("IDisposable d");
-
-            // Uncomment this line once the GoToDefinition tests are merged
-            // Editor.GoToDefinition();
+            PlaceCaret("IDisposable d", charsOffset: -1);
+            Editor.GoToDefinition();
             Editor.GoToImplementation();
-            VerifyTextContains(@"class Implementation : IDisposable", assertCaretPosition: true);
+            VerifyTextContains(@"class Implementation$$ : IDisposable", assertCaretPosition: true);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToImplementation.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
+{
+    [Collection(nameof(SharedIntegrationHostFixture))]
+    public class BasicGoToImplementation : AbstractEditorTest
+    {
+        protected override string LanguageName => LanguageNames.VisualBasic;
+
+        public BasicGoToImplementation(VisualStudioInstanceFactory instanceFactory)
+                    : base(instanceFactory, nameof(BasicGoToImplementation))
+        {
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
+        public void SimpleGoToImplementation()
+        {
+            AddFile("FileImplementation.vb");
+            OpenFile(ProjectName, "FileImplementation.vb");
+            Editor.SetText(
+@"Class Implementation
+  Implements IFoo
+End Class");
+            AddFile("FileInterface.vb");
+            OpenFile(ProjectName, "FileInterface.vb");
+            Editor.SetText(
+@"Interface IFoo 
+End Interface");
+            PlaceCaret("Interface IFoo");
+            Editor.GoToImplementation();
+            VerifyTextContains(@"Class Implementation$$", assertCaretPosition: true);
+            Assert.False(VisualStudio.Instance.Shell.IsActiveTabProvisional());
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToImplementation.cs
@@ -3,8 +3,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
-using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
-using Roslyn.VisualStudio.IntegrationTests.Extensions.SolutionExplorer;
 using Xunit;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
@@ -24,21 +22,21 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
         public void SimpleGoToImplementation()
         {
             var project = new ProjectUtils.Project(ProjectName);
-            this.AddFile("FileImplementation.vb", project);
-            this.OpenFile("FileImplementation.vb", project);
-            Editor.SetText(
+            VisualStudio.SolutionExplorer.AddFile(project, "FileImplementation.vb");
+            VisualStudio.SolutionExplorer.OpenFile(project, "FileImplementation.vb");
+            VisualStudio.Editor.SetText(
 @"Class Implementation
   Implements IFoo
 End Class");
-            this.AddFile("FileInterface.vb", project);
-            this.OpenFile("FileInterface.vb", project);
-            Editor.SetText(
+            VisualStudio.SolutionExplorer.AddFile(project, "FileInterface.vb");
+            VisualStudio.SolutionExplorer.OpenFile(project, "FileInterface.vb");
+            VisualStudio.Editor.SetText(
 @"Interface IFoo 
 End Interface");
-            this.PlaceCaret("Interface IFoo");
-            Editor.GoToImplementation();
-            this.VerifyTextContains(@"Class Implementation$$", assertCaretPosition: true);
-            Assert.False(VisualStudio.Instance.Shell.IsActiveTabProvisional());
+            VisualStudio.Editor.PlaceCaret("Interface IFoo");
+            VisualStudio.Editor.GoToImplementation();
+            VisualStudio.Editor.Verify.TextContains(@"Class Implementation$$", assertCaretPosition: true);
+            Assert.False(VisualStudio.Shell.IsActiveTabProvisional());
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToImplementation.cs
@@ -3,7 +3,10 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.VisualStudio.IntegrationTests.Extensions.Editor;
+using Roslyn.VisualStudio.IntegrationTests.Extensions.SolutionExplorer;
 using Xunit;
+using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -20,20 +23,21 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
         [Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)]
         public void SimpleGoToImplementation()
         {
-            AddFile("FileImplementation.vb");
-            OpenFile(ProjectName, "FileImplementation.vb");
+            var project = new ProjectUtils.Project(ProjectName);
+            this.AddFile("FileImplementation.vb", project);
+            this.OpenFile("FileImplementation.vb", project);
             Editor.SetText(
 @"Class Implementation
   Implements IFoo
 End Class");
-            AddFile("FileInterface.vb");
-            OpenFile(ProjectName, "FileInterface.vb");
+            this.AddFile("FileInterface.vb", project);
+            this.OpenFile("FileInterface.vb", project);
             Editor.SetText(
 @"Interface IFoo 
 End Interface");
-            PlaceCaret("Interface IFoo");
+            this.PlaceCaret("Interface IFoo");
             Editor.GoToImplementation();
-            VerifyTextContains(@"Class Implementation$$", assertCaretPosition: true);
+            this.VerifyTextContains(@"Class Implementation$$", assertCaretPosition: true);
             Assert.False(VisualStudio.Instance.Shell.IsActiveTabProvisional());
         }
     }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualStudioIntegrationTests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="CSharp\CSharpErrorListDesktop.cs" />
     <Compile Include="CSharp\CSharpErrorListNetCore.cs" />
     <Compile Include="CSharp\CSharpFindReferences.cs" />
+    <Compile Include="CSharp\CSharpGoToImplementation.cs" />
     <Compile Include="CSharp\CSharpGenerateTypeDialog.cs" />
     <Compile Include="CSharp\CSharpGoToDefinition.cs" />
     <Compile Include="CSharp\CSharpInteractiveAsyncOutput.cs" />
@@ -82,6 +83,7 @@
     <Compile Include="VisualBasic\BasicChangeSignatureDialog.cs" />
     <Compile Include="VisualBasic\BasicFindReferences.cs" />
     <Compile Include="VisualBasic\BasicGenerateTypeDialog.cs" />
+    <Compile Include="VisualBasic\BasicGoToImplementation.cs" />
     <Compile Include="VisualBasic\BasicIntelliSense.cs" />
     <Compile Include="VisualBasic\BasicSignatureHelp.cs" />
     <Compile Include="VisualBasic\BasicWinForms.cs" />

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -535,6 +535,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             });
         }
 
+        public void GoToDefinition()
+            => GetDTE().ExecuteCommand("Edit.GoToDefinition");
+
         public void GoToImplementation()
             => GetDTE().ExecuteCommand("Edit.GoToImplementation");
     }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -494,9 +494,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public void Undo()
             => GetDTE().ExecuteCommand(WellKnownCommandNames.Edit_Undo);
 
-        public void GoToDefinition()
-            => GetDTE().ExecuteCommand("Edit.GoToDefinition");
-
         protected override ITextBuffer GetBufferContainingCaret(IWpfTextView view)
         {
             return view.GetBufferContainingCaret();

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -534,5 +534,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 return results;
             });
         }
+
+        public void GoToImplementation()
+            => GetDTE().ExecuteCommand("Edit.GoToImplementation");
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Shell_InProc.cs
@@ -20,18 +20,18 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             => InvokeOnUIThread(() =>
             {
                 var shellMonitorSelection = GetGlobalService<SVsShellMonitorSelection, IVsMonitorSelection>();
-                if (!ErrorHandler.Succeeded(shellMonitorSelection.GetCurrentElementValue((uint) VSConstants.VSSELELEMID.SEID_DocumentFrame, out var windowFrameObject)))
+                if (!ErrorHandler.Succeeded(shellMonitorSelection.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_DocumentFrame, out var windowFrameObject)))
                 {
                     throw new InvalidOperationException("Tried to get the active document frame but no documents were open.");
                 }
 
                 var windowFrame = (IVsWindowFrame)windowFrameObject;
-                if (!ErrorHandler.Succeeded(windowFrame.GetProperty((int) VsFramePropID.IsProvisional, out var isProvisionalObject)))
+                if (!ErrorHandler.Succeeded(windowFrame.GetProperty((int)VsFramePropID.IsProvisional, out var isProvisionalObject)))
                 {
                     throw new InvalidOperationException("The active window frame did not have an 'IsProvisional' property.");
                 }
 
-                return (bool) isProvisionalObject;
+                return (bool)isProvisionalObject;
             });
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -274,9 +274,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         }
 
         public void GoToDefinition()
-            => _inProc.GoToDefinition();
+            => _editorInProc.GoToDefinition();
 
         public void GoToImplementation()
-            => _inProc.GoToImplementation();
+            => _editorInProc.GoToImplementation();
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -273,6 +273,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             }).ToArray();
         }
 
+        public void GoToDefinition()
+            => _inProc.GoToDefinition();
+
         public void GoToImplementation()
             => _inProc.GoToImplementation();
     }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -272,5 +272,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
                 return TextSpan.FromBounds(int.Parse(start), int.Parse(end));
             }).ToArray();
         }
+
+        public void GoToImplementation()
+            => _inProc.GoToImplementation();
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/Editor_OutOfProc.cs
@@ -163,9 +163,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void Undo()
             => _editorInProc.Undo();
 
-        public void GoToDefinition()
-            => _editorInProc.GoToDefinition();
-
         public void NavigateToSendKeys(string keys)
             => _editorInProc.SendKeysToNavigateTo(keys);
 


### PR DESCRIPTION
Also fixes https://github.com/dotnet/roslyn/issues/17531 by adding `IsActiveTabProvisional()`

Original tests at https://github.com/dotnet/roslyn-internal/blob/master/Closed/Hosting/RoslynTaoActions/IntegrationTests/BasicGoToImplementation.xml / https://github.com/dotnet/roslyn-internal/blob/master/Closed/Hosting/RoslynTaoActions/IntegrationTests/CSharpGoToImplementation.xml