### PR TITLE
Add SafeDirectories to DSRN load paths

### DIFF
--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -738,11 +738,11 @@ namespace Microsoft.Cci
 
         private static bool s_MicrosoftDiaSymReaderNativeLoadFailed;
 
-        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
         [DllImport("Microsoft.DiaSymReader.Native.x86.dll", EntryPoint = "CreateSymWriter")]
         private extern static void CreateSymWriter32(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symWriter);
 
-        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
         [DllImport("Microsoft.DiaSymReader.Native.amd64.dll", EntryPoint = "CreateSymWriter")]
         private extern static void CreateSymWriter64(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symWriter);
 

--- a/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
+++ b/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
@@ -15,11 +15,11 @@ namespace Roslyn.Test.PdbUtilities
 {
     public static class SymReaderFactory
     {
-        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
         [DllImport("Microsoft.DiaSymReader.Native.x86.dll", EntryPoint = "CreateSymReader")]
         private extern static void CreateSymReader32(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symReader);
 
-        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
         [DllImport("Microsoft.DiaSymReader.Native.amd64.dll", EntryPoint = "CreateSymReader")]
         private extern static void CreateSymReader64(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symReader);
 


### PR DESCRIPTION
Tuns out that if only ```DllImportSearchPath.AssemblyDirectory``` is specified in ```DefaultDllImportSearchPathsAttribute``` the CLR loader first tries to load from the directory of the containing assembly and if not found falls back to LoadLibrary that searches in many places like %PATHS%, current dir, etc (```DllImportSearchPath.LegacyBehavior```). Adding ```DllImportSearchPath.SafeDirectories``` ensures that only limited set of search paths that are configured by the app is used, making the lookup safe and deterministic.

See https://msdn.microsoft.com/en-us/library/system.runtime.interopservices.dllimportsearchpath(v=vs.110).aspx