### PR TITLE
Pass along appropriate loc strings for the 'use pattern matching' code actions.

### DIFF
--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckCodeFixProvider.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
             public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
-                : base(CSharpFeaturesResources.Inline_temporary_variable, createChangedDocument)
+                : base(FeaturesResources.Use_pattern_matching, createChangedDocument)
             {
             }
         }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckCodeFixProvider.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
             public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
-                : base(CSharpFeaturesResources.Inline_temporary_variable, createChangedDocument)
+                : base(FeaturesResources.Use_pattern_matching, createChangedDocument)
             {
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/18148