### PR TITLE
Change assembly checksum caching

### DIFF
--- a/src/Tools/Source/RunTests/Cache/ContentUtil.cs
+++ b/src/Tools/Source/RunTests/Cache/ContentUtil.cs
@@ -5,9 +5,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace RunTests.Cache
 {
@@ -15,7 +16,15 @@ namespace RunTests.Cache
     {
         private readonly TestExecutionOptions _options;
         private readonly MD5 _hash = MD5.Create();
-        private readonly Dictionary<string, string> _fileToChecksumMap = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Building up checksums for assembly values represents a significant amount of time when calculating
+        /// the content for a given test.  As such we aggressively cache these results.
+        /// 
+        /// The cache is done by the MVID of the assembly.  This is guaranteed to be different for different
+        /// content and it's efficient to read.  Hence it's an excellent key.
+        /// </summary>
+        private readonly Dictionary<Guid, string> _assemblyChecksumCacheMap = new Dictionary<Guid, string>();
 
         /// <summary>
         /// Stores a map between a unit test assembly and the reference section of the content file.  For 
@@ -154,7 +163,7 @@ namespace RunTests.Cache
                 return (builder.ToString(), isError: false);
             }
             else
-            { 
+            {
                 // Error if there are any referenced assemblies that we were unable to resolve.
                 var errorBuilder = new StringBuilder();
                 errorBuilder.AppendLine($"Unable to resolve {missingSet.Count} referenced assemblies");
@@ -206,15 +215,32 @@ namespace RunTests.Cache
 
         private string GetFileChecksum(string filePath)
         {
-            string checksum;
-            if (_fileToChecksumMap.TryGetValue(filePath, out checksum))
+            var ext = Path.GetExtension(filePath).ToLower();
+            return (ext == ".dll" || ext == ".exe") 
+                ? GetAssemblyChecksum(filePath)
+                : GetFileChecksumCore(filePath);
+        }
+
+        private string GetAssemblyChecksum(string filePath)
+        {
+            var mvid = GetAssemblyMvid(filePath);
+            if (!_assemblyChecksumCacheMap.TryGetValue(mvid, out var checksum))
             {
-                return checksum;
+                checksum = GetFileChecksumCore(filePath);
+                _assemblyChecksumCacheMap[mvid] = checksum;
             }
 
-            checksum = GetFileChecksumCore(filePath);
-            _fileToChecksumMap.Add(filePath, checksum);
             return checksum;
+        }
+
+        private Guid GetAssemblyMvid(string filePath)
+        {
+            using (var source = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = new PEReader(source))
+            {
+                var metadataReader = reader.GetMetadataReader();
+                return metadataReader.GetGuid(metadataReader.GetModuleDefinition().Mvid);
+            }
         }
 
         private string GetFileChecksumCore(string filePath)


### PR DESCRIPTION
Part of building up our content file for a test description includes
calculating checksums for several thousand assemblies.  This takes up a
significant amount of time if done without optimization (~1 minute).  To
optimize this process RunTests caches checksums on a couple of levels.

One cache is based on file path.  The tool assumes the file system is
static for the duration of the run and hence caches checksums based on
file paths.

This cache was added back when the build outputed the majority of the
build to a single directory.  There are a lot of common assemblies
between our tests hence this was a very effective cache.  Since we've
moved to a more granular output structure this cache is becoming
extremely ineffective.

This change replaces it with an MVID based cache.  Calculating the
checksum of an assembly is relatively expensive but reading it's MVID is
cheap and it's an effective content key for PEs.

Local measurements show this saved us 55% on calculating the content for
the entirety of our test run set (about 20 seconds).