### PR TITLE
Refactor the relationship between the Tagger and Notifier.

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.BatchChangeNotifier.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.BatchChangeNotifier.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
@@ -25,14 +24,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         private class BatchChangeNotifier : ForegroundThreadAffinitizedObject
         {
             private readonly ITextBuffer _subjectBuffer;
-
-            /// <summary>
-            /// If we get more than this many differences, then we just issue it as a single change
-            /// notification.  The number has been completely made up without any data to support it.
-            /// 
-            /// Internal for testing purposes.
-            /// </summary>
-            internal const int CoalesceDifferenceCount = 10;
 
             /// <summary>
             /// The worker we use to do work on the appropriate background or foreground thread.
@@ -66,19 +57,19 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             public bool IsPaused { get; private set; }
             private int _lastPausedTime;
 
-            private readonly Action<SnapshotSpan> _reportChangedSpan;
+            private readonly Action<NormalizedSnapshotSpanCollection> _notifyEditorNow;
 
             public BatchChangeNotifier(
                 ITextBuffer subjectBuffer,
                 IAsynchronousOperationListener listener,
                 IForegroundNotificationService notificationService,
-                Action<SnapshotSpan> reportChangedSpan)
+                Action<NormalizedSnapshotSpanCollection> notifyEditorNow)
             {
-                Contract.ThrowIfNull(reportChangedSpan);
+                Contract.ThrowIfNull(notifyEditorNow);
                 _subjectBuffer = subjectBuffer;
                 _listener = listener;
                 _notificationService = notificationService;
-                _reportChangedSpan = reportChangedSpan;
+                _notifyEditorNow = notifyEditorNow;
             }
 
             public void Pause()
@@ -188,7 +179,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                         var snapshot = snapshotAndSpans.Key;
                         var normalizedSpans = snapshotAndSpans.Value;
 
-                        this.NotifyEditorNow(normalizedSpans);
+                        _notifyEditorNow(normalizedSpans);
                     }
                 }
 
@@ -198,44 +189,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 // reset paused time
                 _lastPausedTime = Environment.TickCount;
-            }
-
-            private void NotifyEditorNow(NormalizedSnapshotSpanCollection normalizedSpans)
-            {
-                this.AssertIsForeground();
-
-                using (Logger.LogBlock(FunctionId.Tagger_BatchChangeNotifier_NotifyEditorNow, CancellationToken.None))
-                {
-                    if (normalizedSpans.Count == 0)
-                    {
-                        return;
-                    }
-
-                    normalizedSpans = CoalesceSpans(normalizedSpans);
-
-                    // Don't use linq here.  It's a hotspot.
-                    foreach (var span in normalizedSpans)
-                    {
-                        _reportChangedSpan(span);
-                    }
-                }
-            }
-
-            internal static NormalizedSnapshotSpanCollection CoalesceSpans(NormalizedSnapshotSpanCollection normalizedSpans)
-            {
-                var snapshot = normalizedSpans.First().Snapshot;
-
-                // Coalesce the spans if there are a lot of them.
-                if (normalizedSpans.Count > CoalesceDifferenceCount)
-                {
-                    // Spans are normalized.  So to find the whole span we just go from the
-                    // start of the first span to the end of the last span.
-                    normalizedSpans = new NormalizedSnapshotSpanCollection(snapshot.GetSpanFromBounds(
-                        normalizedSpans.First().Start,
-                        normalizedSpans.Last().End));
-                }
-
-                return normalizedSpans;
             }
         }
     }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             {
                 _workQueue.AssertIsForeground();
 
-                _eventSource.Changed += OnChanged;
+                _eventSource.Changed += OnEventSourceChanged;
                 _eventSource.UIUpdatesResumed += OnUIUpdatesResumed;
                 _eventSource.UIUpdatesPaused += OnUIUpdatesPaused;
 
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 _eventSource.UIUpdatesPaused -= OnUIUpdatesPaused;
                 _eventSource.UIUpdatesResumed -= OnUIUpdatesResumed;
-                _eventSource.Changed -= OnChanged;
+                _eventSource.Changed -= OnEventSourceChanged;
             }
 
             private void RaiseTagsChanged(ITextBuffer buffer, DiffResult difference)

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 RaiseResumed();
             }
 
-            private void OnChanged(object sender, TaggerEventArgs e)
+            private void OnEventSourceChanged(object sender, TaggerEventArgs e)
             {
                 RecalculateTagsOnChanged(e);
             }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 if (caret.HasValue)
                 {
                     // If it changed position and we're still in a tag, there's nothing more to do
-                    var currentTags = GetTagIntervalTreeForBuffer(caret.Value.Snapshot.TextBuffer);
+                    var currentTags = TryGetTagIntervalTreeForBuffer(caret.Value.Snapshot.TextBuffer);
                     if (currentTags != null && currentTags.GetIntersectingSpans(new SnapshotSpan(caret.Value, 0)).Count > 0)
                     {
                         // Caret is inside a tag.  No need to do anything.
@@ -688,7 +688,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             /// Returns the TagSpanIntervalTree containing the tags for the given buffer. If no tags
             /// exist for the buffer at all, null is returned.
             /// </summary>
-            public TagSpanIntervalTree<TTag> GetTagIntervalTreeForBuffer(ITextBuffer buffer)
+            public TagSpanIntervalTree<TTag> TryGetTagIntervalTreeForBuffer(ITextBuffer buffer)
             {
                 _workQueue.AssertIsForeground();
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 var buffer = requestedSpans.First().Snapshot.TextBuffer;
                 var tags = accurate
                     ? _tagSource.GetAccurateTagIntervalTreeForBuffer(buffer, cancellationToken)
-                    : _tagSource.GetTagIntervalTreeForBuffer(buffer);
+                    : _tagSource.TryGetTagIntervalTreeForBuffer(buffer);
 
                 if (tags == null)
                 {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
+using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Utilities;
@@ -16,6 +18,14 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
     {
         private sealed partial class Tagger : IAccurateTagger<TTag>, IDisposable
         {
+            /// <summary>
+            /// If we get more than this many differences, then we just issue it as a single change
+            /// notification.  The number has been completely made up without any data to support it.
+            /// 
+            /// Internal for testing purposes.
+            /// </summary>
+            private const int CoalesceDifferenceCount = 10;
+
             #region Fields that can be accessed from either thread
 
             private readonly ITextBuffer _subjectBuffer;
@@ -44,7 +54,8 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 Contract.ThrowIfNull(subjectBuffer);
 
                 _subjectBuffer = subjectBuffer;
-                _batchChangeNotifier = new BatchChangeNotifier(subjectBuffer, listener, notificationService, ReportChangedSpan);
+                _batchChangeNotifier = new BatchChangeNotifier(
+                    subjectBuffer, listener, notificationService, NotifyEditorNow);
 
                 _tagSource = tagSource;
 
@@ -62,21 +73,11 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _tagSource.OnTaggerDisposed(this);
             }
 
-            private void ReportChangedSpan(SnapshotSpan changeSpan)
-            {
-                _batchChangeNotifier.AssertIsForeground();
-                TagsChanged?.Invoke(this, new SnapshotSpanEventArgs(changeSpan));
-            }
-
             private void OnPaused(object sender, EventArgs e)
-            {
-                _batchChangeNotifier.Pause();
-            }
+                => _batchChangeNotifier.Pause();
 
             private void OnResumed(object sender, EventArgs e)
-            {
-                _batchChangeNotifier.Resume();
-            }
+                => _batchChangeNotifier.Resume();
 
             private void OnTagsChangedForBuffer(ICollection<KeyValuePair<ITextBuffer, DiffResult>> changes)
             {
@@ -124,15 +125,55 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _tagSource.RegisterNotification(() => _batchChangeNotifier.EnqueueChanges(changes), (int)delay.ComputeTimeDelay(_subjectBuffer).TotalMilliseconds, CancellationToken.None);
             }
 
-            public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection requestedSpans)
+            private void NotifyEditorNow(NormalizedSnapshotSpanCollection normalizedSpans)
             {
-                return GetTagsWorker(requestedSpans, accurate: false, cancellationToken: CancellationToken.None);
+                _batchChangeNotifier.AssertIsForeground();
+
+                using (Logger.LogBlock(FunctionId.Tagger_BatchChangeNotifier_NotifyEditorNow, CancellationToken.None))
+                {
+                    if (normalizedSpans.Count == 0)
+                    {
+                        return;
+                    }
+
+                    var tagsChanged = this.TagsChanged;
+                    if (tagsChanged == null)
+                    {
+                        return;
+                    }
+
+                    normalizedSpans = CoalesceSpans(normalizedSpans);
+
+                    // Don't use linq here.  It's a hotspot.
+                    foreach (var span in normalizedSpans)
+                    {
+                        tagsChanged(this, new SnapshotSpanEventArgs(span));
+                    }
+                }
             }
 
-            public IEnumerable<ITagSpan<TTag>> GetAllTags(NormalizedSnapshotSpanCollection requestedSpans, CancellationToken cancellationToken)
+            internal static NormalizedSnapshotSpanCollection CoalesceSpans(NormalizedSnapshotSpanCollection normalizedSpans)
             {
-                return GetTagsWorker(requestedSpans, accurate: true, cancellationToken: cancellationToken);
+                var snapshot = normalizedSpans.First().Snapshot;
+
+                // Coalesce the spans if there are a lot of them.
+                if (normalizedSpans.Count > CoalesceDifferenceCount)
+                {
+                    // Spans are normalized.  So to find the whole span we just go from the
+                    // start of the first span to the end of the last span.
+                    normalizedSpans = new NormalizedSnapshotSpanCollection(snapshot.GetSpanFromBounds(
+                        normalizedSpans.First().Start,
+                        normalizedSpans.Last().End));
+                }
+
+                return normalizedSpans;
             }
+
+            public IEnumerable<ITagSpan<TTag>> GetTags(NormalizedSnapshotSpanCollection requestedSpans)
+                => GetTagsWorker(requestedSpans, accurate: false, cancellationToken: CancellationToken.None);
+
+            public IEnumerable<ITagSpan<TTag>> GetAllTags(NormalizedSnapshotSpanCollection requestedSpans, CancellationToken cancellationToken)
+                => GetTagsWorker(requestedSpans, accurate: true, cancellationToken: cancellationToken);
 
             private IEnumerable<ITagSpan<TTag>> GetTagsWorker(
                 NormalizedSnapshotSpanCollection requestedSpans,

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 #endif
         }
 
-        internal IAccurateTagger<T> GetOrCreateTagger<T>(ITextView textViewOpt, ITextBuffer subjectBuffer) where T : ITag
+        internal IAccurateTagger<T> CreateTaggerWorker<T>(ITextView textViewOpt, ITextBuffer subjectBuffer) where T : ITag
         {
             if (!subjectBuffer.GetFeatureOnOffOption(EditorComponentOnOffOptions.Tagger))
             {

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -96,11 +96,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 #endif
         }
 
-        private TagSource CreateTagSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
-        {
-            return new TagSource(textViewOpt, subjectBuffer, this, _asyncListener, _notificationService);
-        }
-
         internal IAccurateTagger<T> GetOrCreateTagger<T>(ITextView textViewOpt, ITextBuffer subjectBuffer) where T : ITag
         {
             if (!subjectBuffer.GetFeatureOnOffOption(EditorComponentOnOffOptions.Tagger))
@@ -109,11 +104,6 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             }
 
             var tagSource = GetOrCreateTagSource(textViewOpt, subjectBuffer);
-            if (tagSource == null)
-            {
-                return null;
-            }
-
             return new Tagger(_asyncListener, _notificationService, tagSource, subjectBuffer) as IAccurateTagger<T>;
         }
 
@@ -121,11 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         {
             if (!this.TryRetrieveTagSource(textViewOpt, subjectBuffer, out var tagSource))
             {
-                tagSource = this.CreateTagSource(textViewOpt, subjectBuffer);
-                if (tagSource == null)
-                {
-                    return null;
-                }
+                tagSource = new TagSource(textViewOpt, subjectBuffer, this, _asyncListener, _notificationService);
 
                 this.StoreTagSource(textViewOpt, subjectBuffer, tagSource);
                 tagSource.Disposed += (s, e) => this.RemoveTagSource(textViewOpt, subjectBuffer);

--- a/src/EditorFeatures/Core/Tagging/AsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousTaggerProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 throw new ArgumentNullException(nameof(subjectBuffer));
             }
 
-            return this.GetOrCreateTagger<T>(null, subjectBuffer);
+            return this.CreateTaggerWorker<T>(null, subjectBuffer);
         }
 
         ITagger<T> ITaggerProvider.CreateTagger<T>(ITextBuffer buffer)

--- a/src/EditorFeatures/Core/Tagging/AsynchronousViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AsynchronousViewTaggerProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 throw new ArgumentNullException(nameof(subjectBuffer));
             }
 
-            return this.GetOrCreateTagger<T>(textView, subjectBuffer);
+            return this.CreateTaggerWorker<T>(textView, subjectBuffer);
         }
 
         ITagger<T> IViewTaggerProvider.CreateTagger<T>(ITextView textView, ITextBuffer buffer)


### PR DESCRIPTION
This pulls out some changes i made in https://github.com/dotnet/roslyn/pull/18385
as they are unblock, but aren't otherwise part of the change to speed up initial tags.