### PR TITLE
Fix accessibility issue in option page controls

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
@@ -13,34 +13,34 @@
     mc:Ignorable="d" d:DesignHeight="279" d:DesignWidth="514">
 
     <options:AbstractOptionPageControl.Resources>
-                <DataTemplate DataType="{x:Type options:CheckBoxOptionViewModel}">
-                    <StackPanel Orientation="Horizontal">
-                        <CheckBox x:Uid="OptionCheckBox" 
+        <DataTemplate DataType="{x:Type options:CheckBoxOptionViewModel}">
+            <StackPanel Orientation="Horizontal">
+                <CheckBox x:Uid="OptionCheckBox" 
                                         IsChecked="{Binding IsChecked, Mode=TwoWay}" 
                                         Width="Auto"
                                         Focusable="False"
-                                        Margin="20, 0, 0, 0"
-                                        Content="{Binding Description}">
-                        </CheckBox>
-                    </StackPanel>
-                </DataTemplate>
+                                        Margin="20, 0, 0, 0">
+                    <TextBlock Text="{Binding Description}" Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"/>
+                </CheckBox>
+            </StackPanel>
+        </DataTemplate>
 
-                <DataTemplate DataType="{x:Type options:CheckBoxWithComboOptionViewModel}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <CheckBox x:Uid="OptionCheckBox" 
+        <DataTemplate DataType="{x:Type options:CheckBoxWithComboOptionViewModel}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <CheckBox x:Uid="OptionCheckBox" 
                                         IsChecked="{Binding IsChecked, Mode=TwoWay}"
                                         Width="Auto"
                                         Focusable="False"
                                         Margin="20, 0, 0, 0"
                                         Grid.Column="0"/>
 
-                        <!-- TODO: remove hardcoded width -->
-                        <ComboBox x:Uid="ComboBoxOptions"
+                <!-- TODO: remove hardcoded width -->
+                <ComboBox x:Uid="ComboBoxOptions"
                                   ItemsSource="{Binding NotificationOptions}"
                                   SelectedItem="{Binding SelectedNotificationOption, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                   HorizontalContentAlignment="Left"
@@ -48,50 +48,52 @@
                                   Margin="5, 0, 0, 0"
                                   Width="100"
                                   Grid.Column="1">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <imaging:CrispImage
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <imaging:CrispImage
                                             Height="16" 
                                             Width="16" 
                                             Moniker="{Binding Moniker}"
                                             Grid.Column="0"/>
-                                        <TextBlock 
+                                <TextBlock 
                                             Margin="5, 0, 0, 0" 
                                             Text="{Binding Notification}"
-                                            Grid.Column="1"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
+                                            Grid.Column="1"
+                                            Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"/>
+                            </Grid>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
 
-                        <TextBlock x:Uid="Description" Text="{Binding Description}"
+                <TextBlock x:Uid="Description" Text="{Binding Description}"
                                    Margin="5, 0, 0, 0" Grid.Column="2" TextWrapping="WrapWithOverflow"/>
-                    </Grid>
-                </DataTemplate>
+            </Grid>
+        </DataTemplate>
 
-                <DataTemplate DataType="{x:Type options:HeaderItemViewModel}">
-                    <TextBlock Text="{Binding Header}" Focusable="False"/>
-                </DataTemplate>
+        <DataTemplate DataType="{x:Type options:HeaderItemViewModel}">
+            <TextBlock Text="{Binding Header}" Focusable="False"/>
+        </DataTemplate>
 
-                <DataTemplate DataType="{x:Type options:AbstractRadioButtonViewModel}">
-                    <StackPanel Orientation="Horizontal">
-                        <RadioButton x:Uid="OptionRadioButton" 
+        <DataTemplate DataType="{x:Type options:AbstractRadioButtonViewModel}">
+            <StackPanel Orientation="Horizontal">
+                <RadioButton x:Uid="OptionRadioButton" 
                                         IsChecked="{Binding IsChecked, Mode=TwoWay}" 
                                         Width="Auto"
                                         Focusable="False"
                                         GroupName="{Binding GroupName, Mode=OneWay}"
                                         PreviewKeyDown="Options_PreviewKeyDown"
-                                        Margin="20, 0, 0, 0"
-                                        Content="{Binding Description}" />
-                    </StackPanel>
-                </DataTemplate>
+                                        Margin="20, 0, 0, 0">
+                    <TextBlock Text="{Binding Description}" Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"/>
+                </RadioButton>
+            </StackPanel>
+        </DataTemplate>
     </options:AbstractOptionPageControl.Resources>
-    
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />


### PR DESCRIPTION
The option pages contain controls like Checkboxes and Radiobuttons that
themselves contain TextBlocks. These controls are placed inside a
ListView. This nesting prevents the TextBlocks from properly inheriting
the Foreground from the ancestor ListViewItems so we have to manually
add that binding in order to pick up theme changes.

cc @dpoeschl @dotnet/roslyn-ide 
![image](https://cloud.githubusercontent.com/assets/3751401/24429018/35e9b56e-13c5-11e7-845b-2635396f5c37.png)
