### PR TITLE
Fixes ordering of checks in Venus.ContainedDocument.GetHostType().

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -124,20 +124,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             var projectionBuffer = _containedLanguage.DataBuffer as IProjectionBuffer;
             if (projectionBuffer != null)
             {
-                // For TypeScript hosted in HTML the source buffers will have type names
-                // HTMLX and TypeScript. RazorCSharp has an HTMLX base type but should 
-                // not be associated with the HTML host type. Use ContentType.TypeName 
-                // instead of ContentType.IsOfType for HTMLX to ensure the Razor host 
-                // type is identified correctly.
-                if (projectionBuffer.SourceBuffers.Any(b => b.ContentType.IsOfType(HTML) ||
-                    string.Compare(HTMLX, b.ContentType.TypeName, StringComparison.OrdinalIgnoreCase) == 0))
-                {
-                    return HostType.HTML;
-                }
-
+                // RazorCSharp has an HTMLX base type but should not be associated with
+                // the HTML host type, so we check for it first.
                 if (projectionBuffer.SourceBuffers.Any(b => b.ContentType.IsOfType(Razor)))
                 {
                     return HostType.Razor;
+                }
+
+                // For TypeScript hosted in HTML the source buffers will have type names
+                // HTMLX and TypeScript.
+                if (projectionBuffer.SourceBuffers.Any(b => b.ContentType.IsOfType(HTML) ||
+                    b.ContentType.IsOfType(HTMLX)))
+                {
+                    return HostType.HTML;
                 }
             }
             else


### PR DESCRIPTION
(Rebase of #17221)

The `ContainedDocument.GetHostType` function determines the host type based on the ContentType of the editor.

If an extension provides their own content type deriving from HTMLX (for example, Python and PHP tools both do this), all of the checks fail. This is because to support C#, the check for HTMLX was changed from IsOfType to `==` (approx.).

Instead, the check for Razor should be done first, so that the check for HTMLX can correctly use IsOfType and derived content types are supported.

This will fix https://github.com/Microsoft/PTVS/issues/2178

(I didn't see any obvious tests to clone or update, and I'm not familiar enough with the structure here to want to add one without advice. But happy to do so)