### PR TITLE
Fix Winforms DeleteControl tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpWinForms.cs
@@ -151,7 +151,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             Assert.Contains(@"public System.Windows.Forms.Button SomeButton;", actualText);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18602"), Trait(Traits.Feature, Traits.Features.WinForms)]
+        [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void DeleteControl()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicWinForms.cs
@@ -179,7 +179,7 @@ End Class");
             Assert.Contains(@"Public WithEvents SomeButton As Button", actualText);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18602"), Trait(Traits.Feature, Traits.Features.WinForms)]
+        [Fact, Trait(Traits.Feature, Traits.Features.WinForms)]
         public void DeleteControl()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/Editor_InProc.cs
@@ -428,7 +428,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 var componentChangeService = (IComponentChangeService)designerHost;
                 void ComponentAdded(object sender, ComponentEventArgs e)
                 {
-                    var control = e.Component as System.Windows.Forms.Control;
+                    var control = (System.Windows.Forms.Control)e.Component;
                     if (control.Name == buttonName)
                     {
                         waitHandle.Set();
@@ -462,7 +462,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 var componentChangeService = (IComponentChangeService)designerHost;
                 void ComponentRemoved(object sender, ComponentEventArgs e)
                 {
-                    var control = e.Component as System.Windows.Controls.Control;
+                    var control = (System.Windows.Forms.Control)e.Component;
                     if (control.Name == buttonName)
                     {
                         waitHandle.Set();


### PR DESCRIPTION
The inproc `DeleteWinformButton` was casting to the WPF control type when it should have been casting to the WinForms control type.
Tag @dotnet/roslyn-ide @333fred for review.
Fixes https://github.com/dotnet/roslyn/issues/18602