### PR TITLE
	Move the SymbolFinder API over to SymbolAndProjectId

### DIFF
--- a/src/Features/Core/Portable/AddImport/CodeActions/PackageReference.InstallPackageAndAddImportCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/PackageReference.InstallPackageAndAddImportCodeAction.cs
@@ -12,7 +12,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
 {
-    internal abstract partial class AbstractAddImportCodeFixProvider<TSimpleNameSyntax> : CodeFixProvider, IEqualityComparer<PortableExecutableReference>
+    internal abstract partial class AbstractAddImportCodeFixProvider<TSimpleNameSyntax> 
     {
         private partial class PackageReference
         {

--- a/src/Features/Core/Portable/AddImport/SearchScopes/AllSymbolsProjectSearchScope.cs
+++ b/src/Features/Core/Portable/AddImport/SearchScopes/AllSymbolsProjectSearchScope.cs
@@ -25,10 +25,13 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
             {
             }
 
-            protected override Task<ImmutableArray<ISymbol>> FindDeclarationsAsync(
+            protected override async Task<ImmutableArray<ISymbol>> FindDeclarationsAsync(
                 string name, SymbolFilter filter, SearchQuery searchQuery)
             {
-                return SymbolFinder.FindAllDeclarationsWithNormalQueryAsync(_project, searchQuery, filter, CancellationToken);
+                var declarations = await SymbolFinder.FindAllDeclarationsWithNormalQueryAsync(
+                    _project, searchQuery, filter, CancellationToken).ConfigureAwait(false);
+
+                return declarations.SelectAsArray(d => d.Symbol);
             }
         }
     }

--- a/src/Features/Core/Portable/AddImport/SearchScopes/SourceSymbolsProjectSearchScope.cs
+++ b/src/Features/Core/Portable/AddImport/SearchScopes/SourceSymbolsProjectSearchScope.cs
@@ -45,7 +45,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                 // needed.
                 var lazyAssembly = _projectToAssembly.GetOrAdd(_project, CreateLazyAssembly);
 
-                return await info.FindAsync(searchQuery, lazyAssembly, filter, CancellationToken).ConfigureAwait(false);
+                var declarations = await info.FindAsync(
+                    searchQuery, lazyAssembly, _project.Id,
+                    filter, CancellationToken).ConfigureAwait(false);
+
+                return declarations.SelectAsArray(d => d.Symbol);
             }
 
             private static AsyncLazy<IAssemblySymbol> CreateLazyAssembly(Project project)

--- a/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
+++ b/src/Features/Core/Portable/AddImport/SymbolReferenceFinder.cs
@@ -89,11 +89,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
             }
 
             internal Task<ImmutableArray<SymbolReference>> FindInMetadataSymbolsAsync(
-                IAssemblySymbol assembly, PortableExecutableReference metadataReference,
+                IAssemblySymbol assembly, ProjectId assemblyProjectId, PortableExecutableReference metadataReference,
                 bool exact, CancellationToken cancellationToken)
             {
                 var searchScope = new MetadataSymbolsSearchScope(
-                    _owner, _document.Project.Solution, assembly, metadataReference, exact, cancellationToken);
+                    _owner, _document.Project.Solution, assembly, assemblyProjectId, 
+                    metadataReference, exact, cancellationToken);
                 return DoAsync(searchScope);
             }
 

--- a/src/Features/Core/Portable/CodeFixes/Qualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Qualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -140,14 +140,17 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
             var syntaxFacts = project.LanguageServices.GetService<ISyntaxFactsService>();
             syntaxFacts.GetNameAndArityOfSimpleName(node, out var name, out var arity);
 
-            var symbols = await SymbolFinder.FindDeclarationsAsync(project, name, this.IgnoreCase, SymbolFilter.Type, cancellationToken).ConfigureAwait(false);
+            var symbolAndProjectIds = await SymbolFinder.FindAllDeclarationsAsync(
+                project, name, this.IgnoreCase, SymbolFilter.Type, cancellationToken).ConfigureAwait(false);
+            var symbols = symbolAndProjectIds.SelectAsArray(t => t.Symbol);
 
             // also lookup type symbols with the "Attribute" suffix.
             var inAttributeContext = syntaxFacts.IsAttributeName(node);
             if (inAttributeContext)
             {
-                symbols = symbols.Concat(
-                    await SymbolFinder.FindDeclarationsAsync(project, name + "Attribute", this.IgnoreCase, SymbolFilter.Type, cancellationToken).ConfigureAwait(false));
+                var attributeSymbolAndProjectIds = await SymbolFinder.FindAllDeclarationsAsync(
+                    project, name + "Attribute", this.IgnoreCase, SymbolFilter.Type, cancellationToken).ConfigureAwait(false);
+                symbols = symbols.Concat(attributeSymbolAndProjectIds.SelectAsArray(t => t.Symbol));
             }
 
             var accessibleTypeSymbols = symbols
@@ -186,8 +189,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
                 return ImmutableArray<SymbolResult>.Empty;
             }
 
-            var symbols = await SymbolFinder.FindDeclarationsAsync(
+            var symbolAndProjectIds = await SymbolFinder.FindAllDeclarationsAsync(
                 project, name, this.IgnoreCase, SymbolFilter.Namespace, cancellationToken).ConfigureAwait(false);
+
+            var symbols = symbolAndProjectIds.SelectAsArray(t => t.Symbol);
 
             // There might be multiple namespaces that this name will resolve successfully in.
             // Some of them may be 'better' results than others.  For example, say you have

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
@@ -107,9 +107,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
             Dim syntaxFactService = document.Project.Solution.Workspace.Services.GetLanguageServices(targetType.Language).GetService(Of ISyntaxFactsService)
 
             Dim eventHandlerName As String = actualEventName + "Handler"
-            Dim existingSymbols = Await SymbolFinder.FindSourceDeclarationsAsync(
+            Dim existingSymbolAndProjectIds = Await SymbolFinder.FindSourceDeclarationsWithNormalQueryInLocalProcessAsync(
                 document.Project.Solution, eventHandlerName, Not syntaxFactService.IsCaseSensitive, SymbolFilter.Type, cancellationToken).ConfigureAwait(False)
 
+            Dim existingSymbols = existingSymbolAndProjectIds.SelectAsArray(Function(t) t.Symbol)
             If existingSymbols.Any(Function(existingSymbol) existingSymbol IsNot Nothing _
                                                    AndAlso existingSymbol.ContainingNamespace Is targetType.ContainingNamespace) Then
                 ' There already exists a delegate that matches the event handler name

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols
 {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
@@ -78,7 +78,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         project.Solution, referenceOpt, loadOnly: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                     if (info != null)
                     {
-                        var symbols = await info.FindAsync(project, query, assembly, filter, cancellationToken).ConfigureAwait(false);
+                        var symbols = await info.FindAsync(
+                            query, assembly, project.Id, filter, cancellationToken).ConfigureAwait(false);
                         list.AddRange(symbols);
                     }
                 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     {
         private static Task AddCompilationDeclarationsWithNormalQueryAsync(
             Project project, SearchQuery query, SymbolFilter filter,
-            ArrayBuilder<ISymbol> list, CancellationToken cancellationToken)
+            ArrayBuilder<SymbolAndProjectId> list, CancellationToken cancellationToken)
         {
             Debug.Assert(query.Kind != SearchKind.Custom);
             return AddCompilationDeclarationsWithNormalQueryAsync(
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             Project project,
             SearchQuery query,
             SymbolFilter filter,
-            ArrayBuilder<ISymbol> list,
+            ArrayBuilder<SymbolAndProjectId> list,
             Compilation startingCompilation,
             IAssemblySymbol startingAssembly,
             CancellationToken cancellationToken)
@@ -45,14 +45,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                 var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var symbolsWithName = compilation.GetSymbolsWithName(query.GetPredicate(), filter, cancellationToken)
+                                                 .Select(s => new SymbolAndProjectId(s, project.Id))
                                                  .ToImmutableArray();
 
                 if (startingCompilation != null && startingAssembly != null && compilation.Assembly != startingAssembly)
                 {
                     // Return symbols from skeleton assembly in this case so that symbols have 
                     // the same language as startingCompilation.
-                    symbolsWithName = symbolsWithName.Select(s => s.GetSymbolKey().Resolve(startingCompilation, cancellationToken: cancellationToken).Symbol)
-                                                     .WhereNotNull()
+                    symbolsWithName = symbolsWithName.Select(s => s.WithSymbol(s.Symbol.GetSymbolKey().Resolve(startingCompilation, cancellationToken: cancellationToken).Symbol))
+                                                     .Where(s => s.Symbol != null)
                                                      .ToImmutableArray();
                 }
 
@@ -61,8 +62,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         private static async Task AddMetadataDeclarationsWithNormalQueryAsync(
-            Solution solution, IAssemblySymbol assembly, PortableExecutableReference referenceOpt, 
-            SearchQuery query, SymbolFilter filter, ArrayBuilder<ISymbol> list, CancellationToken cancellationToken)
+            Project project, IAssemblySymbol assembly, PortableExecutableReference referenceOpt, 
+            SearchQuery query, SymbolFilter filter, ArrayBuilder<SymbolAndProjectId> list, 
+            CancellationToken cancellationToken)
         {
             // All entrypoints to this function are Find functions that are only searching
             // for specific strings (i.e. they never do a custom search).
@@ -73,18 +75,18 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 if (referenceOpt != null)
                 {
                     var info = await SymbolTreeInfo.TryGetInfoForMetadataReferenceAsync(
-                        solution, referenceOpt, loadOnly: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                        project.Solution, referenceOpt, loadOnly: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                     if (info != null)
                     {
-                        var symbols = await info.FindAsync(query, assembly, filter, cancellationToken).ConfigureAwait(false);
+                        var symbols = await info.FindAsync(project, query, assembly, filter, cancellationToken).ConfigureAwait(false);
                         list.AddRange(symbols);
                     }
                 }
             }
         }
 
-        internal static ImmutableArray<ISymbol> FilterByCriteria(ImmutableArray<ISymbol> symbols, SymbolFilter criteria)
-            => symbols.WhereAsArray(s => MeetCriteria(s, criteria));
+        internal static ImmutableArray<SymbolAndProjectId> FilterByCriteria(ImmutableArray<SymbolAndProjectId> symbols, SymbolFilter criteria)
+            => symbols.WhereAsArray(s => MeetCriteria(s.Symbol, criteria));
 
         private static bool MeetCriteria(ISymbol symbol, SymbolFilter filter)
         {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations_CustomQueries.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations_CustomQueries.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -28,10 +29,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Find the symbols for declarations made in source with a matching name.
         /// </summary>
         public static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Solution solution, Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken = default(CancellationToken))
-            => await FindSourceDeclarationsWithCustomQueryAsync(
+        {
+            var declarations = await FindSourceDeclarationsWithCustomQueryAsync(
                 solution, SearchQuery.CreateCustom(predicate), filter, cancellationToken).ConfigureAwait(false);
 
-        private static async Task<ImmutableArray<ISymbol>> FindSourceDeclarationsWithCustomQueryAsync(
+            return declarations.SelectAsArray(d => d.Symbol);
+        }
+
+        private static async Task<ImmutableArray<SymbolAndProjectId>> FindSourceDeclarationsWithCustomQueryAsync(
             Solution solution, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
             if (solution == null)
@@ -41,12 +46,12 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             if (query.Name != null && string.IsNullOrWhiteSpace(query.Name))
             {
-                return ImmutableArray<ISymbol>.Empty;
+                return ImmutableArray<SymbolAndProjectId>.Empty;
             }
 
             using (Logger.LogBlock(FunctionId.SymbolFinder_Solution_Predicate_FindSourceDeclarationsAsync, cancellationToken))
             {
-                var result = ArrayBuilder<ISymbol>.GetInstance();
+                var result = ArrayBuilder<SymbolAndProjectId>.GetInstance();
                 foreach (var projectId in solution.ProjectIds)
                 {
                     var project = solution.GetProject(projectId);
@@ -68,10 +73,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Find the symbols for declarations made in source with a matching name.
         /// </summary>
         public static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsAsync(Project project, Func<string, bool> predicate, SymbolFilter filter, CancellationToken cancellationToken = default(CancellationToken))
-            => await FindSourceDeclarationsWithCustomQueryAsync(
+        {
+            var declarations = await FindSourceDeclarationsWithCustomQueryAsync(
                 project, SearchQuery.CreateCustom(predicate), filter, cancellationToken).ConfigureAwait(false);
 
-        private static async Task<ImmutableArray<ISymbol>> FindSourceDeclarationsWithCustomQueryAsync(
+            return declarations.SelectAsArray(d => d.Symbol);
+        }
+
+        private static async Task<ImmutableArray<SymbolAndProjectId>> FindSourceDeclarationsWithCustomQueryAsync(
             Project project, SearchQuery query, SymbolFilter filter, CancellationToken cancellationToken)
         {
             if (project == null)
@@ -81,19 +90,22 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             if (query.Name != null && string.IsNullOrWhiteSpace(query.Name))
             {
-                return ImmutableArray<ISymbol>.Empty;
+                return ImmutableArray<SymbolAndProjectId>.Empty;
             }
 
             using (Logger.LogBlock(FunctionId.SymbolFinder_Project_Predicate_FindSourceDeclarationsAsync, cancellationToken))
             {
                 if (!await project.ContainsSymbolsWithNameAsync(query.GetPredicate(), filter, cancellationToken).ConfigureAwait(false))
                 {
-                    return ImmutableArray<ISymbol>.Empty;
+                    return ImmutableArray<SymbolAndProjectId>.Empty;
                 }
 
                 var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
-                var unfiltered = compilation.GetSymbolsWithName(query.GetPredicate(), filter, cancellationToken).ToImmutableArray();
+                var unfiltered = compilation.GetSymbolsWithName(query.GetPredicate(), filter, cancellationToken)
+                                            .Select(s => new SymbolAndProjectId(s, project.Id))
+                                            .ToImmutableArray();
+                    
                 return FilterByCriteria(unfiltered, filter);
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations_SourceDeclarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Declarations_SourceDeclarations.cs
@@ -30,8 +30,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             using (Logger.LogBlock(FunctionId.SymbolFinder_Solution_Name_FindSourceDeclarationsAsync, cancellationToken))
             {
-                return await FindSourceDeclarationsWithNormalQueryAsync(
+                var declarations = await FindSourceDeclarationsWithNormalQueryAsync(
                     solution, name, ignoreCase, filter, cancellationToken).ConfigureAwait(false);
+                return declarations.SelectAsArray(t => t.Symbol);
             }
         }
 
@@ -49,12 +50,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         {
             using (Logger.LogBlock(FunctionId.SymbolFinder_Project_Name_FindSourceDeclarationsAsync, cancellationToken))
             {
-                return await FindSourceDeclarationsithNormalQueryInLocalProcessAsync(
+                var declarations = await FindSourceDeclarationsithNormalQueryInLocalProcessAsync(
                     project, name, ignoreCase, filter, cancellationToken).ConfigureAwait(false);
+
+                return declarations.SelectAsArray(t => t.Symbol);
             }
         }
 
-        private static async Task<ImmutableArray<ISymbol>> FindSourceDeclarationsWithNormalQueryAsync(
+        private static async Task<ImmutableArray<SymbolAndProjectId>> FindSourceDeclarationsWithNormalQueryAsync(
             Solution solution, string name, bool ignoreCase, SymbolFilter filter, CancellationToken cancellationToken)
         {
             if (solution == null)
@@ -69,11 +72,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             if (string.IsNullOrWhiteSpace(name))
             {
-                return ImmutableArray<ISymbol>.Empty;
+                return ImmutableArray<SymbolAndProjectId>.Empty;
             }
 
             var query = SearchQuery.Create(name, ignoreCase);
-            var result = ArrayBuilder<ISymbol>.GetInstance();
+            var result = ArrayBuilder<SymbolAndProjectId>.GetInstance();
             foreach (var projectId in solution.ProjectIds)
             {
                 var project = solution.GetProject(projectId);
@@ -84,7 +87,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return result.ToImmutableAndFree();
         }
 
-        private static async Task<IEnumerable<ISymbol>> FindSourceDeclarationsithNormalQueryInLocalProcessAsync(
+        private static async Task<ImmutableArray<SymbolAndProjectId>> FindSourceDeclarationsithNormalQueryInLocalProcessAsync(
             Project project, string name, bool ignoreCase, SymbolFilter filter, CancellationToken cancellationToken)
         {
             if (project == null)
@@ -99,12 +102,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             if (string.IsNullOrWhiteSpace(name))
             {
-                return SpecializedCollections.EmptyEnumerable<ISymbol>();
+                return ImmutableArray<SymbolAndProjectId>.Empty;
             }
 
-            var list = ArrayBuilder<ISymbol>.GetInstance();
+            var list = ArrayBuilder<SymbolAndProjectId>.GetInstance();
             await AddCompilationDeclarationsWithNormalQueryAsync(
-                project, SearchQuery.Create(name, ignoreCase), filter, list, cancellationToken).ConfigureAwait(false);
+                project, SearchQuery.Create(name, ignoreCase),
+                filter, list, cancellationToken).ConfigureAwait(false);
             return list.ToImmutableAndFree();
         }
     }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -115,19 +115,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         public Task<ImmutableArray<SymbolAndProjectId>> FindAsync(
-            Project project, SearchQuery query, IAssemblySymbol assembly, SymbolFilter filter, CancellationToken cancellationToken)
+            SearchQuery query, IAssemblySymbol assembly, ProjectId assemblyProjectId, SymbolFilter filter, CancellationToken cancellationToken)
         {
             // All entrypoints to this function are Find functions that are only searching
             // for specific strings (i.e. they never do a custom search).
             Debug.Assert(query.Kind != SearchKind.Custom);
 
             return this.FindAsync(
-                project, query, new AsyncLazy<IAssemblySymbol>(assembly),
-                filter, cancellationToken);
+                query, new AsyncLazy<IAssemblySymbol>(assembly),
+                assemblyProjectId, filter, cancellationToken);
         }
 
         public async Task<ImmutableArray<SymbolAndProjectId>> FindAsync(
-            Project project, SearchQuery query, AsyncLazy<IAssemblySymbol> lazyAssembly,
+            SearchQuery query, AsyncLazy<IAssemblySymbol> lazyAssembly, ProjectId assemblyProjectId,
             SymbolFilter filter, CancellationToken cancellationToken)
         {
             // All entrypoints to this function are Find functions that are only searching
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var symbols = await FindAsyncWorker(query, lazyAssembly, cancellationToken).ConfigureAwait(false);
 
             return SymbolFinder.FilterByCriteria(
-                symbols.SelectAsArray(s => new SymbolAndProjectId(s, project.Id)),
+                symbols.SelectAsArray(s => new SymbolAndProjectId(s, assemblyProjectId)),
                 filter);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -114,25 +114,30 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             _spellCheckerTask = spellCheckerTask;
         }
 
-        public Task<ImmutableArray<ISymbol>> FindAsync(
-            SearchQuery query, IAssemblySymbol assembly, SymbolFilter filter, CancellationToken cancellationToken)
+        public Task<ImmutableArray<SymbolAndProjectId>> FindAsync(
+            Project project, SearchQuery query, IAssemblySymbol assembly, SymbolFilter filter, CancellationToken cancellationToken)
         {
             // All entrypoints to this function are Find functions that are only searching
             // for specific strings (i.e. they never do a custom search).
             Debug.Assert(query.Kind != SearchKind.Custom);
 
-            return this.FindAsync(query, new AsyncLazy<IAssemblySymbol>(assembly), filter, cancellationToken);
+            return this.FindAsync(
+                project, query, new AsyncLazy<IAssemblySymbol>(assembly),
+                filter, cancellationToken);
         }
 
-        public async Task<ImmutableArray<ISymbol>> FindAsync(
-            SearchQuery query, AsyncLazy<IAssemblySymbol> lazyAssembly, SymbolFilter filter, CancellationToken cancellationToken)
+        public async Task<ImmutableArray<SymbolAndProjectId>> FindAsync(
+            Project project, SearchQuery query, AsyncLazy<IAssemblySymbol> lazyAssembly,
+            SymbolFilter filter, CancellationToken cancellationToken)
         {
             // All entrypoints to this function are Find functions that are only searching
             // for specific strings (i.e. they never do a custom search).
             Debug.Assert(query.Kind != SearchKind.Custom);
 
+            var symbols = await FindAsyncWorker(query, lazyAssembly, cancellationToken).ConfigureAwait(false);
+
             return SymbolFinder.FilterByCriteria(
-                await FindAsyncWorker(query, lazyAssembly, cancellationToken).ConfigureAwait(false),
+                symbols.SelectAsArray(s => new SymbolAndProjectId(s, project.Id)),
                 filter);
         }
 


### PR DESCRIPTION
This enables having htis API run OOP in the future.