### PR TITLE
Fix Extract Method in methods containing local functions outside the region

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly ImmutableArray<ISymbol> _dataFlowsIn;
 
-        private readonly HashSet<Symbol> _dataFlowsOut = new HashSet<Symbol>();
+        private HashSet<Symbol> _dataFlowsOut = new HashSet<Symbol>();
 
 #if DEBUG
         // we'd like to ensure that only variables get returned in DataFlowsOut that were assigned to inside the region.
@@ -73,6 +73,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             base.EnterRegion();
+        }
+
+        protected override void NoteRead(Symbol variable, ParameterSymbol rangeVariableUnderlyingParameter)
+        {
+            if (!(variable is FieldSymbol) && this.State.Reachable && !IsInside)
+            {
+                int slot = GetOrCreateSlot(variable);
+                if (slot > 0 && !this.State.IsAssigned(slot))
+                {
+                    _dataFlowsOut.Add(variable);
+                }
+            }
+
+            base.NoteRead(variable, rangeVariableUnderlyingParameter);
         }
 
         protected override void NoteWrite(Symbol variable, BoundExpression value, bool read)
@@ -230,6 +244,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitQueryClause(BoundQueryClause node)
         {
             return base.VisitQueryClause(node);
+        }
+
+        public override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
+        {
+            // Only need to save _dataFlowsOut. _assignedInside is only used when InInside is true, and if a local
+            // function appears in the analyzed region it will be marked as bad.
+            var oldDataFlowsOut = _dataFlowsOut;
+
+            try
+            {
+                _dataFlowsOut = new HashSet<Symbol>();
+                return base.VisitLocalFunctionStatement(node);
+            }
+            finally
+            {
+                _dataFlowsOut = oldDataFlowsOut;
+            }
         }
 
         protected override void ReportUnassigned(Symbol symbol, SyntaxNode node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
@@ -20,6 +20,13 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly ImmutableArray<ISymbol> _dataFlowsIn;
 
+        private readonly HashSet<Symbol> _dataFlowsOut = new HashSet<Symbol>();
+
+#if DEBUG
+        // we'd like to ensure that only variables get returned in DataFlowsOut that were assigned to inside the region.
+        private readonly HashSet<Symbol> _assignedInside = new HashSet<Symbol>();
+#endif
+
         private DataFlowsOutWalker(CSharpCompilation compilation, Symbol member, BoundNode node, BoundNode firstInRegion, BoundNode lastInRegion, HashSet<Symbol> unassignedVariables, ImmutableArray<ISymbol> dataFlowsIn)
             : base(compilation, member, node, firstInRegion, lastInRegion, unassignedVariables, trackUnassignments: true)
         {
@@ -44,13 +51,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 walker.Free();
             }
         }
-
-        private readonly HashSet<Symbol> _dataFlowsOut = new HashSet<Symbol>();
-
-#if DEBUG
-        // we'd like to ensure that only variables get returned in DataFlowsOut that were assigned to inside the region.
-        private readonly HashSet<Symbol> _assignedInside = new HashSet<Symbol>();
-#endif
 
         private new HashSet<Symbol> Analyze(ref bool badRegion)
         {

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.cs
@@ -10080,6 +10080,380 @@ namespace ClassLibrary9
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodUnreferencedLocalFunction1()
+        {
+            var code = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            [|int localValue = arg;|]
+
+            int LocalCapture() => arg;
+        }
+    }
+}";
+            var expected = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            NewMethod(arg);
+
+            int LocalCapture() => arg;
+        }
+
+        private static void NewMethod(int arg)
+        {
+            int localValue = arg;
+        }
+    }
+}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodUnreferencedLocalFunction2()
+        {
+            var code = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            int LocalCapture() => arg;
+
+            [|int localValue = arg;|]
+        }
+    }
+}";
+            var expected = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            int LocalCapture() => arg;
+
+            NewMethod(arg);
+        }
+
+        private static void NewMethod(int arg)
+        {
+            int localValue = arg;
+        }
+    }
+}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodUnreferencedLocalFunction3()
+        {
+            var code = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            [|arg = arg + 3;|]
+
+            int LocalCapture() => arg;
+        }
+    }
+}";
+            var expected = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            NewMethod(arg);
+
+            int LocalCapture() => arg;
+        }
+
+        private static void NewMethod(int arg)
+        {
+            arg = arg + 3;
+        }
+    }
+}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodUnreferencedLocalFunction4()
+        {
+            var code = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            int LocalCapture() => arg;
+
+            [|arg = arg + 3;|]
+        }
+    }
+}";
+            var expected = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            int LocalCapture() => arg;
+
+            NewMethod(arg);
+        }
+
+        private static void NewMethod(int arg)
+        {
+            arg = arg + 3;
+        }
+    }
+}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodUnreferencedLocalFunction5()
+        {
+            var code = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            [|arg = arg + 3;|]
+
+            arg = 1;
+
+            int LocalCapture() => arg;
+        }
+    }
+}";
+            var expected = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            NewMethod(arg);
+
+            arg = 1;
+
+            int LocalCapture() => arg;
+        }
+
+        private static void NewMethod(int arg)
+        {
+            arg = arg + 3;
+        }
+    }
+}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        [Theory]
+        [InlineData("LocalCapture();")]
+        [InlineData("System.Func<int> function = LocalCapture;")]
+        [InlineData("System.Func<int> function = () => LocalCapture();")]
+        [Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodFlowsToLocalFunction1(string usageSyntax)
+        {
+            var code = $@"namespace ExtractMethodCrashRepro
+{{
+    public static class SomeClass
+    {{
+        private static void Repro( int arg )
+        {{
+            [|arg = arg + 3;|]
+
+            {usageSyntax}
+
+            int LocalCapture() => arg;
+        }}
+    }}
+}}";
+            var expected = $@"namespace ExtractMethodCrashRepro
+{{
+    public static class SomeClass
+    {{
+        private static void Repro( int arg )
+        {{
+            arg = NewMethod(arg);
+
+            {usageSyntax}
+
+            int LocalCapture() => arg;
+        }}
+
+        private static int NewMethod(int arg)
+        {{
+            arg = arg + 3;
+            return arg;
+        }}
+    }}
+}}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        [Theory]
+        [InlineData("LocalCapture();")]
+        [InlineData("System.Func<int> function = LocalCapture;")]
+        [InlineData("System.Func<int> function = () => LocalCapture();")]
+        [Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodFlowsToLocalFunction2(string usageSyntax)
+        {
+            var code = $@"namespace ExtractMethodCrashRepro
+{{
+    public static class SomeClass
+    {{
+        private static void Repro( int arg )
+        {{
+            int LocalCapture() => arg;
+
+            [|arg = arg + 3;|]
+
+            {usageSyntax}
+        }}
+    }}
+}}";
+            var expected = $@"namespace ExtractMethodCrashRepro
+{{
+    public static class SomeClass
+    {{
+        private static void Repro( int arg )
+        {{
+            int LocalCapture() => arg;
+
+            arg = NewMethod(arg);
+
+            {usageSyntax}
+        }}
+
+        private static int NewMethod(int arg)
+        {{
+            arg = arg + 3;
+            return arg;
+        }}
+    }}
+}}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        /// <summary>
+        /// This test verifies that Extract Method works properly when the region to extract references a local
+        /// function, the local function uses an unassigned but wholly local variable.
+        /// </summary>
+        [Theory]
+        [InlineData("LocalCapture();")]
+        [InlineData("System.Func<int> function = LocalCapture;")]
+        [InlineData("System.Func<int> function = () => LocalCapture();")]
+        [Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodFlowsToLocalFunctionWithUnassignedLocal(string usageSyntax)
+        {
+            var code = $@"namespace ExtractMethodCrashRepro
+{{
+    public static class SomeClass
+    {{
+        private static void Repro( int arg )
+        {{
+            int local;
+            int LocalCapture() => arg + local;
+
+            [|arg = arg + 3;|]
+
+            {usageSyntax}
+        }}
+    }}
+}}";
+            var expected = $@"namespace ExtractMethodCrashRepro
+{{
+    public static class SomeClass
+    {{
+        private static void Repro( int arg )
+        {{
+            int local;
+            int LocalCapture() => arg + local;
+
+            arg = NewMethod(arg);
+
+            {usageSyntax}
+        }}
+
+        private static int NewMethod(int arg)
+        {{
+            arg = arg + 3;
+            return arg;
+        }}
+    }}
+}}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
+        [WorkItem(18347, "https://github.com/dotnet/roslyn/issues/18347")]
+        public async Task ExtractMethodDoesNotFlowToLocalFunction1()
+        {
+            var code = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            [|arg = arg + 3;|]
+
+            arg = 1;
+
+            int LocalCapture() => arg;
+        }
+    }
+}";
+            var expected = @"namespace ExtractMethodCrashRepro
+{
+    public static class SomeClass
+    {
+        private static void Repro( int arg )
+        {
+            NewMethod(arg);
+
+            arg = 1;
+
+            int LocalCapture() => arg;
+        }
+
+        private static void NewMethod(int arg)
+        {
+            arg = arg + 3;
+        }
+    }
+}";
+
+            await TestExtractMethodAsync(code, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]
         public async Task ExtractMethod_Argument1()
         {
             var service = new CSharpExtractMethodService();


### PR DESCRIPTION
Fixes #17165
Fixes #18347

Tagging @dotnet/roslyn-ide and @agocke for review.