### PR TITLE
Fix extract method test baseline

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractMethod.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractMethod.cs
@@ -60,7 +60,10 @@ public class Program
         return result;
     }
 
-    private static void [|NewMethod|]() => Console.WriteLine(""Hello World"");
+    private static void [|NewMethod|]()
+    {
+        Console.WriteLine(""Hello World"");
+    }
 }";
 
             MarkupTestFile.GetSpans(expectedMarkup, out var expectedText, out ImmutableArray<TextSpan> spans);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractMethod.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractMethod.cs
@@ -72,7 +72,10 @@ public class Program
             AssertEx.SetEqual(spans, VisualStudio.Editor.GetTagSpans(VisualStudio.InlineRenameDialog.ValidRenameTag));
 
             VisualStudio.Editor.SendKeys("SayHello", VirtualKey.Enter);
-            VisualStudio.Editor.Verify.TextContains(@"private static void SayHello() => Console.WriteLine(""Hello World"")");
+            VisualStudio.Editor.Verify.TextContains(@"private static void SayHello()
+{
+    Console.WriteLine(""Hello World"");
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractMethod.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractMethod.cs
@@ -73,9 +73,9 @@ public class Program
 
             VisualStudio.Editor.SendKeys("SayHello", VirtualKey.Enter);
             VisualStudio.Editor.Verify.TextContains(@"private static void SayHello()
-{
-    Console.WriteLine(""Hello World"");
-}");
+    {
+        Console.WriteLine(""Hello World"");
+    }");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.ExtractMethod)]


### PR DESCRIPTION
The test machines don't use expression bodied members.
Tag @dotnet/roslyn-ide @333fred 
Fixes https://github.com/dotnet/roslyn/issues/18639