### PR TITLE
Remove mention of platforms from Microsoft.CodeAnalysis.Compilers Nupkg

### DIFF
--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -5,11 +5,6 @@
     <summary>.NET Compiler Platform ("Roslyn")</summary>
     <description>
       .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
-
-Supported Platforms:
-- .NET Framework 4.5
-- Windows 8
-- Portable Class Libraries
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.CSharp" version="[$version$]" />


### PR DESCRIPTION
This is a nuspec-only change to the description of the package. The supported platforms still listed .NET 4.5 and Windows 8, which were dropped when we upgraded to netstandard 1.3.