### PR TITLE
Handle missing variable declaration in foreach loop in VariablesDeclared

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -131,12 +131,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (deconstructionAssignment == null)
                 {
-                    // regular, not deconstructing, foreach declares exactly one iteration variable
-                    _variablesDeclared.Add(node.IterationVariables.Single());
+                    _variablesDeclared.AddAll(node.IterationVariables);
                 }
                 else
                 {
-                    // deconstruction foreach declares multiple variables
+                    // Deconstruction foreach declares multiple variables.
                     ((BoundTupleExpression)deconstructionAssignment.Left).VisitAllElements((x, self) => self.Visit(x), this);
                 }
             }

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
@@ -1930,5 +1930,44 @@ namespace N
 
             await TestExtractMethodAsync(code, expected);
         }
+
+        [WorkItem(17971, "https://github.com/dotnet/roslyn/issues/17971")]
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        public async Task BrokenForeachLoop()
+        {
+            var code = @"using System;
+namespace ConsoleApp1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            [|Console.WriteLine(1);
+            foreach ()
+            Console.WriteLine(2);|]
+        }
+    }
+}";
+            var expected = @"using System;
+namespace ConsoleApp1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            NewMethod();
+        }
+
+        private static void NewMethod()
+        {
+            Console.WriteLine(1);
+            foreach ()
+                Console.WriteLine(2);
+        }
+    }
+}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
     }
 }


### PR DESCRIPTION
Fixes #17921 

@dotnet/roslyn-compiler Please review this small crash fix.
