### PR TITLE
Need to pass MSBuild to SignTool in all cases

### DIFF
--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -10,12 +10,13 @@
     <BinariesPath>$(ProjectDir)Binaries\$(Configuration)</BinariesPath>
     <RoslynNuGetApiKey Condition="'$(RoslynNuGetApiKey)' == ''">"no key"</RoslynNuGetApiKey>
     <PublishAssetsArgs Condition="'$(SkipPublish)' == 'true'">-test</PublishAssetsArgs>
+    <SignRoslynArgs>-msbuildPath "$(MSBuildBinPath)\msbuild.exe"</SignRoslynArgs>
   </PropertyGroup>
 
   <!-- Non-official builds / local testing have different defaults -->
   <PropertyGroup Condition="'$(OfficialBuild)' != 'true'">
     <BranchName Condition="'$(BranchName)' == ''">master</BranchName>
-    <SignRoslynArgs>-test</SignRoslynArgs>
+    <SignRoslynArgs>$(SignRoslynArgs) -test</SignRoslynArgs>
     <PublishAssetsArgs>-test</PublishAssetsArgs>
     <CopyInsertionFileArgs>-test</CopyInsertionFileArgs>
     <SetupStep2Properties>FinalizeValidate=false;ManifestPublishUrl=https://vsdrop.corp.microsoft.com/file/v1/Products/DevDiv/dotnet/roslyn/master/20160729.6</SetupStep2Properties>


### PR DESCRIPTION
Cherry-pick https://github.com/dotnet/roslyn/pull/18195/commits/52b4950070ecee3c3bfa271d0324f9e242b96824 to unbreak signed build

/cc @dotnet/roslyn-infrastructure 