### PR TITLE
Added support for invoking members with "in" parameters.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -902,12 +902,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // check all arguments that are not passed by value
             if (!argRefKinds.IsDefault)
             {
-                for (var argIdx = 0; argIdx < args.Length; argIdx++)
+                for (var argIndex = 0; argIndex < args.Length; argIndex++)
                 {
-                    if (argRefKinds[argIdx] != RefKind.None && !CheckValueKind(args[argIdx].Syntax, args[argIdx], BindValueKind.ReturnableReference, false, diagnostics))
+                    if (argRefKinds[argIndex] != RefKind.None && !CheckValueKind(args[argIndex].Syntax, args[argIndex], BindValueKind.ReturnableReference, false, diagnostics))
                     {
                         var errorCode = checkingReceiver ? ErrorCode.ERR_RefReturnCall2 : ErrorCode.ERR_RefReturnCall;
-                        var parameterIndex = argToParamsOpt.IsDefault ? argIdx : argToParamsOpt[argIdx];
+                        var parameterIndex = argToParamsOpt.IsDefault ? argIndex : argToParamsOpt[argIndex];
                         var parameterName = parameters[parameterIndex].Name;
                         Error(diagnostics, errorCode, syntax, symbol, parameterName);
                         return false;
@@ -918,9 +918,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // check all "in" parameters 
-            for (var paramIdx = 0; paramIdx < parameters.Length; paramIdx++)
+            for (var paramIndex = 0; paramIndex < parameters.Length; paramIndex++)
             {
-                var parameter = parameters[paramIdx];
+                var parameter = parameters[paramIndex];
 
                 if (parameter.RefKind != RefKind.RefReadOnly)
                 {
@@ -935,18 +935,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 BoundExpression argument = null;
                 if (argToParamsOpt.IsDefault)
                 {
-                    if (paramIdx < args.Length)
+                    if (paramIndex < args.Length)
                     {
-                        argument = args[paramIdx];
+                        argument = args[paramIndex];
                     }
                 }
                 else
                 {
-                    for (int argIdx = 0; argIdx < args.Length; argIdx++)
+                    for (int argIndex = 0; argIndex < args.Length; argIndex++)
                     {
-                        if (argToParamsOpt[argIdx] == paramIdx)
+                        if (argToParamsOpt[argIndex] == paramIndex)
                         {
-                            argument = args[argIdx];
+                            argument = args[argIndex];
+                            break;
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2470,7 +2470,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (argumentCount == parameterCount && argToParamMap.IsDefaultOrEmpty)
             {
                 ImmutableArray<RefKind> parameterRefKinds = member.GetParameterRefKinds();
-                if (parameterRefKinds.IsDefaultOrEmpty || !parameterRefKinds.Any())
+                if (parameterRefKinds.IsDefaultOrEmpty)
                 {
                     return new EffectiveParameters(member.GetParameterTypes(), parameterRefKinds);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2470,7 +2470,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (argumentCount == parameterCount && argToParamMap.IsDefaultOrEmpty)
             {
                 ImmutableArray<RefKind> parameterRefKinds = member.GetParameterRefKinds();
-                if (parameterRefKinds.IsDefaultOrEmpty || !parameterRefKinds.Any(refKind => refKind == RefKind.Ref))
+                if (parameterRefKinds.IsDefaultOrEmpty || !parameterRefKinds.Any())
                 {
                     return new EffectiveParameters(member.GetParameterTypes(), parameterRefKinds);
                 }
@@ -2515,6 +2515,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         private RefKind GetEffectiveParameterRefKind(ParameterSymbol parameter, RefKind argRefKind, bool allowRefOmittedArguments, ref bool hasAnyRefOmittedArgument)
         {
             var paramRefKind = parameter.RefKind;
+
+            if (paramRefKind == RefKind.RefReadOnly)
+            {
+                // "in" parameters are effectively None for the purpose of overload resolution.
+                paramRefKind = RefKind.None;
+            }
 
             // Omit ref feature for COM interop: We can pass arguments by value for ref parameters if we are calling a method/property on an instance of a COM imported type.
             // We must ignore the 'ref' on the parameter while determining the applicability of argument for the given method call.

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Writeable,
 
             // reference itself will not be written to, but may be used for call, callvirt.
-            // for all purposes it the same as Writeable, except when fetching an address of an array element
+            // for all purposes it is the same as Writeable, except when fetching an address of an array element
             // where it results in a ".readonly" prefix to deal with array covariance.
             Constrained,
 
@@ -521,7 +521,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         /// <summary>
         /// Emits receiver in a form that allows member accesses ( O or &amp; ). 
-        /// For verifiably reference types it is the actual reference. 
+        /// For verifier-reference types it is the actual reference. 
         /// For the value types it is an address of the receiver.
         /// For generic types it is either a boxed receiver or the address of the receiver with readonly intent. 
         /// 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -496,6 +496,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
+                //NOTE: we are not propagating AddressKind here.
+                //      the reason is that while Constrained permits calls, it does not permit 
+                //      taking field addresses, so we have to turn Constrained into writeable.
+                //      It is less error prone to just pass a bool "isReadonly" 
                 return EmitInstanceFieldAddress(fieldAccess, isReadonly: addressKind == AddressKind.Readonly);
             }
         }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Constrained,
 
             // reference itself will not be written to, nor it will be used to modify fields.
-            Readonly,
+            ReadOnly,
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     var methodRefKind = call.Method.RefKind;
 
                     if (methodRefKind == RefKind.Ref || 
-                        (addressKind == AddressKind.Readonly && methodRefKind == RefKind.RefReadOnly))
+                        (addressKind == AddressKind.ReadOnly && methodRefKind == RefKind.RefReadOnly))
                     {
                         EmitCallExpression(call, UseKind.UsedAsAddress);
                         break;
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     throw ExceptionUtilities.UnexpectedValue(assignment.RefKind);
 
                 default:
-                    Debug.Assert(!HasHome(expression, addressKind != AddressKind.Readonly));
+                    Debug.Assert(!HasHome(expression, addressKind != AddressKind.ReadOnly));
                     return EmitAddressOfTempClone(expression);
             }
 
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             EmitBox(receiverType, expression.Syntax);
             _builder.EmitBranch(ILOpCode.Brtrue, whenValueTypeLabel);
 
-            var receiverTemp = EmitAddress(expression.ReferenceTypeReceiver, AddressKind.Readonly);
+            var receiverTemp = EmitAddress(expression.ReferenceTypeReceiver, AddressKind.ReadOnly);
             Debug.Assert(receiverTemp == null);
             _builder.EmitBranch(ILOpCode.Br, doneLabel);
             _builder.AdjustStack(-1);
@@ -484,7 +484,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             FieldSymbol field = fieldAccess.FieldSymbol;
 
-            if (!HasHome(fieldAccess, addressKind != AddressKind.Readonly))
+            if (!HasHome(fieldAccess, addressKind != AddressKind.ReadOnly))
             {
                 // accessing a field that is not writable (const or readonly)
                 return EmitAddressOfTempClone(fieldAccess);
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 //      the reason is that while Constrained permits calls, it does not permit 
                 //      taking field addresses, so we have to turn Constrained into writeable.
                 //      It is less error prone to just pass a bool "isReadonly" 
-                return EmitInstanceFieldAddress(fieldAccess, isReadonly: addressKind == AddressKind.Readonly);
+                return EmitInstanceFieldAddress(fieldAccess, isReadonly: addressKind == AddressKind.ReadOnly);
             }
         }
 
@@ -578,7 +578,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             var field = fieldAccess.FieldSymbol;
 
-            var tempOpt = EmitReceiverRef(fieldAccess.ReceiverOpt, isReadonly? AddressKind.Readonly: AddressKind.Writeable);
+            var tempOpt = EmitReceiverRef(fieldAccess.ReceiverOpt, isReadonly? AddressKind.ReadOnly: AddressKind.Writeable);
 
             _builder.EmitOpCode(ILOpCode.Ldflda);
             EmitSymbolToken(field, fieldAccess.Syntax);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -399,10 +399,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             FieldSymbol field = fieldAccess.FieldSymbol;
 
-            // const fields are literal values with no homes
+            // const fields are literal values with no homes. (ex: decimal.Zero)
             if (field.IsConst)
             {
-                //PROTOTYPE(readonlyRefs): does this actually happen?
                 return false;
             }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -575,16 +575,22 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitArgument(BoundExpression argument, RefKind refKind)
         {
-            if (refKind == RefKind.None)
+            switch(refKind)
             {
-                EmitExpression(argument, true);
-            }
-            else
-            {
-                var temp = EmitAddress(argument, AddressKind.Writeable);
+                case RefKind.None:
+                    EmitExpression(argument, true);
+                    break;
 
-                // Dynamic is allowed to be passed by reference, via a temp.
-                Debug.Assert(temp == null || argument.Type.IsDynamic(), "passing args byref should not clone them into temps");
+                case RefKind.RefReadOnly:
+                    //PROTOTYPE(reaadonlyRefs): leaking a temp here
+                    //PROTOTYPE(reaadonlyRefs): readonly fields should not be cloned to temps
+                    var temp = EmitAddress(argument, AddressKind.Writeable);
+                    break;
+
+                default:
+                    var unexpectedTemp = EmitAddress(argument, AddressKind.Writeable);
+                    Debug.Assert(unexpectedTemp == null, "passing args byref should not clone them into temps");
+                    break;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1023,9 +1023,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             // can we take address at all?
-            //PROTOTYPE(readonlyRefs): we only need to read, so we could pass "false" here
-            //                         but that may result in getting a ref off a readonly field, which could upset verifier
-            if (!HasHome(receiver, needWriteable: true))
+            if (!HasHome(receiver, needWriteable: false))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -384,8 +384,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // or if we have default(T) (to do box just once)
             var nullCheckOnCopy = LocalRewriter.CanChangeValueBetweenReads(receiver, localsMayBeAssignedOrCaptured: false) ||
                                    (receiverType.IsReferenceType && receiverType.TypeKind == TypeKind.TypeParameter) ||
-                                   (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol)) ||
-                                   (receiver.IsDefaultValue() && notConstrained);
+                                   (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol));
 
             // ===== RECEIVER
             if (nullCheckOnCopy)
@@ -502,7 +501,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 Debug.Assert(receiverTemp == null);
                 // receiver may be used as target of a struct call (if T happens to be a sruct)
                 receiverTemp = EmitReceiverRef(receiver, AddressKind.Constrained);
-                Debug.Assert(receiverTemp == null);
+                Debug.Assert(receiverTemp == null || receiver.IsDefaultValue());
             }
 
             EmitExpression(expression.WhenNotNull, used);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -362,7 +362,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // const but not default, must be a reference type
                 Debug.Assert(receiverType.IsVerifierReference());
                 // receiver is a reference type, so addresskind does not matter, but we do not intend to write.
-                receiverTemp = EmitReceiverRef(receiver, AddressKind.Readonly);
+                receiverTemp = EmitReceiverRef(receiver, AddressKind.ReadOnly);
                 EmitExpression(expression.WhenNotNull, used);
                 if (receiverTemp != null)
                 {
@@ -593,7 +593,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 case RefKind.RefReadOnly:
                     //PROTOTYPE(reaadonlyRefs): leaking a temp here
-                    var temp = EmitAddress(argument, AddressKind.Readonly);
+                    var temp = EmitAddress(argument, AddressKind.ReadOnly);
                     break;
 
                 default:
@@ -947,7 +947,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // there are also cases where we must emit receiver as a reference
             if (FieldLoadMustUseRef(receiver) || FieldLoadPrefersRef(receiver))
             {
-                return EmitFieldLoadReceiverAddress(receiver) ? null : EmitReceiverRef(receiver, AddressKind.Readonly);
+                return EmitFieldLoadReceiverAddress(receiver) ? null : EmitReceiverRef(receiver, AddressKind.ReadOnly);
             }
 
             EmitExpression(receiver, true);
@@ -1434,7 +1434,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                             //
                             //PROTOTYPE(readonlyRefs): all methods that a struct could inherit from bases are non-mutating
                             //                         we are passing here "Writeable" just to keep verifier happy
-                            //                         we should pass here "Readonly" and avoid unnecessary copy
+                            //                         we should pass here "ReadOnly" and avoid unnecessary copy
                             tempOpt = EmitReceiverRef(receiver, AddressKind.Writeable);
                             callKind = CallKind.ConstrainedCallVirt;
                         }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                             EmitCondBranch(receiver, ref fallThrough, sense: false);
                             // receiver is a reference type, and we only intend to read it
-                            EmitReceiverRef(receiver, AddressKind.Readonly);
+                            EmitReceiverRef(receiver, AddressKind.ReadOnly);
                             EmitCondBranch(ca.WhenNotNull, ref dest, sense: true);
 
                             if (fallThrough != null)
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                             // gotoif(!receiver.Access) labDest
                             EmitCondBranch(receiver, ref dest, sense: false);
                             // receiver is a reference type, and we only intend to read it
-                            EmitReceiverRef(receiver, AddressKind.Readonly);
+                            EmitReceiverRef(receiver, AddressKind.ReadOnly);
                             condition = ca.WhenNotNull;
                             goto oneMoreTime;
                         }
@@ -718,7 +718,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                this.EmitAddress(expressionOpt, this._method.RefKind == RefKind.RefReadOnly? AddressKind.Readonly: AddressKind.Writeable);
+                this.EmitAddress(expressionOpt, this._method.RefKind == RefKind.RefReadOnly? AddressKind.ReadOnly: AddressKind.Writeable);
             }
 
             if (ShouldUseIndirectReturn())

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -487,7 +487,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                             object fallThrough = null;
 
                             EmitCondBranch(receiver, ref fallThrough, sense: false);
-                            EmitReceiverRef(receiver, isAccessConstrained: false);
+                            // receiver is a reference type, and we only intend to read it
+                            EmitReceiverRef(receiver, AddressKind.Readonly);
                             EmitCondBranch(ca.WhenNotNull, ref dest, sense: true);
 
                             if (fallThrough != null)
@@ -500,7 +501,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                             // gotoif(receiver == null) labDest
                             // gotoif(!receiver.Access) labDest
                             EmitCondBranch(receiver, ref dest, sense: false);
-                            EmitReceiverRef(receiver, isAccessConstrained: false);
+                            // receiver is a reference type, and we only intend to read it
+                            EmitReceiverRef(receiver, AddressKind.Readonly);
                             condition = ca.WhenNotNull;
                             goto oneMoreTime;
                         }
@@ -716,7 +718,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                this.EmitAddress(expressionOpt, AddressKind.Writeable);
+                this.EmitAddress(expressionOpt, this._method.RefKind == RefKind.RefReadOnly? AddressKind.Readonly: AddressKind.Writeable);
             }
 
             if (ShouldUseIndirectReturn())
@@ -1012,7 +1014,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         var temp = AllocateTemp(exceptionSource.Type, exceptionSource.Syntax);
                         _builder.EmitLocalStore(temp);
 
-                        var receiverTemp = EmitReceiverRef(left.ReceiverOpt);
+                        var receiverTemp = EmitReceiverRef(left.ReceiverOpt, AddressKind.Writeable);
                         Debug.Assert(receiverTemp == null);
 
                         _builder.EmitLocalLoad(temp);

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -145,6 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 RefKind refKind;
                 return !IsParams && IsMetadataOptional &&
                        ((refKind = RefKind) == RefKind.None ||
+                        (refKind == RefKind.RefReadOnly) ||
                         (refKind == RefKind.Ref && ContainingSymbol.ContainingType.IsComImport));
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -377,8 +377,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // CONSIDER: reported on the parameter name, or on the value of the initializer?
             // CONSIDER: Consider making this consistent.
 
-            //PROTOTYPE(refReadonly): do we allow optional values for "In" parameters?
-            if (refKind != RefKind.None)
+            if (refKind == RefKind.Ref || refKind == RefKind.Out)
             {
                 // error CS1741: A ref or out parameter cannot have a default value
                 diagnostics.Add(ErrorCode.ERR_RefOutDefaultValue, argPassingKeyword.GetLocation());

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -151,6 +151,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void MethodChecks(MethodDeclarationSyntax syntax, Binder withTypeParamsBinder, DiagnosticBag diagnostics)
         {
+            Debug.Assert(this.MethodKind != MethodKind.UserDefinedOperator, "SourceUserDefinedOperatorSymbolBase overrides this");
+
             SyntaxToken arglistToken;
 
             // Constraint checking for parameter and return types must be delayed until
@@ -248,18 +250,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (this.MethodKind == MethodKind.UserDefinedOperator)
-            {
-                foreach (var p in this.Parameters)
-                {
-                    if (p.RefKind != RefKind.None)
-                    {
-                        diagnostics.Add(ErrorCode.ERR_IllegalRefParam, location);
-                        break;
-                    }
-                }
-            }
-            else if (IsPartial)
+            if (IsPartial)
             {
                 // check that there are no out parameters in a partial
                 foreach (var p in this.Parameters)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // SPEC: The parameters of an operator must be value parameters.
             foreach (var p in this.Parameters)
             {
-                if (p.RefKind != RefKind.None)
+                if (p.RefKind != RefKind.None && p.RefKind != RefKind.RefReadOnly)
                 {
                     diagnostics.Add(ErrorCode.ERR_IllegalRefParam, this.Locations[0]);
                     break;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -68,7 +68,7 @@ class Program
   IL_0000:  ldc.i4.s   42
   IL_0002:  stloc.0
   IL_0003:  ldloca.s   V_0
-  IL_0005:  call       ""ref readonly int Program.M(ref readonly int)""
+  IL_0005:  call       ""ref readonly int Program.M(in int)""
   IL_000a:  ldind.i4
   IL_000b:  call       ""void System.Console.WriteLine(int)""
   IL_0010:  ret
@@ -103,7 +103,7 @@ class Program
   IL_0000:  ldc.i4.s   42
   IL_0002:  stloc.0
   IL_0003:  ldloca.s   V_0
-  IL_0005:  call       ""ref readonly int Program.M(ref readonly int)""
+  IL_0005:  call       ""ref readonly int Program.M(in int)""
   IL_000a:  ldind.i4
   IL_000b:  call       ""void System.Console.WriteLine(int)""
   IL_0010:  ret
@@ -137,14 +137,14 @@ class Program
   // Code size       17 (0x11)
   .maxstack  1
   IL_0000:  ldsflda    ""int Program.F""
-  IL_0005:  call       ""ref readonly int Program.M(ref readonly int)""
+  IL_0005:  call       ""ref readonly int Program.M(in int)""
   IL_000a:  ldind.i4
   IL_000b:  call       ""void System.Console.WriteLine(int)""
   IL_0010:  ret
 }");
 
 
-            comp.VerifyIL("Program.M(ref readonly int)", @"
+            comp.VerifyIL("Program.M(in int)", @"
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -180,12 +180,12 @@ class Program
 
             var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: "42");
 
-            comp.VerifyIL("Program.M(ref readonly int)", @"
+            comp.VerifyIL("Program.M(in int)", @"
 {
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  call       ""ref readonly int Program.M1(ref readonly int)""
+  IL_0001:  call       ""ref readonly int Program.M1(in int)""
   IL_0006:  ret
 }");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -40,6 +40,77 @@ class Program
         }
 
         [Fact]
+        public void InParamPassLValue()
+        {
+            var text = @"
+class Program
+{
+    public static void Main()
+    {
+        var local = 42;
+        System.Console.WriteLine(M(local));
+    }
+
+    static ref readonly int M(in int x)
+    {
+        return ref x;
+    }
+}
+";
+
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput:"42");
+
+            comp.VerifyIL("Program.Main()", @"
+{
+  // Code size       17 (0x11)
+  .maxstack  1
+  .locals init (int V_0) //local
+  IL_0000:  ldc.i4.s   42
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  call       ""ref readonly int Program.M(ref readonly int)""
+  IL_000a:  ldind.i4
+  IL_000b:  call       ""void System.Console.WriteLine(int)""
+  IL_0010:  ret
+}");
+        }
+
+        [Fact]
+        public void InParamPassRValue()
+        {
+            var text = @"
+class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine(M(42));
+    }
+
+    static ref readonly int M(in int x)
+    {
+        return ref x;
+    }
+}
+";
+
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: "42");
+
+            comp.VerifyIL("Program.Main()", @"
+{
+  // Code size       17 (0x11)
+  .maxstack  1
+  .locals init (int V_0)
+  IL_0000:  ldc.i4.s   42
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  call       ""ref readonly int Program.M(ref readonly int)""
+  IL_000a:  ldind.i4
+  IL_000b:  call       ""void System.Console.WriteLine(int)""
+  IL_0010:  ret
+}");
+        }
+
+        [Fact]
         public void RefReturnParamAccess1()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -43,35 +43,67 @@ class Program
         public void InParamPassLValue()
         {
             var text = @"
-class Program
+struct Program
 {
     public static void Main()
     {
         var local = 42;
         System.Console.WriteLine(M(local));
+
+        S1 s1 = default(S1);
+        s1.X = 42;
+
+        s1 += s1;
+
+        System.Console.WriteLine(s1.X);
     }
 
     static ref readonly int M(in int x)
     {
         return ref x;
     }
+
+
+    struct S1
+    {
+        public int X;
+
+        public static S1 operator +(in S1 x, in S1 y)
+        {
+            return new S1(){X = x.X + y.X};
+        }
+    }
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput:"42");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"42
+84");
 
             comp.VerifyIL("Program.Main()", @"
 {
-  // Code size       17 (0x11)
-  .maxstack  1
-  .locals init (int V_0) //local
+  // Code size       55 (0x37)
+  .maxstack  2
+  .locals init (int V_0, //local
+                Program.S1 V_1) //s1
   IL_0000:  ldc.i4.s   42
   IL_0002:  stloc.0
   IL_0003:  ldloca.s   V_0
   IL_0005:  call       ""ref readonly int Program.M(in int)""
   IL_000a:  ldind.i4
   IL_000b:  call       ""void System.Console.WriteLine(int)""
-  IL_0010:  ret
+  IL_0010:  ldloca.s   V_1
+  IL_0012:  initobj    ""Program.S1""
+  IL_0018:  ldloca.s   V_1
+  IL_001a:  ldc.i4.s   42
+  IL_001c:  stfld      ""int Program.S1.X""
+  IL_0021:  ldloca.s   V_1
+  IL_0023:  ldloca.s   V_1
+  IL_0025:  call       ""Program.S1 Program.S1.op_Addition(in Program.S1, in Program.S1)""
+  IL_002a:  stloc.1
+  IL_002b:  ldloc.1
+  IL_002c:  ldfld      ""int Program.S1.X""
+  IL_0031:  call       ""void System.Console.WriteLine(int)""
+  IL_0036:  ret
 }");
         }
 
@@ -84,29 +116,44 @@ class Program
     public static void Main()
     {
         System.Console.WriteLine(M(42));
+        System.Console.WriteLine(new Program()[5, 6]);
     }
 
     static ref readonly int M(in int x)
     {
         return ref x;
     }
+
+    int this[in int x, in int y] => x + y;
 }
 ";
 
-            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: "42");
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"42
+11");
 
             comp.VerifyIL("Program.Main()", @"
 {
-  // Code size       17 (0x11)
-  .maxstack  1
-  .locals init (int V_0)
+  // Code size       40 (0x28)
+  .maxstack  3
+  .locals init (int V_0,
+                int V_1,
+                int V_2)
   IL_0000:  ldc.i4.s   42
   IL_0002:  stloc.0
   IL_0003:  ldloca.s   V_0
   IL_0005:  call       ""ref readonly int Program.M(in int)""
   IL_000a:  ldind.i4
   IL_000b:  call       ""void System.Console.WriteLine(int)""
-  IL_0010:  ret
+  IL_0010:  newobj     ""Program..ctor()""
+  IL_0015:  ldc.i4.5
+  IL_0016:  stloc.1
+  IL_0017:  ldloca.s   V_1
+  IL_0019:  ldc.i4.6
+  IL_001a:  stloc.2
+  IL_001b:  ldloca.s   V_2
+  IL_001d:  call       ""int Program.this[in int, in int].get""
+  IL_0022:  call       ""void System.Console.WriteLine(int)""
+  IL_0027:  ret
 }");
         }
         
@@ -187,6 +234,69 @@ class Program
   IL_0000:  ldarg.0
   IL_0001:  call       ""ref readonly int Program.M1(in int)""
   IL_0006:  ret
+}");
+        }
+
+        [Fact]
+        public void InParamBase()
+        {
+            var text = @"
+class Program
+{
+    public static readonly string S = ""hi"";
+    public string SI;
+
+    public static void Main()
+    {
+        var p = new P1(S);
+        System.Console.WriteLine(p.SI);
+
+         System.Console.WriteLine(p.M(42));
+    }
+
+    public Program(in string x)
+    {
+       SI = x;
+    }
+
+    public virtual ref readonly int M(in int x)
+    {
+        return ref x;
+    }
+}
+
+class P1 : Program
+{
+    public P1(in string x) : base(x){}
+
+    public override ref readonly int M(in int x)
+    {
+        return ref base.M(x);
+    }
+}
+";
+
+            var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"hi
+42");
+
+            comp.VerifyIL("P1..ctor(in string)", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  call       ""Program..ctor(in string)""
+  IL_0007:  ret
+}");
+
+            comp.VerifyIL("P1.M(in int)", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  call       ""ref readonly int Program.M(in int)""
+  IL_0007:  ret
 }");
         }
 
@@ -422,6 +532,72 @@ class Program
   IL_0005:  ldarg.1
   IL_0006:  ldflda     ""int System.ValueTuple<int, int>.Item1""
   IL_000b:  ret
+}");
+        }
+
+        [Fact]
+        public void ReadonlyParamOptional()
+        {
+            var text = @"
+class Program
+{
+    static void Main()
+    {
+        System.Console.WriteLine(M());
+    }
+
+    static int M(in int x = 42) => x;
+}
+
+";
+
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput:@"42");
+
+            comp.VerifyIL("Program.Main", @"
+{
+  // Code size       16 (0x10)
+  .maxstack  1
+  .locals init (int V_0)
+  IL_0000:  ldc.i4.s   42
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_0
+  IL_0005:  call       ""int Program.M(in int)""
+  IL_000a:  call       ""void System.Console.WriteLine(int)""
+  IL_000f:  ret
+}");
+        }
+
+        [Fact]
+        public void ReadonlyParamConv()
+        {
+            var text = @"
+class Program
+{
+    static void Main()
+    {
+        var arg = 42;
+        System.Console.WriteLine(M(arg));
+    }
+
+    static double M(in double x) => x;
+}
+
+";
+
+            var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false, expectedOutput: @"42");
+
+            comp.VerifyIL("Program.Main", @"
+{
+  // Code size       17 (0x11)
+  .maxstack  1
+  .locals init (double V_0)
+  IL_0000:  ldc.i4.s   42
+  IL_0002:  conv.r8
+  IL_0003:  stloc.0
+  IL_0004:  ldloca.s   V_0
+  IL_0006:  call       ""double Program.M(in double)""
+  IL_000b:  call       ""void System.Console.WriteLine(double)""
+  IL_0010:  ret
 }");
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
@@ -28,7 +28,6 @@ class Program
 }
 ";
 
-            //PROTOTYPE(readonlyRefs): this should work for now because readonly is treated as regular ref
             var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular);
 
             comp.VerifyIL("Program.M()", @"
@@ -530,6 +529,141 @@ class Program
                 // (15,24): error CS8165: Cannot return by reference a member of result of 'Program.M1(out int)' because the argument passed to parameter 'x' cannot be returned by reference
                 //             return ref M1(out local).Alice;
                 Diagnostic(ErrorCode.ERR_RefReturnCall2, "M1(out local)").WithArguments("Program.M1(out int)", "x").WithLocation(15, 24)
+            );
+        }
+
+        [Fact]
+        public void ReadonlyReturnByRefReadonlyLocalSafety1()
+        {
+            var text = @"
+class Program
+{
+    ref readonly int Test()
+    {
+        int local = 42;
+
+        return ref this[local];
+    }
+
+    ref readonly int this[in int x] => ref x;
+}
+
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (8,25): error CS8168: Cannot return local 'local' by reference because it is not a ref local
+                //         return ref this[local];
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "local").WithArguments("local").WithLocation(8, 25),
+                // (8,24): error CS8164: Cannot return by reference a result of 'Program.this[in int]' because the argument passed to parameter 'x' cannot be returned by reference
+                //         return ref this[local];
+                Diagnostic(ErrorCode.ERR_RefReturnCall, "[local]").WithArguments("Program.this[in int]", "x").WithLocation(8, 24)
+            );
+        }
+
+        [Fact]
+        public void ReadonlyReturnByRefReadonlyLiteralSafety1()
+        {
+            var text = @"
+class Program
+{
+    ref readonly int Test()
+    {
+        return ref this[42];
+    }
+
+    ref readonly int this[in int x] => ref x;
+}
+
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (6,25): error CS8156: An expression cannot be used in this context because it may not be returned by reference
+                //         return ref this[42];
+                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "42").WithLocation(6, 25),
+                // (6,24): error CS8164: Cannot return by reference a result of 'Program.this[in int]' because the argument passed to parameter 'x' cannot be returned by reference
+                //         return ref this[42];
+                Diagnostic(ErrorCode.ERR_RefReturnCall, "[42]").WithArguments("Program.this[in int]", "x").WithLocation(6, 24)
+            );
+        }
+
+        [Fact]
+        public void ReadonlyReturnByRefReadonlyLiteralSafety2()
+        {
+            var text = @"
+class Program
+{
+    ref readonly int Test()
+    {
+        return ref M(42);
+    }
+
+    ref readonly int M(in int x) => ref x;
+}
+
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (6,22): error CS8156: An expression cannot be used in this context because it may not be returned by reference
+                //         return ref M(42);
+                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "42").WithLocation(6, 22),
+                // (6,20): error CS8164: Cannot return by reference a result of 'Program.M(in int)' because the argument passed to parameter 'x' cannot be returned by reference
+                //         return ref M(42);
+                Diagnostic(ErrorCode.ERR_RefReturnCall, "M(42)").WithArguments("Program.M(in int)", "x").WithLocation(6, 20)
+            );
+        }
+
+        [Fact]
+        public void ReadonlyReturnByRefReadonlyOptSafety()
+        {
+            var text = @"
+class Program
+{
+    ref readonly int Test()
+    {
+        return ref M();
+    }
+
+    ref readonly int M(in int x = 42) => ref x;
+}
+
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (6,20): error CS8164: Cannot return by reference a result of 'Program.M(in int)' because the argument passed to parameter 'x' cannot be returned by reference
+                //         return ref M();
+                Diagnostic(ErrorCode.ERR_RefReturnCall, "M()").WithArguments("Program.M(in int)", "x").WithLocation(6, 20)
+            );
+        }
+
+        [Fact]
+        public void ReadonlyReturnByRefReadonlyConvSafety()
+        {
+            var text = @"
+class Program
+{
+    ref readonly int Test()
+    {
+        byte b = 42;
+        return ref M(b);
+    }
+
+    ref readonly int M(in int x) => ref x;
+}
+
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (7,22): error CS8156: An expression cannot be used in this context because it may not be returned by reference
+                //         return ref M(b);
+                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "b").WithLocation(7, 22),
+                // (7,20): error CS8164: Cannot return by reference a result of 'Program.M(in int)' because the argument passed to parameter 'x' cannot be returned by reference
+                //         return ref M(b);
+                Diagnostic(ErrorCode.ERR_RefReturnCall, "M(b)").WithArguments("Program.M(in int)", "x").WithLocation(7, 20)
             );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReadonlyReturnTests.cs
@@ -459,46 +459,33 @@ class Program
 
             var comp = CompileAndVerify(text, new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, verify: false);
 
-            //PROTOTYPE(readonlyRef): correct emit is NYI. We should not make copies when returning r/o fields
             comp.VerifyIL("Program.Test", @"
 {
-  // Code size       70 (0x46)
+  // Code size       57 (0x39)
   .maxstack  1
-  .locals init (bool V_0, //b
-                int V_1,
-                System.ValueTuple<int, int> V_2,
-                int V_3,
-                System.ValueTuple<int, int> V_4)
+  .locals init (bool V_0) //b
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  brfalse.s  IL_0020
+  IL_0003:  brfalse.s  IL_001a
   IL_0005:  ldloc.0
-  IL_0006:  brfalse.s  IL_0012
+  IL_0006:  brfalse.s  IL_000f
   IL_0008:  ldarg.0
-  IL_0009:  ldfld      ""int Program.F""
-  IL_000e:  stloc.1
-  IL_000f:  ldloca.s   V_1
-  IL_0011:  ret
-  IL_0012:  ldsfld     ""(int Alice, int Bob) Program.F1""
-  IL_0017:  stloc.2
-  IL_0018:  ldloca.s   V_2
-  IL_001a:  ldflda     ""int System.ValueTuple<int, int>.Item1""
-  IL_001f:  ret
-  IL_0020:  ldloc.0
-  IL_0021:  brfalse.s  IL_0032
-  IL_0023:  ldarg.0
-  IL_0024:  ldfld      ""Program.S Program.S1""
-  IL_0029:  ldfld      ""int Program.S.F""
-  IL_002e:  stloc.3
-  IL_002f:  ldloca.s   V_3
-  IL_0031:  ret
-  IL_0032:  ldsfld     ""Program.S Program.S2""
-  IL_0037:  ldfld      ""(int Alice, int Bob) Program.S.F1""
-  IL_003c:  stloc.s    V_4
-  IL_003e:  ldloca.s   V_4
-  IL_0040:  ldflda     ""int System.ValueTuple<int, int>.Item1""
-  IL_0045:  ret
+  IL_0009:  ldflda     ""int Program.F""
+  IL_000e:  ret
+  IL_000f:  ldsflda    ""(int Alice, int Bob) Program.F1""
+  IL_0014:  ldflda     ""int System.ValueTuple<int, int>.Item1""
+  IL_0019:  ret
+  IL_001a:  ldloc.0
+  IL_001b:  brfalse.s  IL_0029
+  IL_001d:  ldarg.0
+  IL_001e:  ldflda     ""Program.S Program.S1""
+  IL_0023:  ldflda     ""int Program.S.F""
+  IL_0028:  ret
+  IL_0029:  ldsflda    ""Program.S Program.S2""
+  IL_002e:  ldflda     ""(int Alice, int Bob) Program.S.F1""
+  IL_0033:  ldflda     ""int System.ValueTuple<int, int>.Item1""
+  IL_0038:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -12024,11 +12024,12 @@ struct MyManagedStruct
         n.n.num = x;
     }
 }";
-            var compilation = CompileAndVerify(source, expectedOutput: @"42");
+            var compilation = CompileAndVerify(source, expectedOutput: @"42", verify: false);
 
             // Dev10
             compilation.VerifyIL("Program.Main",
-@"{
+@"
+{
   // Code size       76 (0x4c)
   .maxstack  3
   .locals init (MyManagedStruct V_0)
@@ -12047,9 +12048,9 @@ struct MyManagedStruct
   IL_0023:  ldflda     ""MyManagedStruct.Nested.Nested1 MyManagedStruct.Nested.n""
   IL_0028:  ldc.i4     0x1c8
   IL_002d:  call       ""void MyManagedStruct.Nested.Nested1.mutate(int)""
-  IL_0032:  ldfld      ""MyManagedStruct cls1.y""
-  IL_0037:  ldfld      ""MyManagedStruct.Nested MyManagedStruct.n""
-  IL_003c:  ldfld      ""MyManagedStruct.Nested.Nested1 MyManagedStruct.Nested.n""
+  IL_0032:  ldflda     ""MyManagedStruct cls1.y""
+  IL_0037:  ldflda     ""MyManagedStruct.Nested MyManagedStruct.n""
+  IL_003c:  ldflda     ""MyManagedStruct.Nested.Nested1 MyManagedStruct.Nested.n""
   IL_0041:  ldfld      ""int MyManagedStruct.Nested.Nested1.num""
   IL_0046:  call       ""void System.Console.WriteLine(int)""
   IL_004b:  ret

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
@@ -2835,7 +2835,8 @@ class Repro
                 // warning CS1685: The predefined type 'ExtensionAttribute' is defined in multiple assemblies in the global alias; using definition from 'System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
                 Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.Runtime.CompilerServices.ExtensionAttribute", "System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089").WithLocation(1, 1));
 
-            CompileAndVerify(comp, expectedOutput: "dynamic42");
+            //PROTOTYPE(readonlyRefs): we are producing more efficient code here, but verifier is not happy. Should confirm this is ok.
+            CompileAndVerify(comp, expectedOutput: "dynamic42", verify: false);
         }
     }
 }


### PR DESCRIPTION
Added support for "in" parameters at call sites.

== What works:

- regular methods
- operators
- indexers
- constructors/base calls
- optional "in" parameters
- implicit conversions at the call sites
- return safety when affected by "in" inputs

UNDONE:
temps introduced for RValues are currently method-wide. We will tighten this in a separate change.
Bug: https://github.com/dotnet/roslyn/issues/18181

TESTS:
There are many new tests in this change.
However, this change unblocks big areas of functionality which now become testable, such as overload resolution and generic inference.
It is not the goal of this change to add all the tests that are now possible to write. Only simple functionality is tested.

Comprehensive testing of various areas will come later. For major ones we have tracking bugs:
https://github.com/dotnet/roslyn/issues/18172
https://github.com/dotnet/roslyn/issues/18171
https://github.com/dotnet/roslyn/issues/17798

