### PR TITLE
"ref readonly" local functions should be treated as "ref readonly"

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             _binder = binder;
-            _refKind = (syntax.ReturnType.Kind() == SyntaxKind.RefType) ? RefKind.Ref : RefKind.None;
+            _syntax.ReturnType.SkipRef(out _refKind);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -19,12 +19,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly Symbol _containingSymbol;
         private readonly DeclarationModifiers _declarationModifiers;
         private readonly ImmutableArray<LocalFunctionTypeParameterSymbol> _typeParameters;
-        private readonly RefKind _refKind;
 
         private ImmutableArray<ParameterSymbol> _lazyParameters;
         private bool _lazyIsVarArg;
         private ImmutableArray<TypeParameterConstraintClause> _lazyTypeParameterConstraints;
         private TypeSymbol _lazyReturnType;
+        private RefKind _lazyRefKind;
         private TypeSymbol _iteratorElementType;
 
         // Lock for initializing lazy fields and registering their diagnostics
@@ -73,7 +73,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             _binder = binder;
-            _syntax.ReturnType.SkipRef(out _refKind);
         }
 
         /// <summary>
@@ -184,7 +183,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _refKind;
+                ComputeReturnType();
+                return _lazyRefKind;
             }
         }
 
@@ -196,8 +196,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var diagnostics = DiagnosticBag.GetInstance();
-            RefKind refKind;
-            TypeSyntax returnTypeSyntax = _syntax.ReturnType.SkipRef(out refKind);
+            TypeSyntax returnTypeSyntax = _syntax.ReturnType.SkipRef(out _lazyRefKind);
             TypeSymbol returnType = _binder.BindType(returnTypeSyntax, diagnostics);
             if (IsAsync &&
                 returnType.SpecialType != SpecialType.System_Void &&
@@ -208,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, this.Locations[0]);
             }
 
-            Debug.Assert(refKind == RefKind.None
+            Debug.Assert(_lazyRefKind == RefKind.None
                 || returnType.SpecialType != SpecialType.System_Void
                 || returnTypeSyntax.HasErrors);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             bool hasBlockBody = syntax.Body != null;
             _isExpressionBodied = !hasBlockBody && syntax.ExpressionBody != null;
-            syntax.ReturnType.SkipRef(out _refKind);
+            _refKind = syntax.ReturnType.GetRefKind();
 
             if (hasBlockBody || _isExpressionBodied)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _location = location;
             _containingType = containingType;
             _syntaxRef = syntax.GetReference();
-            syntax.Type.SkipRef(out _refKind);
+            _refKind = syntax.Type.GetRefKind();
 
             SyntaxTokenList modifiers = syntax.Modifiers;
             bodyBinder = bodyBinder.WithUnsafeRegionIfNecessary(modifiers);

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -148,6 +148,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal static RefKind GetRefKind(this TypeSyntax syntax)
+        {
+            syntax.SkipRef(out var refKind);
+            return refKind;
+        }
+
         internal static TypeSyntax SkipRef(this TypeSyntax syntax, out RefKind refKind)
         {
             refKind = RefKind.None;
@@ -158,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     RefKind.RefReadOnly :
                     RefKind.Ref;
 
-                syntax = ((RefTypeSyntax)syntax).Type;
+                syntax = refType.Type;
             }
 
             return syntax;


### PR DESCRIPTION
The code was ignoring "readonly" part for local functions,

Fixes:#18357