### PR TITLE
Fix documentation format for tuples in VB too

### DIFF
--- a/src/Compilers/VisualBasic/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.vb
+++ b/src/Compilers/VisualBasic/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.vb
@@ -127,6 +127,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Function
 
             Public Overrides Function VisitNamedType(symbol As NamedTypeSymbol, builder As StringBuilder) As Object
+                If symbol.IsTupleType Then
+                    Return VisitNamedType(DirectCast(symbol, TupleTypeSymbol).UnderlyingNamedType, builder)
+                End If
+
                 If symbol.ContainingSymbol IsNot Nothing AndAlso symbol.ContainingSymbol.Name.Length <> 0 Then
                     Visit(symbol.ContainingSymbol, builder)
                     builder.Append("."c)

--- a/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/DocumentationComments/MethodDocumentationCommentTests.vb
@@ -53,6 +53,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
                             Public Sub M5(ParamArray args() As Object)
                             End Sub
+
+                            Public Sub M7(z As (x1 As Integer, x2 As Integer, x3 As Integer, x4 As Integer, x5 As Integer, x6 As Integer, x7 As Short))
+                            End Sub
+
+                            Public Sub M10(y As (x1 As Integer, x2 As Short), z As System.Tuple(Of Integer, Short))
+                            End Sub
                         End Class
 
                         Class MyList(Of T)
@@ -130,6 +136,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         Public Sub TestMethod6()
             Assert.Equal("M:Acme.Widget.M5(System.Object[])",
                          _widgetClass.GetMembers("M5").Single().GetDocumentationCommentId())
+        End Sub
+
+        <Fact>
+        Public Sub TestMethod7()
+            Assert.Equal("M:Acme.Widget.M7(System.ValueTuple{System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int32,System.Int16})",
+                         _widgetClass.GetMembers("M7").Single().GetDocumentationCommentId())
+        End Sub
+
+        <Fact>
+        Public Sub TestMethod10()
+            Assert.Equal("M:Acme.Widget.M10(System.ValueTuple{System.Int32,System.Int16},System.Tuple{System.Int32,System.Int16})",
+                         _widgetClass.GetMembers("M10").Single().GetDocumentationCommentId())
         End Sub
 
         <Fact>


### PR DESCRIPTION
Corresponding change to https://github.com/dotnet/roslyn/pull/18380 for VB

@dotnet/roslyn-compiler for review.