### PR TITLE
Support getting and setting Module accessibility through the SyntaxGenerator

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -2468,6 +2468,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     Return DirectCast(declaration, EnumBlockSyntax).EnumStatement.Modifiers
                 Case SyntaxKind.EnumStatement
                     Return DirectCast(declaration, EnumStatementSyntax).Modifiers
+                Case SyntaxKind.ModuleBlock
+                    Return DirectCast(declaration, ModuleBlockSyntax).ModuleStatement.Modifiers
+                Case SyntaxKind.ModuleStatement
+                    Return DirectCast(declaration, ModuleStatementSyntax).Modifiers
                 Case SyntaxKind.DelegateFunctionStatement,
                      SyntaxKind.DelegateSubStatement
                     Return DirectCast(declaration, DelegateStatementSyntax).Modifiers
@@ -2538,6 +2542,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     Return DirectCast(declaration, EnumBlockSyntax).WithEnumStatement(DirectCast(declaration, EnumBlockSyntax).EnumStatement.WithModifiers(tokens))
                 Case SyntaxKind.EnumStatement
                     Return DirectCast(declaration, EnumStatementSyntax).WithModifiers(tokens)
+                Case SyntaxKind.ModuleBlock
+                    Return DirectCast(declaration, ModuleBlockSyntax).WithModuleStatement(DirectCast(declaration, ModuleBlockSyntax).ModuleStatement.WithModifiers(tokens))
+                Case SyntaxKind.ModuleStatement
+                    Return DirectCast(declaration, ModuleStatementSyntax).WithModifiers(tokens)
                 Case SyntaxKind.DelegateFunctionStatement,
                      SyntaxKind.DelegateSubStatement
                     Return DirectCast(declaration, DelegateStatementSyntax).WithModifiers(tokens)
@@ -2618,38 +2626,40 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         Private Function CanHaveAccessibility(declaration As SyntaxNode) As Boolean
             Select Case declaration.Kind
                 Case SyntaxKind.ClassBlock,
-                    SyntaxKind.ClassStatement,
-                    SyntaxKind.StructureBlock,
-                    SyntaxKind.StructureStatement,
-                    SyntaxKind.InterfaceBlock,
-                    SyntaxKind.InterfaceStatement,
-                    SyntaxKind.EnumBlock,
-                    SyntaxKind.EnumStatement,
-                    SyntaxKind.DelegateFunctionStatement,
-                    SyntaxKind.DelegateSubStatement,
-                    SyntaxKind.FieldDeclaration,
-                    SyntaxKind.FunctionBlock,
-                    SyntaxKind.SubBlock,
-                    SyntaxKind.ConstructorBlock,
-                    SyntaxKind.FunctionStatement,
-                    SyntaxKind.SubStatement,
-                    SyntaxKind.SubNewStatement,
-                    SyntaxKind.PropertyBlock,
-                    SyntaxKind.PropertyStatement,
-                    SyntaxKind.OperatorBlock,
-                    SyntaxKind.OperatorStatement,
-                    SyntaxKind.EventBlock,
-                    SyntaxKind.EventStatement,
-                    SyntaxKind.GetAccessorBlock,
-                    SyntaxKind.GetAccessorStatement,
-                    SyntaxKind.SetAccessorBlock,
-                    SyntaxKind.SetAccessorStatement,
-                    SyntaxKind.AddHandlerAccessorBlock,
-                    SyntaxKind.AddHandlerAccessorStatement,
-                    SyntaxKind.RemoveHandlerAccessorBlock,
-                    SyntaxKind.RemoveHandlerAccessorStatement,
-                    SyntaxKind.RaiseEventAccessorBlock,
-                    SyntaxKind.RaiseEventAccessorStatement
+                     SyntaxKind.ClassStatement,
+                     SyntaxKind.StructureBlock,
+                     SyntaxKind.StructureStatement,
+                     SyntaxKind.InterfaceBlock,
+                     SyntaxKind.InterfaceStatement,
+                     SyntaxKind.EnumBlock,
+                     SyntaxKind.EnumStatement,
+                     SyntaxKind.ModuleBlock,
+                     SyntaxKind.ModuleStatement,
+                     SyntaxKind.DelegateFunctionStatement,
+                     SyntaxKind.DelegateSubStatement,
+                     SyntaxKind.FieldDeclaration,
+                     SyntaxKind.FunctionBlock,
+                     SyntaxKind.SubBlock,
+                     SyntaxKind.ConstructorBlock,
+                     SyntaxKind.FunctionStatement,
+                     SyntaxKind.SubStatement,
+                     SyntaxKind.SubNewStatement,
+                     SyntaxKind.PropertyBlock,
+                     SyntaxKind.PropertyStatement,
+                     SyntaxKind.OperatorBlock,
+                     SyntaxKind.OperatorStatement,
+                     SyntaxKind.EventBlock,
+                     SyntaxKind.EventStatement,
+                     SyntaxKind.GetAccessorBlock,
+                     SyntaxKind.GetAccessorStatement,
+                     SyntaxKind.SetAccessorBlock,
+                     SyntaxKind.SetAccessorStatement,
+                     SyntaxKind.AddHandlerAccessorBlock,
+                     SyntaxKind.AddHandlerAccessorStatement,
+                     SyntaxKind.RemoveHandlerAccessorBlock,
+                     SyntaxKind.RemoveHandlerAccessorStatement,
+                     SyntaxKind.RaiseEventAccessorBlock,
+                     SyntaxKind.RaiseEventAccessorStatement
                     Return True
                 Case Else
                     Return False

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -2301,7 +2301,7 @@ End Class
         Public Sub TestGetAccessibility()
             Assert.Equal(Accessibility.Internal, _g.GetAccessibility(_g.ClassDeclaration("c", accessibility:=Accessibility.Internal)))
             Assert.Equal(Accessibility.Internal, _g.GetAccessibility(_g.StructDeclaration("s", accessibility:=Accessibility.Internal)))
-            Assert.Equal(Accessibility.Internal, _g.GetAccessibility(_g.EnumDeclaration("i", accessibility:=Accessibility.Internal)))
+            Assert.Equal(Accessibility.Internal, _g.GetAccessibility(_g.InterfaceDeclaration("i", accessibility:=Accessibility.Internal)))
             Assert.Equal(Accessibility.Internal, _g.GetAccessibility(_g.EnumDeclaration("e", accessibility:=Accessibility.Internal)))
             Assert.Equal(Accessibility.Internal, _g.GetAccessibility(_g.DelegateDeclaration("d", accessibility:=Accessibility.Internal)))
             Assert.Equal(Accessibility.Internal, _g.GetAccessibility(_g.MethodDeclaration("m", accessibility:=Accessibility.Internal)))
@@ -2318,6 +2318,11 @@ End Class
             Assert.Equal(Accessibility.NotApplicable, _g.GetAccessibility(_g.LocalDeclarationStatement(_g.IdentifierName("t"), "loc")))
             Assert.Equal(Accessibility.NotApplicable, _g.GetAccessibility(_g.Attribute("a")))
             Assert.Equal(Accessibility.NotApplicable, _g.GetAccessibility(SyntaxFactory.TypeParameter("tp")))
+
+            Dim m = SyntaxFactory.ModuleBlock(
+                SyntaxFactory.ModuleStatement("module2").
+                              WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword))))
+            Assert.Equal(Accessibility.Public, _g.GetAccessibility(m))
         End Sub
 
         <Fact>
@@ -2341,6 +2346,11 @@ End Class
             Assert.Equal(Accessibility.NotApplicable, _g.GetAccessibility(_g.WithAccessibility(_g.LocalDeclarationStatement(_g.IdentifierName("t"), "loc"), Accessibility.Private)))
             Assert.Equal(Accessibility.NotApplicable, _g.GetAccessibility(_g.WithAccessibility(_g.Attribute("a"), Accessibility.Private)))
             Assert.Equal(Accessibility.NotApplicable, _g.GetAccessibility(_g.WithAccessibility(SyntaxFactory.TypeParameter("tp"), Accessibility.Private)))
+
+            Dim m = SyntaxFactory.ModuleBlock(
+                SyntaxFactory.ModuleStatement("module2").
+                              WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword))))
+            Assert.Equal(Accessibility.Internal, _g.GetAccessibility(_g.WithAccessibility(m, Accessibility.Internal)))
         End Sub
 
         <Fact>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/18111