### PR TITLE
Remove LocalFunctionTypeParameterSymbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
@@ -128,7 +128,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal int ExtraSynthesizedParameterCount => this._structClosures.IsDefault ? 0 : this._structClosures.Length;
 
         internal override bool GenerateDebugInfo => !this.IsAsync;
-        internal override bool IsExpressionBodied => false;
         internal MethodSymbol TopLevelMethod => _topLevelMethod;
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -27,7 +27,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                               Location location,
                                               string name,
                                               DeclarationModifiers declarationModifiers)
-            : base(containingType, syntaxReference, blockSyntaxReference, location)
+            : base(containingType,
+                   syntaxReference,
+                   blockSyntaxReference,
+                   expressionBodySyntaxOpt: null,
+                   location: location)
         {
             Debug.Assert((object)containingType != null);
             Debug.Assert((object)baseMethod != null);
@@ -149,11 +153,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public sealed override bool IsImplicitlyDeclared
         {
             get { return true; }
-        }
-
-        internal override bool IsExpressionBodied
-        {
-            get { return false; }
         }
 
         internal override TypeSymbol IteratorElementType

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -35,7 +35,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Binder binder,
             Symbol containingSymbol,
             LocalFunctionStatementSyntax syntax)
-            : base(containingSymbol, syntax.GetReference(), syntax.ExpressionBody?.GetReference() ?? syntax.Body?.GetReference(), syntax.Location)
+            : base(containingSymbol,
+                   syntax.GetReference(),
+                   syntax.ExpressionBody?.GetReference(),
+                   syntax.Body?.GetReference(),
+                   syntax.Location)
         {
             _syntax = syntax;
             _containingSymbol = containingSymbol;
@@ -279,8 +283,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override ObsoleteAttributeData ObsoleteAttributeData => null;
 
         public override Symbol AssociatedSymbol => null;
-
-        internal override bool IsExpressionBodied => _syntax.Body == null && _syntax.ExpressionBody != null;
 
         internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -11,14 +12,12 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal sealed class LocalFunctionSymbol : MethodSymbol
+    internal sealed class LocalFunctionSymbol : SourceMethodSymbol
     {
-
         private readonly Binder _binder;
         private readonly LocalFunctionStatementSyntax _syntax;
         private readonly Symbol _containingSymbol;
-        private readonly DeclarationModifiers _declarationModifiers;
-        private readonly ImmutableArray<LocalFunctionTypeParameterSymbol> _typeParameters;
+        private readonly ImmutableArray<SourceMethodTypeParameterSymbol> _typeParameters;
         private readonly RefKind _refKind;
 
         private ImmutableArray<ParameterSymbol> _lazyParameters;
@@ -36,14 +35,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Binder binder,
             Symbol containingSymbol,
             LocalFunctionStatementSyntax syntax)
+            : base(containingSymbol, syntax.GetReference(), syntax.ExpressionBody?.GetReference() ?? syntax.Body?.GetReference(), syntax.Location)
         {
             _syntax = syntax;
             _containingSymbol = containingSymbol;
 
-            _declarationModifiers =
-                DeclarationModifiers.Private |
-                DeclarationModifiers.Static |
-                syntax.Modifiers.ToDeclarationModifiers();
+            MakeFlags(
+                methodKind: MethodKind.LocalFunction,
+                declarationModifiers: DeclarationModifiers.Private |
+                                      DeclarationModifiers.Static |
+                                      syntax.Modifiers.ToDeclarationModifiers(),
+                returnsVoid: false, /* arbitrary, flags.ReturnsVoid is unused in local functions */
+                isExtensionMethod: false);
 
             ScopeBinder = binder;
 
@@ -58,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                _typeParameters = ImmutableArray<LocalFunctionTypeParameterSymbol>.Empty;
+                _typeParameters = ImmutableArray<SourceMethodTypeParameterSymbol>.Empty;
                 ReportErrorIfHasConstraints(_syntax.ConstraintClauses, _declarationDiagnostics);
             }
 
@@ -227,12 +230,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool ReturnsVoid => ReturnType?.SpecialType == SpecialType.System_Void;
 
-        public override int Arity => TypeParameters.Length;
-
-        public override ImmutableArray<TypeSymbol> TypeArguments => TypeParameters.Cast<TypeParameterSymbol, TypeSymbol>();
-
         public override ImmutableArray<TypeParameterSymbol> TypeParameters 
-            => _typeParameters.Cast<LocalFunctionTypeParameterSymbol, TypeParameterSymbol>();
+            => _typeParameters.Cast<SourceMethodTypeParameterSymbol, TypeParameterSymbol>();
 
         public override bool IsExtensionMethod
         {
@@ -259,25 +258,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override MethodKind MethodKind => MethodKind.LocalFunction;
-
-        public sealed override Symbol ContainingSymbol => _containingSymbol;
-
         public override string Name => _syntax.Identifier.ValueText;
 
         public SyntaxToken NameToken => _syntax.Identifier;
 
         public Binder SignatureBinder => _binder;
 
-        internal override bool HasSpecialName => false;
-
-        public override bool HidesBaseMethodsByName => false;
-
         public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<MethodSymbol>.Empty;
 
         public override ImmutableArray<Location> Locations => ImmutableArray.Create(_syntax.Identifier.GetLocation());
-
-        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray.Create(_syntax.GetReference());
 
         internal override bool GenerateDebugInfo => true;
 
@@ -289,48 +278,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ObsoleteAttributeData ObsoleteAttributeData => null;
 
-        internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation => null;
-
-        internal override CallingConvention CallingConvention => CallingConvention.Default;
-
-        internal override bool HasDeclarativeSecurity => false;
-
-        internal override bool RequiresSecurityObject => false;
-
         public override Symbol AssociatedSymbol => null;
 
-        public override Accessibility DeclaredAccessibility => ModifierUtils.EffectiveAccessibility(_declarationModifiers);
-
-        public override bool IsAsync => (_declarationModifiers & DeclarationModifiers.Async) != 0;
-
-        public override bool IsStatic => (_declarationModifiers & DeclarationModifiers.Static) != 0;
-
-        public override bool IsVirtual => (_declarationModifiers & DeclarationModifiers.Virtual) != 0;
-
-        public override bool IsOverride => (_declarationModifiers & DeclarationModifiers.Override) != 0;
-
-        public override bool IsAbstract => (_declarationModifiers & DeclarationModifiers.Abstract) != 0;
-
-        public override bool IsSealed => (_declarationModifiers & DeclarationModifiers.Sealed) != 0;
-
-        public override bool IsExtern => (_declarationModifiers & DeclarationModifiers.Extern) != 0;
-
-        public bool IsUnsafe => (_declarationModifiers & DeclarationModifiers.Unsafe) != 0;
-
-        internal bool IsExpressionBodied => _syntax.Body == null && _syntax.ExpressionBody != null;
-
-        public override DllImportData GetDllImportData() => null;
-
-        internal override ImmutableArray<string> GetAppliedConditionalSymbols() => ImmutableArray<string>.Empty;
+        internal override bool IsExpressionBodied => _syntax.Body == null && _syntax.ExpressionBody != null;
 
         internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false) => false;
 
         internal override bool IsMetadataVirtual(bool ignoreInterfaceImplementationChanges = false) => false;
-
-        internal override IEnumerable<SecurityAttribute> GetSecurityInformation()
-        {
-            throw ExceptionUtilities.Unreachable;
-        }
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {
@@ -352,9 +306,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        private ImmutableArray<LocalFunctionTypeParameterSymbol> MakeTypeParameters(DiagnosticBag diagnostics)
+        private ImmutableArray<SourceMethodTypeParameterSymbol> MakeTypeParameters(DiagnosticBag diagnostics)
         {
-            var result = ArrayBuilder<LocalFunctionTypeParameterSymbol>.GetInstance();
+            var result = ArrayBuilder<SourceMethodTypeParameterSymbol>.GetInstance();
             var typeParameters = _syntax.TypeParameterList.Parameters;
             for (int ordinal = 0; ordinal < typeParameters.Count; ordinal++)
             {
@@ -387,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics.Add(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, location, name, tpEnclosing.ContainingSymbol);
                 }
 
-                var typeParameter = new LocalFunctionTypeParameterSymbol(
+                var typeParameter = new SourceMethodTypeParameterSymbol(
                         this,
                         name,
                         ordinal,
@@ -400,64 +354,62 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return result.ToImmutableAndFree();
         }
 
-        internal TypeParameterConstraintKind GetTypeParameterConstraints(int ordinal)
+        protected override ImmutableArray<TypeParameterConstraintClause> TypeParameterConstraints
         {
-            var clause = this.GetTypeParameterConstraintClause(ordinal);
-            return (clause != null) ? clause.Constraints : TypeParameterConstraintKind.None;
-        }
-
-        internal ImmutableArray<TypeSymbol> GetTypeParameterConstraintTypes(int ordinal)
-        {
-            var clause = this.GetTypeParameterConstraintClause(ordinal);
-            return (clause != null) ? clause.ConstraintTypes : ImmutableArray<TypeSymbol>.Empty;
-        }
-
-        private TypeParameterConstraintClause GetTypeParameterConstraintClause(int ordinal)
-        {
-            if (_lazyTypeParameterConstraints == null)
+            get
             {
-                var diagnostics = DiagnosticBag.GetInstance();
-                var constraints = MakeTypeParameterConstraints(diagnostics);
+                MakeTypeParameterConstraints();
+                return _lazyTypeParameterConstraints;
+            }
+        }
 
-                lock (_declarationDiagnostics)
+        private void MakeTypeParameterConstraints()
+        {
+            if (!_lazyTypeParameterConstraints.IsDefault)
+            {
+                return;
+            }
+
+            var diagnostics = DiagnosticBag.GetInstance();
+            var constaints = GetConstraints();
+
+            lock (_declarationDiagnostics)
+            {
+                if (_lazyTypeParameterConstraints == null)
                 {
-                    if (_lazyTypeParameterConstraints == null)
-                    {
-                        _declarationDiagnostics.AddRange(diagnostics);
-                        _lazyTypeParameterConstraints = constraints;
-                    }
+                    _declarationDiagnostics.AddRange(diagnostics);
+                    _lazyTypeParameterConstraints = constaints;
                 }
-                diagnostics.Free();
             }
 
-            var clauses = _lazyTypeParameterConstraints;
-            return (clauses.Length > 0) ? clauses[ordinal] : null;
-        }
+            diagnostics.Free();
+            return;
 
-        private ImmutableArray<TypeParameterConstraintClause> MakeTypeParameterConstraints(DiagnosticBag diagnostics)
-        {
-            var typeParameters = this.TypeParameters;
-            if (typeParameters.Length == 0)
+            ImmutableArray<TypeParameterConstraintClause> GetConstraints()
             {
-                return ImmutableArray<TypeParameterConstraintClause>.Empty;
+                var typeParameters = this.TypeParameters;
+                if (typeParameters.Length == 0)
+                {
+                    return ImmutableArray<TypeParameterConstraintClause>.Empty;
+                }
+
+                var constraintClauses = _syntax.ConstraintClauses;
+                if (constraintClauses.Count == 0)
+                {
+                    return ImmutableArray<TypeParameterConstraintClause>.Empty;
+                }
+
+                var syntaxTree = _syntax.SyntaxTree;
+
+                // Wrap binder from factory in a generic constraints specific binder
+                // to avoid checking constraints when binding type names.
+                Debug.Assert(!_binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
+                var binder = _binder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks);
+
+                var result = binder.BindTypeParameterConstraintClauses(this, typeParameters, constraintClauses, diagnostics);
+                this.CheckConstraintTypesVisibility(new SourceLocation(_syntax.Identifier), result, diagnostics);
+                return result;
             }
-
-            var constraintClauses = _syntax.ConstraintClauses;
-            if (constraintClauses.Count == 0)
-            {
-                return ImmutableArray<TypeParameterConstraintClause>.Empty;
-            }
-
-            var syntaxTree = _syntax.SyntaxTree;
-
-            // Wrap binder from factory in a generic constraints specific binder
-            // to avoid checking constraints when binding type names.
-            Debug.Assert(!_binder.Flags.Includes(BinderFlags.GenericConstraintsClause));
-            var binder = _binder.WithAdditionalFlags(BinderFlags.GenericConstraintsClause | BinderFlags.SuppressConstraintChecks);
-
-            var result = binder.BindTypeParameterConstraintClauses(this, typeParameters, constraintClauses, diagnostics);
-            this.CheckConstraintTypesVisibility(new SourceLocation(_syntax.Identifier), result, diagnostics);
-            return result;
         }
 
         public override int GetHashCode()
@@ -473,6 +425,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var localFunction = symbol as LocalFunctionSymbol;
             return (object)localFunction != null
                 && localFunction._syntax == _syntax;
+        }
+
+        protected override void MethodChecks(DiagnosticBag diagnostics)
+        {
+            throw ExceptionUtilities.Unreachable;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -30,7 +30,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ConstructorDeclarationSyntax syntax,
             MethodKind methodKind,
             DiagnosticBag diagnostics) :
-            base(containingType, syntax.GetReference(), syntax.Body?.GetReference() ?? syntax.ExpressionBody?.GetReference(), ImmutableArray.Create(location))
+            base(containingType,
+                 syntax.GetReference(),
+                 syntax.Body?.GetReference(),
+                 syntax.ExpressionBody?.GetReference(),
+                 ImmutableArray.Create(location))
         {
             bool modifierErrors;
             var declarationModifiers = this.MakeModifiers(syntax.Modifiers, methodKind, location, diagnostics, out modifierErrors);
@@ -233,14 +237,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 return base.AttributeOwner;
-            }
-        }
-
-        internal override bool IsExpressionBodied
-        {
-            get
-            {
-                return _isExpressionBodied;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventAccessorSymbol.cs
@@ -29,7 +29,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics)
             : base(@event,
                    syntax.GetReference(),
-                   ((SyntaxNode)syntax.Body ?? syntax.ExpressionBody)?.GetReference(),
+                   syntax.Body?.GetReference(),
+                   syntax.ExpressionBody?.GetReference(),
                    ImmutableArray.Create(syntax.Keyword.GetLocation()))
         {
             Debug.Assert(syntax != null);
@@ -128,17 +129,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool GenerateDebugInfo
         {
             get { return true; }
-        }
-
-        internal override bool IsExpressionBodied
-        {
-            get
-            {
-                var syntax = GetSyntax();
-                var hasBody = syntax.Body != null;
-                var hasExpressionBody = syntax.ExpressionBody != null;
-                return !hasBody && hasExpressionBody;
-            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -23,7 +23,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DelegateDeclarationSyntax syntax,
             MethodKind methodKind,
             DeclarationModifiers declarationModifiers)
-            : base(delegateType, syntax.GetReference(), bodySyntaxReferenceOpt: null, location: syntax.Identifier.GetLocation())
+            : base(delegateType,
+                   syntax.GetReference(),
+                   blockBodySyntaxOpt: null,
+                   expressionBodySyntaxOpt: null,
+                   location: syntax.Identifier.GetLocation())
         {
             _returnType = returnType;
             this.MakeFlags(methodKind, declarationModifiers, _returnType.SpecialType == SpecialType.System_Void, isExtensionMethod: false);
@@ -149,11 +153,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return true;
             }
-        }
-
-        internal override bool IsExpressionBodied
-        {
-            get { return false; }
         }
 
         internal override bool GenerateDebugInfo

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDestructorSymbol.cs
@@ -15,8 +15,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal SourceDestructorSymbol(
             SourceMemberContainerTypeSymbol containingType,
             DestructorDeclarationSyntax syntax,
-            DiagnosticBag diagnostics) :
-            base(containingType, syntax.GetReference(), syntax.Body?.GetReference() ?? syntax.ExpressionBody?.GetReference() , syntax.Identifier.GetLocation())
+            DiagnosticBag diagnostics)
+            : base(containingType,
+                   syntax.GetReference(),
+                   syntax.Body?.GetReference(),
+                   syntax.ExpressionBody?.GetReference(),
+                   syntax.Identifier.GetLocation())
         {
             const MethodKind methodKind = MethodKind.Destructor;
             Location location = this.Locations[0];
@@ -124,14 +128,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override string Name
         {
             get { return WellKnownMemberNames.DestructorName; }
-        }
-
-        internal override bool IsExpressionBodied
-        {
-            get
-            {
-                return _isExpressionBodied;
-            }
         }
 
         internal override OneOrMany<SyntaxList<AttributeListSyntax>> GetAttributeDeclarations()

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -22,13 +22,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public SourceEventAccessorSymbol(
             SourceEventSymbol @event,
             SyntaxReference syntaxReference,
-            SyntaxReference blockSyntaxReference,
+            SyntaxReference blockBodySyntaxOpt,
+            SyntaxReference expressionBodySyntaxOpt,
             ImmutableArray<Location> locations)
             : base(@event.containingType,
                    syntaxReference,
-                   blockSyntaxReference,
-                   expressionBodySyntaxOpt: null,
-                   locations: locations)
+                   blockBodySyntaxOpt,
+                   expressionBodySyntaxOpt,
+                   locations)
         {
             _event = @event;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventAccessorSymbol.cs
@@ -24,7 +24,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             SyntaxReference syntaxReference,
             SyntaxReference blockSyntaxReference,
             ImmutableArray<Location> locations)
-            : base(@event.containingType, syntaxReference, blockSyntaxReference, locations)
+            : base(@event.containingType,
+                   syntaxReference,
+                   blockSyntaxReference,
+                   expressionBodySyntaxOpt: null,
+                   locations: locations)
         {
             _event = @event;
         }
@@ -195,12 +199,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return null;
-        }
-
-        internal override bool IsExpressionBodied
-        {
-            // Events cannot be expression-bodied
-            get { return false; }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -69,8 +69,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics) :
             base(containingType,
                  syntax.GetReference(),
-                 // Prefer a block body if both exist
-                 syntax.Body?.GetReference() ?? syntax.ExpressionBody?.GetReference(),
+                 syntax.Body?.GetReference(), 
+                 syntax.ExpressionBody?.GetReference(),
                  location)
         {
             _name = name;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -744,11 +744,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool IsExpressionBodied
-        {
-            get { return _isExpressionBodied; }
-        }
-
         private DeclarationModifiers MakeModifiers(SyntaxTokenList modifiers, MethodKind methodKind, Location location, DiagnosticBag diagnostics, out bool modifierErrors)
         {
             bool isInterface = this.ContainingType.IsInterface;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -470,32 +470,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _typeParameters; }
         }
 
-        internal TypeParameterConstraintKind GetTypeParameterConstraints(int ordinal)
+        protected override ImmutableArray<TypeParameterConstraintClause> TypeParameterConstraints
         {
-            var clause = this.GetTypeParameterConstraintClause(ordinal);
-            return (clause != null) ? clause.Constraints : TypeParameterConstraintKind.None;
-        }
-
-        internal ImmutableArray<TypeSymbol> GetTypeParameterConstraintTypes(int ordinal)
-        {
-            var clause = this.GetTypeParameterConstraintClause(ordinal);
-            return (clause != null) ? clause.ConstraintTypes : ImmutableArray<TypeSymbol>.Empty;
-        }
-
-        private TypeParameterConstraintClause GetTypeParameterConstraintClause(int ordinal)
-        {
-            if (_lazyTypeParameterConstraints.IsDefault)
+            get
             {
-                var diagnostics = DiagnosticBag.GetInstance();
-                if (ImmutableInterlocked.InterlockedInitialize(ref _lazyTypeParameterConstraints, MakeTypeParameterConstraints(diagnostics)))
+                if (_lazyTypeParameterConstraints.IsDefault)
                 {
-                    this.AddDeclarationDiagnostics(diagnostics);
+                    var diagnostics = DiagnosticBag.GetInstance();
+                    if (ImmutableInterlocked.InterlockedInitialize(ref _lazyTypeParameterConstraints, MakeTypeParameterConstraints(diagnostics)))
+                    {
+                        this.AddDeclarationDiagnostics(diagnostics);
+                    }
+                    diagnostics.Free();
                 }
-                diagnostics.Free();
+                return _lazyTypeParameterConstraints;
             }
-
-            var clauses = _lazyTypeParameterConstraints;
-            return (clauses.Length > 0) ? clauses[ordinal] : null;
         }
 
         private ImmutableArray<TypeParameterConstraintClause> MakeTypeParameterConstraints(DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -56,26 +56,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 set { _flags = value ? (_flags | ReturnsVoidBit) : (_flags & ~ReturnsVoidBit); }
             }
 
-            public MethodKind MethodKind
-            {
-                get { return (MethodKind)((_flags >> MethodKindOffset) & MethodKindMask); }
-            }
-
-            public bool IsExtensionMethod
-            {
-                get { return (_flags & IsExtensionMethodBit) != 0; }
-            }
-
-            public bool IsMetadataVirtualLocked
-            {
-                get { return (_flags & IsMetadataVirtualLockedBit) != 0; }
-            }
-
-            public DeclarationModifiers DeclarationModifiers
-            {
-                get { return (DeclarationModifiers)((_flags >> DeclarationModifiersOffset) & DeclarationModifiersMask); }
-            }
-
+            public MethodKind MethodKind => (MethodKind)((_flags >> MethodKindOffset) & MethodKindMask);
+            public bool IsExtensionMethod => (_flags & IsExtensionMethodBit) != 0;
+            public bool IsMetadataVirtualLocked => (_flags & IsMetadataVirtualLockedBit) != 0;
+            public DeclarationModifiers DeclarationModifiers => (DeclarationModifiers)((_flags >> DeclarationModifiersOffset) & DeclarationModifiersMask);
 #if DEBUG
             static Flags()
             {
@@ -177,11 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         //are stashed here in service of API usage patterns
         //where method body diagnostics are requested multiple times.
         private ImmutableArray<Diagnostic> _cachedDiagnostics;
-        internal ImmutableArray<Diagnostic> Diagnostics
-        {
-            get { return _cachedDiagnostics; }
-        }
-
+        internal ImmutableArray<Diagnostic> Diagnostics => _cachedDiagnostics;
         internal ImmutableArray<Diagnostic> SetDiagnostics(ImmutableArray<Diagnostic> newSet, out bool diagsWritten)
         {
             //return the diagnostics that were actually saved in the event that there were two threads racing. 
@@ -268,11 +248,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// their own lock objects, so that we don't have to add a new field to every
         /// SourceMethodSymbol.
         /// </summary>
-        protected virtual object MethodChecksLockObject
-        {
-            get { return this.syntaxReferenceOpt; }
-        }
-
+        protected virtual object MethodChecksLockObject => this.syntaxReferenceOpt;
         protected void LazyMethodChecks()
         {
             if (!state.HasComplete(CompletionPart.FinishMethodChecks))
@@ -332,63 +308,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks);
         }
 
-        public sealed override Symbol ContainingSymbol
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        public sealed override Symbol ContainingSymbol => _containingType;
 
-        public override NamedTypeSymbol ContainingType
-        {
-            get
-            {
-                return _containingType;
-            }
-        }
+        public override NamedTypeSymbol ContainingType => _containingType;
 
-        public override Symbol AssociatedSymbol
-        {
-            get
-            {
-                return null;
-            }
-        }
+        public override Symbol AssociatedSymbol => null;
 
         #region Flags
 
-        public override bool ReturnsVoid
-        {
-            get
-            {
-                return this.flags.ReturnsVoid;
-            }
-        }
+        public override bool ReturnsVoid => this.flags.ReturnsVoid;
 
-        public sealed override MethodKind MethodKind
-        {
-            get
-            {
-                return this.flags.MethodKind;
-            }
-        }
+        public sealed override MethodKind MethodKind => this.flags.MethodKind;
 
-        public override bool IsExtensionMethod
-        {
-            get
-            {
-                return this.flags.IsExtensionMethod;
-            }
-        }
+        public override bool IsExtensionMethod => this.flags.IsExtensionMethod;
 
-        private bool IsMetadataVirtualLocked
-        {
-            get
-            {
-                return this.flags.IsMetadataVirtualLocked;
-            }
-        }
+        private bool IsMetadataVirtualLocked => this.flags.IsMetadataVirtualLocked;
 
         // TODO (tomat): sealed
         internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
@@ -414,102 +348,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
 
-        protected DeclarationModifiers DeclarationModifiers
-        {
-            get
-            {
-                return this.flags.DeclarationModifiers;
-            }
-        }
+        protected DeclarationModifiers DeclarationModifiers => this.flags.DeclarationModifiers;
 
         // TODO (tomat): sealed?
-        public override Accessibility DeclaredAccessibility
-        {
-            get
-            {
-                return ModifierUtils.EffectiveAccessibility(this.DeclarationModifiers);
-            }
-        }
+        public override Accessibility DeclaredAccessibility => ModifierUtils.EffectiveAccessibility(this.DeclarationModifiers);
 
-        public sealed override bool IsExtern
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Extern) != 0;
-            }
-        }
+        public sealed override bool IsExtern => (this.DeclarationModifiers & DeclarationModifiers.Extern) != 0;
 
-        public sealed override bool IsSealed
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Sealed) != 0;
-            }
-        }
+        public sealed override bool IsSealed => (this.DeclarationModifiers & DeclarationModifiers.Sealed) != 0;
 
-        public sealed override bool IsAbstract
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Abstract) != 0;
-            }
-        }
+        public sealed override bool IsAbstract => (this.DeclarationModifiers & DeclarationModifiers.Abstract) != 0;
 
-        public sealed override bool IsOverride
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Override) != 0;
-            }
-        }
+        public sealed override bool IsOverride => (this.DeclarationModifiers & DeclarationModifiers.Override) != 0;
 
-        internal bool IsPartial
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Partial) != 0;
-            }
-        }
+        internal bool IsPartial => (this.DeclarationModifiers & DeclarationModifiers.Partial) != 0;
 
-        public sealed override bool IsVirtual
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Virtual) != 0;
-            }
-        }
+        public sealed override bool IsVirtual => (this.DeclarationModifiers & DeclarationModifiers.Virtual) != 0;
 
-        internal bool IsNew
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.New) != 0;
-            }
-        }
+        internal bool IsNew => (this.DeclarationModifiers & DeclarationModifiers.New) != 0;
 
-        public sealed override bool IsStatic
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Static) != 0;
-            }
-        }
+        public sealed override bool IsStatic => (this.DeclarationModifiers & DeclarationModifiers.Static) != 0;
 
-        internal bool IsUnsafe
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
-            }
-        }
+        internal bool IsUnsafe => (this.DeclarationModifiers & DeclarationModifiers.Unsafe) != 0;
 
-        public sealed override bool IsAsync
-        {
-            get
-            {
-                return (this.DeclarationModifiers & DeclarationModifiers.Async) != 0;
-            }
-        }
+        public sealed override bool IsAsync => (this.DeclarationModifiers & DeclarationModifiers.Async) != 0;
 
         internal sealed override Cci.CallingConvention CallingConvention
         {
@@ -535,57 +397,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region Syntax
 
-        internal SyntaxNode BodySyntax
-        {
-            get
-            {
-                return this.bodySyntaxReferenceOpt?.GetSyntax();
-            }
-        }
+        internal SyntaxNode BodySyntax => this.bodySyntaxReferenceOpt?.GetSyntax();
 
-        internal SyntaxReference SyntaxRef
-        {
-            get
-            {
-                return this.syntaxReferenceOpt;
-            }
-        }
+        internal SyntaxReference SyntaxRef => this.syntaxReferenceOpt;
 
-        internal CSharpSyntaxNode SyntaxNode
-        {
-            get
-            {
-                return (this.syntaxReferenceOpt == null) ? null : (CSharpSyntaxNode)this.syntaxReferenceOpt.GetSyntax();
-            }
-        }
+        internal CSharpSyntaxNode SyntaxNode => (this.syntaxReferenceOpt == null) ? null : (CSharpSyntaxNode)this.syntaxReferenceOpt.GetSyntax();
 
-        internal SyntaxTree SyntaxTree
-        {
-            get
-            {
-                return this.syntaxReferenceOpt?.SyntaxTree;
-            }
-        }
+        internal SyntaxTree SyntaxTree => this.syntaxReferenceOpt?.SyntaxTree;
 
         /// <summary>
         /// Overridden by <see cref="SourceMemberMethodSymbol"/>, 
         /// which might return locations of partial methods.
         /// </summary>
-        public override ImmutableArray<Location> Locations
-        {
-            get
-            {
-                return this.locations;
-            }
-        }
+        public override ImmutableArray<Location> Locations => this.locations;
 
-        public sealed override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
-        {
-            get
-            {
-                return (this.syntaxReferenceOpt == null) ? ImmutableArray<SyntaxReference>.Empty : ImmutableArray.Create(this.syntaxReferenceOpt);
-            }
-        }
+        public sealed override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => (this.syntaxReferenceOpt == null) ? ImmutableArray<SyntaxReference>.Empty : ImmutableArray.Create(this.syntaxReferenceOpt);
 
         public override string GetDocumentationCommentXml(CultureInfo preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -594,37 +420,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #endregion
 
-        public override ImmutableArray<CustomModifier> ReturnTypeCustomModifiers
-        {
-            get
-            {
-                return ImmutableArray<CustomModifier>.Empty;
-            }
-        }
+        public override ImmutableArray<CustomModifier> ReturnTypeCustomModifiers => ImmutableArray<CustomModifier>.Empty;
 
-        public override ImmutableArray<CustomModifier> RefCustomModifiers
-        {
-            get
-            {
-                return ImmutableArray<CustomModifier>.Empty;
-            }
-        }
+        public override ImmutableArray<CustomModifier> RefCustomModifiers => ImmutableArray<CustomModifier>.Empty;
 
-        public sealed override ImmutableArray<TypeSymbol> TypeArguments
-        {
-            get
-            {
-                return TypeParameters.Cast<TypeParameterSymbol, TypeSymbol>();
-            }
-        }
+        public sealed override ImmutableArray<TypeSymbol> TypeArguments => TypeParameters.Cast<TypeParameterSymbol, TypeSymbol>();
 
-        public sealed override int Arity
-        {
-            get
-            {
-                return TypeParameters.Length;
-            }
-        }
+        public sealed override int Arity => TypeParameters.Length;
 
         internal sealed override bool TryGetThisParameter(out ParameterSymbol thisParameter)
         {
@@ -653,13 +455,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         //overridden appropriately in SourceMemberMethodSymbol
-        public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations
-        {
-            get
-            {
-                return ImmutableArray<MethodSymbol>.Empty;
-            }
-        }
+        public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<MethodSymbol>.Empty;
 
         internal sealed override OverriddenOrHiddenMembersResult OverriddenOrHiddenMembers
         {
@@ -675,11 +471,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool RequiresCompletion
-        {
-            get { return true; }
-        }
-
+        internal sealed override bool RequiresCompletion => true;
         internal sealed override bool HasComplete(CompletionPart part)
         {
             return state.HasComplete(part);
@@ -762,29 +554,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Used for example for event accessors. The "remove" method delegates attribute binding to the "add" method. 
         /// The bound attribute data are then applied to both accessors.
         /// </remarks>
-        protected virtual SourceMethodSymbol BoundAttributesSource
-        {
-            get
-            {
-                return null;
-            }
-        }
+        protected virtual SourceMethodSymbol BoundAttributesSource => null;
 
-        protected virtual IAttributeTargetSymbol AttributeOwner
-        {
-            get { return this; }
-        }
-
-        IAttributeTargetSymbol IAttributeTargetSymbol.AttributesOwner
-        {
-            get { return this.AttributeOwner; }
-        }
-
-        AttributeLocation IAttributeTargetSymbol.DefaultAttributeLocation
-        {
-            get { return AttributeLocation.Method; }
-        }
-
+        protected virtual IAttributeTargetSymbol AttributeOwner => this;
+        IAttributeTargetSymbol IAttributeTargetSymbol.AttributesOwner => this.AttributeOwner;
+        AttributeLocation IAttributeTargetSymbol.DefaultAttributeLocation => AttributeLocation.Method;
         AttributeLocation IAttributeTargetSymbol.AllowedAttributeLocations
         {
             get
@@ -1401,21 +1175,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             base.PostDecodeWellKnownAttributes(boundAttributes, allAttributeSyntaxNodes, diagnostics, symbolPart, decodedData);
         }
 
-        public sealed override bool HidesBaseMethodsByName
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public sealed override bool HidesBaseMethodsByName => false;
 
-        internal override bool HasRuntimeSpecialName
-        {
-            get
-            {
-                return base.HasRuntimeSpecialName || IsVtableGapInterfaceMethod();
-            }
-        }
+        internal override bool HasRuntimeSpecialName => base.HasRuntimeSpecialName || IsVtableGapInterfaceMethod();
 
         private bool IsVtableGapInterfaceMethod()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -169,19 +169,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _cachedDiagnostics;
         }
 
-        protected SourceMethodSymbol(Symbol containingSymbol, SyntaxReference syntaxReferenceOpt, SyntaxReference bodySyntaxReferenceOpt, Location location)
-            : this(containingSymbol, syntaxReferenceOpt, bodySyntaxReferenceOpt, ImmutableArray.Create(location))
+        protected SourceMethodSymbol(
+            Symbol containingSymbol,
+            SyntaxReference syntaxReferenceOpt,
+            SyntaxReference blockBodySyntaxOpt,
+            SyntaxReference expressionBodySyntaxOpt,
+            Location location)
+            : this(containingSymbol,
+                   syntaxReferenceOpt,
+                   blockBodySyntaxOpt,
+                   expressionBodySyntaxOpt,
+                   ImmutableArray.Create(location))
         {
         }
 
-        protected SourceMethodSymbol(Symbol containingSymbol, SyntaxReference syntaxReferenceOpt, SyntaxReference bodySyntaxReferenceOpt, ImmutableArray<Location> locations)
+        protected SourceMethodSymbol(Symbol containingSymbol,
+            SyntaxReference syntaxReferenceOpt,
+            SyntaxReference blockBodySyntaxOpt,
+            SyntaxReference expressionBodySyntaxOpt,
+            ImmutableArray<Location> locations)
         {
             Debug.Assert((object)containingSymbol != null);
             Debug.Assert(!locations.IsEmpty);
 
             _containingSymbol = containingSymbol;
             this.syntaxReferenceOpt = syntaxReferenceOpt;
-            this.bodySyntaxReferenceOpt = bodySyntaxReferenceOpt;
+            // Prefer block body to expression body
+            this.bodySyntaxReferenceOpt = blockBodySyntaxOpt ?? expressionBodySyntaxOpt;
             this.locations = locations;
         }
 
@@ -1366,7 +1380,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If the method has both block body and an expression body
         /// present, this is not treated as expression-bodied.
         /// </remarks>
-        internal abstract bool IsExpressionBodied { get; }
+        internal bool IsExpressionBodied => bodySyntaxReferenceOpt?.GetSyntax().Kind() == SyntaxKind.ArrowExpressionClause;
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -539,7 +539,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return (this.bodySyntaxReferenceOpt == null) ? null : this.bodySyntaxReferenceOpt.GetSyntax();
+                return this.bodySyntaxReferenceOpt?.GetSyntax();
             }
         }
 
@@ -563,7 +563,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return this.syntaxReferenceOpt == null ? null : this.syntaxReferenceOpt.SyntaxTree;
+                return this.syntaxReferenceOpt?.SyntaxTree;
             }
         }
 
@@ -1040,7 +1040,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (lazyCustomAttributesBag != null && lazyCustomAttributesBag.IsEarlyDecodedWellKnownAttributeDataComputed)
                 {
                     var data = (CommonMethodEarlyWellKnownAttributeData)lazyCustomAttributesBag.EarlyDecodedWellKnownAttributeData;
-                    return data != null ? data.ObsoleteAttributeData : null;
+                    return data?.ObsoleteAttributeData;
                 }
 
                 var reference = this.syntaxReferenceOpt;
@@ -1490,7 +1490,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public sealed override DllImportData GetDllImportData()
         {
             var data = this.GetDecodedWellKnownAttributeData();
-            return data != null ? data.DllImportPlatformInvokeData : null;
+            return data?.DllImportPlatformInvokeData;
         }
 
         internal sealed override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation
@@ -1498,7 +1498,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 var data = this.GetDecodedReturnTypeWellKnownAttributeData();
-                return data != null ? data.MarshallingInformation : null;
+                return data?.MarshallingInformation;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -94,14 +94,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics);
         }
 
-        internal override bool IsExpressionBodied
-        {
-            get
-            {
-                return _isExpressionBodied;
-            }
-        }
-
         private static void GetNameAndExplicitInterfaceImplementations(
             PropertySymbol explicitlyImplementedPropertyOpt,
             string propertyName,
@@ -142,8 +134,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<MethodSymbol> explicitInterfaceImplementations,
             Location location,
             ArrowExpressionClauseSyntax syntax,
-            DiagnosticBag diagnostics) :
-            base(containingType, syntax.GetReference(), syntax.GetReference(), location)
+            DiagnosticBag diagnostics)
+            : base(containingType,
+                   syntax.GetReference(),
+                   blockBodySyntaxOpt: null,
+                   expressionBodySyntaxOpt: syntax.GetReference(),
+                   location: location)
         {
             _property = property;
             _explicitInterfaceImplementations = explicitInterfaceImplementations;
@@ -196,7 +192,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics)
             : base(containingType,
                    syntax.GetReference(),
-                   ((SyntaxNode)syntax.Body ?? syntax.ExpressionBody)?.GetReference(),
+                   syntax.Body?.GetReference(),
+                   syntax.ExpressionBody?.GetReference(),
                    location)
         {
             _property = property;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -381,13 +381,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
     internal sealed class SourceMethodTypeParameterSymbol : SourceTypeParameterSymbolBase
     {
-        private readonly SourceMemberMethodSymbol _owner;
+        private readonly SourceMethodSymbol _owner;
 
-        public SourceMethodTypeParameterSymbol(SourceMemberMethodSymbol owner, string name, int ordinal, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
+        public SourceMethodTypeParameterSymbol(SourceMethodSymbol owner, string name, int ordinal, ImmutableArray<Location> locations, ImmutableArray<SyntaxReference> syntaxRefs)
             : base(name, ordinal, locations, syntaxRefs)
         {
             _owner = owner;
         }
+
+        internal override void AddDeclarationDiagnostics(DiagnosticBag diagnostics) => _owner.AddDeclarationDiagnostics(diagnostics);
 
         public override TypeParameterKind TypeParameterKind
         {
@@ -444,49 +446,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return _owner.GetTypeParameterConstraints(this.Ordinal);
         }
-    }
-
-    // TODO: https://github.com/dotnet/roslyn/issues/17244 This type is probably not necessary
-    internal sealed class LocalFunctionTypeParameterSymbol : SourceTypeParameterSymbolBase
-    {
-        private readonly LocalFunctionSymbol _owner;
-
-        public LocalFunctionTypeParameterSymbol(
-            LocalFunctionSymbol owner,
-            string name,
-            int ordinal,
-            ImmutableArray<Location> locations,
-            ImmutableArray<SyntaxReference> syntaxRefs)
-            : base(name, ordinal, locations, syntaxRefs)
-        {
-            _owner = owner;
-        }
-
-        internal override void AddDeclarationDiagnostics(DiagnosticBag diagnostics)
-            => _owner.AddDeclarationDiagnostics(diagnostics);
-
-        public override TypeParameterKind TypeParameterKind => TypeParameterKind.Method;
-
-        public override Symbol ContainingSymbol => _owner;
-
-        public override bool HasConstructorConstraint
-            => (GetDeclaredConstraints() & TypeParameterConstraintKind.Constructor) != 0;
-
-        public override bool HasValueTypeConstraint
-            => (GetDeclaredConstraints() & TypeParameterConstraintKind.ValueType) != 0;
-
-        public override bool HasReferenceTypeConstraint
-            => (GetDeclaredConstraints() & TypeParameterConstraintKind.ReferenceType) != 0;
-
-        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters => _owner.TypeParameters;
-
-        protected override TypeParameterBounds ResolveBounds(ConsList<TypeParameterSymbol> inProgress, DiagnosticBag diagnostics)
-        {
-            var constraintTypes = _owner.GetTypeParameterConstraintTypes(this.Ordinal);
-            return this.ResolveBounds(this.ContainingAssembly.CorLibrary, inProgress.Prepend(this), constraintTypes, false, this.DeclaringCompilation, diagnostics);
-        }
-
-        private TypeParameterConstraintKind GetDeclaredConstraints() => _owner.GetTypeParameterConstraints(Ordinal);
     }
 
     /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceTypeParameterSymbol.cs
@@ -34,53 +34,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _syntaxRefs = syntaxRefs;
         }
 
-        public override ImmutableArray<Location> Locations
-        {
-            get
-            {
-                return _locations;
-            }
-        }
+        public override ImmutableArray<Location> Locations => _locations;
 
-        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
-        {
-            get
-            {
-                return _syntaxRefs;
-            }
-        }
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _syntaxRefs;
 
-        internal ImmutableArray<SyntaxReference> SyntaxReferences
-        {
-            get
-            {
-                return _syntaxRefs;
-            }
-        }
+        internal ImmutableArray<SyntaxReference> SyntaxReferences => _syntaxRefs;
 
-        public override int Ordinal
-        {
-            get
-            {
-                return _ordinal;
-            }
-        }
+        public override int Ordinal => _ordinal;
 
-        public override VarianceKind Variance
-        {
-            get
-            {
-                return VarianceKind.None;
-            }
-        }
+        public override VarianceKind Variance => VarianceKind.None;
 
-        public override string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public override string Name => _name;
 
         internal override ImmutableArray<TypeSymbol> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress)
         {
@@ -133,21 +97,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        IAttributeTargetSymbol IAttributeTargetSymbol.AttributesOwner
-        {
-            get { return this; }
-        }
-
-        AttributeLocation IAttributeTargetSymbol.DefaultAttributeLocation
-        {
-            get { return AttributeLocation.TypeParameter; }
-        }
-
-        AttributeLocation IAttributeTargetSymbol.AllowedAttributeLocations
-        {
-            get { return AttributeLocation.TypeParameter; }
-        }
-
+        IAttributeTargetSymbol IAttributeTargetSymbol.AttributesOwner => this;
+        AttributeLocation IAttributeTargetSymbol.DefaultAttributeLocation => AttributeLocation.TypeParameter;
+        AttributeLocation IAttributeTargetSymbol.AllowedAttributeLocations => AttributeLocation.TypeParameter;
         /// <summary>
         /// Gets the attributes applied on this symbol.
         /// Returns an empty array if there are no attributes.
@@ -317,24 +269,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _varianceKind = varianceKind;
         }
 
-        public override TypeParameterKind TypeParameterKind
-        {
-            get
-            {
-                return TypeParameterKind.Type;
-            }
-        }
+        public override TypeParameterKind TypeParameterKind => TypeParameterKind.Type;
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _owner; }
-        }
-
-        public override VarianceKind Variance
-        {
-            get { return _varianceKind; }
-        }
-
+        public override Symbol ContainingSymbol => _owner;
+        public override VarianceKind Variance => _varianceKind;
         public override bool HasConstructorConstraint
         {
             get
@@ -362,11 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters
-        {
-            get { return _owner.TypeParameters; }
-        }
-
+        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters => _owner.TypeParameters;
         protected override TypeParameterBounds ResolveBounds(ConsList<TypeParameterSymbol> inProgress, DiagnosticBag diagnostics)
         {
             var constraintTypes = _owner.GetTypeParameterConstraintTypes(this.Ordinal);
@@ -391,19 +325,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override void AddDeclarationDiagnostics(DiagnosticBag diagnostics) => _owner.AddDeclarationDiagnostics(diagnostics);
 
-        public override TypeParameterKind TypeParameterKind
-        {
-            get
-            {
-                return TypeParameterKind.Method;
-            }
-        }
+        public override TypeParameterKind TypeParameterKind => TypeParameterKind.Method;
 
-        public override Symbol ContainingSymbol
-        {
-            get { return _owner; }
-        }
-
+        public override Symbol ContainingSymbol => _owner;
         public override bool HasConstructorConstraint
         {
             get
@@ -431,11 +355,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters
-        {
-            get { return _owner.TypeParameters; }
-        }
-
+        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters => _owner.TypeParameters;
         protected override TypeParameterBounds ResolveBounds(ConsList<TypeParameterSymbol> inProgress, DiagnosticBag diagnostics)
         {
             var constraintTypes = _owner.GetTypeParameterConstraintTypes(this.Ordinal);
@@ -469,11 +389,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _overridingMethod = overridingMethod;
         }
 
-        public SourceMemberMethodSymbol OverridingMethod
-        {
-            get { return _overridingMethod; }
-        }
-
+        public SourceMemberMethodSymbol OverridingMethod => _overridingMethod;
         public TypeParameterSymbol GetOverriddenTypeParameter(int ordinal)
         {
             var overriddenMethod = this.OverriddenMethod;
@@ -574,24 +490,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _map = map;
         }
 
-        public SourceMemberMethodSymbol Owner
-        {
-            get { return _map.OverridingMethod; }
-        }
+        public SourceMemberMethodSymbol Owner => _map.OverridingMethod;
+        public override TypeParameterKind TypeParameterKind => TypeParameterKind.Method;
 
-        public override TypeParameterKind TypeParameterKind
-        {
-            get
-            {
-                return TypeParameterKind.Method;
-            }
-        }
-
-        public override Symbol ContainingSymbol
-        {
-            get { return this.Owner; }
-        }
-
+        public override Symbol ContainingSymbol => this.Owner;
         public override bool HasConstructorConstraint
         {
             get
@@ -619,11 +521,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters
-        {
-            get { return this.Owner.TypeParameters; }
-        }
-
+        protected override ImmutableArray<TypeParameterSymbol> ContainerTypeParameters => this.Owner.TypeParameters;
         protected override TypeParameterBounds ResolveBounds(ConsList<TypeParameterSymbol> inProgress, DiagnosticBag diagnostics)
         {
             var typeParameter = this.OverriddenTypeParameter;
@@ -644,12 +542,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// method that the owner method is overriding, the corresponding type
         /// parameter on that method is used. Otherwise, the result is null.
         /// </summary>
-        private TypeParameterSymbol OverriddenTypeParameter
-        {
-            get
-            {
-                return _map.GetOverriddenTypeParameter(this.Ordinal);
-            }
-        }
+        private TypeParameterSymbol OverriddenTypeParameter => _map.GetOverriddenTypeParameter(this.Ordinal);
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -2,12 +2,9 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using System.Collections.Generic;
-using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -28,7 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             SyntaxTokenList modifiersSyntax,
             DiagnosticBag diagnostics,
             bool isExpressionBodied) :
-            base(containingType, syntaxReference, bodySyntaxReference, location)
+            base(containingType,
+                 syntaxReference,
+                 bodySyntaxReference,
+                 expressionBodySyntaxOpt: null,
+                 location: location)
         {
             _name = name;
             _isExpressionBodied = isExpressionBodied;
@@ -623,11 +624,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 LazyMethodChecks();
                 return _lazyReturnType;
             }
-        }
-
-        internal override bool IsExpressionBodied
-        {
-            get { return _isExpressionBodied; }
         }
 
         internal sealed override OneOrMany<SyntaxList<AttributeListSyntax>> GetAttributeDeclarations()

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldLikeEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedFieldLikeEventAccessorSymbol.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly string _name;
 
         internal SynthesizedFieldLikeEventAccessorSymbol(SourceFieldLikeEventSymbol @event, bool isAdder)
-            : base(@event, null, null, @event.Locations)
+            : base(@event, null, null, null, @event.Locations)
         {
             this.MakeFlags(
                 isAdder ? MethodKind.EventAdd : MethodKind.EventRemove,


### PR DESCRIPTION
LocalFunctionTypeParameterSymbol duplicates a lot of code from SourceMethodTypeParamaterSymbol, mainly because LocalFunctionSymbol inherits from MethodSymbol, not SourceMethodSymbol.

This PR refactors LocalFunctionSymbol to inherit from SourceMethodSymbol and removes LocalFunctionTypeParameterSymbol entirely.

Fixes #17244