### PR TITLE
Classify type names, even when arity does not match.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -253,7 +253,7 @@ class C
 class C
 {
     dynamic<int> d;
-}");
+}", Class("dynamic"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
@@ -279,7 +279,7 @@ class C
 class C
 {
     A d;
-}");
+}", Class("A"));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -253,7 +253,7 @@ class C
 class C
 {
     dynamic<int> d;
-}", Class("dynamic"));
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -792,7 +792,7 @@ class MyClass
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
-        public async Task TestGenericTypeWithWrongArity()
+        public async Task TestGenericTypeWithNoArity()
         {
             await TestAsync(
 @"
@@ -812,6 +812,36 @@ class Program : IReadOnlyCollection
                 Class("Program"),
                 Punctuation.Colon,
                 Interface("IReadOnlyCollection"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestGenericTypeWithWrongArity()
+        {
+            await TestAsync(
+@"
+using System.Collections.Generic;
+
+class Program : IReadOnlyCollection<int,string>
+{
+}",
+                Keyword("using"),
+                Identifier("System"),
+                Operators.Dot,
+                Identifier("Collections"),
+                Operators.Dot,
+                Identifier("Generic"),
+                Punctuation.Semicolon,
+                Keyword("class"),
+                Class("Program"),
+                Punctuation.Colon,
+                Identifier("IReadOnlyCollection"),
+                Punctuation.OpenAngle,
+                Keyword("int"),
+                Punctuation.Comma,
+                Keyword("string"),
+                Punctuation.CloseAngle,
                 Punctuation.OpenCurly,
                 Punctuation.CloseCurly);
         }

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -788,9 +788,32 @@ class MyClass
                 Punctuation.CloseParen,
                 Punctuation.OpenCurly,
                 Punctuation.CloseCurly,
-                Punctuation.CloseCurly
+                Punctuation.CloseCurly);
+        }
 
-                );
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestGenericTypeWithWrongArity()
+        {
+            await TestAsync(
+@"
+using System.Collections.Generic;
+
+class Program : IReadOnlyCollection
+{
+}",
+                Keyword("using"),
+                Identifier("System"),
+                Operators.Dot,
+                Identifier("Collections"),
+                Operators.Dot,
+                Identifier("Generic"),
+                Punctuation.Semicolon,
+                Keyword("class"),
+                Class("Program"),
+                Punctuation.Colon,
+                Interface("IReadOnlyCollection"),
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly);
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
@@ -224,10 +224,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
                         break;
 
                     case CandidateReason.WrongArity:
-                        // even if the arity is wrong, we want to classify to indicate that we have
-                        // understood what is going on.  The user will get a clear error telling them
-                        // the arity is wrong.
-                        return firstSymbol;
+                        if (name.GetRightmostName().Arity == 0)
+                        {
+                            // When the user writes something like "IList" we don't want to *not* classify 
+                            // just because the type bound to "IList<T>".  This is also important for use
+                            // cases like "Add-using" where it can be confusing when the using is added for
+                            // "using System.Collection.Generic" but then the type name still does not classify.
+                            return firstSymbol;
+                        }
+
+                        break;
                 }
             }
 

--- a/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
@@ -222,6 +222,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
                         }
 
                         break;
+
+                    case CandidateReason.WrongArity:
+                        // even if the arity is wrong, we want to classify to indicate that we have
+                        // understood what is going on.  The user will get a clear error telling them
+                        // the arity is wrong.
+                        return firstSymbol;
                 }
             }
 


### PR DESCRIPTION
This work was inspired by part of the experience reported here:
https://github.com/dotnet/roslyn/issues/18623

Specifically, "add using" was used to resolve an unknown type.  However, even after adding the user, the type name did not classify (due to the user not providing arity, while the type requires arity).  This is a fairly confusing experience and makes it feel like the fix didn't actually fix anything.  This is also very reasonable for the user to do as it's totally normal to do something like say ```IList (add-using) <type-args>```

This PR changes things so that we do still classify if the user doesn't have type-args, but we bind to something generic.  The user still gets a message saying the arity doesn't match, but at least the experience indicates to them that we still know what's going on.