### PR TITLE
Don't show a lightbulb when on a sig-change *reference* locatoin.

### DIFF
--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignatureTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ChangeSignatureTests.cs
@@ -24,14 +24,14 @@ class Ext
 
         [WorkItem(1905, "https://github.com/dotnet/roslyn/issues/1905")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
-        public async Task TestAfterSemicolonForInvocationInExpressionStatement()
+        public async Task TestAfterSemicolonForInvocationInExpressionStatement_ViaCommand()
         {
             var markup = @"
 class Program
 {
     static void Main(string[] args)
     {
-        M1(1, 2);[||]
+        M1(1, 2);$$
         M2(1, 2, 3);
     }
 
@@ -53,10 +53,31 @@ class Program
     static void M2(int x, int y, int z) { }
 }";
 
-            await TestChangeSignatureViaCodeActionAsync(
+            await TestChangeSignatureViaCommandAsync(
+                LanguageNames.CSharp,
                 markup: markup, 
                 updatedSignature: new[] { 1, 0 },
-                expectedCode: expectedCode);
+                expectedUpdatedInvocationDocumentCode: expectedCode);
+        }
+        
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        public async Task TestAfterSemicolonForInvocationInExpressionStatement_ViaCodeAction()
+        {
+            var markup = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        M1(1, 2);[||]
+        M2(1, 2, 3);
+    }
+
+    static void M1(int x, int y) { }
+
+    static void M2(int x, int y, int z) { }
+}";
+
+            await TestMissingAsync(markup);
         }
 
         [WorkItem(17309, "https://github.com/dotnet/roslyn/issues/17309")]

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.InvocationLocation.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.InvocationLocation.cs
@@ -836,14 +836,14 @@ class Program
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
-        public async Task ReorderMethodParameters_CodeRefactoring_AtCallSite()
+        public async Task ReorderMethodParameters_CodeRefactoring_AtCallSite_ViaCommand()
         {
             var markup = @"
 class Program
 {
     void M(int x, int y)
     {
-        M([||]5, 6);
+        M($$5, 6);
     }
 }";
             var permutation = new[] { 1, 0 };
@@ -855,8 +855,25 @@ class Program
         M(6, 5);
     }
 }";
-            await TestChangeSignatureViaCodeActionAsync(markup, expectedCodeAction: true, updatedSignature: permutation, expectedCode: updatedCode);
+            await TestChangeSignatureViaCommandAsync(
+                LanguageNames.CSharp, markup, updatedSignature: permutation, 
+                expectedUpdatedInvocationDocumentCode: updatedCode);
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        public async Task ReorderMethodParameters_CodeRefactoring_AtCallSite_ViaCodeAction()
+        {
+            var markup = @"
+class Program
+{
+    void M(int x, int y)
+    {
+        M([||]5, 6);
+    }
+}";
+            await TestMissingAsync(markup);
+        }
+
         #endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.InvocationLocation.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.InvocationLocation.cs
@@ -165,7 +165,7 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
-        public async Task ReorderMethodParameters_InvokeInMethodBody()
+        public async Task ReorderMethodParameters_InvokeInMethodBody_ViaCommand()
         {
             var markup = @"
 using System;
@@ -176,18 +176,25 @@ class MyClass
         $$
     }
 }";
-            var permutation = new[] { 1, 0 };
-            var updatedCode = @"
+
+            await TestChangeSignatureViaCommandAsync(
+                LanguageNames.CSharp, markup, expectedSuccess: false);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        public async Task ReorderMethodParameters_InvokeInMethodBody_ViaSmartTag()
+        {
+            var markup = @"
 using System;
 class MyClass
 {
-    public void Foo(string y, int x)
+    public void Foo(int x, string y)
     {
-        
+        [||]
     }
 }";
 
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+            await TestMissingAsync(markup);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParameters.InvocationLocations.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParameters.InvocationLocations.vb
@@ -612,11 +612,11 @@ End Class]]></Text>.NormalizedValue()
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
-        Public Async Function ReorderIndexerParameters_CodeRefactoring_InCallSite() As Threading.Tasks.Task
+        Public Async Function ReorderIndexerParameters_CodeRefactoring_InCallSite_ViaCommand() As Task
             Dim markup = <Text><![CDATA[
 Class C
     Sub Foo(x As Integer, y As Integer)
-        Foo([||]1, 2)
+        Foo($$1, 2)
     End Sub
 End Class]]></Text>.NormalizedValue()
             Dim permutation = {1, 0}
@@ -627,7 +627,21 @@ Class C
     End Sub
 End Class]]></Text>.NormalizedValue()
 
-            Await TestChangeSignatureViaCodeActionAsync(markup, expectedCodeAction:=True, updatedSignature:=permutation, expectedCode:=updatedCode)
+            Await TestChangeSignatureViaCommandAsync(
+                LanguageNames.VisualBasic, markup, updatedSignature:=permutation,
+                expectedUpdatedInvocationDocumentCode:=updatedCode)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
+        Public Async Function ReorderIndexerParameters_CodeRefactoring_InCallSite_ViaCodeAction() As Threading.Tasks.Task
+            Dim markup = <Text><![CDATA[
+Class C
+    Sub Foo(x As Integer, y As Integer)
+        Foo([||]1, 2)
+    End Sub
+End Class]]></Text>.NormalizedValue()
+
+            Await TestMissingAsync(markup)
         End Function
 #End Region
 

--- a/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/CSharpChangeSignatureService.cs
@@ -22,24 +22,53 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
     [ExportLanguageService(typeof(AbstractChangeSignatureService), LanguageNames.CSharp), Shared]
     internal sealed class CSharpChangeSignatureService : AbstractChangeSignatureService
     {
-        private static readonly ImmutableArray<SyntaxKind> _invokableAncestorKinds = ImmutableArray.Create(
-                SyntaxKind.MethodDeclaration,
-                SyntaxKind.ConstructorDeclaration,
-                SyntaxKind.IndexerDeclaration,
+        private static readonly ImmutableArray<SyntaxKind> _declarationKinds = ImmutableArray.Create(
+            SyntaxKind.MethodDeclaration,
+            SyntaxKind.ConstructorDeclaration,
+            SyntaxKind.IndexerDeclaration,
+            SyntaxKind.DelegateDeclaration,
+            SyntaxKind.SimpleLambdaExpression,
+            SyntaxKind.ParenthesizedLambdaExpression);
+
+        private static readonly ImmutableArray<SyntaxKind> _declarationAndInvocableKinds =
+            _declarationKinds.Concat(ImmutableArray.Create(
                 SyntaxKind.InvocationExpression,
                 SyntaxKind.ElementAccessExpression,
                 SyntaxKind.ThisConstructorInitializer,
                 SyntaxKind.BaseConstructorInitializer,
                 SyntaxKind.ObjectCreationExpression,
                 SyntaxKind.Attribute,
-                SyntaxKind.NameMemberCref,
-                SyntaxKind.SimpleLambdaExpression,
-                SyntaxKind.ParenthesizedLambdaExpression,
-                SyntaxKind.DelegateDeclaration);
+                SyntaxKind.NameMemberCref));
 
-        private static readonly ImmutableArray<SyntaxKind> _invokableAncestorInDeclarationKinds =
-            _invokableAncestorKinds.AddRange(
-                ImmutableArray.Create(SyntaxKind.Block, SyntaxKind.ArrowExpressionClause));
+        private static readonly ImmutableArray<SyntaxKind> _updatableAncestorKinds = ImmutableArray.Create(
+            SyntaxKind.ConstructorDeclaration,
+            SyntaxKind.IndexerDeclaration,
+            SyntaxKind.InvocationExpression,
+            SyntaxKind.ElementAccessExpression,
+            SyntaxKind.ThisConstructorInitializer,
+            SyntaxKind.BaseConstructorInitializer,
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.Attribute,
+            SyntaxKind.DelegateDeclaration,
+            SyntaxKind.SimpleLambdaExpression,
+            SyntaxKind.ParenthesizedLambdaExpression,
+            SyntaxKind.NameMemberCref);
+
+        private static readonly ImmutableArray<SyntaxKind> _updatableNodeKinds = ImmutableArray.Create(
+            SyntaxKind.MethodDeclaration,
+            SyntaxKind.ConstructorDeclaration,
+            SyntaxKind.IndexerDeclaration,
+            SyntaxKind.InvocationExpression,
+            SyntaxKind.ElementAccessExpression,
+            SyntaxKind.ThisConstructorInitializer,
+            SyntaxKind.BaseConstructorInitializer,
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.Attribute,
+            SyntaxKind.DelegateDeclaration,
+            SyntaxKind.NameMemberCref,
+            SyntaxKind.AnonymousMethodExpression,
+            SyntaxKind.ParenthesizedLambdaExpression,
+            SyntaxKind.SimpleLambdaExpression);
 
         public override async Task<ISymbol> GetInvocationSymbolAsync(
             Document document, int position, bool restrictToDeclarations, CancellationToken cancellationToken)
@@ -56,18 +85,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
                 position = token.Span.End;
             }
 
-            var ancestorDeclarationKinds = restrictToDeclarations 
-                ? _invokableAncestorInDeclarationKinds
-                : _invokableAncestorKinds;
-
-            var matchingNode = token.Parent.AncestorsAndSelf().FirstOrDefault(n => ancestorDeclarationKinds.Contains(n.Kind()));
-
-            // If we walked up and we hit a block/expression-body, then we didn't find anything
-            // viable to reorder.  Just bail here.  This helps prevent Change-sig from appearing
-            // too aggressively inside method bodies.
-            if (matchingNode == null ||
-                matchingNode.IsKind(SyntaxKind.Block) ||
-                matchingNode.IsKind(SyntaxKind.ArrowExpressionClause))
+            var matchingNode = GetMatchingNode(token.Parent, restrictToDeclarations);
+            if (matchingNode == null)
             {
                 return null;
             }
@@ -78,13 +97,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
                 return null;
             }
 
+            // If we're actually on the declaration of some symbol, ensure that we're
+            // in a good location for that symbol (i.e. not in the attributes/constraints).
+            if (!InSymbolHeader(matchingNode, position))
+            {
+                return null;
+            }
+
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var symbol = semanticModel.GetDeclaredSymbol(matchingNode, cancellationToken);
             if (symbol != null)
             {
-                // If we're actually on the declaration of some symbol, ensure that we're
-                // in a good location for that symbol (i.e. not in the attributes/constraints).
-                return restrictToDeclarations && !InSymbolHeader(matchingNode, position) ? null : symbol;
+                return symbol;
             }
 
             if (matchingNode.IsKind(SyntaxKind.ObjectCreationExpression))
@@ -103,6 +127,29 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 
             var symbolInfo = semanticModel.GetSymbolInfo(matchingNode, cancellationToken);
             return symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+        }
+
+        private SyntaxNode GetMatchingNode(SyntaxNode node, bool restrictToDeclarations)
+        {
+            var matchKinds = restrictToDeclarations
+                ? _declarationKinds
+                : _declarationAndInvocableKinds;
+
+            for (var current = node; current != null; current = current.Parent)
+            {
+                if (restrictToDeclarations &&
+                    current.Kind() == SyntaxKind.Block || current.Kind() == SyntaxKind.ArrowExpressionClause)
+                {
+                    return null;
+                }
+
+                if (matchKinds.Contains(current.Kind()))
+                {
+                    return current;
+                }
+            }
+
+            return null;
         }
 
         private bool InSymbolHeader(SyntaxNode matchingNode, int position)
@@ -127,40 +174,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             // Case we haven't handled yet.  Just assume we're in the header.
             return true;
         }
-
-        private ImmutableArray<SyntaxKind> _updatableAncestorKinds = new[]
-            {
-                SyntaxKind.ConstructorDeclaration,
-                SyntaxKind.IndexerDeclaration,
-                SyntaxKind.InvocationExpression,
-                SyntaxKind.ElementAccessExpression,
-                SyntaxKind.ThisConstructorInitializer,
-                SyntaxKind.BaseConstructorInitializer,
-                SyntaxKind.ObjectCreationExpression,
-                SyntaxKind.Attribute,
-                SyntaxKind.DelegateDeclaration,
-                SyntaxKind.SimpleLambdaExpression,
-                SyntaxKind.ParenthesizedLambdaExpression,
-                SyntaxKind.NameMemberCref
-            }.ToImmutableArray();
-
-        private ImmutableArray<SyntaxKind> _updatableNodeKinds = new[]
-            {
-                SyntaxKind.MethodDeclaration,
-                SyntaxKind.ConstructorDeclaration,
-                SyntaxKind.IndexerDeclaration,
-                SyntaxKind.InvocationExpression,
-                SyntaxKind.ElementAccessExpression,
-                SyntaxKind.ThisConstructorInitializer,
-                SyntaxKind.BaseConstructorInitializer,
-                SyntaxKind.ObjectCreationExpression,
-                SyntaxKind.Attribute,
-                SyntaxKind.DelegateDeclaration,
-                SyntaxKind.NameMemberCref,
-                SyntaxKind.AnonymousMethodExpression,
-                SyntaxKind.ParenthesizedLambdaExpression,
-                SyntaxKind.SimpleLambdaExpression
-            }.ToImmutableArray();
 
         public override SyntaxNode FindNodeToUpdate(Document document, SyntaxNode node)
         {

--- a/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
@@ -150,6 +150,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
                 Return False
             End If
 
+            Dim asClause = matchingNode.ChildNodes().LastOrDefault(Function(n) TypeOf n Is AsClauseSyntax)
+            If asClause IsNot Nothing Then
+                Return position <= asClause.FullSpan.End
+            End If
+
             ' If the symbol has a parameter list, then the caret shouldn't be past the end of it.
             Dim parameterList = matchingNode.ChildNodes().LastOrDefault(
                 Function(n) TypeOf n Is ParameterListSyntax)

--- a/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/VisualBasicChangeSignatureService.vb
@@ -15,6 +15,66 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
     Friend Class VisualBasicChangeSignatureService
         Inherits AbstractChangeSignatureService
 
+        Private Shared ReadOnly _declarationKinds As ImmutableArray(Of SyntaxKind) = ImmutableArray.Create(
+            SyntaxKind.SubStatement,
+            SyntaxKind.FunctionStatement,
+            SyntaxKind.SubNewStatement,
+            SyntaxKind.PropertyStatement,
+            SyntaxKind.DelegateSubStatement,
+            SyntaxKind.DelegateFunctionStatement,
+            SyntaxKind.EventStatement)
+
+        Private Shared ReadOnly _declarationAndInvocableKinds As ImmutableArray(Of SyntaxKind) =
+            _declarationKinds.Concat(ImmutableArray.Create(
+                SyntaxKind.SubBlock,
+                SyntaxKind.FunctionBlock,
+                SyntaxKind.ConstructorBlock,
+                SyntaxKind.PropertyBlock,
+                SyntaxKind.InvocationExpression,
+                SyntaxKind.EventBlock,
+                SyntaxKind.ObjectCreationExpression))
+
+        Private Shared ReadOnly _nodeKindsToIgnore As ImmutableArray(Of SyntaxKind) = ImmutableArray.Create(
+            SyntaxKind.ImplementsClause)
+
+        Private Shared ReadOnly _updatableNodeKinds As ImmutableArray(Of SyntaxKind) = ImmutableArray.Create(
+            SyntaxKind.CrefReference,
+            SyntaxKind.ImplementsClause,
+            SyntaxKind.SubStatement,
+            SyntaxKind.FunctionStatement,
+            SyntaxKind.DelegateSubStatement,
+            SyntaxKind.DelegateFunctionStatement,
+            SyntaxKind.EventBlock,
+            SyntaxKind.EventStatement,
+            SyntaxKind.RaiseEventStatement,
+            SyntaxKind.PropertyStatement,
+            SyntaxKind.InvocationExpression,
+            SyntaxKind.Attribute,
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.SubNewStatement,
+            SyntaxKind.ConstructorBlock,
+            SyntaxKind.SingleLineSubLambdaExpression,
+            SyntaxKind.MultiLineSubLambdaExpression,
+            SyntaxKind.SingleLineFunctionLambdaExpression,
+            SyntaxKind.MultiLineFunctionLambdaExpression)
+
+        Private Shared ReadOnly _updatableAncestorKinds As ImmutableArray(Of SyntaxKind) = ImmutableArray.Create(
+            SyntaxKind.CrefReference,
+            SyntaxKind.ImplementsClause,
+            SyntaxKind.SubStatement,
+            SyntaxKind.FunctionStatement,
+            SyntaxKind.DelegateSubStatement,
+            SyntaxKind.DelegateFunctionStatement,
+            SyntaxKind.EventBlock,
+            SyntaxKind.EventStatement,
+            SyntaxKind.RaiseEventStatement,
+            SyntaxKind.PropertyStatement,
+            SyntaxKind.InvocationExpression,
+            SyntaxKind.Attribute,
+            SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.SubNewStatement,
+            SyntaxKind.ConstructorBlock)
+
         Public Overrides Async Function GetInvocationSymbolAsync(
                 document As Document,
                 position As Integer,
@@ -23,22 +83,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
             Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
             Dim token = tree.GetRoot(cancellationToken).FindToken(If(position <> tree.Length, position, Math.Max(0, position - 1)))
 
-            Dim matchingNode = token.Parent.AncestorsAndSelf().FirstOrDefault(Function(n) _invokableAncestorKinds.Contains(n.Kind))
+            Dim matchingNode = GetMatchingNode(token.Parent, restrictToDeclarations)
 
-            If matchingNode Is Nothing OrElse (restrictToDeclarations AndAlso _nonDeclarationKinds.Contains(matchingNode.Kind)) Then
+            If matchingNode Is Nothing Then
                 Return Nothing
             End If
 
             ' Don't show change-signature in the random whitespace/trivia for code.
-
             If Not matchingNode.Span.IntersectsWith(position) Then
+                Return Nothing
+            End If
+
+            ' If we're actually on the declaration of some symbol, ensure that we're
+            ' in a good location for that symbol (i.e. Not in the attributes or after the parameter list).
+            If Not IsInSymbolHeader(matchingNode, position) Then
                 Return Nothing
             End If
 
             Dim semanticModel = Await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(False)
             Dim symbol = TryGetDeclaredSymbol(semanticModel, matchingNode, token, cancellationToken)
             If symbol IsNot Nothing Then
-                Return If(restrictToDeclarations AndAlso Not IsInSymbolHeader(matchingNode, position), Nothing, symbol)
+                Return symbol
             End If
 
             If matchingNode.Kind() = SyntaxKind.ObjectCreationExpression Then
@@ -53,6 +118,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
 
             Dim symbolInfo = semanticModel.GetSymbolInfo(matchingNode, cancellationToken)
             Return If(symbolInfo.Symbol, symbolInfo.CandidateSymbols.FirstOrDefault())
+        End Function
+
+        Private Function GetMatchingNode(node As SyntaxNode, restrictToDeclarations As Boolean) As SyntaxNode
+            Dim current = node
+            While current IsNot Nothing
+                If restrictToDeclarations Then
+                    If _declarationKinds.Contains(current.Kind()) Then
+                        Return current
+                    End If
+                Else
+                    If _declarationAndInvocableKinds.Contains(current.Kind()) Then
+                        Return current
+                    End If
+                End If
+
+                current = current.Parent
+            End While
+
+            Return Nothing
         End Function
 
         Private Function IsInSymbolHeader(matchingNode As SyntaxNode, position As Integer) As Boolean
@@ -102,78 +186,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
 
             Return semanticModel.GetDeclaredSymbol(matchingNode, cancellationToken)
         End Function
-
-        Private Shared ReadOnly _nonDeclarationKinds As ImmutableArray(Of SyntaxKind) = ImmutableArray.Create(
-            SyntaxKind.SubBlock,
-            SyntaxKind.FunctionBlock,
-            SyntaxKind.PropertyBlock,
-            SyntaxKind.EventBlock,
-            SyntaxKind.ConstructorBlock)
-
-        Private _invokableAncestorKinds As ImmutableArray(Of SyntaxKind) = New List(Of SyntaxKind) From
-            {
-                SyntaxKind.SubBlock,
-                SyntaxKind.SubStatement,
-                SyntaxKind.FunctionBlock,
-                SyntaxKind.FunctionStatement,
-                SyntaxKind.ConstructorBlock,
-                SyntaxKind.SubNewStatement,
-                SyntaxKind.PropertyBlock,
-                SyntaxKind.PropertyStatement,
-                SyntaxKind.InvocationExpression,
-                SyntaxKind.DelegateSubStatement,
-                SyntaxKind.DelegateFunctionStatement,
-                SyntaxKind.EventStatement,
-                SyntaxKind.EventBlock,
-                SyntaxKind.ObjectCreationExpression
-            }.ToImmutableArray()
-
-        Private _nodeKindsToIgnore As ImmutableArray(Of SyntaxKind) = New List(Of SyntaxKind) From
-            {
-                SyntaxKind.ImplementsClause
-            }.ToImmutableArray()
-
-        Private _updatableNodeKinds As ImmutableArray(Of SyntaxKind) = New List(Of SyntaxKind) From
-            {
-                SyntaxKind.CrefReference,
-                SyntaxKind.ImplementsClause,
-                SyntaxKind.SubStatement,
-                SyntaxKind.FunctionStatement,
-                SyntaxKind.DelegateSubStatement,
-                SyntaxKind.DelegateFunctionStatement,
-                SyntaxKind.EventBlock,
-                SyntaxKind.EventStatement,
-                SyntaxKind.RaiseEventStatement,
-                SyntaxKind.PropertyStatement,
-                SyntaxKind.InvocationExpression,
-                SyntaxKind.Attribute,
-                SyntaxKind.ObjectCreationExpression,
-                SyntaxKind.SubNewStatement,
-                SyntaxKind.ConstructorBlock,
-                SyntaxKind.SingleLineSubLambdaExpression,
-                SyntaxKind.MultiLineSubLambdaExpression,
-                SyntaxKind.SingleLineFunctionLambdaExpression,
-                SyntaxKind.MultiLineFunctionLambdaExpression
-            }.ToImmutableArray()
-
-        Private _updatableAncestorKinds As ImmutableArray(Of SyntaxKind) = New List(Of SyntaxKind) From
-            {
-                SyntaxKind.CrefReference,
-                SyntaxKind.ImplementsClause,
-                SyntaxKind.SubStatement,
-                SyntaxKind.FunctionStatement,
-                SyntaxKind.DelegateSubStatement,
-                SyntaxKind.DelegateFunctionStatement,
-                SyntaxKind.EventBlock,
-                SyntaxKind.EventStatement,
-                SyntaxKind.RaiseEventStatement,
-                SyntaxKind.PropertyStatement,
-                SyntaxKind.InvocationExpression,
-                SyntaxKind.Attribute,
-                SyntaxKind.ObjectCreationExpression,
-                SyntaxKind.SubNewStatement,
-                SyntaxKind.ConstructorBlock
-            }.ToImmutableArray()
 
         Public Overrides Function FindNodeToUpdate(document As Document, node As SyntaxNode) As SyntaxNode
             Dim vbnode = DirectCast(node, VisualBasicSyntaxNode)


### PR DESCRIPTION
Use can still invoke sig-change through ctrl-r, ctrl-o at that locatoin.  But we won't spam the
lightbulb with this action at basically every single source location.