### PR TITLE
Allow exporting the same language service for multiple languages

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceAttribute.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/ExportLanguageServiceAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
     /// Use this attribute to declare a <see cref="ILanguageService"/> implementation for inclusion in a MEF-based workspace.
     /// </summary>
     [MetadataAttribute]
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class ExportLanguageServiceAttribute : ExportAttribute
     {
         /// <summary>


### PR DESCRIPTION
Sometimes, a language service can perfectly service more than one language, such as one that 
consumes other language-agnostic APIs, such as SyntaxGenerator. 

In such cases, forcing the author to create two classes that are essentially empty and just inherit 
the general-purpose implementation, just to satisfy the requirement that only one [ExportLanguageService] 
can be specified, seems wasteful.

Example:

```
public abstract class RewriterService : ILanguageService, IRewriterService
{
   public SyntaxNode Rewrite(Project project, SyntaxNode node)
   {
      var generator = SyntaxGenerator.GetGenerator(project);
      // do some fancy language-agnostic transformations using the generator
     return transformedNode;
   }
}

[ExportLanguageService(typeof(IRewriterService), LanguageNames.CSharp)]
public class CSharpRewriterService : RewriterService { }

[ExportLanguageService(typeof(IRewriterService), LanguageNames.VisualBasic)]
public class VisualBasicRewriterService : RewriterService { }
```

As you can see, the implementation can support both languages, yet because 
the export attribute doesn't have the `AllowMultiple = true`, we are forced to 
create two dummy derived classes just so we can apply the attribute there instead.

With this change, we'd enable the code to simply become:

```
[ExportLanguageService(typeof(IRewriterService), LanguageNames.CSharp)]
[ExportLanguageService(typeof(IRewriterService), LanguageNames.VisualBasic)]
public class RewriterService : ILanguageService, IRewriterService
...
```