### PR TITLE
Ensure proper handling of a line-break following an incomplete string interpolation.

### DIFF
--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -776,7 +776,6 @@ End Module
     <Fact>
     <WorkItem(405887, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887")>
     Public Sub IncrementalParseInterpolationInSingleLineIf()
-        ' The code below intentionally is missing a space between the "Then" and "Console"
         Dim code As String = (<![CDATA[
 Module Module1
     Sub Test1(val1 As Integer)

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -772,6 +772,32 @@ End Module
         Assert.Equal(False, incrementalTree.GetRoot().ContainsDiagnostics)
         VerifyEquivalent(incrementalTree, expectedTree)
     End Sub
+
+    <Fact>
+    <WorkItem(405887, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887")>
+    Public Sub IncrementalParseInterpolationInSingleLineIf()
+        ' The code below intentionally is missing a space between the "Then" and "Console"
+        Dim code As String = (<![CDATA[
+Module Module1
+    Sub Test1(val1 As Integer)
+        If val1 = 1 Then System.Console.WriteLine($"abc '" & sServiceName & "'")
+    End Sub
+End Module
+]]>).Value
+
+        Dim oldText = SourceText.From(code)
+        Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
+
+        Const replace = """ &"
+        Dim insertionPoint = code.IndexOf(replace, StringComparison.Ordinal)
+        Dim newText = oldText.WithChanges(New TextChange(New TextSpan(insertionPoint, replace.Length), "{"))
+        Dim expectedTree = VisualBasicSyntaxTree.ParseText(newText)
+        Dim incrementalTree = oldTree.WithChangedText(newText)
+
+        Assert.Equal(True, expectedTree.GetRoot().ContainsDiagnostics)
+        Assert.Equal(True, incrementalTree.GetRoot().ContainsDiagnostics)
+        VerifyEquivalent(incrementalTree, expectedTree)
+    End Sub
 #End Region
 
     <WorkItem(543489, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543489")>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
@@ -9122,4 +9122,158 @@ BC42105: Function 'Test2' doesn't return a value on all code paths. A null refer
     ~~~~~~~~~~~~
 </expected>)
     End Sub
+
+    <Fact>
+    <WorkItem(405887, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887")>
+    Public Sub ParseLineIfWithIncompleteInterpolatedString_01()
+        Dim compilationDef =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Module Module1
+    Sub Test1(val1 As Integer)
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'")
+    End Sub
+End Module
+    ]]></file>
+</compilation>
+
+        Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseDll)
+        CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected><![CDATA[
+BC30625: 'Module' statement must end with a matching 'End Module'.
+Module Module1
+~~~~~~~~~~~~~~
+BC30026: 'End Sub' expected.
+    Sub Test1(val1 As Integer)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30451: 'sServiceName' is not declared. It may be inaccessible due to its protection level.
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'")
+                                                           ~~~~~~~~~~~~
+BC30370: '}' expected.
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'")
+                                                                             ~
+BC30198: ')' expected.
+End Module
+          ~
+]]></expected>)
+    End Sub
+
+    <Fact>
+    <WorkItem(405887, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887")>
+    Public Sub ParseLineIfWithIncompleteInterpolatedString_02()
+        Dim compilationDef =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Module Module1
+    Sub Test1(val1 As Integer)
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'"})
+    End Sub
+End Module
+    ]]></file>
+</compilation>
+
+        Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseDll)
+        CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected><![CDATA[
+BC30625: 'Module' statement must end with a matching 'End Module'.
+Module Module1
+~~~~~~~~~~~~~~
+BC30026: 'End Sub' expected.
+    Sub Test1(val1 As Integer)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30451: 'sServiceName' is not declared. It may be inaccessible due to its protection level.
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'"})
+                                                           ~~~~~~~~~~~~
+BC30198: ')' expected.
+End Module
+          ~
+]]></expected>)
+    End Sub
+
+    <Fact>
+    <WorkItem(405887, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887")>
+    Public Sub ParseLineIfWithIncompleteInterpolatedString_03()
+        Dim compilationDef =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Module Module1
+    Sub Test1(val1 As Integer)
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'"}")
+    End Sub
+End Module
+    ]]></file>
+</compilation>
+
+        Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseDll)
+        CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected><![CDATA[
+BC30451: 'sServiceName' is not declared. It may be inaccessible due to its protection level.
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'"}")
+                                                           ~~~~~~~~~~~~
+]]></expected>)
+    End Sub
+
+    <Fact>
+    <WorkItem(405887, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887")>
+    Public Sub ParseLineIfWithIncompleteInterpolatedString_04()
+        Dim compilationDef =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Module Module1
+    Sub Test1(val1 As Integer)
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'" ")
+    End Sub
+End Module
+    ]]></file>
+</compilation>
+
+        Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseDll)
+        CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected><![CDATA[
+BC30451: 'sServiceName' is not declared. It may be inaccessible due to its protection level.
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'" ")
+                                                           ~~~~~~~~~~~~
+BC30370: '}' expected.
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'" ")
+                                                                              ~
+]]></expected>)
+    End Sub
+
+    <Fact>
+    <WorkItem(405887, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887")>
+    Public Sub ParseLineIfWithIncompleteInterpolatedString_05()
+        Dim compilationDef =
+<compilation>
+    <file name="a.vb"><![CDATA[
+Module Module1
+    Sub Test1(val1 As Integer)
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'"")
+    End Sub
+End Module
+    ]]></file>
+</compilation>
+
+        Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(compilationDef, TestOptions.ReleaseDll)
+        CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected><![CDATA[
+BC30625: 'Module' statement must end with a matching 'End Module'.
+Module Module1
+~~~~~~~~~~~~~~
+BC30026: 'End Sub' expected.
+    Sub Test1(val1 As Integer)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30451: 'sServiceName' is not declared. It may be inaccessible due to its protection level.
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'"")
+                                                           ~~~~~~~~~~~~
+BC30648: String constants must end with a double quote.
+        If val1 = 1 Then System.Console.WriteLine($"abc '{ sServiceName & "'"")
+                                                                          ~~~~~~
+BC30198: ')' expected.
+End Module
+          ~
+BC30370: '}' expected.
+End Module
+          ~
+]]></expected>)
+    End Sub
 End Class


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=405887.
The error recovery wasn’t including the line-break into interpolated string, yet wasn’t creating proper statement terminator token for it. The change ensures that the line-break is treated as part of the string for the purpose of the error recovery, this is what would happen if the interpolation was properly terminated with ‘}’ before the end of the line.

@dotnet/roslyn-compiler Please review.