### PR TITLE
Add a little bit of type-safety to editor-config storage locations.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/UseExpressionBodyForMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/UseExpressionBodyForMethodsTests.cs
@@ -68,6 +68,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public void TestOptionEditorConfig1()
+        {
+            Assert.Null(CSharpCodeStyleOptions.ParseExpressionBodyPreference("true", null));
+            Assert.Null(CSharpCodeStyleOptions.ParseExpressionBodyPreference("false", null));
+            Assert.Null(CSharpCodeStyleOptions.ParseExpressionBodyPreference("when_on_single_line", null));
+            Assert.Null(CSharpCodeStyleOptions.ParseExpressionBodyPreference("true:blah", null));
+            Assert.Null(CSharpCodeStyleOptions.ParseExpressionBodyPreference("when_blah:error", null));
+
+            var option = CSharpCodeStyleOptions.ParseExpressionBodyPreference("false:error", null);
+            Assert.Equal(ExpressionBodyPreference.Never, option.Value);
+            Assert.Equal(NotificationOption.Error, option.Notification);
+
+            option = CSharpCodeStyleOptions.ParseExpressionBodyPreference("true:warning", null);
+            Assert.Equal(ExpressionBodyPreference.WhenPossible, option.Value);
+            Assert.Equal(NotificationOption.Warning, option.Notification);
+
+            option = CSharpCodeStyleOptions.ParseExpressionBodyPreference("when_on_single_line:suggestion", null);
+            Assert.Equal(ExpressionBodyPreference.WhenOnSingleLine, option.Value);
+            Assert.Equal(NotificationOption.Suggestion, option.Notification);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestUseExpressionBody1()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/Next/Options/EditorConfigDocumentOptionsProvider.DocumentOptions.cs
+++ b/src/EditorFeatures/Next/Options/EditorConfigDocumentOptionsProvider.DocumentOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Options
 
             public bool TryGetDocumentOption(Document document, OptionKey option, OptionSet underlyingOptions, out object value)
             {
-                var editorConfigPersistence = option.Option.StorageLocations.OfType<EditorConfigStorageLocation>().SingleOrDefault();
+                var editorConfigPersistence = option.Option.StorageLocations.OfType<IEditorConfigStorageLocation>().SingleOrDefault();
                 if (editorConfigPersistence == null)
                 {
                     value = null;

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -11,37 +11,37 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeForIntrinsicTypes = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(UseImplicitTypeForIntrinsicTypes), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_var_for_built_in_types"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_var_for_built_in_types"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeForIntrinsicTypes")});
 
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWhereApparent = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(UseImplicitTypeWhereApparent), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_var_when_type_is_apparent"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_var_when_type_is_apparent"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWhereApparent")});
 
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWherePossible = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(UseImplicitTypeWherePossible), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_var_elsewhere"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_var_elsewhere"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWherePossible")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferConditionalDelegateCall = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferConditionalDelegateCall), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_conditional_delegate_call"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_conditional_delegate_call"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.PreferConditionalDelegateCall")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferPatternMatchingOverAsWithNullCheck = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferPatternMatchingOverAsWithNullCheck), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_pattern_matching_over_as_with_null_check"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_pattern_matching_over_as_with_null_check"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferPatternMatchingOverAsWithNullCheck)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferPatternMatchingOverIsWithCastCheck = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferPatternMatchingOverIsWithCastCheck), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_pattern_matching_over_is_with_cast_check"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_pattern_matching_over_is_with_cast_check"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferPatternMatchingOverIsWithCastCheck)}")});
 
         public static readonly CodeStyleOption<ExpressionBodyPreference> NeverWithNoneEnforcement =
@@ -63,54 +63,66 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedConstructors),
             defaultValue: NeverWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_constructors", s => ParseExpressionBodyPreference(s, ExpressionBodyPreference.Never)),
+                new EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>("csharp_style_expression_bodied_constructors", s => ParseExpressionBodyPreference(s, NeverWithNoneEnforcement)),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedConstructors)}")});
 
         public static readonly Option<CodeStyleOption<ExpressionBodyPreference>> PreferExpressionBodiedMethods = new Option<CodeStyleOption<ExpressionBodyPreference>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedMethods),
             defaultValue: NeverWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_methods", s => ParseExpressionBodyPreference(s, ExpressionBodyPreference.Never)),
+                new EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>("csharp_style_expression_bodied_methods", s => ParseExpressionBodyPreference(s, NeverWithNoneEnforcement)),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedMethods)}")});
 
         public static readonly Option<CodeStyleOption<ExpressionBodyPreference>> PreferExpressionBodiedOperators = new Option<CodeStyleOption<ExpressionBodyPreference>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedOperators),
             defaultValue: NeverWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_operators", s => ParseExpressionBodyPreference(s, ExpressionBodyPreference.Never)),
+                new EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>("csharp_style_expression_bodied_operators", s => ParseExpressionBodyPreference(s, NeverWithNoneEnforcement)),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedOperators)}")});
 
         public static readonly Option<CodeStyleOption<ExpressionBodyPreference>> PreferExpressionBodiedProperties = new Option<CodeStyleOption<ExpressionBodyPreference>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedProperties),
             defaultValue: WhenPossibleWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_properties", s => ParseExpressionBodyPreference(s, ExpressionBodyPreference.WhenOnSingleLine)),
+                new EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>("csharp_style_expression_bodied_properties", s => ParseExpressionBodyPreference(s, WhenPossibleWithNoneEnforcement)),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedProperties)}")});
 
         public static readonly Option<CodeStyleOption<ExpressionBodyPreference>> PreferExpressionBodiedIndexers = new Option<CodeStyleOption<ExpressionBodyPreference>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedIndexers),
             defaultValue: WhenPossibleWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_indexers", s => ParseExpressionBodyPreference(s, ExpressionBodyPreference.WhenOnSingleLine)),
+                new EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>("csharp_style_expression_bodied_indexers", s => ParseExpressionBodyPreference(s, WhenPossibleWithNoneEnforcement)),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedIndexers)}")});
 
         public static readonly Option<CodeStyleOption<ExpressionBodyPreference>> PreferExpressionBodiedAccessors = new Option<CodeStyleOption<ExpressionBodyPreference>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedAccessors), 
             defaultValue: WhenPossibleWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_style_expression_bodied_accessors", s => ParseExpressionBodyPreference(s, ExpressionBodyPreference.WhenOnSingleLine)),
+                new EditorConfigStorageLocation<CodeStyleOption<ExpressionBodyPreference>>("csharp_style_expression_bodied_accessors", s => ParseExpressionBodyPreference(s, WhenPossibleWithNoneEnforcement)),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedAccessors)}")});
 
-        private static object ParseExpressionBodyPreference(string value, ExpressionBodyPreference @default)
+        public static CodeStyleOption<ExpressionBodyPreference> ParseExpressionBodyPreference(
+            string optionString, CodeStyleOption<ExpressionBodyPreference> @default)
         {
-            if (bool.TryParse(value, out var boolValue))
+            // optionString must be similar to true:error or when_on_single_line:suggestion.
+            if (CodeStyleHelpers.TryGetCodeStyleValueAndOptionalNotification(optionString,
+                    out var value, out var notificationOpt))
             {
-                return boolValue ? ExpressionBodyPreference.WhenPossible : ExpressionBodyPreference.Never;
-            }
+                // A notification value must be provided.
+                if (notificationOpt != null)
+                {
+                    if (bool.TryParse(value, out var boolValue))
+                    {
+                        return boolValue
+                            ? new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, notificationOpt)
+                            : new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.Never, notificationOpt);
+                    }
 
-            if (value == "when_on_single_line")
-            {
-                return ExpressionBodyPreference.WhenOnSingleLine;
+                    if (value == "when_on_single_line")
+                    {
+                        return new CodeStyleOption<ExpressionBodyPreference>(ExpressionBodyPreference.WhenOnSingleLine, notificationOpt);
+                    }
+                }
             }
 
             return @default;
@@ -119,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
         public static readonly Option<CodeStyleOption<bool>> PreferBraces = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferBraces), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_prefer_braces"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_prefer_braces"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferBraces)}")});
 
         public static IEnumerable<Option<CodeStyleOption<bool>>> GetCodeStyleOptions()

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
@@ -8,232 +8,232 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         public static Option<bool> SpacingAfterMethodDeclarationName { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpacingAfterMethodDeclarationName), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_method_declaration_name_and_open_parenthesis"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_name_and_open_parenthesis"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAfterMethodDeclarationName")});
 
         public static Option<bool> SpaceWithinMethodDeclarationParenthesis { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinMethodDeclarationParenthesis), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_method_declaration_parameter_list_parentheses"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_parameter_list_parentheses"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodDeclarationParenthesis")});
 
         public static Option<bool> SpaceBetweenEmptyMethodDeclarationParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBetweenEmptyMethodDeclarationParentheses), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_method_declaration_empty_parameter_list_parentheses"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_declaration_empty_parameter_list_parentheses"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodDeclarationParentheses")});
 
         public static Option<bool> SpaceAfterMethodCallName { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterMethodCallName), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_method_call_name_and_opening_parenthesis"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_name_and_opening_parenthesis"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterMethodCallName")});
 
         public static Option<bool> SpaceWithinMethodCallParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinMethodCallParentheses), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_method_call_parameter_list_parentheses"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_parameter_list_parentheses"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodCallParentheses")});
 
         public static Option<bool> SpaceBetweenEmptyMethodCallParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBetweenEmptyMethodCallParentheses), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_method_call_empty_parameter_list_parentheses"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_method_call_empty_parameter_list_parentheses"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodCallParentheses")});
 
         public static Option<bool> SpaceAfterControlFlowStatementKeyword { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterControlFlowStatementKeyword), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_after_keywords_in_control_flow_statements"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_keywords_in_control_flow_statements"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterControlFlowStatementKeyword")});
 
         public static Option<bool> SpaceWithinExpressionParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinExpressionParentheses), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.Expressions)),
+                new EditorConfigStorageLocation<bool>("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.Expressions)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinExpressionParentheses")});
 
         public static Option<bool> SpaceWithinCastParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinCastParentheses), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.TypeCasts)),
+                new EditorConfigStorageLocation<bool>("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.TypeCasts)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinCastParentheses")});
 
         public static Option<bool> SpaceWithinOtherParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinOtherParentheses), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.ControlFlowStatements)),
+                new EditorConfigStorageLocation<bool>("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.ControlFlowStatements)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinOtherParentheses")});
 
         public static Option<bool> SpaceAfterCast { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterCast), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_after_cast"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_cast"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterCast")});
 
         public static Option<bool> SpacesIgnoreAroundVariableDeclaration { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpacesIgnoreAroundVariableDeclaration), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_around_declaration_statements", s => DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(s)),
+                new EditorConfigStorageLocation<bool>("csharp_space_around_declaration_statements", s => DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(s)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacesIgnoreAroundVariableDeclaration")});
 
         public static Option<bool> SpaceBeforeOpenSquareBracket { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeOpenSquareBracket), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_before_open_square_brackets"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_open_square_brackets"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeOpenSquareBracket")});
 
         public static Option<bool> SpaceBetweenEmptySquareBrackets { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBetweenEmptySquareBrackets), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_empty_square_brackets"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_empty_square_brackets"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptySquareBrackets")});
 
         public static Option<bool> SpaceWithinSquareBrackets { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinSquareBrackets), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_between_square_brackets"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_between_square_brackets"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinSquareBrackets")});
 
         public static Option<bool> SpaceAfterColonInBaseTypeDeclaration { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterColonInBaseTypeDeclaration), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_after_colon_in_inheritance_clause"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_colon_in_inheritance_clause"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterColonInBaseTypeDeclaration")});
 
         public static Option<bool> SpaceAfterComma { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterComma), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_after_comma"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_comma"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterComma")});
 
         public static Option<bool> SpaceAfterDot { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterDot), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_after_dot"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_dot"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterDot")});
 
         public static Option<bool> SpaceAfterSemicolonsInForStatement { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterSemicolonsInForStatement), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_after_semicolon_in_for_statement"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_after_semicolon_in_for_statement"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterSemicolonsInForStatement")});
 
         public static Option<bool> SpaceBeforeColonInBaseTypeDeclaration { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeColonInBaseTypeDeclaration), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_before_colon_in_inheritance_clause"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_colon_in_inheritance_clause"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeColonInBaseTypeDeclaration")});
 
         public static Option<bool> SpaceBeforeComma { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeComma), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_before_comma"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_comma"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeComma")});
 
         public static Option<bool> SpaceBeforeDot { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeDot), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_before_dot"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_dot"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeDot")});
 
         public static Option<bool> SpaceBeforeSemicolonsInForStatement { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeSemicolonsInForStatement), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_before_semicolon_in_for_statement"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_space_before_semicolon_in_for_statement"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeSemicolonsInForStatement")});
 
         public static Option<BinaryOperatorSpacingOptions> SpacingAroundBinaryOperator { get; } = new Option<BinaryOperatorSpacingOptions>(nameof(CSharpFormattingOptions), nameof(SpacingAroundBinaryOperator), defaultValue: BinaryOperatorSpacingOptions.Single,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_space_around_binary_operators ", s => ParseEditorConfigSpacingAroundBinaryOperator(s)),
+                new EditorConfigStorageLocation<BinaryOperatorSpacingOptions>("csharp_space_around_binary_operators ", s => ParseEditorConfigSpacingAroundBinaryOperator(s)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAroundBinaryOperator")});
 
         public static Option<bool> IndentBraces { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(IndentBraces), defaultValue: false,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_indent_braces"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_indent_braces"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.OpenCloseBracesIndent")});
 
         public static Option<bool> IndentBlock { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(IndentBlock), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_indent_block_contents"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_indent_block_contents"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentBlock")});
 
         public static Option<bool> IndentSwitchSection { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(IndentSwitchSection), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_indent_switch_labels"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_indent_switch_labels"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchSection")});
 
         public static Option<bool> IndentSwitchCaseSection { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(IndentSwitchCaseSection), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_indent_case_contents"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_indent_case_contents"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchCaseSection")});
 
         public static Option<LabelPositionOptions> LabelPositioning { get; } = new Option<LabelPositionOptions>(nameof(CSharpFormattingOptions), nameof(LabelPositioning), defaultValue: LabelPositionOptions.OneLess,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_indent_labels", s => ParseEditorConfigLablePositioning(s)),
+                new EditorConfigStorageLocation<LabelPositionOptions>("csharp_indent_labels", s => ParseEditorConfigLablePositioning(s)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.LabelPositioning")});
 
         public static Option<bool> WrappingPreserveSingleLine { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(WrappingPreserveSingleLine), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_preserve_single_line_blocks"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_preserve_single_line_blocks"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingPreserveSingleLine")});
 
         public static Option<bool> WrappingKeepStatementsOnSingleLine { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(WrappingKeepStatementsOnSingleLine), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_preserve_single_line_statements"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_preserve_single_line_statements"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingKeepStatementsOnSingleLine")});
 
         public static Option<bool> NewLinesForBracesInTypes { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInTypes), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Types)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.Types)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesBracesType")});
 
         public static Option<bool> NewLinesForBracesInMethods { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInMethods), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Methods)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.Methods)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInMethods")});
 
         public static Option<bool> NewLinesForBracesInProperties { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInProperties), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Properties)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.Properties)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInProperties")});
 
         public static Option<bool> NewLinesForBracesInAccessors { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInAccessors), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Accessors)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.Accessors)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAccessors")});
 
         public static Option<bool> NewLinesForBracesInAnonymousMethods { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInAnonymousMethods), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.AnonymousMethods)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.AnonymousMethods)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAnonymousMethods")});
 
         public static Option<bool> NewLinesForBracesInControlBlocks { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInControlBlocks), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.ControlBlocks)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.ControlBlocks)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInControlBlocks")});
 
         public static Option<bool> NewLinesForBracesInAnonymousTypes { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInAnonymousTypes), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.AnonymousTypes)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.AnonymousTypes)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAnonymousTypes")});
 
         public static Option<bool> NewLinesForBracesInObjectCollectionArrayInitializers { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInObjectCollectionArrayInitializers), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.ObjectCollectionsArrayInitializers)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.ObjectCollectionsArrayInitializers)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInObjectCollectionArrayInitializers")});
 
         public static Option<bool> NewLinesForBracesInLambdaExpressionBody { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInLambdaExpressionBody), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Lambdas)),
+                new EditorConfigStorageLocation<bool>("csharp_new_line_before_open_brace", value => DetermineIfNewLineOptionIsSet(value, NewLineOption.Lambdas)),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInLambdaExpressionBody")});
 
         public static Option<bool> NewLineForElse { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForElse), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_else"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_else"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForElse")});
 
         public static Option<bool> NewLineForCatch { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForCatch), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_catch"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_catch"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForCatch")});
 
         public static Option<bool> NewLineForFinally { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForFinally), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_finally"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_finally"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForFinally")});
 
         public static Option<bool> NewLineForMembersInObjectInit { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForMembersInObjectInit), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_members_in_object_initializers"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_members_in_object_initializers"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInObjectInit")});
 
         public static Option<bool> NewLineForMembersInAnonymousTypes { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForMembersInAnonymousTypes), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_before_members_in_anonymous_types"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_before_members_in_anonymous_types"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInAnonymousTypes")});
 
         public static Option<bool> NewLineForClausesInQuery { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForClausesInQuery), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("csharp_new_line_between_query_expression_clauses"),
+                EditorConfigStorageLocation.ForBoolOption("csharp_new_line_between_query_expression_clauses"),
                 new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForClausesInQuery")});
     }
 

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
@@ -1,52 +1,94 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Diagnostics;
+
 namespace Microsoft.CodeAnalysis.CodeStyle
 {
     internal static class CodeStyleHelpers
     {
-        public static CodeStyleOption<bool> ParseEditorConfigCodeStyleOption(string arg)
-        {
-            TryParseEditorConfigCodeStyleOption(arg, out var option);
-            return option;
-        }
-
         public static bool TryParseEditorConfigCodeStyleOption(string arg, out CodeStyleOption<bool> option)
         {
-            var args = arg.Split(':');
-            var isEnabled = false;
-            if (args.Length != 2)
+            if (TryGetCodeStyleValueAndOptionalNotification(
+                    arg, out string value, out NotificationOption notificationOpt))
             {
-                if (args.Length == 1)
+                // First value has to be true or false.  Anything else is unsupported.
+                if (bool.TryParse(value.Trim(), out var isEnabled))
                 {
-                    if (bool.TryParse(args[0].Trim(), out isEnabled) && !isEnabled)
+                    // We allow 'false' to be provided without a notification option.  However,
+                    // 'true' must always be provided with a notification option.
+                    if (isEnabled == false)
                     {
-                        option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
+                        notificationOpt = notificationOpt ?? NotificationOption.None;
+                        option = new CodeStyleOption<bool>(false, notificationOpt);
                         return true;
                     }
-                    else
+                    else if (notificationOpt != null)
                     {
-                        option = CodeStyleOption<bool>.Default;
-                        return false;
+                        option = new CodeStyleOption<bool>(true, notificationOpt);
+                        return true;
                     }
                 }
-                option = CodeStyleOption<bool>.Default;
-                return false;
             }
 
-            if (!bool.TryParse(args[0].Trim(), out isEnabled))
+            option = CodeStyleOption<bool>.Default;
+            return false;
+        }
+
+        /// <summary>
+        /// Given an editor-config code-style-option, gives back the constituent parts of the 
+        /// option.  For example, if the option is "true:error" then "true" will be returned
+        /// in <paramref name="value"/> and <see cref="NotificationOption.Error"/> will be returned
+        /// in <paramref name="notificationOpt"/>.  Note that users are allowed to not provide
+        /// a NotificationOption, so <paramref name="notificationOpt"/> may be null.  The caller
+        /// of this method must decide what to do in that case.
+        /// </summary>
+        public static bool TryGetCodeStyleValueAndOptionalNotification(
+            string arg, out string value, out NotificationOption notificationOpt)
+        {
+            var args = arg.Split(':');
+            Debug.Assert(args.Length > 0);
+
+            // We allow a single value to be provided in some cases.  For example users 
+            // can provide 'false' without supplying a notification as well.  Allow the 
+            // caller of this to determine what to do in this case.
+            if (args.Length == 1)
             {
-                option = CodeStyleOption<bool>.Default;
-                return false;
+                value = args[0];
+                notificationOpt = null;
+                return true;
             }
 
-            switch (args[1].Trim())
+            if (args.Length == 2)
             {
-                case EditorConfigSeverityStrings.Silent: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None); return true;
-                case EditorConfigSeverityStrings.Suggestion: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Suggestion); return true;
-                case EditorConfigSeverityStrings.Warning: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Warning); return true;
-                case EditorConfigSeverityStrings.Error: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Error); return true;
-                default: option = new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None); return false;
+                // If we have two args, then the second must be a notification option.  If 
+                // it isn't, then this isn't a valid code style option at all.
+                if (TryParseNotification(args[1], out var localNotification))
+                {
+                    value = args[0];
+                    notificationOpt = localNotification;
+                    return true;
+                }
             }
+
+            // We only support 0 or 1 args.  Anything else can't be parsed properly.
+            value = null;
+            notificationOpt = null;
+            return false;
+        }
+
+        public static bool TryParseNotification(string value, out NotificationOption notification)
+        {
+            switch (value.Trim())
+            {
+                case EditorConfigSeverityStrings.Silent: notification = NotificationOption.None; return true;
+                case EditorConfigSeverityStrings.Suggestion: notification = NotificationOption.Suggestion; return true;
+                case EditorConfigSeverityStrings.Warning: notification = NotificationOption.Warning; return true;
+                case EditorConfigSeverityStrings.Error: notification = NotificationOption.Error; return true;
+            }
+
+            notification = NotificationOption.None;
+            return false;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOption.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         public CodeStyleOption(T value, NotificationOption notification)
         {
             Value = value;
-            Notification = notification;
+            Notification = notification ?? throw new ArgumentNullException(nameof(notification));
         }
 
         public T Value { get; set; }

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyFieldAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyFieldAccess), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_qualification_for_field"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_qualification_for_field"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyFieldAccess")});
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyPropertyAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyPropertyAccess), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_qualification_for_property"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_qualification_for_property"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyPropertyAccess")});
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyMethodAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyMethodAccess), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_qualification_for_method"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_qualification_for_method"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyMethodAccess")});
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyEventAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyEventAccess), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_qualification_for_event"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_qualification_for_event"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyEventAccess")});
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIntrinsicPredefinedTypeKeywordInDeclaration = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInDeclaration), defaultValue: TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_predefined_type_for_locals_parameters_members"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_predefined_type_for_locals_parameters_members"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInDeclaration.CodeStyle")});
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIntrinsicPredefinedTypeKeywordInMemberAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInMemberAccess), defaultValue: TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_predefined_type_for_member_access"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_predefined_type_for_member_access"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInMemberAccess.CodeStyle")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferThrowExpression = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferThrowExpression),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("csharp_style_throw_expression"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_throw_expression"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferThrowExpression")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferObjectInitializer = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferObjectInitializer),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_object_initializer"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_object_initializer"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferObjectInitializer")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferCollectionInitializer = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferCollectionInitializer),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_collection_initializer"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_collection_initializer"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCollectionInitializer")});
 
         internal static readonly PerLanguageOption<bool> PreferObjectInitializer_FadeOutCode = new PerLanguageOption<bool>(
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferCoalesceExpression),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_coalesce_expression"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_coalesce_expression"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCoalesceExpression") });
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferNullPropagation = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferNullPropagation),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_null_propagation"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_null_propagation"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferNullPropagation") });
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferInlinedVariableDeclaration = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferInlinedVariableDeclaration),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("csharp_style_inlined_variable_declaration"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_style_inlined_variable_declaration"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferInlinedVariableDeclaration") });
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferExplicitTupleNames = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferExplicitTupleNames),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("dotnet_style_explicit_tuple_names"),
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("dotnet_style_explicit_tuple_names"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferExplicitTupleNames") });
     }
 }

--- a/src/Workspaces/Core/Portable/Editing/GenerationOptions.cs
+++ b/src/Workspaces/Core/Portable/Editing/GenerationOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Editing
     {
         public static readonly PerLanguageOption<bool> PlaceSystemNamespaceFirst = new PerLanguageOption<bool>(nameof(GenerationOptions), nameof(PlaceSystemNamespaceFirst), defaultValue: true,
             storageLocations: new OptionStorageLocation[] {
-                new EditorConfigStorageLocation("dotnet_sort_system_directives_first"),
+                EditorConfigStorageLocation.ForBoolOption("dotnet_sort_system_directives_first"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PlaceSystemNamespaceFirst")});
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
+++ b/src/Workspaces/Core/Portable/Formatting/FormattingOptions.cs
@@ -9,17 +9,17 @@ namespace Microsoft.CodeAnalysis.Formatting
     {
         public static PerLanguageOption<bool> UseTabs { get; } =
             new PerLanguageOption<bool>(nameof(FormattingOptions), nameof(UseTabs), defaultValue: false,
-                storageLocations: new EditorConfigStorageLocation("indent_style", s => s == "tab"));
+                storageLocations: new EditorConfigStorageLocation<bool>("indent_style", s => s == "tab"));
 
         // This is also serialized by the Visual Studio-specific LanguageSettingsPersister
         public static PerLanguageOption<int> TabSize { get; } = 
             new PerLanguageOption<int>(nameof(FormattingOptions), nameof(TabSize), defaultValue: 4,
-                storageLocations: new EditorConfigStorageLocation("tab_width"));
+                storageLocations: EditorConfigStorageLocation.ForInt32Option("tab_width"));
 
         // This is also serialized by the Visual Studio-specific LanguageSettingsPersister
         public static PerLanguageOption<int> IndentationSize { get; } =
             new PerLanguageOption<int>(nameof(FormattingOptions), nameof(IndentationSize), defaultValue: 4,
-                storageLocations: new EditorConfigStorageLocation("indent_size"));
+                storageLocations: EditorConfigStorageLocation.ForInt32Option("indent_size"));
 
         // This is also serialized by the Visual Studio-specific LanguageSettingsPersister
         public static PerLanguageOption<IndentStyle> SmartIndent { get; } =
@@ -27,13 +27,13 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public static PerLanguageOption<string> NewLine { get; } =
             new PerLanguageOption<string>(nameof(FormattingOptions), nameof(NewLine), defaultValue: "\r\n",
-                storageLocations: new EditorConfigStorageLocation("end_of_line", ParseEditorConfigEndOfLine));
+                storageLocations: new EditorConfigStorageLocation<string>("end_of_line", ParseEditorConfigEndOfLine));
 
         internal static Option<bool> InsertFinalNewLine { get; } =
             new Option<bool>(nameof(FormattingOptions), nameof(InsertFinalNewLine), defaultValue: false,
-                storageLocations: new EditorConfigStorageLocation("insert_final_newline"));
+                storageLocations: EditorConfigStorageLocation.ForBoolOption("insert_final_newline"));
 
-        private static object ParseEditorConfigEndOfLine(string endOfLineValue)
+        private static Optional<string> ParseEditorConfigEndOfLine(string endOfLineValue)
         {
             switch (endOfLineValue)
             {

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.CodeStyle;
+
+namespace Microsoft.CodeAnalysis.Options
+{
+    internal static class EditorConfigStorageLocation
+    {
+        public static EditorConfigStorageLocation<bool> ForBoolOption(string keyName)
+            => new EditorConfigStorageLocation<bool>(keyName, s_parseBool);
+
+        public static EditorConfigStorageLocation<int> ForInt32Option(string keyName)
+            => new EditorConfigStorageLocation<int>(keyName, s_parseInt32);
+
+        public static EditorConfigStorageLocation<CodeStyleOption<bool>> ForBoolCodeStyleOption(string keyName)
+            => new EditorConfigStorageLocation<CodeStyleOption<bool>>(keyName, s_parseBoolCodeStyleOption);
+
+        private static Func<string, Optional<bool>> s_parseBool = ParseBool;
+        private static Optional<bool> ParseBool(string str)
+            => bool.TryParse(str, out var result) ? result : new Optional<bool>();
+
+        private static Func<string, Optional<int>> s_parseInt32 = ParseInt32;
+        private static Optional<int> ParseInt32(string str)
+            => int.TryParse(str, out var result) ? result : new Optional<int>();
+
+        private static Func<string, Optional<CodeStyleOption<bool>>> s_parseBoolCodeStyleOption = ParseBoolCodeStyleOption;
+        private static Optional<CodeStyleOption<bool>> ParseBoolCodeStyleOption(string str)
+            => CodeStyleHelpers.TryParseEditorConfigCodeStyleOption(str, out var result) ? result : new Optional<CodeStyleOption<bool>>();
+    }
+}

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation`1.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation`1.cs
@@ -2,9 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -17,90 +14,38 @@ namespace Microsoft.CodeAnalysis.Options
 
         private readonly Func<string, Type, Optional<T>> _parseValue;
 
-        private readonly Func<object, IReadOnlyDictionary<string, object>, Type, (object result, bool succeeded)> _tryParseDictionary;
-
-        private static Func<object, IReadOnlyDictionary<string, object>, Type, (object result, bool succeeded)> _cachedTryParseDictionary = (underlyingOption, dictionary, type) =>
-        {
-            if (type == typeof(NamingStylePreferences))
-            {
-                var editorconfigNamingStylePreferences = EditorConfigNamingStyleParser.GetNamingStylesFromDictionary(dictionary);
-
-                if (!editorconfigNamingStylePreferences.NamingRules.Any() &&
-                    !editorconfigNamingStylePreferences.NamingStyles.Any() &&
-                    !editorconfigNamingStylePreferences.SymbolSpecifications.Any())
-                {
-                    // We were not able to parse any rules from editorconfig, tell the caller that the parse failed
-                    return (result: editorconfigNamingStylePreferences, succeeded: false);
-                }
-
-                var workspaceNamingStylePreferences = underlyingOption as NamingStylePreferences;
-                if (workspaceNamingStylePreferences != null)
-                {
-                    // We parsed naming styles from editorconfig, append them to our existing styles
-                    var combinedNamingStylePreferences = workspaceNamingStylePreferences.PrependNamingStylePreferences(editorconfigNamingStylePreferences);
-                    return (result: (object)combinedNamingStylePreferences, succeeded: true);
-                }
-
-                // no existing naming styles were passed so just return the set of styles that were parsed from editorconfig
-                return (result: editorconfigNamingStylePreferences, succeeded: true);
-            }
-            else
-            {
-                throw new NotSupportedException(WorkspacesResources.Option_0_has_an_unsupported_type_to_use_with_1_You_should_specify_a_parsing_function);
-            }
-        };
-
-        public bool TryGetOption(object underlyingOption, IReadOnlyDictionary<string, object> allRawConventions, Type type, out object result)
-        {
-            if (_parseValue != null && KeyName != null)
-            {
-                if (allRawConventions.TryGetValue(KeyName, out object value))
-                {
-                    var optionalValue = _parseValue(value.ToString(), type);
-                    if (optionalValue.HasValue)
-                    {
-                        result = optionalValue.Value;
-                    }
-                    else
-                    {
-                        result = null;
-                    }
-
-                    return result != null;
-                }
-            }
-            else if (_tryParseDictionary != null)
-            {
-                var tuple = _tryParseDictionary(underlyingOption, allRawConventions, type);
-                result = tuple.result;
-                return tuple.succeeded;
-            }
-
-            result = null;
-            return false;
-        }
-
         public EditorConfigStorageLocation(string keyName, Func<string, Optional<T>> parseValue)
         {
-            KeyName = keyName;
+            if (parseValue == null)
+            {
+                throw new ArgumentNullException(nameof(parseValue));
+            }
+
+            KeyName = keyName ?? throw new ArgumentNullException(nameof(keyName));
 
             // If we're explicitly given a parsing function we can throw away the type when parsing
             _parseValue = (s, type) => parseValue(s);
         }
 
-        public EditorConfigStorageLocation()
+        public bool TryGetOption(object underlyingOption, IReadOnlyDictionary<string, object> allRawConventions, Type type, out object result)
         {
-            Contract.ThrowIfFalse(typeof(T) == typeof(NamingStylePreferences),
-                $"Using {nameof(EditorConfigStorageLocation)}() with arguments is only supported for {nameof(NamingStylePreferences)}");
+            if (allRawConventions.TryGetValue(KeyName, out object value))
+            {
+                var optionalValue = _parseValue(value.ToString(), type);
+                if (optionalValue.HasValue)
+                {
+                    result = optionalValue.Value;
+                }
+                else
+                {
+                    result = null;
+                }
 
-            // If the user didn't pass a keyName assume we need to parse the entire dictionary
-            _tryParseDictionary = _cachedTryParseDictionary;
-        }
+                return result != null;
+            }
 
-        public EditorConfigStorageLocation(Func<object, IReadOnlyDictionary<string, object>, (object result, bool succeeded)> tryParseDictionary)
-        {
-            // If we're explicitly given a parsing function we can throw away the type when parsing
-            _tryParseDictionary = (underlyingOption, dictionary, type) => tryParseDictionary(underlyingOption, dictionary);
+            result = null;
+            return false;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation`1.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/EditorConfigStorageLocation`1.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -49,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Options
             }
         };
 
-        bool IEditorConfigStorageLocation.TryGetOption(object underlyingOption, IReadOnlyDictionary<string, object> allRawConventions, Type type, out object result)
+        public bool TryGetOption(object underlyingOption, IReadOnlyDictionary<string, object> allRawConventions, Type type, out object result)
         {
             if (_parseValue != null && KeyName != null)
             {
@@ -89,6 +90,9 @@ namespace Microsoft.CodeAnalysis.Options
 
         public EditorConfigStorageLocation()
         {
+            Contract.ThrowIfFalse(typeof(T) == typeof(NamingStylePreferences),
+                $"Using {nameof(EditorConfigStorageLocation)}() with arguments is only supported for {nameof(NamingStylePreferences)}");
+
             // If the user didn't pass a keyName assume we need to parse the entire dictionary
             _tryParseDictionary = _cachedTryParseDictionary;
         }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/IEditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/IEditorConfigStorageLocation.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Options
+{
+    internal interface IEditorConfigStorageLocation
+    {
+        bool TryGetOption(object underlyingOption, IReadOnlyDictionary<string, object> allRawConventions, Type type, out object value);
+    }
+}

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/NamingStylePreferenceEditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/NamingStylePreferenceEditorConfigStorageLocation.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -41,8 +43,11 @@ namespace Microsoft.CodeAnalysis.Options
                 // no existing naming styles were passed so just return the set of styles that were parsed from editorconfig
                 return (result: editorconfigNamingStylePreferences, succeeded: true);
             }
-
-            return (result: null, succeeded: false);
+            else
+            {
+                return Contract.FailWithReturn<(object, bool)>(
+                    $"{nameof(NamingStylePreferenceEditorConfigStorageLocation)} can only be called with {nameof(PerLanguageOption<NamingStylePreferences>)}<{nameof(NamingStylePreferences)}>.");
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/EditorConfig/NamingStylePreferenceEditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfig/NamingStylePreferenceEditorConfigStorageLocation.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+
+namespace Microsoft.CodeAnalysis.Options
+{
+    internal sealed class NamingStylePreferenceEditorConfigStorageLocation : OptionStorageLocation, IEditorConfigStorageLocation
+    {
+        public bool TryGetOption(object underlyingOption, IReadOnlyDictionary<string, object> allRawConventions, Type type, out object result)
+        {
+            var tuple = ParseDictionary(underlyingOption, allRawConventions, type);
+            result = tuple.result;
+            return tuple.succeeded;
+        }
+
+        private static (object result, bool succeeded) ParseDictionary(
+            object underlyingOption, IReadOnlyDictionary<string, object> allRawConventions, Type type)
+        {
+            if (type == typeof(NamingStylePreferences))
+            {
+                var editorconfigNamingStylePreferences = EditorConfigNamingStyleParser.GetNamingStylesFromDictionary(allRawConventions);
+
+                if (!editorconfigNamingStylePreferences.NamingRules.Any() &&
+                    !editorconfigNamingStylePreferences.NamingStyles.Any() &&
+                    !editorconfigNamingStylePreferences.SymbolSpecifications.Any())
+                {
+                    // We were not able to parse any rules from editorconfig, tell the caller that the parse failed
+                    return (result: editorconfigNamingStylePreferences, succeeded: false);
+                }
+
+                if (underlyingOption is NamingStylePreferences workspaceNamingStylePreferences)
+                {
+                    // We parsed naming styles from editorconfig, append them to our existing styles
+                    var combinedNamingStylePreferences = workspaceNamingStylePreferences.PrependNamingStylePreferences(editorconfigNamingStylePreferences);
+                    return (result: combinedNamingStylePreferences, succeeded: true);
+                }
+
+                // no existing naming styles were passed so just return the set of styles that were parsed from editorconfig
+                return (result: editorconfigNamingStylePreferences, succeeded: true);
+            }
+
+            return (result: null, succeeded: false);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Simplification/SimplificationOptions.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationOptions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Simplification
         /// </summary>
         internal static PerLanguageOption<NamingStylePreferences> NamingPreferences { get; } = new PerLanguageOption<NamingStylePreferences>(nameof(SimplificationOptions), nameof(NamingPreferences), defaultValue: NamingStylePreferences.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation(),
+                new EditorConfigStorageLocation<NamingStylePreferences>(),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.NamingPreferences")});
     }
 }

--- a/src/Workspaces/Core/Portable/Simplification/SimplificationOptions.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationOptions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Simplification
         /// </summary>
         internal static PerLanguageOption<NamingStylePreferences> NamingPreferences { get; } = new PerLanguageOption<NamingStylePreferences>(nameof(SimplificationOptions), nameof(NamingPreferences), defaultValue: NamingStylePreferences.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation<NamingStylePreferences>(),
+                new NamingStylePreferenceEditorConfigStorageLocation(),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.NamingPreferences")});
     }
 }

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -388,6 +388,8 @@
     <Compile Include="FindSymbols\SyntaxTree\SyntaxTreeIndex.DeclarationInfo.cs" />
     <Compile Include="FindSymbols\SyntaxTree\SyntaxTreeIndex.IdentifierInfo.cs" />
     <Compile Include="NamingStyles\Serialization\NamingStylePreferencesExtensions.cs" />
+    <Compile Include="Options\EditorConfig\EditorConfigStorageLocation.cs" />
+    <Compile Include="Options\EditorConfig\IEditorConfigStorageLocation.cs" />
     <Compile Include="PatternMatching\PatternMatch.cs" />
     <Compile Include="PatternMatching\PatternMatcher.AllLowerCamelCaseMatcher.cs" />
     <Compile Include="PatternMatching\PatternMatcher.cs" />
@@ -439,7 +441,7 @@
     <Compile Include="FindSymbols\SymbolFinder_Remote.cs" />
     <Compile Include="FindSymbols\SymbolTree\SymbolTreeInfo.FirstEntityHandleProvider.cs" />
     <Compile Include="LanguageServices\SyntaxFactsService\AbstractSyntaxFactsService.cs" />
-    <Compile Include="Options\EditorConfigStorageLocation.cs" />
+    <Compile Include="Options\EditorConfig\EditorConfigStorageLocation`1.cs" />
     <Compile Include="Options\GlobalOptionService.cs" />
     <Compile Include="Options\IDocumentOptions.cs" />
     <Compile Include="Options\IDocumentOptionsProvider.cs" />

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -390,6 +390,7 @@
     <Compile Include="NamingStyles\Serialization\NamingStylePreferencesExtensions.cs" />
     <Compile Include="Options\EditorConfig\EditorConfigStorageLocation.cs" />
     <Compile Include="Options\EditorConfig\IEditorConfigStorageLocation.cs" />
+    <Compile Include="Options\EditorConfig\NamingStylePreferenceEditorConfigStorageLocation.cs" />
     <Compile Include="PatternMatching\PatternMatch.cs" />
     <Compile Include="PatternMatching\PatternMatcher.AllLowerCamelCaseMatcher.cs" />
     <Compile Include="PatternMatching\PatternMatcher.cs" />

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -972,16 +972,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Option &apos;{0}&apos; has an unsupported type to use with {1}. You should specify a parsing function..
-        /// </summary>
-        internal static string Option_0_has_an_unsupported_type_to_use_with_1_You_should_specify_a_parsing_function {
-            get {
-                return ResourceManager.GetString("Option_0_has_an_unsupported_type_to_use_with_1_You_should_specify_a_parsing_funct" +
-                        "ion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Options did not come from Workspace.
         /// </summary>
         internal static string Options_did_not_come_from_Workspace {

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -492,9 +492,6 @@
   <data name="Deserialization_reader_for_0_read_incorrect_number_of_values" xml:space="preserve">
     <value>Deserialization reader for '{0}' read incorrect number of values.</value>
   </data>
-  <data name="Option_0_has_an_unsupported_type_to_use_with_1_You_should_specify_a_parsing_function" xml:space="preserve">
-    <value>Option '{0}' has an unsupported type to use with {1}. You should specify a parsing function.</value>
-  </data>
   <data name="Pascal_Case" xml:space="preserve">
     <value>Pascal Case</value>
   </data>

--- a/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
+++ b/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
         [InlineData("true:suggestion", true, DiagnosticSeverity.Info)]
         [InlineData("true:warning", true, DiagnosticSeverity.Warning)]
         [InlineData("true:error", true, DiagnosticSeverity.Error)]
+        [InlineData("true", false, DiagnosticSeverity.Hidden)]
         [InlineData("false:silent", false, DiagnosticSeverity.Hidden)]
         [InlineData("false:suggestion", false, DiagnosticSeverity.Info)]
         [InlineData("false:warning", false, DiagnosticSeverity.Warning)]
@@ -43,7 +44,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
 
             var codeStyleOption = new CodeStyleOption<bool>(value: isEnabled, notification: notificationOption);
 
-            var result = CodeStyleHelpers.ParseEditorConfigCodeStyleOption(args);
+            CodeStyleHelpers.TryParseEditorConfigCodeStyleOption(args, out var result);
             Assert.True(result.Value == isEnabled,
                         $"Expected {nameof(isEnabled)} to be {isEnabled}, was {result.Value}");
             Assert.True(result.Notification.Value == severity,

--- a/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
+++ b/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestEmptyDictionaryReturnNoNamingStylePreferencesObjectReturnsFalse()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation<NamingStylePreferences>();
+            var editorConfigStorageLocation = new NamingStylePreferenceEditorConfigStorageLocation();
             var result = editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(NamingStylePreferences), out var @object);
             Assert.False(result, "Expected TryParseReadonlyDictionary to return 'false' for empty dictionary");
         }
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestEmptyDictionaryDefaultNamingStylePreferencesObjectReturnsFalse()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation<NamingStylePreferences>();
+            var editorConfigStorageLocation = new NamingStylePreferenceEditorConfigStorageLocation();
             var existingNamingStylePreferences = new NamingStylePreferences(
                 ImmutableArray.Create<SymbolSpecification>(),
                 ImmutableArray.Create<NamingStyle>(),
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
             };
             var existingNamingStylePreferences = ParseDictionary(initialDictionary);
 
-            var editorConfigStorageLocation = new EditorConfigStorageLocation<NamingStylePreferences>();
+            var editorConfigStorageLocation = new NamingStylePreferenceEditorConfigStorageLocation();
             var newDictionary = new Dictionary<string, object>()
             {
                 ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity"] = "error",
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestObjectTypeThrowsNotSupportedException()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation<NamingStylePreferences>();
+            var editorConfigStorageLocation = new NamingStylePreferenceEditorConfigStorageLocation();
             Assert.Throws<NotSupportedException>(() =>
             {
                 editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(object), out var @object);

--- a/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
+++ b/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestEmptyDictionaryReturnNoNamingStylePreferencesObjectReturnsFalse()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation();
+            var editorConfigStorageLocation = new EditorConfigStorageLocation<object>();
             var result = editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(NamingStylePreferences), out var @object);
             Assert.False(result, "Expected TryParseReadonlyDictionary to return 'false' for empty dictionary");
         }
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestEmptyDictionaryDefaultNamingStylePreferencesObjectReturnsFalse()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation();
+            var editorConfigStorageLocation = new EditorConfigStorageLocation<object>();
             var existingNamingStylePreferences = new NamingStylePreferences(
                 ImmutableArray.Create<SymbolSpecification>(),
                 ImmutableArray.Create<NamingStyle>(),
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
             };
             var existingNamingStylePreferences = ParseDictionary(initialDictionary);
 
-            var editorConfigStorageLocation = new EditorConfigStorageLocation();
+            var editorConfigStorageLocation = new EditorConfigStorageLocation<object>();
             var newDictionary = new Dictionary<string, object>()
             {
                 ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity"] = "error",
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestObjectTypeThrowsNotSupportedException()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation();
+            var editorConfigStorageLocation = new EditorConfigStorageLocation<object>();
             Assert.Throws<NotSupportedException>(() =>
             {
                 editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(object), out var @object);

--- a/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
+++ b/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
@@ -77,10 +77,10 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         }
 
         [Fact]
-        public static void TestObjectTypeThrowsNotSupportedException()
+        public static void TestObjectTypeThrowsInvalidOperationException()
         {
             var editorConfigStorageLocation = new NamingStylePreferenceEditorConfigStorageLocation();
-            Assert.Throws<NotSupportedException>(() =>
+            Assert.Throws<InvalidOperationException>(() =>
             {
                 editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(object), out var @object);
             });

--- a/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
+++ b/src/Workspaces/CoreTest/EditorConfigStorageLocation/EditorConfigStorageLocationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestEmptyDictionaryReturnNoNamingStylePreferencesObjectReturnsFalse()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation<object>();
+            var editorConfigStorageLocation = new EditorConfigStorageLocation<NamingStylePreferences>();
             var result = editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(NamingStylePreferences), out var @object);
             Assert.False(result, "Expected TryParseReadonlyDictionary to return 'false' for empty dictionary");
         }
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestEmptyDictionaryDefaultNamingStylePreferencesObjectReturnsFalse()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation<object>();
+            var editorConfigStorageLocation = new EditorConfigStorageLocation<NamingStylePreferences>();
             var existingNamingStylePreferences = new NamingStylePreferences(
                 ImmutableArray.Create<SymbolSpecification>(),
                 ImmutableArray.Create<NamingStyle>(),
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
             };
             var existingNamingStylePreferences = ParseDictionary(initialDictionary);
 
-            var editorConfigStorageLocation = new EditorConfigStorageLocation<object>();
+            var editorConfigStorageLocation = new EditorConfigStorageLocation<NamingStylePreferences>();
             var newDictionary = new Dictionary<string, object>()
             {
                 ["dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity"] = "error",
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.EditorConfig.StorageLocation
         [Fact]
         public static void TestObjectTypeThrowsNotSupportedException()
         {
-            var editorConfigStorageLocation = new EditorConfigStorageLocation<object>();
+            var editorConfigStorageLocation = new EditorConfigStorageLocation<NamingStylePreferences>();
             Assert.Throws<NotSupportedException>(() =>
             {
                 editorConfigStorageLocation.TryGetOption(new object(), new Dictionary<string, object>(), typeof(object), out var @object);


### PR DESCRIPTION
It turns out that we weren't properly parsing editor config options for UseExpressionBody.  Unfortunately, because the internal API is object based, this wasn't caught.  I've moved to a model where EditorConfig options are strongly typed and enforce that you must pass a proper parsing function to them.