### PR TITLE
add IVT so F# can consume CommandLineParser

### DIFF
--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -733,6 +733,7 @@
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.CodeAnalysis" />
     <InternalsVisibleTo Include="VBCSCompiler" />
     <InternalsVisibleTo Include="VBCSCompilerPortable" />
+    <InternalsVisibleToFSharp Include="FSharp.LanguageService" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.CommandLine.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.Emit.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.WinRT.UnitTests" />


### PR DESCRIPTION
As part of the work to enable F# to use the Roslyn project system as per dotnet/roslyn-project-system#1853, F# needs to provide an implementation of [`CommandLineParser`](http://source.roslyn.io/#Microsoft.CodeAnalysis/CommandLine/CommonCommandLineParser.cs,ae11db03d7f7007c), but the abstract methods in that class are internal (i.e., [`CommonParse()`](http://source.roslyn.io/#Microsoft.CodeAnalysis/CommandLine/CommonCommandLineParser.cs,59) and [`GenerateErrorForNoFilesFoundInRecurse()`](http://source.roslyn.io/#Microsoft.CodeAnalysis/CommandLine/CommonCommandLineParser.cs,981)).  This PR simply adds the appropriate IVT.

There is also the possibility of exposing those two methods in the public API if another IVT doesn't want to be granted.

@dotnet/roslyn-ide