### PR TITLE
Fix Microbuild

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -35,7 +35,14 @@
          Use the Microsoft.Net.Compilers.props file with the fix checked into the repo instead of the one that comes along with the nuget package:
          $(NuGetPackageRoot)\Microsoft.Net.Compilers\$(ToolsetCompilerPackageVersion)\build\Microsoft.Net.Compilers.props -->
     <ToolsetCompilerPropsFilePath>$(MSBuildThisFileDirectory)Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
-    <TargetFrameworkRootPath>$(NuGetPackageRoot)\RoslynTools.ReferenceAssemblies\$(RoslynToolsReferenceAssembliesVersion)\tools\Framework</TargetFrameworkRootPath>
+
+    <!-- 
+        TargetFrameworkRootPath can't be overriden completely on MSBuild 14.0 installations.  This is still
+        used in Microbuild hence we need to suppress this when building there.  Following item tracks the 
+        removal of this work around
+
+        https://github.com/dotnet/roslyn/issues/18189 -->
+    <TargetFrameworkRootPath Condition="'$(MSBuildToolsVersion)' != '14.0'">$(NuGetPackageRoot)\RoslynTools.ReferenceAssemblies\$(RoslynToolsReferenceAssembliesVersion)\tools\Framework</TargetFrameworkRootPath>
 
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
     <VisualStudioReferenceMajorVersion Condition="'$(VisualStudioReferenceMajorVersion)' == ''">$(VisualStudioVersion.Substring(0, $(VisualStudioVersion.IndexOf('.'))))</VisualStudioReferenceMajorVersion>


### PR DESCRIPTION
Microbuild is still building us with MSBuild 14.0.  Need to suppress our use of
TargetFrameworkRootPath until Microbuild fully migrates to MSBuild 15.0.