### PR TITLE
Cherry pick exe config change from #18018

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/App.config
+++ b/src/Compilers/Server/VBCSCompiler/App.config
@@ -2,6 +2,9 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 
 <configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
   <runtime>
     <gcServer enabled="true"/>
     <gcConcurrent enabled="false"/>

--- a/src/Compilers/VisualBasic/vbc/App.config
+++ b/src/Compilers/VisualBasic/vbc/App.config
@@ -2,6 +2,9 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 
 <configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+  </startup>
   <runtime>
     <gcServer enabled="true" />
     <gcConcurrent enabled="false"/>

--- a/src/Interactive/csi/App.config
+++ b/src/Interactive/csi/App.config
@@ -5,8 +5,4 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
-  <runtime>
-    <gcServer enabled="true" />
-    <gcConcurrent enabled="false"/>
-  </runtime>
 </configuration>

--- a/src/Interactive/csi/csi.csproj
+++ b/src/Interactive/csi/csi.csproj
@@ -34,6 +34,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="csi.rsp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Interactive/vbi/App.config
+++ b/src/Interactive/vbi/App.config
@@ -5,8 +5,4 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
-  <runtime>
-    <gcServer enabled="true" />
-    <gcConcurrent enabled="false"/>
-  </runtime>
 </configuration>

--- a/src/Interactive/vbi/vbi.vbproj
+++ b/src/Interactive/vbi/vbi.vbproj
@@ -34,6 +34,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="project.json" />
     <None Include="vbi.rsp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Sets the minimum runtime for Roslyn exes to .NET 4.6, producing a useful error when
run on a lower runtime. Addresses issues in #17908.

(cherry picked from commit 56ec8d17b7883b77b6d1ec06ae11b8b90974f288)

VSO bug https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=397672&_a=edit&triage=true