### PR TITLE
Fix tuple printing in xml documentation

### DIFF
--- a/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
@@ -170,6 +170,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override object VisitNamedType(NamedTypeSymbol symbol, StringBuilder builder)
             {
+                if (symbol.IsTupleType)
+                {
+                    return VisitTupleType((TupleTypeSymbol)symbol, builder);
+                }
+
                 if ((object)symbol.ContainingSymbol != null && symbol.ContainingSymbol.Name.Length != 0)
                 {
                     Visit(symbol.ContainingSymbol, builder);
@@ -209,6 +214,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
+                return null;
+            }
+
+            private object VisitTupleType(TupleTypeSymbol symbol, StringBuilder builder)
+            {
+                builder.Append('(');
+
+                bool needsComma = false;
+
+                foreach (var type in symbol.TupleElementTypes)
+                {
+                    if (needsComma)
+                    {
+                        builder.Append(',');
+                    }
+
+                    Visit(type, builder);
+
+                    needsComma = true;
+                }
+
+                builder.Append(')');
                 return null;
             }
 

--- a/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
@@ -219,23 +219,35 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private object VisitTupleType(TupleTypeSymbol symbol, StringBuilder builder)
             {
-                builder.Append('(');
+                return VisitTupleType(symbol.TupleElementTypes, 0, builder);
+            }
 
+            private object VisitTupleType(ImmutableArray<TypeSymbol> types, int index, StringBuilder builder)
+            {
+                builder.Append("System.ValueTuple<");
+
+                int totalLength = types.Length;
+                int chunk = Math.Min(7, totalLength - index);
                 bool needsComma = false;
-
-                foreach (var type in symbol.TupleElementTypes)
+                for (int i = 0; i < chunk; i++)
                 {
                     if (needsComma)
                     {
                         builder.Append(',');
                     }
 
-                    Visit(type, builder);
-
+                    Visit(types[index + i], builder);
                     needsComma = true;
                 }
 
-                builder.Append(')');
+                int nextIndex = index + 7;
+                if (nextIndex < totalLength)
+                {
+                    builder.Append(',');
+                    VisitTupleType(types, nextIndex, builder);
+                }
+
+                builder.Append('>');
                 return null;
             }
 

--- a/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
@@ -224,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private object VisitTupleType(ImmutableArray<TypeSymbol> types, int index, StringBuilder builder)
             {
-                builder.Append("System.ValueTuple<");
+                builder.Append("System.ValueTuple{");
 
                 int totalLength = types.Length;
                 int chunk = Math.Min(7, totalLength - index);
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     VisitTupleType(types, nextIndex, builder);
                 }
 
-                builder.Append('>');
+                builder.Append('}');
                 return null;
             }
 

--- a/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (symbol.IsTupleType)
                 {
-                    return VisitTupleType((TupleTypeSymbol)symbol, builder);
+                    return VisitNamedType(((TupleTypeSymbol)symbol).UnderlyingNamedType, builder);
                 }
 
                 if ((object)symbol.ContainingSymbol != null && symbol.ContainingSymbol.Name.Length != 0)
@@ -214,40 +214,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                return null;
-            }
-
-            private object VisitTupleType(TupleTypeSymbol symbol, StringBuilder builder)
-            {
-                return VisitTupleType(symbol.TupleElementTypes, 0, builder);
-            }
-
-            private object VisitTupleType(ImmutableArray<TypeSymbol> types, int index, StringBuilder builder)
-            {
-                builder.Append("System.ValueTuple{");
-
-                int totalLength = types.Length;
-                int chunk = Math.Min(7, totalLength - index);
-                bool needsComma = false;
-                for (int i = 0; i < chunk; i++)
-                {
-                    if (needsComma)
-                    {
-                        builder.Append(',');
-                    }
-
-                    Visit(types[index + i], builder);
-                    needsComma = true;
-                }
-
-                int nextIndex = index + 7;
-                if (nextIndex < totalLength)
-                {
-                    builder.Append(',');
-                    VisitTupleType(types, nextIndex, builder);
-                }
-
-                builder.Append('}');
                 return null;
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.cs
@@ -45,7 +45,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public unsafe void M4(char *pc, Color **pf) { }
         public unsafe void M5(void *pv, double *[][,] pd) { }
         public void M6(int i, params object[] args) { }
-        public void M7((int x, short y) z) { }
+        public void M7((int x1, int x2, int x3, int x4, int x5, int x6, short x7) z) { }
+        public void M8((int x1, int x2, int x3, int x4, int x5, int x6, short x7, int x8) z) { }
+        public void M9((int x1, int x2, int x3, int x4, int x5, int x6, short x7, (string y1, string y2)) z) { }
+        public void M10((int x1, short x2) z) { }
     }
     class MyList<T>
     {
@@ -126,9 +129,31 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [Fact]
-        public void TestTuples()
+        public void TestTupleLength7()
         {
-            Assert.Equal("M:Acme.Widget.M7((System.Int32,System.Int16))", _widgetClass.GetMembers("M7").Single().GetDocumentationCommentId());
+            Assert.Equal("M:Acme.Widget.M7(System.ValueTuple<System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16>)",
+                _widgetClass.GetMembers("M7").Single().GetDocumentationCommentId());
+        }
+
+        [Fact]
+        public void TestTupleLength8()
+        {
+            Assert.Equal("M:Acme.Widget.M8(System.ValueTuple<System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16,System.ValueTuple<System.Int32>>)",
+                _widgetClass.GetMembers("M8").Single().GetDocumentationCommentId());
+        }
+
+        [Fact]
+        public void TestTupleLength9()
+        {
+            Assert.Equal("M:Acme.Widget.M9(System.ValueTuple<System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16,System.ValueTuple<System.ValueTuple<System.String,System.String>>>)",
+                _widgetClass.GetMembers("M9").Single().GetDocumentationCommentId());
+        }
+
+        [Fact]
+        public void TestTupleLength2()
+        {
+            Assert.Equal("M:Acme.Widget.M10(System.ValueTuple<System.Int32,System.Int16>)",
+                _widgetClass.GetMembers("M10").Single().GetDocumentationCommentId());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public unsafe void M4(char *pc, Color **pf) { }
         public unsafe void M5(void *pv, double *[][,] pd) { }
         public void M6(int i, params object[] args) { }
+        public void M7((int x, short y) z) { }
     }
     class MyList<T>
     {
@@ -122,6 +123,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestParams()
         {
             Assert.Equal("M:Acme.Widget.M6(System.Int32,System.Object[])", _widgetClass.GetMembers("M6").Single().GetDocumentationCommentId());
+        }
+
+        [Fact]
+        public void TestTuples()
+        {
+            Assert.Equal("M:Acme.Widget.M7((System.Int32,System.Int16))", _widgetClass.GetMembers("M7").Single().GetDocumentationCommentId());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void M7((int x1, int x2, int x3, int x4, int x5, int x6, short x7) z) { }
         public void M8((int x1, int x2, int x3, int x4, int x5, int x6, short x7, int x8) z) { }
         public void M9((int x1, int x2, int x3, int x4, int x5, int x6, short x7, (string y1, string y2)) z) { }
-        public void M10((int x1, short x2) z) { }
+        public void M10((int x1, short x2) y, System.Tuple<int, short> z) { }
     }
     class MyList<T>
     {
@@ -131,28 +131,28 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestTupleLength7()
         {
-            Assert.Equal("M:Acme.Widget.M7(System.ValueTuple<System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16>)",
+            Assert.Equal("M:Acme.Widget.M7(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16})",
                 _widgetClass.GetMembers("M7").Single().GetDocumentationCommentId());
         }
 
         [Fact]
         public void TestTupleLength8()
         {
-            Assert.Equal("M:Acme.Widget.M8(System.ValueTuple<System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16,System.ValueTuple<System.Int32>>)",
+            Assert.Equal("M:Acme.Widget.M8(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16,System.ValueTuple{System.Int32}})",
                 _widgetClass.GetMembers("M8").Single().GetDocumentationCommentId());
         }
 
         [Fact]
         public void TestTupleLength9()
         {
-            Assert.Equal("M:Acme.Widget.M9(System.ValueTuple<System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16,System.ValueTuple<System.ValueTuple<System.String,System.String>>>)",
+            Assert.Equal("M:Acme.Widget.M9(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16,System.ValueTuple{System.ValueTuple{System.String,System.String}}})",
                 _widgetClass.GetMembers("M9").Single().GetDocumentationCommentId());
         }
 
         [Fact]
         public void TestTupleLength2()
         {
-            Assert.Equal("M:Acme.Widget.M10(System.ValueTuple<System.Int32,System.Int16>)",
+            Assert.Equal("M:Acme.Widget.M10(System.ValueTuple{System.Int32,System.Int16},System.Tuple{System.Int32,System.Int16})",
                 _widgetClass.GetMembers("M10").Single().GetDocumentationCommentId());
         }
 


### PR DESCRIPTION
Tuple types currently print "System." in xml documentation, because they have an empty `Name` and have `Arity` of zero. With this fix, they print as ~~tuple format (as parens)~~ System.ValueTuple{...}.

Fixes https://github.com/dotnet/roslyn/issues/18274
