### PR TITLE
Reorder asserts in BuildWithCommandLine so we can see log output duri…

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
@@ -54,9 +54,9 @@ class Program
             var process = Process.Start(pathToDevenv, commandLine);
             process.WaitForExit();
 
-            Assert.Equal(0, process.ExitCode);
-
             Assert.Contains("Rebuild All: 1 succeeded, 0 failed, 0 skipped", File.ReadAllText(logFileName));
+
+            Assert.Equal(0, process.ExitCode);
         }
     }
 }


### PR DESCRIPTION
…ng test failures. Tagging @jasonmalinowski @dotnet/roslyn-ide for review.