### PR TITLE
Move to using OutputPath for controlling output

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -11,14 +11,14 @@
         <_CopyReferences>false</_CopyReferences>
         <_CopyProjectReferences>false</_CopyProjectReferences>
         <CopyNuGetImplementations>false</CopyNuGetImplementations>
-        <OutDir>$(OutDir)Exes\$(MSBuildProjectName)\</OutDir>
+        <OutputPath>$(OutputPath)Exes\$(MSBuildProjectName)\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'UnitTest'">
       <PropertyGroup>
         <_IsAnyUnitTest>true</_IsAnyUnitTest>
         <CopyNuGetImplementations>true</CopyNuGetImplementations>
-        <OutDir>$(OutDir)UnitTests\$(MSBuildProjectName)\</OutDir>
+        <OutputPath>$(OutputPath)UnitTests\$(MSBuildProjectName)\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'UnitTestPortable' OR '$(RoslynProjectType)' == 'UnitTestDesktop'">
@@ -39,21 +39,21 @@
         <_IsAnyUnitTest>true</_IsAnyUnitTest>
         <_IsAnyPortableUnitTest>true</_IsAnyPortableUnitTest>
         <CopyNuGetImplementations>false</CopyNuGetImplementations>
-        <OutDir>$(OutDir)Dlls\$(MSBuildProjectName)\</OutDir>
+        <OutputPath>$(OutputPath)Dlls\$(MSBuildProjectName)\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'CompilerGeneratorTool'">
       <PropertyGroup>
         <_CopyReferences>false</_CopyReferences>
         <CopyNuGetImplementations>false</CopyNuGetImplementations>
-        <OutDir>$(OutDir)Exes\</OutDir>
+        <OutputPath>$(OutputPath)Exes\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'Vsix'">
       <PropertyGroup>
         <_CopyReferences>false</_CopyReferences>
         <CopyNuGetImplementations>true</CopyNuGetImplementations>
-        <OutDir>$(OutDir)Vsix\$(MSBuildProjectName)\</OutDir>
+        <OutputPath>$(OutputPath)Vsix\$(MSBuildProjectName)\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'DeploymentTest'">
@@ -62,8 +62,8 @@
       <PropertyGroup>
         <AllowedReferenceRelatedFileExtensions>$(AllowedReferenceRelatedFileExtensions);.pdb</AllowedReferenceRelatedFileExtensions>
         <CopyNuGetImplementations>true</CopyNuGetImplementations>
-        <OutDir Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable'">$(OutDir)CoreClrTest</OutDir>
-        <OutDir Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable'">$(OutDir)UnitTests\Portable\</OutDir>
+        <OutputPath Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable'">$(OutputPath)CoreClrTest</OutputPath>
+        <OutputPath Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable'">$(OutputPath)UnitTests\Portable\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'Custom'">
@@ -74,19 +74,19 @@
         <_CopyReferences>false</_CopyReferences>
         <_CopyProjectReferences>false</_CopyProjectReferences>
         <CopyNuGetImplementations>false</CopyNuGetImplementations>
-        <OutDir>$(OutDir)Dlls\$(MSBuildProjectName)\</OutDir>
+        <OutputPath>$(OutputPath)Dlls\$(MSBuildProjectName)\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == '' AND '$(OutputType)' == 'Exe'">
       <PropertyGroup>
         <CopyNuGetImplementations>true</CopyNuGetImplementations>
-        <OutDir>$(OutDir)Exes\$(MSBuildProjectName)\</OutDir>
+        <OutputPath>$(OutputPath)Exes\$(MSBuildProjectName)\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == '' AND '$(OutputType)' == 'WinExe'">
       <PropertyGroup>
         <CopyNuGetImplementations>true</CopyNuGetImplementations>
-        <OutDir>$(OutDir)Exes\$(MSBuildProjectName)\</OutDir>
+        <OutputPath>$(OutputPath)Exes\$(MSBuildProjectName)\</OutputPath>
       </PropertyGroup>
     </When>
   </Choose>
@@ -114,7 +114,6 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <OutputPath>$(OutDir)</OutputPath>
     <RoslynPublicKey>0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</RoslynPublicKey>
     <RoslynInternalKey>002400000480000094000000060200000024000052534131000400000100010055e0217eb635f69281051f9a823e0c7edd90f28063eb6c7a742a19b4f6139778ee0af438f47aed3b6e9f99838aa8dba689c7a71ddb860c96d923830b57bbd5cd6119406ddb9b002cf1c723bf272d6acbb7129e9d6dd5a5309c94e0ff4b2c884d45a55f475cd7dba59198086f61f5a8c8b5e601c0edbf269733f6f578fc8579c2</RoslynInternalKey>
 

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -27,7 +27,7 @@
     <SignAssembly>true</SignAssembly>
     <UseRoslynAnalyzers Condition="'$(UseRoslynAnalyzers)' == ''">true</UseRoslynAnalyzers>
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$(RepoRoot)Binaries\</BaseOutputPath>
-    <OutDir>$(BaseOutputPath)$(Configuration)\</OutDir>
+    <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RepoRoot)Binaries\Obj\</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(MSBuildProjectName)\</IntermediateOutputPath>
 
@@ -47,7 +47,7 @@
     <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
 
     <!-- Disable AppX packaging for the Roslyn source. Not setting this to false has the side effect
-         that any builds of portable projects end up in a sub folder of $(OutDir). Search for this flag in
+         that any builds of portable projects end up in a sub folder of $(OutputPath). Search for this flag in
          Microsoft.Common.CurrentVersion.targets to see how it is consumed -->
     <WindowsAppContainer>false</WindowsAppContainer>
 

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -4,6 +4,7 @@ param (
     [switch]$build = $false, 
     [switch]$restore = $false,
     [switch]$test = $false,
+    [switch]$test64 = $false,
     [switch]$clean = $false,
     [switch]$clearPackageCache = $false,
     [string]$project = "",
@@ -17,7 +18,8 @@ function Print-Usage() {
     Write-Host "Build.ps1"
     Write-Host "`t-build                Run a build operation (default false)"
     Write-Host "`t-restore              Run a restore operation (default false)"
-    Write-Host "`t-test                 Run tests (default false)"
+    Write-Host "`t-test                 Run unit tests (default false)"
+    Write-Host "`t-test64               Run unit tests in 64 bit mode"
     Write-Host "`t-clean                Do a clean build / restore (default false)"
     Write-Host "`t-clearPackageCache    Clear package cache before restoring"
     Write-Host "`t-project <path>       Project the build or restore should target"
@@ -38,7 +40,11 @@ function Run-Build() {
 
 function Run-Test() {
     $proj = Join-Path $repoDir "BuildAndTest.proj"
-    Exec-Command $msbuild "/v:m /p:SkipCoreClr=true /t:Test $proj" | Out-Host
+    $args = "/v:m /p:SkipCoreClr=true /p:ManualTest=true /t:Test $proj"
+    if ($test64) { 
+        $args += " /p:Test64=true"
+    }
+    Exec-Command $msbuild $args | Out-Host
 }
 
 try {
@@ -68,7 +74,7 @@ try {
         Run-Build
     }
 
-    if ($test) { 
+    if ($test -or $test64) { 
         Run-Test
     }
 }

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -5,17 +5,17 @@
 
   <Target Name="Build">
     <!-- NuGetPerBuildPreReleaseVersion -->
-    <Exec Command="$(OutDir)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutDir) $(NuGetPerBuildPreReleaseVersion) $(OutDir)NuGet\PerBuildPreRelease" Condition="'$(NuGetPerBuildPreReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPerBuildPreReleaseVersion) $(OutputPath)NuGet\PerBuildPreRelease" Condition="'$(NuGetPerBuildPreReleaseVersion)' != ''" />
 
     <!-- NuGetPreReleaseVersion -->
-    <Exec Command="$(OutDir)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutDir) $(NuGetPreReleaseVersion) $(OutDir)NuGet\PreRelease" Condition="'$(NuGetPreReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPreReleaseVersion) $(OutputPath)NuGet\PreRelease" Condition="'$(NuGetPreReleaseVersion)' != ''" />
 
     <!-- NuGetReleaseVersion -->
-    <Exec Command="$(OutDir)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutDir) $(NuGetReleaseVersion) $(OutDir)NuGet\Release" Condition="'$(NuGetReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetReleaseVersion) $(OutputPath)NuGet\Release" Condition="'$(NuGetReleaseVersion)' != ''" />
   </Target>
 
   <Target Name="Clean">
-    <RemoveDir Directories="$(OutDir)NuGet" />
+    <RemoveDir Directories="$(OutputPath)NuGet" />
   </Target>
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build">

--- a/src/Setup/DevDivPackages/Roslyn.proj
+++ b/src/Setup/DevDivPackages/Roslyn.proj
@@ -3,16 +3,16 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\build\Targets\Settings.props" />
   <PropertyGroup>
-    <InsertionFilesDir>$(OutDir)DevDivInsertionFiles</InsertionFilesDir>
+    <InsertionFilesDir>$(OutputPath)\DevDivInsertionFiles</InsertionFilesDir>
     <VsToolsetDir>$(InsertionFilesDir)\VS.Tools.Roslyn</VsToolsetDir>
-    <PackagesOutDir>$(OutDir)DevDivPackages\Roslyn</PackagesOutDir>
+    <PackagesOutDir>$(OutputPath)\DevDivPackages\Roslyn</PackagesOutDir>
   </PropertyGroup>
   <ItemGroup>
     <NuSpec Include="$(InsertionFilesDir)\VS.ExternalAPIs.Roslyn.nuspec">
       <Version>$(NuGetPerBuildPreReleaseVersion)</Version>
       <!-- TFS build number isn't set on CI server -->
       <Version Condition="'$(NuGetPerBuildPreReleaseVersion)' == ''">$(NuGetReleaseVersion)-cibuild</Version>
-      <BaseDir>$(OutDir)</BaseDir>
+      <BaseDir>$(OutputPath)</BaseDir>
     </NuSpec>
     <NuSpec Include="$(VsToolsetDir)\VS.Tools.Roslyn.nuspec">
       <Version>$(NuGetPerBuildPreReleaseVersion)</Version>

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swixproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swixproj
@@ -6,7 +6,8 @@
   <PropertyGroup>
     <OutputArchitecture>neutral</OutputArchitecture>
     <OutputLocalized>false</OutputLocalized>
-    <OutputPath>$(OutputPath)Insertion</OutputPath>
+    <RoslynOutputPath>$(OutputPath)</RoslynOutputPath>
+    <OutputPath>$(OutputPath)\Insertion</OutputPath>
     <IsPackage>true</IsPackage>
     <OutputType>vsix</OutputType>
   </PropertyGroup>
@@ -14,7 +15,7 @@
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.props" />
 
   <PropertyGroup>
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);Version=$(VsixVersion);OutputPath=$(OutputPath)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);Version=$(VsixVersion);OutputPath=$(RoslynOutputPath)</PackagePreprocessorDefinitions>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
 

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swixproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swixproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <OutputArchitecture>neutral</OutputArchitecture>
     <OutputLocalized>false</OutputLocalized>
-    <OutputPath>$(OutDir)Insertion</OutputPath>
+    <OutputPath>$(OutputPath)Insertion</OutputPath>
     <IsPackage>true</IsPackage>
     <OutputType>vsix</OutputType>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildCoreVersion)\build\MicroBuild.Core.props" />
 
   <PropertyGroup>
-    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);Version=$(VsixVersion);OutputPath=$(OutDir)</PackagePreprocessorDefinitions>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);Version=$(VsixVersion);OutputPath=$(OutputPath)</PackagePreprocessorDefinitions>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
 

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.vsmanproj
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.vsmanproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
-    <OutputPath>$(OutDir)Insertion\</OutputPath>
+    <OutputPath>$(OutputPath)Insertion\</OutputPath>
     <IsPackage>true</IsPackage>
     <FinalizeValidate>false</FinalizeValidate>
     <ValidateManifest>false</ValidateManifest>

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/Microsoft.CodeAnalysis.LanguageServices.vsmanproj
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/Microsoft.CodeAnalysis.LanguageServices.vsmanproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
-    <OutputPath>$(OutDir)Insertion</OutputPath>
+    <OutputPath>$(OutputPath)\Insertion</OutputPath>
     <IsPackage>true</IsPackage>
     <FinalizeValidate>false</FinalizeValidate>
     <ValidateManifest>false</ValidateManifest>

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swixproj
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swixproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <OutputArchitecture>neutral</OutputArchitecture>
     <OutputLocalized>false</OutputLocalized>
-    <OutputPath>$(OutDir)Insertion</OutputPath>
+    <OutputPath>$(OutputPath)\Insertion</OutputPath>
     <IsPackage>true</IsPackage>
     <OutputType>vsix</OutputType>
   </PropertyGroup>

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.vsmanproj
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.vsmanproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
-    <OutputPath>$(OutDir)Insertion\</OutputPath>
+    <OutputPath>$(OutputPath)\Insertion\</OutputPath>
     <IsPackage>true</IsPackage>
     <FinalizeValidate>false</FinalizeValidate>
     <ValidateManifest>false</ValidateManifest>

--- a/src/Setup/SetupStep1.proj
+++ b/src/Setup/SetupStep1.proj
@@ -25,7 +25,7 @@
          where building multiple projects that produce VSIXes larger than 10MB will race against each other -->
     <MSBuild Projects="@(Project)" Targets="Build" BuildInParallel="false" />
 
-    <Copy SourceFiles="@(PowerShellScriptsToCopy)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(PowerShellScriptsToCopy)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(PowerShellScriptsToCopy)" DestinationFolder="Templates\CSharp\Diagnostic\Analyzer" />
     <Copy SourceFiles="@(PowerShellScriptsToCopy)" DestinationFolder="Templates\VisualBasic\Diagnostic\Analyzer\tools" />
 

--- a/src/Setup/SetupStep2.proj
+++ b/src/Setup/SetupStep2.proj
@@ -8,7 +8,7 @@
 
     <!-- Build CoreXT packages for insertion into DevDiv (order of the following actions matters) -->
     <MSBuild Projects="DevDivInsertionFiles\DevDivInsertionFiles.sln" />
-    <Exec Command="&quot;$(OutDir)\Exes\DevDivInsertionFiles\Roslyn.BuildDevDivInsertionFiles.exe&quot; &quot;$(OutDir)\&quot; &quot;$(MSBuildThisFileDirectory)\&quot; &quot;$(NuGetPackageRoot)&quot; $(AssemblyVersion)" LogStandardErrorAsError="true" />
+    <Exec Command="&quot;$(OutputPath)\Exes\DevDivInsertionFiles\Roslyn.BuildDevDivInsertionFiles.exe&quot; &quot;$(OutputPath)\&quot; &quot;$(MSBuildThisFileDirectory)\&quot; &quot;$(NuGetPackageRoot)&quot; $(AssemblyVersion)" LogStandardErrorAsError="true" />
     <MSBuild Projects="DevDivPackages\Roslyn.proj" />
     <MSBuild Projects="DevDivVsix\PortableFacades\PortableFacades.vsmanproj" />
     <MSBuild Projects="DevDivVsix\CompilersPackage\Microsoft.CodeAnalysis.Compilers.vsmanproj" />

--- a/src/Setup/Vsix/Vsix.proj
+++ b/src/Setup/Vsix/Vsix.proj
@@ -6,7 +6,7 @@
     <VsixUploadConfigs Include="myget_org-extensions.config" />
   </ItemGroup>
   <Target Name="Build">
-    <Copy SourceFiles="@(VsixUploadConfigs)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(VsixUploadConfigs)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
   </Target>
   <Target Name="Clean" />
 </Project>


### PR DESCRIPTION
Based on discussions with SDK team, attempting to switch to using
`$(OutputPath)` for controlling our output directory instead of
`$(OutDir)`.  This is how the SDK recommends teams do it and need
to validate whether this will work for us or not.

The relevant SDK discussion is here 

https://github.com/dotnet/sdk/issues/1113