### PR TITLE
Report an NFW instead of asserting when we encounter a symbol we can't roundtrip to OOP.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_AllDeclarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_AllDeclarations.cs
@@ -118,8 +118,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             foreach (var dehydrated in array)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var rehydrated = await dehydrated.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
-                result.Add(rehydrated);
+                var rehydrated = await dehydrated.TryRehydrateAsync(solution, cancellationToken).ConfigureAwait(false);
+                if (rehydrated != null)
+                {
+                    result.Add(rehydrated.Value);
+                }
             }
 
             return result.ToImmutableAndFree();

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.FindReferencesServerCallback.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder.FindReferencesServerCallback.cs
@@ -52,15 +52,20 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             public async Task OnDefinitionFoundAsync(SerializableSymbolAndProjectId definition)
             {
-                var symbolAndProjectId = await definition.RehydrateAsync(
+                var symbolAndProjectId = await definition.TryRehydrateAsync(
                     _solution, _cancellationToken).ConfigureAwait(false);
+
+                if (!symbolAndProjectId.HasValue)
+                {
+                    return;
+                }
 
                 lock (_gate)
                 {
-                    _definitionMap[definition] = symbolAndProjectId;
+                    _definitionMap[definition] = symbolAndProjectId.Value;
                 }
 
-                await _progress.OnDefinitionFoundAsync(symbolAndProjectId).ConfigureAwait(false);
+                await _progress.OnDefinitionFoundAsync(symbolAndProjectId.Value).ConfigureAwait(false);
             }
 
             public async Task OnReferenceFoundAsync(


### PR DESCRIPTION
Mitigation for https://github.com/dotnet/roslyn/issues/18676

This should prevent hte assert, while still allowing us to collect enough information to determine what's happening.