### PR TITLE
Fix "Hide base member" code fix for constants

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
@@ -118,5 +118,18 @@ class App : Application
     public new const int Test = Application.Test + 1;
 }");
         }
+
+        [WorkItem(14455, "https://github.com/dotnet/roslyn/issues/14455")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddNew)]
+        public async Task TestAddNewToConstantInternalFields()
+        {
+            await TestInRegularAndScriptAsync(
+@"class A { internal const int i = 0; }
+class B : A { [|internal const int i = 1;|] }
+",
+@"class A { internal const int i = 0; }
+class B : A { internal new const int i = 1; }
+");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
@@ -93,5 +93,29 @@ class App : Application
     public new int Test;
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddNew)]
+        public async Task TestAddNewToConstant()
+        {
+            await TestInRegularAndScriptAsync(
+@"class Application
+{
+    public const int Test = 1;
+}
+
+class App : Application
+{
+    [|public const int Test = Application.Test + 1;|]
+}",
+@"class Application
+{
+    public const int Test = 1;
+}
+
+class App : Application
+{
+    public new const int Test = Application.Test + 1;
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
@@ -34,7 +34,7 @@ class App : Application
 
 class App : Application
 {
-    public static new App Current { get; set; }
+    public new static App Current { get; set; }
 }");
         }
 
@@ -64,7 +64,7 @@ class App : Application
 
 class App : Application
 {
-    public static new void Method()
+    public new static void Method()
     {
     }
 }");

--- a/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
@@ -94,6 +94,7 @@ class App : Application
 }");
         }
 
+        [WorkItem(18391, "Issue where 'new' keyword would be in the wrong order on 'const' fields.")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddNew)]
         public async Task TestAddNewToConstant()
         {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/HideBase/HideBaseTests.cs
@@ -94,7 +94,7 @@ class App : Application
 }");
         }
 
-        [WorkItem(18391, "Issue where 'new' keyword would be in the wrong order on 'const' fields.")]
+        [WorkItem(18391, "https://github.com/dotnet/roslyn/issues/18391")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddNew)]
         public async Task TestAddNewToConstant()
         {

--- a/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
@@ -53,8 +53,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
                 var fieldDeclaration = node as FieldDeclarationSyntax;
                 if (fieldDeclaration != null)
                 {
-                    var generator = _document.GetLanguageService<SyntaxGenerator>();
-                    newNode = generator.WithModifiers(fieldDeclaration, generator.GetModifiers(fieldDeclaration).WithIsNew(true));
+                    var generator = SyntaxGenerator.GetGenerator(_document);
+                    return generator.WithModifiers(fieldDeclaration, generator.GetModifiers(fieldDeclaration).WithIsNew(true));
                 }
 
                 //Make sure we preserve any trivia from the original node

--- a/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
@@ -36,31 +36,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
 
             private SyntaxNode GetNewNode(Document document, SyntaxNode node, CancellationToken cancellationToken)
             {
-                SyntaxNode newNode = null;
-
-                var propertyStatement = node as PropertyDeclarationSyntax;
-                if (propertyStatement != null)
-                {
-                    newNode = propertyStatement.AddModifiers(SyntaxFactory.Token(SyntaxKind.NewKeyword)) as SyntaxNode;
-                }
-
-                var methodStatement = node as MethodDeclarationSyntax;
-                if (methodStatement != null)
-                {
-                    newNode = methodStatement.AddModifiers(SyntaxFactory.Token(SyntaxKind.NewKeyword));
-                }
-
-                var fieldDeclaration = node as FieldDeclarationSyntax;
-                if (fieldDeclaration != null)
-                {
-                    var generator = SyntaxGenerator.GetGenerator(_document);
-                    return generator.WithModifiers(fieldDeclaration, generator.GetModifiers(fieldDeclaration).WithIsNew(true));
-                }
-
-                //Make sure we preserve any trivia from the original node
-                newNode = newNode.WithTriviaFrom(node);
-
-                return newNode.WithAdditionalAnnotations(Formatter.Annotation);
+                var generator = SyntaxGenerator.GetGenerator(_document);
+                return generator.WithModifiers(node, generator.GetModifiers(node).WithIsNew(true));
             }
         }
     }

--- a/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using System.Threading;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
 {
@@ -51,7 +53,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
                 var fieldDeclaration = node as FieldDeclarationSyntax;
                 if (fieldDeclaration != null)
                 {
-                    newNode = fieldDeclaration.AddModifiers(SyntaxFactory.Token(SyntaxKind.NewKeyword));
+                    var generator = _document.GetLanguageService<SyntaxGenerator>();
+                    newNode = generator.WithModifiers(fieldDeclaration, generator.GetModifiers(fieldDeclaration).WithIsNew(true));
                 }
 
                 //Make sure we preserve any trivia from the original node


### PR DESCRIPTION
Imported the SyntaxGenerator to ensure that when adding `new` keyword to fields with existing modifiers, it would add them in the proper order without overriding any of them.

Fixes #18391