### PR TITLE
enable main methods to be asynchronous

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9873,6 +9873,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to async main.
+        /// </summary>
+        internal static string IDS_FeatureAsyncMain {
+            get {
+                return ResourceManager.GetString("IDS_FeatureAsyncMain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to automatically implemented properties.
         /// </summary>
         internal static string IDS_FeatureAutoImplementedProperties {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3590,6 +3590,9 @@ Give the compiler some way to differentiate the methods. For example, you can gi
   <data name="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsyncInClassOrStruct" xml:space="preserve">
     <value>Async methods are not allowed in an Interface, Class, or Structure which has the 'SecurityCritical' or 'SecuritySafeCritical' attribute.</value>
   </data>
+  <data name="ERR_MainCantBeAsync" xml:space="preserve">
+    <value>'{0}': an entry point cannot be marked with the 'async' modifier</value>
+  </data>
   <data name="ERR_BadAwaitInQuery" xml:space="preserve">
     <value>The 'await' operator may only be used in a query expression within the first collection expression of the initial 'from' clause or within the collection expression of a 'join' clause</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3590,9 +3590,6 @@ Give the compiler some way to differentiate the methods. For example, you can gi
   <data name="ERR_SecurityCriticalOrSecuritySafeCriticalOnAsyncInClassOrStruct" xml:space="preserve">
     <value>Async methods are not allowed in an Interface, Class, or Structure which has the 'SecurityCritical' or 'SecuritySafeCritical' attribute.</value>
   </data>
-  <data name="ERR_MainCantBeAsync" xml:space="preserve">
-    <value>'{0}': an entry point cannot be marked with the 'async' modifier</value>
-  </data>
   <data name="ERR_BadAwaitInQuery" xml:space="preserve">
     <value>The 'await' operator may only be used in a query expression within the first collection expression of the initial 'from' clause or within the collection expression of a 'join' clause</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5041,4 +5041,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_VoidAssignment" xml:space="preserve">
     <value>A value of type 'void' may not be assigned.</value>
   </data>
+  <data name="IDS_FeatureAsyncMain" xml:space="preserve">
+    <value>async main</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // version. Do not make any changes to the public interface without making the corresponding
         // change to the VB version.
         //
-        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
         internal static readonly ParallelOptions DefaultParallelOptions = new ParallelOptions();
 
@@ -93,9 +93,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Holds onto data related to reference binding.
         /// The manager is shared among multiple compilations that we expect to have the same result of reference binding.
-        /// In most cases this can be determined without performing the binding. If the compilation however contains a circular 
+        /// In most cases this can be determined without performing the binding. If the compilation however contains a circular
         /// metadata reference (a metadata reference that refers back to the compilation) we need to avoid sharing of the binding results.
-        /// We do so by creating a new reference manager for such compilation. 
+        /// We do so by creating a new reference manager for such compilation.
         /// </summary>
         private ReferenceManager _referenceManager;
 
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// The options the compilation was created with. 
+        /// The options the compilation was created with.
         /// </summary>
         public new CSharpCompilationOptions Options
         {
@@ -172,14 +172,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override INamedTypeSymbol CommonCreateErrorTypeSymbol(INamespaceOrTypeSymbol container, string name, int arity)
         {
             return new ExtendedErrorTypeSymbol(
-                       container.EnsureCSharpSymbolOrNull<INamespaceOrTypeSymbol, NamespaceOrTypeSymbol>(nameof(container)), 
+                       container.EnsureCSharpSymbolOrNull<INamespaceOrTypeSymbol, NamespaceOrTypeSymbol>(nameof(container)),
                        name, arity, errorInfo: null);
         }
 
         protected override INamespaceSymbol CommonCreateErrorNamespaceSymbol(INamespaceSymbol container, string name)
         {
             return new MissingNamespaceSymbol(
-                       container.EnsureCSharpSymbolOrNull<INamespaceSymbol, NamespaceSymbol>(nameof(container)), 
+                       container.EnsureCSharpSymbolOrNull<INamespaceSymbol, NamespaceSymbol>(nameof(container)),
                        name);
         }
 
@@ -408,8 +408,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public new CSharpCompilation WithAssemblyName(string assemblyName)
         {
-            // Can't reuse references since the source assembly name changed and the referenced symbols might 
-            // have internals-visible-to relationship with this compilation or they might had a circular reference 
+            // Can't reuse references since the source assembly name changed and the referenced symbols might
+            // have internals-visible-to relationship with this compilation or they might had a circular reference
             // to this compilation.
 
             return new CSharpCompilation(
@@ -429,9 +429,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Creates a new compilation with the specified references.
         /// </summary>
         /// <remarks>
-        /// The new <see cref="CSharpCompilation"/> will query the given <see cref="MetadataReference"/> for the underlying 
-        /// metadata as soon as the are needed. 
-        /// 
+        /// The new <see cref="CSharpCompilation"/> will query the given <see cref="MetadataReference"/> for the underlying
+        /// metadata as soon as the are needed.
+        ///
         /// The new compilation uses whatever metadata is currently being provided by the <see cref="MetadataReference"/>.
         /// E.g. if the current compilation references a metadata file that has changed since the creation of the compilation
         /// the new compilation is going to use the updated version, while the current compilation will be using the previous (it doesn't change).
@@ -684,7 +684,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Creates a new compilation without the specified syntax trees. Preserves metadata info for use with trees
-        /// added later. 
+        /// added later.
         /// </summary>
         public new CSharpCompilation RemoveSyntaxTrees(params SyntaxTree[] trees)
         {
@@ -693,7 +693,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Creates a new compilation without the specified syntax trees. Preserves metadata info for use with trees
-        /// added later. 
+        /// added later.
         /// </summary>
         public new CSharpCompilation RemoveSyntaxTrees(IEnumerable<SyntaxTree> trees)
         {
@@ -746,7 +746,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Creates a new compilation without any syntax trees. Preserves metadata info
-        /// from this compilation for use with trees added later. 
+        /// from this compilation for use with trees added later.
         /// </summary>
         public new CSharpCompilation RemoveAllSyntaxTrees()
         {
@@ -805,7 +805,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // TODO(tomat): Consider comparing #r's of the old and the new tree. If they are exactly the same we could still reuse.
-            // This could be a perf win when editing a script file in the IDE. The services create a new compilation every keystroke 
+            // This could be a perf win when editing a script file in the IDE. The services create a new compilation every keystroke
             // that replaces the tree with a new one.
             var reuseReferenceManager = !oldTree.HasReferenceOrLoadDirectives() && !newTree.HasReferenceOrLoadDirectives();
             syntaxAndDeclarations = syntaxAndDeclarations.ReplaceSyntaxTree(oldTree, newTree);
@@ -872,7 +872,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         /// <returns><see cref="AssemblySymbol"/> or <see cref="ModuleSymbol"/> corresponding to the given reference or null if there is none.</returns>
         /// <remarks>
-        /// Uses object identity when comparing two references. 
+        /// Uses object identity when comparing two references.
         /// </remarks>
         internal new Symbol GetAssemblyOrModuleSymbol(MetadataReference reference)
         {
@@ -976,7 +976,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Get all modules in this compilation, including the source module, added modules, and all
         /// modules of referenced assemblies that do not come from an assembly with an extern alias.
-        /// Metadata imported from aliased assemblies is not visible at the source level except through 
+        /// Metadata imported from aliased assemblies is not visible at the source level except through
         /// the use of an extern alias directive. So exclude them from this list which is used to construct
         /// the global namespace.
         /// </summary>
@@ -1017,7 +1017,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Gets the <see cref="MetadataReference"/> that corresponds to the assembly symbol. 
+        /// Gets the <see cref="MetadataReference"/> that corresponds to the assembly symbol.
         /// </summary>
         public new MetadataReference GetMetadataReference(IAssemblySymbol assemblySymbol)
         {
@@ -1065,7 +1065,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Gets the root namespace that contains all namespaces and types defined in source code or in 
+        /// Gets the root namespace that contains all namespaces and types defined in source code or in
         /// referenced metadata, merged into a single namespace hierarchy.
         /// </summary>
         internal new NamespaceSymbol GlobalNamespace
@@ -1075,7 +1075,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if ((object)_lazyGlobalNamespace == null)
                 {
                     // Get the root namespace from each module, and merge them all together
-                    // Get all modules in this compilation, ones referenced directly by the compilation 
+                    // Get all modules in this compilation, ones referenced directly by the compilation
                     // as well as those referenced by all referenced assemblies.
 
                     var modules = ArrayBuilder<ModuleSymbol>.GetInstance();
@@ -1458,7 +1458,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (!candidate.HasEntryPointSignature(this))
                     {
-                        // a single error for partial methods:
+                        // a single error for partial methods
                         warnings.Add(ErrorCode.WRN_InvalidMainSig, candidate.Locations.First(), candidate);
                         continue;
                     }
@@ -1468,6 +1468,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // a single error for partial methods:
                         warnings.Add(ErrorCode.WRN_MainCantBeGeneric, candidate.Locations.First(), candidate);
                         continue;
+                    }
+
+                    if (candidate.IsAsync && LanguageVersion < LanguageVersion.CSharp7_1)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_MainCantBeAsync, candidate.Locations.First(), candidate);
                     }
 
                     viableEntryPoints.Add(candidate);
@@ -2166,8 +2171,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 //remove some errors that don't have locations in the tree, like "no suitable main method."
                 //Members in trees other than the one being examined are not compiled. This includes field
-                //initializers which can result in 'field is never initialized' warnings for fields in partial 
-                //types when the field is in a different source file than the one for which we're getting diagnostics. 
+                //initializers which can result in 'field is never initialized' warnings for fields in partial
+                //types when the field is in a different source file than the one for which we're getting diagnostics.
                 //For that reason the bag must be also filtered by tree.
                 IEnumerable<Diagnostic> methodBodyDiagnostics = GetDiagnosticsForMethodBodiesInTree(syntaxTree, filterSpanWithinTree, cancellationToken);
 
@@ -2725,14 +2730,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return TupleTypeSymbol.Create(
                 locationOpt: null, // no location for the type declaration
                 elementTypes: typesBuilder.ToImmutableAndFree(),
-                elementLocations: elementLocations, 
-                elementNames: elementNames, 
+                elementLocations: elementLocations,
+                elementNames: elementNames,
                 compilation: this,
                 shouldCheckConstraints: false);
         }
 
         protected override INamedTypeSymbol CommonCreateTupleTypeSymbol(
-            INamedTypeSymbol underlyingType, 
+            INamedTypeSymbol underlyingType,
             ImmutableArray<string> elementNames,
             ImmutableArray<Location> elementLocations)
         {
@@ -2752,7 +2757,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         protected override INamedTypeSymbol CommonCreateAnonymousTypeSymbol(
-            ImmutableArray<ITypeSymbol> memberTypes, 
+            ImmutableArray<ITypeSymbol> memberTypes,
             ImmutableArray<string> memberNames,
             ImmutableArray<Location> memberLocations,
             ImmutableArray<bool> memberIsReadOnly)
@@ -2850,7 +2855,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         #endregion
 
         /// <summary>
-        /// Returns if the compilation has all of the members necessary to emit metadata about 
+        /// Returns if the compilation has all of the members necessary to emit metadata about
         /// dynamic types.
         /// </summary>
         /// <returns></returns>
@@ -2906,7 +2911,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return sustainedLowLatency != null && sustainedLowLatency.ContainingAssembly == Assembly.CorLibrary;
             }
         }
-        
+
         internal override bool IsIOperationFeatureEnabled()
         {
             var options = (CSharpParseOptions)this.SyntaxTrees.FirstOrDefault()?.Options;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1473,6 +1473,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (candidate.IsAsync)
                     {
+                        // PROTOTYPE: Get the diagnostic to point to a smaller syntax piece.
                         CheckFeatureAvailability(candidate.DeclaringSyntaxReferences.Single().GetSyntax(), MessageID.IDS_FeatureAsyncMain, diagnostics);
                     }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Symbols;
+using static Microsoft.CodeAnalysis.CSharp.Binder;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -1470,9 +1471,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         continue;
                     }
 
-                    if (candidate.IsAsync && LanguageVersion < LanguageVersion.CSharp7_1)
+                    if (candidate.IsAsync)
                     {
-                        diagnostics.Add(ErrorCode.ERR_MainCantBeAsync, candidate.Locations.First(), candidate);
+                        CheckFeatureAvailability(candidate.DeclaringSyntaxReferences.Single().GetSyntax(), MessageID.IDS_FeatureAsyncMain, diagnostics);
                     }
 
                     viableEntryPoints.Add(candidate);

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1369,7 +1369,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal new MethodSymbol GetEntryPoint(CancellationToken cancellationToken)
         {
             EntryPoint entryPoint = GetEntryPointAndDiagnostics(cancellationToken);
-            return entryPoint == null ? null : entryPoint.MethodSymbol;
+            return entryPoint?.MethodSymbol;
         }
 
         internal EntryPoint GetEntryPointAndDiagnostics(CancellationToken cancellationToken)
@@ -1456,7 +1456,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var viableEntryPoints = ArrayBuilder<MethodSymbol>.GetInstance();
                 foreach (var candidate in entryPointCandidates)
                 {
-                    if (!candidate.HasEntryPointSignature())
+                    if (!candidate.HasEntryPointSignature(this))
                     {
                         // a single error for partial methods:
                         warnings.Add(ErrorCode.WRN_InvalidMainSig, candidate.Locations.First(), candidate);
@@ -1468,11 +1468,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // a single error for partial methods:
                         warnings.Add(ErrorCode.WRN_MainCantBeGeneric, candidate.Locations.First(), candidate);
                         continue;
-                    }
-
-                    if (candidate.IsAsync)
-                    {
-                        diagnostics.Add(ErrorCode.ERR_MainCantBeAsync, candidate.Locations.First(), candidate);
                     }
 
                     viableEntryPoints.Add(candidate);

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1473,7 +1473,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (candidate.IsAsync)
                     {
-                        // PROTOTYPE: Get the diagnostic to point to a smaller syntax piece.
+                        // PROTOTYPE(async-main): Get the diagnostic to point to a smaller syntax piece.
                         CheckFeatureAvailability(candidate.DeclaringSyntaxReferences.Single().GetSyntax(), MessageID.IDS_FeatureAsyncMain, diagnostics);
                     }
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1104,7 +1104,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_VarargsAsync = 4006,
         ERR_ByRefTypeAndAwait = 4007,
         ERR_BadAwaitArgVoidCall = 4008,
-        // ERR_MainCantBeAsync = 4009,
+        ERR_MainCantBeAsync = 4009,
         ERR_CantConvAsyncAnonFuncReturns = 4010,
         ERR_BadAwaiterPattern = 4011,
         ERR_BadSpecialByRefLocal = 4012,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1104,7 +1104,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_VarargsAsync = 4006,
         ERR_ByRefTypeAndAwait = 4007,
         ERR_BadAwaitArgVoidCall = 4008,
-        ERR_MainCantBeAsync = 4009,
+        // ERR_MainCantBeAsync = 4009,
         ERR_CantConvAsyncAnonFuncReturns = 4010,
         ERR_BadAwaiterPattern = 4011,
         ERR_BadSpecialByRefLocal = 4012,

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -127,6 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureExpressionBodiedAccessor = MessageBase + 12715,
         IDS_FeatureExpressionBodiedDeOrConstructor = MessageBase + 12716,
         IDS_ThrowExpression = MessageBase + 12717,
+        IDS_FeatureAsyncMain = MessageBase + 12718,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -183,6 +184,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Checks are in the LanguageParser unless otherwise noted.
             switch (feature)
             {
+                // C# 7.1 features.
+                case MessageID.IDS_FeatureAsyncMain:
+                    return LanguageVersion.CSharp7_1;
+
                 // C# 7 features.
                 case MessageID.IDS_FeatureBinaryLiteral:
                 case MessageID.IDS_FeatureDigitSeparator:

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal virtual bool IsDirectlyExcludedFromCodeCoverage { get => false; }
 
         /// <summary>
-        /// Returns true if this method is an extension method. 
+        /// Returns true if this method is an extension method.
         /// </summary>
         public abstract bool IsExtensionMethod { get; }
 
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal abstract IEnumerable<Microsoft.Cci.SecurityAttribute> GetSecurityInformation();
 
         /// <summary>
-        /// Marshalling information for return value (FieldMarshal in metadata). 
+        /// Marshalling information for return value (FieldMarshal in metadata).
         /// </summary>
         internal abstract MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation { get; }
 
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Returns true if this method hides base methods by name. This cannot be specified directly
         /// in the C# language, but can be true for methods defined in other languages imported from
-        /// metadata. The equivalent of the "hidebyname" flag in metadata. 
+        /// metadata. The equivalent of the "hidebyname" flag in metadata.
         /// </summary>
         public abstract bool HidesBaseMethodsByName { get; }
 
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract TypeSymbol ReturnType { get; }
 
         /// <summary>
-        /// Returns the type arguments that have been substituted for the type parameters. 
+        /// Returns the type arguments that have been substituted for the type parameters.
         /// If nothing has been substituted for a given type parameter,
         /// then the type parameter itself is consider the type argument.
         /// </summary>
@@ -275,13 +275,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Returns interface methods explicitly implemented by this method.
         /// </summary>
         /// <remarks>
-        /// Methods imported from metadata can explicitly implement more than one method, 
+        /// Methods imported from metadata can explicitly implement more than one method,
         /// that is why return type is ImmutableArray.
         /// </remarks>
         public abstract ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations { get; }
 
         /// <summary>
-        /// Returns the list of custom modifiers, if any, associated with the return type. 
+        /// Returns the list of custom modifiers, if any, associated with the return type.
         /// </summary>
         public abstract ImmutableArray<CustomModifier> ReturnTypeCustomModifiers { get; }
 
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// returns the property that this method is the getter or setter for.
         /// If this method has MethodKind of MethodKind.EventAdd or MethodKind.EventRemove,
         /// returns the event that this method is the adder or remover for.
-        /// Note, the set of possible associated symbols might be expanded in the future to 
+        /// Note, the set of possible associated symbols might be expanded in the future to
         /// reflect changes in the languages.
         /// </summary>
         public abstract Symbol AssociatedSymbol { get; }
@@ -327,19 +327,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             while (m.IsOverride && !m.HidesBaseMethodsByName)
             {
                 // We might not be able to access the overridden method. For example,
-                // 
+                //
                 //   .assembly A
                 //   {
                 //      InternalsVisibleTo("B")
                 //      public class A { internal virtual void M() { } }
                 //   }
-                // 
+                //
                 //   .assembly B
                 //   {
                 //      InternalsVisibleTo("C")
                 //      public class B : A { internal override void M() { } }
                 //   }
-                // 
+                //
                 //   .assembly C
                 //   {
                 //      public class C : B { ... new B().M ... }       // A.M is not accessible from here
@@ -374,9 +374,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// If this method overrides another method (because it both had the override modifier
         /// and there correctly was a method to override), returns the overridden method.
-        /// Note that if an overriding method D.M overrides C.M, which in turn overrides 
+        /// Note that if an overriding method D.M overrides C.M, which in turn overrides
         /// virtual method A.M, the "overridden method" of D.M is C.M, not the original virtual
-        /// method A.M. Note also that constructed generic methods are not considered to 
+        /// method A.M. Note also that constructed generic methods are not considered to
         /// override anything.
         /// </summary>
         public MethodSymbol OverriddenMethod
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Determines whether this method is a candidate for a default assembly entry point 
+        /// Determines whether this method is a candidate for a default assembly entry point
         /// (i.e. it is a static method called "Main").
         /// </summary>
         internal bool IsEntryPointCandidate
@@ -597,8 +597,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Checks if the method has an entry point compatible signature, i.e.
-        /// - the return type is either void, int, <see cref="System.Threading.Tasks.Task" />, 
-        /// or <see cref="System.Threading.Tasks.Task{T}" /> Where T is an int.
+        /// - the return type is either void, int, <see cref="System.Threading.Tasks.Task" />,
+        /// or <see cref="System.Threading.Tasks.Task{T}" /> where T is an int.
         /// - has either no parameter or a single parameter of type string[]
         /// </summary>
         internal bool HasEntryPointSignature(CSharpCompilation compilation)
@@ -633,12 +633,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             TypeSymbol returnType = ReturnType;
-            if (returnType.SpecialType != SpecialType.System_Int32 && returnType.SpecialType != SpecialType.System_Void && !IsAsyncMainReturnType(returnType))
+            bool isAsyncMainReturnType = IsAsyncMainReturnType(returnType);
+            if (returnType.SpecialType != SpecialType.System_Int32 && returnType.SpecialType != SpecialType.System_Void && !isAsyncMainReturnType)
             {
                 return false;
             }
 
-            if (!IsAsyncMainReturnType(returnType) && IsAsync)
+            // Prior to 7.1, async methods were considered to "have the entrypoint signature".
+            // In order to keep back-compat, we need to let these through if compiling using a previous language version.
+            if (!isAsyncMainReturnType && IsAsync && compilation.LanguageVersion >= LanguageVersion.CSharp7_1)
             {
                 return false;
             }
@@ -763,7 +766,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// If this method is a reduced extension method, returns a type inferred during reduction process for the type parameter. 
+        /// If this method is a reduced extension method, returns a type inferred during reduction process for the type parameter.
         /// </summary>
         /// <param name="reducedFromTypeParameter">Type parameter of the corresponding <see cref="ReducedFrom"/> method.</param>
         /// <returns>Inferred type or Nothing if nothing was inferred.</returns>
@@ -913,7 +916,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
-            // If the member is in an assembly with unified references, 
+            // If the member is in an assembly with unified references,
             // we check if its definition depends on a type from a unified reference.
             if (this.ContainingModule.HasUnifiedReferences)
             {
@@ -933,7 +936,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Return error code that has highest priority while calculating use site error for this symbol. 
+        /// Return error code that has highest priority while calculating use site error for this symbol.
         /// </summary>
         protected override int HighestPriorityUseSiteError
         {
@@ -974,7 +977,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Generates bound block representing method's body for methods in lowered form and adds it to
-        /// a collection of method bodies of the current module. This method is supposed to only be 
+        /// a collection of method bodies of the current module. This method is supposed to only be
         /// called for method symbols which return SynthesizesLoweredBoundBody == true.
         /// </summary>
         internal virtual void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
@@ -1005,7 +1008,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <remarks>
         /// Syntax offset is a unique identifier for the local within the emitted method body.
         /// It's based on position of the local declarator. In single-part method bodies it's simply the distance
-        /// from the start of the method body syntax span. If a method body has multiple parts (such as a constructor 
+        /// from the start of the method body syntax span. If a method body has multiple parts (such as a constructor
         /// comprising of code for member initializers and constructor initializer calls) the offset is calculated
         /// as if all source these parts were concatenated together and prepended to the constructor body.
         /// The resulting syntax offset is then negative for locals defined outside of the constructor body.
@@ -1257,7 +1260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// If this is a method of a tuple type, return corresponding underlying method from the
-        /// tuple underlying type. Otherwise, null. 
+        /// tuple underlying type. Otherwise, null.
         /// </summary>
         public virtual MethodSymbol TupleUnderlyingMethod
         {

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -646,6 +646,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
+            if (RefKind != RefKind.None)
+            {
+                return false;
+            }
+
             if (Parameters.Length == 0)
             {
                 return true;

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -597,7 +597,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Checks if the method has an entry point compatible signature, i.e.
-        /// - the return type is either void, int, Task, or Task&lt;int&gt;
+        /// - the return type is either void, int, <see cref="System.Threading.Tasks.Task" />, 
+        /// or <see cref="System.Threading.Tasks.Task{int}" />
         /// - has either no parameter or a single parameter of type string[]
         /// </summary>
         internal bool HasEntryPointSignature(CSharpCompilation compilation)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -598,7 +598,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Checks if the method has an entry point compatible signature, i.e.
         /// - the return type is either void, int, <see cref="System.Threading.Tasks.Task" />, 
-        /// or <see cref="System.Threading.Tasks.Task{int}" />
+        /// or <see cref="System.Threading.Tasks.Task{T}" /> Where T is an int.
         /// - has either no parameter or a single parameter of type string[]
         /// </summary>
         internal bool HasEntryPointSignature(CSharpCompilation compilation)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -611,14 +611,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     return false;
                 }
-                // Change this to `namedType.IsNonGenericTaskType` if you want to support "task-like" objects.
                 else if (namedType.ConstructedFrom == compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task))
                 {
+                    // Change this to `namedType.IsNonGenericTaskType` if you want to support "task-like" objects.
                     return true;
                 }
-                // Change this to `namedType.IsGenericTaskType` if you want to support "task-like" objects.
                 else if (namedType.ConstructedFrom == compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T))
                 {
+                    // Change this to `namedType.IsGenericTaskType` if you want to support "task-like" objects.
                     return namedType.TypeArguments[0].SpecialType == SpecialType.System_Int32;
                 }
                 else

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -1270,6 +1270,30 @@ class A
         }
 
         [Fact]
+        public void MainCantBeAsyncInt()
+        {
+            var source = @"
+using System.Threading.Tasks;
+
+class A
+{
+    async static int Main()
+    {
+        await Task.Factory.StartNew(() => 5);
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics(
+                // (6,23): warning CS0028: 'A.Main()' has the wrong signature to be an entry point
+                //     async static void Main()
+                Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("A.Main()").WithLocation(6, 23),
+                // error CS5001: Program does not contain a static 'Main' method suitable for an entry point
+                Diagnostic(ErrorCode.ERR_NoEntryPoint).WithLocation(1, 1));
+            var entry = compilation.GetEntryPoint(CancellationToken.None);
+            Assert.Null(entry);
+        }
+
+        [Fact]
         public void MainCanBeAsyncAndGenericOnInt()
         {
             var origSource = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -1259,7 +1259,13 @@ class A
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
-            compilation.VerifyDiagnostics(Diagnostic(ErrorCode.ERR_MainCantBeAsync, "Main").WithArguments("A.Main(string[])").WithLocation(6, 23));
+            compilation.VerifyDiagnostics(
+                // (6,5): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
+                //     async static Task Main(string[] args)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, @"async static Task Main(string[] args)
+    {
+        await Task.Factory.StartNew(() => { });
+    }").WithArguments("async main", "7.1").WithLocation(6, 5));
         }
 
         [Fact]
@@ -1325,10 +1331,12 @@ class A
 }";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
             compilation.VerifyDiagnostics(
-                // (6,23): error CS4009: 'A.Main()': an entry point cannot be marked with the 'async' modifier
+                // (6,5): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     async static void Main()
-                Diagnostic(ErrorCode.ERR_MainCantBeAsync, "Main").WithArguments("A.Main()").WithLocation(6, 23)
-            );
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, @"async static void Main()
+    {
+        await Task.Factory.StartNew(() => { });
+    }").WithArguments("async main", "7.1").WithLocation(6, 5));
         }
 
         [Fact]
@@ -1375,10 +1383,14 @@ class A
             compilation.VerifyDiagnostics(
                 // (6,22): error CS1983: The return type of an async method must be void, Task or Task<T>
                 //     async static int Main()
-                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "Main").WithLocation(6, 22),
-                // (6,22): error CS4009: 'A.Main()': an entry point cannot be marked with the 'async' modifier
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "Main"),
+                // (6,5): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     async static int Main()
-                Diagnostic(ErrorCode.ERR_MainCantBeAsync, "Main").WithArguments("A.Main()").WithLocation(6, 22));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, @"async static int Main()
+    {
+        return await Task.Factory.StartNew(() => 5);
+    }").WithArguments("async main", "7.1").WithLocation(6, 5)
+);
         }
 
         [Fact]
@@ -1420,9 +1432,13 @@ class A
 }";
                 var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
                 compilation.VerifyDiagnostics(
-                    // (6,28): error CS4009: 'A.Main(string[])': an entry point cannot be marked with the 'async' modifier
-                    //     async static Task<int> Main(string[] args)
-                    Diagnostic(ErrorCode.ERR_MainCantBeAsync, "Main").WithArguments("A.Main(string[])").WithLocation(6, 28));
+// (6,5): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
+                //     async static Task<int> Main(string[] args)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, @"async static Task<int> Main(string[] args)
+    {
+        return await Task.Factory.StartNew(() => 5);
+    }").WithArguments("async main", "7.1").WithLocation(6, 5)
+);
         }
 
         [Fact]
@@ -1464,9 +1480,13 @@ class A
 }";
                 var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7));
                 compilation.VerifyDiagnostics(
-                    // (6,28): error CS4009: 'A.Main()': an entry point cannot be marked with the 'async' modifier
+                    // (6,5): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                     //     async static Task<int> Main()
-                    Diagnostic(ErrorCode.ERR_MainCantBeAsync, "Main").WithArguments("A.Main()").WithLocation(6, 28));
+                    Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, @"async static Task<int> Main()
+    {
+        return await Task.Factory.StartNew(() => 5);
+    }").WithArguments("async main", "7.1").WithLocation(6, 5)
+                    );
         }
 
         [Fact]
@@ -3747,8 +3767,8 @@ class Test
     }
 }";
             CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
-                // (4,30): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //     async public static void Main()
+                // (5,30): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     async public static Task Main()
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "Main"));
         }
 
@@ -3766,10 +3786,12 @@ class Test
             CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7)).VerifyDiagnostics(
                 // (5,30): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     async public static Task Main()
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "Main").WithLocation(5, 30),
-                // (5,30): error CS4009: 'Test.Main()': an entry point cannot be marked with the 'async' modifier
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "Main"),
+                // (5,5): error CS8107: Feature 'async main' is not available in C# 7. Please use language version 7.1 or greater.
                 //     async public static Task Main()
-                Diagnostic(ErrorCode.ERR_MainCantBeAsync, "Main").WithArguments("Test.Main()").WithLocation(5, 30));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, @"async public static Task Main()
+    {
+    }").WithArguments("async main", "7.1").WithLocation(5, 5));
         }
 
         [Fact, WorkItem(547088, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547088")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -1246,6 +1246,28 @@ class A
         }
 
         [Fact]
+        public void MainCantBeAsyncWithRefTask()
+        {
+            var source = @"
+using System.Threading.Tasks;
+
+class A
+{
+    static ref Task Main(string[] args)
+    {
+        throw new System.Exception();
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1));
+            compilation.VerifyDiagnostics(
+                // (6,21): warning CS0028: 'A.Main(string[])' has the wrong signature to be an entry point
+                //     static ref Task Main(string[] args)
+                Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("A.Main(string[])").WithLocation(6, 21),
+                // error CS5001: Program does not contain a static 'Main' method suitable for an entry point
+                Diagnostic(ErrorCode.ERR_NoEntryPoint).WithLocation(1, 1));
+        }
+
+        [Fact]
         public void MainCantBeAsyncWithArgs_CSharp7()
         {
             var source = @"


### PR DESCRIPTION
This is the first chunk in enabling Async-Main.  It merely concerns itself with deciding which methods have valid entrypoint signatures.