### PR TITLE
Removes control type from NavBar's accessible names

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarAutomationStrings.cs
+++ b/src/EditorFeatures/Core/Extensibility/NavigationBar/NavigationBarAutomationStrings.cs
@@ -4,11 +4,11 @@ namespace Microsoft.CodeAnalysis.Editor
 {
     internal static class NavigationBarAutomationStrings
     {
-        public const string ProjectDropdownName = "ProjectsDropdown";
+        public const string ProjectDropdownName = "Projects";
         public const string ProjectDropdownId = "ProjectsList";
-        public const string TypeDropdownName = "ObjectsDropdown";
+        public const string TypeDropdownName = "Objects";
         public const string TypeDropdownId = "ScopesList";
-        public const string MemberDropdownName = "MembersDropdown";
+        public const string MemberDropdownName = "Members";
         public const string MemberDropdownId = "FunctionsList";
     }
 }


### PR DESCRIPTION
This fixes #18443 - Accessible name should not contain the type of the control.

Narrator automatically adds the control type, which means that with this fix in place, hitting Ctrl+F2 as described in #18443 will make Narrator say "Projects, WpfApp1, ComboBox"

Screenshot from AccEvent:
![image](https://cloud.githubusercontent.com/assets/1673956/24684004/cb86c96c-1957-11e7-83f5-4b0c6ac73c0c.png)
