### PR TITLE
Fix CsharpCodeActions.FastDoubleInvoke flakiness

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -75,7 +75,7 @@ class Program
 }
 ");
             VisualStudio.Editor.InvokeCodeActionList();
-            VisualStudio.Editor.Verify.CodeAction("using System;", applyFix: true, blockUntilComplete: false);
+            VisualStudio.Editor.Verify.CodeAction("using System;", applyFix: true, blockUntilComplete: true);
             VisualStudio.Editor.InvokeCodeActionListWithoutWaiting();
             VisualStudio.Editor.Verify.CodeAction("Simplify name 'System.ArgumentException'", applyFix: true, blockUntilComplete: true);
 


### PR DESCRIPTION
Tag @dotnet/roslyn-ide @333fred 

This scenario was implemented to match the corresponding scenario in https://github.com/dotnet/roslyn-internal/blob/master/Closed/Hosting/RoslynTaoActions/IntegrationTests/CSharpCodeActions.xml. As it turns out, the `NoSubsequentWait` flag is ignored in the Tao version of the test http://index/?query=verifycodeactions&rightProject=RoslynTaoActions&file=Actions%5CVisualStudio%5CVerifyCodeActionsAction.cs&line=73. Update the new version of the test to also wait for the lightbulb after the first invocation.

Fixes https://github.com/dotnet/roslyn/issues/18634#event-1040885748