### PR TITLE
Allow WpfFact tests to run from Test Explorer

### DIFF
--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -36,6 +36,7 @@
     <Compile Include="InternalUtilities\NoThrowStreamDisposer.cs" />
     <Compile Include="InternalUtilities\OrderedMultiDictionary.cs" />
     <Compile Include="InternalUtilities\PlatformInformation.cs" />
+    <Compile Include="InternalUtilities\SemaphoreExtensions.cs" />
     <Compile Include="Operations\ArgumentKind.cs" />
     <Compile Include="Operations\BinaryOperandsKind.cs" />
     <Compile Include="Operations\BinaryOperationKind.cs" />

--- a/src/Compilers/Core/Portable/InternalUtilities/SemaphoreExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SemaphoreExtensions.cs
@@ -8,7 +8,7 @@ namespace Roslyn.Utilities
 {
     internal static class SemaphoreExtensions
     {
-        public static SemaphoreDisposer DisposableWait(this Semaphore semaphore, CancellationToken cancellationToken = default(CancellationToken))
+        public static SemaphoreDisposer DisposableWait(this Semaphore semaphore, CancellationToken cancellationToken)
         {
             if (cancellationToken.CanBeCanceled)
             {
@@ -27,7 +27,7 @@ namespace Roslyn.Utilities
             return new SemaphoreDisposer(semaphore);
         }
 
-        public static Task<SemaphoreDisposer> DisposableWaitAsync(this Semaphore semaphore, CancellationToken cancellationToken = default(CancellationToken))
+        public static Task<SemaphoreDisposer> DisposableWaitAsync(this Semaphore semaphore, CancellationToken cancellationToken)
         {
             return Task.Run(() => DisposableWait(semaphore, cancellationToken));
         }

--- a/src/Compilers/Core/Portable/InternalUtilities/SemaphoreExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SemaphoreExtensions.cs
@@ -29,7 +29,11 @@ namespace Roslyn.Utilities
 
         public static Task<SemaphoreDisposer> DisposableWaitAsync(this Semaphore semaphore, CancellationToken cancellationToken)
         {
-            return Task.Run(() => DisposableWait(semaphore, cancellationToken));
+            return Task.Factory.StartNew(
+                () => DisposableWait(semaphore, cancellationToken),
+                cancellationToken,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
         }
 
         internal struct SemaphoreDisposer : IDisposable

--- a/src/Compilers/Core/Portable/InternalUtilities/SemaphoreExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SemaphoreExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Roslyn.Utilities
+{
+    internal static class SemaphoreExtensions
+    {
+        public static SemaphoreDisposer DisposableWait(this Semaphore semaphore, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (cancellationToken.CanBeCanceled)
+            {
+                int signalledIndex = WaitHandle.WaitAny(new[] { semaphore, cancellationToken.WaitHandle });
+                if (signalledIndex != 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    throw ExceptionUtilities.Unreachable;
+                }
+            }
+            else
+            {
+                semaphore.WaitOne();
+            }
+
+            return new SemaphoreDisposer(semaphore);
+        }
+
+        public static Task<SemaphoreDisposer> DisposableWaitAsync(this Semaphore semaphore, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Task.Run(() => DisposableWait(semaphore, cancellationToken));
+        }
+
+        internal struct SemaphoreDisposer : IDisposable
+        {
+            private readonly Semaphore _semaphore;
+
+            public SemaphoreDisposer(Semaphore semaphore)
+            {
+                _semaphore = semaphore;
+            }
+
+            public void Dispose()
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Threading;
+using System;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -11,11 +11,12 @@ namespace Roslyn.Test.Utilities
         private readonly IMessageSink _diagnosticMessageSink;
 
         /// <summary>
-        /// A <see cref="SemaphoreSlim"/> used to ensure that only a single <see cref="WpfFactAttribute"/>-attributed test runs at once.
-        /// This requirement must be made because, currently, <see cref="WpfTestCase"/>'s logic sets various static state before a method
-        /// runs. If two tests run interleaved on the same scheduler (i.e. if one yields with an await) then all bets are off.
+        /// The name of a <see cref="Semaphore"/> used to ensure that only a single
+        /// <see cref="WpfFactAttribute"/>-attributed test runs at once. This requirement must be made because,
+        /// currently, <see cref="WpfTestCase"/>'s logic sets various static state before a method runs. If two tests
+        /// run interleaved on the same scheduler (i.e. if one yields with an await) then all bets are off.
         /// </summary>
-        private readonly SemaphoreSlim _wpfTestSerializationGate = new SemaphoreSlim(initialCount: 1);
+        private readonly Guid _wpfTestSerializationGate = Guid.NewGuid();
 
         public WpfFactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
         {

--- a/src/EditorFeatures/TestUtilities/Threading/WpfTestCase.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfTestCase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +19,13 @@ namespace Roslyn.Test.Utilities
     public class WpfTestCase : XunitTestCase
     {
         private readonly SemaphoreSlim _wpfTestSerializationGate;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public WpfTestCase()
+        {
+            _wpfTestSerializationGate = new SemaphoreSlim(1);
+        }
 
         public WpfTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, SemaphoreSlim wpfTestSerializationGate, object[] testMethodArguments = null)
             : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)

--- a/src/EditorFeatures/TestUtilities/Threading/WpfTestCase.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfTestCase.cs
@@ -42,7 +42,7 @@ namespace Roslyn.Test.Utilities
                 Debug.Assert(sta.Threads.Length == 1);
                 Debug.Assert(sta.Threads[0] == Thread.CurrentThread);
 
-                using (await _wpfTestSerializationGate.DisposableWaitAsync())
+                using (await _wpfTestSerializationGate.DisposableWaitAsync(CancellationToken.None))
                 {
                     try
                     {

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -129,6 +129,9 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\ReferenceEqualityComparer.cs">
       <Link>InternalUtilities\ReferenceEqualityComparer.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SemaphoreExtensions.cs">
+      <Link>InternalUtilities\SemaphoreExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\SemaphoreSlimExtensions.cs">
       <Link>InternalUtilities\SemaphoreSlimExtensions.cs</Link>
     </Compile>


### PR DESCRIPTION
This commit adds the necessary deserialization constructor which allows
WpfFact tests to be run from Test Explorer in Visual Studio. This is very
helpful for cases like debugging a unit test.