### PR TITLE
Match Roslyn EE to native EE behaviour with property accessibility

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
@@ -617,5 +617,46 @@ public class C<T>
             Verify(GetChildren(evalResult),
                 EvalResult("X", "0", "int", "o.X"));
         }
+
+        [WorkItem(18581, "https://github.com/dotnet/roslyn/issues/18581")]
+        [Fact]
+        public void AccessibilityNotTrumpedByAttribute()
+        {
+            var source =
+@"using System.Diagnostics;
+class C
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private int[] _someArray = { 10, 20 };
+
+    private object SomethingPrivate = 3;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+    internal object InternalCollapsed { get { return 1; } }
+    [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+    private object PrivateCollapsed { get { return 3; } }
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    private int[] PrivateRootHidden { get { return _someArray; } }
+}";
+            var assembly = GetAssembly(source);
+            var type = assembly.GetType("C");
+            var value = CreateDkmClrValue(
+                value: type.Instantiate(),
+                type: type,
+                evalFlags: DkmEvaluationResultFlags.None);
+            var evalResult = FormatResult("new C()", value, inspectionContext: CreateDkmInspectionContext(DkmEvaluationFlags.HideNonPublicMembers));
+            Verify(evalResult,
+                EvalResult("new C()", "{C}", "C", "new C()", DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("[0]", "10", "int", "(new C()).PrivateRootHidden[0]"),
+                EvalResult("[1]", "20", "int", "(new C()).PrivateRootHidden[1]"),
+                EvalResult("Non-Public members", null, "", "new C(), hidden", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Data));
+            var nonPublicChildren = GetChildren(children[2]);
+            Verify(nonPublicChildren,
+                EvalResult("InternalCollapsed", "1", "object {int}", "(new C()).InternalCollapsed", DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Property, DkmEvaluationResultAccessType.Internal),
+                EvalResult("PrivateCollapsed", "3", "object {int}", "(new C()).PrivateCollapsed", DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Property, DkmEvaluationResultAccessType.Private),
+                EvalResult("SomethingPrivate", "3", "object {int}", "(new C()).SomethingPrivate", DkmEvaluationResultFlags.None, DkmEvaluationResultCategory.Data, DkmEvaluationResultAccessType.Private));
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerBrowsableAttributeTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
 {
-    internal class DebuggerBrowsableAttributeTests : CSharpResultProviderTestBase
+    public class DebuggerBrowsableAttributeTests : CSharpResultProviderTestBase
     {
         [Fact]
         public void Never()
@@ -565,10 +565,11 @@ public class C
                 value: type.Instantiate(),
                 type: new DkmClrType(runtime.DefaultModule, runtime.DefaultAppDomain, (TypeImpl)type),
                 evalFlags: DkmEvaluationResultFlags.None);
-            var evalResult = FormatResult("o", value, inspectionContext: CreateDkmInspectionContext(DkmEvaluationFlags.HideNonPublicMembers));
+            var inspectionContext = CreateDkmInspectionContext(DkmEvaluationFlags.HideNonPublicMembers);
+            var evalResult = FormatResult("o", value, inspectionContext: inspectionContext);
             Verify(evalResult,
                 EvalResult("o", "{C}", "C", "o", DkmEvaluationResultFlags.Expandable));
-            var children = GetChildren(evalResult);
+            var children = GetChildren(evalResult, inspectionContext: inspectionContext);
             Verify(children,
                 EvalResult("Static members", null, "", "A", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Class),
                 EvalResult("Non-Public members", null, "", "o.FA, hidden", DkmEvaluationResultFlags.Expandable | DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Data),

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerTypeProxyAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerTypeProxyAttributeTests.cs
@@ -1100,5 +1100,50 @@ class P
             Verify(children,
                 EvalResult("F", "3", "int", "(new C(3)).F"));
         }
+
+        [Fact]
+        public void AccessibilityTrumpedByAttribute()
+        {
+            var source =
+@"using System.Diagnostics;
+[DebuggerTypeProxy(typeof(P))]
+class C
+{
+}
+class P
+{
+    public P(C c)
+    {
+    }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private int[] _someArray = { 10, 20 };
+
+    private object SomethingPrivate = 3;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+    internal object InternalCollapsed { get { return 1; } }
+    [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+    private object PrivateCollapsed { get { return 3; } }
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    private int[] PrivateRootHidden { get { return _someArray; } }
+}";
+            var assembly = GetAssembly(source);
+            var type = assembly.GetType("C");
+            var value = CreateDkmClrValue(
+                value: type.Instantiate(),
+                type: type,
+                evalFlags: DkmEvaluationResultFlags.None);
+            var evalResult = FormatResult("new C()", value, inspectionContext: CreateDkmInspectionContext(DkmEvaluationFlags.HideNonPublicMembers));
+            Verify(evalResult,
+                EvalResult("new C()", "{C}", "C", "new C()", DkmEvaluationResultFlags.Expandable));
+            var children = GetChildren(evalResult);
+            Verify(children,
+                EvalResult("InternalCollapsed", "1", "object {int}", "new P(new C()).InternalCollapsed", DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("PrivateCollapsed", "3", "object {int}", "new P(new C()).PrivateCollapsed", DkmEvaluationResultFlags.ReadOnly),
+                EvalResult("[0]", "10", "int", "new P(new C()).PrivateRootHidden[0]"),
+                EvalResult("[1]", "20", "int", "new P(new C()).PrivateRootHidden[1]"),
+                EvalResult("Raw View", null, "", "new C(), raw", DkmEvaluationResultFlags.ReadOnly, DkmEvaluationResultCategory.Data));
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerTypeProxyAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerTypeProxyAttributeTests.cs
@@ -1101,6 +1101,7 @@ class P
                 EvalResult("F", "3", "int", "(new C(3)).F"));
         }
 
+        [WorkItem(18581, "https://github.com/dotnet/roslyn/issues/18581")]
         [Fact]
         public void AccessibilityTrumpedByAttribute()
         {

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/DebuggerTypeProxyExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/DebuggerTypeProxyExpansion.cs
@@ -117,7 +117,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 proxyValue,
                 ExpansionFlags.IncludeBaseMembers,
                 TypeHelpers.IsPublic,
-                resultProvider);
+                resultProvider,
+                isProxyType: true);
             if (proxyMembers != null)
             {
                 string proxyMemberFullNamePrefix = null;

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -26,7 +26,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             DkmClrValue value,
             ExpansionFlags flags,
             Predicate<MemberInfo> predicate,
-            ResultProvider resultProvider)
+            ResultProvider resultProvider,
+            bool isProxyType)
         {
             // For members of type DynamicProperty (part of Dynamic View expansion), we want
             // to expand the underlying value (not the members of the DynamicProperty type).
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 Debug.Assert(!value.IsNull);
                 value = value.GetFieldValue("value", inspectionContext);
             }
-
+            
             var runtimeType = type.GetLmrType();
             // Primitives, enums, function pointers, and null values with a declared type that is an interface have no visible members.
             Debug.Assert(!runtimeType.IsInterface || value.IsNull);
@@ -67,7 +68,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var allMembers = ArrayBuilder<MemberAndDeclarationInfo>.GetInstance();
             var includeInherited = (flags & ExpansionFlags.IncludeBaseMembers) == ExpansionFlags.IncludeBaseMembers;
             var hideNonPublic = (inspectionContext.EvaluationFlags & DkmEvaluationFlags.HideNonPublicMembers) == DkmEvaluationFlags.HideNonPublicMembers;
-            runtimeType.AppendTypeMembers(allMembers, predicate, declaredTypeAndInfo.Type, appDomain, includeInherited, hideNonPublic);
+            runtimeType.AppendTypeMembers(allMembers, predicate, declaredTypeAndInfo.Type, appDomain, includeInherited, hideNonPublic, isProxyType);
 
             foreach (var member in allMembers)
             {
@@ -94,6 +95,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             GetPublicAndNonPublicMembers(
                 instanceMembers,
                 customTypeInfoMap,
+                isProxyType,
                 out publicInstanceExpansion,
                 out nonPublicInstanceExpansion);
 
@@ -103,6 +105,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             GetPublicAndNonPublicMembers(
                 staticMembers,
                 customTypeInfoMap,
+                isProxyType,
                 out publicStaticExpansion,
                 out nonPublicStaticExpansion);
 
@@ -166,6 +169,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         private static void GetPublicAndNonPublicMembers(
             ArrayBuilder<MemberAndDeclarationInfo> allMembers,
             CustomTypeInfoTypeArgumentMap customTypeInfoMap,
+            bool isProxyType,
             out Expansion publicExpansion,
             out Expansion nonPublicExpansion)
         {
@@ -194,7 +198,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 // The native EE shows proxy type members as public members if they have a
                 // DebuggerBrowsable attribute of any value. Match that behaviour here.
-                if (member.HideNonPublic && !member.IsPublic && !member.BrowsableState.HasValue)
+                if (member.HideNonPublic && !member.IsPublic && (!isProxyType || !member.BrowsableState.HasValue))
                 {
                     nonPublicMembers.Add(member);
                 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     }
                 }
 
-                if (member.HideNonPublic && !member.IsPublic)
+                if (member.HideNonPublic && !member.IsPublic && !member.BrowsableState.HasValue)
                 {
                     nonPublicMembers.Add(member);
                 }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/MemberExpansion.cs
@@ -192,6 +192,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     }
                 }
 
+                // The native EE shows proxy type members as public members if they have a
+                // DebuggerBrowsable attribute of any value. Match that behaviour here.
                 if (member.HideNonPublic && !member.IsPublic && !member.BrowsableState.HasValue)
                 {
                     nonPublicMembers.Add(member);

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ResultsViewExpansion.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Expansion/ResultsViewExpansion.cs
@@ -180,7 +180,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 proxyValue,
                 flags: ExpansionFlags.None,
                 predicate: TypeHelpers.IsPublic,
-                resultProvider: resultProvider);
+                resultProvider: resultProvider,
+                isProxyType: false);
             return new ResultsViewExpansion(proxyValue, proxyMembers);
         }
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -29,7 +29,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             Type declaredType,
             DkmClrAppDomain appDomain,
             bool includeInherited,
-            bool hideNonPublic)
+            bool hideNonPublic,
+            bool isProxyType)
         {
             Debug.Assert(!type.IsInterface);
 
@@ -64,9 +65,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 foreach (var member in type.GetMembers(MemberBindingFlags))
                 {
-                    // The native EE shows members regardless of accessibility if they have a
+                    // The native EE shows proxy members regardless of accessibility if they have a
                     // DebuggerBrowsable attribute of any value. Match that behaviour here.
-                    if (browsableState == null || !browsableState.ContainsKey(member.Name))
+                    if (!isProxyType || browsableState == null || !browsableState.ContainsKey(member.Name))
                     {
                         if (!predicate(member))
                         {

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -191,15 +191,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     {
                         // Native EE uses the accessibility of the property rather than getter
                         // so "public object P { private get; set; }" is treated as public.
-                        // Instead, we drop properties if the getter is inaccessible.
+                        // We match this behaviour to maintain compatibility with F#, where it
+                        // is impossible to make property getters public on internal types.
                         var getMethod = GetNonIndexerGetMethod((PropertyInfo)member);
-                        if (getMethod == null)
-                        {
-                            return false;
-                        }
-                        var attributes = getMethod.Attributes;
-                        return ((attributes & System.Reflection.MethodAttributes.Public) == System.Reflection.MethodAttributes.Public) ||
-                            ((attributes & System.Reflection.MethodAttributes.Family) == System.Reflection.MethodAttributes.Family);
+                        return getMethod != null;
                     }
                 default:
                     return false;

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/ResultProvider.cs
@@ -978,7 +978,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 return TupleExpansion.CreateExpansion(inspectionContext, declaredTypeAndInfo, value, cardinality);
             }
 
-            return MemberExpansion.CreateExpansion(inspectionContext, declaredTypeAndInfo, value, flags, TypeHelpers.IsVisibleMember, this);
+            return MemberExpansion.CreateExpansion(inspectionContext, declaredTypeAndInfo, value, flags, TypeHelpers.IsVisibleMember, this, isProxyType: false);
         }
 
         private static DkmEvaluationResult CreateEvaluationResultFromException(Exception e, EvalResult result, DkmInspectionContext inspectionContext)

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/MemberInfo/ConstructorInfoImpl.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/MemberInfo/ConstructorInfoImpl.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         {
             get
             {
-                throw new NotImplementedException();
+                return Constructor.Name;
             }
         }
 


### PR DESCRIPTION
**Customer scenario**

The Roslyn EE breaks debug proxy types in FSharp.Core, meaning that maps, lists and sets are near impossible to debug as the Roslyn EE thinks all of the properties on the debug proxy types are not public. Roslyn EE is correct - the properties aren't public - but the Native EE accepted this. It's important to note that properties on internal types in F# are *impossible* to make public.

I believe that as the Roslyn EE causes a regression with F# compared to the Native EE, the old behaviour should be used instead.

See https://github.com/Microsoft/visualfsharp/issues/2184#issuecomment-292645097. 

**Before**:

![image](https://cloud.githubusercontent.com/assets/64654/24877897/d3a7eb28-1e28-11e7-8dfe-d9f0b05f49e8.png)

**After**:

![image](https://cloud.githubusercontent.com/assets/64654/24877842/a907e6c0-1e28-11e7-8d96-a34610e6b210.png)

**Bugs this fixes:**

Fixes #18581, fixes https://github.com/Microsoft/visualfsharp/issues/2184

**Workarounds, if any**

**Risk**

**Performance impact**

 "Low"

**Is this a regression from a previous update?**

**Root cause analysis:**

**How did we miss it? What tests are we adding to guard against it in the future?**

**How was the bug found?**

customer reported 





