### PR TITLE
Report use-site diagnostics if System.ValueTuple base type is an error type

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -791,7 +791,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             {
                 Debug.Assert(!needDeclaration);
                 namedTypeSymbol = namedTypeSymbol.TupleUnderlyingType;
-                CheckTupleUnderlying(namedTypeSymbol, syntaxNodeOpt, diagnostics);
+                CheckTupleUnderlyingType(namedTypeSymbol, syntaxNodeOpt, diagnostics);
             }
 
             // Substitute error types with a special singleton object.
@@ -892,21 +892,39 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return namedTypeSymbol;
         }
 
-        private void CheckTupleUnderlying(NamedTypeSymbol namedTypeSymbol, SyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
+        private void CheckTupleUnderlyingType(NamedTypeSymbol namedTypeSymbol, SyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics)
         {
             // check that underlying type of a ValueTuple is indeed a value type (or error)
             // this should never happen, in theory,
             // but if it does happen we should make it a failure.
             // NOTE: declaredBase could be null for interfaces
             var declaredBase = namedTypeSymbol.BaseTypeNoUseSiteDiagnostics;
-            if (declaredBase == null || declaredBase.SpecialType != SpecialType.System_ValueType)
+            if ((object)declaredBase != null && declaredBase.SpecialType == SpecialType.System_ValueType)
             {
-                // Try to decrease noise by not complaining about the same type over and over again.
-                if (_reportedErrorTypesMap.Add(namedTypeSymbol))
+                return;
+            }
+
+            // Try to decrease noise by not complaining about the same type over and over again.
+            if (!_reportedErrorTypesMap.Add(namedTypeSymbol))
+            {
+                return;
+            }
+
+            var location = syntaxNodeOpt == null ? NoLocation.Singleton : syntaxNodeOpt.Location;
+            if ((object)declaredBase != null)
+            {
+                var diagnosticInfo = declaredBase.GetUseSiteDiagnostic();
+                if (diagnosticInfo != null && diagnosticInfo.Severity == DiagnosticSeverity.Error)
                 {
-                    diagnostics.Add(new CSDiagnostic(new CSDiagnosticInfo(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct, namedTypeSymbol.MetadataName), syntaxNodeOpt == null ? NoLocation.Singleton : syntaxNodeOpt.Location));
+                    diagnostics.Add(diagnosticInfo, location);
+                    return;
                 }
             }
+
+            diagnostics.Add(
+                new CSDiagnostic(
+                    new CSDiagnosticInfo(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct, namedTypeSymbol.MetadataName),
+                    location));
         }
 
         public static bool IsGenericType(NamedTypeSymbol toCheck)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16,7 +16,6 @@ using Roslyn.Test.Utilities;
 using Xunit;
 
 using static TestResources.NetFX.ValueTuple;
-using System.Reflection.PortableExecutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
@@ -19981,9 +19980,7 @@ namespace System
                 //         (int a, int b) x;
                 Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct, "x").WithArguments("ValueTuple`2").WithLocation(6, 24)
             );
-
         }
-
 
         [Fact]
         [WorkItem(11689, "https://github.com/dotnet/roslyn/issues/11689")]
@@ -20056,7 +20053,6 @@ namespace System
                 //         var x = (1,2,3,4,5,6,7,8,9);
                 Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct, "x = (1,2,3,4,5,6,7,8,9)").WithArguments("ValueTuple`2").WithLocation(6, 13)
             );
-
         }
 
         [Fact]
@@ -20098,7 +20094,6 @@ namespace System
                 // error CS8180: Predefined type 'ValueTuple`2' must be a struct.
                 Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct).WithArguments("ValueTuple`2").WithLocation(1, 1)
             );
-
         }
 
         [Fact]
@@ -20132,7 +20127,6 @@ namespace System
                 // error CS8180: Predefined type 'ValueTuple`2' must be a struct.
                 Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct).WithArguments("ValueTuple`2").WithLocation(1, 1)
             );
-
         }
 
         [Fact]
@@ -20178,7 +20172,6 @@ namespace System
                 //         (int, int)[] x = null;
                 Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct, "x = null").WithArguments("ValueTuple`2").WithLocation(10, 22)
             );
-
         }
 
         [Fact]
@@ -20224,7 +20217,123 @@ namespace System
         return (1, 1);
     }").WithArguments("ValueTuple`2").WithLocation(9, 5)
             );
+        }
 
+        [Fact]
+        public void ValueTupleBaseError_NoSystemRuntime()
+        {
+            var source =
+@"interface I
+{
+    ((int, int), (int, int)) F();
+}";
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef });
+            comp.VerifyEmitDiagnostics(
+                // (3,6): error CS0012: The type 'ValueType' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+                //     ((int, int), (int, int)) F();
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "(int, int)").WithArguments("System.ValueType", "System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").WithLocation(3, 6),
+                // (3,18): error CS0012: The type 'ValueType' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+                //     ((int, int), (int, int)) F();
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "(int, int)").WithArguments("System.ValueType", "System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").WithLocation(3, 18),
+                // (3,5): error CS0012: The type 'ValueType' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+                //     ((int, int), (int, int)) F();
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "((int, int), (int, int))").WithArguments("System.ValueType", "System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").WithLocation(3, 5));
+        }
+
+        [WorkItem(16879, "https://github.com/dotnet/roslyn/issues/16879")]
+        [Fact]
+        public void ValueTupleBaseError_MissingReference()
+        {
+            var source0 =
+@"public class A
+{
+}
+public class B
+{
+}";
+            var comp0 = CreateCompilationWithMscorlib(source0, assemblyName: "92872377-08d1-4723-8906-a43b03e56ed3");
+            comp0.VerifyDiagnostics();
+            var ref0 = comp0.EmitToImageReference();
+            var source1 =
+@"public class C<T>
+{
+}
+namespace System
+{
+    public class ValueTuple<T1, T2> : A
+    {
+        public ValueTuple(T1 _1, T2 _2) { }
+    }
+    public class ValueTuple<T1, T2, T3> : C<B>
+    {
+        public ValueTuple(T1 _1, T2 _2, T3 _3) { }
+    }
+}";
+            var comp1 = CreateCompilationWithMscorlib(source1, references: new[] { ref0 });
+            comp1.VerifyDiagnostics();
+            var ref1 = comp1.EmitToImageReference();
+            var source =
+@"interface I
+{
+    (int, (int, int), (int, int)) F();
+}";
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ref1 });
+            comp.VerifyEmitDiagnostics(
+                // error CS0012: The type 'B' is defined in an assembly that is not referenced. You must add a reference to assembly '92872377-08d1-4723-8906-a43b03e56ed3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("B", "92872377-08d1-4723-8906-a43b03e56ed3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"),
+                // error CS0012: The type 'A' is defined in an assembly that is not referenced. You must add a reference to assembly '92872377-08d1-4723-8906-a43b03e56ed3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                Diagnostic(ErrorCode.ERR_NoTypeDef).WithArguments("A", "92872377-08d1-4723-8906-a43b03e56ed3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
+        }
+
+        [Fact]
+        public void ValueTupleBase_AssemblyUnification()
+        {
+            var source0v1 =
+@"[assembly: System.Reflection.AssemblyVersion(""1.0.0.0"")]
+public class A
+{
+}";
+            var signedDllOptions = TestOptions.ReleaseDll.
+                WithCryptoKeyFile(SigningTestHelpers.KeyPairFile).
+                WithStrongNameProvider(new SigningTestHelpers.VirtualizedStrongNameProvider(ImmutableArray<string>.Empty));
+            var comp0v1 = CreateCompilationWithMscorlib(source0v1, assemblyName: "A", options: signedDllOptions);
+            comp0v1.VerifyDiagnostics();
+            var ref0v1 = comp0v1.EmitToImageReference();
+            var source0v2 =
+@"[assembly: System.Reflection.AssemblyVersion(""2.0.0.0"")]
+public class A
+{
+}";
+            var comp0v2 = CreateCompilationWithMscorlib(source0v2, assemblyName: "A", options: signedDllOptions);
+            comp0v2.VerifyDiagnostics();
+            var ref0v2 = comp0v2.EmitToImageReference();
+            var source1 =
+@"public class B : A
+{
+}";
+            var comp1 = CreateCompilationWithMscorlib(source1, references: new[] { ref0v1 });
+            comp1.VerifyDiagnostics();
+            var ref1 = comp1.EmitToImageReference();
+            var source2 =
+@"namespace System
+{
+    public class ValueTuple<T1, T2> : B
+    {
+        public ValueTuple(T1 _1, T2 _2) { }
+    }
+}";
+            var comp2 = CreateCompilationWithMscorlib(source2, references: new[] { ref1, ref0v1 });
+            comp2.VerifyDiagnostics();
+            var ref2 = comp2.EmitToImageReference();
+            var source =
+@"interface I
+{
+    (int, int) F();
+}";
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ref0v2, ref1, ref2 });
+            comp.VerifyEmitDiagnostics(
+                // error CS8182: Predefined type 'ValueTuple`2' must be a struct.
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeMustBeStruct).WithArguments("ValueTuple`2").WithLocation(1, 1));
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Portable/Emit/SymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SymbolTranslator.vb
@@ -120,7 +120,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 Debug.Assert(Not needDeclaration)
                 namedTypeSymbol = namedTypeSymbol.TupleUnderlyingType
 
-                CheckTupleUnderlying(namedTypeSymbol, syntaxNodeOpt, diagnostics)
+                CheckTupleUnderlyingType(namedTypeSymbol, syntaxNodeOpt, diagnostics)
             End If
 
             ' Substitute error types with a special singleton object.
@@ -203,21 +203,34 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return namedTypeSymbol
         End Function
 
-        Private Sub CheckTupleUnderlying(namedTypeSymbol As NamedTypeSymbol, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag)
+        Private Sub CheckTupleUnderlyingType(namedTypeSymbol As NamedTypeSymbol, syntaxNodeOpt As SyntaxNode, diagnostics As DiagnosticBag)
             ' check that underlying type of a ValueTuple is indeed a value type (or error)
             ' this should never happen, in theory,
             ' but if it does happen we should make it a failure.
             ' NOTE: declaredBase could be null for interfaces
             Dim declaredBase = namedTypeSymbol.BaseTypeNoUseSiteDiagnostics
-            If declaredBase Is Nothing OrElse declaredBase.SpecialType <> SpecialType.System_ValueType Then
-                ' Try to decrease noise by not complaining about the same type over and over again.
-                If (_reportedErrorTypesMap.Add(namedTypeSymbol)) Then
-                    diagnostics.Add(New VBDiagnostic(
-                                    ErrorFactory.ErrorInfo(ERRID.ERR_PredefinedValueTupleTypeMustBeStruct, namedTypeSymbol.MetadataName),
-                                    If(syntaxNodeOpt Is Nothing, NoLocation.Singleton, syntaxNodeOpt.GetLocation())))
+            If declaredBase IsNot Nothing AndAlso declaredBase.SpecialType = SpecialType.System_ValueType Then
+                Return
+            End If
 
+            ' Try to decrease noise by not complaining about the same type over and over again.
+            If Not _reportedErrorTypesMap.Add(namedTypeSymbol) Then
+                Return
+            End If
+
+            Dim location = If(syntaxNodeOpt Is Nothing, NoLocation.Singleton, syntaxNodeOpt.GetLocation())
+            If declaredBase IsNot Nothing Then
+                Dim diagnosticInfo = declaredBase.GetUseSiteErrorInfo()
+                If diagnosticInfo IsNot Nothing Then
+                    diagnostics.Add(diagnosticInfo, location)
+                    Return
                 End If
             End If
+
+            diagnostics.Add(
+                New VBDiagnostic(
+                    ErrorFactory.ErrorInfo(ERRID.ERR_PredefinedValueTupleTypeMustBeStruct, namedTypeSymbol.MetadataName),
+                    location))
         End Sub
 
         Friend Overloads Function Translate([param] As TypeParameterSymbol) As Microsoft.Cci.IGenericParameterReference

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -17281,6 +17281,149 @@ BC37281: Predefined type 'ValueTuple`2' must be a structure.
         End Sub
 
         <Fact>
+        Public Sub ValueTupleBaseError_NoSystemRuntime()
+            Dim comp = CreateCompilationWithMscorlib(
+<compilation>
+    <file name="a.vb">
+Interface I
+    Function F() As ((Integer, Integer), (Integer, Integer))
+End Interface
+    </file>
+</compilation>,
+                references:={ValueTupleRef})
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC30652: Reference required to assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' containing the type 'ValueType'. Add one to your project.
+    Function F() As ((Integer, Integer), (Integer, Integer))
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30652: Reference required to assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' containing the type 'ValueType'. Add one to your project.
+    Function F() As ((Integer, Integer), (Integer, Integer))
+                     ~~~~~~~~~~~~~~~~~~
+BC30652: Reference required to assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' containing the type 'ValueType'. Add one to your project.
+    Function F() As ((Integer, Integer), (Integer, Integer))
+                                         ~~~~~~~~~~~~~~~~~~
+</errors>)
+        End Sub
+
+        <WorkItem(16879, "https://github.com/dotnet/roslyn/issues/16879")>
+        <Fact>
+        Public Sub ValueTupleBaseError_MissingReference()
+            Dim comp0 = CreateCompilationWithMscorlib(
+<compilation name="5a03232e-1a0f-4d1b-99ba-5d7b40ea931e">
+    <file name="a.vb">
+Public Class A
+End Class
+Public Class B
+End Class
+    </file>
+</compilation>)
+            comp0.AssertNoDiagnostics()
+            Dim ref0 = comp0.EmitToImageReference()
+            Dim comp1 = CreateCompilationWithMscorlib(
+<compilation>
+    <file name="a.vb">
+Public Class C(Of T)
+End Class
+Namespace System
+    Public Class ValueTuple(Of T1, T2)
+        Inherits A
+        Public Sub New(_1 As T1, _2 As T2)
+        End Sub
+    End Class
+    Public Class ValueTuple(Of T1, T2, T3)
+        Inherits C(Of B)
+        Public Sub New(_1 As T1, _2 As T2, _3 As T3)
+        End Sub
+    End Class
+End Namespace
+    </file>
+</compilation>,
+                references:={ref0})
+            Dim ref1 = comp1.EmitToImageReference()
+            Dim comp = CreateCompilationWithMscorlib(
+<compilation>
+    <file name="a.vb">
+Interface I
+    Function F() As (Integer, (Integer, Integer), (Integer, Integer))
+End Interface
+    </file>
+</compilation>,
+                references:={ref1})
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC30652: Reference required to assembly '5a03232e-1a0f-4d1b-99ba-5d7b40ea931e, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'A'. Add one to your project.
+BC30652: Reference required to assembly '5a03232e-1a0f-4d1b-99ba-5d7b40ea931e, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' containing the type 'B'. Add one to your project.
+</errors>)
+        End Sub
+
+        <Fact>
+        Public Sub ValueTupleBase_AssemblyUnification()
+            Dim signedDllOptions = TestOptions.ReleaseDll.
+                WithCryptoKeyFile(SigningTestHelpers.KeyPairFile).
+                WithStrongNameProvider(New SigningTestHelpers.VirtualizedStrongNameProvider(ImmutableArray(Of String).Empty))
+            Dim comp0v1 = CreateCompilationWithMscorlib(
+<compilation name="A">
+    <file name="a.vb"><![CDATA[
+<Assembly: System.Reflection.AssemblyVersion("1.0.0.0")>
+Public Class A
+End Class
+    ]]></file>
+</compilation>,
+                options:=signedDllOptions)
+            comp0v1.AssertNoDiagnostics()
+            Dim ref0v1 = comp0v1.EmitToImageReference()
+            Dim comp0v2 = CreateCompilationWithMscorlib(
+<compilation name="A">
+    <file name="a.vb"><![CDATA[
+<Assembly: System.Reflection.AssemblyVersion("2.0.0.0")>
+Public Class A
+End Class
+    ]]></file>
+</compilation>,
+                options:=signedDllOptions)
+            comp0v2.AssertNoDiagnostics()
+            Dim ref0v2 = comp0v2.EmitToImageReference()
+            Dim comp1 = CreateCompilationWithMscorlib(
+<compilation>
+    <file name="a.vb">
+Public Class B
+    Inherits A
+End Class
+    </file>
+</compilation>,
+                references:={ref0v1})
+            comp1.AssertNoDiagnostics()
+            Dim ref1 = comp1.EmitToImageReference()
+            Dim comp2 = CreateCompilationWithMscorlib(
+<compilation>
+    <file name="a.vb">
+Namespace System
+    Public Class ValueTuple(Of T1, T2)
+        Inherits B
+        Public Sub New(_1 As T1, _2 As T2)
+        End Sub
+    End Class
+End Namespace
+    </file>
+</compilation>,
+                references:={ref0v1, ref1})
+            Dim ref2 = comp2.EmitToImageReference()
+            Dim comp = CreateCompilationWithMscorlib(
+<compilation>
+    <file name="a.vb">
+Interface I
+    Function F() As (Integer, Integer)
+End Interface
+    </file>
+</compilation>,
+                references:={ref0v2, ref1, ref2})
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC37281: Predefined type 'ValueTuple`2' must be a structure.
+</errors>)
+        End Sub
+
+        <Fact>
         Public Sub TernaryTypeInferenceWithDynamicAndTupleNames()
             ' No dynamic in VB
 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/MissingAssemblyTests.cs
@@ -11,8 +11,8 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.DiaSymReader;
 using Microsoft.VisualStudio.Debugger.Evaluation;
-using Roslyn.Test.PdbUtilities;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -752,6 +752,100 @@ class UseLinq
 
                 Assert.Equal(2, retryCount);
             });
+        }
+
+        [Fact]
+        public void TupleNoSystemRuntime()
+        {
+            var source =
+@"class C
+{
+    static void M()
+    {
+        var x = 1;
+        var y = (x, 2);
+        var z = (3, 4, (5, 6));
+    }
+}";
+            TupleContextNoSystemRuntime(
+                source,
+                "C.M",
+                "y",
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (int V_0, //x
+                (int, int) V_1, //y
+                (int, int, (int, int)) V_2) //z
+  IL_0000:  ldloc.1
+  IL_0001:  ret
+}");
+        }
+
+        [WorkItem(16879, "https://github.com/dotnet/roslyn/issues/16879")]
+        [Fact]
+        public void NonTupleNoSystemRuntime()
+        {
+            var source =
+@"class C
+{
+    static void M()
+    {
+        var x = 1;
+        var y = (x, 2);
+        var z = (3, 4, (5, 6));
+    }
+}";
+            TupleContextNoSystemRuntime(
+                source,
+                "C.M",
+                "x",
+@"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (int V_0, //x
+                (int, int) V_1, //y
+                (int, int, (int, int)) V_2) //z
+  IL_0000:  ldloc.0
+  IL_0001:  ret
+}");
+        }
+
+        private static void TupleContextNoSystemRuntime(string source, string methodName, string expression, string expectedIL)
+        {
+            var comp = CreateCompilationWithMscorlib(source, new[] { SystemRuntimeFacadeRef, ValueTupleRef }, options: TestOptions.DebugDll);
+            using (var systemRuntime = SystemRuntimeFacadeRef.ToModuleInstance())
+            {
+                WithRuntimeInstance(comp, new[] { MscorlibRef, ValueTupleRef }, runtime =>
+                {
+                    ImmutableArray<MetadataBlock> blocks;
+                    Guid moduleVersionId;
+                    ISymUnmanagedReader symReader;
+                    int methodToken;
+                    int localSignatureToken;
+                    GetContextState(runtime, methodName, out blocks, out moduleVersionId, out symReader, out methodToken, out localSignatureToken);
+                    string errorMessage;
+                    CompilationTestData testData;
+                    int retryCount = 0;
+                    var compileResult = ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
+                        runtime.Modules.Select(m => m.MetadataBlock).ToImmutableArray(),
+                        expression,
+                        ImmutableArray<Alias>.Empty,
+                        (b, u) => EvaluationContext.CreateMethodContext(b.ToCompilation(), symReader, moduleVersionId, methodToken, methodVersion: 1, ilOffset: 0, localSignatureToken: localSignatureToken),
+                        (AssemblyIdentity assemblyIdentity, out uint uSize) =>
+                        {
+                            retryCount++;
+                            Assert.Equal("System.Runtime", assemblyIdentity.Name);
+                            var block = systemRuntime.MetadataBlock;
+                            uSize = (uint)block.Size;
+                            return block.Pointer;
+                        },
+                        errorMessage: out errorMessage,
+                        testData: out testData);
+                    Assert.Equal(1, retryCount);
+                    testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL);
+                });
+            }
         }
 
         private sealed class TestCompileResult : CompileResult

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/MissingAssemblyTests.vb
@@ -9,8 +9,8 @@ Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Imports Microsoft.DiaSymReader
 Imports Microsoft.VisualStudio.Debugger.Evaluation
-Imports Roslyn.Test.PdbUtilities
 Imports Roslyn.Test.Utilities
 Imports Roslyn.Utilities
 Imports Xunit
@@ -590,6 +590,92 @@ End Class"
 
                     Assert.Equal(2, retryCount)
                 End Sub)
+        End Sub
+
+        <Fact>
+        Public Sub TupleNoSystemRuntime()
+            Const source =
+"Class C
+    Shared Sub M()
+        Dim x = 1
+        Dim y = (x, 2)
+        Dim z = (3, 4, (5, 6))
+    End Sub
+End Class"
+            TupleContextNoSystemRuntime(
+                source,
+                "C.M",
+                "y",
+"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (Integer V_0, //x
+                (Integer, Integer) V_1, //y
+                (Integer, Integer, (Integer, Integer)) V_2) //z
+  IL_0000:  ldloc.1
+  IL_0001:  ret
+}")
+        End Sub
+
+        <WorkItem(16879, "https://github.com/dotnet/roslyn/issues/16879")>
+        <Fact>
+        Public Sub NonTupleNoSystemRuntime()
+            Const source =
+"Class C
+    Shared Sub M()
+        Dim x = 1
+        Dim y = (x, 2)
+        Dim z = (3, 4, (5, 6))
+    End Sub
+End Class"
+            TupleContextNoSystemRuntime(
+                source,
+                "C.M",
+                "x",
+"{
+  // Code size        2 (0x2)
+  .maxstack  1
+  .locals init (Integer V_0, //x
+                (Integer, Integer) V_1, //y
+                (Integer, Integer, (Integer, Integer)) V_2) //z
+  IL_0000:  ldloc.0
+  IL_0001:  ret
+}")
+        End Sub
+
+        Private Shared Sub TupleContextNoSystemRuntime(source As String, methodName As String, expression As String, expectedIL As String)
+            Dim comp = CreateCompilationWithMscorlib({source}, references:={ValueTupleRef, SystemRuntimeFacadeRef}, options:=TestOptions.DebugDll)
+            Using systemRuntime = SystemRuntimeFacadeRef.ToModuleInstance()
+                WithRuntimeInstance(comp, {MscorlibRef, ValueTupleRef},
+                    Sub(runtime)
+                        Dim methodBlocks As ImmutableArray(Of MetadataBlock) = Nothing
+                        Dim moduleVersionId As Guid = Nothing
+                        Dim symReader As ISymUnmanagedReader = Nothing
+                        Dim typeToken = 0
+                        Dim methodToken = 0
+                        Dim localSignatureToken = 0
+                        GetContextState(runtime, "C.M", methodBlocks, moduleVersionId, symReader, methodToken, localSignatureToken)
+                        Dim errorMessage As String = Nothing
+                        Dim testData As CompilationTestData = Nothing
+                        Dim retryCount = 0
+                        Dim compileResult = ExpressionCompilerTestHelpers.CompileExpressionWithRetry(
+                            runtime.Modules.Select(Function(m) m.MetadataBlock).ToImmutableArray(),
+                            expression,
+                            ImmutableArray(Of [Alias]).Empty,
+                            Function(b, u) EvaluationContext.CreateMethodContext(b.ToCompilation(), MakeDummyLazyAssemblyReaders(), symReader, moduleVersionId, methodToken, methodVersion:=1, ilOffset:=0, localSignatureToken:=localSignatureToken),
+                            Function(assemblyIdentity As AssemblyIdentity, ByRef uSize As UInteger)
+                                retryCount += 1
+                                Assert.Equal("System.Runtime", assemblyIdentity.Name)
+                                Dim block = systemRuntime.MetadataBlock
+                                uSize = CUInt(block.Size)
+                                Return block.Pointer
+                            End Function,
+                            errorMessage:=errorMessage,
+                            testData:=testData)
+                        Assert.Equal(1, retryCount)
+                        testData.GetMethodData("<>x.<>m0").VerifyIL(expectedIL)
+                    End Sub)
+            End Using
         End Sub
 
         Private Shared Function GetMissingAssemblyIdentities(code As ERRID, ParamArray arguments() As Object) As ImmutableArray(Of AssemblyIdentity)


### PR DESCRIPTION
[Port b46690a07de68c5a094b084441de6dbad1d2b8f2 to dev15.2.x branch.]

VSO Bug https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=406153&fullScreen=false&_a=edit

Report use-site diagnostics, if any, from `System.ValueTuple` base type rather than `"'ValueTuple' must be a struct"`.

This may result in a clearer error message for the user when an assembly is missing. More importantly, it allows the EE to recognize such cases at runtime so the EE can load the missing assembly explicitly.

**Customer scenario**
Expression evaluation in the debugger fails in frames containing tuples before `System.Runtime.dll` is loaded by the debugger.

**Bugs this fixes**
#16879.

**Workarounds, if any**
None

**Risk**
Low risk. The change is the error reported when the base type of `System.ValueTuple` is not found.

**Performance impact**
No change

**Is this a regression**
No, tuples are a new feature in VS2017.

**How was the bug found?**
Customer reported

- 4 customers reported via [github issue](https://github.com/dotnet/roslyn/issues/16879)
- 1 windows insider report on [github](https://github.com/dotnet/roslyn/issues/17157)
- 3 customers reported on stackoverflow ([here](http://stackoverflow.com/questions/42856319/how-can-i-remove-exception-predefined-type-valuetuple2-must-be-a-struct-whe), [here](http://stackoverflow.com/questions/43006178/vs2017-error-debugging-task-of-tuple/43006552#43006552) and [here](http://stackoverflow.com/questions/43006178/vs2017-error-debugging-task-of-tuple/43006552))
- [User Feedback](https://developercommunity.visualstudio.com/content/problem/24460/when-using-tuples-maybe-combined-in-method-in-meth.html)


