### PR TITLE
Replace file existence check of $(IbcMergePath) with an empty property check

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -424,7 +424,7 @@
   <!-- The path to IBCMerge.exe must be specified at build time via $(IbcMergePath).  Typically this is passed as a
        build definition variable -->
   <Target Name="ApplyOptimizations"
-          Condition="'$(OfficialBuild)' == 'true' AND '$(NonShipping)' != 'true' AND '$(SkipApplyOptimizations)' != 'true' AND Exists('$(OptimizationDataFile)') AND Exists('$(IbcMergePath)')"
+          Condition="'$(OfficialBuild)' == 'true' AND '$(NonShipping)' != 'true' AND '$(SkipApplyOptimizations)' != 'true' AND Exists('$(OptimizationDataFile)') AND '$(IbcMergePath)' != ''"
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
       <Message Text="Adding optimization data to @(IntermediateAssembly)" />


### PR DESCRIPTION
We recently have RPS failure caused by increased size of NGen'd files. With a closer look, it seems that particular build (20170323.2) inserted didn't run target "ApplyOptimizations", which we suspect has something to do with mlangfs1 went offline thus `Exists('$(IbcMergePath)')` is false.

This change is to ensure signed build would fail in similar scenario in the future.

@KevinH-MS @TyOverby 
cc @dotnet/roslyn-infrastructure 