### PR TITLE
make command line struct's .ctors public

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommandLineReference.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineReference.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -17,7 +14,7 @@ namespace Microsoft.CodeAnalysis
         private readonly string _reference;
         private readonly MetadataReferenceProperties _properties;
 
-        internal CommandLineReference(string reference, MetadataReferenceProperties properties)
+        public CommandLineReference(string reference, MetadataReferenceProperties properties)
         {
             Debug.Assert(!string.IsNullOrEmpty(reference));
             _reference = reference;

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineSourceFile.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineSourceFile.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -13,7 +12,7 @@ namespace Microsoft.CodeAnalysis
         private readonly string _path;
         private readonly bool _isScript;
 
-        internal CommandLineSourceFile(string path, bool isScript)
+        public CommandLineSourceFile(string path, bool isScript)
         {
             Debug.Assert(!string.IsNullOrEmpty(path));
 

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -10,6 +10,8 @@
 Microsoft.CodeAnalysis.CommandLineArguments.DisplayVersion.get -> bool
 Microsoft.CodeAnalysis.CommandLineArguments.EmbeddedFiles.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CommandLineSourceFile>
 Microsoft.CodeAnalysis.CommandLineArguments.SourceLink.get -> string
+Microsoft.CodeAnalysis.CommandLineReference.CommandLineReference(string reference, Microsoft.CodeAnalysis.MetadataReferenceProperties properties) -> void
+Microsoft.CodeAnalysis.CommandLineSourceFile.CommandLineSourceFile(string path, bool isScript) -> void
 Microsoft.CodeAnalysis.Compilation.CreateAnonymousTypeSymbol(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> memberTypes, System.Collections.Immutable.ImmutableArray<string> memberNames, System.Collections.Immutable.ImmutableArray<bool> memberIsReadOnly = default(System.Collections.Immutable.ImmutableArray<bool>), System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location> memberLocations = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location>)) -> Microsoft.CodeAnalysis.INamedTypeSymbol
 Microsoft.CodeAnalysis.Compilation.CreateErrorNamespaceSymbol(Microsoft.CodeAnalysis.INamespaceSymbol container, string name) -> Microsoft.CodeAnalysis.INamespaceSymbol
 Microsoft.CodeAnalysis.Compilation.CreateTupleTypeSymbol(Microsoft.CodeAnalysis.INamedTypeSymbol underlyingType, System.Collections.Immutable.ImmutableArray<string> elementNames = default(System.Collections.Immutable.ImmutableArray<string>), System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location> elementLocations = default(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location>)) -> Microsoft.CodeAnalysis.INamedTypeSymbol


### PR DESCRIPTION
EDIT:
I've re-thought this and I've come up with a simpler solution. See the explanation in my comment [here](https://github.com/dotnet/roslyn/pull/18258#issuecomment-290204982).

(Original text)
To integrate F# with the project system, F# needs to provide an implementation of `CommandLineArguments`, but that has some internal-only setters.  This PR simply makes those `protected internal`, instead so they're consumable without adding IVTs.

@dotnet/roslyn-compiler and specifically, @jaredpar and @jasonmalinowski.