### PR TITLE
Allow verify and change commands in RepoUtil to work cross plat

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -328,7 +328,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteWorkspaces", "src\Wor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceHub", "src\Workspaces\Remote\ServiceHub\ServiceHub.csproj", "{80FDDD00-9393-47F7-8BAF-7E87CE011068}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepoUtil", "src\Tools\RepoUtil\RepoUtil.csproj", "{1CA184D3-89CB-4074-BEC5-F8AEBA657D41}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepoUtil", "src\Tools\RepoUtil\RepoUtil.old.csproj", "{1CA184D3-89CB-4074-BEC5-F8AEBA657D41}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuildTask", "src\Compilers\Core\MSBuildTask\MSBuildTask.csproj", "{7AD4FE65-9A30-41A6-8004-AA8F89BCB7F3}"
 EndProject

--- a/src/Tools/RepoUtil/ChangeCommand.cs
+++ b/src/Tools/RepoUtil/ChangeCommand.cs
@@ -202,7 +202,7 @@ namespace RepoUtil
             var msbuildData = _repoData.RepoConfig.MSBuildGenerateData;
             if (msbuildData.HasValue)
             {
-                var fileName = new FileName(_generateDirectory, msbuildData.Value.RelativeFilePath.Replace("\\", "/"));
+                var fileName = new FileName(_generateDirectory, msbuildData.Value.RelativeFilePath);
                 var packages = GenerateUtil.GetFilteredPackages(msbuildData.Value, _repoData);
                 GenerateUtil.WriteMSBuildContent(fileName, packages);
             }

--- a/src/Tools/RepoUtil/ChangeCommand.cs
+++ b/src/Tools/RepoUtil/ChangeCommand.cs
@@ -202,7 +202,7 @@ namespace RepoUtil
             var msbuildData = _repoData.RepoConfig.MSBuildGenerateData;
             if (msbuildData.HasValue)
             {
-                var fileName = new FileName(_generateDirectory, msbuildData.Value.RelativeFilePath);
+                var fileName = new FileName(_generateDirectory, msbuildData.Value.RelativeFilePath.Replace("\\", "/"));
                 var packages = GenerateUtil.GetFilteredPackages(msbuildData.Value, _repoData);
                 GenerateUtil.WriteMSBuildContent(fileName, packages);
             }

--- a/src/Tools/RepoUtil/GenerateData.cs
+++ b/src/Tools/RepoUtil/GenerateData.cs
@@ -19,7 +19,7 @@ namespace RepoUtil
 
         internal GenerateData(string relativeFileName, ImmutableArray<Regex> packages)
         {
-            RelativeFilePath = relativeFileName;
+            RelativeFilePath = relativeFileName.Replace("\\", "/");
             Packages = packages;
         }
     }

--- a/src/Tools/RepoUtil/RepoUtil.csproj
+++ b/src/Tools/RepoUtil/RepoUtil.csproj
@@ -1,86 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\build\Targets\Settings.props" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ProjectGuid>{1CA184D3-89CB-4074-BEC5-F8AEBA657D41}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>RepoUtil</RootNamespace>
-    <AssemblyName>RepoUtil</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <TargetFrameworkProfile />
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PackageId>RepoUtil</PackageId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="WindowsBase" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ChangeCommand.cs" />
-    <Compile Include="ConflictingPackagesException.cs" />
-    <Compile Include="Constants.cs" />
-    <Compile Include="ConsumesCommand.cs" />
-    <Compile Include="FileName.cs" />
-    <Compile Include="GenerateData.cs" />
-    <Compile Include="GenerateUtil.cs" />
-    <Compile Include="ICommand.cs" />
-    <Compile Include="JsonTypes.cs" />
-    <Compile Include="NuGetConfigUtil.cs" />
-    <Compile Include="NuGetFeed.cs" />
-    <Compile Include="NuGetPackage.cs" />
-    <Compile Include="NuGetPackageChange.cs" />
-    <Compile Include="NuGetPackageSource.cs" />
-    <Compile Include="NuSpecUtil.cs" />
-    <Compile Include="ProducesCommand.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="ProjectJsonUtil.cs" />
-    <Compile Include="RepoConfig.cs" />
-    <Compile Include="RepoData.cs" />
-    <Compile Include="UsageCommand.cs" />
-    <Compile Include="ViewCommand.cs" />
-    <Compile Include="VerifyCommand.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-    <None Include="project.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.6">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.6 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="..\..\..\build\Targets\Imports.targets" />
+
 </Project>

--- a/src/Tools/RepoUtil/RepoUtil.csproj
+++ b/src/Tools/RepoUtil/RepoUtil.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\'))</RepoRoot>
+    <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$(RepoRoot)Binaries\</BaseOutputPath>
+    <OutDir>$(BaseOutputPath)$(Configuration)\</OutDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RepoRoot)Binaries\Obj\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(MSBuildProjectName)\</IntermediateOutputPath>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-    <PackageId>RepoUtil</PackageId>
+    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/RepoUtil/RepoUtil.old.csproj
+++ b/src/Tools/RepoUtil/RepoUtil.old.csproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\build\Targets\Settings.props" />
+  <PropertyGroup>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ProjectGuid>{1CA184D3-89CB-4074-BEC5-F8AEBA657D41}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RepoUtil</RootNamespace>
+    <AssemblyName>RepoUtil</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <TargetFrameworkProfile />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ChangeCommand.cs" />
+    <Compile Include="ConflictingPackagesException.cs" />
+    <Compile Include="Constants.cs" />
+    <Compile Include="ConsumesCommand.cs" />
+    <Compile Include="FileName.cs" />
+    <Compile Include="GenerateData.cs" />
+    <Compile Include="GenerateUtil.cs" />
+    <Compile Include="ICommand.cs" />
+    <Compile Include="JsonTypes.cs" />
+    <Compile Include="NuGetConfigUtil.cs" />
+    <Compile Include="NuGetFeed.cs" />
+    <Compile Include="NuGetPackage.cs" />
+    <Compile Include="NuGetPackageChange.cs" />
+    <Compile Include="NuGetPackageSource.cs" />
+    <Compile Include="NuSpecUtil.cs" />
+    <Compile Include="ProducesCommand.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="ProjectJsonUtil.cs" />
+    <Compile Include="RepoConfig.cs" />
+    <Compile Include="RepoData.cs" />
+    <Compile Include="UsageCommand.cs" />
+    <Compile Include="ViewCommand.cs" />
+    <Compile Include="VerifyCommand.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.6">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.6 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <Import Project="..\..\..\build\Targets\Imports.targets" />
+</Project>

--- a/src/Tools/RepoUtil/RepoUtil.sln
+++ b/src/Tools/RepoUtil/RepoUtil.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepoUtil", "RepoUtil.csproj", "{1CA184D3-89CB-4074-BEC5-F8AEBA657D41}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepoUtil", "RepoUtil.old.csproj", "{1CA184D3-89CB-4074-BEC5-F8AEBA657D41}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Tools/RepoUtil/VerifyCommand.cs
+++ b/src/Tools/RepoUtil/VerifyCommand.cs
@@ -101,7 +101,7 @@ namespace RepoUtil
                 var packages = GenerateUtil.GetFilteredPackages(data, repoData);
 
                 // Need to verify the contents of the generated file are correct.
-                var fileName = new FileName(_generateDirectory, data.RelativeFilePath.Replace("\\", "/"));
+                var fileName = new FileName(_generateDirectory, data.RelativeFilePath);
                 var actualContent = File.ReadAllText(fileName.FullPath, GenerateUtil.Encoding);
                 var expectedContent = GenerateUtil.GenerateMSBuildContent(packages);
                 if (actualContent.Trim() != expectedContent.Trim())

--- a/src/Tools/RepoUtil/VerifyCommand.cs
+++ b/src/Tools/RepoUtil/VerifyCommand.cs
@@ -101,10 +101,10 @@ namespace RepoUtil
                 var packages = GenerateUtil.GetFilteredPackages(data, repoData);
 
                 // Need to verify the contents of the generated file are correct.
-                var fileName = new FileName(_generateDirectory, data.RelativeFilePath);
+                var fileName = new FileName(_generateDirectory, data.RelativeFilePath.Replace("\\", "/"));
                 var actualContent = File.ReadAllText(fileName.FullPath, GenerateUtil.Encoding);
                 var expectedContent = GenerateUtil.GenerateMSBuildContent(packages);
-                if (actualContent != expectedContent)
+                if (actualContent.Trim() != expectedContent.Trim())
                 {
                     writer.WriteLine($"{fileName.RelativePath} does not have the expected contents");
                     allGood = false;
@@ -112,7 +112,7 @@ namespace RepoUtil
 
                 if (!allGood)
                 {
-                    writer.WriteLine($@"Generated contents out of date. Run ""RepoUtil.change"" to correct");
+                    writer.WriteLine($@"Generated contents out of date. Run ""RepoUtil change"" to correct");
                     return false;
                 }
 


### PR DESCRIPTION
Quick fix to workaround this issue before the shift over to 2.0

The way I have this setup in my build is to inject a RuntimeIdentifier (probably need to add a default for win7-x64) and publish a stand alone app. I could make this a lot neater but wasn't sure how much effort should go into this before moving over to the 2.0 tooling.

/cc @ellismg @jaredpar 