### PR TITLE
Extract code related to DB persistent, but not specific to Esent, into its own class.

### DIFF
--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Interactive\Commands\ResetInteractiveTests.cs" />
     <Compile Include="Interactive\Commands\TestResetInteractive.cs" />
     <Compile Include="Interactive\TestInteractiveEvaluator.cs" />
+    <Compile Include="PersistentStorage\EsentPersistentStorageTests.cs" />
     <Compile Include="PersistentStorage\SolutionSizeTests.cs" />
     <Compile Include="ProjectSystemShim\CPS\AnalyzersTests.cs" />
     <Compile Include="ProjectSystemShim\CPS\CSharpCompilerOptionsTests.cs" />
@@ -226,7 +227,6 @@
     <Compile Include="F1Help\F1HelpTests.cs" />
     <Compile Include="Options\OptionViewModelTests.cs" />
     <Compile Include="PersistentStorage\OptionServiceMock.cs" />
-    <Compile Include="PersistentStorage\PersistentStorageTests.cs" />
     <Compile Include="ProjectSystemShim\LegacyProject\AnalyzersTests.cs" />
     <Compile Include="ProjectSystemShim\LegacyProject\CSharpCompilerOptionsTests.cs" />
     <Compile Include="ProjectSystemShim\CSharpHelpers.cs" />

--- a/src/VisualStudio/CSharp/Test/PersistentStorage/EsentPersistentStorageTests.cs
+++ b/src/VisualStudio/CSharp/Test/PersistentStorage/EsentPersistentStorageTests.cs
@@ -7,17 +7,14 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.Shared.Options;
-using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Esent;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Storage;
-using Microsoft.VisualStudio.LanguageServices.Implementation;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 {
-    public class PersistentStorageTests : IDisposable
+    public class EsentPersistentStorageTests : IDisposable
     {
         private const int NumThreads = 10;
         private const string PersistentFolderPrefix = "PersistentStorageTests_";
@@ -34,7 +31,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
         private const string Data1 = "Hello ESENT";
         private const string Data2 = "Goodbye ESENT";
 
-        public PersistentStorageTests()
+        public EsentPersistentStorageTests()
         {
             _persistentFolder = Path.Combine(Path.GetTempPath(), PersistentFolderPrefix + Guid.NewGuid());
             Directory.CreateDirectory(_persistentFolder);
@@ -316,9 +313,9 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
 
         private IPersistentStorage GetStorage(Solution solution)
         {
-            var storage = new PersistentStorageService(_persistentEnabledOptionService, testing: true).GetStorage(solution);
+            var storage = new EsentPersistentStorageService(_persistentEnabledOptionService, testing: true).GetStorage(solution);
 
-            Assert.NotEqual(PersistentStorageService.NoOpPersistentStorageInstance, storage);
+            Assert.NotEqual(EsentPersistentStorageService.NoOpPersistentStorageInstance, storage);
             return storage;
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -33,6 +33,7 @@ using VSLangProj;
 using VSLangProj140;
 using OLEServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 using OleInterop = Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.CodeAnalysis.Esent;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
@@ -1310,7 +1311,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             private void RegisterPrimarySolutionForPersistentStorage(
                 SolutionId solutionId)
             {
-                var service = _workspace.Services.GetService<IPersistentStorageService>() as PersistentStorageService;
+                var service = _workspace.Services.GetService<IPersistentStorageService>() as AbstractPersistentStorageService;
                 if (service == null)
                 {
                     return;
@@ -1322,7 +1323,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             private void UnregisterPrimarySolutionForPersistentStorage(
                 SolutionId solutionId, bool synchronousShutdown)
             {
-                var service = _workspace.Services.GetService<IPersistentStorageService>() as PersistentStorageService;
+                var service = _workspace.Services.GetService<IPersistentStorageService>() as AbstractPersistentStorageService;
                 if (service == null)
                 {
                     return;

--- a/src/Workspaces/Core/Desktop/Workspace/Esent/EsentPersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Esent/EsentPersistentStorage.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;

--- a/src/Workspaces/Core/Desktop/Workspace/Esent/EsentPersistentStorageService.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Esent/EsentPersistentStorageService.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.SolutionSize;
+using Microsoft.CodeAnalysis.Storage;
+using Microsoft.Isam.Esent.Interop;
+
+namespace Microsoft.CodeAnalysis.Esent
+{
+    internal partial class EsentPersistentStorageService : AbstractPersistentStorageService, IPersistentStorageService
+    {
+        public EsentPersistentStorageService(
+            IOptionService optionService,
+            SolutionSizeTracker solutionSizeTracker)
+            : base(optionService, solutionSizeTracker)
+        {
+        }
+
+        public EsentPersistentStorageService(IOptionService optionService, bool testing) 
+            : base(optionService, testing)
+        {
+        }
+
+        public EsentPersistentStorageService(IOptionService optionService) 
+            : base(optionService)
+        {
+        }
+
+        protected override string GetDatabaseFilePath(string workingFolderPath)
+            => EsentPersistentStorage.GetDatabaseFile(workingFolderPath);
+
+        protected override bool TryCreatePersistentStorage(
+            string workingFolderPath, string solutionPath,
+            out AbstractPersistentStorage persistentStorage)
+        {
+            persistentStorage = null;
+            EsentPersistentStorage esent = null;
+
+            try
+            {
+                esent = new EsentPersistentStorage(OptionService, workingFolderPath, solutionPath, this.Release);
+                esent.Initialize();
+
+                persistentStorage = esent;
+                return true;
+            }
+            catch (EsentAccessDeniedException ex)
+            {
+                // esent db is already in use by someone.
+                if (esent != null)
+                {
+                    esent.Close();
+                }
+
+                EsentLogger.LogException(ex);
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                if (esent != null)
+                {
+                    esent.Close();
+                }
+
+                EsentLogger.LogException(ex);
+            }
+
+            try
+            {
+                if (esent != null)
+                {
+                    Directory.Delete(esent.EsentDirectory, recursive: true);
+                }
+            }
+            catch
+            {
+                // somehow, we couldn't delete the directory.
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Workspaces/Core/Desktop/Workspace/Storage/PersistenceStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Storage/PersistenceStorageServiceFactory.cs
@@ -2,6 +2,7 @@
 
 using System.Composition;
 using System.Threading;
+using Microsoft.CodeAnalysis.Esent;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Storage
             if (_singleton == null)
             {
                 var optionService = workspaceServices.GetService<IOptionService>();
-                Interlocked.CompareExchange(ref _singleton, new PersistentStorageService(optionService, _solutionSizeTracker), null);
+                Interlocked.CompareExchange(ref _singleton, new EsentPersistentStorageService(optionService, _solutionSizeTracker), null);
             }
 
             return _singleton;

--- a/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
+++ b/src/Workspaces/Core/Desktop/Workspaces.Desktop.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Workspace\MSBuild\VisualBasic\VisualBasicProjectFileLoaderFactory.cs" />
     <Compile Include="Workspace\MSBuild\MSBuildProjectLoader.cs" />
     <Compile Include="Workspace\SolutionSize\SolutionSizeTracker.cs" />
+    <Compile Include="Workspace\Esent\EsentPersistentStorageService.cs" />
     <Compile Include="Workspace\Storage\PersistenceStorageServiceFactory.cs" />
     <Compile Include="Workspace\Storage\PersistentStorageService.cs" />
   </ItemGroup>

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/AbstractPersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/AbstractPersistentStorage.cs
@@ -33,9 +33,7 @@ namespace Microsoft.CodeAnalysis.Host
         public string SolutionFilePath { get; }
 
         protected bool PersistenceEnabled
-        {
-            get { return _optionService.GetOption(PersistentStorageOptions.Enabled); }
-        }
+            => _optionService.GetOption(PersistentStorageOptions.Enabled);
 
         public void Dispose()
         {

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -210,13 +210,13 @@ namespace Microsoft.CodeAnalysis.Remote
             return session;
         }
 
-        private static PersistentStorageService GetPersistentStorageService()
+        private static AbstractPersistentStorageService GetPersistentStorageService()
         {
             // A bit slimy.  We just create an adhoc workspace so it will create the singleton
             // PersistentStorageService.  This service will be shared among all Workspaces we 
             // create in this process.  So updating it will be seen by all.
             var workspace = new AdhocWorkspace(RoslynServices.HostServices);
-            var persistentStorageService = workspace.Services.GetService<IPersistentStorageService>() as PersistentStorageService;
+            var persistentStorageService = workspace.Services.GetService<IPersistentStorageService>() as AbstractPersistentStorageService;
             return persistentStorageService;
         }
     }


### PR DESCRIPTION
This way we can share the majority of battle-tested DB code between the SQLite and Esent implementations.  