### PR TITLE
Debugger displays for command-line items

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommandLineAnalyzerReference.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineAnalyzerReference.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -8,6 +9,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Describes a command line analyzer assembly specification.
     /// </summary>
+    [DebuggerDisplay("{FilePath,nq}")]
     public struct CommandLineAnalyzerReference : IEquatable<CommandLineAnalyzerReference>
     {
         private readonly string _path;

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineReference.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineReference.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Describes a command line metadata reference (assembly or netmodule) specification.
     /// </summary>
+    [DebuggerDisplay("{Reference,nq}")]
     public struct CommandLineReference : IEquatable<CommandLineReference>
     {
         private readonly string _reference;

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineSourceFile.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineSourceFile.cs
@@ -7,6 +7,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Describes a source file specification stored on command line arguments.
     /// </summary>
+    [DebuggerDisplay("{Path,nq}")]
     public struct CommandLineSourceFile
     {
         private readonly string _path;


### PR DESCRIPTION
Added debugger displays for the command-line items, so they they look better under the debugger.