### PR TITLE
Create a build task to locate .editorconfig files impacting a compile

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ErrorString {
@@ -143,15 +143,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MSB3082: Task failed because &quot;{0}&quot; was not found..
-        /// </summary>
-        internal static string General_ToolFileNotFound {
-            get {
-                return ResourceManager.GetString("General_ToolFileNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to MSB3087: An incompatible host object was passed into the &quot;{0}&quot; task.  The host object for this task must implement the &quot;{1}&quot; interface..
         /// </summary>
         internal static string General_IncorrectHostObject {
@@ -184,6 +175,24 @@ namespace Microsoft.CodeAnalysis.BuildTasks {
         internal static string General_ReferenceDoesNotExist {
             get {
                 return ResourceManager.GetString("General_ReferenceDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MSB3082: Task failed because &quot;{0}&quot; was not found..
+        /// </summary>
+        internal static string General_ToolFileNotFound {
+            get {
+                return ResourceManager.GetString("General_ToolFileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File &quot;{0}&quot; could not be read: {1}.
+        /// </summary>
+        internal static string General_UnableToReadFile {
+            get {
+                return ResourceManager.GetString("General_UnableToReadFile", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/MSBuildTask/ErrorString.resx
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.resx
@@ -186,4 +186,7 @@
     <value>MSB3402: There was an error creating the pdb file "{0}". {1}</value>
     <comment>{StrBegin="MSB3402: "}</comment>
   </data>
+  <data name="General_UnableToReadFile" xml:space="preserve">
+    <value>File "{0}" could not be read: {1}</value>
+  </data>
 </root>

--- a/src/Compilers/Core/MSBuildTask/LocateEditorConfigFiles.cs
+++ b/src/Compilers/Core/MSBuildTask/LocateEditorConfigFiles.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.CodeAnalysis.BuildTasks
+{
+    /// <summary>
+    /// Locates the applicable set of .editorconfig files based on given inputs. Walks through
+    /// parent directories locating the ones that exist.
+    /// </summary>
+    public sealed class LocateEditorConfigFiles : Task
+    {
+        /// <summary>
+        /// The set of source and other files that we should find the applicable .editorconfig files to.
+        /// </summary>
+        [Required]
+        public ITaskItem[] InputFiles { get; set; }
+
+        [Output]
+        public ITaskItem[] EditorConfigFiles { get; private set; }
+
+        public LocateEditorConfigFiles()
+        {
+            TaskResources = ErrorString.ResourceManager;
+        }
+
+        public override bool Execute()
+        {
+            try
+            {
+                ExecuteCore();
+                return !Log.HasLoggedErrors;
+            }
+            catch (Exception ex)
+            {
+                // We'll explicitly log friendly errors and then rethrow in the case of IO errors while reading the file system.
+                // We'll only print the raw exception if we didn't already log something nice.
+                if (!Log.HasLoggedErrors)
+                {
+                    Log.LogErrorFromException(ex);
+                }
+
+                return false;
+            }
+        }
+
+        private void ExecuteCore()
+        {
+            var directoriesAddedToQueue = new HashSet<string>(StringComparer.Ordinal);
+            var directoriesToVisit = new Queue<DirectoryInfo>();
+            var editorConfigFiles = new List<ITaskItem>();
+
+            void addNewDirectoryIfNotAlreadyAdded(DirectoryInfo directory)
+            {
+                // If we're being passed files that don't exist, we'll just skip them and let the compiler handle the actual reporting.
+                if (directory.Exists)
+                {
+                    if (directoriesAddedToQueue.Add(directory.FullName))
+                    {
+                        directoriesToVisit.Enqueue(directory);
+                    }
+                }
+            }
+
+            foreach (var inputFile in InputFiles)
+            {
+                addNewDirectoryIfNotAlreadyAdded(new DirectoryInfo(Path.GetDirectoryName(Path.GetFullPath(inputFile.ItemSpec))));
+            }
+
+            while (directoriesToVisit.Count > 0)
+            {
+                var directory = directoriesToVisit.Dequeue();
+                var editorConfigFilePath = Path.Combine(directory.FullName, ".editorconfig");
+                bool isRootEditorConfig = false;
+
+                try
+                {
+                    if (File.Exists(editorConfigFilePath))
+                    {
+                        editorConfigFiles.Add(new TaskItem(editorConfigFilePath));
+
+                        // We will attempt to determine if this is a root .editorconfig, so we can stop enumerating farther if necessary.
+                        // We will do no further interpretation of the .editorconfig.
+
+                        isRootEditorConfig = FileIsRootEditorConfig(editorConfigFilePath);
+                    }
+                }
+                catch (IOException exception)
+                {
+                    // We'll log the error and continue; the "it failed" is handled in Execute().
+                    Log.LogErrorFromResources(nameof(ErrorString.General_UnableToReadFile), editorConfigFilePath, exception.Message);
+                }
+
+                if (!isRootEditorConfig && directory.Parent != null)
+                {
+                    addNewDirectoryIfNotAlreadyAdded(directory.Parent);
+                }
+            }
+
+            EditorConfigFiles = editorConfigFiles.ToArray();
+        }
+
+        // These Regexes are the regexes from Microsoft.VisualStudio.CodingConventions.EditorConfig.
+        private static readonly Regex s_sectionMatcher = new Regex(@"^\s*\[(([^#;]|\\#|\\;)+)\]\s*([#;].*)?$", RegexOptions.Compiled);
+        private static readonly Regex s_propertyMatcher = new Regex(@"^\s*([\w\.\-_]+)\s*[=:]\s*(.*?)\s*([#;].*)?$", RegexOptions.Compiled);
+
+        internal static bool FileIsRootEditorConfig(string editorConfigFilePath)
+        {
+            using (FileStream fileStream = OpenFile(editorConfigFilePath))
+            using (StreamReader reader = new StreamReader(fileStream))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    // Once we're in a section, we don't need to go looking for root = true anymore
+                    if (s_sectionMatcher.IsMatch(line))
+                    {
+                        return false;
+                    }
+
+                    var propMatches = s_propertyMatcher.Matches(line);
+                    if (propMatches.Count == 1 && propMatches[0].Groups.Count > 2)
+                    {
+                        var key = propMatches[0].Groups[1].Value;
+                        var value = propMatches[0].Groups[2].Value;
+
+                        if (key == "root")
+                        {
+                            return value == "true";
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static FileStream OpenFile(string editorConfigFilePath)
+        {
+            try
+            {
+                return new FileStream(editorConfigFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            }
+            catch (IOException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new IOException(e.Message, e);
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -55,6 +55,7 @@
     </Compile>
     <Compile Include="AssemblyResolution.cs" />
     <Compile Include="CanonicalError.cs" />
+    <Compile Include="LocateEditorConfigFiles.cs" />
     <Compile Include="ValidateBootstrap.cs" />
     <Compile Include="CommandLineBuilderExtension.cs" />
     <Compile Include="Csc.cs" />
@@ -73,6 +74,9 @@
     <Compile Include="RCWForCurrentContext.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="Vbc.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleToTest Include="Microsoft.Build.Tasks.CodeAnalysis.UnitTests" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ErrorString.resx">

--- a/src/Compilers/Core/MSBuildTaskTests/LocateEditorConfigFilesTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/LocateEditorConfigFilesTests.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
+{
+    public class LocateEditorConfigFilesTests : IDisposable
+    {
+        private readonly TempRoot _tempRoot;
+        private readonly TempDirectory _tempDirectory;
+
+        public LocateEditorConfigFilesTests()
+        {
+            _tempRoot = new TempRoot();
+            _tempDirectory = _tempRoot.CreateDirectory();
+        }
+
+        public void Dispose()
+        {
+            _tempRoot.Dispose();
+        }
+
+        [Fact]
+        public void NoInputsGivesNoOutputs()
+        {
+            var task = new LocateEditorConfigFiles();
+            task.InputFiles = Array.Empty<ITaskItem>();
+            Assert.True(task.Execute());
+            Assert.Empty(task.EditorConfigFiles);
+        }
+
+        [Fact]
+        public void EditorConfigInSameDirectoryIsFound()
+        {
+            var sourceFile = _tempDirectory.CreateFile("Cat.cs");
+            var editorConfigFile = _tempDirectory.CreateFile(".editorconfig").WriteAllText("root = true");
+
+            var task = new LocateEditorConfigFiles();
+            task.InputFiles = MSBuildUtil.CreateTaskItems(sourceFile.Path);
+            Assert.True(task.Execute());
+            Assert.Equal(editorConfigFile.Path, Assert.Single(task.EditorConfigFiles).ItemSpec);
+        }
+
+        [Fact]
+        public void EditorConfigInParentDirectoryIsFound()
+        {
+            var sourceFile = _tempDirectory.CreateDirectory("Subdirectory").CreateFile("Cat.cs");
+            var editorConfigFile = _tempDirectory.CreateFile(".editorconfig").WriteAllText("root = true");
+
+            var task = new LocateEditorConfigFiles();
+            task.InputFiles = MSBuildUtil.CreateTaskItems(sourceFile.Path);
+            Assert.True(task.Execute());
+            Assert.Equal(editorConfigFile.Path, Assert.Single(task.EditorConfigFiles).ItemSpec);
+        }
+
+        [Fact]
+        public void EditorConfigInParentDirectoryIsFoundWithMultipleInputs()
+        {
+            var sourceFile1 = _tempDirectory.CreateDirectory("Subdirectory").CreateFile("Cat.cs");
+            var sourceFile2 = _tempDirectory.CreateFile("Dog.cs");
+            var editorConfigFile = _tempDirectory.CreateFile(".editorconfig").WriteAllText("root = true");
+
+            var task = new LocateEditorConfigFiles();
+            task.InputFiles = MSBuildUtil.CreateTaskItems(sourceFile1.Path, sourceFile2.Path);
+            Assert.True(task.Execute());
+            Assert.Equal(editorConfigFile.Path, Assert.Single(task.EditorConfigFiles).ItemSpec);
+        }
+
+        [Fact]
+        public void EditorConfigInParentDirectoryIsNotFoundIfChildHasRoot()
+        {
+            var subdirectory = _tempDirectory.CreateDirectory("Subdirectory");
+            var sourceFile = subdirectory.CreateFile("Cat.cs");
+            var editorConfigFileChild = subdirectory.CreateFile(".editorconfig").WriteAllText("root = true");
+            var editorConfigFileParent = _tempDirectory.CreateFile(".editorconfig").WriteAllText("root = true");
+
+            var task = new LocateEditorConfigFiles();
+            task.InputFiles = MSBuildUtil.CreateTaskItems(sourceFile.Path);
+            Assert.True(task.Execute());
+            Assert.Equal(editorConfigFileChild.Path, Assert.Single(task.EditorConfigFiles).ItemSpec);
+        }
+
+        [Fact]
+        public void EditorConfigPreservesCaseDuringSearch()
+        {
+            // We want to validate that the lookup preserves case sensitivity of file paths. To do this, we'll create
+            // two directory paths with names that differ by case, and then pass both files to them. We'll call CreateDirectory
+            // with both casings, so on case-sensitive file systems we'll have two actual directories and on case-insensitive
+            // ones we'll actually only have one, but we'll preserve in both cases.
+            var subdirectory1 = _tempDirectory.CreateDirectory("Subdirectory");
+            var subdirectory2 = _tempDirectory.CreateDirectory("SubDirectory");
+            var editorConfigFile1 = subdirectory1.CreateFile(".editorconfig").WriteAllText("root = true");
+            var editorConfigFile2 = subdirectory2.CreateOrOpenFile(".editorconfig").WriteAllText("root = true");
+
+            var sourceFile1 = Path.Combine(subdirectory1.Path, "Cat.cs");
+            var sourceFile2 = Path.Combine(subdirectory2.Path, "Cat.cs");
+
+            Assert.NotEqual(editorConfigFile1, editorConfigFile2);
+            Assert.NotEqual(sourceFile1, sourceFile2);
+
+            var task = new LocateEditorConfigFiles();
+            task.InputFiles = MSBuildUtil.CreateTaskItems(sourceFile1, sourceFile2);
+            Assert.True(task.Execute());
+
+            var paths = task.EditorConfigFiles.Select(i => i.ItemSpec);
+            Assert.Contains(editorConfigFile1.Path, paths);
+            Assert.Contains(editorConfigFile2.Path, paths);
+        }
+
+        [Fact]
+        public void EditorConfigMultipleFilesAreOrderedCorrectly()
+        {
+            var subdirectory = _tempDirectory.CreateDirectory("Subdirectory");
+            var editorConfigFileParent = _tempDirectory.CreateFile(".editorconfig").WriteAllText("root = true");
+            var editorConfigFileChild = subdirectory.CreateFile(".editorconfig");
+
+            var sourceFile = Path.Combine(subdirectory.Path, "Cat.cs");
+
+            var task = new LocateEditorConfigFiles();
+            task.InputFiles = MSBuildUtil.CreateTaskItems(sourceFile);
+            Assert.True(task.Execute());
+
+            var paths = task.EditorConfigFiles.Select(i => i.ItemSpec);
+            Assert.Equal(new[] { editorConfigFileChild.Path, editorConfigFileParent.Path }, paths);
+        }
+
+        [Fact]
+        public void LockedEditorConfigHandledGracefully()
+        {
+            var editorConfigFile = _tempDirectory.CreateFile(".editorconfig");
+            var sourceFile = Path.Combine(_tempDirectory.Path, "Cat.cs");
+
+            using (var stream = new FileStream(editorConfigFile.Path, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                var task = new LocateEditorConfigFiles();
+                var buildEngine = new MockBuildEngine();
+                task.BuildEngine = buildEngine;
+
+                task.InputFiles = MSBuildUtil.CreateTaskItems(sourceFile);
+                Assert.False(task.Execute());
+
+                var error = Assert.Single(buildEngine.Errors);
+                Assert.Contains(editorConfigFile.Path, error);
+            }
+        }
+
+        [Fact]
+        public void EmptyEditorConfigFileIsRoot()
+        {
+            var tempFile = _tempDirectory.CreateFile(".editorconfig").WriteAllText("");
+            Assert.False(LocateEditorConfigFiles.FileIsRootEditorConfig(tempFile.Path));
+        }
+
+        [Fact]
+        public void RootEditorConfigFileIsRoot()
+        {
+            var tempFile = _tempDirectory.CreateFile(".editorconfig").WriteAllText("root = true");
+            Assert.True(LocateEditorConfigFiles.FileIsRootEditorConfig(tempFile.Path));
+        }
+
+        [Fact]
+        public void NonRootEditorConfigFileIsNotRoot()
+        {
+            var tempFile = _tempDirectory.CreateFile(".editorconfig").WriteAllText("root = false");
+            Assert.False(LocateEditorConfigFiles.FileIsRootEditorConfig(tempFile.Path));
+        }
+
+        [Fact]
+        public void RootPropertyInSectionIsNotActualRoot()
+        {
+            var tempFile = _tempDirectory.CreateFile(".editorconfig").WriteAllText("[*]\r\nroot = true");
+            Assert.False(LocateEditorConfigFiles.FileIsRootEditorConfig(tempFile.Path));
+        }
+    }
+}

--- a/src/Compilers/Core/MSBuildTaskTests/MSBuildTaskTests.csproj
+++ b/src/Compilers/Core/MSBuildTaskTests/MSBuildTaskTests.csproj
@@ -67,8 +67,10 @@
     <Compile Include="CscTests.cs" />
     <Compile Include="CsiTests.cs" />
     <Compile Include="IntegrationTests.cs" />
+    <Compile Include="MockBuildEngine.cs" />
     <Compile Include="MSBuildUtil.cs" />
     <Compile Include="VbcTests.cs" />
+    <Compile Include="LocateEditorConfigFilesTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Compilers/Core/MSBuildTaskTests/MockBuildEngine.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/MockBuildEngine.cs
@@ -2,18 +2,19 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using Microsoft.Build.Framework;
 
-namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
+namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
 {
-    internal class MockEngine : IBuildEngine
+    internal class MockBuildEngine : IBuildEngine
     {
         public int ColumnNumberOfTaskNode
         {
             get
             {
-                throw new NotImplementedException();
+                return 1;
             }
         }
 
@@ -29,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         {
             get
             {
-                throw new NotImplementedException();
+                return 1;
             }
         }
 
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         {
             get
             {
-                throw new NotImplementedException();
+                return "Project.csproj";
             }
         }
 
@@ -46,23 +47,23 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             throw new NotImplementedException();
         }
 
-        private readonly StringBuilder _messages = new StringBuilder();
-        private readonly StringBuilder _errors = new StringBuilder();
-        private readonly StringBuilder _warnings = new StringBuilder();
+        private readonly List<string> _messages = new List<string>();
+        private readonly List<string> _errors = new List<string>();
+        private readonly List<string> _warnings = new List<string>();
 
         public void LogCustomEvent(CustomBuildEventArgs e)
         {
             throw new NotImplementedException();
         }
 
-        public void LogErrorEvent(BuildErrorEventArgs e) => _errors.AppendLine(e.Message);
+        public void LogErrorEvent(BuildErrorEventArgs e) => _errors.Add(e.Message);
 
-        public void LogMessageEvent(BuildMessageEventArgs e) => _messages.AppendLine(e.Message);
+        public void LogMessageEvent(BuildMessageEventArgs e) => _messages.Add(e.Message);
 
-        public void LogWarningEvent(BuildWarningEventArgs e) => _warnings.AppendLine(e.Message);
+        public void LogWarningEvent(BuildWarningEventArgs e) => _warnings.Add(e.Message);
 
-        public string Messages => _messages.ToString();
-        public string Errors => _errors.ToString();
-        public string Warnings => _warnings.ToString();
+        public IList<string> Messages => _messages;
+        public IList<string> Errors => _errors;
+        public IList<string> Warnings => _warnings;
     }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -80,7 +80,6 @@
     <Compile Include="DesktopBuildServerControllerTests.cs" />
     <Compile Include="EndToEndDeterminismTest.cs" />
     <Compile Include="VBCSCompilerServerTests.cs" />
-    <Compile Include="MockEngine.cs" />
     <Compile Include="RunKeepAliveTests.cs" />
     <Compile Include="ServerUtil.cs" />
     <Compile Include="TestableCompilerServerHost.cs" />

--- a/src/Test/Utilities/Portable/TempFiles/TempDirectory.cs
+++ b/src/Test/Utilities/Portable/TempFiles/TempDirectory.cs
@@ -54,7 +54,17 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public TempFile CreateFile(string name)
         {
             string filePath = System.IO.Path.Combine(_path, name);
-            TempRoot.CreateStream(filePath);
+            TempRoot.CreateStream(filePath, FileMode.CreateNew);
+            return _root.AddFile(new DisposableFile(filePath));
+        }
+
+        /// <summary>
+        /// Creates a file or opens an existing file in this directory.
+        /// </summary>
+        public TempFile CreateOrOpenFile(string name)
+        {
+            string filePath = System.IO.Path.Combine(_path, name);
+            TempRoot.CreateStream(filePath, FileMode.OpenOrCreate);
             return _root.AddFile(new DisposableFile(filePath));
         }
 

--- a/src/Test/Utilities/Portable/TempFiles/TempFile.cs
+++ b/src/Test/Utilities/Portable/TempFiles/TempFile.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
                 try
                 {
-                    TempRoot.CreateStream(_path);
+                    TempRoot.CreateStream(_path, FileMode.CreateNew);
                     break;
                 }
                 catch (PathTooLongException)

--- a/src/Test/Utilities/Portable/TempFiles/TempRoot.cs
+++ b/src/Test/Utilities/Portable/TempFiles/TempRoot.cs
@@ -63,9 +63,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return file;
         }
 
-        internal static void CreateStream(string fullPath)
+        internal static void CreateStream(string fullPath, FileMode mode)
         {
-            using (var file = new FileStream(fullPath, FileMode.CreateNew)) { }
+            using (var file = new FileStream(fullPath, mode)) { }
         }
     }
 }


### PR DESCRIPTION
Since a single invocation of Csc/Vbc should depend solely on the inputs
to the task we can't be dynamically discovering files in the task
itself. Thus, we'll discover the files in a task that we'll run before
CoreCompile.

Actually calling this task will happen in a follow-up PR.

*Review*: @dotnet/roslyn-compiler, @dotnet/roslyn-ide