### PR TITLE
Shorten the version moniker "readonly-ref" --> "rdonly-ref"

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -15,7 +15,7 @@
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
     <!-- PROTOTYPE(readonlyRefs) This needs to be reverted before merging to master -->
-    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">readonly-ref</RoslynNuGetMoniker>
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">rdonly-ref</RoslynNuGetMoniker>
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>
 


### PR DESCRIPTION
"readonly-ref" combined with version number crosses the limit for the version length and causes nuget errors like:
 Error : The special version part cannot exceed 20 characters.