### PR TITLE
Reduce memory footprint of EnC TraceLog 

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/TraceLogTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/TraceLogTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
             log.Write("a");
             log.Write("b {0} {1} {2}", 1, "x", 3);
             log.Write("c");
-            log.Write("d {0}", 1);
+            log.Write("d {0} {1}", null, null);
             log.Write("e");
             log.Write("f");
 
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
                 "f",
                 "b 1 x 3",
                 "c",
-                "d 1",
+                "d <null> <null>",
                 "e"
             }, log.GetEntries().Select(e => e.ToString()));
         }

--- a/src/EditorFeatures/Test/EditAndContinue/TraceLogTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/TraceLogTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.UnitTests.EditAndContinue
+{
+    public class TraceLogTests
+    {
+        [Fact]
+        public void Write()
+        {
+            var log = new TraceLog(5, "log");
+
+            log.Write("a");
+            log.Write("b {0} {1} {2}", 1, "x", 3);
+            log.Write("c");
+            log.Write("d {0}", 1);
+            log.Write("e");
+            log.Write("f");
+
+            AssertEx.Equal(new[] 
+            {
+                "f",
+                "b 1 x 3",
+                "c",
+                "d 1",
+                "e"
+            }, log.GetEntries().Select(e => e.ToString()));
+        }
+    }
+}

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Diagnostics\DiagnosticsSquiggleTaggerProviderTests.cs" />
     <Compile Include="Diagnostics\SuppressMessageAttributeTests.cs" />
     <Compile Include="CodeFixes\ExtensionOrderingTests.cs" />
+    <Compile Include="EditAndContinue\TraceLogTests.cs" />
     <Compile Include="Extensions\SourceTextContainerExtensionsTests.cs" />
     <Compile Include="Preview\TestOnly_CompilerDiagnosticAnalyzerProviderService.cs" />
     <Compile Include="Structure\BlockStructureServiceTests.cs" />

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (diagnostics.Count > 0)
                 {
-                    DocumentAnalysisResults.Log.Write("{0} syntactic rude edits, first: {1}", diagnostics.Count, document.FilePath);
+                    DocumentAnalysisResults.Log.Write("{0} syntactic rude edits, first: '{1}'", diagnostics.Count, document.FilePath);
                     return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), diagnostics.AsImmutable());
                 }
 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     if (syntaxErrorCount > 0)
                     {
-                        DocumentAnalysisResults.Log.Write("{0}: unchanged with syntax errors ({1})", document.Name, syntaxDiagnostics.First().Location);
+                        DocumentAnalysisResults.Log.Write("{0}: unchanged with syntax errors", document.Name);
                     }
                     else
                     {
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     // Bail, since we can't do syntax diffing on broken trees (it would not produce useful results anyways).
                     // If we needed to do so for some reason, we'd need to harden the syntax tree comparers.
-                    DocumentAnalysisResults.Log.Write("{0}: syntax error ({1} total)", syntaxDiagnostics.First().Location, syntaxErrorCount);
+                    DocumentAnalysisResults.Log.Write("Syntax errors: {0} total", syntaxErrorCount);
 
                     return DocumentAnalysisResults.SyntaxErrors(ImmutableArray<RudeEditDiagnostic>.Empty);
                 }
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (diagnostics.Count > 0)
                 {
-                    DocumentAnalysisResults.Log.Write("{0} syntactic rude edits, first: {1}{2}", diagnostics.Count, document.FilePath, diagnostics.First().Span);
+                    DocumentAnalysisResults.Log.Write("{0} syntactic rude edits, first: {1}", diagnostics.Count, document.FilePath);
                     return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), diagnostics.AsImmutable());
                 }
 
@@ -443,7 +443,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 var firstError = newCompilation.GetDiagnostics(cancellationToken).FirstOrDefault(d => d.Severity == DiagnosticSeverity.Error);
                 if (firstError != null)
                 {
-                    DocumentAnalysisResults.Log.Write("Semantic errors, first: {0}", firstError.Location);
+                    var location = firstError.Location;
+                    DocumentAnalysisResults.Log.Write("Semantic errors, first: {0}", location.IsInSource ? location.SourceTree.FilePath : location.MetadataModule.Name);
 
                     return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), ImmutableArray.Create<RudeEditDiagnostic>(), hasSemanticErrors: true);
                 }
@@ -467,7 +468,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 if (diagnostics.Count > 0)
                 {
-                    DocumentAnalysisResults.Log.Write("{0} trivia rude edits, first: {1}{2}", diagnostics.Count, document.FilePath, diagnostics.First().Span);
+                    DocumentAnalysisResults.Log.Write("{0} trivia rude edits, first: {1}@{2}", diagnostics.Count, document.FilePath, diagnostics.First().Span.Start);
                     return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), diagnostics.AsImmutable());
                 }
 
@@ -495,7 +496,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     if (diagnostics.Count > 0)
                     {
-                        DocumentAnalysisResults.Log.Write("{0}{1}: semantic rude edit ({2} total)", document.FilePath, diagnostics.First().Span, diagnostics.Count);
+                        DocumentAnalysisResults.Log.Write("{0}@{1}: semantic rude edit ({2} total)", document.FilePath, diagnostics.First().Span.Start, diagnostics.Count);
                         return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), diagnostics.AsImmutable());
                     }
                 }
@@ -620,7 +621,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                      trackingService.TryGetSpan(new ActiveStatementId(documentId, i), newText, out trackedSpan);
                     if (!TryGetTextSpan(oldText.Lines, oldActiveStatements[i].Span, out var oldStatementSpan))
                     {
-                        DocumentAnalysisResults.Log.Write("Invalid active statement span: {0}", oldStatementSpan);
+                        DocumentAnalysisResults.Log.Write("Invalid active statement span: [{0}..{1})", oldStatementSpan.Start, oldStatementSpan.End);
                         newExceptionRegions[i] = ImmutableArray.Create<LinePositionSpan>();
                         continue;
                     }
@@ -630,7 +631,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     // Guard against invalid active statement spans (in case PDB was somehow out of sync with the source).
                     if (oldMember == null)
                     {
-                        DocumentAnalysisResults.Log.Write("Invalid active statement span: {0}", oldStatementSpan);
+                        DocumentAnalysisResults.Log.Write("Invalid active statement span: [{0}..{1})", oldStatementSpan.Start, oldStatementSpan.End);
                         newExceptionRegions[i] = ImmutableArray.Create<LinePositionSpan>();
                         continue;
                     }
@@ -644,7 +645,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     // Guard against invalid active statement spans (in case PDB was somehow out of sync with the source).
                     if (oldBody == null || newBody == null)
                     {
-                        DocumentAnalysisResults.Log.Write("Invalid active statement span: {0}", oldStatementSpan);
+                        DocumentAnalysisResults.Log.Write("Invalid active statement span: [{0}..{1})", oldStatementSpan.Start, oldStatementSpan.End);
                         newExceptionRegions[i] = ImmutableArray.Create<LinePositionSpan>();
                         continue;
                     }

--- a/src/Features/Core/Portable/EditAndContinue/TraceLog.cs
+++ b/src/Features/Core/Portable/EditAndContinue/TraceLog.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Threading;
+using Roslyn.Utilities;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue
 {
@@ -11,47 +14,85 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     /// <remarks>
     /// Recent entries are captured in a memory dump.
     /// If DEBUG is defined, all entries written to <see cref="DebugWrite(string)"/> or
-    /// <see cref="DebugWrite(string, object[])"/> are print to <see cref="Debug"/> output.
+    /// <see cref="DebugWrite(string, Arg[])"/> are print to <see cref="Debug"/> output.
     /// </remarks>
     internal sealed class TraceLog
     {
-        private readonly string[] _log;
+        internal struct Arg
+        {
+            public readonly string String;
+            public readonly int Int32;
+
+            public Arg(string value)
+            {
+                Debug.Assert(value != null);
+
+                Int32 = 0;
+                String = value;
+            }
+
+            public Arg(int value)
+            {
+                Int32 = value;
+                String = null;
+            }
+
+            public override string ToString() => String ?? Int32.ToString();
+
+            public static implicit operator Arg(string value) => new Arg(value);
+            public static implicit operator Arg(int value) => new Arg(value);
+        }
+
+        internal struct Entry
+        {
+            public readonly string MessageFormat;
+            public readonly Arg[] ArgsOpt;
+
+            public Entry(string format, Arg[] argsOpt)
+            {
+                MessageFormat = format;
+                ArgsOpt = argsOpt;
+            }
+
+            public override string ToString() => 
+                string.Format(MessageFormat, ArgsOpt?.Select(a => (object)a).ToArray() ?? Array.Empty<object>());
+        }
+
+        private readonly Entry[] _log;
         private readonly string _id;
         private int _currentLine;
 
         public TraceLog(int logSize, string id)
         {
-            _log = new string[logSize];
+            _log = new Entry[logSize];
             _id = id;
         }
 
-        private void Append(string str)
+        private void Append(Entry entry)
         {
             int index = Interlocked.Increment(ref _currentLine);
-            _log[(index - 1) % _log.Length] = str;
+            _log[(index - 1) % _log.Length] = entry;
         }
 
-        public void Write(string str)
-        {
-            Append(str);
-        }
+        public void Write(string str) => Write(str, null);
 
-        [Conditional("DEBUG")]
-        public void DebugWrite(string str)
+        public void Write(string format, params Arg[] args)
         {
-            Append(str);
-            Debug.WriteLine(str, _id);
-        }
-
-        public void Write(string format, params object[] args)
-        {
-            Write(string.Format(format, args));
+            Append(new Entry(format, args));
         }
 
         [Conditional("DEBUG")]
-        public void DebugWrite(string format, params object[] args)
+        public void DebugWrite(string str) => DebugWrite(str, null);
+
+        [Conditional("DEBUG")]
+        public void DebugWrite(string format, params Arg[] args)
         {
-            DebugWrite(string.Format(format, args));
+            var entry = new Entry(format, args);
+            Append(entry);
+            Debug.WriteLine(entry.ToString(), _id);
         }
+
+        // test only
+        internal Entry[] GetEntries() => _log;
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/TraceLog.cs
+++ b/src/Features/Core/Portable/EditAndContinue/TraceLog.cs
@@ -25,10 +25,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             public Arg(string value)
             {
-                Debug.Assert(value != null);
-
                 Int32 = 0;
-                String = value;
+                String = value ?? "<null>";
             }
 
             public Arg(int value)

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -592,7 +592,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             foreach (var vsActiveStatement in vsActiveStatements)
             {
                 log.DebugWrite("+AS[{0}]: {1} {2} {3} {4} '{5}'",
-                    vsActiveStatement.id,
+                    unchecked((int)vsActiveStatement.id),
                     vsActiveStatement.tsPosition.iStartLine,
                     vsActiveStatement.tsPosition.iStartIndex,
                     vsActiveStatement.tsPosition.iEndLine,
@@ -746,7 +746,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     // We might not have an active statement available if PDB got out of sync with the source.
                     if (session == null || ids == null || !ids.TryGetValue(vsId, out var id))
                     {
-                        log.Write("GetCurrentActiveStatementPosition failed for AS {0}.", vsId);
+                        log.Write("GetCurrentActiveStatementPosition failed for AS {0}.", unchecked((int)vsId));
                         return VSConstants.E_FAIL;
                     }
 
@@ -767,7 +767,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                         if (activeSpans.IsDefault)
                         {
                             // The document has syntax errors and the tracking span is gone.
-                            log.Write("Position not available for AS {0} due to syntax errors", vsId);
+                            log.Write("Position not available for AS {0} due to syntax errors", unchecked((int)vsId));
                             return VSConstants.E_FAIL;
                         }
 
@@ -775,8 +775,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     }
 
                     ptsNewPosition[0] = lineSpan.ToVsTextSpan();
-                    log.DebugWrite("AS position: {0} {1} {2}", vsId, lineSpan,
-                        session.BaseActiveStatements[id.DocumentId][id.Ordinal].Flags);
+                    log.DebugWrite("AS position: {0} ({1},{2})-({3},{4}) {5}", 
+                        unchecked((int)vsId), 
+                        lineSpan.Start.Line, lineSpan.Start.Character, lineSpan.End.Line, lineSpan.End.Character,
+                        (int)session.BaseActiveStatements[id.DocumentId][id.Ordinal].Flags);
 
                     return VSConstants.S_OK;
                 }
@@ -827,7 +829,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                             // been modified.
                             // TODO (https://github.com/dotnet/roslyn/issues/1204): this check should be unnecessary.
                             _lastEditSessionSummary = ProjectAnalysisSummary.NoChanges;
-                            log.Write($"Project '{_vsProject.DisplayName}' has not yet been loaded into the solution");
+                            log.Write("Project '{0}' has not yet been loaded into the solution", _vsProject.DisplayName);
                         }
                         else
                         {
@@ -864,7 +866,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
 
                     log.Write("EnC state of '{0}' queried: {1}{2}",
                         _vsProject.DisplayName,
-                        pENCBuildState[0],
+                        EncStateToString(pENCBuildState[0]),
                         _encService.EditSession != null ? "" : " (no session)");
 
                     return VSConstants.S_OK;
@@ -873,6 +875,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             catch (Exception e) when (FatalError.ReportWithoutCrash(e))
             {
                 return VSConstants.E_FAIL;
+            }
+        }
+
+        private static string EncStateToString(ENC_BUILD_STATE state)
+        {
+            switch (state)
+            {
+                case ENC_BUILD_STATE.ENC_NOT_MODIFIED: return "ENC_NOT_MODIFIED";
+                case ENC_BUILD_STATE.ENC_NONCONTINUABLE_ERRORS: return "ENC_NONCONTINUABLE_ERRORS";
+                case ENC_BUILD_STATE.ENC_COMPILE_ERRORS: return "ENC_COMPILE_ERRORS";
+                case ENC_BUILD_STATE.ENC_APPLY_READY: return "ENC_APPLY_READY";
+                default: return state.ToString();
             }
         }
 
@@ -1033,9 +1047,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
 
                     log.DebugWrite("Gen {0}: MVID={1}, BaseId={2}, EncId={3}",
                         moduleDef.Generation,
-                        reader.GetGuid(moduleDef.Mvid),
-                        reader.GetGuid(moduleDef.BaseGenerationId),
-                        reader.GetGuid(moduleDef.GenerationId));
+                        reader.GetGuid(moduleDef.Mvid).ToString(),
+                        reader.GetGuid(moduleDef.BaseGenerationId).ToString(),
+                        reader.GetGuid(moduleDef.GenerationId).ToString());
                 }
 #endif
 

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             if (doc == null)
             {
                 // TODO (https://github.com/dotnet/roslyn/issues/1204): this check should be unnecessary.
-                log.Write($"GetTextBuffer: document not found for '{documentId?.GetDebuggerDisplay()}'");
+                log.Write("GetTextBuffer: document not found for '#{0} - {1}'", documentId.Id.ToString(), documentId.DebugName);
                 return null;
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
@@ -148,7 +148,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             if (doc == null)
             {
                 // TODO (https://github.com/dotnet/roslyn/issues/1204): this check should be unnecessary.
-                log.Write("GetTextBuffer: document not found for '#{0} - {1}'", documentId.Id.ToString(), documentId.DebugName);
+                if (documentId != null)
+                {
+                    log.Write("GetTextBuffer: document not found for '#{0} - {1}'", documentId.Id.ToString(), documentId.DebugName);
+                }
+                else
+                {
+                    log.Write("GetTextBuffer: document not found");
+                }
+
                 return null;
             }
 


### PR DESCRIPTION
Store log messages more efficiently by avoiding their formatting. The format and arguments are stored in the log. The formatting is performed only when inspecting the log. Since the format strings are literals they will be reused and no new strings are gonna be allocated while logging.

Fixes internal bug https://devdiv.visualstudio.com/DevDiv/_workitems?id=389508