### PR TITLE
Interface completion provider shows objects fix

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceCompletionProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
+using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
@@ -97,6 +98,21 @@ class Bar : IFoo
 }";
 
             await VerifyProviderCommitAsync(markup, "Foo()", expected, '(', "");
+        }
+
+        [WorkItem(15988, "https://github.com/dotnet/roslyn/issues/15988")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task EnsureNoObjectMembersAreShown()
+        {
+            TraceListener[] listeners = {
+                                            new TextWriterTraceListener(Console.Out)
+                                        };
+            Debug.Listeners.AddRange(listeners);
+            var markup = @"class C : IComparable {
+	int IComparable.
+}";
+            var periodIndex = markup.IndexOf(".");
+            Console.WriteLine(string.Format("Period index is {0}", periodIndex));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceCompletionProviderTests.cs
@@ -104,15 +104,10 @@ class Bar : IFoo
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task EnsureNoObjectMembersAreShown()
         {
-            TraceListener[] listeners = {
-                                            new TextWriterTraceListener(Console.Out)
-                                        };
-            Debug.Listeners.AddRange(listeners);
             var markup = @"class C : IComparable {
-	int IComparable.
+	int IComparable.$$
 }";
-            var periodIndex = markup.IndexOf(".");
-            Console.WriteLine(string.Format("Period index is {0}", periodIndex));
+            VerifyItemIsAbsentAsync(markup, "GetHashCode");
         }
     }
 }


### PR DESCRIPTION
Fixing issue https://github.com/dotnet/roslyn/issues/15988 to prevent methods from the object base class showing up when the completion list is requested from the ExplicitInterfaceCompletionProvider.