### PR TITLE
Don't crash when renaming a method to Finalize and there's a destructor present

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -3585,6 +3585,31 @@ partial class {|current:$$C|} { }
                 result.AssertLabeledSpansAre("current", type:=RelatedLocationType.NoConflict)
             End Using
         End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(16567, "https://github.com/dotnet/roslyn/issues/16567")>
+        Public Sub RenameMethodToFinalizeWithDestructorPresent()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class C
+{
+    ~{|Conflict:C|}() { }
+    void $$[|M|]() 
+    { 
+        int x = 7;
+        int y = ~x;
+    }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="Finalize")
+
+                result.AssertLabeledSpansAre("Conflict", type:=RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
     End Class
 End Namespace
 

--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -215,7 +215,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                     isRenameLocation ||
                     token.ValueText == _replacementText ||
                     isOldText ||
-                    _possibleNameConflicts.Contains(token.ValueText);
+                    _possibleNameConflicts.Contains(token.ValueText) ||
+                    IsPossiblyDestructorConflict(token, _replacementText);
 
                 if (tokenNeedsConflictCheck)
                 {
@@ -228,6 +229,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
                 }
 
                 return newToken;
+            }
+
+            private bool IsPossiblyDestructorConflict(SyntaxToken token, string replacementText)
+            {
+                return _replacementText == "Finalize" &&
+                    token.IsKind(SyntaxKind.IdentifierToken) && 
+                    token.Parent.IsKind(SyntaxKind.DestructorDeclaration);
             }
 
             private SyntaxNode Complexify(SyntaxNode originalNode, SyntaxNode newNode)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/16567

Ask Mode Template
=============

**Customer scenario**: The customer has a destructor `~ClassName` but renames another method to `Finalize` and the product crashes.

**Bugs this fixes:** https://github.com/dotnet/roslyn/issues/16567

**Workarounds, if any**: Don't rename methods to `Finalize` when you already have a destructor.

**Risk**: Very low.

**Performance impact**: Very low. Just a couple of syntactic checks when someone types during rename.

**Is this a regression from a previous update?** No.

**Root cause analysis:** Declaration conflicts usually involve the names of things being the same, and this is a case where the names differ that we missed.

**How was the bug found?** Customer reported in https://connect.microsoft.com/VisualStudio/feedback/details/3118377/unknown-hard-error-and-application-crash-using-vs15-enterprise