### PR TITLE
Fix a bug in code gen for switch on byte or ushort

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -3014,6 +3014,72 @@ class C
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion1, "b").WithArguments("switch on boolean type", "2"));
         }
 
+        [Fact]
+        public void SmallUnsignedEdgeCase01()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main(string[] args)
+    {
+        RunTest(126);
+        RunTest(127);
+        RunTest(128);
+        RunTest(129);
+
+        void RunTest(byte testByte)
+        {
+            switch (testByte)
+            {
+                case 127: // 0111 1111
+                case 128: // 1000 0000
+                    Console.Write(0);
+                    break;
+                default:
+                    Console.Write(1);
+                    break;
+            }
+        }
+    }
+}";
+            var comp = CompileAndVerify(source, expectedOutput: @"1001");
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void SmallUnsignedEdgeCase02()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main(string[] args)
+    {
+        RunTest(32766);
+        RunTest(32767);
+        RunTest(32768);
+        RunTest(32769);
+
+        void RunTest(ushort testUshort)
+        {
+            switch (testUshort)
+            {
+                case 32767: // 0111 1111 1111 1111
+                case 32768: // 1000 0000 0000 0000
+                    Console.Write(0);
+                    break;
+                default:
+                    Console.Write(1);
+                    break;
+            }
+        }
+    }
+}";
+            var comp = CompileAndVerify(source, expectedOutput: @"1001");
+            comp.VerifyDiagnostics();
+        }
+
         #endregion
     }
 }

--- a/src/Compilers/Core/Portable/CodeGen/SwitchIntegralJumpTableEmitter.cs
+++ b/src/Compilers/Core/Portable/CodeGen/SwitchIntegralJumpTableEmitter.cs
@@ -466,7 +466,20 @@ namespace Microsoft.CodeAnalysis.CodeGen
             }
             else
             {
-                _builder.EmitIntConstant(endConstant.Int32Value - startConstant.Int32Value);
+                int Int32Value(ConstantValue value)
+                {
+                    // ConstantValue does not correctly convert byte and ushort values to int.
+                    // It sign extends them rather than padding them. We compensate for that here.
+                    // See also https://github.com/dotnet/roslyn/issues/18579
+                    switch (value.Discriminator)
+                    {
+                        case ConstantValueTypeDiscriminator.Byte: return value.ByteValue;
+                        case ConstantValueTypeDiscriminator.UInt16: return value.UInt16Value;
+                        default: return value.Int32Value;
+                    }
+                }
+
+                _builder.EmitIntConstant(Int32Value(endConstant) - Int32Value(startConstant));
             }
 
             _builder.EmitBranch(ILOpCode.Ble_un, targetLabel, ILOpCode.Bgt_un);


### PR DESCRIPTION
Fixes #18188

The bug arose because of an interaction of this line (new in VS2017)

``` c#
                _builder.EmitIntConstant(endConstant.Int32Value - startConstant.Int32Value);
```

in `SwitchIntegralJumpTableEmitter` and an incorrect implementation of `Int32Value` for constants of type `ushort` and `ubyte`, which is recorded as a separate bug in https://github.com/dotnet/roslyn/issues/18579. Specifically, the implementation causes improper sign extension of what should be treated as an unsigned value.

We never caught this before because we didn't rely on it. Constant folding in the compiler goes through another (redundant) code path that gets the padding vs sign extension correct. Because this is a serious regression in the compiler, I am hoping we can include this fix is some upcoming patch at our earliest opportunity. Therefore I have included a simple, local fix for the symptom, while leaving the larger issue of `ConstantValue` to be dealt with in a later larger change. 

@VSadov @dotnet/roslyn-compiler May I please have a couple of reviews of this simple fix to a nasty bug?
