### PR TITLE
Support ExperimentalAttribute

### DIFF
--- a/docs/features/ExperimentalAttribute.md
+++ b/docs/features/ExperimentalAttribute.md
@@ -1,0 +1,142 @@
+ExperimentalAttribute
+=====================
+Report warnings for references to types and members marked with `Windows.Foundation.Metadata.ExperimentalAttribute`.
+```
+namespace Windows.Foundation.Metadata
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum |
+        AttributeTargets.Interface | AttributeTargets.Delegate,
+        AllowMultiple = false)]
+    public sealed class ExperimentalAttribute : Attribute
+    {
+    }
+}
+```
+
+## Warnings
+The warning message is a specific message, where `'{0}'` is the fully-qualified type or member name.
+```
+'{0}' is for evaluation purposes only and is subject to change or removal in future updates.
+```
+
+The warning is reported for any reference to a type or member marked with the attribute.
+(The `AttributeUsage` is for types only so the attribute cannot be applied to non-type members from C# or VB,
+but the attribute could be applied to non-type members outside of C# or VB.)
+```
+[Experimental]
+class A
+{
+    internal object F;
+    internal static object G;
+    internal class B { }
+}
+class C
+{
+    static void Main()
+    {
+        F(default(A));   // warning CS08305: 'A' is for evaluation purposes only ...
+        F(typeof(A));    // warning CS08305: 'A' is for evaluation purposes only ...
+        F(nameof(A));    // warning CS08305: 'A' is for evaluation purposes only ...
+        var a = new A(); // warning CS08305: 'A' is for evaluation purposes only ...
+        F(a.F);
+        F(A.G);          // warning CS08305: 'A' is for evaluation purposes only ...
+        F<A.B>(null);    // warning CS08305: 'A' is for evaluation purposes only ...
+    }
+    static void F<T>(T t)
+    {
+    }
+}
+```
+
+The attribute is not inherited from base types or overridden members.
+```
+[Experimental]
+class A<T>
+{
+    [Experimental]
+    internal virtual void F()
+    {
+    }
+}
+class B : A<int> // warning CS08305: 'A<int>' is for evaluation purposes only ...
+{
+    internal override void F()
+    {
+        base.F(); // warning CS08305: 'A<int>.F' is for evaluation purposes only ...
+    }
+}
+class C
+{
+    static void F(A<object> a, B b) // warning CS08305: 'A<object>' is for evaluation purposes only ...
+    {
+        a.F(); // warning CS08305: 'A<object>.F' is for evaluation purposes only ...
+        b.F();
+    }
+}
+```
+
+There is no automatic suppression of warnings: warnings are generated for all references, even within `[Experimental]` members.
+Suppressing the warning requires an explicit compiler option or `#pragma`.
+```
+[Experimental] enum E { }
+[Experimental]
+class C
+{
+    private C(E e) // warning CS08305: 'E' is for evaluation purposes only ...
+    {
+    }
+    internal static C Create() // warning CS08305: 'C' is for evaluation purposes only ...
+    {
+        return Create(0);
+    }
+#pragma warning disable 8305
+    internal static C Create(E e)
+    {
+        return new C(e);
+    }
+}
+```
+
+## ObsoleteAttribute and DeprecatedAttribute
+`ExperimentalAttribute` is independent of `System.ObsoleteAttribute` or `Windows.Framework.Metadata.DeprecatedAttribute`.
+
+Warnings for `[Experimental]` are reported within `[Obsolete]` or `[Deprecated]` members.
+Warnings and errors for `[Obsolete]` and `[Deprecated]` are reported inside `[Experimental]` members.
+```
+[Obsolete]
+class A
+{
+    static object F() => new C(); // warning CS08305: 'C' is for evaluation purposes only ...
+}
+[Deprecated(null, DeprecationType.Deprecate, 0)]
+class B
+{
+    static object F() => new C(); // warning CS08305: 'C' is for evaluation purposes only ...
+}
+[Experimental]
+class C
+{
+    static object F() => new B(); // warning CS0612: 'B' is obsolete
+}
+```
+
+Warnings and errors for `[Obsolete]` and `[Deprecated]` are reported instead of `[Experimental]` if there are multiple attributes.
+```
+[Obsolete]
+[Experimental]
+class A
+{
+}
+[Experimental]
+[Deprecated(null, DeprecationType.Deprecate, 0)]
+class B
+{
+}
+class C
+{
+    static A F() => null; // warning CS0612: 'A' is obsolete
+    static B G() => null; // warning CS0612: 'B' is obsolete
+}
+
+```

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 leastOverriddenSymbol.GetAttributes();
             }
 
-            ThreeState reportedOnOverridden = ReportDiagnosticsIfObsoleteInternal(diagnostics, leastOverriddenSymbol, node, containingMember, location);
+            var diagnosticKind = ReportDiagnosticsIfObsoleteInternal(diagnostics, leastOverriddenSymbol, node, containingMember, location);
 
             // CONSIDER: In place of hasBaseReceiver, dev11 also accepts cases where symbol.ContainingType is a "simple type" (e.g. int)
             // or a special by-ref type (e.g. ArgumentHandle).  These cases are probably more important for other checks performed by
@@ -540,63 +540,43 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // If the overridden member was not definitely obsolete and this is a (non-virtual) base member
             // access, then check the overriding symbol as well.
-            if (reportedOnOverridden != ThreeState.True && checkOverridingSymbol)
+            switch (diagnosticKind)
             {
-                Debug.Assert(reportedOnOverridden != ThreeState.Unknown, "We forced attribute binding above.");
-
-                ReportDiagnosticsIfObsoleteInternal(diagnostics, symbol, node, containingMember, location);
+                case ObsoleteDiagnosticKind.NotObsolete:
+                case ObsoleteDiagnosticKind.Lazy:
+                    if (checkOverridingSymbol)
+                    {
+                        Debug.Assert(diagnosticKind != ObsoleteDiagnosticKind.Lazy, "We forced attribute binding above.");
+                        ReportDiagnosticsIfObsoleteInternal(diagnostics, symbol, node, containingMember, location);
+                    }
+                    break;
             }
         }
 
-        /// <returns>
-        /// True if the symbol is definitely obsolete.
-        /// False if the symbol is definitely not obsolete.
-        /// Unknown if the symbol may be obsolete.
-        /// 
-        /// NOTE: The return value reflects obsolete-ness, not whether or not the diagnostic was reported.
-        /// </returns>
-        internal static ThreeState ReportDiagnosticsIfObsoleteInternal(DiagnosticBag diagnostics, Symbol symbol, SyntaxNodeOrToken node, Symbol containingMember, BinderFlags location)
+        internal static ObsoleteDiagnosticKind ReportDiagnosticsIfObsoleteInternal(DiagnosticBag diagnostics, Symbol symbol, SyntaxNodeOrToken node, Symbol containingMember, BinderFlags location)
         {
             Debug.Assert(diagnostics != null);
 
-            var kind = symbol.ObsoleteKind;
-            switch (kind)
-            {
-                case ObsoleteAttributeKind.None:
-                    return ThreeState.False;
-                case ObsoleteAttributeKind.Uninitialized:
-                    // If we haven't cracked attributes on the symbol at all or we haven't
-                    // cracked attribute arguments enough to be able to report diagnostics for
-                    // ObsoleteAttribute, store the symbol so that we can report diagnostics at a 
-                    // later stage.
-                    diagnostics.Add(new LazyObsoleteDiagnosticInfo(symbol, containingMember, location), node.GetLocation());
-                    return ThreeState.Unknown;
-            }
+            var kind = ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind(symbol, containingMember);
 
-            kind = containingMember.GetObsoleteContextKind();
+            DiagnosticInfo info = null;
             switch (kind)
             {
-                case ObsoleteAttributeKind.None:
-                case ObsoleteAttributeKind.Experimental:
-                    // We have all the information we need to report diagnostics right now. So do it.
-                    var diagInfo = ObsoleteAttributeHelpers.CreateObsoleteDiagnostic(symbol, location);
-                    if (diagInfo != null)
-                    {
-                        diagnostics.Add(diagInfo, node.GetLocation());
-                    }
+                case ObsoleteDiagnosticKind.Diagnostic:
+                    info = ObsoleteAttributeHelpers.CreateObsoleteDiagnostic(symbol, location);
                     break;
-                case ObsoleteAttributeKind.Uninitialized:
-                    // If the context is unknown, then store the symbol so that we can do this check at a
-                    // later stage
-                    diagnostics.Add(new LazyObsoleteDiagnosticInfo(symbol, containingMember, location), node.GetLocation());
-                    break;
-                default:
-                    // If we are in a context that is already obsolete, there is no point reporting
-                    // more obsolete diagnostics.
+                case ObsoleteDiagnosticKind.Lazy:
+                case ObsoleteDiagnosticKind.LazyPotentiallySuppressed:
+                    info = new LazyObsoleteDiagnosticInfo(symbol, containingMember, location);
                     break;
             }
 
-            return ThreeState.True;
+            if (info != null)
+            {
+                diagnostics.Add(info, node.GetLocation());
+            }
+
+            return kind;
         }
 
         internal static bool IsSymbolAccessibleConditional(

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -649,7 +649,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!string.IsNullOrEmpty(collectionExprType.Name) || !collectionExpr.HasErrors)
             {
-                diagnostics.Add(ErrorCode.ERR_ForEachMissingMember, _syntax.Expression.Location, collectionExprType.ToDisplayString(), GetEnumeratorMethodName);
+                diagnostics.Add(ErrorCode.ERR_ForEachMissingMember, _syntax.Expression.Location, collectionExprType, GetEnumeratorMethodName);
             }
             return false;
         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -12546,6 +12546,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is for evaluation purposes only and is subject to change or removal in future updates..
+        /// </summary>
+        internal static string WRN_Experimental {
+            get {
+                return ResourceManager.GetString("WRN_Experimental", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type is for evaluation purposes only and is subject to change or removal in future updates..
+        /// </summary>
+        internal static string WRN_Experimental_Title {
+            get {
+                return ResourceManager.GetString("WRN_Experimental_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Explicit interface implementation &apos;{0}&apos; matches more than one interface member. Which interface member is actually chosen is implementation-dependent. Consider using a non-explicit implementation instead..
         /// </summary>
         internal static string WRN_ExplicitImplCollision {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5050,6 +5050,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_VoidAssignment" xml:space="preserve">
     <value>A value of type 'void' may not be assigned.</value>
   </data>
+  <data name="WRN_Experimental" xml:space="preserve">
+    <value>'{0}' is for evaluation purposes only and is subject to change or removal in future updates.</value>
+  </data>
+  <data name="WRN_Experimental_Title" xml:space="preserve">
+    <value>Type is for evaluation purposes only and is subject to change or removal in future updates.</value>
+  </data>
   <data name="ERR_CompilerAndLanguageVersion" xml:space="preserve">
     <value>Compiler version: '{0}'. Language version: {1}.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1473,6 +1473,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FeatureNotAvailableInVersion7_1 = 8302,
         ERR_LanguageVersionCannotHaveLeadingZeroes = 8303,
         ERR_CompilerAndLanguageVersion = 8304,
+        WRN_Experimental = 8305,
 
         ERR_BadDynamicMethodArgDefaultLiteral = 9000,
         ERR_DefaultLiteralNotValid = 9001,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -317,6 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_AlignmentMagnitude:
                 case ErrorCode.WRN_AttributeIgnoredWhenPublicSigning:
                 case ErrorCode.WRN_TupleLiteralNameMismatch:
+                case ErrorCode.WRN_Experimental:
                 case ErrorCode.WRN_DefaultInSwitch:
                     return 1;
                 default:

--- a/src/Compilers/CSharp/Portable/Errors/LazyObsoleteDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/LazyObsoleteDiagnosticInfo.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // from a different compilation's source. In that case, force completion of attributes.
                 _symbol.ForceCompleteObsoleteAttribute();
 
-                var kind = ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind(_symbol, _containingSymbol);
+                var kind = ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind(_symbol, _containingSymbol, forceComplete: true);
                 Debug.Assert(kind != ObsoleteDiagnosticKind.Lazy);
                 Debug.Assert(kind != ObsoleteDiagnosticKind.LazyPotentiallySuppressed);
 

--- a/src/Compilers/CSharp/Portable/Errors/LazyObsoleteDiagnosticInfo.cs
+++ b/src/Compilers/CSharp/Portable/Errors/LazyObsoleteDiagnosticInfo.cs
@@ -33,10 +33,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (_symbol.ObsoleteState == ThreeState.True)
                 {
-                    var inObsoleteContext = ObsoleteAttributeHelpers.GetObsoleteContextState(_containingSymbol, forceComplete: true);
-                    Debug.Assert(inObsoleteContext != ThreeState.Unknown);
+                    var kind = _containingSymbol.GetObsoleteContextKind(forceComplete: true);
+                    Debug.Assert(kind != ObsoleteAttributeKind.Uninitialized);
 
-                    if (inObsoleteContext == ThreeState.False)
+                    if (kind == ObsoleteAttributeKind.None)
                     {
                         DiagnosticInfo info = ObsoleteAttributeHelpers.CreateObsoleteDiagnostic(_symbol, _binderFlags);
                         if (info != null)

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -173,6 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_AlignmentMagnitude:
                 case ErrorCode.WRN_AttributeIgnoredWhenPublicSigning:
                 case ErrorCode.WRN_TupleLiteralNameMismatch:
+                case ErrorCode.WRN_Experimental:
                 case ErrorCode.WRN_DefaultInSwitch:
                     return true;
                 default:

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (local.Type.IsRestrictedType())
                 {
-                    diagnostics.Add(ErrorCode.ERR_ByRefTypeAndAwait, local.Locations[0], local.Type.ToDisplayString());
+                    diagnostics.Add(ErrorCode.ERR_ByRefTypeAndAwait, local.Locations[0], local.Type);
                 }
 
                 _locals.Add(local);

--- a/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// symbol's Obsoleteness is Unknown. False, if we are certain that no symbol in the parent
         /// hierarchy is Obsolete.
         /// </returns>
-        internal static ThreeState GetObsoleteContextState(this Symbol symbol, bool forceComplete = false)
+        private static ThreeState GetObsoleteContextState(Symbol symbol, bool forceComplete)
         {
             while ((object)symbol != null)
             {
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return ThreeState.False;
         }
 
-        internal static ObsoleteDiagnosticKind GetObsoleteDiagnosticKind(Symbol symbol, Symbol containingMember)
+        internal static ObsoleteDiagnosticKind GetObsoleteDiagnosticKind(Symbol symbol, Symbol containingMember, bool forceComplete = false)
         {
             switch (symbol.ObsoleteKind)
             {
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return ObsoleteDiagnosticKind.Lazy;
             }
 
-            switch (containingMember.GetObsoleteContextState())
+            switch (GetObsoleteContextState(containingMember, forceComplete))
             {
                 case ThreeState.False:
                     return ObsoleteDiagnosticKind.Diagnostic;

--- a/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ObsoleteAttributeHelpers.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal static ObsoleteAttributeData GetObsoleteDataFromMetadata(EntityHandle token, PEModuleSymbol containingModule)
         {
             ObsoleteAttributeData obsoleteAttributeData;
-            bool isObsolete = containingModule.Module.HasDeprecatedOrObsoleteAttribute(token, out obsoleteAttributeData);
+            bool isObsolete = containingModule.Module.HasDeprecatedOrExperimentalOrObsoleteAttribute(token, out obsoleteAttributeData);
             Debug.Assert(isObsolete == (obsoleteAttributeData != null));
             Debug.Assert(obsoleteAttributeData == null || !obsoleteAttributeData.IsUninitialized);
             return obsoleteAttributeData;
@@ -94,6 +94,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (location.Includes(BinderFlags.SuppressObsoleteChecks))
             {
                 return null;
+            }
+
+            if (data.Kind == ObsoleteAttributeKind.Experimental)
+            {
+                Debug.Assert(data.Message == null);
+                Debug.Assert(!data.IsError);
+                // Provide an explicit format for fully-qualified type names.
+                return new CSDiagnosticInfo(ErrorCode.WRN_Experimental, new FormattedSymbol(symbol, SymbolDisplayFormat.CSharpErrorMessageFormat));
             }
 
             // Issue a specialized diagnostic for add methods of collection initializers

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CSharpAttributeData boundAttribute;
             ObsoleteAttributeData obsoleteData;
 
-            if (EarlyDecodeDeprecatedOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
+            if (EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
             {
                 if (obsoleteData != null)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -264,7 +264,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CSharpAttributeData boundAttribute;
             ObsoleteAttributeData obsoleteData;
 
-            if (EarlyDecodeDeprecatedOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
+            if (EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
             {
                 if (obsoleteData != null)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -1007,7 +1007,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     CSharpAttributeData boundAttribute;
                     ObsoleteAttributeData obsoleteData;
 
-                    if (EarlyDecodeDeprecatedOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
+                    if (EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
                     {
                         if (obsoleteData != null)
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -557,7 +557,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             ObsoleteAttributeData obsoleteData;
-            if (EarlyDecodeDeprecatedOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
+            if (EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
             {
                 if (obsoleteData != null)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1107,7 +1107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CSharpAttributeData boundAttribute;
             ObsoleteAttributeData obsoleteData;
 
-            if (EarlyDecodeDeprecatedOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
+            if (EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(ref arguments, out boundAttribute, out obsoleteData))
             {
                 if (obsoleteData != null)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1018,21 +1018,27 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var data = this.ObsoleteAttributeData;
-                if (data == null)
+                switch (ObsoleteKind)
                 {
-                    return ThreeState.False;
-                }
-                else if (data.IsUninitialized)
-                {
-                    return ThreeState.Unknown;
-                }
-                else
-                {
-                    return ThreeState.True;
+                    case ObsoleteAttributeKind.None:
+                        return ThreeState.False;
+                    case ObsoleteAttributeKind.Uninitialized:
+                        return ThreeState.Unknown;
+                    default:
+                        return ThreeState.True;
                 }
             }
         }
+
+        internal ObsoleteAttributeKind ObsoleteKind
+        {
+            get
+            {
+                var data = this.ObsoleteAttributeData;
+                return (data == null) ? ObsoleteAttributeKind.None : data.Kind;
+            }
+        }
+
 
         /// <summary>
         /// Returns data decoded from <see cref="ObsoleteAttribute"/> attribute or null if there is no <see cref="ObsoleteAttribute"/> attribute.

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1021,6 +1021,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (ObsoleteKind)
                 {
                     case ObsoleteAttributeKind.None:
+                    case ObsoleteAttributeKind.Experimental:
                         return ThreeState.False;
                     case ObsoleteAttributeKind.Uninitialized:
                         return ThreeState.Unknown;

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
@@ -137,58 +137,51 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal static bool EarlyDecodeDeprecatedOrObsoleteAttribute(
+        internal static bool EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(
             ref EarlyDecodeWellKnownAttributeArguments<EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation> arguments,
             out CSharpAttributeData attributeData,
             out ObsoleteAttributeData obsoleteData)
         {
+            var type = arguments.AttributeType;
+            var syntax = arguments.AttributeSyntax;
+
+            ObsoleteAttributeKind kind;
+            if (CSharpAttributeData.IsTargetEarlyAttribute(type, syntax, AttributeDescription.ObsoleteAttribute))
+            {
+                kind = ObsoleteAttributeKind.Obsolete;
+            }
+            else if (CSharpAttributeData.IsTargetEarlyAttribute(type, syntax, AttributeDescription.DeprecatedAttribute))
+            {
+                kind = ObsoleteAttributeKind.Deprecated;
+            }
+            else if (CSharpAttributeData.IsTargetEarlyAttribute(type, syntax, AttributeDescription.ExperimentalAttribute))
+            {
+                kind = ObsoleteAttributeKind.Experimental;
+            }
+            else
+            {
+                obsoleteData = null;
+                attributeData = null;
+                return false;
+            }
+
             bool hasAnyDiagnostics;
-
-            if (CSharpAttributeData.IsTargetEarlyAttribute(arguments.AttributeType, arguments.AttributeSyntax, AttributeDescription.ObsoleteAttribute))
+            attributeData = arguments.Binder.GetAttribute(syntax, type, out hasAnyDiagnostics);
+            if (!attributeData.HasErrors)
             {
-                attributeData = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, out hasAnyDiagnostics);
-                if (!attributeData.HasErrors)
+                obsoleteData = attributeData.DecodeObsoleteAttribute(kind);
+                if (hasAnyDiagnostics)
                 {
-                    obsoleteData = attributeData.DecodeObsoleteAttribute();
-                    if (hasAnyDiagnostics)
-                    {
-                        attributeData = null;
-                    }
-                }
-                else
-                {
-                    obsoleteData = null;
                     attributeData = null;
                 }
-
-                return true;
             }
-
-            if (CSharpAttributeData.IsTargetEarlyAttribute(arguments.AttributeType, arguments.AttributeSyntax, AttributeDescription.DeprecatedAttribute))
+            else
             {
-                attributeData = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, out hasAnyDiagnostics);
-                if (!attributeData.HasErrors)
-                {
-                    obsoleteData = attributeData.DecodeDeprecatedAttribute();
-                    if (hasAnyDiagnostics)
-                    {
-                        attributeData = null;
-                    }
-                }
-                else
-                {
-                    obsoleteData = null;
-                    attributeData = null;
-                }
-
-                return true;
+                obsoleteData = null;
+                attributeData = null;
             }
-
-            obsoleteData = null;
-            attributeData = null;
-            return false;
+            return true;
         }
-
 
         /// <summary>
         /// This method is called by the binder when it is finished binding a set of attributes on the symbol so that

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Experimental.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Experimental.cs
@@ -562,7 +562,6 @@ using Windows.Foundation.Metadata;
                 Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "EP").WithArguments("EP", "DP").WithLocation(20, 19));
         }
 
-        // Suppress diagnostics in unused import statements.
         [Fact]
         public void TestImportStatements()
         {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Experimental.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Experimental.cs
@@ -1,0 +1,353 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class AttributeTests_Experimental : CSharpTestBase
+    {
+        private const string DeprecatedAttributeSource =
+@"using System;
+namespace Windows.Foundation.Metadata
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = true)]
+    public sealed class DeprecatedAttribute : Attribute
+    {
+        public DeprecatedAttribute(System.String message, DeprecationType type, System.UInt32 version)
+        {
+        }
+    }
+    public enum DeprecationType
+    {
+        Deprecate = 0,
+        Remove = 1
+    }
+}";
+
+        private const string ExperimentalAttributeSource =
+@"using System;
+namespace Windows.Foundation.Metadata
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Delegate,
+        AllowMultiple = false)]
+    public sealed class ExperimentalAttribute : Attribute
+    {
+    }
+}";
+
+        [Fact]
+        public void TestExperimentalAttribute()
+        {
+            var source1 =
+@"using Windows.Foundation.Metadata;
+namespace N
+{
+    [Experimental] public struct S { }
+    [Experimental] internal delegate void D<T>();
+    public class A<T>
+    {
+        [Experimental] public class B { }
+        static void M()
+        {
+            new B();
+            D<int> d = null;
+            d();
+        }
+    }
+    [Experimental] public enum E { A }
+}";
+            var comp1 = CreateStandardCompilation(new[] { Parse(ExperimentalAttributeSource), Parse(source1) });
+            comp1.VerifyDiagnostics(
+                // (11,17): warning CS8305: 'N.A<T>.B' is for evaluation purposes only and is subject to change or removal in future updates.
+                //             new B();
+                Diagnostic(ErrorCode.WRN_Experimental, "B").WithArguments("N.A<T>.B").WithLocation(11, 17),
+                // (12,13): warning CS8305: 'N.D<int>' is for evaluation purposes only and is subject to change or removal in future updates.
+                //             D<int> d = null;
+                Diagnostic(ErrorCode.WRN_Experimental, "D<int>").WithArguments("N.D<int>").WithLocation(12, 13));
+
+            var source2 =
+@"using N;
+using B = N.A<int>.B;
+#pragma warning disable 219
+class C
+{
+    static void F()
+    {
+        object o = new B();
+        o = default(S);
+        var e = default(E);
+        e = E.A;
+    }
+}";
+            var comp2A = CreateStandardCompilation(source2, new[] { comp1.EmitToImageReference() });
+            comp2A.VerifyDiagnostics(
+                // (8,24): warning CS8305: 'N.A<int>.B' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         object o = new B();
+                Diagnostic(ErrorCode.WRN_Experimental, "B").WithArguments("N.A<int>.B").WithLocation(8, 24),
+                // (9,21): warning CS8305: 'N.S' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         o = default(S);
+                Diagnostic(ErrorCode.WRN_Experimental, "S").WithArguments("N.S").WithLocation(9, 21),
+                // (10,25): warning CS8305: 'N.E' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         var e = default(E);
+                Diagnostic(ErrorCode.WRN_Experimental, "E").WithArguments("N.E").WithLocation(10, 25),
+                // (11,13): warning CS8305: 'N.E' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         e = E.A;
+                Diagnostic(ErrorCode.WRN_Experimental, "E").WithArguments("N.E").WithLocation(11, 13));
+
+            var comp2B = CreateStandardCompilation(source2, new[] { new CSharpCompilationReference(comp1) });
+            comp2B.VerifyDiagnostics(
+                // (8,24): warning CS8305: 'N.A<int>.B' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         object o = new B();
+                Diagnostic(ErrorCode.WRN_Experimental, "B").WithArguments("N.A<int>.B").WithLocation(8, 24),
+                // (9,21): warning CS8305: 'N.S' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         o = default(S);
+                Diagnostic(ErrorCode.WRN_Experimental, "S").WithArguments("N.S").WithLocation(9, 21),
+                // (10,25): warning CS8305: 'N.E' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         var e = default(E);
+                Diagnostic(ErrorCode.WRN_Experimental, "E").WithArguments("N.E").WithLocation(10, 25),
+                // (11,13): warning CS8305: 'N.E' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         e = E.A;
+                Diagnostic(ErrorCode.WRN_Experimental, "E").WithArguments("N.E").WithLocation(11, 13));
+        }
+
+        // [Experimental] applied to members even though
+        // AttributeUsage is types only.
+        [Fact]
+        public void TestExperimentalMembers()
+        {
+            var source0 =
+@".class public Windows.Foundation.Metadata.ExperimentalAttribute extends [mscorlib]System.Attribute
+{
+  .custom instance void [mscorlib]System.AttributeUsageAttribute::.ctor(valuetype [mscorlib]System.AttributeTargets) = ( 01 00 1C 14 00 00 01 00 54 02 0D 41 6C 6C 6F 77   // ........T..Allow
+                                                                                                                         4D 75 6C 74 69 70 6C 65 00 )                      // Multiple.
+}
+.class public E extends [mscorlib]System.Enum
+{
+  .field public specialname rtspecialname int32 value__
+  .field public static literal valuetype E A = int32(0x00000000)
+  .custom instance void Windows.Foundation.Metadata.ExperimentalAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field public static literal valuetype E B = int32(0x00000001)
+}
+.class interface public I
+{
+  .method public abstract virtual instance void F()
+  {
+    .custom instance void Windows.Foundation.Metadata.ExperimentalAttribute::.ctor() = ( 01 00 00 00 ) 
+  }
+}
+.class public C implements I
+{
+  .method public virtual final instance void F() { ret }
+}";
+            var ref0 = CompileIL(source0);
+            var source1 =
+@"#pragma warning disable 219
+class Program
+{
+    static void Main()
+    {
+        E e = default(E);
+        e = E.A;        // warning CS8305: 'E.A' is for evaluation purposes only
+        e = E.B;
+        var o = default(C);
+        o.F();
+        ((I)o).F();     // warning CS8305: 'I.F()' is for evaluation purposes only
+    }
+}";
+            var comp1 = CreateStandardCompilation(source1, new[] { ref0 });
+            comp1.VerifyDiagnostics(
+                // (7,13): warning CS8305: 'E.A' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         e = E.A;        // warning CS8305: 'F.A' is for evaluation purposes only
+                Diagnostic(ErrorCode.WRN_Experimental, "E.A").WithArguments("E.A").WithLocation(7, 13),
+                // (11,9): warning CS8305: 'I.F()' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         ((I)o).F();     // warning CS8305: 'I.F()' is for evaluation purposes only
+                Diagnostic(ErrorCode.WRN_Experimental, "((I)o).F()").WithArguments("I.F()").WithLocation(11, 9));
+        }
+
+        // [Obsolete] and [Deprecated] diagnostics are not
+        // suppressed inside [Experimental] type.
+        [Fact]
+        public void TestExperimentalTypeWithDeprecatedAndObsoleteMembers()
+        {
+            var source =
+@"using System;
+using Windows.Foundation.Metadata;
+[Experimental]
+class A
+{
+    internal void F0() { }
+    [Deprecated("""", DeprecationType.Deprecate, 0)]
+    internal void F1() { }
+    [Deprecated("""", DeprecationType.Remove, 0)]
+    internal void F2() { }
+    [Obsolete("""", false)]
+    internal void F3() { }
+    [Obsolete("""", true)]
+    internal void F4() { }
+    [Experimental]
+    internal class B { }
+}
+class C
+{
+    static void F(A a)
+    {
+        a.F0();
+        a.F1();
+        a.F2();
+        a.F3();
+        a.F4();
+        (new A.B()).ToString();
+    }
+}";
+            var comp = CreateCompilationWithMscorlibAndSystemCore(new[] { Parse(DeprecatedAttributeSource), Parse(ExperimentalAttributeSource), Parse(source) });
+            comp.VerifyDiagnostics(
+                // (20,19): warning CS8305: 'A' is for evaluation purposes only and is subject to change or removal in future updates.
+                //     static void F(A a)
+                Diagnostic(ErrorCode.WRN_Experimental, "A").WithArguments("A").WithLocation(20, 19),
+                // (23,9): warning CS0618: 'A.F1()' is obsolete: ''
+                //         a.F1();
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "a.F1()").WithArguments("A.F1()", "").WithLocation(23, 9),
+                // (24,9): error CS0619: 'A.F2()' is obsolete: ''
+                //         a.F2();
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "a.F2()").WithArguments("A.F2()", "").WithLocation(24, 9),
+                // (25,9): warning CS0618: 'A.F3()' is obsolete: ''
+                //         a.F3();
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "a.F3()").WithArguments("A.F3()", "").WithLocation(25, 9),
+                // (26,9): error CS0619: 'A.F4()' is obsolete: ''
+                //         a.F4();
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "a.F4()").WithArguments("A.F4()", "").WithLocation(26, 9),
+                // (27,14): warning CS8305: 'A' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         (new A.B()).ToString();
+                Diagnostic(ErrorCode.WRN_Experimental, "A").WithArguments("A").WithLocation(27, 14),
+                // (27,14): warning CS8305: 'A.B' is for evaluation purposes only and is subject to change or removal in future updates.
+                //         (new A.B()).ToString();
+                Diagnostic(ErrorCode.WRN_Experimental, "A.B").WithArguments("A.B").WithLocation(27, 14));
+        }
+
+        // Diagnostics for [Experimental] types
+        // are suppressed in [Obsolete] members.
+        [Fact]
+        public void TestExperimentalTypeInObsoleteMember()
+        {
+            var source =
+@"using System;
+using Windows.Foundation.Metadata;
+[Experimental]
+class A
+{
+}
+class B
+{
+    static object F0() => new A();
+    [Obsolete("""", false)]
+    static object F1() => new A();
+}";
+            var comp = CreateCompilationWithMscorlibAndSystemCore(new[] { Parse(ExperimentalAttributeSource), Parse(source) });
+            comp.VerifyDiagnostics(
+                // (9,31): warning CS8305: 'A' is for evaluation purposes only and is subject to change or removal in future updates.
+                //     static object F0() => new A();
+                Diagnostic(ErrorCode.WRN_Experimental, "A").WithArguments("A").WithLocation(9, 31));
+        }
+
+        // Combinations of attributes.
+        [Fact]
+        public void TestDeprecatedAndExperimentalAndObsoleteAttributes()
+        {
+            var source1 =
+@"using System;
+using Windows.Foundation.Metadata;
+[Obsolete(""OA"", false),                          Deprecated(""DA"", DeprecationType.Deprecate, 0)]public struct SA { }
+[Obsolete(""OB"", false),                          Deprecated(""DB"", DeprecationType.Remove, 0)]   public struct SB { }
+[Obsolete(""OC"", false),                          Experimental]                                  public struct SC { }
+[Obsolete(""OD"", true),                           Deprecated(""DC"", DeprecationType.Deprecate, 0)]public struct SD { }
+[Obsolete(""OE"", true),                           Deprecated(""DD"", DeprecationType.Remove, 0)]   public struct SE { }
+[Obsolete(""OF"", true),                           Experimental]                                  public struct SF { }
+[Deprecated(""DG"", DeprecationType.Deprecate, 0), Obsolete(""OG"", false)]                         public interface IG { }
+[Deprecated(""DH"", DeprecationType.Deprecate, 0), Obsolete(""OH"", true)]                          public interface IH { }
+[Deprecated(""DI"", DeprecationType.Deprecate, 0), Experimental]                                  public interface II { }
+[Deprecated(""DJ"", DeprecationType.Remove, 0),    Obsolete(""OJ"", false)]                         public interface IJ { }
+[Deprecated(""DK"", DeprecationType.Remove, 0),    Obsolete(""OK"", true)]                          public interface IK { }
+[Deprecated(""DL"", DeprecationType.Remove, 0),    Experimental]                                  public interface IL { }
+[Experimental,                                   Obsolete(""OM"", false)]                         public enum EM { }
+[Experimental,                                   Obsolete(""ON"", true)]                          public enum EN { }
+[Experimental,                                   Deprecated(""DO"", DeprecationType.Deprecate, 0)]public enum EO { }
+[Experimental,                                   Deprecated(""DP"", DeprecationType.Remove, 0)]   public enum EP { }";
+            var comp1 = CreateCompilationWithMscorlibAndSystemCore(new[] { Parse(DeprecatedAttributeSource), Parse(ExperimentalAttributeSource), Parse(source1) });
+            comp1.VerifyDiagnostics();
+
+            var source2 =
+@"class C
+{
+    static void F(object o) { }
+    static void Main()
+    {
+        F(default(SA));
+        F(default(SB));
+        F(default(SC));
+        F(default(SD));
+        F(default(SE));
+        F(default(SF));
+        F(default(IG));
+        F(default(IH));
+        F(default(II));
+        F(default(IJ));
+        F(default(IK));
+        F(default(EM));
+        F(default(EN));
+        F(default(EO));
+        F(default(EP));
+    }
+}";
+            var comp2 = CreateCompilationWithMscorlibAndSystemCore(source2, references: new[] { comp1.EmitToImageReference() });
+            comp2.VerifyDiagnostics(
+                // (6,19): warning CS0618: 'SA' is obsolete: 'DA'
+                //         F(default(SA));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "SA").WithArguments("SA", "DA").WithLocation(6, 19),
+                // (7,19): error CS0619: 'SB' is obsolete: 'DB'
+                //         F(default(SB));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "SB").WithArguments("SB", "DB").WithLocation(7, 19),
+                // (8,19): warning CS0618: 'SC' is obsolete: 'OC'
+                //         F(default(SC));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "SC").WithArguments("SC", "OC").WithLocation(8, 19),
+                // (9,19): warning CS0618: 'SD' is obsolete: 'DC'
+                //         F(default(SD));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "SD").WithArguments("SD", "DC").WithLocation(9, 19),
+                // (10,19): error CS0619: 'SE' is obsolete: 'DD'
+                //         F(default(SE));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "SE").WithArguments("SE", "DD").WithLocation(10, 19),
+                // (11,19): error CS0619: 'SF' is obsolete: 'OF'
+                //         F(default(SF));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "SF").WithArguments("SF", "OF").WithLocation(11, 19),
+                // (12,19): warning CS0618: 'IG' is obsolete: 'DG'
+                //         F(default(IG));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "IG").WithArguments("IG", "DG").WithLocation(12, 19),
+                // (13,19): warning CS0618: 'IH' is obsolete: 'DH'
+                //         F(default(IH));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "IH").WithArguments("IH", "DH").WithLocation(13, 19),
+                // (14,19): warning CS0618: 'II' is obsolete: 'DI'
+                //         F(default(II));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "II").WithArguments("II", "DI").WithLocation(14, 19),
+                // (15,19): error CS0619: 'IJ' is obsolete: 'DJ'
+                //         F(default(IJ));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "IJ").WithArguments("IJ", "DJ").WithLocation(15, 19),
+                // (16,19): error CS0619: 'IK' is obsolete: 'DK'
+                //         F(default(IK));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "IK").WithArguments("IK", "DK").WithLocation(16, 19),
+                // (17,19): warning CS0618: 'EM' is obsolete: 'OM'
+                //         F(default(EM));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "EM").WithArguments("EM", "OM").WithLocation(17, 19),
+                // (18,19): error CS0619: 'EN' is obsolete: 'ON'
+                //         F(default(EN));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "EN").WithArguments("EN", "ON").WithLocation(18, 19),
+                // (19,19): warning CS0618: 'EO' is obsolete: 'DO'
+                //         F(default(EO));
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "EO").WithArguments("EO", "DO").WithLocation(19, 19),
+                // (20,19): error CS0619: 'EP' is obsolete: 'DP'
+                //         F(default(EP));
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "EP").WithArguments("EP", "DP").WithLocation(20, 19));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using PEParameterSymbol = Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEParameterSymbol;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -4705,15 +4704,15 @@ namespace System
             var compilation = CreateStandardCompilation(syntaxTree);
 
             var comp = compilation.VerifyDiagnostics(
-                // test.cs(4,3): warning CS0436: The type 'System.AttributeUsageAttribute' in 'test.cs' conflicts with the imported type 'System.AttributeUsageAttribute' in 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'. Using the type defined in 'test.cs'.
-                // 	[AttributeUsage(AttributeTargets.Class)]
-                Diagnostic(ErrorCode.WRN_SameFullNameThisAggAgg, "AttributeUsage").WithArguments("test.cs", "System.AttributeUsageAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.AttributeUsageAttribute"),
-                // test.cs(5,3): warning CS0436: The type 'System.AttributeUsageAttribute' in 'test.cs' conflicts with the imported type 'System.AttributeUsageAttribute' in 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'. Using the type defined in 'test.cs'.
-                // 	[AttributeUsage(AttributeTargets.Class)]
-                Diagnostic(ErrorCode.WRN_SameFullNameThisAggAgg, "AttributeUsage").WithArguments("test.cs", "System.AttributeUsageAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.AttributeUsageAttribute"),
-                // test.cs(5,3): error CS0579: Duplicate 'AttributeUsage' attribute
-                // 	[AttributeUsage(AttributeTargets.Class)]
-                Diagnostic(ErrorCode.ERR_DuplicateAttribute, "AttributeUsage").WithArguments("AttributeUsage"));
+                // test.cs(4,6): warning CS0436: The type 'AttributeUsageAttribute' in 'test.cs' conflicts with the imported type 'AttributeUsageAttribute' in 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'. Using the type defined in 'test.cs'.
+                //     [AttributeUsage(AttributeTargets.Class)]
+                Diagnostic(ErrorCode.WRN_SameFullNameThisAggAgg, "AttributeUsage").WithArguments("test.cs", "System.AttributeUsageAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.AttributeUsageAttribute").WithLocation(4, 6),
+                // test.cs(5,6): warning CS0436: The type 'AttributeUsageAttribute' in 'test.cs' conflicts with the imported type 'AttributeUsageAttribute' in 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'. Using the type defined in 'test.cs'.
+                //     [AttributeUsage(AttributeTargets.Class)]
+                Diagnostic(ErrorCode.WRN_SameFullNameThisAggAgg, "AttributeUsage").WithArguments("test.cs", "System.AttributeUsageAttribute", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.AttributeUsageAttribute").WithLocation(5, 6),
+                // test.cs(5,6): error CS0579: Duplicate 'AttributeUsage' attribute
+                //     [AttributeUsage(AttributeTargets.Class)]
+                Diagnostic(ErrorCode.ERR_DuplicateAttribute, "AttributeUsage").WithArguments("AttributeUsage").WithLocation(5, 6));
         }
 
         [WorkItem(541733, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541733")]
@@ -6534,31 +6533,30 @@ namespace N
     }
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
-                // (12,22): error CS0619: 'N.A' is obsolete: 'Do not use'
+                // (12,22): error CS0619: 'A' is obsolete: 'Do not use'
                 //     public class E : Z { }
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Z").WithArguments("N.A", "Do not use"),
-                // (13,27): error CS0619: 'N.A' is obsolete: 'Do not use'
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Z").WithArguments("N.A", "Do not use").WithLocation(12, 22),
+                // (13,27): error CS0619: 'A' is obsolete: 'Do not use'
                 //     public class D : List<Y>
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Y").WithArguments("N.A", "Do not use"),
-                // (10,22): error CS0619: 'N.A' is obsolete: 'Do not use'
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Y").WithArguments("N.A", "Do not use").WithLocation(13, 27),
+                // (10,22): error CS0619: 'A' is obsolete: 'Do not use'
                 //     public class B : X { }
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "X").WithArguments("N.A", "Do not use"),
-                // (11,22): error CS0619: 'N.A' is obsolete: 'Do not use'
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "X").WithArguments("N.A", "Do not use").WithLocation(10, 22),
+                // (11,22): error CS0619: 'A' is obsolete: 'Do not use'
                 //     public class C : Y { }
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Y").WithArguments("N.A", "Do not use"),
-                // (16,16): error CS0619: 'N.A' is obsolete: 'Do not use'
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Y").WithArguments("N.A", "Do not use").WithLocation(11, 22),
+                // (16,16): error CS0619: 'A' is obsolete: 'Do not use'
                 //         public Y y1;
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Y").WithArguments("N.A", "Do not use"),
-                // (17,21): error CS0619: 'N.A' is obsolete: 'Do not use'
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Y").WithArguments("N.A", "Do not use").WithLocation(16, 16),
+                // (17,21): error CS0619: 'A' is obsolete: 'Do not use'
                 //         public List<Y> y2;
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Y").WithArguments("N.A", "Do not use"),
-                // (18,16): error CS0619: 'N.A' is obsolete: 'Do not use'
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Y").WithArguments("N.A", "Do not use").WithLocation(17, 21),
+                // (18,16): error CS0619: 'A' is obsolete: 'Do not use'
                 //         public Z z;
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Z").WithArguments("N.A", "Do not use"),
-                // (15,16): error CS0619: 'N.A' is obsolete: 'Do not use'
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "Z").WithArguments("N.A", "Do not use").WithLocation(18, 16),
+                // (15,16): error CS0619: 'A' is obsolete: 'Do not use'
                 //         public X x;
-                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "X").WithArguments("N.A", "Do not use")
-                );
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "X").WithArguments("N.A", "Do not use").WithLocation(15, 16));
         }
 
         [Fact]
@@ -7704,12 +7702,39 @@ class Class6
             compilation2.VerifyDiagnostics(expected);
         }
 
+        // Report warning or error based on last attribute.
+        [WorkItem(18755, "https://github.com/dotnet/roslyn/issues/18755")]
         [Fact]
-        public void TestDeprecatedAttributeTH1()
+        public void TestMultipleDeprecatedAttributes()
         {
-            var source1 = @"
-using System;
-using Windows.Foundation.Metadata;
+            var source =
+@"using Windows.Foundation.Metadata;
+class C
+{
+    [Deprecated(""Removed"", DeprecationType.Remove, 0)]
+    [Deprecated(""Deprecated"", DeprecationType.Deprecate, 0)]
+    static void F() { }
+    [Deprecated(""Deprecated"", DeprecationType.Deprecate, 0)]
+    [Deprecated(""Removed"", DeprecationType.Remove, 0)]
+    static void G() { }
+    static void Main()
+    {
+        F();
+        G();
+    }
+}";
+            var compilation = CreateCompilation(source, WinRtRefs, TestOptions.ReleaseDll);
+            compilation.VerifyDiagnostics(
+                // (12,9): warning CS0618: 'C.F()' is obsolete: 'Deprecated'
+                //         F();
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "F()").WithArguments("C.F()", "Deprecated").WithLocation(12, 9),
+                // (13,9): error CS0619: 'C.G()' is obsolete: 'Removed'
+                //         G();
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "G()").WithArguments("C.G()", "Removed").WithLocation(13, 9));
+        }
+
+        private const string DeprecatedAttributeSourceTH1 =
+@"using System;
 
 namespace Windows.Foundation.Metadata
 {
@@ -7732,24 +7757,28 @@ namespace Windows.Foundation.Metadata
         Deprecate = 0,
         Remove = 1
     }
-}
+}";
+
+        [Fact]
+        public void TestDeprecatedAttributeTH1()
+        {
+            var source1 = @"
+using Windows.Foundation.Metadata;
 
 public class Test
 {
         [Deprecated(""hello"", DeprecationType.Deprecate, 1, typeof(int))]
         public static void Foo()
         {
-
         }
 
         [Deprecated(""hi"", DeprecationType.Deprecate, 1)]
         public static void Bar()
         {
-
         }
 }
 ";
-            var compilation1 = CreateCompilationWithMscorlibAndSystemCore(source1);
+            var compilation1 = CreateCompilationWithMscorlibAndSystemCore(new[] { Parse(DeprecatedAttributeSourceTH1), Parse(source1) });
 
             var source2 = @"
 namespace ConsoleApplication74
@@ -7763,11 +7792,8 @@ namespace ConsoleApplication74
         }
     }
 }
-
-
 ";
             var compilation2 = CreateCompilationWithMscorlibAndSystemCore(source2, new[] { compilation1.EmitToImageReference() });
-
 
             compilation2.VerifyDiagnostics(
     // (8,13): warning CS0618: 'Test.Foo()' is obsolete: 'hello'
@@ -7780,7 +7806,6 @@ namespace ConsoleApplication74
 
             var compilation3 = CreateCompilationWithMscorlibAndSystemCore(source2, new[] { new CSharpCompilationReference(compilation1) });
 
-
             compilation3.VerifyDiagnostics(
     // (8,13): warning CS0618: 'Test.Foo()' is obsolete: 'hello'
     //             Test.Foo();
@@ -7791,12 +7816,8 @@ namespace ConsoleApplication74
 );
         }
 
-        [Fact]
-        public void TestDeprecatedAttributeTH2()
-        {
-            var source1 = @"
-using System;
-using Windows.Foundation.Metadata;
+        private const string DeprecatedAttributeSourceTH2 =
+@"using System;
 
 namespace Windows.Foundation.Metadata
 {
@@ -7819,24 +7840,28 @@ namespace Windows.Foundation.Metadata
         Deprecate = 0,
         Remove = 1
     }
-}
+}";
+
+        [Fact]
+        public void TestDeprecatedAttributeTH2()
+        {
+            var source1 = @"
+using Windows.Foundation.Metadata;
 
 public class Test
 {
         [Deprecated(""hello"", DeprecationType.Deprecate, 1, ""hello"")]
         public static void Foo()
         {
-
         }
 
         [Deprecated(""hi"", DeprecationType.Deprecate, 1)]
         public static void Bar()
         {
-
         }
 }
 ";
-            var compilation1 = CreateCompilationWithMscorlibAndSystemCore(source1);
+            var compilation1 = CreateCompilationWithMscorlibAndSystemCore(new[] { Parse(DeprecatedAttributeSourceTH2), Parse(source1) });
 
             var source2 = @"
 namespace ConsoleApplication74
@@ -7850,11 +7875,8 @@ namespace ConsoleApplication74
         }
     }
 }
-
-
 ";
             var compilation2 = CreateCompilationWithMscorlibAndSystemCore(source2, new[] { compilation1.EmitToImageReference() });
-
 
             compilation2.VerifyDiagnostics(
     // (8,13): warning CS0618: 'Test.Foo()' is obsolete: 'hello'
@@ -7867,7 +7889,6 @@ namespace ConsoleApplication74
 
             var compilation3 = CreateCompilationWithMscorlibAndSystemCore(source2, new[] { new CSharpCompilationReference(compilation1) });
 
-
             compilation3.VerifyDiagnostics(
     // (8,13): warning CS0618: 'Test.Foo()' is obsolete: 'hello'
     //             Test.Foo();
@@ -7877,7 +7898,6 @@ namespace ConsoleApplication74
     Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "Test.Bar()").WithArguments("Test.Bar()", "hi").WithLocation(9, 13)
 );
         }
-
 
         [Fact, WorkItem(858839, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/858839")]
         public void Bug858839_1()

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Attributes\AttributeTests_CallerInfoAttributes.cs" />
     <Compile Include="Attributes\AttributeTests_Conditional.cs" />
     <Compile Include="Attributes\AttributeTests_Dynamic.cs" />
+    <Compile Include="Attributes\AttributeTests_Experimental.cs" />
     <Compile Include="Attributes\AttributeTests_Locations.cs" />
     <Compile Include="Attributes\AttributeTests_MarshalAs.cs" />
     <Compile Include="Attributes\AttributeTests_Security.cs" />

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -46,7 +46,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        // ErrorCode should not have duplicates.
+        /// <summary>
+        /// ErrorCode should not have duplicates.
+        /// </summary>
         [Fact]
         public void NoDuplicates()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -46,6 +46,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
+        // ErrorCode should not have duplicates.
+        [Fact]
+        public void NoDuplicates()
+        {
+            var values = Enum.GetValues(typeof(ErrorCode));
+            var set = new HashSet<ErrorCode>();
+            foreach (ErrorCode value in values)
+            {
+                Assert.True(set.Add(value));
+            }
+        }
+
         [Fact]
         public void TestDiagnostic()
         {
@@ -229,6 +241,7 @@ class X
                         case ErrorCode.WRN_ReferencedAssemblyDoesNotHaveStrongName:
                         case ErrorCode.WRN_AlignmentMagnitude:
                         case ErrorCode.WRN_TupleLiteralNameMismatch:
+                        case ErrorCode.WRN_Experimental:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1019,7 +1019,7 @@ namespace Microsoft.CodeAnalysis
             return TryExtractStringArrayValueFromAttribute(info.Handle, out tupleElementNames);
         }
 
-        internal bool HasDeprecatedOrObsoleteAttribute(EntityHandle token, out ObsoleteAttributeData obsoleteData)
+        internal bool HasDeprecatedOrExperimentalOrObsoleteAttribute(EntityHandle token, out ObsoleteAttributeData obsoleteData)
         {
             AttributeInfo info;
 
@@ -1033,6 +1033,14 @@ namespace Microsoft.CodeAnalysis
             if (info.HasValue)
             {
                 return TryExtractObsoleteDataFromAttribute(info, out obsoleteData);
+            }
+
+            // [Experimental] is always a warning, not an
+            // error, so search for [Experimental] last.
+            info = FindTargetAttribute(token, AttributeDescription.ExperimentalAttribute);
+            if (info.HasValue)
+            {
+                return TryExtractExperimentalDataFromAttribute(info, out obsoleteData);
             }
 
             obsoleteData = null;
@@ -1151,7 +1159,7 @@ namespace Microsoft.CodeAnalysis
             {
                 case 0:
                     // ObsoleteAttribute()
-                    obsoleteData = new ObsoleteAttributeData(message: null, isError: false);
+                    obsoleteData = new ObsoleteAttributeData(ObsoleteAttributeKind.Obsolete, message: null, isError: false);
                     return true;
 
                 case 1:
@@ -1159,7 +1167,7 @@ namespace Microsoft.CodeAnalysis
                     string message;
                     if (TryExtractStringValueFromAttribute(attributeInfo.Handle, out message))
                     {
-                        obsoleteData = new ObsoleteAttributeData(message, isError: false);
+                        obsoleteData = new ObsoleteAttributeData(ObsoleteAttributeKind.Obsolete, message, isError: false);
                         return true;
                     }
 
@@ -1186,6 +1194,21 @@ namespace Microsoft.CodeAnalysis
                 case 2: // DeprecatedAttribute(String, DeprecationType, UInt32, Type) 
                 case 3: // DeprecatedAttribute(String, DeprecationType, UInt32, String) 
                     return TryExtractValueFromAttribute(attributeInfo.Handle, out obsoleteData, s_attributeDeprecatedDataExtractor);
+
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(attributeInfo.SignatureIndex);
+            }
+        }
+
+        private bool TryExtractExperimentalDataFromAttribute(AttributeInfo attributeInfo, out ObsoleteAttributeData obsoleteData)
+        {
+            Debug.Assert(attributeInfo.HasValue);
+
+            switch (attributeInfo.SignatureIndex)
+            {
+                case 0: // ExperimentalAttribute(String) 
+                    obsoleteData = ObsoleteAttributeData.Experimental;
+                    return true;
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(attributeInfo.SignatureIndex);
@@ -1434,13 +1457,13 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal static bool CrackObsoleteAttributeData(out ObsoleteAttributeData value, ref BlobReader sig)
+        private static bool CrackObsoleteAttributeData(out ObsoleteAttributeData value, ref BlobReader sig)
         {
             string message;
             if (CrackStringInAttributeValue(out message, ref sig) && sig.RemainingBytes >= 1)
             {
                 bool isError = sig.ReadBoolean();
-                value = new ObsoleteAttributeData(message, isError);
+                value = new ObsoleteAttributeData(ObsoleteAttributeKind.Obsolete, message, isError);
                 return true;
             }
 
@@ -1448,12 +1471,12 @@ namespace Microsoft.CodeAnalysis
             return false;
         }
 
-        internal static bool CrackDeprecatedAttributeData(out ObsoleteAttributeData value, ref BlobReader sig)
+        private static bool CrackDeprecatedAttributeData(out ObsoleteAttributeData value, ref BlobReader sig)
         {
             StringAndInt args;
             if (CrackStringAndIntInAttributeValue(out args, ref sig))
             {
-                value = new ObsoleteAttributeData(args.StringValue, args.IntValue == 1);
+                value = new ObsoleteAttributeData(ObsoleteAttributeKind.Deprecated, args.StringValue, args.IntValue == 1);
                 return true;
             }
 
@@ -1569,7 +1592,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         // Note: not a general purpose helper
-        internal static bool CrackDecimalInDecimalConstantAttribute(out decimal value, ref BlobReader sig)
+        private static bool CrackDecimalInDecimalConstantAttribute(out decimal value, ref BlobReader sig)
         {
             byte scale;
             byte sign;

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1206,7 +1206,7 @@ namespace Microsoft.CodeAnalysis
 
             switch (attributeInfo.SignatureIndex)
             {
-                case 0: // ExperimentalAttribute(String) 
+                case 0: // ExperimentalAttribute() 
                     obsoleteData = ObsoleteAttributeData.Experimental;
                     return true;
 

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -393,6 +393,7 @@ namespace Microsoft.CodeAnalysis
             s_signature_HasThis_Void_String_DeprecationType_UInt32_String,
         };
 
+        private static readonly byte[][] s_signaturesOfExperimentalAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfExcludeFromCodeCoverageAttribute = { s_signature_HasThis_Void };
 
         // early decoded attributes:
@@ -502,6 +503,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription AssemblyConfigurationAttribute = new AttributeDescription("System.Reflection", "AssemblyConfigurationAttribute", s_signaturesOfAssemblyConfigurationAttribute);
         internal static readonly AttributeDescription AssemblyAlgorithmIdAttribute = new AttributeDescription("System.Reflection", "AssemblyAlgorithmIdAttribute", s_signaturesOfAssemblyAlgorithmIdAttribute);
         internal static readonly AttributeDescription DeprecatedAttribute = new AttributeDescription("Windows.Foundation.Metadata", "DeprecatedAttribute", s_signaturesOfDeprecatedAttribute);
+        internal static readonly AttributeDescription ExperimentalAttribute = new AttributeDescription("Windows.Foundation.Metadata", "ExperimentalAttribute", s_signaturesOfExperimentalAttribute);
         internal static readonly AttributeDescription ExcludeFromCodeCoverageAttribute = new AttributeDescription("System.Diagnostics.CodeAnalysis", "ExcludeFromCodeCoverageAttribute", s_signaturesOfExcludeFromCodeCoverageAttribute);
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -32,7 +31,6 @@ namespace Microsoft.CodeAnalysis
 
         public SyntaxReference ApplicationSyntaxReference { get { return CommonApplicationSyntaxReference; } }
         protected abstract SyntaxReference CommonApplicationSyntaxReference { get; }
-
 
         /// <summary>
         /// Constructor arguments on the attribute.
@@ -196,10 +194,25 @@ namespace Microsoft.CodeAnalysis
 
         #endregion
 
+        internal ObsoleteAttributeData DecodeObsoleteAttribute(ObsoleteAttributeKind kind)
+        {
+            switch (kind)
+            {
+                case ObsoleteAttributeKind.Obsolete:
+                    return DecodeObsoleteAttribute();
+                case ObsoleteAttributeKind.Deprecated:
+                    return DecodeDeprecatedAttribute();
+                case ObsoleteAttributeKind.Experimental:
+                    return DecodeExperimentalAttribute();
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(kind);
+            }
+        }
+
         /// <summary>
-        /// Decode the arguments to ObsoleteAttribute. ObsoleteAttribute can have 0,1 or 2 arguments.
+        /// Decode the arguments to ObsoleteAttribute. ObsoleteAttribute can have 0, 1 or 2 arguments.
         /// </summary>
-        internal ObsoleteAttributeData DecodeObsoleteAttribute()
+        private ObsoleteAttributeData DecodeObsoleteAttribute()
         {
             ImmutableArray<TypedConstant> args = this.CommonConstructorArguments;
 
@@ -221,13 +234,13 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            return new ObsoleteAttributeData(message, isError);
+            return new ObsoleteAttributeData(ObsoleteAttributeKind.Obsolete, message, isError);
         }
 
         /// <summary>
         /// Decode the arguments to DeprecatedAttribute. DeprecatedAttribute can have 3 or 4 arguments.
         /// </summary>
-        internal ObsoleteAttributeData DecodeDeprecatedAttribute()
+        private ObsoleteAttributeData DecodeDeprecatedAttribute()
         {
             var args = this.CommonConstructorArguments;
 
@@ -245,7 +258,17 @@ namespace Microsoft.CodeAnalysis
                 isError = ((int)args[1].Value == 1);
             }
 
-            return new ObsoleteAttributeData(message, isError);
+            return new ObsoleteAttributeData(ObsoleteAttributeKind.Deprecated, message, isError);
+        }
+
+        /// <summary>
+        /// Decode the arguments to ExperimentalAttribute. ExperimentalAttribute has 0 arguments.
+        /// </summary>
+        private ObsoleteAttributeData DecodeExperimentalAttribute()
+        {
+            // ExperimentalAttribute() 
+            Debug.Assert(this.CommonConstructorArguments.Length == 0);
+            return ObsoleteAttributeData.Experimental;
         }
 
         internal static void DecodeMethodImplAttribute<T, TAttributeSyntaxNode, TAttributeData, TAttributeLocation>(

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonMethodEarlyWellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonMethodEarlyWellKnownAttributeData.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/Symbols/Attributes/ObsoleteAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/ObsoleteAttributeData.cs
@@ -1,43 +1,44 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
+    internal enum ObsoleteAttributeKind
+    {
+        None,
+        Obsolete,
+        Deprecated,
+        Experimental,
+    }
+
     /// <summary>
     /// Information decoded from <see cref="ObsoleteAttribute"/>.
     /// </summary>
-    internal class ObsoleteAttributeData
+    internal sealed class ObsoleteAttributeData
     {
-        private readonly string _message;
-        private readonly bool _isError;
-        public static readonly ObsoleteAttributeData Uninitialized = new ObsoleteAttributeData();
+        public static readonly ObsoleteAttributeData Uninitialized = new ObsoleteAttributeData(ObsoleteAttributeKind.None, null, false);
+        public static readonly ObsoleteAttributeData Experimental = new ObsoleteAttributeData(ObsoleteAttributeKind.Experimental, null, false);
 
-        private ObsoleteAttributeData() : this(null, false)
+        public ObsoleteAttributeData(ObsoleteAttributeKind kind, string message, bool isError)
         {
+            Kind = kind;
+            Message = message;
+            IsError = isError;
         }
 
-        public ObsoleteAttributeData(string message, bool isError)
-        {
-            _message = message;
-            _isError = isError;
-        }
+        public readonly ObsoleteAttributeKind Kind;
 
         /// <summary>
         /// True if an error should be thrown for the <see cref="ObsoleteAttribute"/>. Default is false in which case
         /// a warning is thrown.
         /// </summary>
-        public bool IsError { get { return _isError; } }
+        public readonly bool IsError;
 
         /// <summary>
         /// The message that will be shown when an error/warning is created for <see cref="ObsoleteAttribute"/>.
         /// </summary>
-        public string Message { get { return _message; } }
+        public readonly string Message;
 
         internal bool IsUninitialized
         {

--- a/src/Compilers/Core/Portable/Symbols/Attributes/ObsoleteAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/ObsoleteAttributeData.cs
@@ -7,6 +7,7 @@ namespace Microsoft.CodeAnalysis
     internal enum ObsoleteAttributeKind
     {
         None,
+        Uninitialized,
         Obsolete,
         Deprecated,
         Experimental,
@@ -17,7 +18,7 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     internal sealed class ObsoleteAttributeData
     {
-        public static readonly ObsoleteAttributeData Uninitialized = new ObsoleteAttributeData(ObsoleteAttributeKind.None, null, false);
+        public static readonly ObsoleteAttributeData Uninitialized = new ObsoleteAttributeData(ObsoleteAttributeKind.Uninitialized, null, false);
         public static readonly ObsoleteAttributeData Experimental = new ObsoleteAttributeData(ObsoleteAttributeKind.Experimental, null, false);
 
         public ObsoleteAttributeData(ObsoleteAttributeKind kind, string message, bool isError)

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1951,9 +1951,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         WRN_UnableToLoadAnalyzer = 42378
 
         WRN_AttributeIgnoredWhenPublicSigning = 42379
+        WRN_Experimental = 42380
 
-        ' // AVAILABLE                             42380 - 49998
-        ERRWRN_Last = WRN_UnableToLoadAnalyzer + 1
+        ' // AVAILABLE                             42381 - 49998
+        ERRWRN_Last = WRN_Experimental
 
         '// HIDDENS AND INFOS BEGIN HERE
         HDN_UnusedImportClause = 50000

--- a/src/Compilers/VisualBasic/Portable/Errors/LazyObsoleteDiagnosticInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/LazyObsoleteDiagnosticInfo.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' from a different compilation's source. In that case, force completion of attributes.
                 _symbol.ForceCompleteObsoleteAttribute()
 
-                Dim kind = ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind(_containingSymbol, _symbol)
+                Dim kind = ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind(_containingSymbol, _symbol, forceComplete:=True)
                 Debug.Assert(kind <> ObsoleteDiagnosticKind.Lazy)
                 Debug.Assert(kind <> ObsoleteDiagnosticKind.LazyPotentiallySuppressed)
 

--- a/src/Compilers/VisualBasic/Portable/Errors/LazyObsoleteDiagnosticInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/LazyObsoleteDiagnosticInfo.vb
@@ -26,10 +26,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 _symbol.ForceCompleteObsoleteAttribute()
 
                 If _symbol.ObsoleteState = ThreeState.True Then
-                    Dim inObsoleteContext = ObsoleteAttributeHelpers.GetObsoleteContextState(_containingSymbol, forceComplete:=True)
-                    Debug.Assert(inObsoleteContext <> ThreeState.Unknown)
+                    Dim kind = ObsoleteAttributeHelpers.GetObsoleteContextKind(_containingSymbol, forceComplete:=True)
+                    Debug.Assert(kind <> ObsoleteAttributeKind.Uninitialized)
 
-                    If inObsoleteContext = ThreeState.False Then
+                    If kind = ObsoleteAttributeKind.None Then
                         Dim info As DiagnosticInfo = ObsoleteAttributeHelpers.CreateObsoleteDiagnostic(_symbol)
                         If info IsNot Nothing Then
                             Interlocked.CompareExchange(Me._lazyActualObsoleteDiagnostic, info, Nothing)

--- a/src/Compilers/VisualBasic/Portable/Errors/LazyObsoleteDiagnosticInfo.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/LazyObsoleteDiagnosticInfo.vb
@@ -25,25 +25,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' from a different compilation's source. In that case, force completion of attributes.
                 _symbol.ForceCompleteObsoleteAttribute()
 
-                If _symbol.ObsoleteState = ThreeState.True Then
-                    Dim kind = ObsoleteAttributeHelpers.GetObsoleteContextKind(_containingSymbol, forceComplete:=True)
-                    Debug.Assert(kind <> ObsoleteAttributeKind.Uninitialized)
+                Dim kind = ObsoleteAttributeHelpers.GetObsoleteDiagnosticKind(_containingSymbol, _symbol)
+                Debug.Assert(kind <> ObsoleteDiagnosticKind.Lazy)
+                Debug.Assert(kind <> ObsoleteDiagnosticKind.LazyPotentiallySuppressed)
 
-                    If kind = ObsoleteAttributeKind.None Then
-                        Dim info As DiagnosticInfo = ObsoleteAttributeHelpers.CreateObsoleteDiagnostic(_symbol)
-                        If info IsNot Nothing Then
-                            Interlocked.CompareExchange(Me._lazyActualObsoleteDiagnostic, info, Nothing)
-                            Return Me._lazyActualObsoleteDiagnostic
-                        End If
-                    End If
-                End If
+                Dim info = If(kind = ObsoleteDiagnosticKind.Diagnostic,
+                    ObsoleteAttributeHelpers.CreateObsoleteDiagnostic(_symbol),
+                    Nothing)
 
                 ' If this symbol is not obsolete or is in an obsolete context, we don't want to report any diagnostics.
                 ' Therefore make this a Void diagnostic.
-                Interlocked.CompareExchange(Me._lazyActualObsoleteDiagnostic, ErrorFactory.VoidDiagnosticInfo, Nothing)
+                Interlocked.CompareExchange(_lazyActualObsoleteDiagnostic, If(info, ErrorFactory.VoidDiagnosticInfo), Nothing)
             End If
 
             Return _lazyActualObsoleteDiagnostic
         End Function
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
@@ -651,11 +651,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function Update(resultKind As LookupResultKind, symbols As ImmutableArray(Of Symbol), childBoundNodes As ImmutableArray(Of BoundExpression), type As TypeSymbol) As BoundBadExpression
             If resultKind <> Me.ResultKind OrElse symbols <> Me.Symbols OrElse childBoundNodes <> Me.ChildBoundNodes OrElse type IsNot Me.Type Then
                 Dim result = New BoundBadExpression(Me.Syntax, resultKind, symbols, childBoundNodes, type, Me.HasErrors)
-
+                
                 If Me.WasCompilerGenerated Then
                     result.SetWasCompilerGenerated()
                 End If
-
+                
                 Return result
             End If
             Return Me

--- a/src/Compilers/VisualBasic/Portable/Generated/ErrorFacts.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/ErrorFacts.Generated.vb
@@ -168,7 +168,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                      ERRID.WRN_AnalyzerCannotBeCreated,
                      ERRID.WRN_NoAnalyzerInAssembly,
                      ERRID.WRN_UnableToLoadAnalyzer,
-                     ERRID.WRN_AttributeIgnoredWhenPublicSigning
+                     ERRID.WRN_AttributeIgnoredWhenPublicSigning,
+                     ERRID.WRN_Experimental
                     Return True
                 Case Else
                     Return False

--- a/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
@@ -46,11 +46,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </returns>
         Private Shared Function GetObsoleteContextState(symbol As Symbol, forceComplete As Boolean) As ThreeState
             While symbol IsNot Nothing
-                ' For property or event accessors, check the associated property or event instead.
-                If symbol.IsAccessor() Then
-                    symbol = DirectCast(symbol, MethodSymbol).AssociatedSymbol
-                End If
-
                 If forceComplete Then
                     symbol.ForceCompleteObsoleteAttribute()
                 End If
@@ -60,7 +55,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return state
                 End If
 
-                symbol = symbol.ContainingSymbol
+                ' For property or event accessors, check the associated property or event instead.
+                If symbol.IsAccessor() Then
+                    symbol = DirectCast(symbol, MethodSymbol).AssociatedSymbol
+                Else
+                    symbol = symbol.ContainingSymbol
+                End If
             End While
 
             Return ThreeState.False

--- a/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ObsoleteAttributeHelpers.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' symbol's Obsoleteness is Unknown. False, if we are certain that no symbol in the parent
         ''' hierarchy is Obsolete.
         ''' </returns>
-        Friend Shared Function GetObsoleteContextState(symbol As Symbol, Optional forceComplete As Boolean = False) As ThreeState
+        Private Shared Function GetObsoleteContextState(symbol As Symbol, forceComplete As Boolean) As ThreeState
             While symbol IsNot Nothing
                 ' For property or event accessors, check the associated property or event instead.
                 If symbol.IsAccessor() Then
@@ -66,7 +66,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return ThreeState.False
         End Function
 
-        Friend Shared Function GetObsoleteDiagnosticKind(context As Symbol, symbol As Symbol) As ObsoleteDiagnosticKind
+        Friend Shared Function GetObsoleteDiagnosticKind(context As Symbol, symbol As Symbol, Optional forceComplete As Boolean = False) As ObsoleteDiagnosticKind
             Debug.Assert(context IsNot Nothing)
             Debug.Assert(symbol IsNot Nothing)
 
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return ObsoleteDiagnosticKind.Lazy
             End Select
 
-            Select Case ObsoleteAttributeHelpers.GetObsoleteContextState(context)
+            Select Case GetObsoleteContextState(context, forceComplete)
                 Case ThreeState.False
                     Return ObsoleteDiagnosticKind.Diagnostic
                 Case ThreeState.True

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
@@ -634,7 +634,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim boundAttribute As VisualBasicAttributeData = Nothing
             Dim obsoleteData As ObsoleteAttributeData = Nothing
 
-            If EarlyDecodeDeprecatedOrObsoleteAttribute(arguments, boundAttribute, obsoleteData) Then
+            If EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(arguments, boundAttribute, obsoleteData) Then
                 If obsoleteData IsNot Nothing Then
                     arguments.GetOrCreateData(Of CommonEventEarlyWellKnownAttributeData)().ObsoleteAttributeData = obsoleteData
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
@@ -293,7 +293,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim BoundAttribute As VisualBasicAttributeData = Nothing
             Dim obsoleteData As ObsoleteAttributeData = Nothing
 
-            If EarlyDecodeDeprecatedOrObsoleteAttribute(arguments, BoundAttribute, obsoleteData) Then
+            If EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(arguments, BoundAttribute, obsoleteData) Then
                 If obsoleteData IsNot Nothing Then
                     arguments.GetOrCreateData(Of CommonFieldEarlyWellKnownAttributeData)().ObsoleteAttributeData = obsoleteData
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -1529,7 +1529,7 @@ lReportErrorOnTwoTokens:
                     Dim BoundAttribute As VisualBasicAttributeData = Nothing
                     Dim obsoleteData As ObsoleteAttributeData = Nothing
 
-                    If EarlyDecodeDeprecatedOrObsoleteAttribute(arguments, BoundAttribute, obsoleteData) Then
+                    If EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(arguments, BoundAttribute, obsoleteData) Then
                         If obsoleteData IsNot Nothing Then
                             arguments.GetOrCreateData(Of MethodEarlyWellKnownAttributeData)().ObsoleteAttributeData = obsoleteData
                         End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceModuleSymbol.vb
@@ -327,6 +327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             checker.AddName("ExtensionAttribute", QuickAttributes.Extension)
             checker.AddName("ObsoleteAttribute", QuickAttributes.Obsolete)
             checker.AddName("DeprecatedAttribute", QuickAttributes.Obsolete)
+            checker.AddName("ExperimentalAttribute", QuickAttributes.Obsolete)
             checker.AddName("MyGroupCollectionAttribute", QuickAttributes.MyGroupCollection)
 
             ' Now process alias imports

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -2004,7 +2004,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim boundAttribute As VisualBasicAttributeData = Nothing
             Dim obsoleteData As ObsoleteAttributeData = Nothing
 
-            If EarlyDecodeDeprecatedOrObsoleteAttribute(arguments, boundAttribute, obsoleteData) Then
+            If EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(arguments, boundAttribute, obsoleteData) Then
                 If obsoleteData IsNot Nothing Then
                     arguments.GetOrCreateData(Of TypeEarlyWellKnownAttributeData)().ObsoleteAttributeData = obsoleteData
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
@@ -534,7 +534,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim boundAttribute As VisualBasicAttributeData = Nothing
             Dim obsoleteData As ObsoleteAttributeData = Nothing
 
-            If EarlyDecodeDeprecatedOrObsoleteAttribute(arguments, boundAttribute, obsoleteData) Then
+            If EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(arguments, boundAttribute, obsoleteData) Then
                 If obsoleteData IsNot Nothing Then
                     arguments.GetOrCreateData(Of CommonPropertyEarlyWellKnownAttributeData)().ObsoleteAttributeData = obsoleteData
                 End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -425,7 +425,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property ObsoleteState As ThreeState
             Get
                 Select Case ObsoleteKind
-                    Case ObsoleteAttributeKind.None
+                    Case ObsoleteAttributeKind.None, ObsoleteAttributeKind.Experimental
                         Return ThreeState.False
                     Case ObsoleteAttributeKind.Uninitialized
                         Return ThreeState.Unknown

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -424,14 +424,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Friend ReadOnly Property ObsoleteState As ThreeState
             Get
+                Select Case ObsoleteKind
+                    Case ObsoleteAttributeKind.None
+                        Return ThreeState.False
+                    Case ObsoleteAttributeKind.Uninitialized
+                        Return ThreeState.Unknown
+                    Case Else
+                        Return ThreeState.True
+                End Select
+            End Get
+        End Property
+
+        Friend ReadOnly Property ObsoleteKind As ObsoleteAttributeKind
+            Get
                 Dim data = Me.ObsoleteAttributeData
-                If data Is Nothing Then
-                    Return ThreeState.False
-                ElseIf data Is ObsoleteAttributeData.Uninitialized Then
-                    Return ThreeState.Unknown
-                Else
-                    Return ThreeState.True
-                End If
+                Return If(data Is Nothing, ObsoleteAttributeKind.None, data.Kind)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol_Attributes.vb
@@ -2,12 +2,8 @@
 
 Imports System.Collections.Generic
 Imports System.Collections.Immutable
-Imports System.Globalization
 Imports System.Runtime.InteropServices
-Imports System.Text
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.CodeGen
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports TypeKind = Microsoft.CodeAnalysis.TypeKind
@@ -141,49 +137,42 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Nothing
         End Function
 
-        Friend Function EarlyDecodeDeprecatedOrObsoleteAttribute(
+        Friend Function EarlyDecodeDeprecatedOrExperimentalOrObsoleteAttribute(
             ByRef arguments As EarlyDecodeWellKnownAttributeArguments(Of EarlyWellKnownAttributeBinder, NamedTypeSymbol, AttributeSyntax, AttributeLocation),
             <Out> ByRef boundAttribute As VisualBasicAttributeData,
             <Out> ByRef obsoleteData As ObsoleteAttributeData
         ) As Boolean
 
+            Dim type = arguments.AttributeType
+            Dim syntax = arguments.AttributeSyntax
+
+            Dim kind As ObsoleteAttributeKind
+
+            If VisualBasicAttributeData.IsTargetEarlyAttribute(type, syntax, AttributeDescription.ObsoleteAttribute) Then
+                kind = ObsoleteAttributeKind.Obsolete
+            ElseIf VisualBasicAttributeData.IsTargetEarlyAttribute(type, syntax, AttributeDescription.DeprecatedAttribute) Then
+                kind = ObsoleteAttributeKind.Deprecated
+            ElseIf VisualBasicAttributeData.IsTargetEarlyAttribute(type, syntax, AttributeDescription.ExperimentalAttribute) Then
+                kind = ObsoleteAttributeKind.Experimental
+            Else
+                boundAttribute = Nothing
+                obsoleteData = Nothing
+                Return False
+            End If
+
             Dim hasAnyDiagnostics As Boolean = False
-
-            If VisualBasicAttributeData.IsTargetEarlyAttribute(arguments.AttributeType, arguments.AttributeSyntax, AttributeDescription.ObsoleteAttribute) Then
-                ' Handle ObsoleteAttribute
-                boundAttribute = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, hasAnyDiagnostics)
-                If Not boundAttribute.HasErrors Then
-                    obsoleteData = boundAttribute.DecodeObsoleteAttribute()
-                    If hasAnyDiagnostics Then
-                        boundAttribute = Nothing
-                    End If
-                Else
-                    obsoleteData = Nothing
+            boundAttribute = arguments.Binder.GetAttribute(syntax, type, hasAnyDiagnostics)
+            If Not boundAttribute.HasErrors Then
+                obsoleteData = boundAttribute.DecodeObsoleteAttribute(kind)
+                If hasAnyDiagnostics Then
                     boundAttribute = Nothing
                 End If
-
-                Return True
+            Else
+                obsoleteData = Nothing
+                boundAttribute = Nothing
             End If
+            Return True
 
-            If VisualBasicAttributeData.IsTargetEarlyAttribute(arguments.AttributeType, arguments.AttributeSyntax, AttributeDescription.DeprecatedAttribute) Then
-                ' Handle DeprecatedAttribute
-                boundAttribute = arguments.Binder.GetAttribute(arguments.AttributeSyntax, arguments.AttributeType, hasAnyDiagnostics)
-                If Not boundAttribute.HasErrors Then
-                    obsoleteData = boundAttribute.DecodeDeprecatedAttribute()
-                    If hasAnyDiagnostics Then
-                        boundAttribute = Nothing
-                    End If
-                Else
-                    obsoleteData = Nothing
-                    boundAttribute = Nothing
-                End If
-
-                Return True
-            End If
-
-            boundAttribute = Nothing
-            obsoleteData = Nothing
-            Return False
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -13387,6 +13387,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to &apos;{0}&apos; is for evaluation purposes only and is subject to change or removal in future updates..
+        '''</summary>
+        Friend ReadOnly Property WRN_Experimental() As String
+            Get
+                Return ResourceManager.GetString("WRN_Experimental", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Type is for evaluation purposes only and is subject to change or removal in future updates..
+        '''</summary>
+        Friend ReadOnly Property WRN_Experimental_Title() As String
+            Get
+                Return ResourceManager.GetString("WRN_Experimental_Title", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Type of member &apos;{0}&apos; is not CLS-compliant..
         '''</summary>
         Friend ReadOnly Property WRN_FieldNotCLSCompliant1() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5476,4 +5476,10 @@
   <data name="ERR_BadSourceCodeKind" xml:space="preserve">
     <value>Provided source code kind is unsupported or invalid: '{0}'</value>
   </data>
+  <data name="WRN_Experimental" xml:space="preserve">
+    <value>'{0}' is for evaluation purposes only and is subject to change or removal in future updates.</value>
+  </data>
+  <data name="WRN_Experimental_Title" xml:space="preserve">
+    <value>Type is for evaluation purposes only and is subject to change or removal in future updates.</value>
+  </data>
 </root>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Experimental.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Experimental.vb
@@ -664,6 +664,59 @@ BC30668: 'CP' is obsolete: 'DP'.
      </errors>)
         End Sub
 
+        <Fact()>
+        Public Sub TestImportStatements()
+            Dim ref0 = CreateDeprecatedAndExperimentalAttributeReference()
+            Dim source =
+<compilation>
+    <file><![CDATA[
+Imports System
+Imports Windows.Foundation.Metadata
+Imports CA = C(Of A)
+Imports CB = C(Of B)
+Imports CC = C(Of C)
+Imports CD = C(Of D)
+<Obsolete>
+Class A
+End Class
+<Obsolete>
+Class B
+End Class
+<Experimental>
+Class C
+End Class
+<Experimental>
+Class D
+End Class
+Class C(Of T)
+End Class
+Class P
+    Shared Sub Main()
+        Dim o
+        o = New CB()
+        o = New CD()
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlib(source, references:={ref0})
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC40008: 'A' is obsolete.
+Imports CA = C(Of A)
+                  ~
+BC40008: 'B' is obsolete.
+Imports CB = C(Of B)
+                  ~
+BC42380: 'C' is for evaluation purposes only and is subject to change or removal in future updates.
+Imports CC = C(Of C)
+                  ~
+BC42380: 'D' is for evaluation purposes only and is subject to change or removal in future updates.
+Imports CD = C(Of D)
+                  ~
+]]></errors>)
+        End Sub
+
         Private Shared Function CreateDeprecatedAndExperimentalAttributeReference() As MetadataReference
             Dim comp = CreateCompilationWithMscorlib(DeprecatedAndExperimentalAttributeSource)
             comp.AssertNoDiagnostics()

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Experimental.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Experimental.vb
@@ -1,0 +1,436 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Xml.Linq
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Roslyn.Test.Utilities
+Imports Xunit
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
+
+    Public Class AttributeTests_Experimental
+        Inherits BasicTestBase
+
+        Private Shared ReadOnly DeprecatedAndExperimentalAttributeSource As XElement =
+<compilation>
+    <file><![CDATA[
+Imports System
+Namespace Windows.Foundation.Metadata
+    <AttributeUsage(
+        AttributeTargets.Class Or AttributeTargets.Struct Or AttributeTargets.Enum Or AttributeTargets.Constructor Or AttributeTargets.Method Or AttributeTargets.Property Or AttributeTargets.Field Or AttributeTargets.Event Or AttributeTargets.Interface Or AttributeTargets.Delegate,
+        AllowMultiple:=True)>
+    Public NotInheritable Class DeprecatedAttribute
+        Inherits Attribute
+        Public Sub New(message As String, type As DeprecationType, version As UInteger)
+        End Sub
+    End Class
+    Public Enum DeprecationType
+        Deprecate
+        Remove
+    End Enum
+End Namespace
+]]>
+    </file>
+    <file><![CDATA[
+Imports System
+Namespace Windows.Foundation.Metadata
+    <AttributeUsage(
+        AttributeTargets.Class Or AttributeTargets.Struct Or AttributeTargets.Enum Or AttributeTargets.Interface Or AttributeTargets.Delegate,
+        AllowMultiple:=False)>
+    Public NotInheritable Class ExperimentalAttribute
+        Inherits Attribute
+    End Class
+End Namespace
+]]>
+    </file>
+</compilation>
+
+        <Fact()>
+        Public Sub TestExperimentalAttribute()
+            Dim comp0 = CreateCompilationWithMscorlib(DeprecatedAndExperimentalAttributeSource)
+            comp0.AssertNoDiagnostics()
+            Dim ref0 = comp0.EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file><![CDATA[
+Imports Windows.Foundation.Metadata
+Namespace N
+    <Experimental>
+    Public Structure S
+    End Structure
+    <Experimental>
+    Public Delegate Sub D(Of T)()
+    Public Class A(Of T)
+        <Experimental>
+        Public Class B
+        End Class
+        Private Shared Sub M()
+            Dim o = New B()
+            Dim d As D(Of Integer) = Nothing
+            d()
+        End Sub
+    End Class
+    <Experimental>
+    Public Enum E
+        A
+    End Enum
+End Namespace
+]]>
+    </file>
+</compilation>
+            Dim comp1 = CreateCompilationWithMscorlib(source1, references:={ref0})
+            comp1.AssertTheseDiagnostics(<errors>
+BC42380: 'N.A(Of T).B' is for evaluation purposes only and is subject to change or removal in future updates.
+            Dim o = New B()
+                        ~
+BC42380: 'N.D(Of Integer)' is for evaluation purposes only and is subject to change or removal in future updates.
+            Dim d As D(Of Integer) = Nothing
+                     ~~~~~~~~~~~~~
+     </errors>)
+
+            Dim source2 =
+<compilation>
+    <file><![CDATA[
+Imports N
+Imports B = N.A(Of Integer).B
+Class C
+    Shared Sub F()
+        Dim o As Object = New B()
+        o = New S()
+        Dim e As E
+        e = E.A
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>
+            Dim comp2A = CreateCompilationWithMscorlib(source2, references:={ref0, comp1.EmitToImageReference()})
+            comp2A.AssertTheseDiagnostics(<errors>
+BC42380: 'N.A(Of Integer).B' is for evaluation purposes only and is subject to change or removal in future updates.
+Imports B = N.A(Of Integer).B
+            ~~~~~~~~~~~~~~~~~
+BC42380: 'N.S' is for evaluation purposes only and is subject to change or removal in future updates.
+        o = New S()
+                ~
+BC42380: 'N.E' is for evaluation purposes only and is subject to change or removal in future updates.
+        Dim e As E
+                 ~
+BC42380: 'N.E' is for evaluation purposes only and is subject to change or removal in future updates.
+        e = E.A
+            ~
+     </errors>)
+
+            Dim comp2B = CreateCompilationWithMscorlib(source2, references:={ref0, New VisualBasicCompilationReference(comp1)})
+            comp2B.AssertTheseDiagnostics(<errors>
+BC42380: 'N.A(Of Integer).B' is for evaluation purposes only and is subject to change or removal in future updates.
+Imports B = N.A(Of Integer).B
+            ~~~~~~~~~~~~~~~~~
+BC42380: 'N.S' is for evaluation purposes only and is subject to change or removal in future updates.
+        o = New S()
+                ~
+BC42380: 'N.E' is for evaluation purposes only and is subject to change or removal in future updates.
+        Dim e As E
+                 ~
+BC42380: 'N.E' is for evaluation purposes only and is subject to change or removal in future updates.
+        e = E.A
+            ~
+     </errors>)
+        End Sub
+
+        ' <Experimental> applied to members even though
+        ' AttributeUsage is types only.
+        <Fact()>
+        Public Sub TestExperimentalMembers()
+            Dim source0 =
+".class public Windows.Foundation.Metadata.ExperimentalAttribute extends [mscorlib]System.Attribute
+{
+  .custom instance void [mscorlib]System.AttributeUsageAttribute::.ctor(valuetype [mscorlib]System.AttributeTargets) = ( 01 00 1C 14 00 00 01 00 54 02 0D 41 6C 6C 6F 77   // ........T..Allow
+                                                                                                                         4D 75 6C 74 69 70 6C 65 00 )                      // Multiple.
+}
+.class public E extends [mscorlib]System.Enum
+{
+  .field public specialname rtspecialname int32 value__
+  .field public static literal valuetype E A = int32(0x00000000)
+  .custom instance void Windows.Foundation.Metadata.ExperimentalAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field public static literal valuetype E B = int32(0x00000001)
+}
+.class interface public I
+{
+  .method public abstract virtual instance void F()
+  {
+    .custom instance void Windows.Foundation.Metadata.ExperimentalAttribute::.ctor() = ( 01 00 00 00 ) 
+  }
+}
+.class public C implements I
+{
+  .method public virtual final instance void F() { ret }
+}"
+            Dim ref0 = CompileIL(source0)
+            Dim source1 =
+<compilation>
+    <file><![CDATA[
+Class Program
+    Shared Sub Main()
+        Dim e As E
+        e = E.A              ' BC42380: 'A' is for evaluation purposes only
+        e = E.B
+        Dim o As C = Nothing
+        o.F()
+        DirectCast(o, I).F() ' BC42380: 'Sub F()' is for evaluation purposes only
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>
+            Dim comp1 = CreateCompilationWithMscorlib(source1, references:={ref0})
+            comp1.AssertTheseDiagnostics(<errors>
+BC42380: 'A' is for evaluation purposes only and is subject to change or removal in future updates.
+        e = E.A              ' BC42380: 'A' is for evaluation purposes only
+            ~~~
+BC42380: 'Sub F()' is for evaluation purposes only and is subject to change or removal in future updates.
+        DirectCast(o, I).F() ' BC42380: 'Sub F()' is for evaluation purposes only
+        ~~~~~~~~~~~~~~~~~~~~
+     </errors>)
+
+            Dim source2 =
+<compilation>
+    <file><![CDATA[
+Imports N
+Imports B = N.A(Of Integer).B
+Class C
+    Shared Sub F()
+        Dim o As Object = New B()
+        o = New S()
+        Dim e As E
+        e = E.A
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>
+        End Sub
+
+        ' <Obsolete> and <Deprecated> diagnostics are not
+        ' suppressed inside <Experimental> type.
+        <Fact()>
+        Public Sub TestExperimentalTypeWithDeprecatedAndObsoleteMembers()
+            Dim comp0 = CreateCompilationWithMscorlib(DeprecatedAndExperimentalAttributeSource)
+            comp0.AssertNoDiagnostics()
+            Dim ref0 = comp0.EmitToImageReference()
+
+            Dim source =
+<compilation>
+    <file><![CDATA[
+Imports System
+Imports Windows.Foundation.Metadata
+<Experimental>
+Class A
+    Friend Sub F0()
+    End Sub
+    <Deprecated("", DeprecationType.Deprecate, 0)>
+    Friend Sub F1()
+    End Sub
+    <Deprecated("", DeprecationType.Remove, 0)>
+    Friend Sub F2()
+    End Sub
+    <Obsolete("", False)>
+    Friend Sub F3()
+    End Sub
+    <Obsolete("", True)>
+    Friend Sub F4()
+    End Sub
+    <Experimental>
+    Friend Class B
+    End Class
+End Class
+Class C
+    Shared Sub F(a As A)
+        a.F0()
+        a.F1()
+        a.F2()
+        a.F3()
+        a.F4()
+        Dim b = New A.B()
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlib(source, references:={ref0})
+            comp.AssertTheseDiagnostics(<errors>
+BC42380: 'A' is for evaluation purposes only and is subject to change or removal in future updates.
+    Shared Sub F(a As A)
+                      ~
+BC40008: 'Friend Sub F1()' is obsolete.
+        a.F1()
+        ~~~~~~
+BC31075: 'Friend Sub F2()' is obsolete.
+        a.F2()
+        ~~~~~~
+BC40008: 'Friend Sub F3()' is obsolete.
+        a.F3()
+        ~~~~~~
+BC31075: 'Friend Sub F4()' is obsolete.
+        a.F4()
+        ~~~~~~
+BC42380: 'A' is for evaluation purposes only and is subject to change or removal in future updates.
+        Dim b = New A.B()
+                    ~
+BC42380: 'A.B' is for evaluation purposes only and is subject to change or removal in future updates.
+        Dim b = New A.B()
+                    ~~~
+     </errors>)
+        End Sub
+
+        ' Diagnostics for <Experimental> types
+        ' are suppressed in [Obsolete] members.
+        <Fact()>
+        Public Sub TestExperimentalTypeInObsoleteMember()
+            Dim comp0 = CreateCompilationWithMscorlib(DeprecatedAndExperimentalAttributeSource)
+            comp0.AssertNoDiagnostics()
+            Dim ref0 = comp0.EmitToImageReference()
+
+            Dim source =
+<compilation>
+    <file><![CDATA[
+Imports System
+Imports Windows.Foundation.Metadata
+<Experimental>
+Class A
+End Class
+Class C
+    Shared Function F0() As Object
+        Return If(New A(), 0)
+    End Function
+    <Obsolete("", False)>
+    Shared Function F1() As Object
+        Return If(New A(), 1)
+    End Function
+End Class
+]]>
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlib(source, references:={ref0})
+            comp.AssertTheseDiagnostics(<errors>
+BC42380: 'A' is for evaluation purposes only and is subject to change or removal in future updates.
+        Return If(New A(), 0)
+                      ~
+     </errors>)
+        End Sub
+
+        ' Combinations of attributes.
+        <Fact()>
+        Public Sub TestDeprecatedAndExperimentalAndObsoleteAttributes()
+            Dim comp0 = CreateCompilationWithMscorlib(DeprecatedAndExperimentalAttributeSource)
+            comp0.AssertNoDiagnostics()
+            Dim ref0 = comp0.EmitToImageReference()
+
+            Dim source1 =
+<compilation>
+    <file><![CDATA[
+Imports System
+Imports Windows.Foundation.Metadata
+<Obsolete("OA", False),                          Deprecated("DA", DeprecationType.Deprecate, 0)>
+Public Structure SA : End Structure
+<Obsolete("OB", False),                          Deprecated("DB", DeprecationType.Remove, 0)>   Public Structure SB : End Structure
+<Obsolete("OC", False),                          Experimental>                                  Public Structure SC : End Structure
+<Obsolete("OD", True),                           Deprecated("DC", DeprecationType.Deprecate, 0)>Public Structure SD : End Structure
+<Obsolete("OE", True),                           Deprecated("DD", DeprecationType.Remove, 0)>   Public Structure SE : End Structure
+<Obsolete("OF", True),                           Experimental>                                  Public Structure SF : End Structure
+<Deprecated("DG", DeprecationType.Deprecate, 0), Obsolete("OG", False)>                         Public Interface IG : End Interface
+<Deprecated("DH", DeprecationType.Deprecate, 0), Obsolete("OH", True)>                          Public Interface IH : End Interface
+<Deprecated("DI", DeprecationType.Deprecate, 0), Experimental>                                  Public Interface II : End Interface
+<Deprecated("DJ", DeprecationType.Remove, 0),    Obsolete("OJ", False)>                         Public Interface IJ : End Interface
+<Deprecated("DK", DeprecationType.Remove, 0),    Obsolete("OK", True)>                          Public Interface IK : End Interface
+<Deprecated("DL", DeprecationType.Remove, 0),    Experimental>                                  Public Interface IL : End Interface
+<Experimental,                                   Obsolete("OM", False)>                         Public Class CM : End Class
+<Experimental,                                   Obsolete("ON", True)>                          Public Class CN : End Class
+<Experimental,                                   Deprecated("DO", DeprecationType.Deprecate, 0)>Public Class CO : End Class
+<Experimental,                                   Deprecated("DP", DeprecationType.Remove, 0)>   Public Class CP : End Class
+]]>
+    </file>
+</compilation>
+            Dim comp1 = CreateCompilationWithMscorlib(source1, references:={ref0})
+            comp1.AssertTheseDiagnostics(<errors/>)
+
+            Dim source2 =
+<compilation>
+    <file><![CDATA[
+Class C
+    Shared Sub F(o As Object)
+    End Sub
+    Shared Sub Main()
+        F(New SA())
+        F(New SB())
+        F(New SC())
+        F(New SD())
+        F(New SE())
+        F(New SF())
+        F(GetType(IG))
+        F(GetType(IH))
+        F(GetType(II))
+        F(GetType(IJ))
+        F(GetType(IK))
+        F(New CM())
+        F(New CN())
+        F(New CO())
+        F(New CP())
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>
+            Dim comp2 = CreateCompilationWithMscorlib(source2, references:={ref0, comp1.EmitToImageReference()})
+            comp2.AssertTheseDiagnostics(<errors>
+BC40000: 'SA' is obsolete: 'DA'.
+        F(New SA())
+              ~~
+BC30668: 'SB' is obsolete: 'DB'.
+        F(New SB())
+              ~~
+BC40000: 'SC' is obsolete: 'OC'.
+        F(New SC())
+              ~~
+BC40000: 'SD' is obsolete: 'DC'.
+        F(New SD())
+              ~~
+BC30668: 'SE' is obsolete: 'DD'.
+        F(New SE())
+              ~~
+BC30668: 'SF' is obsolete: 'OF'.
+        F(New SF())
+              ~~
+BC40000: 'IG' is obsolete: 'DG'.
+        F(GetType(IG))
+                  ~~
+BC40000: 'IH' is obsolete: 'DH'.
+        F(GetType(IH))
+                  ~~
+BC40000: 'II' is obsolete: 'DI'.
+        F(GetType(II))
+                  ~~
+BC30668: 'IJ' is obsolete: 'DJ'.
+        F(GetType(IJ))
+                  ~~
+BC30668: 'IK' is obsolete: 'DK'.
+        F(GetType(IK))
+                  ~~
+BC40000: 'CM' is obsolete: 'OM'.
+        F(New CM())
+              ~~
+BC30668: 'CN' is obsolete: 'ON'.
+        F(New CN())
+              ~~
+BC40000: 'CO' is obsolete: 'DO'.
+        F(New CO())
+              ~~
+BC30668: 'CP' is obsolete: 'DP'.
+        F(New CP())
+              ~~
+     </errors>)
+        End Sub
+
+    End Class
+
+End Namespace
+

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
@@ -719,22 +719,41 @@ End Class
 <compilation>
     <file><![CDATA[
 Imports System
-<Obsolete>
-Class A
+Namespace Windows.Foundation.Metadata
+    Public NotInheritable Class DeprecatedAttribute
+        Inherits Attribute
+        Public Sub New(message As String, type As DeprecationType, version As UInteger)
+        End Sub
+    End Class
+    Public Enum DeprecationType
+        Deprecate
+        Remove
+    End Enum
+End Namespace
+]]>
+    </file>
+    <file><![CDATA[
+Imports Windows.Foundation.Metadata
+<Deprecated(Nothing, DeprecationType.Deprecate, 0)>Class A
 End Class
-<Obsolete>
-Class B
+<Deprecated(Nothing, DeprecationType.Deprecate, 0)>Class B
 End Class
-Class C
+<Deprecated(Nothing, DeprecationType.Deprecate, 0)>Class C
+End Class
+Class D
     ReadOnly Property P As Object
         Get
             Return New A()
         End Get
     End Property
-    <Obsolete>
-    ReadOnly Property Q As Object
+    <Deprecated(Nothing, DeprecationType.Deprecate, 0)>ReadOnly Property Q As Object
         Get
             Return New B()
+        End Get
+    End Property
+    ReadOnly Property R As Object
+        <Deprecated(Nothing, DeprecationType.Deprecate, 0)>Get
+            Return New C()
         End Get
     End Property
 End Class
@@ -751,13 +770,29 @@ End Class
 <compilation>
     <file><![CDATA[
 Imports System
-<Obsolete>
-Class A
+Namespace Windows.Foundation.Metadata
+    Public NotInheritable Class DeprecatedAttribute
+        Inherits Attribute
+        Public Sub New(message As String, type As DeprecationType, version As UInteger)
+        End Sub
+    End Class
+    Public Enum DeprecationType
+        Deprecate
+        Remove
+    End Enum
+End Namespace
+]]>
+    </file>
+    <file><![CDATA[
+Imports System
+Imports Windows.Foundation.Metadata
+<Deprecated(Nothing, DeprecationType.Deprecate, 0)>Class A
 End Class
-<Obsolete>
-Class B
+<Deprecated(Nothing, DeprecationType.Deprecate, 0)>Class B
 End Class
-Class C
+<Deprecated(Nothing, DeprecationType.Deprecate, 0)>Class C
+End Class
+Class D
     Custom Event E As EventHandler
         AddHandler(value As EventHandler)
         End AddHandler
@@ -767,12 +802,20 @@ Class C
         RaiseEvent
         End RaiseEvent
     End Event
-    <Obsolete>
-    Custom Event F As EventHandler
+    <Deprecated(Nothing, DeprecationType.Deprecate, 0)>Custom Event F As EventHandler
         AddHandler(value As EventHandler)
         End AddHandler
         RemoveHandler(value As EventHandler)
             M(New B())
+        End RemoveHandler
+        RaiseEvent
+        End RaiseEvent
+    End Event
+    Custom Event G As EventHandler
+        AddHandler(value As EventHandler)
+        End AddHandler
+        <Deprecated(Nothing, DeprecationType.Deprecate, 0)>RemoveHandler(value As EventHandler)
+            M(New C())
         End RemoveHandler
         RaiseEvent
         End RaiseEvent
@@ -784,7 +827,8 @@ End Class
     </file>
 </compilation>
             CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                Diagnostic(ERRID.WRN_UseOfObsoleteSymbolNoMessage1, "A").WithArguments("A").WithLocation(13, 19))
+                Diagnostic(ERRID.ERR_ObsoleteInvalidOnEventMember, "<Deprecated(Nothing, DeprecationType.Deprecate, 0)>RemoveHandler(value As EventHandler)").WithArguments("Windows.Foundation.Metadata.DeprecatedAttribute").WithLocation(31, 9),
+                Diagnostic(ERRID.WRN_UseOfObsoleteSymbolNoMessage1, "A").WithArguments("A").WithLocation(14, 19))
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
@@ -760,8 +760,12 @@ End Class
 ]]>
     </file>
 </compilation>
-            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                Diagnostic(ERRID.WRN_UseOfObsoleteSymbolNoMessage1, "A").WithArguments("A").WithLocation(11, 24))
+            Dim comp = CreateCompilationWithMscorlib(source)
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC40008: 'A' is obsolete.
+            Return New A()
+                       ~
+]]></errors>)
         End Sub
 
         <Fact>
@@ -826,9 +830,15 @@ End Class
 ]]>
     </file>
 </compilation>
-            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                Diagnostic(ERRID.ERR_ObsoleteInvalidOnEventMember, "<Deprecated(Nothing, DeprecationType.Deprecate, 0)>RemoveHandler(value As EventHandler)").WithArguments("Windows.Foundation.Metadata.DeprecatedAttribute").WithLocation(31, 9),
-                Diagnostic(ERRID.WRN_UseOfObsoleteSymbolNoMessage1, "A").WithArguments("A").WithLocation(14, 19))
+            Dim comp = CreateCompilationWithMscorlib(source)
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC40008: 'A' is obsolete.
+            M(New A())
+                  ~
+BC31142: 'Windows.Foundation.Metadata.DeprecatedAttribute' cannot be applied to the 'AddHandler', 'RemoveHandler', or 'RaiseEvent' definitions. If required, apply the attribute directly to the event.
+        <Deprecated(Nothing, DeprecationType.Deprecate, 0)>RemoveHandler(value As EventHandler)
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+]]></errors>)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_ObsoleteAttribute.vb
@@ -714,6 +714,80 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub TestObsoleteAndPropertyAccessors()
+            Dim source =
+<compilation>
+    <file><![CDATA[
+Imports System
+<Obsolete>
+Class A
+End Class
+<Obsolete>
+Class B
+End Class
+Class C
+    ReadOnly Property P As Object
+        Get
+            Return New A()
+        End Get
+    End Property
+    <Obsolete>
+    ReadOnly Property Q As Object
+        Get
+            Return New B()
+        End Get
+    End Property
+End Class
+]]>
+    </file>
+</compilation>
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                Diagnostic(ERRID.WRN_UseOfObsoleteSymbolNoMessage1, "A").WithArguments("A").WithLocation(11, 24))
+        End Sub
+
+        <Fact>
+        Public Sub TestObsoleteAndEventAccessors()
+            Dim source =
+<compilation>
+    <file><![CDATA[
+Imports System
+<Obsolete>
+Class A
+End Class
+<Obsolete>
+Class B
+End Class
+Class C
+    Custom Event E As EventHandler
+        AddHandler(value As EventHandler)
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+            M(New A())
+        End RemoveHandler
+        RaiseEvent
+        End RaiseEvent
+    End Event
+    <Obsolete>
+    Custom Event F As EventHandler
+        AddHandler(value As EventHandler)
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+            M(New B())
+        End RemoveHandler
+        RaiseEvent
+        End RaiseEvent
+    End Event
+    Shared Sub M(o As Object)
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                Diagnostic(ERRID.WRN_UseOfObsoleteSymbolNoMessage1, "A").WithArguments("A").WithLocation(13, 19))
+        End Sub
+
+        <Fact>
         Public Sub TestObsoleteAttributeCycles_02()
             Dim source =
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -58,6 +58,7 @@
     <Compile Include="AssemblyAttributes.vb" />
     <Compile Include="Attributes\AssemblyAttributes.vb" />
     <Compile Include="Attributes\AttributeTests.vb" />
+    <Compile Include="Attributes\AttributeTests_Experimental.vb" />
     <Compile Include="Attributes\AttributeTests_Tuples.vb" />
     <Compile Include="Attributes\AttributeTests_Conditional.vb" />
     <Compile Include="Attributes\AttributeTests_MarshalAs.vb" />

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticTests.vb
@@ -30,6 +30,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Next
         End Sub
 
+        ''' <summary>
+        ''' ERRID should not have duplicates.
+        ''' </summary>
+        <Fact()>
+        Public Sub NoDuplicates()
+            Dim excludedIds = {ERRID.ERRWRN_Last}
+            Dim values = [Enum].GetValues(GetType(ERRID))
+            Dim [set] = New HashSet(Of ERRID)
+            For Each id As ERRID In values
+                If Array.IndexOf(excludedIds, id) >= 0 Then
+                    Continue For
+                End If
+                Assert.True([set].Add(id))
+            Next
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
@@ -340,7 +340,7 @@ BC31030: Conditional compilation constant '2' is not valid: Identifier expected.
         End Sub
 
         <Fact>
-        Public Sub DiagnositcsInCompilationOptionsParseOptionsAreDedupedWithParseTreesParseOptions()
+        Public Sub DiagnosticsInCompilationOptionsParseOptionsAreDedupedWithParseTreesParseOptions()
             Dim dict1 = New Dictionary(Of String, Object)
             dict1.Add("1", Nothing)
             Dim dict2 = New Dictionary(Of String, Object)
@@ -372,7 +372,7 @@ BC31030: Conditional compilation constant '2' is not valid: Identifier expected.
         End Sub
 
         <Fact>
-        Public Sub DiagnositcsInCompilationOptionsParseOptionsAreReportedSeparately()
+        Public Sub DiagnosticsInCompilationOptionsParseOptionsAreReportedSeparately()
             Dim dict1 = New Dictionary(Of String, Object)
             dict1.Add("1", Nothing)
             Dim dict2 = New Dictionary(Of String, Object)


### PR DESCRIPTION
**Customer scenario**

Report warnings referencing symbols marked with `Windows.Foundation.Metadata.ExperimentalAttribute`.

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

No warnings using experimental APIs.

**Risk**

Low. Relies on the same support used for `[Obsolete]` and `[Deprecated]`.

**Performance impact**

Low.
