### PR TITLE
Ensure MethodToStateMachineRewriter.VisitScope properly rewrites local symbols referenced by the node.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -625,16 +625,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitScope(BoundScope node)
         {
             Debug.Assert(!node.Locals.IsEmpty);
-            var newLocals = ArrayBuilder<LocalSymbol>.GetInstance();
+            var newLocalsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
             var hoistedLocalsWithDebugScopes = ArrayBuilder<StateMachineFieldSymbol>.GetInstance();
+            bool localsRewritten = false;
             foreach (var local in node.Locals)
             {
                 Debug.Assert(local.SynthesizedKind == SynthesizedLocalKind.UserDefined &&
                     local.ScopeDesignatorOpt?.Kind() == SyntaxKind.SwitchSection);
 
-                if (!NeedsProxy(local))
+                LocalSymbol localToUse;
+                if (TryRewriteLocal(local, out localToUse))
                 {
-                    newLocals.Add(local);
+                    newLocalsBuilder.Add(localToUse);
+                    localsRewritten |= ((object)local != localToUse);
                     continue;
                 }
 
@@ -648,14 +651,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 BoundStatement translated;
 
-                if (newLocals.Count == 0)
+                if (newLocalsBuilder.Count == 0)
                 {
-                    newLocals.Free();
+                    newLocalsBuilder.Free();
                     translated = new BoundStatementList(node.Syntax, statements);
                 }
                 else
                 {
-                    translated = node.Update(newLocals.ToImmutableAndFree(), statements);
+                    translated = node.Update(newLocalsBuilder.ToImmutableAndFree(), statements);
                 }
 
                 return MakeStateMachineScope(hoistedLocalsWithDebugScopes.ToImmutable(), translated);
@@ -663,8 +666,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 hoistedLocalsWithDebugScopes.Free();
-                newLocals.Free();
-                return node.Update(node.Locals, statements);
+                ImmutableArray<LocalSymbol> newLocals;
+
+                if (localsRewritten)
+                {
+                    newLocals = newLocalsBuilder.ToImmutableAndFree();
+                }
+                else
+                {
+                    newLocalsBuilder.Free();
+                    newLocals = node.Locals;
+                }
+
+                return node.Update(newLocals, statements);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -2541,6 +2541,127 @@ class Program
         }
 
         [Fact]
+        [WorkItem(16066, "https://github.com/dotnet/roslyn/issues/16066")]
+        [WorkItem(16066, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
+        public void SwitchAwaitGenericsAndOptimization()
+        {
+            var source =
+@"
+using System.Threading.Tasks;
+
+class Test
+{
+    static void Main()
+    {
+        System.Console.WriteLine(SendMessageAsync<string>(""a"").Result);
+        System.Console.WriteLine(SendMessageAsync<string>('a').Result);
+    }
+
+    public static async Task<string> SendMessageAsync<T>(object response)
+    {
+        switch (response)
+        {
+            case T expected:
+                return ""T"";
+            default:
+                return ""default"";
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            compilation.VerifyDiagnostics(
+                // (12,38): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //     public static async Task<string> SendMessageAsync<T>(object response)
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "SendMessageAsync").WithLocation(12, 38)
+                );
+            var comp = CompileAndVerify(compilation, expectedOutput:
+@"T
+default");
+        }
+
+        [Fact]
+        [WorkItem(16066, "https://github.com/dotnet/roslyn/issues/16066")]
+        [WorkItem(16066, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
+        public void SwitchLambdaGenericsAndOptimization()
+        {
+            var source =
+@"
+class Test
+{
+    static void Main()
+    {
+        System.Console.WriteLine(SendMessage<string>(""a""));
+        System.Console.WriteLine(SendMessage<string>('a'));
+    }
+
+    public static string SendMessage<T>(object input)
+    {
+        System.Func<object, string> f = (response) =>
+        {
+            switch (response)
+            {
+                case T expected:
+                    return ""T"";
+                default:
+                    return ""default"";
+            }
+        };
+
+        return f(input);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            compilation.VerifyDiagnostics();
+            var comp = CompileAndVerify(compilation, expectedOutput:
+@"T
+default");
+        }
+
+        [Fact]
+        [WorkItem(16066, "https://github.com/dotnet/roslyn/issues/16066")]
+        [WorkItem(16066, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
+        public void SwitchIteratorGenericsAndOptimization()
+        {
+            var source =
+@"
+class Test
+{
+    static void Main()
+    {
+        foreach (var s in SendMessage<string>(""a""))
+        {
+            System.Console.WriteLine(s);
+        }
+        foreach (var s in SendMessage<string>('a'))
+        {
+            System.Console.WriteLine(s);
+        }
+    }
+
+    public static System.Collections.Generic.IEnumerable<string> SendMessage<T>(object response)
+    {
+        switch (response)
+        {
+            case T expected:
+                yield return ""T"";
+                yield break;
+            default:
+                yield return ""default"";
+                yield break;
+        }
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            compilation.VerifyDiagnostics();
+            var comp = CompileAndVerify(compilation, expectedOutput:
+@"T
+default");
+        }
+
+        [Fact]
         [WorkItem(17088, "https://github.com/dotnet/roslyn/issues/17088")]
         public void TupleNameDifferences_01()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -2542,7 +2542,7 @@ class Program
 
         [Fact]
         [WorkItem(16066, "https://github.com/dotnet/roslyn/issues/16066")]
-        [WorkItem(16066, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
+        [WorkItem(401335, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
         public void SwitchAwaitGenericsAndOptimization()
         {
             var source =
@@ -2582,7 +2582,7 @@ default");
 
         [Fact]
         [WorkItem(16066, "https://github.com/dotnet/roslyn/issues/16066")]
-        [WorkItem(16066, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
+        [WorkItem(401335, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
         public void SwitchLambdaGenericsAndOptimization()
         {
             var source =
@@ -2621,7 +2621,7 @@ default");
 
         [Fact]
         [WorkItem(16066, "https://github.com/dotnet/roslyn/issues/16066")]
-        [WorkItem(16066, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
+        [WorkItem(401335, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335")]
         public void SwitchIteratorGenericsAndOptimization()
         {
             var source =


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=401335.

@dotnet/roslyn-compiler Please review.