### PR TITLE
Parenthesize assignment expression when creating collection initializer element.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -275,7 +275,7 @@ class C
 }");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
         public async Task TestMissingBeforeCSharp3()
         {
 
@@ -754,7 +754,7 @@ class C
         }
 
         [WorkItem(17853, "https://github.com/dotnet/roslyn/issues/17853")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
         public async Task TestMissingForDynamic()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -771,7 +771,7 @@ class C
         }
 
         [WorkItem(17953, "https://github.com/dotnet/roslyn/issues/17953")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
         public async Task TestMissingAcrossPreprocessorDirective()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -791,7 +791,7 @@ public class Foo
         }
 
         [WorkItem(17953, "https://github.com/dotnet/roslyn/issues/17953")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
         public async Task TestAvailableInsidePreprocessorDirective()
         {
             await TestInRegularAndScript1Async(
@@ -823,6 +823,72 @@ public class Foo
 #endif
     }
 }", ignoreTrivia: false);
+        }
+
+        [WorkItem(18242, "https://github.com/dotnet/roslyn/issues/18242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
+        public async Task TestObjectInitializerAssignmentAmbiguity()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System.Collections.Generic;
+
+public class Foo
+{
+    public void M()
+    {
+        int lastItem;
+        var list = [||]new List<int>();
+        list.Add(lastItem = 5);
+    }
+}",
+@"
+using System.Collections.Generic;
+
+public class Foo
+{
+    public void M()
+    {
+        int lastItem;
+        var list = new List<int>
+        {
+            (lastItem = 5)
+        };
+    }
+}");
+        }
+
+        [WorkItem(18242, "https://github.com/dotnet/roslyn/issues/18242")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
+        public async Task TestObjectInitializerCompoundAssignment()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System.Collections.Generic;
+
+public class Foo
+{
+    public void M()
+    {
+        int lastItem = 0;
+        var list = [||]new List<int>();
+        list.Add(lastItem += 5);
+    }
+}",
+@"
+using System.Collections.Generic;
+
+public class Foo
+{
+    public void M()
+    {
+        int lastItem = 0;
+        var list = new List<int>
+        {
+            (lastItem += 5)
+        };
+    }
+}");
         }
     }
 }

--- a/src/Features/CSharp/Portable/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseCollectionInitializer/CSharpUseCollectionInitializerCodeFixProvider.cs
@@ -100,7 +100,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCollectionInitializer
 
             if (arguments.Count == 1)
             {
-                return arguments[0].Expression;
+                // Assignment expressions in a collection initializer will cause the compiler to 
+                // report an error.  This is because { a = b } is teh form for an object initializer,
+                // and the two forms are not allowed to mix/match.  Parenthesize the assignment to
+                // avoid the ambiguity.
+                var expression = arguments[0].Expression;
+                return SyntaxFacts.IsAssignmentExpression(expression.Kind())
+                    ? SyntaxFactory.ParenthesizedExpression(expression)
+                    : expression;
             }
 
             return SyntaxFactory.InitializerExpression(


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/18242