### PR TITLE
Add tests for simplifying type names

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -3820,6 +3820,81 @@ class Program
                 parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6));
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [WorkItem(15996, "https://github.com/dotnet/roslyn/issues/15996")]
+        public async Task TestMemberOfBuiltInType1()
+        {
+            await TestAsync(
+@"using System;
+class C
+{
+    void Main()
+    {
+        [|UInt32|] value = UInt32.MaxValue;
+    }
+}",
+@"using System;
+class C
+{
+    void Main()
+    {
+        uint value = UInt32.MaxValue;
+    }
+}",
+                parseOptions: CSharpParseOptions.Default,
+                options: PreferIntrinsicTypeInDeclaration);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [WorkItem(15996, "https://github.com/dotnet/roslyn/issues/15996")]
+        public async Task TestMemberOfBuiltInType2()
+        {
+            await TestAsync(
+@"using System;
+class C
+{
+    void Main()
+    {
+        UInt32 value = [|UInt32|].MaxValue;
+    }
+}",
+@"using System;
+class C
+{
+    void Main()
+    {
+        UInt32 value = uint.MaxValue;
+    }
+}",
+                parseOptions: CSharpParseOptions.Default,
+                options: PreferIntrinsicTypeInMemberAccess);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [WorkItem(15996, "https://github.com/dotnet/roslyn/issues/15996")]
+        public async Task TestMemberOfBuiltInType3()
+        {
+            await TestAsync(
+@"using System;
+class C
+{
+    void Main()
+    {
+        [|UInt32|].Parse(""foo"");
+    }
+}",
+@"using System;
+class C
+{
+    void Main()
+    {
+        uint.Parse(""foo"");
+    }
+}",
+                parseOptions: CSharpParseOptions.Default,
+                options: PreferIntrinsicTypeInMemberAccess);
+        }
+
         private async Task TestWithPredefinedTypeOptionsAsync(string code, string expected, int index = 0)
         {
             await TestInRegularAndScriptAsync(code, expected, index: index, options: PreferIntrinsicTypeEverywhere);

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -2430,5 +2430,62 @@ End Class")
                 diagnosticId:=IDEDiagnosticIds.RemoveQualificationDiagnosticId,
                 diagnosticSeverity:=DiagnosticSeverity.Error)
         End Function
+
+        <WorkItem(15996, "https://github.com/dotnet/roslyn/issues/15996")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        Public Async Function TestMemberOfBuiltInType1() As Task
+            Await TestInRegularAndScriptAsync(
+"Imports System
+Module Module1
+    Sub Main()
+        Dim var As [|UInt32|] = UInt32.MinValue
+    End Sub
+End Module",
+"Imports System
+Module Module1
+    Sub Main()
+        Dim var As UInteger = UInt32.MinValue
+    End Sub
+End Module",
+                options:=PreferIntrinsicPredefinedTypeInDeclaration())
+        End Function
+
+        <WorkItem(15996, "https://github.com/dotnet/roslyn/issues/15996")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        Public Async Function TestMemberOfBuiltInType2() As Task
+            Await TestInRegularAndScriptAsync(
+"Imports System
+Module Module1
+    Sub Main()
+        Dim var As UInt32 = [|UInt32|].MinValue
+    End Sub
+End Module",
+"Imports System
+Module Module1
+    Sub Main()
+        Dim var As UInt32 = UInteger.MinValue
+    End Sub
+End Module",
+                options:=PreferIntrinsicTypeInMemberAccess())
+        End Function
+
+        <WorkItem(15996, "https://github.com/dotnet/roslyn/issues/15996")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        Public Async Function TestMemberOfBuiltInType3() As Task
+            Await TestInRegularAndScriptAsync(
+"Imports System
+Module Module1
+    Sub Main()
+        [|UInt32|].Parse(""Foo"")
+    End Sub
+End Module",
+"Imports System
+Module Module1
+    Sub Main()
+        UInteger.Parse(""Foo"")
+    End Sub
+End Module",
+                options:=PreferIntrinsicTypeInMemberAccess())
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Closes #15996

@davkean Can you verify that these tests reflect your scenario? I was not able to reproduce the described behavior, so perhaps it has since been fixed?

@dotnet/roslyn-ide for review

## Ask Mode

**Customer scenario**

This change only adds tests. It does not change code distributed to customers.

**Bugs this fixes:**

N/A. The original bug was fixed at an unknown point but these regression tests were not added.

**Workarounds, if any**

N/A

**Risk**

Very low. Only possible issue is a broken build due to failing tests.

**Performance impact**

None (no changes are made to production code).

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

N/A

**How was the bug found?**

Internal customer (@davkean).