### PR TITLE
Avoiding turning RValue expressions into effectively LValues as a sideeffect of lowering reductions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -234,6 +234,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Conversion ExplicitDynamic => new Conversion(ConversionKind.ExplicitDynamic);
         internal static Conversion InterpolatedString => new Conversion(ConversionKind.InterpolatedString);
         internal static Conversion Deconstruction => new Conversion(ConversionKind.Deconstruction);
+        internal static Conversion IdentityValue => new Conversion(ConversionKind.IdentityValue);
 
         // trivial conversions that could be underlying in nullable conversion
         // NOTE: tuple conversions can be underlying as well, but they are not trivial 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -43,5 +43,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         IntPtr,
         InterpolatedString, // a conversion from an interpolated string to IFormattable or FormattableString
         Deconstruction, // The Deconstruction conversion is not part of the language, it is an implementation detail 
+
+        // IdentityValue is not a part of the language. 
+        // It is used by lowering to ensure that trivially reduced expressions 
+        // do not become exposed to mutations if used as receivers of struct methods.
+        IdentityValue,  
     }
 }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -21,6 +21,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     _builder.EmitOpCode(ILOpCode.Conv_u);
                     EmitPopIfUnused(used);
                     return;
+                case ConversionKind.IdentityValue:
+                    EmitExpressionCore(conversion.Operand, used);
+                    return;
             }
 
             if (!used && !conversion.ConversionHasSideEffects())

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -772,26 +772,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static RefKind ReceiverSpillRefKind(BoundExpression receiver)
         {
-            if (!receiver.Type.IsReferenceType)
-            {
-                switch (receiver.Kind)
-                {
-                    case BoundKind.Parameter:
-                    case BoundKind.Local:
-                    case BoundKind.ArrayAccess:
-                    case BoundKind.ThisReference:
-                    case BoundKind.BaseReference:
-                    case BoundKind.PointerIndirectionOperator:
-                    case BoundKind.RefValueOperator:
-                    case BoundKind.FieldAccess:
-                        return RefKind.Ref;
-
-                    case BoundKind.Call:
-                        return ((BoundCall)receiver).Method.RefKind;
-                }
-            }
-
-            return RefKind.None;
+            return LocalRewriter.ReceiverCanBeAssigned(receiver) ? 
+                RefKind.Ref : 
+                RefKind.None;
         }
 
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -772,7 +772,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static RefKind ReceiverSpillRefKind(BoundExpression receiver)
         {
-            return LocalRewriter.ReceiverCanBeAssigned(receiver) ? 
+            return LocalRewriter.WouldBeAssignableIfUsedAsMethodReceiver(receiver) ? 
                 RefKind.Ref : 
                 RefKind.None;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/ExpressionLambdaRewriter.cs
@@ -630,6 +630,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         var operand = Visit(node.Operand);
                         return node.ExplicitCastInCode ? Convert(operand, node.Type, false) : operand;
                     }
+                case ConversionKind.IdentityValue:
+                    {
+                        return Visit(node.Operand);
+                    }
                 case ConversionKind.ImplicitNullable:
                     if (node.Operand.Type.IsNullableType())
                     {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -552,6 +552,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.BaseReference:
                 case BoundKind.PointerIndirectionOperator:
                 case BoundKind.RefValueOperator:
+                case BoundKind.PseudoVariable:
                 case BoundKind.FieldAccess:
                     return true;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -503,7 +503,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Receivers of struct methods are required to be at least RValues but can be assignable variables.
         /// Whether the mutations from the method are propagated back to the 
         /// receiver instance is conditional on whether the receiver is a variable that can be assigned. 
-        /// If not, then the invokation is performed on a copy.
+        /// If not, then the invocation is performed on a copy.
         /// 
         /// An inconvenient situation may arise when the receiver is an RValue expression (like a ternary operator),
         /// which is trivially reduced during lowering to one of its operands and 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -498,5 +498,75 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression rhs = assignment.Right;
             return rhs.IsDefaultValue();
         }
+
+        /// <summary>
+        /// Receivers of struct methods are alowed to be RValues or LValues.
+        /// Whether the mutations from the method are propagated back to the 
+        /// receiver instance is conditional on whether the receiver is an LValue.
+        /// 
+        /// An inconvenient situation may arise when an the receiver is an RValue expression,
+        /// which is trivially reduced during lowering to one of its operands and 
+        /// such operand happens to be an LValue. That operation alone would 
+        /// expose the operand to mutations while it would not be exposed otherwise.
+        /// I.E. the transformation becomes semantically observable.
+        /// 
+        /// To prevent such situations, we will wrap the operand into a node whose only 
+        /// purpose is to never be an LValue.
+        /// </summary>
+        private static BoundExpression EnsureNotLvalueReceiver(BoundExpression expr)
+        {
+            // Leave as-is where receiver mutations cannot happen.
+            if (!ReceiverCanBeAssigned(expr))
+            {
+                return expr;
+            }
+
+            // - reference type receivers are byval
+            // - special value types do not have mutating members
+            var type = expr.Type.OriginalDefinition;
+            if (type.IsReferenceType || type.SpecialType != SpecialType.None)
+            {
+                return expr;
+            }
+
+            return new BoundConversion(
+                expr.Syntax,
+                expr,
+                Conversion.IdentityValue,
+                @checked: false,
+                explicitCastInCode: true,
+                constantValueOpt: null,
+                type: expr.Type)
+            { WasCompilerGenerated = true };
+        }
+
+        internal static bool ReceiverCanBeAssigned(BoundExpression receiver)
+        {
+            // - reference type receivers are byval
+            // - special value types (int32, Nullable<T>, . .) do not have mutating members
+            if (receiver.Type.IsReferenceType ||
+                receiver.Type.OriginalDefinition.SpecialType != SpecialType.None)
+            {
+                return false;
+            }
+
+            switch (receiver.Kind)
+            {
+                case BoundKind.Parameter:
+                case BoundKind.Local:
+                case BoundKind.ArrayAccess:
+                case BoundKind.ThisReference:
+                case BoundKind.BaseReference:
+                case BoundKind.PointerIndirectionOperator:
+                case BoundKind.RefValueOperator:
+                case BoundKind.FieldAccess:
+                    return true;
+
+                case BoundKind.Call:
+                    return ((BoundCall)receiver).Method.RefKind != RefKind.None;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.DiscardExpression:
                     {
-                        return EnsureNotLvalueReceiver(rewrittenRight);
+                        return EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenRight);
                     }
 
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AssignmentOperator.cs
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 case BoundKind.DiscardExpression:
                     {
-                        return rewrittenRight;
+                        return EnsureNotLvalueReceiver(rewrittenRight);
                     }
 
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
@@ -47,11 +47,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConstantValue conditionConstantValue = rewrittenCondition.ConstantValue;
             if (conditionConstantValue == ConstantValue.True)
             {
-                return EnsureNotLvalueReceiver(rewrittenConsequence);
+                return EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenConsequence);
             }
             else if (conditionConstantValue == ConstantValue.False)
             {
-                return EnsureNotLvalueReceiver(rewrittenAlternative);
+                return EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenAlternative);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
@@ -44,19 +44,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConstantValue constantValueOpt,
             TypeSymbol rewrittenType)
         {
-            // NOTE: This optimization assumes that a constant has no side effects. In the future we 
-            // might wish to represent nodes that are known to the optimizer as having constant
-            // values as a sequence of side effects and a constant value; in that case the result
-            // of this should be a sequence containing the side effect and the consequence or alternative.
-
             ConstantValue conditionConstantValue = rewrittenCondition.ConstantValue;
             if (conditionConstantValue == ConstantValue.True)
             {
-                return rewrittenConsequence;
+                return EnsureNotLvalueReceiver(rewrittenConsequence);
             }
             else if (conditionConstantValue == ConstantValue.False)
             {
-                return rewrittenAlternative;
+                return EnsureNotLvalueReceiver(rewrittenAlternative);
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -132,11 +132,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
                     }
 
-                    // 4.1.6 C# spec: To force a value of a floating point type to the exact precision of its type, an explicit cast can be used.
-                    // If this is not an identity conversion of a float with unknown precision, strip away the identity conversion.
-                    if (!(explicitCastInCode && IsFloatPointExpressionOfUnknownPrecision(rewrittenOperand)))
+                    if (!explicitCastInCode)
                     {
                         return rewrittenOperand;
+                    }
+                    
+                    // 4.1.6 C# spec: To force a value of a floating point type to the exact precision of its type, an explicit cast can be used.
+                    // If this is not an identity conversion of a float with unknown precision, strip away the identity conversion.
+                    if (!IsFloatPointExpressionOfUnknownPrecision(rewrittenOperand))
+                    {
+                        return EnsureNotLvalueReceiver(rewrittenOperand);
                     }
 
                     break;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // If this is not an identity conversion of a float with unknown precision, strip away the identity conversion.
                     if (!IsFloatPointExpressionOfUnknownPrecision(rewrittenOperand))
                     {
-                        return EnsureNotLvalueReceiver(rewrittenOperand);
+                        return EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenOperand);
                     }
 
                     break;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (rewrittenLeft.IsDefaultValue())
             {
-                return rewrittenRight;
+                return EnsureNotLvalueReceiver(rewrittenRight);
             }
 
             if (rewrittenLeft.ConstantValue != null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (rewrittenLeft.IsDefaultValue())
             {
-                return EnsureNotLvalueReceiver(rewrittenRight);
+                return EnsureNotAssignableIfUsedAsMethodReceiver(rewrittenRight);
             }
 
             if (rewrittenLeft.ConstantValue != null)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
@@ -2354,7 +2354,7 @@ static class LiveList
 
             System.Console.WriteLine(v.field);
 
-            System.Console.WriteLine((true ? v : default(S1)).Increment());
+            System.Console.WriteLine((false ? default(S1): v).Increment());
 
             System.Console.WriteLine(v.field);
 
@@ -2407,6 +2407,43 @@ class Program
             string expectedOutput = @"1
 1";
             CompileAndVerify(source, expectedOutput: expectedOutput, options: TestOptions.UnsafeReleaseExe);
+        }
+
+        [Fact, WorkItem(17756, "https://github.com/dotnet/roslyn/issues/17756")]
+        public void TestConditionalOperatorNotLvalueRefCall()
+        {
+            var source = @"
+class Program
+{
+
+    struct S1 
+    {
+        public int field;
+        public int Increment() => field++;
+    }
+
+    private static S1 sv;
+
+    private static ref S1 M1()
+    {
+        return ref sv;
+    }
+
+    static void Main()
+    {
+        sv.Increment();
+
+        System.Console.WriteLine(sv.field);
+
+        (true ? M1() : default(S1)).Increment();
+
+        System.Console.WriteLine(sv.field);
+    }
+}
+";
+            string expectedOutput = @"1
+1";
+            CompileAndVerify(source, expectedOutput: expectedOutput);
         }
 
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
@@ -2374,5 +2374,40 @@ static class LiveList
 1";
             CompileAndVerify(source, expectedOutput: expectedOutput);
         }
+
+        [Fact, WorkItem(17756, "https://github.com/dotnet/roslyn/issues/17756")]
+        public void TestConditionalOperatorNotLvaluePointerElementAccess()
+        {
+            var source = @"
+class Program
+{
+
+    struct S1 
+    {
+        public int field;
+        public int Increment() => field++;
+
+    }
+
+    unsafe static void Main()
+    {
+        S1 v = default(S1);
+        v.Increment();
+
+        System.Console.WriteLine(v.field);
+
+        S1* pv = &v;
+
+        (true ? pv[0] : default(S1)).Increment();
+
+        System.Console.WriteLine(v.field);
+    }
+}
+";
+            string expectedOutput = @"1
+1";
+            CompileAndVerify(source, expectedOutput: expectedOutput, options: TestOptions.UnsafeReleaseExe);
+        }
+
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConversionTests.cs
@@ -1068,5 +1068,32 @@ public interface IAaa
             var compilation = CreateCompilationWithMscorlib45AndCSruntime(source, options: TestOptions.ReleaseExe.WithAllowUnsafe(true));
             CompileAndVerify(compilation);
         }
+
+        [Fact, WorkItem(17756, "https://github.com/dotnet/roslyn/issues/17756")]
+        public void TestIdentityConversionNotLvalue()
+        {
+            var source = @"
+class Program
+{
+    struct S1
+    {
+        public int field;
+        public int Increment() => field++;
+    }
+
+    static void Main()
+    {
+        S1 v = default(S1);
+        v.Increment(); 
+
+        ((S1)v).Increment();
+
+        System.Console.WriteLine(v.field);
+    }
+}
+";
+            string expectedOutput = @"1";
+            CompileAndVerify(source, expectedOutput: expectedOutput);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6575,5 +6575,32 @@ class C
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "3");
         }
+
+        [Fact, WorkItem(17756, "https://github.com/dotnet/roslyn/issues/17756")]
+        public void TestDiscardedAssignmentNotLvalue()
+        {
+            var source = @"
+class Program
+{
+    struct S1
+    {
+        public int field;
+        public int Increment() => field++;
+    }
+
+    static void Main()
+    {
+        S1 v = default(S1);
+        v.Increment(); 
+
+        (_ = v).Increment();
+
+        System.Console.WriteLine(v.field);
+    }
+}
+";
+            string expectedOutput = @"1";
+            CompileAndVerify(source, expectedOutput: expectedOutput);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -3185,6 +3185,36 @@ public class Test
                 new[] { ExpressionAssemblyRef }, expectedOutput: TrimExpectedOutput(expectedOutput));
         }
 
+        [Fact, WorkItem(17756, "https://github.com/dotnet/roslyn/issues/17756")]
+        public void ConditionalWithTrivialCondition()
+        {
+            var text =
+@"using System;
+using System.Linq.Expressions;
+
+public class Test
+{
+    static void Main()
+    {
+        S1 v = default(S1);
+
+        Expression<Func<int>> testExpr = () => (true ? v : default(S1)).Increment();
+        Console.WriteLine(testExpr);
+    }
+
+    struct S1
+    {
+        public int field;
+        public int Increment() => field++;
+    }
+}";
+            string expectedOutput = @"() => value(Test+<>c__DisplayClass0_0).v.Increment()";
+
+            CompileAndVerify(
+                new[] { text, TreeWalkerLib },
+                new[] { ExpressionAssemblyRef }, expectedOutput: TrimExpectedOutput(expectedOutput));
+        }
+
         [WorkItem(544413, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544413")]
         [Fact]
         public void ExplicitConversionLambdaToExprTree()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -4980,5 +4980,32 @@ class Test
 4242691";
             var result = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expectedOutput);
         }
+
+        [Fact, WorkItem(17756, "https://github.com/dotnet/roslyn/issues/17756")]
+        public void TestCoalesceNotLvalue()
+        {
+            var source = @"
+class Program
+{
+    struct S1
+    {
+        public int field;
+        public int Increment() => field++;
+    }
+
+    static void Main()
+    {
+        S1 v = default(S1);
+        v.Increment(); 
+
+        ((S1?)null ?? v).Increment();
+
+        System.Console.WriteLine(v.field);
+    }
+}
+";
+            string expectedOutput = @"1";
+            CompileAndVerify(source, expectedOutput: expectedOutput);
+        }
     }
 }


### PR DESCRIPTION
Avoiding turning RValue expressions into effectively LValues as a sideeffect of lowering reductions.

Fixes:#17756