### PR TITLE
Fix refout crash with GetEntryPoint when Main is private

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -239,6 +239,31 @@ class Test2
         }
 
         [Fact]
+        public void EmitRefAssemblyWhenTargetExe()
+        {
+            CSharpCompilation comp = CreateCompilationWithMscorlib(@"
+public class C
+{
+    internal static void Main()
+    {
+        System.Console.WriteLine(""hello"");
+    }
+}
+", options: TestOptions.DebugExe);
+
+            using (var output = new MemoryStream())
+            using (var metadataOutput = new MemoryStream())
+            {
+                // Previously, this would crash when trying to get the entry point for the ref assembly
+                // (but the Main method is not emitted in the ref assembly...)
+                EmitResult emitResult = comp.Emit(output, metadataPEStream: metadataOutput,
+                    options: new EmitOptions(includePrivateMembers: false));
+                Assert.True(emitResult.Success);
+                emitResult.Diagnostics.Verify();
+            }
+        }
+
+        [Fact]
         public void RefAssembly_HasReferenceAssemblyAttribute()
         {
             var emitRefAssembly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1846,7 +1846,7 @@ namespace Microsoft.Cci
 
         internal void GetEntryPoints(out MethodDefinitionHandle entryPointHandle, out MethodDefinitionHandle debugEntryPointHandle)
         {
-            if (IsFullMetadata)
+            if (IsFullMetadata && !MetadataOnly)
             {
                 // PE entry point is set for executable programs
                 IMethodReference entryPoint = module.PEEntryPoint;


### PR DESCRIPTION
Fixing first reported refout bug (by Danny from Domino).
When the `Main` method is not emitted, we'll get a crash if we try to get the handle for the entry point.

@gafter @AlekseyTs @dotnet/roslyn-compiler for review. Thanks