### PR TITLE
Don't convert 'static/shared' member initialization into an object initializer statement.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseObjectInitializer/UseObjectInitializerTests.vb
@@ -350,5 +350,35 @@ Class C
 End Class",
 ignoreTrivia:=False)
         End Function
+
+        <WorkItem(401322, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=401322")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)>
+        Public Async Function TestSharedMember() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Class C
+    Dim x As Integer
+    Shared y As Integer
+
+    Sub M()
+        Dim z = [||]New C()
+        z.x = 1
+        z.y = 2
+    End Sub
+End Class
+",
+"
+Class C
+    Dim x As Integer
+    Shared y As Integer
+
+    Sub M()
+        Dim z = New C With {
+            .x = 1
+        }
+        z.y = 2
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/UseObjectInitializer/ObjectCreationExpressionAnalyzer.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/ObjectCreationExpressionAnalyzer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.UseCollectionInitializer;
 using Roslyn.Utilities;
 
@@ -102,6 +103,13 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 var expression = (TExpressionSyntax)_syntaxFacts.GetExpressionOfMemberAccessExpression(leftMemberAccess);
                 if (!ValuePatternMatches(expression))
                 {
+                    break;
+                }
+
+                var leftSymbol = _semanticModel.GetSymbolInfo(leftMemberAccess, _cancellationToken).GetAnySymbol();
+                if (leftSymbol?.IsStatic == true)
+                {
+                    // Static members cannot be initialized through an object initializer.
                     break;
                 }
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=401322