### PR TITLE
Implement SourceLink for Windows PDBs

### DIFF
--- a/docs/compilers/CSharp/CommandLine.md
+++ b/docs/compilers/CSharp/CommandLine.md
@@ -29,7 +29,11 @@
 | `/linkresource`:*resinfo* | Link the specified resource to this assembly (Short form: `/linkres`) Where the *resinfo* format  is *file*{`,`*string name*{`,``public``|``private`}}
 | **CODE GENERATION**
 | `/debug`{`+`&#124;`-`} | Emit (or do not Emit) debugging information
-| `/debug`:{`full`&#124;`pdbonly`&#124;`portable`} | Specify debugging type (`full` is default, and  enables attaching a debugger to a running program. `portable` is a cross-platform format)
+| `/debug`:`full` | Emit debugging information to .pdb file using default format for the current platform: _Windows PDB_ on Windows, _Portable PDB_ on other systems
+| `/debug`:`pdbonly` | Same as `/debug:full`. For backward compatibility. 
+| `/debug`:`portable` | Emit debugging information to to .pdb file using cross-platform [Portable PDB format](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md)
+| `/debug`:`embedded` | Emit debugging information into the .dll/.exe itself (.pdb file is not produced) using [Portable PDB format](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md).
+| `/sourcelink`:*file* | [Source link](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/source_link.md) info to embed into PDB.
 | `/optimize`{`+`&#124;`-`} | Enable optimizations (Short form: `/o`)
 | `/deterministic` | Produce a deterministic assembly (including module version GUID and timestamp)
 | **ERRORS AND WARNINGS**

--- a/docs/compilers/Visual Basic/CommandLine.md
+++ b/docs/compilers/Visual Basic/CommandLine.md
@@ -27,9 +27,14 @@
 | `/win32manifest:`*file* | The provided file is embedded in the manifest section of the output PE.
 | `/win32resource:`*file* | Specifies a Win32 resource file (.res).
 | **CODE GENERATION**
+| `/debug`{`+`&#124;`-`} | Emit debugging information.
+| `/debug`:`full` | Emit debugging information to .pdb file using default format for the current platform: _Windows PDB_ on Windows, _Portable PDB_ on other systems
+| `/debug`:`pdbonly` | Same as `/debug:full`. For backward compatibility. 
+| `/debug`:`portable` | Emit debugging information to to .pdb file using cross-platform [Portable PDB format](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md)
+| `/debug`:`embedded` | Emit debugging information into the .dll/.exe itself (.pdb file is not produced) using [Portable PDB format](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md).
+| `/sourcelink`:*file* | [Source link](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/source_link.md) info to embed into PDB.
 | `/optimize`{`+`&#124;`-`} | Enable optimizations.
 | `/removeintchecks`{`+`&#124;`-`} | Remove integer checks. Default off.
-| `/debug`{`+`&#124;`-`} | Emit debugging information.
 | `/debug:full` | Emit full debugging information (default).
 | `/debug:portable` | Emit debugging information in the portable format.
 | `/debug:pdbonly` | Emit PDB file only.

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8675,11 +8675,11 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /sourcelink switch is only supported when emitting Portable PDB (/debug:portable or /debug:embedded must be specified)..
+        ///   Looks up a localized string similar to /sourcelink switch is only supported when emitting PDB..
         /// </summary>
-        internal static string ERR_SourceLinkRequiresPortablePdb {
+        internal static string ERR_SourceLinkRequiresPdb {
             get {
-                return ResourceManager.GetString("ERR_SourceLinkRequiresPortablePdb", resourceCulture);
+                return ResourceManager.GetString("ERR_SourceLinkRequiresPdb", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4450,7 +4450,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
                                (including module version GUID and timestamp)
  /instrument:TestCoverage      Produce an assembly instrumented to collect
                                coverage information
- /sourcelink:&lt;file&gt;            Source link info to embed into Portable PDB.
+ /sourcelink:&lt;file&gt;            Source link info to embed into PDB.
 
                         - ERRORS AND WARNINGS -
  /warnaserror[+|-]             Report all warnings as errors
@@ -4971,8 +4971,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ExpressionTreeContainsTupleConversion" xml:space="preserve">
     <value>An expression tree may not contain a tuple conversion.</value>
   </data>
-  <data name="ERR_SourceLinkRequiresPortablePdb" xml:space="preserve">
-    <value>/sourcelink switch is only supported when emitting Portable PDB (/debug:portable or /debug:embedded must be specified).</value>
+  <data name="ERR_SourceLinkRequiresPdb" xml:space="preserve">
+    <value>/sourcelink switch is only supported when emitting PDB.</value>
   </data>
   <data name="ERR_CannotEmbedWithoutPdb" xml:space="preserve">
     <value>/embed switch is only supported when emitting Portable PDB (/debug:portable or /debug:embedded).</value>

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1193,12 +1193,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 keyFileSetting = ParseGenericPathToFile(keyFileSetting, diagnostics, baseDirectory);
             }
 
-            if (sourceLink != null)
+            if (sourceLink != null && !emitPdb)
             {
-                if (!emitPdb || !debugInformationFormat.IsPortable())
-                {
-                    AddDiagnostic(diagnostics, ErrorCode.ERR_SourceLinkRequiresPortablePdb);
-                }
+                AddDiagnostic(diagnostics, ErrorCode.ERR_SourceLinkRequiresPdb);
             }
             
             if (embedAllSourceFiles)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1060,7 +1060,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InvalidOutputName = 2041,
         ERR_InvalidDebugInformationFormat = 2042,
         ERR_LegacyObjectIdSyntax = 2043,
-        ERR_SourceLinkRequiresPortablePdb = 2044,
+        ERR_SourceLinkRequiresPdb = 2044,
         ERR_CannotEmbedWithoutPdb = 2045,
         // unused 2046-2999
         WRN_CLS_NoVarArgs = 3000,

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -159,6 +159,7 @@
     <Compile Include="PDB\CSharpPDBTestBase.cs" />
     <Compile Include="PDB\PDBIteratorTests.cs" />
     <Compile Include="PDB\PDBLambdaTests.cs" />
+    <Compile Include="PDB\PDBSourceLinkTests.cs" />
     <Compile Include="PDB\PDBTests.cs" />
     <Compile Include="PDB\PDBTupleTests.cs" />
     <Compile Include="PDB\PDBUsingTests.cs" />

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBSourceLinkTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBSourceLinkTests.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Debugging;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
+{
+    public class PDBSourceLinkTests : CSharpPDBTestBase
+    {
+        [Theory]
+        [InlineData(DebugInformationFormat.Pdb)]
+        [InlineData(DebugInformationFormat.PortablePdb)]
+        public void SourceLink(DebugInformationFormat format)
+        {
+            string source = @"
+using System;
+
+class C
+{
+    public static void Main()
+    {
+        Console.WriteLine();
+    }
+}
+";
+            var sourceLinkBlob = Encoding.UTF8.GetBytes(@"
+{
+  ""documents"": {
+     ""f:/build/*"" : ""https://raw.githubusercontent.com/my-org/my-project/1111111111111111111111111111111111111111/*""
+  }
+}
+");
+
+            var c = CreateStandardCompilation(Parse(source, "f:/build/foo.cs"), options: TestOptions.DebugDll);
+
+            var pdbStream = new MemoryStream();
+            c.EmitToArray(EmitOptions.Default.WithDebugInformationFormat(format), pdbStream: pdbStream, sourceLinkStream: new MemoryStream(sourceLinkBlob));
+
+            var actualData = PdbValidation.GetSourceLinkData(pdbStream);
+            AssertEx.Equal(sourceLinkBlob, actualData);
+        }
+
+        [Fact]
+        public void SourceLink_Embedded()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    public static void Main()
+    {
+        Console.WriteLine();
+    }
+}
+";
+            var sourceLinkBlob = Encoding.UTF8.GetBytes(@"
+{
+  ""documents"": {
+     ""f:/build/*"" : ""https://raw.githubusercontent.com/my-org/my-project/1111111111111111111111111111111111111111/*""
+  }
+}
+");
+            var c = CreateStandardCompilation(Parse(source, "f:/build/foo.cs"), options: TestOptions.DebugDll);
+
+            var peBlob = c.EmitToArray(EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.Embedded), sourceLinkStream: new MemoryStream(sourceLinkBlob));
+
+            using (var peReader = new PEReader(peBlob))
+            {
+                var embeddedEntry = peReader.ReadDebugDirectory().Single(e => e.Type == DebugDirectoryEntryType.EmbeddedPortablePdb);
+
+                using (var embeddedMetadataProvider = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(embeddedEntry))
+                {
+                    var pdbReader = embeddedMetadataProvider.GetMetadataReader();
+
+                    var actualBlob =
+                        (from cdiHandle in pdbReader.GetCustomDebugInformation(EntityHandle.ModuleDefinition)
+                         let cdi = pdbReader.GetCustomDebugInformation(cdiHandle)
+                         where pdbReader.GetGuid(cdi.Kind) == PortableCustomDebugInfoKinds.SourceLink
+                         select pdbReader.GetBlobBytes(cdi.Value)).Single();
+
+                    AssertEx.Equal(sourceLinkBlob, actualBlob);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(DebugInformationFormat.Pdb)]
+        [InlineData(DebugInformationFormat.Embedded)]
+        [InlineData(DebugInformationFormat.PortablePdb)]
+        public void SourceLink_Errors(DebugInformationFormat format)
+        {
+            string source = @"
+using System;
+
+class C
+{
+    public static void Main()
+    {
+        Console.WriteLine();
+    }
+}
+";
+            var sourceLinkStream = new TestStream(canRead: true, readFunc: (_, __, ___) => { throw new Exception("Error!"); });
+
+            var c = CreateStandardCompilation(Parse(source, "f:/build/foo.cs"), options: TestOptions.DebugDll);
+            var pdbStream = format != DebugInformationFormat.Embedded ? new MemoryStream() : null;
+            var result = c.Emit(new MemoryStream(), pdbStream, options: EmitOptions.Default.WithDebugInformationFormat(format), sourceLinkStream: sourceLinkStream);
+            result.Diagnostics.Verify(
+                // error CS0041: Unexpected error writing debug information -- 'Error!'
+                Diagnostic(ErrorCode.FTL_DebugEmitFailure).WithArguments("Error!").WithLocation(1, 1));
+        }
+
+        [Theory]
+        [InlineData(DebugInformationFormat.Pdb)]
+        [InlineData(DebugInformationFormat.PortablePdb)]
+        public void SourceLink_Empty(DebugInformationFormat format)
+        {
+            string source = @"
+using System;
+
+class C
+{
+    public static void Main()
+    {
+        Console.WriteLine();
+    }
+}
+";
+            var sourceLinkBlob = new byte[0];
+
+            var c = CreateStandardCompilation(Parse(source, "f:/build/foo.cs"), options: TestOptions.DebugDll);
+
+            var pdbStream = new MemoryStream();
+            c.EmitToArray(EmitOptions.Default.WithDebugInformationFormat(format), pdbStream: pdbStream, sourceLinkStream: new MemoryStream(sourceLinkBlob));
+            pdbStream.Position = 0;
+            var bs = Roslyn.Utilities.StreamExtensions.ReadAllBytes(pdbStream);
+            var actualData = PdbValidation.GetSourceLinkData(pdbStream);
+            AssertEx.Equal(sourceLinkBlob, actualData);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -210,18 +210,6 @@ namespace A.B {
                 options: EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.PortablePdb),
                 sourceLinkStream: new TestStream(canRead: false, canWrite: true, canSeek: true)));
 
-            Assert.Throws<ArgumentException>("sourceLinkStream", () => comp.Emit(
-               peStream: new MemoryStream(),
-               pdbStream: new MemoryStream(),
-               options: EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.Pdb),
-               sourceLinkStream: new MemoryStream()));
-
-            Assert.Throws<ArgumentException>("sourceLinkStream", () => comp.Emit(
-               peStream: new MemoryStream(),
-               pdbStream: null,
-               options: EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.PortablePdb),
-               sourceLinkStream: new MemoryStream()));
-
             Assert.Throws<ArgumentException>("embeddedTexts", () => comp.Emit(
                 peStream: new MemoryStream(),
                 pdbStream: new MemoryStream(),

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/StreamExtensionsTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/StreamExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace Roslyn.Utilities.UnitTests.InternalUtilities
     public class StreamExtensionsTests
     {
         [Fact]
-        public void CallsReadMultipleTimes()
+        public void TryReadAll_CallsReadMultipleTimes()
         {
             var firstRead = true;
             var sourceArray = new byte[] { 1, 2, 3, 4 };
@@ -37,7 +37,7 @@ namespace Roslyn.Utilities.UnitTests.InternalUtilities
         }
 
         [Fact]
-        public void ExceptionsPropagate()
+        public void TryReadAll_ExceptionsPropagate()
         {
             var buffer = new byte[10];
 
@@ -57,7 +57,7 @@ namespace Roslyn.Utilities.UnitTests.InternalUtilities
         }
 
         [Fact]
-        public void ExceptionMayChangeOutput()
+        public void TryReadAll_ExceptionMayChangeOutput()
         {
             var firstRead = true;
             var sourceArray = new byte[] { 1, 2, 3, 4 };
@@ -82,7 +82,7 @@ namespace Roslyn.Utilities.UnitTests.InternalUtilities
         }
 
         [Fact]
-        public void ExceptionMayChangePosition()
+        public void TryReadAll_ExceptionMayChangePosition()
         {
             var firstRead = true;
             var sourceArray = new byte[] { 1, 2, 3, 4 };
@@ -107,7 +107,7 @@ namespace Roslyn.Utilities.UnitTests.InternalUtilities
         }
 
         [Fact]
-        public void PrematureEndOfStream()
+        public void TryReadAll_PrematureEndOfStream()
         {
             var sourceArray = new byte[] { 1, 2, 3, 4 };
             var stream = new MemoryStream(sourceArray);
@@ -117,6 +117,39 @@ namespace Roslyn.Utilities.UnitTests.InternalUtilities
             Assert.Equal(4, stream.TryReadAll(destArray, 0, 6));
             var expected = new byte[] { 1, 2, 3, 4, 0, 0 };
             Assert.Equal(expected, destArray);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadAllBytes(bool canSeek)
+        {
+            var sourceArray = new byte[] { 1, 2, 3, 4 };
+            var stream = new TestStream(canSeek: canSeek, backingStream: new MemoryStream(sourceArray));
+            stream.ReadByte();
+            Assert.Equal(new byte[] { 2, 3, 4 }, stream.ReadAllBytes());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadAllBytes_End(bool canSeek)
+        {
+            var sourceArray = new byte[] { 1, 2 };
+            var stream = new TestStream(canSeek: canSeek, backingStream: new MemoryStream(sourceArray));
+            stream.ReadByte();
+            stream.ReadByte();
+            Assert.Equal(new byte[0], stream.ReadAllBytes());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadAllBytes_Resize(bool canSeek)
+        {
+            var sourceArray = new byte[] { 1, 2 };
+            var stream = new TestStream(canSeek: canSeek, backingStream: new MemoryStream(sourceArray), length: 3);
+            Assert.Equal(new byte[] { 1, 2 }, stream.ReadAllBytes());
         }
     }
 }

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -1190,15 +1190,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Source Link embedding is only supported when emitting Portable PDB..
-        /// </summary>
-        internal static string SourceLinkRequiresPortablePdb {
-            get {
-                return ResourceManager.GetString("SourceLinkRequiresPortablePdb", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to SourceText cannot be embedded. Provide encoding or canBeEmbedded=true at construction..
         /// </summary>
         internal static string SourceTextCannotBeEmbedded {
@@ -1290,6 +1281,15 @@ namespace Microsoft.CodeAnalysis {
         
         /// <summary>
         ///   Looks up a localized string similar to Windows PDB writer doesn&apos;t support deterministic compilation: &apos;{0}&apos;.
+        /// </summary>
+        internal static string SymWriterDoesNotSupportSourceLink {
+            get {
+                return ResourceManager.GetString("SymWriterDoesNotSupportSourceLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Windows PDB writer is not available -- could not find Microsoft.DiaSymReader.Native.{0}.dll.
         /// </summary>
         internal static string SymWriterNotDeterministic {
             get {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -470,6 +470,9 @@
   <data name="SymWriterOlderVersionThanRequired" xml:space="preserve">
     <value>The version of Windows PDB writer is older than required: '{0}'</value>
   </data>
+  <data name="SymWriterDoesNotSupportSourceLink" xml:space="preserve">
+    <value>Windows PDB writer doesn't support SourceLink feature: '{0}'</value>
+  </data>
   <data name="RuleSetBadAttributeValue" xml:space="preserve">
     <value>The attribute {0} has an invalid value of {1}.</value>
   </data>
@@ -560,9 +563,6 @@
   </data>
   <data name="IOperationFeatureDisabled" xml:space="preserve">
     <value>Feature 'IOperation' is disabled.</value>
-  </data>
-  <data name="SourceLinkRequiresPortablePdb" xml:space="preserve">
-    <value>Source Link embedding is only supported when emitting Portable PDB.</value>
   </data>
   <data name="UnrecognizedResourceFileFormat" xml:space="preserve">
     <value>Unrecognized resource file format.</value>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1991,7 +1991,6 @@ namespace Microsoft.CodeAnalysis
         /// </param>
         /// <param name="sourceLinkStream">
         /// Stream containing information linking the compilation to a source control.
-        /// Only supported when emitting Portable PDBs.
         /// </param>
         /// <param name="embeddedTexts">
         /// Texts to embed in the PDB.
@@ -2041,20 +2040,11 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            if (sourceLinkStream != null)
+            if (sourceLinkStream != null && !sourceLinkStream.CanRead)
             {
-                if (options == null || 
-                    options.DebugInformationFormat == DebugInformationFormat.Pdb ||
-                    options.DebugInformationFormat == DebugInformationFormat.PortablePdb && pdbStream == null)
-                {
-                    throw new ArgumentException(CodeAnalysisResources.SourceLinkRequiresPortablePdb, nameof(sourceLinkStream));
-                }
-
-                if (!sourceLinkStream.CanRead)
-                {
-                    throw new ArgumentException(CodeAnalysisResources.StreamMustSupportRead, nameof(sourceLinkStream));
-                }
+                throw new ArgumentException(CodeAnalysisResources.StreamMustSupportRead, nameof(sourceLinkStream));
             }
+
             if (embeddedTexts != null && !embeddedTexts.IsEmpty())
             {
                 if (options == null || 

--- a/src/Compilers/Core/Portable/InternalUtilities/StreamExtensions.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StreamExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 
@@ -46,6 +47,30 @@ namespace Roslyn.Utilities
                 }
             }
             return totalBytesRead;
+        }
+
+        /// <summary>
+        /// Reads all bytes from the current postion of the given stream to its end.
+        /// </summary>
+        public static byte[] ReadAllBytes(this Stream stream)
+        {
+            if (stream.CanSeek)
+            {
+                long length = stream.Length - stream.Position;
+                if (length == 0)
+                {
+                    return Array.Empty<byte>();
+                }
+
+                var buffer = new byte[length];
+                int actualLength = TryReadAll(stream, buffer, 0, buffer.Length);
+                Array.Resize(ref buffer, actualLength);
+                return buffer;
+            }
+
+            var memoryStream = new MemoryStream();
+            stream.CopyTo(memoryStream);
+            return memoryStream.ToArray();
         }
     }
 }

--- a/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
@@ -109,8 +109,8 @@ namespace Microsoft.Cci
     /// <summary>
     /// The highest version of the interface available in Microsoft.DiaSymReader.Native.
     /// </summary>
-    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("22DAEAF2-70F6-4EF1-B0C3-984F0BF27BFD"), SuppressUnmanagedCodeSecurity]
-    internal interface ISymUnmanagedWriter7 : ISymUnmanagedWriter5
+    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("5ba52f3b-6bf8-40fc-b476-d39c529b331e"), SuppressUnmanagedCodeSecurity]
+    internal interface ISymUnmanagedWriter8 : ISymUnmanagedWriter5
     {
         //  ISymUnmanagedWriter, ISymUnmanagedWriter2, ISymUnmanagedWriter3, ISymUnmanagedWriter4, ISymUnmanagedWriter5
         void _VtblGap1_33();
@@ -120,6 +120,11 @@ namespace Microsoft.Cci
 
         // ISymUnmanagedWriter7
         unsafe void UpdateSignatureByHashingContent([In]byte* buffer, int size);
+
+        // ISymUnmanagedWriter8
+        void UpdateSignature(Guid pdbId, uint stamp, int age);
+        unsafe void SetSourceServerData([In]byte* data, int size);
+        unsafe void SetSourceLinkData([In]byte* data, int size);
     }
 
     [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("98ECEE1E-752D-11d3-8D56-00C04F680B2B"), SuppressUnmanagedCodeSecurity]

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -803,11 +803,11 @@ namespace Microsoft.Cci
 
         private void EmbedSourceLink(Stream stream)
         {
-            // TODO: be more efficient: https://github.com/dotnet/roslyn/issues/12853
-            var memoryStream = new MemoryStream();
+            byte[] bytes;
+
             try
             {
-                stream.CopyTo(memoryStream);
+                bytes = stream.ReadAllBytes();
             }
             catch (Exception e) when (!(e is OperationCanceledException))
             {
@@ -817,7 +817,7 @@ namespace Microsoft.Cci
             _debugMetadataOpt.AddCustomDebugInformation(
                 parent: EntityHandle.ModuleDefinition,
                 kind: _debugMetadataOpt.GetOrAddGuid(PortableCustomDebugInfoKinds.SourceLink),
-                value: _debugMetadataOpt.GetOrAddBlob(memoryStream.ToArray()));
+                value: _debugMetadataOpt.GetOrAddBlob(bytes));
         }
     }
 }

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -75,6 +75,11 @@ namespace Microsoft.Cci
 
             if (nativePdbWriterOpt != null)
             {
+                if (context.Module.SourceLinkStreamOpt != null)
+                {
+                    nativePdbWriterOpt.EmbedSourceLink(context.Module.SourceLinkStreamOpt);
+                }
+
                 if (mdWriter.Module.OutputKind == OutputKind.WindowsRuntimeMetadata)
                 {
                     // Dev12: If compiling to winmdobj, we need to add to PDB source spans of

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1239,10 +1239,8 @@ lVbRuntimePlus:
 
             ValidateWin32Settings(noWin32Manifest, win32ResourceFile, win32IconFile, win32ManifestFile, outputKind, diagnostics)
 
-            If sourceLink IsNot Nothing Then
-                If Not emitPdb OrElse debugInformationFormat <> DebugInformationFormat.PortablePdb AndAlso debugInformationFormat <> DebugInformationFormat.Embedded Then
-                    AddDiagnostic(diagnostics, ERRID.ERR_SourceLinkRequiresPortablePdb)
-                End If
+            If sourceLink IsNot Nothing And Not emitPdb Then
+                AddDiagnostic(diagnostics, ERRID.ERR_SourceLinkRequiresPdb)
             End If
 
             If embedAllSourceFiles Then

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1696,7 +1696,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ERR_RefReturningCallInExpressionTree = 37263
 
-        ERR_SourceLinkRequiresPortablePdb = 37264
+        ERR_SourceLinkRequiresPdb = 37264
         ERR_CannotEmbedWithoutPdb = 37265
 
         ERR_InvalidInstrumentationKind = 37266

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -10037,11 +10037,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to /sourcelink switch is only supported when emitting Portable PDB (/debug:portable or /debug:embedded must be specified)..
+        '''  Looks up a localized string similar to /sourcelink switch is only supported when emitting PDB..
         '''</summary>
-        Friend ReadOnly Property ERR_SourceLinkRequiresPortablePdb() As String
+        Friend ReadOnly Property ERR_SourceLinkRequiresPdb() As String
             Get
-                Return ResourceManager.GetString("ERR_SourceLinkRequiresPortablePdb", resourceCulture)
+                Return ResourceManager.GetString("ERR_SourceLinkRequiresPdb", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5107,7 +5107,7 @@
                                   (including module version GUID and timestamp)
 /instrument:TestCoverage          Produce an assembly instrumented to collect
                                   coverage information
-/sourcelink:&lt;file&gt;                Source link info to embed into Portable PDB.
+/sourcelink:&lt;file&gt;                Source link info to embed into PDB.
 
                                   - ERRORS AND WARNINGS -
 /nowarn                           Disable all warnings.
@@ -5418,8 +5418,8 @@
   <data name="ERR_OptionMustBeAbsolutePath" xml:space="preserve">
     <value>Option '{0}' must be an absolute path.</value>
   </data>
-  <data name="ERR_SourceLinkRequiresPortablePdb" xml:space="preserve">
-    <value>/sourcelink switch is only supported when emitting Portable PDB (/debug:portable or /debug:embedded must be specified).</value>
+  <data name="ERR_SourceLinkRequiresPdb" xml:space="preserve">
+    <value>/sourcelink switch is only supported when emitting PDB.</value>
   </data>
   <data name="ERR_TupleDuplicateElementName" xml:space="preserve">
     <value>Tuple element names must be unique.</value>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -2657,19 +2657,19 @@ End Module").Path
             Assert.Equal(Path.Combine(_baseDirectory, "s l.json"), parsedArgs.SourceLink)
 
             parsedArgs = DefaultParse({"/sourcelink:sl.json", "/debug:full", "a.vb"}, _baseDirectory)
-            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SourceLinkRequiresPortablePdb))
+            parsedArgs.Errors.Verify()
 
             parsedArgs = DefaultParse({"/sourcelink:sl.json", "/debug:pdbonly", "a.vb"}, _baseDirectory)
-            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SourceLinkRequiresPortablePdb))
+            parsedArgs.Errors.Verify()
 
             parsedArgs = DefaultParse({"/sourcelink:sl.json", "/debug-", "a.vb"}, _baseDirectory)
-            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SourceLinkRequiresPortablePdb))
+            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SourceLinkRequiresPdb))
 
             parsedArgs = DefaultParse({"/sourcelink:sl.json", "/debug+", "a.vb"}, _baseDirectory)
-            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SourceLinkRequiresPortablePdb))
+            parsedArgs.Errors.Verify()
 
             parsedArgs = DefaultParse({"/sourcelink:sl.json", "a.vb"}, _baseDirectory)
-            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SourceLinkRequiresPortablePdb))
+            parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_SourceLinkRequiresPdb))
         End Sub
 
         <Fact>
@@ -8252,11 +8252,13 @@ End Module
             Assert.Equal($"error BC2012: can't open '{xmlPath}' for writing: Fake IOException{Environment.NewLine}", outWriter.ToString())
         End Sub
 
-        <Fact>
-        Public Sub IOFailure_DisposeSourceLinkFile()
+        <Theory>
+        <InlineData("portable")>
+        <InlineData("full")>
+        Public Sub IOFailure_DisposeSourceLinkFile(format As String)
             Dim srcPath = MakeTrivialExe(Temp.CreateDirectory().Path)
             Dim sourceLinkPath = Path.Combine(Path.GetDirectoryName(srcPath), "test.json")
-            Dim csc = New MockVisualBasicCompiler(_baseDirectory, {"/nologo", "/preferreduilang:en", "/debug:portable", $"/sourcelink:{sourceLinkPath}", srcPath})
+            Dim csc = New MockVisualBasicCompiler(_baseDirectory, {"/nologo", "/preferreduilang:en", "/debug:" & format, $"/sourcelink:{sourceLinkPath}", srcPath})
             csc.FileOpen = Function(filePath, mode, access, share)
                                If filePath = sourceLinkPath Then
                                    Return New TestStream(

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -285,18 +285,6 @@ End Namespace
                 options:=EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.PortablePdb),
                 sourceLinkStream:=New TestStream(canRead:=False, canWrite:=True, canSeek:=True)))
 
-            Assert.Throws(Of ArgumentException)("sourceLinkStream", Sub() comp.Emit(
-                peStream:=New MemoryStream(),
-                pdbStream:=New MemoryStream(),
-                options:=EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.Pdb),
-                sourceLinkStream:=New MemoryStream()))
-
-            Assert.Throws(Of ArgumentException)("sourceLinkStream", Sub() comp.Emit(
-                peStream:=New MemoryStream(),
-                pdbStream:=Nothing,
-                options:=EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.PortablePdb),
-                sourceLinkStream:=New MemoryStream()))
-
             Assert.Throws(Of ArgumentException)("embeddedTexts", Sub() comp.Emit(
                 peStream:=New MemoryStream(),
                 pdbStream:=New MemoryStream(),

--- a/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
+++ b/src/Test/PdbUtilities/Pdb/SymReaderFactory.cs
@@ -23,7 +23,7 @@ namespace Roslyn.Test.PdbUtilities
         [DllImport("Microsoft.DiaSymReader.Native.amd64.dll", EntryPoint = "CreateSymReader")]
         private extern static void CreateSymReader64(ref Guid id, [MarshalAs(UnmanagedType.IUnknown)]out object symReader);
 
-        private static ISymUnmanagedReader3 CreateNativeSymReader(Stream pdbStream, object metadataImporter)
+        private static ISymUnmanagedReader5 CreateNativeSymReader(Stream pdbStream, object metadataImporter)
         {
             object symReader = null;
 
@@ -37,42 +37,42 @@ namespace Roslyn.Test.PdbUtilities
                 CreateSymReader64(ref guid, out symReader);
             }
 
-            var reader = (ISymUnmanagedReader3)symReader;
+            var reader = (ISymUnmanagedReader5)symReader;
             reader.Initialize(pdbStream, metadataImporter);
             return reader;
         }
 
-        private static ISymUnmanagedReader3 CreatePortableSymReader(Stream pdbStream, object metadataImporter)
+        private static ISymUnmanagedReader5 CreatePortableSymReader(Stream pdbStream, object metadataImporter)
         {
-            return (ISymUnmanagedReader3)new PortablePdb.SymBinder().GetReaderFromStream(pdbStream, metadataImporter);
+            return (ISymUnmanagedReader5)new PortablePdb.SymBinder().GetReaderFromStream(pdbStream, metadataImporter);
         }
 
-        public static ISymUnmanagedReader3 CreateReader(byte[] pdbImage, byte[] peImageOpt = null)
+        public static ISymUnmanagedReader5 CreateReader(byte[] pdbImage, byte[] peImageOpt = null)
         {
             return CreateReader(new MemoryStream(pdbImage), (peImageOpt != null) ? new PEReader(new MemoryStream(peImageOpt)) : null);
         }
 
-        public static ISymUnmanagedReader3 CreateReader(ImmutableArray<byte> pdbImage, ImmutableArray<byte> peImageOpt = default(ImmutableArray<byte>))
+        public static ISymUnmanagedReader5 CreateReader(ImmutableArray<byte> pdbImage, ImmutableArray<byte> peImageOpt = default(ImmutableArray<byte>))
         {
             return CreateReader(new MemoryStream(pdbImage.ToArray()), (peImageOpt.IsDefault) ? null : new PEReader(peImageOpt));
         }
 
-        public static ISymUnmanagedReader3 CreateReader(Stream pdbStream, Stream peStreamOpt = null)
+        public static ISymUnmanagedReader5 CreateReader(Stream pdbStream, Stream peStreamOpt = null)
         {
             return CreateReader(pdbStream, (peStreamOpt != null) ? new PEReader(peStreamOpt) : null);
         }
 
-        public static ISymUnmanagedReader3 CreateReader(Stream pdbStream, PEReader peReaderOpt)
+        public static ISymUnmanagedReader5 CreateReader(Stream pdbStream, PEReader peReaderOpt)
         {
             return CreateReader(pdbStream, peReaderOpt?.GetMetadataReader(), peReaderOpt);
         }
 
-        public static ISymUnmanagedReader3 CreateReader(Stream pdbStream, MetadataReader metadataReaderOpt, IDisposable metadataMemoryOwnerOpt)
+        public static ISymUnmanagedReader5 CreateReader(Stream pdbStream, MetadataReader metadataReaderOpt, IDisposable metadataMemoryOwnerOpt)
         {
             return CreateReaderImpl(pdbStream, metadataImporter: new DummyMetadataImport(metadataReaderOpt, metadataMemoryOwnerOpt));
         }
 
-        public static ISymUnmanagedReader3 CreateReaderImpl(Stream pdbStream, object metadataImporter)
+        public static ISymUnmanagedReader5 CreateReaderImpl(Stream pdbStream, object metadataImporter)
         {
             pdbStream.Position = 0;
             bool isPortable = pdbStream.ReadByte() == 'B' && pdbStream.ReadByte() == 'S' && pdbStream.ReadByte() == 'J' && pdbStream.ReadByte() == 'B';


### PR DESCRIPTION
Enables /sourcelink for Windows PDBs. Previously we only supported it for Portable PDBs.

- [x] Create package for Microsoft.DiaSymReader.Native, 1.6.0. The feature requires new diasymreader APIs.