### PR TITLE
Disable currently broken VSI tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -22,7 +22,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18295"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public void GenerateMethodInClosedFile()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpWinForms.cs
@@ -151,7 +151,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             Assert.Contains(@"public System.Windows.Forms.Button SomeButton;", actualText);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18602"), Trait(Traits.Feature, Traits.Features.WinForms)]
         public void DeleteControl()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicWinForms.cs
@@ -179,7 +179,7 @@ End Class");
             Assert.Contains(@"Public WithEvents SomeButton As Button", actualText);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18602"), Trait(Traits.Feature, Traits.Features.WinForms)]
         public void DeleteControl()
         {
             var project = new ProjectUtils.Project(ProjectName);


### PR DESCRIPTION
Disable the 3 failing vsi tests until #18602 and #18295 are fixed. @dotnet/roslyn-ide for review, FYI @jmarolf 