### PR TITLE
Don't offer several code actions on identifiers that are likely intended to be C# keywords.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -165,6 +165,7 @@
   <ItemGroup>
     <Compile Include="AddBraces\AddBracesFixAllTests.cs" />
     <Compile Include="AddBraces\AddBracesTests.cs" />
+    <Compile Include="Diagnostics\AddUsing\AddUsingTestsWithAddImportDiagnosticProvider.cs" />
     <Compile Include="InitializeParameter\AddParameterCheckTests.cs" />
     <Compile Include="AddParameter\AddParameterTests.cs" />
     <Compile Include="AutomaticCompletion\AutomaticBraceCompletionTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.AddImport;
-using Microsoft.CodeAnalysis.CSharp.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
@@ -4533,233 +4532,26 @@ namespace N
 }", index: 1);
         }
 
-        public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+        [WorkItem(18275, "https://github.com/dotnet/roslyn/issues/18275")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestContextualKeyword1()
         {
-            internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-                => (new CSharpUnboundIdentifiersDiagnosticAnalyzer(), new CSharpAddImportCodeFixProvider());
-
-            private Task TestAsync(
-                 string initialMarkup,
-                 string expected,
-                 bool systemSpecialCase,
-                 int index = 0)
-            {
-                return TestInRegularAndScriptAsync(initialMarkup, expected, index: index, options: new Dictionary<OptionKey, object>
-                {
-                    { new OptionKey(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp), systemSpecialCase }
-                });
-            }
-
-            [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestIncompleteLambda1()
-            {
-                await TestInRegularAndScriptAsync(
-@"using System.Linq;
-
-class C
+            await TestMissingInRegularAndScriptAsync(
+@"
+namespace N
 {
-    C()
+    class nameof
     {
-        """".Select(() => {
-        new [|Byte|]",
-@"using System;
-using System.Linq;
-
-class C
-{
-    C()
-    {
-        """".Select(() => {
-        new Byte");
-            }
-
-            [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestIncompleteLambda2()
-            {
-                await TestInRegularAndScriptAsync(
-@"using System.Linq;
-
-class C
-{
-    C()
-    {
-        """".Select(() => {
-            new [|Byte|]() }",
-@"using System;
-using System.Linq;
-
-class C
-{
-    C()
-    {
-        """".Select(() => {
-            new Byte() }");
-            }
-
-            [WorkItem(860648, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860648")]
-            [WorkItem(902014, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/902014")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestIncompleteSimpleLambdaExpression()
-            {
-                await TestInRegularAndScriptAsync(
-@"using System.Linq;
-
-class Program
-{
-    static void Main(string[] args)
-    {
-        args[0].Any(x => [|IBindCtx|]
-        string a;
     }
-}",
-@"using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
+}
 
-class Program
+class C
 {
-    static void Main(string[] args)
+    void M()
     {
-        args[0].Any(x => IBindCtx
-        string a;
+        [|nameof|]
     }
 }");
-            }
-
-            [WorkItem(829970, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829970")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestUnknownIdentifierGenericName()
-            {
-                await TestInRegularAndScriptAsync(
-@"class C
-{
-    private [|List<int>|]
-}",
-@"using System.Collections.Generic;
-
-class C
-{
-    private List<int>
-}");
-            }
-
-            [WorkItem(829970, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829970")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestUnknownIdentifierInAttributeSyntaxWithoutTarget()
-            {
-                await TestInRegularAndScriptAsync(
-@"class C
-{
-    [[|Extension|]]
-}",
-@"using System.Runtime.CompilerServices;
-
-class C
-{
-    [Extension]
-}");
-            }
-
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestOutsideOfMethodWithMalformedGenericParameters()
-            {
-                await TestInRegularAndScriptAsync(
-@"using System;
-
-class Program
-{
-    Func<[|FlowControl|] x }",
-@"using System;
-using System.Reflection.Emit;
-
-class Program
-{
-    Func<FlowControl x }");
-            }
-
-            [WorkItem(752640, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/752640")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestUnknownIdentifierWithSyntaxError()
-            {
-                await TestInRegularAndScriptAsync(
-@"class C
-{
-    [|Directory|] private int i;
-}",
-@"using System.IO;
-
-class C
-{
-    Directory private int i;
-}");
-            }
-
-            [WorkItem(855748, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/855748")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestGenericNameWithBrackets()
-            {
-                await TestInRegularAndScriptAsync(
-@"class Class
-{
-    [|List|]
-}",
-@"using System.Collections.Generic;
-
-class Class
-{
-    List
-}");
-
-                await TestInRegularAndScriptAsync(
-@"class Class
-{
-    [|List<>|]
-}",
-@"using System.Collections.Generic;
-
-class Class
-{
-    List<>
-}");
-
-                await TestInRegularAndScriptAsync(
-@"class Class
-{
-    List[|<>|]
-}",
-@"using System.Collections.Generic;
-
-class Class
-{
-    List<>
-}");
-            }
-
-            [WorkItem(867496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867496")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestMalformedGenericParameters()
-            {
-                await TestInRegularAndScriptAsync(
-@"class Class
-{
-    [|List<|] }",
-@"using System.Collections.Generic;
-
-class Class
-{
-    List< }");
-
-                await TestInRegularAndScriptAsync(
-@"class Class
-{
-    [|List<Y x;|] }",
-@"using System.Collections.Generic;
-
-class Class
-{
-    List<Y x; }");
-            }
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTestsWithAddImportDiagnosticProvider.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTestsWithAddImportDiagnosticProvider.cs
@@ -1,0 +1,247 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.AddImport;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Options;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
+{
+    public partial class AddUsingTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+        {
+            internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+                => (new CSharpUnboundIdentifiersDiagnosticAnalyzer(), new CSharpAddImportCodeFixProvider());
+
+            private Task TestAsync(
+                 string initialMarkup,
+                 string expected,
+                 bool systemSpecialCase,
+                 int index = 0)
+            {
+                return TestInRegularAndScriptAsync(initialMarkup, expected, index: index, options: new Dictionary<OptionKey, object>
+                {
+                    { new OptionKey(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp), systemSpecialCase }
+                });
+            }
+
+            [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestIncompleteLambda1()
+            {
+                await TestInRegularAndScriptAsync(
+@"using System.Linq;
+
+class C
+{
+    C()
+    {
+        """".Select(() => {
+        new [|Byte|]",
+@"using System;
+using System.Linq;
+
+class C
+{
+    C()
+    {
+        """".Select(() => {
+        new Byte");
+            }
+
+            [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestIncompleteLambda2()
+            {
+                await TestInRegularAndScriptAsync(
+@"using System.Linq;
+
+class C
+{
+    C()
+    {
+        """".Select(() => {
+            new [|Byte|]() }",
+@"using System;
+using System.Linq;
+
+class C
+{
+    C()
+    {
+        """".Select(() => {
+            new Byte() }");
+            }
+
+            [WorkItem(860648, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860648")]
+            [WorkItem(902014, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/902014")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestIncompleteSimpleLambdaExpression()
+            {
+                await TestInRegularAndScriptAsync(
+@"using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        args[0].Any(x => [|IBindCtx|]
+        string a;
+    }
+}",
+@"using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        args[0].Any(x => IBindCtx
+        string a;
+    }
+}");
+            }
+
+            [WorkItem(829970, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829970")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestUnknownIdentifierGenericName()
+            {
+                await TestInRegularAndScriptAsync(
+@"class C
+{
+    private [|List<int>|]
+}",
+@"using System.Collections.Generic;
+
+class C
+{
+    private List<int>
+}");
+            }
+
+            [WorkItem(829970, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829970")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestUnknownIdentifierInAttributeSyntaxWithoutTarget()
+            {
+                await TestInRegularAndScriptAsync(
+@"class C
+{
+    [[|Extension|]]
+}",
+@"using System.Runtime.CompilerServices;
+
+class C
+{
+    [Extension]
+}");
+            }
+
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestOutsideOfMethodWithMalformedGenericParameters()
+            {
+                await TestInRegularAndScriptAsync(
+@"using System;
+
+class Program
+{
+    Func<[|FlowControl|] x }",
+@"using System;
+using System.Reflection.Emit;
+
+class Program
+{
+    Func<FlowControl x }");
+            }
+
+            [WorkItem(752640, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/752640")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestUnknownIdentifierWithSyntaxError()
+            {
+                await TestInRegularAndScriptAsync(
+@"class C
+{
+    [|Directory|] private int i;
+}",
+@"using System.IO;
+
+class C
+{
+    Directory private int i;
+}");
+            }
+
+            [WorkItem(855748, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/855748")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestGenericNameWithBrackets()
+            {
+                await TestInRegularAndScriptAsync(
+@"class Class
+{
+    [|List|]
+}",
+@"using System.Collections.Generic;
+
+class Class
+{
+    List
+}");
+
+                await TestInRegularAndScriptAsync(
+@"class Class
+{
+    [|List<>|]
+}",
+@"using System.Collections.Generic;
+
+class Class
+{
+    List<>
+}");
+
+                await TestInRegularAndScriptAsync(
+@"class Class
+{
+    List[|<>|]
+}",
+@"using System.Collections.Generic;
+
+class Class
+{
+    List<>
+}");
+            }
+
+            [WorkItem(867496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867496")]
+            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+            public async Task TestMalformedGenericParameters()
+            {
+                await TestInRegularAndScriptAsync(
+@"class Class
+{
+    [|List<|] }",
+@"using System.Collections.Generic;
+
+class Class
+{
+    List< }");
+
+                await TestInRegularAndScriptAsync(
+@"class Class
+{
+    [|List<Y x;|] }",
+@"using System.Collections.Generic;
+
+class Class
+{
+    List<Y x; }");
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTestsWithAddImportDiagnosticProvider.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTestsWithAddImportDiagnosticProvider.cs
@@ -13,30 +13,28 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddUsing
 {
-    public partial class AddUsingTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
-        public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
-        {
-            internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-                => (new CSharpUnboundIdentifiersDiagnosticAnalyzer(), new CSharpAddImportCodeFixProvider());
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (new CSharpUnboundIdentifiersDiagnosticAnalyzer(), new CSharpAddImportCodeFixProvider());
 
-            private Task TestAsync(
-                 string initialMarkup,
-                 string expected,
-                 bool systemSpecialCase,
-                 int index = 0)
-            {
-                return TestInRegularAndScriptAsync(initialMarkup, expected, index: index, options: new Dictionary<OptionKey, object>
+        private Task TestAsync(
+             string initialMarkup,
+             string expected,
+             bool systemSpecialCase,
+             int index = 0)
+        {
+            return TestInRegularAndScriptAsync(initialMarkup, expected, index: index, options: new Dictionary<OptionKey, object>
                 {
                     { new OptionKey(GenerationOptions.PlaceSystemNamespaceFirst, LanguageNames.CSharp), systemSpecialCase }
                 });
-            }
+        }
 
-            [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestIncompleteLambda1()
-            {
-                await TestInRegularAndScriptAsync(
+        [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestIncompleteLambda1()
+        {
+            await TestInRegularAndScriptAsync(
 @"using System.Linq;
 
 class C
@@ -54,13 +52,13 @@ class C
     {
         """".Select(() => {
         new Byte");
-            }
+        }
 
-            [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestIncompleteLambda2()
-            {
-                await TestInRegularAndScriptAsync(
+        [WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestIncompleteLambda2()
+        {
+            await TestInRegularAndScriptAsync(
 @"using System.Linq;
 
 class C
@@ -78,14 +76,14 @@ class C
     {
         """".Select(() => {
             new Byte() }");
-            }
+        }
 
-            [WorkItem(860648, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860648")]
-            [WorkItem(902014, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/902014")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestIncompleteSimpleLambdaExpression()
-            {
-                await TestInRegularAndScriptAsync(
+        [WorkItem(860648, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860648")]
+        [WorkItem(902014, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/902014")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestIncompleteSimpleLambdaExpression()
+        {
+            await TestInRegularAndScriptAsync(
 @"using System.Linq;
 
 class Program
@@ -107,13 +105,13 @@ class Program
         string a;
     }
 }");
-            }
+        }
 
-            [WorkItem(829970, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829970")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestUnknownIdentifierGenericName()
-            {
-                await TestInRegularAndScriptAsync(
+        [WorkItem(829970, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829970")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestUnknownIdentifierGenericName()
+        {
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     private [|List<int>|]
@@ -124,13 +122,13 @@ class C
 {
     private List<int>
 }");
-            }
+        }
 
-            [WorkItem(829970, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829970")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestUnknownIdentifierInAttributeSyntaxWithoutTarget()
-            {
-                await TestInRegularAndScriptAsync(
+        [WorkItem(829970, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/829970")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestUnknownIdentifierInAttributeSyntaxWithoutTarget()
+        {
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     [[|Extension|]]
@@ -141,12 +139,12 @@ class C
 {
     [Extension]
 }");
-            }
+        }
 
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestOutsideOfMethodWithMalformedGenericParameters()
-            {
-                await TestInRegularAndScriptAsync(
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestOutsideOfMethodWithMalformedGenericParameters()
+        {
+            await TestInRegularAndScriptAsync(
 @"using System;
 
 class Program
@@ -158,13 +156,13 @@ using System.Reflection.Emit;
 class Program
 {
     Func<FlowControl x }");
-            }
+        }
 
-            [WorkItem(752640, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/752640")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestUnknownIdentifierWithSyntaxError()
-            {
-                await TestInRegularAndScriptAsync(
+        [WorkItem(752640, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/752640")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestUnknownIdentifierWithSyntaxError()
+        {
+            await TestInRegularAndScriptAsync(
 @"class C
 {
     [|Directory|] private int i;
@@ -175,13 +173,13 @@ class C
 {
     Directory private int i;
 }");
-            }
+        }
 
-            [WorkItem(855748, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/855748")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestGenericNameWithBrackets()
-            {
-                await TestInRegularAndScriptAsync(
+        [WorkItem(855748, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/855748")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestGenericNameWithBrackets()
+        {
+            await TestInRegularAndScriptAsync(
 @"class Class
 {
     [|List|]
@@ -193,7 +191,7 @@ class Class
     List
 }");
 
-                await TestInRegularAndScriptAsync(
+            await TestInRegularAndScriptAsync(
 @"class Class
 {
     [|List<>|]
@@ -205,7 +203,7 @@ class Class
     List<>
 }");
 
-                await TestInRegularAndScriptAsync(
+            await TestInRegularAndScriptAsync(
 @"class Class
 {
     List[|<>|]
@@ -216,13 +214,13 @@ class Class
 {
     List<>
 }");
-            }
+        }
 
-            [WorkItem(867496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867496")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
-            public async Task TestMalformedGenericParameters()
-            {
-                await TestInRegularAndScriptAsync(
+        [WorkItem(867496, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867496")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestMalformedGenericParameters()
+        {
+            await TestInRegularAndScriptAsync(
 @"class Class
 {
     [|List<|] }",
@@ -232,7 +230,7 @@ class Class
 {
     List< }");
 
-                await TestInRegularAndScriptAsync(
+            await TestInRegularAndScriptAsync(
 @"class Class
 {
     [|List<Y x;|] }",
@@ -241,7 +239,6 @@ class Class
 class Class
 {
     List<Y x; }");
-            }
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
@@ -1318,5 +1318,27 @@ namespace n2
     }
 }");
         }
+
+        [WorkItem(18275, "https://github.com/dotnet/roslyn/issues/18275")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestContextualKeyword1()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+namespace N
+{
+    class nameof
+    {
+    }
+}
+
+class C
+{
+    void M()
+    {
+        [|nameof|]
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -7154,5 +7154,27 @@ public class Foo
     public string String { get; private set; }
 }");
         }
+
+        [WorkItem(18275, "https://github.com/dotnet/roslyn/issues/18275")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestContextualKeyword1()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+namespace N
+{
+    class nameof
+    {
+    }
+}
+
+class C
+{
+    void M()
+    {
+        [|nameof|]
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -21,19 +21,13 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
         AbstractGenerateVariableService<CSharpGenerateVariableService, SimpleNameSyntax, ExpressionSyntax>
     {
         protected override bool IsExplicitInterfaceGeneration(SyntaxNode node)
-        {
-            return node is PropertyDeclarationSyntax;
-        }
+            => node is PropertyDeclarationSyntax;
 
         protected override bool IsIdentifierNameGeneration(SyntaxNode node)
-        {
-            return node is IdentifierNameSyntax;
-        }
+            => node is IdentifierNameSyntax identifier && !identifier.Identifier.CouldBeKeyword();
 
         protected override bool ContainingTypesOrSelfHasUnsafeKeyword(INamedTypeSymbol containingType)
-        {
-            return containingType.ContainingTypesOrSelfHasUnsafeKeyword();
-        }
+            => containingType.ContainingTypesOrSelfHasUnsafeKeyword();
 
         protected override bool TryInitializeExplicitInterfaceState(
             SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken,

--- a/src/Workspaces/CSharp/Portable/Extensions/SimpleNameSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SimpleNameSyntaxExtensions.cs
@@ -62,9 +62,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return false;
             }
 
-            if (simpleName.IsVar)
+            if (simpleName.Identifier.CouldBeKeyword())
             {
-                // 'var' is much more likely to represent a keyword rather than "a possible type name".
+                // Something that looks like a keyword is almost certainly not intended to be a
+                // "Standalone type name".  
+                //
+                // 1. Users are not going to name types the same name as C# keywords (contextual or otherwise).
+                // 2. Types in .Net are virtually always start with a Uppercase. While keywords are lowercase)
+                //
+                // Having a lowercase identifier which matches a c# keyword is enough of a signal 
+                // to just not treat this as a standalone type name (even though for some identifiers
+                // it could be according to the language).
                 return false;
             }
 

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
@@ -299,5 +299,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         {
             return token.IsKind(SyntaxKind.OpenBraceToken) && token.Parent.IsKind(SyntaxKind.AccessorList);
         }
+
+        /// <summary>
+        /// Returns true if this token is something that looks like a C# keyword. This includes 
+        /// actual keywords, contextual keywords, and even 'var' and 'dynamic'
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public static bool CouldBeKeyword(this SyntaxToken token)
+        {
+            if (token.IsKeyword())
+            {
+                return true;
+            }
+
+            if (token.Kind() == SyntaxKind.IdentifierToken)
+            {
+                var simpleNameText = token.ValueText;
+                return simpleNameText == "var" ||
+                    simpleNameText == "dynamic" ||
+                    SyntaxFacts.GetContextualKeywordKind(simpleNameText) != SyntaxKind.None;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
@@ -317,8 +317,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             {
                 var simpleNameText = token.ValueText;
                 return simpleNameText == "var" ||
-                    simpleNameText == "dynamic" ||
-                    SyntaxFacts.GetContextualKeywordKind(simpleNameText) != SyntaxKind.None;
+                       simpleNameText == "dynamic" ||
+                       SyntaxFacts.GetContextualKeywordKind(simpleNameText) != SyntaxKind.None;
             }
 
             return false;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/18275