### PR TITLE
Don't offer to convert an 'if' to a 'throw expressoin' if there is an 'else clause'

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
@@ -360,5 +360,33 @@ public interface ISyntax
 {
 }");
         }
+
+        [WorkItem(18670, "https://github.com/dotnet/roslyn/issues/18670")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
+        public async Task TestNotWithElseClause()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+using System;
+
+class C
+{
+    int? _x;
+
+    public C(int? x)
+    {
+        if (x == null)
+        {
+            [|throw|] new ArgumentNullException(nameof(x));
+        }
+        else
+        {
+            Console.WriteLine();
+        }
+
+        _x = x;
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -110,6 +110,12 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
                 return;
             }
 
+            if (ifOperation.IfFalseStatement != null)
+            {
+                // Can't offer this if the 'if-statement' has an 'else-clause'.
+                return;
+            }
+
             var containingBlock = GetOperation(
                 semanticModel, ifOperation.Syntax.Parent, cancellationToken) as IBlockStatement;
             if (containingBlock == null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/18670