### PR TITLE
SemanticModel should cache synthesized bound statements in a separate cache in order to avoid “polluting” the regular cache.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -223,13 +223,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <param name="currentBoundNode">The bound node.</param>
             private bool ShouldAddNode(BoundNode currentBoundNode)
             {
-                BoundBlock block;
-
                 // Do not add compiler generated nodes.
-                if (currentBoundNode.WasCompilerGenerated &&
-                    (currentBoundNode.Kind != BoundKind.Block ||
-                     (block = (BoundBlock)currentBoundNode).Statements.Length != 1 ||
-                     block.Statements.Single().WasCompilerGenerated))
+                if (currentBoundNode.WasCompilerGenerated)
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly ReaderWriterLockSlim _nodeMapLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
         // The bound nodes associated with a syntax node, from highest in the tree to lowest.
         private readonly Dictionary<SyntaxNode, ImmutableArray<BoundNode>> _guardedNodeMap = new Dictionary<SyntaxNode, ImmutableArray<BoundNode>>();
+        private Dictionary<SyntaxNode, BoundStatement> _lazyGuardedSynthesizedStatementsMap;
 
         internal readonly Binder RootBinder;
 
@@ -1184,6 +1185,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        private void GuardedAddSynthesizedStatementToMap(StatementSyntax node, BoundStatement statement)
+        {
+            if (_lazyGuardedSynthesizedStatementsMap == null)
+            {
+                _lazyGuardedSynthesizedStatementsMap = new Dictionary<SyntaxNode, BoundStatement>();
+            }
+
+            _lazyGuardedSynthesizedStatementsMap.Add(node, statement);
+        }
+
+        private BoundStatement GuardedGetSynthesizedStatementFromMap(StatementSyntax node)
+        {
+            if (_lazyGuardedSynthesizedStatementsMap != null &&
+                _lazyGuardedSynthesizedStatementsMap.TryGetValue(node, out BoundStatement result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+
         private ImmutableArray<BoundNode> GuardedGetBoundNodesFromMap(CSharpSyntaxNode node)
         {
             Debug.Assert(_nodeMapLock.IsWriteLockHeld || _nodeMapLock.IsReadLockHeld);
@@ -1896,12 +1918,28 @@ done:
             public override BoundStatement BindStatement(StatementSyntax node, DiagnosticBag diagnostics)
             {
                 // Check the bound node cache to see if the statement was already bound.
+                BoundStatement synthesizedStatement = _semanticModel.GuardedGetSynthesizedStatementFromMap(node);
+
+                if (synthesizedStatement != null)
+                {
+                    return synthesizedStatement;
+                }
+
                 ImmutableArray<BoundNode> boundNodes = _semanticModel.GuardedGetBoundNodesFromMap(node);
 
                 if (boundNodes.IsDefaultOrEmpty)
                 {
                     // Not bound already. Bind it. It will get added to the cache later by a MemberSemanticModel.NodeMapBuilder.
-                    return base.BindStatement(node, diagnostics);
+                    var statement = base.BindStatement(node, diagnostics);
+
+                    // Synthesized statements are not added to the _guardedNodeMap, we cache them explicitly here in  
+                    // _lazyGuardedSynthesizedStatementsMap
+                    if (statement.WasCompilerGenerated)
+                    {
+                        _semanticModel.GuardedAddSynthesizedStatementToMap(node, statement); 
+                    }
+
+                    return statement;
                 }
                 else
                 {

--- a/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
+++ b/src/EditorFeatures/CSharpTest/InlineDeclaration/CSharpInlineDeclarationTests.cs
@@ -1528,8 +1528,7 @@ class C
         }
 
         [WorkItem(17624, "https://github.com/dotnet/roslyn/issues/17624")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/17635"),
-         Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
         public async Task TestInLoops3()
         {
             await TestInRegularAndScript1Async(


### PR DESCRIPTION
Fixes #10604.
Fixes #16306.

@dotnet/roslyn-compiler Please review.