### PR TITLE
Fix CodeModel crash if the file is closed

### DIFF
--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -220,7 +220,7 @@ class D { }
 
                 await VerifyRootTypeNameAsync(workspace, "C");
 
-                workspace.OnDocumentClosed(document.Id);
+                workspace.CloseDocument(document.Id);
             }
         }
 
@@ -405,7 +405,7 @@ class D { }
 
                 workspace.AddTestProject(project1);
                 workspace.OnDocumentOpened(document.Id, document.GetOpenTextContainer());
-                workspace.OnDocumentClosed(document.Id);
+                workspace.CloseDocument(document.Id);
                 workspace.OnProjectRemoved(project1.Id);
             }
         }
@@ -425,7 +425,7 @@ class D { }
 
                 Assert.Throws<ArgumentException>(() => workspace.OnDocumentRemoved(document.Id));
 
-                workspace.OnDocumentClosed(document.Id);
+                workspace.CloseDocument(document.Id);
                 workspace.OnProjectRemoved(project1.Id);
             }
         }
@@ -692,7 +692,7 @@ class D { }
                 var syntaxTree = await doc.GetSyntaxTreeAsync(CancellationToken.None);
                 Assert.True(syntaxTree.GetRoot().Width() > 0, "syntaxTree.GetRoot().Width should be > 0");
 
-                workspace.OnDocumentClosed(document.Id);
+                workspace.CloseDocument(document.Id);
                 workspace.OnProjectRemoved(project1.Id);
             }
         }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestHostDocument.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestHostDocument.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     {
         private readonly ExportProvider _exportProvider;
         private HostLanguageServices _languageServiceProvider;
-        private readonly string _initialText;
+        private readonly Lazy<string> _initialText;
         private IWpfTextView _textView;
 
         private DocumentId _id;
@@ -32,7 +33,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private readonly SourceCodeKind _sourceCodeKind;
         private readonly string _filePath;
         private readonly IReadOnlyList<string> _folders;
-        private readonly TextLoader _loader;
 
         public DocumentId Id
         {
@@ -82,14 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
         }
 
-        public TextLoader Loader
-        {
-            get
-            {
-                return _loader;
-            }
-        }
-
+        public TextLoader Loader { get; }
         public int? CursorPosition { get; }
         public IList<TextSpan> SelectedSpans { get; }
         public IDictionary<string, IList<TextSpan>> AnnotatedSpans { get; }
@@ -118,6 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _languageServiceProvider = languageServiceProvider;
             this.TextBuffer = textBuffer;
             this.InitialTextSnapshot = textBuffer.CurrentSnapshot;
+            _initialText = new Lazy<string>(() => this.InitialTextSnapshot.GetText());
             _filePath = filePath;
             _folders = folders;
             _name = filePath;
@@ -137,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 this.AnnotatedSpans.Add(namedSpanList);
             }
 
-            _loader = new TestDocumentLoader(this);
+            Loader = new TestDocumentLoader(this);
         }
 
         public TestHostDocument(
@@ -148,10 +142,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             _exportProvider = TestExportProvider.ExportProviderWithCSharpAndVisualBasic;
             _id = id;
-            _initialText = text;
+            _initialText = new Lazy<string>(() => text);
             _name = displayName;
             _sourceCodeKind = sourceCodeKind;
-            _loader = new TestDocumentLoader(this);
+            Loader = new TestDocumentLoader(this);
             _filePath = filePath;
             _folders = folders;
         }
@@ -178,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             {
                 var contentTypeService = _languageServiceProvider.GetService<IContentTypeLanguageService>();
                 var contentType = contentTypeService.GetDefaultContentType();
-                this.TextBuffer = _exportProvider.GetExportedValue<ITextBufferFactoryService>().CreateTextBuffer(_initialText, contentType);
+                this.TextBuffer = _exportProvider.GetExportedValue<ITextBufferFactoryService>().CreateTextBuffer(_initialText.Value, contentType);
                 this.InitialTextSnapshot = this.TextBuffer.CurrentSnapshot;
             }
         }
@@ -194,18 +188,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
             public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
             {
-                return Task.FromResult(TextAndVersion.Create(_hostDocument.LoadText(cancellationToken), VersionStamp.Create(), "test"));
+                // Create a simple SourceText so that way we're not backing "closed" files by editors to best reflect
+                // what closed files look like in reality.
+                var text = SourceText.From(_hostDocument.GetTextBuffer().CurrentSnapshot.GetText());
+                return Task.FromResult(TextAndVersion.Create(text, VersionStamp.Create(), _hostDocument.FilePath));
             }
         }
-
-        public IContentType ContentType
-        {
-            get
-            {
-                return this.TextBuffer.ContentType;
-            }
-        }
-
+        
         public IWpfTextView GetTextView()
         {
             if (_textView == null)
@@ -232,12 +221,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public ITextBuffer GetTextBuffer()
         {
             return this.TextBuffer;
-        }
-
-        public SourceText LoadText(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var loadedBuffer = _exportProvider.GetExportedValue<ITextBufferFactoryService>().CreateTextBuffer(this.InitialTextSnapshot.GetText(), this.InitialTextSnapshot.ContentType);
-            return loadedBuffer.CurrentSnapshot.AsText();
         }
 
         public SourceTextContainer GetOpenTextContainer()

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -210,13 +210,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             base.OnDocumentOpened(documentId, textContainer, isCurrentContext);
         }
-
-        public void OnDocumentClosed(DocumentId documentId)
-        {
-            var testDocument = this.GetTestDocument(documentId);
-            this.OnDocumentClosed(documentId, testDocument.Loader);
-        }
-
+        
         public new void OnParseOptionsChanged(ProjectId projectId, ParseOptions parseOptions)
         {
             base.OnParseOptionsChanged(projectId, parseOptions);
@@ -600,10 +594,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public override void CloseDocument(DocumentId documentId)
         {
-            var currentDoc = this.CurrentSolution.GetDocument(documentId);
-
-            OnDocumentClosed(documentId,
-                TextLoader.From(TextAndVersion.Create(currentDoc.GetTextAsync().Result, currentDoc.GetTextVersionAsync().Result)));
+            var testDocument = this.GetTestDocument(documentId);
+            this.OnDocumentClosed(documentId, testDocument.Loader);
         }
 
         public void ChangeDocument(DocumentId documentId, SourceText text)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -594,7 +594,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public override void OpenDocument(DocumentId documentId, bool activate = true)
         {
-            OnDocumentOpened(documentId, this.CurrentSolution.GetDocument(documentId).GetTextAsync().Result.Container);
+            var testDocument = this.GetTestDocument(documentId);
+            OnDocumentOpened(documentId, testDocument.GetOpenTextContainer());
         }
 
         public override void CloseDocument(DocumentId documentId)

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
@@ -19,20 +19,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
     {
         protected override AbstractNodeLocator CreateNodeLocator()
         {
-            return new NodeLocator(this);
+            return new NodeLocator();
         }
 
         private class NodeLocator : AbstractNodeLocator
         {
-            public NodeLocator(CSharpCodeModelService codeModelService)
-                : base(codeModelService)
-            {
-            }
+            protected override string LanguageName => LanguageNames.CSharp;
 
-            protected override EnvDTE.vsCMPart DefaultPart
-            {
-                get { return EnvDTE.vsCMPart.vsCMPartWholeWithAttributes; }
-            }
+            protected override EnvDTE.vsCMPart DefaultPart => EnvDTE.vsCMPart.vsCMPartWholeWithAttributes;
 
             protected override VirtualTreePoint? GetStartPoint(SourceText text, OptionSet options, SyntaxNode node, EnvDTE.vsCMPart part)
             {

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
@@ -33,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 get { return EnvDTE.vsCMPart.vsCMPartWholeWithAttributes; }
             }
 
-            protected override VirtualTreePoint? GetStartPoint(SourceText text, SyntaxNode node, EnvDTE.vsCMPart part)
+            protected override VirtualTreePoint? GetStartPoint(SourceText text, OptionSet options, SyntaxNode node, EnvDTE.vsCMPart part)
             {
                 switch (node.Kind())
                 {
@@ -53,16 +54,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                     case SyntaxKind.DestructorDeclaration:
                     case SyntaxKind.OperatorDeclaration:
                     case SyntaxKind.ConversionOperatorDeclaration:
-                        return GetStartPoint(text, (BaseMethodDeclarationSyntax)node, part);
+                        return GetStartPoint(text, options, (BaseMethodDeclarationSyntax)node, part);
                     case SyntaxKind.PropertyDeclaration:
                     case SyntaxKind.IndexerDeclaration:
                     case SyntaxKind.EventDeclaration:
-                        return GetStartPoint(text, (BasePropertyDeclarationSyntax)node, part);
+                        return GetStartPoint(text, options, (BasePropertyDeclarationSyntax)node, part);
                     case SyntaxKind.GetAccessorDeclaration:
                     case SyntaxKind.SetAccessorDeclaration:
                     case SyntaxKind.AddAccessorDeclaration:
                     case SyntaxKind.RemoveAccessorDeclaration:
-                        return GetStartPoint(text, (AccessorDeclarationSyntax)node, part);
+                        return GetStartPoint(text, options, (AccessorDeclarationSyntax)node, part);
                     case SyntaxKind.DelegateDeclaration:
                         return GetStartPoint(text, (DelegateDeclarationSyntax)node, part);
                     case SyntaxKind.NamespaceDeclaration:
@@ -81,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 }
             }
 
-            protected override VirtualTreePoint? GetEndPoint(SourceText text, SyntaxNode node, EnvDTE.vsCMPart part)
+            protected override VirtualTreePoint? GetEndPoint(SourceText text, OptionSet options, SyntaxNode node, EnvDTE.vsCMPart part)
             {
                 switch (node.Kind())
                 {
@@ -141,7 +142,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                     : new VirtualTreePoint(openBrace.SyntaxTree, text, openBrace.Span.End);
             }
 
-            private VirtualTreePoint GetBodyStartPoint(SourceText text, SyntaxToken openBrace, SyntaxToken closeBrace, int memberStartColumn)
+            private VirtualTreePoint GetBodyStartPoint(SourceText text, OptionSet options, SyntaxToken openBrace, SyntaxToken closeBrace, int memberStartColumn)
             {
                 Debug.Assert(!openBrace.IsMissing);
                 Debug.Assert(!closeBrace.IsMissing);
@@ -181,7 +182,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
 
                     // If the line is all whitespace then place the caret at the first indent after the start
                     // of the member.
-                    var indentSize = GetTabSize(text);
+                    var indentSize = GetTabSize(options);
                     var lineText = lineAfterOpenBrace.ToString();
 
                     var lineEndColumn = lineText.GetColumnFromLineOffset(lineText.Length, indentSize);
@@ -347,7 +348,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 return new VirtualTreePoint(node.SyntaxTree, text, startPosition);
             }
 
-            private VirtualTreePoint GetStartPoint(SourceText text, BaseMethodDeclarationSyntax node, EnvDTE.vsCMPart part)
+            private VirtualTreePoint GetStartPoint(SourceText text, OptionSet options, BaseMethodDeclarationSyntax node, EnvDTE.vsCMPart part)
             {
                 int startPosition;
 
@@ -380,9 +381,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                         if (node.Body != null && !node.Body.OpenBraceToken.IsMissing)
                         {
                             var line = text.Lines.GetLineFromPosition(node.SpanStart);
-                            var indentation = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(GetTabSize(text));
+                            var indentation = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(GetTabSize(options));
 
-                            return GetBodyStartPoint(text, node.Body.OpenBraceToken, node.Body.CloseBraceToken, indentation);
+                            return GetBodyStartPoint(text, options, node.Body.OpenBraceToken, node.Body.CloseBraceToken, indentation);
                         }
                         else
                         {
@@ -436,7 +437,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 return node.AccessorList.Accessors.FirstOrDefault();
             }
 
-            private VirtualTreePoint GetStartPoint(SourceText text, BasePropertyDeclarationSyntax node, EnvDTE.vsCMPart part)
+            private VirtualTreePoint GetStartPoint(SourceText text, OptionSet options, BasePropertyDeclarationSyntax node, EnvDTE.vsCMPart part)
             {
                 int startPosition;
 
@@ -467,17 +468,17 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                         if (firstAccessorNode != null)
                         {
                             var line = text.Lines.GetLineFromPosition(firstAccessorNode.SpanStart);
-                            var indentation = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(GetTabSize(text));
+                            var indentation = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(GetTabSize(options));
 
                             if (firstAccessorNode.Body != null)
                             {
-                                return GetBodyStartPoint(text, firstAccessorNode.Body.OpenBraceToken, firstAccessorNode.Body.CloseBraceToken, indentation);
+                                return GetBodyStartPoint(text, options, firstAccessorNode.Body.OpenBraceToken, firstAccessorNode.Body.CloseBraceToken, indentation);
                             }
                             else if (!firstAccessorNode.SemicolonToken.IsMissing)
                             {
                                 // This is total weirdness from the old C# code model with auto props.
                                 // If there isn't a body, the semi-colon is used
-                                return GetBodyStartPoint(text, firstAccessorNode.SemicolonToken, firstAccessorNode.SemicolonToken, indentation);
+                                return GetBodyStartPoint(text, options, firstAccessorNode.SemicolonToken, firstAccessorNode.SemicolonToken, indentation);
                             }
                         }
 
@@ -487,9 +488,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                         if (node.AccessorList != null && !node.AccessorList.OpenBraceToken.IsMissing)
                         {
                             var line = text.Lines.GetLineFromPosition(node.SpanStart);
-                            var indentation = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(GetTabSize(text));
+                            var indentation = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(GetTabSize(options));
 
-                            return GetBodyStartPoint(text, node.AccessorList.OpenBraceToken, node.AccessorList.CloseBraceToken, indentation);
+                            return GetBodyStartPoint(text, options, node.AccessorList.OpenBraceToken, node.AccessorList.CloseBraceToken, indentation);
                         }
 
                         throw Exceptions.ThrowEFail();
@@ -501,7 +502,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 return new VirtualTreePoint(node.SyntaxTree, text, startPosition);
             }
 
-            private VirtualTreePoint GetStartPoint(SourceText text, AccessorDeclarationSyntax node, EnvDTE.vsCMPart part)
+            private VirtualTreePoint GetStartPoint(SourceText text, OptionSet options, AccessorDeclarationSyntax node, EnvDTE.vsCMPart part)
             {
                 int startPosition;
 
@@ -526,9 +527,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                         if (node.Body != null && !node.Body.OpenBraceToken.IsMissing)
                         {
                             var line = text.Lines.GetLineFromPosition(node.SpanStart);
-                            var indentation = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(GetTabSize(text));
+                            var indentation = line.GetColumnOfFirstNonWhitespaceCharacterOrEndOfLine(GetTabSize(options));
 
-                            return GetBodyStartPoint(text, node.Body.OpenBraceToken, node.Body.CloseBraceToken, indentation);
+                            return GetBodyStartPoint(text, options, node.Body.OpenBraceToken, node.Body.CloseBraceToken, indentation);
                         }
 
                         throw Exceptions.ThrowEFail();

--- a/src/VisualStudio/Core/Def/Implementation/ICodeModelNavigationPointService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ICodeModelNavigationPointService.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
@@ -11,11 +12,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         /// <summary>
         /// Retrieves the start point of a given node for the specified EnvDTE.vsCMPart.
         /// </summary>
-        VirtualTreePoint? GetStartPoint(SyntaxNode node, EnvDTE.vsCMPart? part = null);
+        VirtualTreePoint? GetStartPoint(SyntaxNode node, OptionSet options, EnvDTE.vsCMPart? part = null);
 
         /// <summary>
         /// Retrieves the end point of a given node for the specified EnvDTE.vsCMPart.
         /// </summary>
-        VirtualTreePoint? GetEndPoint(SyntaxNode node, EnvDTE.vsCMPart? part = null);
+        VirtualTreePoint? GetEndPoint(SyntaxNode node, OptionSet options, EnvDTE.vsCMPart? part = null);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguageCodeSupport.cs
@@ -60,7 +60,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             var tree = document.GetSyntaxTreeSynchronously(cancellationToken);
             var typeNode = type.DeclaringSyntaxReferences.Where(r => r.SyntaxTree == tree).Select(r => r.GetSyntax(cancellationToken)).First();
             var codeModel = document.Project.LanguageServices.GetService<ICodeModelNavigationPointService>();
-            var point = codeModel.GetStartPoint(typeNode, EnvDTE.vsCMPart.vsCMPartBody);
+            var options = document.GetOptionsAsync(cancellationToken).WaitAndGetResult_Venus(cancellationToken);
+            var point = codeModel.GetStartPoint(typeNode, options, EnvDTE.vsCMPart.vsCMPartBody);
             var reservedNames = semanticModel.LookupSymbols(point.Value.Position, type).Select(m => m.Name);
 
             return NameGenerator.EnsureUniqueness(name, reservedNames, document.Project.LanguageServices.GetService<ISyntaxFactsService>().IsCaseSensitive);
@@ -203,7 +204,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
             var position = type.Locations.First(loc => loc.SourceTree == targetSyntaxTree).SourceSpan.Start;
             var destinationType = syntaxFacts.GetContainingTypeDeclaration(targetSyntaxTree.GetRoot(cancellationToken), position);
-            var insertionPoint = codeModel.GetEndPoint(destinationType, EnvDTE.vsCMPart.vsCMPartBody);
+            var options = targetDocument.GetOptionsAsync(cancellationToken).WaitAndGetResult_Venus(cancellationToken);
+            var insertionPoint = codeModel.GetEndPoint(destinationType, options, EnvDTE.vsCMPart.vsCMPartBody);
 
             if (insertionPoint == null)
             {
@@ -262,10 +264,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             var memberNode = member.DeclaringSyntaxReferences.Select(r => r.GetSyntax(cancellationToken)).FirstOrDefault();
             if (memberNode != null)
             {
-                var navigationPoint = codeModel.GetStartPoint(memberNode, EnvDTE.vsCMPart.vsCMPartNavigate);
+                var memberNodeDocument = thisDocument.Project.Solution.GetDocument(memberNode.SyntaxTree);
+                var options = memberNodeDocument.GetOptionsAsync(cancellationToken).WaitAndGetResult_Venus(cancellationToken);
+                var navigationPoint = codeModel.GetStartPoint(memberNode, options, EnvDTE.vsCMPart.vsCMPartNavigate);
                 if (navigationPoint != null)
                 {
-                    targetDocument = thisDocument.Project.Solution.GetDocument(memberNode.SyntaxTree);
+                    targetDocument = memberNodeDocument;
                     textSpan = navigationPoint.Value.ToVsTextSpan();
                     return true;
                 }

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.AbstractNodeLocator.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.AbstractNodeLocator.cs
@@ -2,6 +2,8 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
@@ -21,24 +23,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             protected abstract EnvDTE.vsCMPart DefaultPart { get; }
 
-            protected abstract VirtualTreePoint? GetStartPoint(SourceText text, SyntaxNode node, EnvDTE.vsCMPart part);
-            protected abstract VirtualTreePoint? GetEndPoint(SourceText text, SyntaxNode node, EnvDTE.vsCMPart part);
+            protected abstract VirtualTreePoint? GetStartPoint(SourceText text, OptionSet options, SyntaxNode node, EnvDTE.vsCMPart part);
+            protected abstract VirtualTreePoint? GetEndPoint(SourceText text, OptionSet options, SyntaxNode node, EnvDTE.vsCMPart part);
 
-            protected int GetTabSize(SourceText text)
+            protected int GetTabSize(OptionSet options)
             {
-                return _codeModelService.GetTabSize(text);
+                return options.GetOption(FormattingOptions.TabSize, _codeModelService.Language);
             }
 
-            public VirtualTreePoint? GetStartPoint(SyntaxNode node, EnvDTE.vsCMPart? part)
+            public VirtualTreePoint? GetStartPoint(SyntaxNode node, OptionSet options, EnvDTE.vsCMPart? part)
             {
                 var text = node.SyntaxTree.GetText();
-                return GetStartPoint(text, node, part ?? DefaultPart);
+                return GetStartPoint(text, options, node, part ?? DefaultPart);
             }
 
-            public VirtualTreePoint? GetEndPoint(SyntaxNode node, EnvDTE.vsCMPart? part)
+            public VirtualTreePoint? GetEndPoint(SyntaxNode node, OptionSet options, EnvDTE.vsCMPart? part)
             {
                 var text = node.SyntaxTree.GetText();
-                return GetEndPoint(text, node, part ?? DefaultPart);
+                return GetEndPoint(text, options, node, part ?? DefaultPart);
             }
         }
     }

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.AbstractNodeLocator.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.AbstractNodeLocator.cs
@@ -14,12 +14,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         protected abstract class AbstractNodeLocator
         {
-            private readonly AbstractCodeModelService _codeModelService;
-
-            protected AbstractNodeLocator(AbstractCodeModelService codeModelService)
-            {
-                _codeModelService = codeModelService;
-            }
+            protected abstract string LanguageName { get; }
 
             protected abstract EnvDTE.vsCMPart DefaultPart { get; }
 
@@ -28,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
             protected int GetTabSize(OptionSet options)
             {
-                return options.GetOption(FormattingOptions.TabSize, _codeModelService.Language);
+                return options.GetOption(FormattingOptions.TabSize, LanguageName);
             }
 
             public VirtualTreePoint? GetStartPoint(SyntaxNode node, OptionSet options, EnvDTE.vsCMPart? part)

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -77,23 +77,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             return _editorOptionsFactoryService.GetEditorOptions(text).GetNewLineCharacter();
         }
 
-        protected int GetTabSize(SourceText text)
-        {
-            var snapshot = text.FindCorrespondingEditorTextSnapshot();
-            return GetTabSize(snapshot);
-        }
-
-        protected int GetTabSize(ITextSnapshot snapshot)
-        {
-            if (snapshot == null)
-            {
-                throw new ArgumentNullException(nameof(snapshot));
-            }
-
-            var textBuffer = snapshot.TextBuffer;
-            return _editorOptionsFactoryService.GetOptions(textBuffer).GetTabSize();
-        }
-
         protected SyntaxToken GetTokenWithoutAnnotation(SyntaxToken current, Func<SyntaxToken, SyntaxToken> nextTokenGetter)
         {
             while (current.ContainsAnnotations)
@@ -552,14 +535,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         public abstract string GetExternalSymbolName(ISymbol symbol);
         public abstract string GetExternalSymbolFullName(ISymbol symbol);
 
-        public VirtualTreePoint? GetStartPoint(SyntaxNode node, EnvDTE.vsCMPart? part)
+        public VirtualTreePoint? GetStartPoint(SyntaxNode node, OptionSet options, EnvDTE.vsCMPart? part)
         {
-            return _nodeLocator.GetStartPoint(node, part);
+            return _nodeLocator.GetStartPoint(node, options, part);
         }
 
-        public VirtualTreePoint? GetEndPoint(SyntaxNode node, EnvDTE.vsCMPart? part)
+        public VirtualTreePoint? GetEndPoint(SyntaxNode node, OptionSet options, EnvDTE.vsCMPart? part)
         {
-            return _nodeLocator.GetEndPoint(node, part);
+            return _nodeLocator.GetEndPoint(node, options, part);
         }
 
         public abstract EnvDTE.vsCMAccess GetAccess(ISymbol symbol);

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
@@ -152,7 +153,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
             get
             {
-                var point = CodeModelService.GetStartPoint(LookupNode());
+                var options = GetDocument().GetOptionsAsync(CancellationToken.None).WaitAndGetResult_CodeModel(CancellationToken.None);
+                var point = CodeModelService.GetStartPoint(LookupNode(), options);
                 if (point == null)
                 {
                     return null;
@@ -166,7 +168,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
             get
             {
-                var point = CodeModelService.GetEndPoint(LookupNode());
+                var options = GetDocument().GetOptionsAsync(CancellationToken.None).WaitAndGetResult_CodeModel(CancellationToken.None);
+                var point = CodeModelService.GetEndPoint(LookupNode(), options);
                 if (point == null)
                 {
                     return null;
@@ -178,7 +181,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         public virtual EnvDTE.TextPoint GetStartPoint(EnvDTE.vsCMPart part)
         {
-            var point = CodeModelService.GetStartPoint(LookupNode(), part);
+            var options = GetDocument().GetOptionsAsync(CancellationToken.None).WaitAndGetResult_CodeModel(CancellationToken.None);
+            var point = CodeModelService.GetStartPoint(LookupNode(), options, part);
             if (point == null)
             {
                 return null;
@@ -189,7 +193,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         public virtual EnvDTE.TextPoint GetEndPoint(EnvDTE.vsCMPart part)
         {
-            var point = CodeModelService.GetEndPoint(LookupNode(), part);
+            var options = GetDocument().GetOptionsAsync(CancellationToken.None).WaitAndGetResult_CodeModel(CancellationToken.None);
+            var point = CodeModelService.GetEndPoint(LookupNode(), options, part);
             if (point == null)
             {
                 return null;

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
@@ -29,6 +29,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                 Assert.NotNull(codeElement)
 
                 expected(codeElement)
+
+                ' Now close the file and ensure the behavior is still the same
+                state.VisualStudioWorkspace.CloseDocument(state.Workspace.Documents.Single().Id)
+
+                codeElement = GetCodeElement(state)
+                Assert.NotNull(codeElement)
+
+                expected(codeElement)
             End Using
         End Function
 

--- a/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/CodeModelTestHelpers.vb
@@ -54,8 +54,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                                 project.LanguageServices,
                                 mockVisualStudioWorkspace)
 
-                Dim editorOptionsFactoryService = workspace.GetService(Of IEditorOptionsFactoryService)()
-                Dim mockTextManagerAdapter = New MockTextManagerAdapter(editorOptionsFactoryService)
+                Dim mockTextManagerAdapter = New MockTextManagerAdapter()
 
                 For Each documentId In project.DocumentIds
                     ' Note that a parent is not specified below. In Visual Studio, this would normally be an EnvDTE.Project instance.

--- a/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockTextManagerAdapter.vb
+++ b/src/VisualStudio/TestUtilities2/CodeModel/Mocks/MockTextManagerAdapter.vb
@@ -1,7 +1,9 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Threading
 Imports Microsoft.CodeAnalysis.Editor
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
+Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 Imports Microsoft.VisualStudio.Text.Editor
@@ -11,16 +13,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.Mocks
     Friend NotInheritable Class MockTextManagerAdapter
         Implements ITextManagerAdapter
 
-        Private ReadOnly _editorOptionsFactoryService As IEditorOptionsFactoryService
-
-        Public Sub New(editorOptionsFactoryService As IEditorOptionsFactoryService)
-            _editorOptionsFactoryService = editorOptionsFactoryService
-        End Sub
-
         Public Function CreateTextPoint(fileCodeModel As FileCodeModel, point As VirtualTreePoint) As EnvDTE.TextPoint Implements ITextManagerAdapter.CreateTextPoint
-            Dim textBuffer = point.Text.Container.TryGetTextBuffer()
-            Dim tabSize = _editorOptionsFactoryService.GetOptions(textBuffer).GetTabSize()
-            Return New MockTextPoint(point, tabSize)
+            Dim options = fileCodeModel.GetDocument().GetOptionsAsync().WaitAndGetResult_CodeModel(CancellationToken.None)
+            Return New MockTextPoint(point, options.GetOption(FormattingOptions.TabSize))
         End Function
     End Class
 End Namespace

--- a/src/VisualStudio/TestUtilities2/MockVisualStudioWorkspace.vb
+++ b/src/VisualStudio/TestUtilities2/MockVisualStudioWorkspace.vb
@@ -96,10 +96,16 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
 
         Private ReadOnly _documentId As DocumentId
         Private ReadOnly _workspace As TestWorkspace
+        Private ReadOnly _needsClose As Boolean = False
 
         Public Sub New(documentId As DocumentId, workspace As TestWorkspace)
             Me._documentId = documentId
             Me._workspace = workspace
+
+            If Not workspace.IsDocumentOpen(documentId) Then
+                _workspace.OpenDocument(documentId)
+                _needsClose = True
+            End If
         End Sub
 
         Public ReadOnly Property TextBuffer As Global.Microsoft.VisualStudio.Text.ITextBuffer Implements IInvisibleEditor.TextBuffer
@@ -109,6 +115,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests
         End Property
 
         Public Sub Dispose() Implements IDisposable.Dispose
+            If _needsClose Then
+                _workspace.CloseDocument(_documentId)
+            End If
         End Sub
 
     End Class

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.NodeLocator.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.NodeLocator.vb
@@ -14,15 +14,17 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
     Partial Friend Class VisualBasicCodeModelService
 
         Protected Overrides Function CreateNodeLocator() As AbstractNodeLocator
-            Return New NodeLocator(Me)
+            Return New NodeLocator()
         End Function
 
         Private Class NodeLocator
             Inherits AbstractNodeLocator
 
-            Public Sub New(codeModelService As VisualBasicCodeModelService)
-                MyBase.New(codeModelService)
-            End Sub
+            Protected Overrides ReadOnly Property LanguageName As String
+                Get
+                    Return LanguageNames.VisualBasic
+                End Get
+            End Property
 
             Protected Overrides ReadOnly Property DefaultPart As EnvDTE.vsCMPart
                 Get

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.NodeLocator.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicCodeModelService.NodeLocator.vb
@@ -3,6 +3,7 @@
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions
@@ -29,22 +30,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 End Get
             End Property
 
-            Protected Overrides Function GetStartPoint(text As SourceText, node As SyntaxNode, part As EnvDTE.vsCMPart) As VirtualTreePoint?
+            Protected Overrides Function GetStartPoint(text As SourceText, options As OptionSet, node As SyntaxNode, part As EnvDTE.vsCMPart) As VirtualTreePoint?
                 Select Case node.Kind
                     Case SyntaxKind.ClassBlock,
                          SyntaxKind.InterfaceBlock,
                          SyntaxKind.ModuleBlock,
                          SyntaxKind.StructureBlock
-                        Return GetTypeBlockStartPoint(text, DirectCast(node, TypeBlockSyntax), part)
+                        Return GetTypeBlockStartPoint(text, options, DirectCast(node, TypeBlockSyntax), part)
                     Case SyntaxKind.EnumBlock
-                        Return GetEnumBlockStartPoint(text, DirectCast(node, EnumBlockSyntax), part)
+                        Return GetEnumBlockStartPoint(text, options, DirectCast(node, EnumBlockSyntax), part)
                     Case SyntaxKind.ClassStatement,
                          SyntaxKind.InterfaceStatement,
                          SyntaxKind.ModuleStatement,
                          SyntaxKind.StructureStatement
-                        Return GetTypeBlockStartPoint(text, DirectCast(node.Parent, TypeBlockSyntax), part)
+                        Return GetTypeBlockStartPoint(text, options, DirectCast(node.Parent, TypeBlockSyntax), part)
                     Case SyntaxKind.EnumStatement
-                        Return GetEnumBlockStartPoint(text, DirectCast(node.Parent, EnumBlockSyntax), part)
+                        Return GetEnumBlockStartPoint(text, options, DirectCast(node.Parent, EnumBlockSyntax), part)
                     Case SyntaxKind.ConstructorBlock,
                          SyntaxKind.FunctionBlock,
                          SyntaxKind.OperatorBlock,
@@ -54,7 +55,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                          SyntaxKind.AddHandlerAccessorBlock,
                          SyntaxKind.RemoveHandlerAccessorBlock,
                          SyntaxKind.RaiseEventAccessorBlock
-                        Return GetMethodBlockStartPoint(text, DirectCast(node, MethodBlockBaseSyntax), part)
+                        Return GetMethodBlockStartPoint(text, options, DirectCast(node, MethodBlockBaseSyntax), part)
                     Case SyntaxKind.SubNewStatement,
                          SyntaxKind.OperatorStatement,
                          SyntaxKind.GetAccessorStatement,
@@ -62,11 +63,11 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                          SyntaxKind.AddHandlerStatement,
                          SyntaxKind.RemoveHandlerStatement,
                          SyntaxKind.RaiseEventStatement
-                        Return GetMethodBlockStartPoint(text, DirectCast(node.Parent, MethodBlockBaseSyntax), part)
+                        Return GetMethodBlockStartPoint(text, options, DirectCast(node.Parent, MethodBlockBaseSyntax), part)
                     Case SyntaxKind.FunctionStatement,
                          SyntaxKind.SubStatement
                         If TypeOf node.Parent Is MethodBlockBaseSyntax Then
-                            Return GetMethodBlockStartPoint(text, DirectCast(node.Parent, MethodBlockBaseSyntax), part)
+                            Return GetMethodBlockStartPoint(text, options, DirectCast(node.Parent, MethodBlockBaseSyntax), part)
                         Else
                             Return GetMethodStatementStartPoint(text, DirectCast(node, MethodStatementSyntax), part)
                         End If
@@ -80,7 +81,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                         Return GetPropertyStatementStartPoint(text, DirectCast(node, PropertyStatementSyntax), part)
 
                     Case SyntaxKind.EventBlock
-                        Return GetEventBlockStartPoint(text, DirectCast(node, EventBlockSyntax), part)
+                        Return GetEventBlockStartPoint(text, options, DirectCast(node, EventBlockSyntax), part)
                     Case SyntaxKind.EventStatement
                         Return GetEventStatementStartPoint(text, DirectCast(node, EventStatementSyntax), part)
 
@@ -89,9 +90,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                         Return GetDelegateStatementStartPoint(text, DirectCast(node, DelegateStatementSyntax), part)
 
                     Case SyntaxKind.NamespaceBlock
-                        Return GetNamespaceBlockStartPoint(text, DirectCast(node, NamespaceBlockSyntax), part)
+                        Return GetNamespaceBlockStartPoint(text, options, DirectCast(node, NamespaceBlockSyntax), part)
                     Case SyntaxKind.NamespaceStatement
-                        Return GetNamespaceBlockStartPoint(text, DirectCast(node.Parent, NamespaceBlockSyntax), part)
+                        Return GetNamespaceBlockStartPoint(text, options, DirectCast(node.Parent, NamespaceBlockSyntax), part)
                     Case SyntaxKind.ModifiedIdentifier
                         Return GetVariableStartPoint(text, DirectCast(node, ModifiedIdentifierSyntax), part)
                     Case SyntaxKind.EnumMemberDeclaration
@@ -119,7 +120,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 End Select
             End Function
 
-            Protected Overrides Function GetEndPoint(text As SourceText, node As SyntaxNode, part As EnvDTE.vsCMPart) As VirtualTreePoint?
+            Protected Overrides Function GetEndPoint(text As SourceText, options As OptionSet, node As SyntaxNode, part As EnvDTE.vsCMPart) As VirtualTreePoint?
                 Select Case node.Kind
                     Case SyntaxKind.ClassBlock,
                          SyntaxKind.InterfaceBlock,
@@ -291,7 +292,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 End If
             End Function
 
-            Private Function GetTypeBlockStartPoint(text As SourceText, typeBlock As TypeBlockSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
+            Private Function GetTypeBlockStartPoint(text As SourceText, options As OptionSet, typeBlock As TypeBlockSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
                 Dim startPosition As Integer
 
                 Select Case part
@@ -341,7 +342,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                         End If
 
                         If part = EnvDTE.vsCMPart.vsCMPartNavigate Then
-                            Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(text), typeBlock.BlockStatement, typeBlock.EndBlockStatement, statementLine.LineNumber + 1)
+                            Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(options), typeBlock.BlockStatement, typeBlock.EndBlockStatement, statementLine.LineNumber + 1)
                         End If
 
                     Case Else
@@ -377,7 +378,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Return New VirtualTreePoint(typeBlock.SyntaxTree, text, startPosition)
             End Function
 
-            Private Function GetEnumBlockStartPoint(text As SourceText, enumBlock As EnumBlockSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
+            Private Function GetEnumBlockStartPoint(text As SourceText, options As OptionSet, enumBlock As EnumBlockSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
                 Dim startPosition As Integer
 
                 Select Case part
@@ -412,7 +413,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                         End If
 
                         If part = EnvDTE.vsCMPart.vsCMPartNavigate Then
-                            Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(text), enumBlock.EnumStatement, enumBlock.EndEnumStatement, statementLine.LineNumber + 1)
+                            Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(options), enumBlock.EnumStatement, enumBlock.EndEnumStatement, statementLine.LineNumber + 1)
                         End If
 
                     Case Else
@@ -448,7 +449,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Return New VirtualTreePoint(enumBlock.SyntaxTree, text, startPosition)
             End Function
 
-            Private Function GetMethodBlockStartPoint(text As SourceText, methodBlock As MethodBlockBaseSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
+            Private Function GetMethodBlockStartPoint(text As SourceText, options As OptionSet, methodBlock As MethodBlockBaseSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
                 Dim startPosition As Integer
 
                 Select Case part
@@ -479,7 +480,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                                     Throw Exceptions.ThrowEFail()
                                 End If
 
-                                Return GetEventBlockStartPoint(text, eventBlock, part)
+                                Return GetEventBlockStartPoint(text, options, eventBlock, part)
                             Case Else
                                 Throw Exceptions.ThrowEFail()
                         End Select
@@ -493,7 +494,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                          EnvDTE.vsCMPart.vsCMPartWhole
                         startPosition = NavigationPointHelpers.GetHeaderStartPosition(methodBlock)
                     Case EnvDTE.vsCMPart.vsCMPartNavigate
-                        Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(text), methodBlock)
+                        Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(options), methodBlock)
                     Case EnvDTE.vsCMPart.vsCMPartBody,
                          EnvDTE.vsCMPart.vsCMPartBodyWithDelimiter
 
@@ -777,7 +778,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                 Return New VirtualTreePoint(propertyStatement.SyntaxTree, text, startPosition)
             End Function
 
-            Private Function GetEventBlockStartPoint(text As SourceText, eventBlock As EventBlockSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
+            Private Function GetEventBlockStartPoint(text As SourceText, options As OptionSet, eventBlock As EventBlockSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
                 Dim startPosition As Integer
 
                 Select Case part
@@ -802,7 +803,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
 
                     Case EnvDTE.vsCMPart.vsCMPartNavigate
 
-                        Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(text), eventBlock)
+                        Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(options), eventBlock)
 
                     Case EnvDTE.vsCMPart.vsCMPartBody,
                          EnvDTE.vsCMPart.vsCMPartBodyWithDelimiter
@@ -974,7 +975,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                     .FirstOrNullable(Function(t) t.Kind = SyntaxKind.ColonTrivia)
             End Function
 
-            Private Function GetNamespaceBlockStartPoint(text As SourceText, namespaceBlock As NamespaceBlockSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
+            Private Function GetNamespaceBlockStartPoint(text As SourceText, options As OptionSet, namespaceBlock As NamespaceBlockSyntax, part As EnvDTE.vsCMPart) As VirtualTreePoint?
                 Dim startPosition As Integer
 
                 Select Case part
@@ -1003,7 +1004,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.CodeModel
                             lineNumber = text.Lines.IndexOf(colonTrivia.Value.SpanStart)
                         End If
 
-                        Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(text), namespaceBlock.NamespaceStatement, namespaceBlock.EndNamespaceStatement, lineNumber)
+                        Return NavigationPointHelpers.GetNavigationPoint(text, GetTabSize(options), namespaceBlock.NamespaceStatement, namespaceBlock.EndNamespaceStatement, lineNumber)
 
                     Case EnvDTE.vsCMPart.vsCMPartBody,
                          EnvDTE.vsCMPart.vsCMPartBodyWithDelimiter


### PR DESCRIPTION
**Customer scenario:** editing a text block (or other operations) inside a XAML editor.

**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/404966

**Workarounds, if any:** magically know that if you open the file being edited by the designer, it won't crash.

**Risk:** moderate. The area is constrained to CodeModel scenarios, but clearly we didn't have enough test coverage.

**Performance impact:** nothing meaningful. Just some cheap operations to get certain formatting options.

**Is this a regression from a previous update?** Yes, this was regressed by #17924 between 15.0 and 15.1.

**Root cause analysis:** I removed the code which forced the file to be opened to a text buffer in #17924. In the preparation of that fix I understood that the reason the opening to a text buffer was being done was to get tab settings, but I failed to correctly realize that in some cases we *were* still reading tab settings. I had traced through the code and concluded that nobody still needed it, so need for the original change was no longer applicable.

We'll be adding tests for the closed-file case.

**How was the bug found?** internal adhoc testing.
