### PR TITLE
Disable BasicIntellisenes.TypeAVariableDeclaration until #18397 is fixed

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicIntelliSense.cs
@@ -120,7 +120,7 @@ End Module",
 assertCaretPosition: true);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18397"), Trait(Traits.Feature, Traits.Features.Completion)]
         public void TypeAVariableDeclaration()
         {
             SetUpEditor(@"


### PR DESCRIPTION
@dotnet/roslyn-ide for review. This is to get the vsi_p0 tests passing again in roslyn-internal, as this test has been failing every time.