### PR TITLE
Removed some unnecessary codegen from async state machine.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -298,30 +298,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 WellKnownMemberNames.GetResult,
                 resultsDiscarded: resultPlace == null);
 
-            var nullAwaiter = F.AssignmentExpression(F.Local(awaiterTemp), F.NullOrDefault(awaiterTemp.Type));
-            if (resultPlace != null && type.SpecialType != SpecialType.System_Void)
-            {
-                // $resultTemp = $awaiterTemp.GetResult();
-                // $awaiterTemp = null;
-                // $resultTemp
-                LocalSymbol resultTemp = F.SynthesizedLocal(type);
-                return F.Block(
-                    ImmutableArray.Create(awaiterTemp, resultTemp),
-                    awaitIfIncomplete,
-                    F.Assignment(F.Local(resultTemp), getResultCall),
-                    F.ExpressionStatement(nullAwaiter),
-                    F.Assignment(resultPlace, F.Local(resultTemp)));
-            }
-            else
-            {
-                // $awaiterTemp.GetResult();
-                // $awaiterTemp = null;
-                return F.Block(
-                    ImmutableArray.Create(awaiterTemp),
-                    awaitIfIncomplete,
-                    F.ExpressionStatement(getResultCall),
-                    F.ExpressionStatement(nullAwaiter));
-            }
+            // [$resultPlace = ] $awaiterTemp.GetResult();
+            BoundStatement getResultStatement = resultPlace != null && type.SpecialType != SpecialType.System_Void ?
+                F.Assignment(resultPlace, getResultCall):
+                F.ExpressionStatement(getResultCall);
+
+            return F.Block(
+                ImmutableArray.Create(awaiterTemp),
+                awaitIfIncomplete,
+                getResultStatement);
         }
 
         private BoundExpression MakeCallMaybeDynamic(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncEHTests.cs
@@ -207,7 +207,7 @@ class Test
             CompileAndVerify(source, expectedOutput: expected).
 VerifyIL("Test.<G>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      867 (0x363)
+  // Code size      819 (0x333)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -245,11 +245,11 @@ VerifyIL("Test.<G>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
           IL_001d:  ldloc.0
           IL_001e:  switch    (
         IL_0075,
-        IL_00e8,
-        IL_015b,
-        IL_01ce,
-        IL_0241,
-        IL_02b4)
+        IL_00e0,
+        IL_014b,
+        IL_01b6,
+        IL_0221,
+        IL_028c)
           IL_003b:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
           IL_0040:  stloc.3
           IL_0041:  ldloca.s   V_3
@@ -271,7 +271,7 @@ VerifyIL("Test.<G>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
           IL_0068:  ldloca.s   V_2
           IL_006a:  ldarg.0
           IL_006b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
-          IL_0070:  leave      IL_0362
+          IL_0070:  leave      IL_0332
           IL_0075:  ldarg.0
           IL_0076:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
           IL_007b:  stloc.2
@@ -285,305 +285,291 @@ VerifyIL("Test.<G>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
           IL_008c:  stfld      ""int Test.<G>d__0.<>1__state""
           IL_0091:  ldloca.s   V_2
           IL_0093:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-          IL_0098:  ldloca.s   V_2
-          IL_009a:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_00a0:  ldarg.0
-          IL_00a1:  ldarg.0
-          IL_00a2:  ldfld      ""int Test.<G>d__0.<x>5__1""
-          IL_00a7:  ldc.i4.1
-          IL_00a8:  add
-          IL_00a9:  stfld      ""int Test.<G>d__0.<x>5__1""
-          IL_00ae:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-          IL_00b3:  stloc.3
-          IL_00b4:  ldloca.s   V_3
-          IL_00b6:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-          IL_00bb:  stloc.2
-          IL_00bc:  ldloca.s   V_2
-          IL_00be:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-          IL_00c3:  brtrue.s   IL_0104
-          IL_00c5:  ldarg.0
-          IL_00c6:  ldc.i4.1
-          IL_00c7:  dup
-          IL_00c8:  stloc.0
-          IL_00c9:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_00ce:  ldarg.0
-          IL_00cf:  ldloc.2
-          IL_00d0:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_0098:  ldarg.0
+          IL_0099:  ldarg.0
+          IL_009a:  ldfld      ""int Test.<G>d__0.<x>5__1""
+          IL_009f:  ldc.i4.1
+          IL_00a0:  add
+          IL_00a1:  stfld      ""int Test.<G>d__0.<x>5__1""
+          IL_00a6:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+          IL_00ab:  stloc.3
+          IL_00ac:  ldloca.s   V_3
+          IL_00ae:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+          IL_00b3:  stloc.2
+          IL_00b4:  ldloca.s   V_2
+          IL_00b6:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+          IL_00bb:  brtrue.s   IL_00fc
+          IL_00bd:  ldarg.0
+          IL_00be:  ldc.i4.1
+          IL_00bf:  dup
+          IL_00c0:  stloc.0
+          IL_00c1:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_00c6:  ldarg.0
+          IL_00c7:  ldloc.2
+          IL_00c8:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_00cd:  ldarg.0
+          IL_00ce:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
+          IL_00d3:  ldloca.s   V_2
           IL_00d5:  ldarg.0
-          IL_00d6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
-          IL_00db:  ldloca.s   V_2
-          IL_00dd:  ldarg.0
-          IL_00de:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
-          IL_00e3:  leave      IL_0362
-          IL_00e8:  ldarg.0
-          IL_00e9:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_00ee:  stloc.2
-          IL_00ef:  ldarg.0
-          IL_00f0:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_00f5:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_00fb:  ldarg.0
-          IL_00fc:  ldc.i4.m1
-          IL_00fd:  dup
-          IL_00fe:  stloc.0
-          IL_00ff:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_0104:  ldloca.s   V_2
-          IL_0106:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-          IL_010b:  ldloca.s   V_2
-          IL_010d:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_0113:  ldarg.0
-          IL_0114:  ldarg.0
-          IL_0115:  ldfld      ""int Test.<G>d__0.<x>5__1""
-          IL_011a:  ldc.i4.1
-          IL_011b:  add
-          IL_011c:  stfld      ""int Test.<G>d__0.<x>5__1""
-          IL_0121:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-          IL_0126:  stloc.3
-          IL_0127:  ldloca.s   V_3
-          IL_0129:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-          IL_012e:  stloc.2
-          IL_012f:  ldloca.s   V_2
-          IL_0131:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-          IL_0136:  brtrue.s   IL_0177
+          IL_00d6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
+          IL_00db:  leave      IL_0332
+          IL_00e0:  ldarg.0
+          IL_00e1:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_00e6:  stloc.2
+          IL_00e7:  ldarg.0
+          IL_00e8:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_00ed:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+          IL_00f3:  ldarg.0
+          IL_00f4:  ldc.i4.m1
+          IL_00f5:  dup
+          IL_00f6:  stloc.0
+          IL_00f7:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_00fc:  ldloca.s   V_2
+          IL_00fe:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+          IL_0103:  ldarg.0
+          IL_0104:  ldarg.0
+          IL_0105:  ldfld      ""int Test.<G>d__0.<x>5__1""
+          IL_010a:  ldc.i4.1
+          IL_010b:  add
+          IL_010c:  stfld      ""int Test.<G>d__0.<x>5__1""
+          IL_0111:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+          IL_0116:  stloc.3
+          IL_0117:  ldloca.s   V_3
+          IL_0119:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+          IL_011e:  stloc.2
+          IL_011f:  ldloca.s   V_2
+          IL_0121:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+          IL_0126:  brtrue.s   IL_0167
+          IL_0128:  ldarg.0
+          IL_0129:  ldc.i4.2
+          IL_012a:  dup
+          IL_012b:  stloc.0
+          IL_012c:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_0131:  ldarg.0
+          IL_0132:  ldloc.2
+          IL_0133:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
           IL_0138:  ldarg.0
-          IL_0139:  ldc.i4.2
-          IL_013a:  dup
-          IL_013b:  stloc.0
-          IL_013c:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_0141:  ldarg.0
-          IL_0142:  ldloc.2
-          IL_0143:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_0148:  ldarg.0
-          IL_0149:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
-          IL_014e:  ldloca.s   V_2
-          IL_0150:  ldarg.0
-          IL_0151:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
-          IL_0156:  leave      IL_0362
-          IL_015b:  ldarg.0
-          IL_015c:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_0161:  stloc.2
-          IL_0162:  ldarg.0
-          IL_0163:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_0168:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+          IL_0139:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
+          IL_013e:  ldloca.s   V_2
+          IL_0140:  ldarg.0
+          IL_0141:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
+          IL_0146:  leave      IL_0332
+          IL_014b:  ldarg.0
+          IL_014c:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_0151:  stloc.2
+          IL_0152:  ldarg.0
+          IL_0153:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_0158:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+          IL_015e:  ldarg.0
+          IL_015f:  ldc.i4.m1
+          IL_0160:  dup
+          IL_0161:  stloc.0
+          IL_0162:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_0167:  ldloca.s   V_2
+          IL_0169:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
           IL_016e:  ldarg.0
-          IL_016f:  ldc.i4.m1
-          IL_0170:  dup
-          IL_0171:  stloc.0
-          IL_0172:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_0177:  ldloca.s   V_2
-          IL_0179:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-          IL_017e:  ldloca.s   V_2
-          IL_0180:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_0186:  ldarg.0
-          IL_0187:  ldarg.0
-          IL_0188:  ldfld      ""int Test.<G>d__0.<x>5__1""
-          IL_018d:  ldc.i4.1
-          IL_018e:  add
-          IL_018f:  stfld      ""int Test.<G>d__0.<x>5__1""
-          IL_0194:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-          IL_0199:  stloc.3
-          IL_019a:  ldloca.s   V_3
-          IL_019c:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-          IL_01a1:  stloc.2
-          IL_01a2:  ldloca.s   V_2
-          IL_01a4:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-          IL_01a9:  brtrue.s   IL_01ea
+          IL_016f:  ldarg.0
+          IL_0170:  ldfld      ""int Test.<G>d__0.<x>5__1""
+          IL_0175:  ldc.i4.1
+          IL_0176:  add
+          IL_0177:  stfld      ""int Test.<G>d__0.<x>5__1""
+          IL_017c:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+          IL_0181:  stloc.3
+          IL_0182:  ldloca.s   V_3
+          IL_0184:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+          IL_0189:  stloc.2
+          IL_018a:  ldloca.s   V_2
+          IL_018c:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+          IL_0191:  brtrue.s   IL_01d2
+          IL_0193:  ldarg.0
+          IL_0194:  ldc.i4.3
+          IL_0195:  dup
+          IL_0196:  stloc.0
+          IL_0197:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_019c:  ldarg.0
+          IL_019d:  ldloc.2
+          IL_019e:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_01a3:  ldarg.0
+          IL_01a4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
+          IL_01a9:  ldloca.s   V_2
           IL_01ab:  ldarg.0
-          IL_01ac:  ldc.i4.3
-          IL_01ad:  dup
-          IL_01ae:  stloc.0
-          IL_01af:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_01b4:  ldarg.0
-          IL_01b5:  ldloc.2
-          IL_01b6:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_01bb:  ldarg.0
-          IL_01bc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
-          IL_01c1:  ldloca.s   V_2
-          IL_01c3:  ldarg.0
-          IL_01c4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
-          IL_01c9:  leave      IL_0362
-          IL_01ce:  ldarg.0
-          IL_01cf:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_01d4:  stloc.2
-          IL_01d5:  ldarg.0
-          IL_01d6:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_01db:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_01e1:  ldarg.0
-          IL_01e2:  ldc.i4.m1
-          IL_01e3:  dup
-          IL_01e4:  stloc.0
-          IL_01e5:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_01ea:  ldloca.s   V_2
-          IL_01ec:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-          IL_01f1:  ldloca.s   V_2
-          IL_01f3:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_01f9:  ldarg.0
-          IL_01fa:  ldarg.0
-          IL_01fb:  ldfld      ""int Test.<G>d__0.<x>5__1""
-          IL_0200:  ldc.i4.1
-          IL_0201:  add
-          IL_0202:  stfld      ""int Test.<G>d__0.<x>5__1""
-          IL_0207:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-          IL_020c:  stloc.3
-          IL_020d:  ldloca.s   V_3
-          IL_020f:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-          IL_0214:  stloc.2
-          IL_0215:  ldloca.s   V_2
-          IL_0217:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-          IL_021c:  brtrue.s   IL_025d
-          IL_021e:  ldarg.0
-          IL_021f:  ldc.i4.4
-          IL_0220:  dup
-          IL_0221:  stloc.0
-          IL_0222:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_0227:  ldarg.0
-          IL_0228:  ldloc.2
-          IL_0229:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_022e:  ldarg.0
-          IL_022f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
-          IL_0234:  ldloca.s   V_2
-          IL_0236:  ldarg.0
-          IL_0237:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
-          IL_023c:  leave      IL_0362
-          IL_0241:  ldarg.0
-          IL_0242:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_0247:  stloc.2
-          IL_0248:  ldarg.0
-          IL_0249:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_024e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_0254:  ldarg.0
-          IL_0255:  ldc.i4.m1
-          IL_0256:  dup
-          IL_0257:  stloc.0
-          IL_0258:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_025d:  ldloca.s   V_2
-          IL_025f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-          IL_0264:  ldloca.s   V_2
-          IL_0266:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_026c:  ldarg.0
-          IL_026d:  ldarg.0
-          IL_026e:  ldfld      ""int Test.<G>d__0.<x>5__1""
-          IL_0273:  ldc.i4.1
-          IL_0274:  add
-          IL_0275:  stfld      ""int Test.<G>d__0.<x>5__1""
-          IL_027a:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-          IL_027f:  stloc.3
-          IL_0280:  ldloca.s   V_3
-          IL_0282:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-          IL_0287:  stloc.2
-          IL_0288:  ldloca.s   V_2
-          IL_028a:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-          IL_028f:  brtrue.s   IL_02d0
-          IL_0291:  ldarg.0
-          IL_0292:  ldc.i4.5
-          IL_0293:  dup
-          IL_0294:  stloc.0
-          IL_0295:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_029a:  ldarg.0
-          IL_029b:  ldloc.2
-          IL_029c:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_02a1:  ldarg.0
-          IL_02a2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
-          IL_02a7:  ldloca.s   V_2
-          IL_02a9:  ldarg.0
-          IL_02aa:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
-          IL_02af:  leave      IL_0362
-          IL_02b4:  ldarg.0
-          IL_02b5:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_02ba:  stloc.2
-          IL_02bb:  ldarg.0
-          IL_02bc:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
-          IL_02c1:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_02c7:  ldarg.0
-          IL_02c8:  ldc.i4.m1
-          IL_02c9:  dup
-          IL_02ca:  stloc.0
-          IL_02cb:  stfld      ""int Test.<G>d__0.<>1__state""
-          IL_02d0:  ldloca.s   V_2
-          IL_02d2:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-          IL_02d7:  ldloca.s   V_2
-          IL_02d9:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-          IL_02df:  ldarg.0
-          IL_02e0:  ldarg.0
-          IL_02e1:  ldfld      ""int Test.<G>d__0.<x>5__1""
-          IL_02e6:  ldc.i4.1
-          IL_02e7:  add
-          IL_02e8:  stfld      ""int Test.<G>d__0.<x>5__1""
-          IL_02ed:  leave.s    IL_0302
+          IL_01ac:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
+          IL_01b1:  leave      IL_0332
+          IL_01b6:  ldarg.0
+          IL_01b7:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_01bc:  stloc.2
+          IL_01bd:  ldarg.0
+          IL_01be:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_01c3:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+          IL_01c9:  ldarg.0
+          IL_01ca:  ldc.i4.m1
+          IL_01cb:  dup
+          IL_01cc:  stloc.0
+          IL_01cd:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_01d2:  ldloca.s   V_2
+          IL_01d4:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+          IL_01d9:  ldarg.0
+          IL_01da:  ldarg.0
+          IL_01db:  ldfld      ""int Test.<G>d__0.<x>5__1""
+          IL_01e0:  ldc.i4.1
+          IL_01e1:  add
+          IL_01e2:  stfld      ""int Test.<G>d__0.<x>5__1""
+          IL_01e7:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+          IL_01ec:  stloc.3
+          IL_01ed:  ldloca.s   V_3
+          IL_01ef:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+          IL_01f4:  stloc.2
+          IL_01f5:  ldloca.s   V_2
+          IL_01f7:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+          IL_01fc:  brtrue.s   IL_023d
+          IL_01fe:  ldarg.0
+          IL_01ff:  ldc.i4.4
+          IL_0200:  dup
+          IL_0201:  stloc.0
+          IL_0202:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_0207:  ldarg.0
+          IL_0208:  ldloc.2
+          IL_0209:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_020e:  ldarg.0
+          IL_020f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
+          IL_0214:  ldloca.s   V_2
+          IL_0216:  ldarg.0
+          IL_0217:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
+          IL_021c:  leave      IL_0332
+          IL_0221:  ldarg.0
+          IL_0222:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_0227:  stloc.2
+          IL_0228:  ldarg.0
+          IL_0229:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_022e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+          IL_0234:  ldarg.0
+          IL_0235:  ldc.i4.m1
+          IL_0236:  dup
+          IL_0237:  stloc.0
+          IL_0238:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_023d:  ldloca.s   V_2
+          IL_023f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+          IL_0244:  ldarg.0
+          IL_0245:  ldarg.0
+          IL_0246:  ldfld      ""int Test.<G>d__0.<x>5__1""
+          IL_024b:  ldc.i4.1
+          IL_024c:  add
+          IL_024d:  stfld      ""int Test.<G>d__0.<x>5__1""
+          IL_0252:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+          IL_0257:  stloc.3
+          IL_0258:  ldloca.s   V_3
+          IL_025a:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+          IL_025f:  stloc.2
+          IL_0260:  ldloca.s   V_2
+          IL_0262:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+          IL_0267:  brtrue.s   IL_02a8
+          IL_0269:  ldarg.0
+          IL_026a:  ldc.i4.5
+          IL_026b:  dup
+          IL_026c:  stloc.0
+          IL_026d:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_0272:  ldarg.0
+          IL_0273:  ldloc.2
+          IL_0274:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_0279:  ldarg.0
+          IL_027a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
+          IL_027f:  ldloca.s   V_2
+          IL_0281:  ldarg.0
+          IL_0282:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Test.<G>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Test.<G>d__0)""
+          IL_0287:  leave      IL_0332
+          IL_028c:  ldarg.0
+          IL_028d:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_0292:  stloc.2
+          IL_0293:  ldarg.0
+          IL_0294:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Test.<G>d__0.<>u__1""
+          IL_0299:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+          IL_029f:  ldarg.0
+          IL_02a0:  ldc.i4.m1
+          IL_02a1:  dup
+          IL_02a2:  stloc.0
+          IL_02a3:  stfld      ""int Test.<G>d__0.<>1__state""
+          IL_02a8:  ldloca.s   V_2
+          IL_02aa:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+          IL_02af:  ldarg.0
+          IL_02b0:  ldarg.0
+          IL_02b1:  ldfld      ""int Test.<G>d__0.<x>5__1""
+          IL_02b6:  ldc.i4.1
+          IL_02b7:  add
+          IL_02b8:  stfld      ""int Test.<G>d__0.<x>5__1""
+          IL_02bd:  leave.s    IL_02d2
         }
         finally
         {
-          IL_02ef:  ldloc.0
-          IL_02f0:  ldc.i4.0
-          IL_02f1:  bge.s      IL_0301
-          IL_02f3:  ldarg.0
-          IL_02f4:  ldarg.0
-          IL_02f5:  ldfld      ""int Test.<G>d__0.<x>5__1""
-          IL_02fa:  ldc.i4.1
-          IL_02fb:  add
-          IL_02fc:  stfld      ""int Test.<G>d__0.<x>5__1""
-          IL_0301:  endfinally
+          IL_02bf:  ldloc.0
+          IL_02c0:  ldc.i4.0
+          IL_02c1:  bge.s      IL_02d1
+          IL_02c3:  ldarg.0
+          IL_02c4:  ldarg.0
+          IL_02c5:  ldfld      ""int Test.<G>d__0.<x>5__1""
+          IL_02ca:  ldc.i4.1
+          IL_02cb:  add
+          IL_02cc:  stfld      ""int Test.<G>d__0.<x>5__1""
+          IL_02d1:  endfinally
         }
-        IL_0302:  leave.s    IL_0317
+        IL_02d2:  leave.s    IL_02e7
       }
       finally
       {
-        IL_0304:  ldloc.0
-        IL_0305:  ldc.i4.0
-        IL_0306:  bge.s      IL_0316
-        IL_0308:  ldarg.0
-        IL_0309:  ldarg.0
-        IL_030a:  ldfld      ""int Test.<G>d__0.<x>5__1""
-        IL_030f:  ldc.i4.1
-        IL_0310:  add
-        IL_0311:  stfld      ""int Test.<G>d__0.<x>5__1""
-        IL_0316:  endfinally
+        IL_02d4:  ldloc.0
+        IL_02d5:  ldc.i4.0
+        IL_02d6:  bge.s      IL_02e6
+        IL_02d8:  ldarg.0
+        IL_02d9:  ldarg.0
+        IL_02da:  ldfld      ""int Test.<G>d__0.<x>5__1""
+        IL_02df:  ldc.i4.1
+        IL_02e0:  add
+        IL_02e1:  stfld      ""int Test.<G>d__0.<x>5__1""
+        IL_02e6:  endfinally
       }
-      IL_0317:  leave.s    IL_032c
+      IL_02e7:  leave.s    IL_02fc
     }
     finally
     {
-      IL_0319:  ldloc.0
-      IL_031a:  ldc.i4.0
-      IL_031b:  bge.s      IL_032b
-      IL_031d:  ldarg.0
-      IL_031e:  ldarg.0
-      IL_031f:  ldfld      ""int Test.<G>d__0.<x>5__1""
-      IL_0324:  ldc.i4.1
-      IL_0325:  add
-      IL_0326:  stfld      ""int Test.<G>d__0.<x>5__1""
-      IL_032b:  endfinally
+      IL_02e9:  ldloc.0
+      IL_02ea:  ldc.i4.0
+      IL_02eb:  bge.s      IL_02fb
+      IL_02ed:  ldarg.0
+      IL_02ee:  ldarg.0
+      IL_02ef:  ldfld      ""int Test.<G>d__0.<x>5__1""
+      IL_02f4:  ldc.i4.1
+      IL_02f5:  add
+      IL_02f6:  stfld      ""int Test.<G>d__0.<x>5__1""
+      IL_02fb:  endfinally
     }
-    IL_032c:  ldarg.0
-    IL_032d:  ldfld      ""int Test.<G>d__0.<x>5__1""
-    IL_0332:  stloc.1
-    IL_0333:  leave.s    IL_034e
+    IL_02fc:  ldarg.0
+    IL_02fd:  ldfld      ""int Test.<G>d__0.<x>5__1""
+    IL_0302:  stloc.1
+    IL_0303:  leave.s    IL_031e
   }
   catch System.Exception
   {
-    IL_0335:  stloc.s    V_4
-    IL_0337:  ldarg.0
-    IL_0338:  ldc.i4.s   -2
-    IL_033a:  stfld      ""int Test.<G>d__0.<>1__state""
-    IL_033f:  ldarg.0
-    IL_0340:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
-    IL_0345:  ldloc.s    V_4
-    IL_0347:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_034c:  leave.s    IL_0362
+    IL_0305:  stloc.s    V_4
+    IL_0307:  ldarg.0
+    IL_0308:  ldc.i4.s   -2
+    IL_030a:  stfld      ""int Test.<G>d__0.<>1__state""
+    IL_030f:  ldarg.0
+    IL_0310:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
+    IL_0315:  ldloc.s    V_4
+    IL_0317:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_031c:  leave.s    IL_0332
   }
-  IL_034e:  ldarg.0
-  IL_034f:  ldc.i4.s   -2
-  IL_0351:  stfld      ""int Test.<G>d__0.<>1__state""
-  IL_0356:  ldarg.0
-  IL_0357:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
-  IL_035c:  ldloc.1
-  IL_035d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_0362:  ret
+  IL_031e:  ldarg.0
+  IL_031f:  ldc.i4.s   -2
+  IL_0321:  stfld      ""int Test.<G>d__0.<>1__state""
+  IL_0326:  ldarg.0
+  IL_0327:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__0.<>t__builder""
+  IL_032c:  ldloc.1
+  IL_032d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_0332:  ret
 }
-
 ");
         }
-
-
+        
         [Fact, WorkItem(855080, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/855080")]
         public void GenericCatchVariableInAsyncMethod()
         {
@@ -745,7 +731,7 @@ class Test
             CompileAndVerify(source, expectedOutput: expected).
 VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      221 (0xdd)
+  // Code size      210 (0xd2)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -758,7 +744,7 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_005b
+    IL_0008:  brfalse.s  IL_0058
     IL_000a:  ldarg.0
     IL_000b:  ldnull
     IL_000c:  stfld      ""object Test.<G>d__1.<>7__wrap1""
@@ -782,7 +768,7 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
     IL_002e:  stloc.3
     IL_002f:  ldloca.s   V_3
     IL_0031:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0036:  brtrue.s   IL_0077
+    IL_0036:  brtrue.s   IL_0074
     IL_0038:  ldarg.0
     IL_0039:  ldc.i4.0
     IL_003a:  dup
@@ -796,61 +782,59 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
     IL_004e:  ldloca.s   V_3
     IL_0050:  ldarg.0
     IL_0051:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
-    IL_0056:  leave      IL_00dc
-    IL_005b:  ldarg.0
-    IL_005c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_0061:  stloc.3
-    IL_0062:  ldarg.0
-    IL_0063:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_0068:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_006e:  ldarg.0
-    IL_006f:  ldc.i4.m1
-    IL_0070:  dup
-    IL_0071:  stloc.0
-    IL_0072:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_0077:  ldloca.s   V_3
-    IL_0079:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_007e:  ldloca.s   V_3
-    IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0086:  ldarg.0
-    IL_0087:  ldfld      ""object Test.<G>d__1.<>7__wrap1""
-    IL_008c:  stloc.2
-    IL_008d:  ldloc.2
-    IL_008e:  brfalse.s  IL_00a5
-    IL_0090:  ldloc.2
-    IL_0091:  isinst     ""System.Exception""
-    IL_0096:  dup
-    IL_0097:  brtrue.s   IL_009b
-    IL_0099:  ldloc.2
-    IL_009a:  throw
-    IL_009b:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_00a0:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_00a5:  ldarg.0
-    IL_00a6:  ldnull
-    IL_00a7:  stfld      ""object Test.<G>d__1.<>7__wrap1""
-    IL_00ac:  stloc.1
-    IL_00ad:  leave.s    IL_00c8
+    IL_0056:  leave.s    IL_00d1
+    IL_0058:  ldarg.0
+    IL_0059:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_005e:  stloc.3
+    IL_005f:  ldarg.0
+    IL_0060:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_0065:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_006b:  ldarg.0
+    IL_006c:  ldc.i4.m1
+    IL_006d:  dup
+    IL_006e:  stloc.0
+    IL_006f:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_0074:  ldloca.s   V_3
+    IL_0076:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_007b:  ldarg.0
+    IL_007c:  ldfld      ""object Test.<G>d__1.<>7__wrap1""
+    IL_0081:  stloc.2
+    IL_0082:  ldloc.2
+    IL_0083:  brfalse.s  IL_009a
+    IL_0085:  ldloc.2
+    IL_0086:  isinst     ""System.Exception""
+    IL_008b:  dup
+    IL_008c:  brtrue.s   IL_0090
+    IL_008e:  ldloc.2
+    IL_008f:  throw
+    IL_0090:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_0095:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_009a:  ldarg.0
+    IL_009b:  ldnull
+    IL_009c:  stfld      ""object Test.<G>d__1.<>7__wrap1""
+    IL_00a1:  stloc.1
+    IL_00a2:  leave.s    IL_00bd
   }
   catch System.Exception
   {
-    IL_00af:  stloc.s    V_4
-    IL_00b1:  ldarg.0
-    IL_00b2:  ldc.i4.s   -2
-    IL_00b4:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_00b9:  ldarg.0
-    IL_00ba:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_00bf:  ldloc.s    V_4
-    IL_00c1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00c6:  leave.s    IL_00dc
+    IL_00a4:  stloc.s    V_4
+    IL_00a6:  ldarg.0
+    IL_00a7:  ldc.i4.s   -2
+    IL_00a9:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_00ae:  ldarg.0
+    IL_00af:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_00b4:  ldloc.s    V_4
+    IL_00b6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00bb:  leave.s    IL_00d1
   }
-  IL_00c8:  ldarg.0
-  IL_00c9:  ldc.i4.s   -2
-  IL_00cb:  stfld      ""int Test.<G>d__1.<>1__state""
-  IL_00d0:  ldarg.0
-  IL_00d1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-  IL_00d6:  ldloc.1
-  IL_00d7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00dc:  ret
+  IL_00bd:  ldarg.0
+  IL_00be:  ldc.i4.s   -2
+  IL_00c0:  stfld      ""int Test.<G>d__1.<>1__state""
+  IL_00c5:  ldarg.0
+  IL_00c6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+  IL_00cb:  ldloc.1
+  IL_00cc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00d1:  ret
 }
 ");
         }
@@ -993,16 +977,16 @@ class Test
 
             v.VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      481 (0x1e1)
+  // Code size      461 (0x1cd)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                int V_3,
-                Test.<G>d__1 V_4,
-                object V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_6,
-                System.Exception V_7)
+                Test.<G>d__1 V_3,
+                object V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                System.Exception V_6,
+                int V_7)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Test.<G>d__1.<>1__state""
   IL_0006:  stloc.0
@@ -1016,7 +1000,7 @@ class Test
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
     IL_0012:  br.s       IL_002f
-    IL_0014:  br         IL_0121
+    IL_0014:  br         IL_0115
    -IL_0019:  nop
    -IL_001a:  ldarg.0
     IL_001b:  ldc.i4.0
@@ -1033,14 +1017,14 @@ class Test
      ~IL_0030:  ldloc.0
       IL_0031:  brfalse.s  IL_0035
       IL_0033:  br.s       IL_0037
-      IL_0035:  br.s       IL_0074
+      IL_0035:  br.s       IL_0073
      -IL_0037:  nop
      -IL_0038:  call       ""System.Threading.Tasks.Task<int> Test.F()""
       IL_003d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
       IL_0042:  stloc.2
      ~IL_0043:  ldloca.s   V_2
       IL_0045:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-      IL_004a:  brtrue.s   IL_0090
+      IL_004a:  brtrue.s   IL_008f
       IL_004c:  ldarg.0
       IL_004d:  ldc.i4.0
       IL_004e:  dup
@@ -1050,164 +1034,156 @@ class Test
       IL_0056:  ldloc.2
       IL_0057:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
       IL_005c:  ldarg.0
-      IL_005d:  stloc.s    V_4
-      IL_005f:  ldarg.0
-      IL_0060:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-      IL_0065:  ldloca.s   V_2
-      IL_0067:  ldloca.s   V_4
-      IL_0069:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
-      IL_006e:  nop
-      IL_006f:  leave      IL_01e0
-     >IL_0074:  ldarg.0
-      IL_0075:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-      IL_007a:  stloc.2
-      IL_007b:  ldarg.0
-      IL_007c:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-      IL_0081:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-      IL_0087:  ldarg.0
-      IL_0088:  ldc.i4.m1
-      IL_0089:  dup
-      IL_008a:  stloc.0
-      IL_008b:  stfld      ""int Test.<G>d__1.<>1__state""
+      IL_005d:  stloc.3
+      IL_005e:  ldarg.0
+      IL_005f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+      IL_0064:  ldloca.s   V_2
+      IL_0066:  ldloca.s   V_3
+      IL_0068:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
+      IL_006d:  nop
+      IL_006e:  leave      IL_01cc
+     >IL_0073:  ldarg.0
+      IL_0074:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+      IL_0079:  stloc.2
+      IL_007a:  ldarg.0
+      IL_007b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+      IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+      IL_0086:  ldarg.0
+      IL_0087:  ldc.i4.m1
+      IL_0088:  dup
+      IL_0089:  stloc.0
+      IL_008a:  stfld      ""int Test.<G>d__1.<>1__state""
+      IL_008f:  ldarg.0
       IL_0090:  ldloca.s   V_2
       IL_0092:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-      IL_0097:  stloc.3
-      IL_0098:  ldloca.s   V_2
-      IL_009a:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-      IL_00a0:  ldarg.0
-      IL_00a1:  ldloc.3
-      IL_00a2:  stfld      ""int Test.<G>d__1.<>s__5""
-      IL_00a7:  ldarg.0
-      IL_00a8:  ldarg.0
-      IL_00a9:  ldfld      ""int Test.<G>d__1.<>s__5""
-      IL_00ae:  stfld      ""int Test.<G>d__1.<x>5__1""
-     -IL_00b3:  ldarg.0
-      IL_00b4:  ldarg.0
-      IL_00b5:  ldfld      ""int Test.<G>d__1.<x>5__1""
-      IL_00ba:  stfld      ""int Test.<G>d__1.<>s__4""
-      IL_00bf:  br.s       IL_00c1
-      IL_00c1:  ldarg.0
-      IL_00c2:  ldc.i4.1
-      IL_00c3:  stfld      ""int Test.<G>d__1.<>s__3""
-      IL_00c8:  leave.s    IL_00d6
+      IL_0097:  stfld      ""int Test.<G>d__1.<>s__5""
+      IL_009c:  ldarg.0
+      IL_009d:  ldarg.0
+      IL_009e:  ldfld      ""int Test.<G>d__1.<>s__5""
+      IL_00a3:  stfld      ""int Test.<G>d__1.<x>5__1""
+     -IL_00a8:  ldarg.0
+      IL_00a9:  ldarg.0
+      IL_00aa:  ldfld      ""int Test.<G>d__1.<x>5__1""
+      IL_00af:  stfld      ""int Test.<G>d__1.<>s__4""
+      IL_00b4:  br.s       IL_00b6
+      IL_00b6:  ldarg.0
+      IL_00b7:  ldc.i4.1
+      IL_00b8:  stfld      ""int Test.<G>d__1.<>s__3""
+      IL_00bd:  leave.s    IL_00cb
     }
     catch object
     {
-     ~IL_00ca:  stloc.s    V_5
-      IL_00cc:  ldarg.0
-      IL_00cd:  ldloc.s    V_5
-      IL_00cf:  stfld      ""object Test.<G>d__1.<>s__2""
-      IL_00d4:  leave.s    IL_00d6
+     ~IL_00bf:  stloc.s    V_4
+      IL_00c1:  ldarg.0
+      IL_00c2:  ldloc.s    V_4
+      IL_00c4:  stfld      ""object Test.<G>d__1.<>s__2""
+      IL_00c9:  leave.s    IL_00cb
     }
-   -IL_00d6:  nop
-   -IL_00d7:  ldarg.0
-    IL_00d8:  ldarg.0
-    IL_00d9:  ldfld      ""int Test.<G>d__1.<x>5__1""
-    IL_00de:  stfld      ""int Test.<G>d__1.<>s__6""
-    IL_00e3:  call       ""System.Threading.Tasks.Task<int> Test.F()""
-    IL_00e8:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00ed:  stloc.s    V_6
-   ~IL_00ef:  ldloca.s   V_6
-    IL_00f1:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_00f6:  brtrue.s   IL_013e
-    IL_00f8:  ldarg.0
-    IL_00f9:  ldc.i4.1
-    IL_00fa:  dup
-    IL_00fb:  stloc.0
-    IL_00fc:  stfld      ""int Test.<G>d__1.<>1__state""
-   <IL_0101:  ldarg.0
-    IL_0102:  ldloc.s    V_6
-    IL_0104:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_0109:  ldarg.0
-    IL_010a:  stloc.s    V_4
-    IL_010c:  ldarg.0
-    IL_010d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_0112:  ldloca.s   V_6
-    IL_0114:  ldloca.s   V_4
-    IL_0116:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
-    IL_011b:  nop
-    IL_011c:  leave      IL_01e0
-   >IL_0121:  ldarg.0
-    IL_0122:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_0127:  stloc.s    V_6
+   -IL_00cb:  nop
+   -IL_00cc:  ldarg.0
+    IL_00cd:  ldarg.0
+    IL_00ce:  ldfld      ""int Test.<G>d__1.<x>5__1""
+    IL_00d3:  stfld      ""int Test.<G>d__1.<>s__6""
+    IL_00d8:  call       ""System.Threading.Tasks.Task<int> Test.F()""
+    IL_00dd:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_00e2:  stloc.s    V_5
+   ~IL_00e4:  ldloca.s   V_5
+    IL_00e6:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_00eb:  brtrue.s   IL_0132
+    IL_00ed:  ldarg.0
+    IL_00ee:  ldc.i4.1
+    IL_00ef:  dup
+    IL_00f0:  stloc.0
+    IL_00f1:  stfld      ""int Test.<G>d__1.<>1__state""
+   <IL_00f6:  ldarg.0
+    IL_00f7:  ldloc.s    V_5
+    IL_00f9:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_00fe:  ldarg.0
+    IL_00ff:  stloc.3
+    IL_0100:  ldarg.0
+    IL_0101:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_0106:  ldloca.s   V_5
+    IL_0108:  ldloca.s   V_3
+    IL_010a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
+    IL_010f:  nop
+    IL_0110:  leave      IL_01cc
+   >IL_0115:  ldarg.0
+    IL_0116:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_011b:  stloc.s    V_5
+    IL_011d:  ldarg.0
+    IL_011e:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
+    IL_0123:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
     IL_0129:  ldarg.0
-    IL_012a:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
-    IL_012f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0135:  ldarg.0
-    IL_0136:  ldc.i4.m1
-    IL_0137:  dup
-    IL_0138:  stloc.0
-    IL_0139:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_013e:  ldloca.s   V_6
-    IL_0140:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0145:  stloc.3
-    IL_0146:  ldloca.s   V_6
-    IL_0148:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_014e:  ldarg.0
-    IL_014f:  ldloc.3
-    IL_0150:  stfld      ""int Test.<G>d__1.<>s__7""
-    IL_0155:  ldarg.0
-    IL_0156:  ldarg.0
-    IL_0157:  ldfld      ""int Test.<G>d__1.<>s__6""
-    IL_015c:  ldarg.0
-    IL_015d:  ldfld      ""int Test.<G>d__1.<>s__7""
-    IL_0162:  add
-    IL_0163:  stfld      ""int Test.<G>d__1.<x>5__1""
-   -IL_0168:  nop
-   ~IL_0169:  ldarg.0
-    IL_016a:  ldfld      ""object Test.<G>d__1.<>s__2""
-    IL_016f:  stloc.s    V_5
-    IL_0171:  ldloc.s    V_5
-    IL_0173:  brfalse.s  IL_0192
-    IL_0175:  ldloc.s    V_5
-    IL_0177:  isinst     ""System.Exception""
-    IL_017c:  stloc.s    V_7
-    IL_017e:  ldloc.s    V_7
-    IL_0180:  brtrue.s   IL_0185
-    IL_0182:  ldloc.s    V_5
-    IL_0184:  throw
-    IL_0185:  ldloc.s    V_7
-    IL_0187:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_018c:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_0191:  nop
-    IL_0192:  ldarg.0
-    IL_0193:  ldfld      ""int Test.<G>d__1.<>s__3""
-    IL_0198:  stloc.3
-    IL_0199:  ldloc.3
-    IL_019a:  ldc.i4.1
-    IL_019b:  beq.s      IL_019f
-    IL_019d:  br.s       IL_01a8
-    IL_019f:  ldarg.0
-    IL_01a0:  ldfld      ""int Test.<G>d__1.<>s__4""
-    IL_01a5:  stloc.1
-    IL_01a6:  leave.s    IL_01cb
-    IL_01a8:  ldarg.0
-    IL_01a9:  ldnull
-    IL_01aa:  stfld      ""object Test.<G>d__1.<>s__2""
-    IL_01af:  leave.s    IL_01cb
+    IL_012a:  ldc.i4.m1
+    IL_012b:  dup
+    IL_012c:  stloc.0
+    IL_012d:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_0132:  ldarg.0
+    IL_0133:  ldloca.s   V_5
+    IL_0135:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_013a:  stfld      ""int Test.<G>d__1.<>s__7""
+    IL_013f:  ldarg.0
+    IL_0140:  ldarg.0
+    IL_0141:  ldfld      ""int Test.<G>d__1.<>s__6""
+    IL_0146:  ldarg.0
+    IL_0147:  ldfld      ""int Test.<G>d__1.<>s__7""
+    IL_014c:  add
+    IL_014d:  stfld      ""int Test.<G>d__1.<x>5__1""
+   -IL_0152:  nop
+   ~IL_0153:  ldarg.0
+    IL_0154:  ldfld      ""object Test.<G>d__1.<>s__2""
+    IL_0159:  stloc.s    V_4
+    IL_015b:  ldloc.s    V_4
+    IL_015d:  brfalse.s  IL_017c
+    IL_015f:  ldloc.s    V_4
+    IL_0161:  isinst     ""System.Exception""
+    IL_0166:  stloc.s    V_6
+    IL_0168:  ldloc.s    V_6
+    IL_016a:  brtrue.s   IL_016f
+    IL_016c:  ldloc.s    V_4
+    IL_016e:  throw
+    IL_016f:  ldloc.s    V_6
+    IL_0171:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_0176:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_017b:  nop
+    IL_017c:  ldarg.0
+    IL_017d:  ldfld      ""int Test.<G>d__1.<>s__3""
+    IL_0182:  stloc.s    V_7
+    IL_0184:  ldloc.s    V_7
+    IL_0186:  ldc.i4.1
+    IL_0187:  beq.s      IL_018b
+    IL_0189:  br.s       IL_0194
+    IL_018b:  ldarg.0
+    IL_018c:  ldfld      ""int Test.<G>d__1.<>s__4""
+    IL_0191:  stloc.1
+    IL_0192:  leave.s    IL_01b7
+    IL_0194:  ldarg.0
+    IL_0195:  ldnull
+    IL_0196:  stfld      ""object Test.<G>d__1.<>s__2""
+    IL_019b:  leave.s    IL_01b7
   }
   catch System.Exception
   {
-   ~IL_01b1:  stloc.s    V_7
-    IL_01b3:  ldarg.0
-    IL_01b4:  ldc.i4.s   -2
-    IL_01b6:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_01bb:  ldarg.0
-    IL_01bc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_01c1:  ldloc.s    V_7
-    IL_01c3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_01c8:  nop
-    IL_01c9:  leave.s    IL_01e0
+   ~IL_019d:  stloc.s    V_6
+    IL_019f:  ldarg.0
+    IL_01a0:  ldc.i4.s   -2
+    IL_01a2:  stfld      ""int Test.<G>d__1.<>1__state""
+    IL_01a7:  ldarg.0
+    IL_01a8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_01ad:  ldloc.s    V_6
+    IL_01af:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_01b4:  nop
+    IL_01b5:  leave.s    IL_01cc
   }
- -IL_01cb:  ldarg.0
-  IL_01cc:  ldc.i4.s   -2
-  IL_01ce:  stfld      ""int Test.<G>d__1.<>1__state""
- ~IL_01d3:  ldarg.0
-  IL_01d4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-  IL_01d9:  ldloc.1
-  IL_01da:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_01df:  nop
-  IL_01e0:  ret
+ -IL_01b7:  ldarg.0
+  IL_01b8:  ldc.i4.s   -2
+  IL_01ba:  stfld      ""int Test.<G>d__1.<>1__state""
+ ~IL_01bf:  ldarg.0
+  IL_01c0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+  IL_01c5:  ldloc.1
+  IL_01c6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_01cb:  nop
+  IL_01cc:  ret
 }", sequencePoints: "Test+<G>d__1.MoveNext");
         }
 
@@ -1504,7 +1480,7 @@ class Test
             CompileAndVerify(source, expectedOutput: expected).
 VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      178 (0xb2)
+  // Code size      170 (0xaa)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1540,7 +1516,7 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
     }
     IL_0019:  ldloc.3
     IL_001a:  ldc.i4.1
-    IL_001b:  bne.un.s   IL_0080
+    IL_001b:  bne.un.s   IL_0078
     IL_001d:  call       ""System.Threading.Tasks.Task<int> Test.F()""
     IL_0022:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
     IL_0027:  stloc.s    V_4
@@ -1560,7 +1536,7 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
     IL_0049:  ldloca.s   V_4
     IL_004b:  ldarg.0
     IL_004c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<G>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<G>d__1)""
-    IL_0051:  leave.s    IL_00b1
+    IL_0051:  leave.s    IL_00a9
     IL_0053:  ldarg.0
     IL_0054:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<G>d__1.<>u__1""
     IL_0059:  stloc.s    V_4
@@ -1574,33 +1550,31 @@ VerifyIL("Test.<G>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNe
     IL_006b:  stfld      ""int Test.<G>d__1.<>1__state""
     IL_0070:  ldloca.s   V_4
     IL_0072:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0077:  ldloca.s   V_4
-    IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007f:  stloc.2
-    IL_0080:  ldloc.2
-    IL_0081:  stloc.1
-    IL_0082:  leave.s    IL_009d
+    IL_0077:  stloc.2
+    IL_0078:  ldloc.2
+    IL_0079:  stloc.1
+    IL_007a:  leave.s    IL_0095
   }
   catch System.Exception
   {
-    IL_0084:  stloc.s    V_5
+    IL_007c:  stloc.s    V_5
+    IL_007e:  ldarg.0
+    IL_007f:  ldc.i4.s   -2
+    IL_0081:  stfld      ""int Test.<G>d__1.<>1__state""
     IL_0086:  ldarg.0
-    IL_0087:  ldc.i4.s   -2
-    IL_0089:  stfld      ""int Test.<G>d__1.<>1__state""
-    IL_008e:  ldarg.0
-    IL_008f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-    IL_0094:  ldloc.s    V_5
-    IL_0096:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_009b:  leave.s    IL_00b1
+    IL_0087:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+    IL_008c:  ldloc.s    V_5
+    IL_008e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0093:  leave.s    IL_00a9
   }
+  IL_0095:  ldarg.0
+  IL_0096:  ldc.i4.s   -2
+  IL_0098:  stfld      ""int Test.<G>d__1.<>1__state""
   IL_009d:  ldarg.0
-  IL_009e:  ldc.i4.s   -2
-  IL_00a0:  stfld      ""int Test.<G>d__1.<>1__state""
-  IL_00a5:  ldarg.0
-  IL_00a6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
-  IL_00ab:  ldloc.1
-  IL_00ac:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00b1:  ret
+  IL_009e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<G>d__1.<>t__builder""
+  IL_00a3:  ldloc.1
+  IL_00a4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00a9:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -503,7 +503,7 @@ class Test
 
             verifier.VerifyIL("C.<F>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      199 (0xc7)
+  // Code size      191 (0xbf)
   .maxstack  3
   .locals init (int V_0,
                 C V_1,
@@ -550,7 +550,7 @@ class Test
     IL_0060:  ldloca.s   V_4
     IL_0062:  ldarg.0
     IL_0063:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__1)""
-    IL_0068:  leave.s    IL_00c6
+    IL_0068:  leave.s    IL_00be
     IL_006a:  ldarg.0
     IL_006b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__1.<>u__1""
     IL_0070:  stloc.s    V_4
@@ -564,31 +564,29 @@ class Test
     IL_0082:  stfld      ""int C.<F>d__1.<>1__state""
     IL_0087:  ldloca.s   V_4
     IL_0089:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008e:  ldloca.s   V_4
-    IL_0090:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0096:  stloc.2
-    IL_0097:  leave.s    IL_00b2
+    IL_008e:  stloc.2
+    IL_008f:  leave.s    IL_00aa
   }
   catch System.Exception
   {
-    IL_0099:  stloc.s    V_5
+    IL_0091:  stloc.s    V_5
+    IL_0093:  ldarg.0
+    IL_0094:  ldc.i4.s   -2
+    IL_0096:  stfld      ""int C.<F>d__1.<>1__state""
     IL_009b:  ldarg.0
-    IL_009c:  ldc.i4.s   -2
-    IL_009e:  stfld      ""int C.<F>d__1.<>1__state""
-    IL_00a3:  ldarg.0
-    IL_00a4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__1.<>t__builder""
-    IL_00a9:  ldloc.s    V_5
-    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00b0:  leave.s    IL_00c6
+    IL_009c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__1.<>t__builder""
+    IL_00a1:  ldloc.s    V_5
+    IL_00a3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00a8:  leave.s    IL_00be
   }
+  IL_00aa:  ldarg.0
+  IL_00ab:  ldc.i4.s   -2
+  IL_00ad:  stfld      ""int C.<F>d__1.<>1__state""
   IL_00b2:  ldarg.0
-  IL_00b3:  ldc.i4.s   -2
-  IL_00b5:  stfld      ""int C.<F>d__1.<>1__state""
-  IL_00ba:  ldarg.0
-  IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__1.<>t__builder""
-  IL_00c0:  ldloc.2
-  IL_00c1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00c6:  ret
+  IL_00b3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__1.<>t__builder""
+  IL_00b8:  ldloc.2
+  IL_00b9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00be:  ret
 }
 ");
 
@@ -636,7 +634,7 @@ class Test
 
             verifier.VerifyIL("C.<F>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      652 (0x28c)
+  // Code size      612 (0x264)
   .maxstack  3
   .locals init (int V_0,
                 C V_1,
@@ -655,10 +653,10 @@ class Test
     IL_000e:  ldloc.0
     IL_000f:  switch    (
         IL_006f,
-        IL_00e8,
-        IL_0161,
-        IL_01c7,
-        IL_022a)
+        IL_00e0,
+        IL_0151,
+        IL_01af,
+        IL_020a)
     IL_0028:  ldarg.0
     IL_0029:  ldloc.1
     IL_002a:  call       ""int C.x.get""
@@ -684,7 +682,7 @@ class Test
     IL_0062:  ldloca.s   V_3
     IL_0064:  ldarg.0
     IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
-    IL_006a:  leave      IL_028b
+    IL_006a:  leave      IL_0263
     IL_006f:  ldarg.0
     IL_0070:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
     IL_0075:  stloc.3
@@ -698,195 +696,185 @@ class Test
     IL_0086:  stfld      ""int C.<F>d__2.<>1__state""
     IL_008b:  ldloca.s   V_3
     IL_008d:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0092:  ldloca.s   V_3
-    IL_0094:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_009a:  ldarg.0
-    IL_009b:  ldarg.0
-    IL_009c:  ldfld      ""int C.<F>d__2.<c>5__1""
-    IL_00a1:  ldloc.1
-    IL_00a2:  call       ""int C.x.get""
-    IL_00a7:  add
-    IL_00a8:  stfld      ""int C.<F>d__2.<c>5__1""
-    IL_00ad:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_00b2:  stloc.s    V_4
-    IL_00b4:  ldloca.s   V_4
-    IL_00b6:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_00bb:  stloc.3
-    IL_00bc:  ldloca.s   V_3
-    IL_00be:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_00c3:  brtrue.s   IL_0104
-    IL_00c5:  ldarg.0
-    IL_00c6:  ldc.i4.1
-    IL_00c7:  dup
-    IL_00c8:  stloc.0
-    IL_00c9:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_00ce:  ldarg.0
-    IL_00cf:  ldloc.3
-    IL_00d0:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_0092:  ldarg.0
+    IL_0093:  ldarg.0
+    IL_0094:  ldfld      ""int C.<F>d__2.<c>5__1""
+    IL_0099:  ldloc.1
+    IL_009a:  call       ""int C.x.get""
+    IL_009f:  add
+    IL_00a0:  stfld      ""int C.<F>d__2.<c>5__1""
+    IL_00a5:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_00aa:  stloc.s    V_4
+    IL_00ac:  ldloca.s   V_4
+    IL_00ae:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_00b3:  stloc.3
+    IL_00b4:  ldloca.s   V_3
+    IL_00b6:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_00bb:  brtrue.s   IL_00fc
+    IL_00bd:  ldarg.0
+    IL_00be:  ldc.i4.1
+    IL_00bf:  dup
+    IL_00c0:  stloc.0
+    IL_00c1:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_00c6:  ldarg.0
+    IL_00c7:  ldloc.3
+    IL_00c8:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_00cd:  ldarg.0
+    IL_00ce:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_00d3:  ldloca.s   V_3
     IL_00d5:  ldarg.0
-    IL_00d6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
-    IL_00db:  ldloca.s   V_3
-    IL_00dd:  ldarg.0
-    IL_00de:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
-    IL_00e3:  leave      IL_028b
-    IL_00e8:  ldarg.0
-    IL_00e9:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_00ee:  stloc.3
-    IL_00ef:  ldarg.0
-    IL_00f0:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_00f5:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_00fb:  ldarg.0
-    IL_00fc:  ldc.i4.m1
-    IL_00fd:  dup
-    IL_00fe:  stloc.0
-    IL_00ff:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_0104:  ldloca.s   V_3
-    IL_0106:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_010b:  ldloca.s   V_3
-    IL_010d:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0113:  ldarg.0
-    IL_0114:  ldarg.0
-    IL_0115:  ldfld      ""int C.<F>d__2.<c>5__1""
-    IL_011a:  ldloc.1
-    IL_011b:  call       ""int C.x.get""
-    IL_0120:  add
-    IL_0121:  stfld      ""int C.<F>d__2.<c>5__1""
-    IL_0126:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_012b:  stloc.s    V_4
-    IL_012d:  ldloca.s   V_4
-    IL_012f:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0134:  stloc.3
-    IL_0135:  ldloca.s   V_3
-    IL_0137:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_013c:  brtrue.s   IL_017d
+    IL_00d6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_00db:  leave      IL_0263
+    IL_00e0:  ldarg.0
+    IL_00e1:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_00e6:  stloc.3
+    IL_00e7:  ldarg.0
+    IL_00e8:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_00ed:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_00f3:  ldarg.0
+    IL_00f4:  ldc.i4.m1
+    IL_00f5:  dup
+    IL_00f6:  stloc.0
+    IL_00f7:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_00fc:  ldloca.s   V_3
+    IL_00fe:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_0103:  ldarg.0
+    IL_0104:  ldarg.0
+    IL_0105:  ldfld      ""int C.<F>d__2.<c>5__1""
+    IL_010a:  ldloc.1
+    IL_010b:  call       ""int C.x.get""
+    IL_0110:  add
+    IL_0111:  stfld      ""int C.<F>d__2.<c>5__1""
+    IL_0116:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_011b:  stloc.s    V_4
+    IL_011d:  ldloca.s   V_4
+    IL_011f:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_0124:  stloc.3
+    IL_0125:  ldloca.s   V_3
+    IL_0127:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_012c:  brtrue.s   IL_016d
+    IL_012e:  ldarg.0
+    IL_012f:  ldc.i4.2
+    IL_0130:  dup
+    IL_0131:  stloc.0
+    IL_0132:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0137:  ldarg.0
+    IL_0138:  ldloc.3
+    IL_0139:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
     IL_013e:  ldarg.0
-    IL_013f:  ldc.i4.2
-    IL_0140:  dup
-    IL_0141:  stloc.0
-    IL_0142:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_0147:  ldarg.0
-    IL_0148:  ldloc.3
-    IL_0149:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_014e:  ldarg.0
-    IL_014f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
-    IL_0154:  ldloca.s   V_3
-    IL_0156:  ldarg.0
-    IL_0157:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
-    IL_015c:  leave      IL_028b
-    IL_0161:  ldarg.0
-    IL_0162:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_0167:  stloc.3
-    IL_0168:  ldarg.0
-    IL_0169:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_016e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0174:  ldarg.0
-    IL_0175:  ldc.i4.m1
-    IL_0176:  dup
-    IL_0177:  stloc.0
-    IL_0178:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_017d:  ldloca.s   V_3
-    IL_017f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0184:  ldloca.s   V_3
-    IL_0186:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_018c:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_0191:  stloc.s    V_4
-    IL_0193:  ldloca.s   V_4
-    IL_0195:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_019a:  stloc.3
-    IL_019b:  ldloca.s   V_3
-    IL_019d:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_01a2:  brtrue.s   IL_01e3
+    IL_013f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_0144:  ldloca.s   V_3
+    IL_0146:  ldarg.0
+    IL_0147:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_014c:  leave      IL_0263
+    IL_0151:  ldarg.0
+    IL_0152:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_0157:  stloc.3
+    IL_0158:  ldarg.0
+    IL_0159:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_015e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0164:  ldarg.0
+    IL_0165:  ldc.i4.m1
+    IL_0166:  dup
+    IL_0167:  stloc.0
+    IL_0168:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_016d:  ldloca.s   V_3
+    IL_016f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_0174:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_0179:  stloc.s    V_4
+    IL_017b:  ldloca.s   V_4
+    IL_017d:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_0182:  stloc.3
+    IL_0183:  ldloca.s   V_3
+    IL_0185:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_018a:  brtrue.s   IL_01cb
+    IL_018c:  ldarg.0
+    IL_018d:  ldc.i4.3
+    IL_018e:  dup
+    IL_018f:  stloc.0
+    IL_0190:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0195:  ldarg.0
+    IL_0196:  ldloc.3
+    IL_0197:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_019c:  ldarg.0
+    IL_019d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_01a2:  ldloca.s   V_3
     IL_01a4:  ldarg.0
-    IL_01a5:  ldc.i4.3
-    IL_01a6:  dup
-    IL_01a7:  stloc.0
-    IL_01a8:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_01ad:  ldarg.0
-    IL_01ae:  ldloc.3
-    IL_01af:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_01b4:  ldarg.0
-    IL_01b5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
-    IL_01ba:  ldloca.s   V_3
-    IL_01bc:  ldarg.0
-    IL_01bd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
-    IL_01c2:  leave      IL_028b
-    IL_01c7:  ldarg.0
-    IL_01c8:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_01cd:  stloc.3
-    IL_01ce:  ldarg.0
-    IL_01cf:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_01d4:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_01da:  ldarg.0
-    IL_01db:  ldc.i4.m1
-    IL_01dc:  dup
-    IL_01dd:  stloc.0
-    IL_01de:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_01e3:  ldloca.s   V_3
-    IL_01e5:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_01ea:  ldloca.s   V_3
-    IL_01ec:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_01f2:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_01f7:  stloc.s    V_4
-    IL_01f9:  ldloca.s   V_4
-    IL_01fb:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0200:  stloc.3
-    IL_0201:  ldloca.s   V_3
-    IL_0203:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_0208:  brtrue.s   IL_0246
+    IL_01a5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_01aa:  leave      IL_0263
+    IL_01af:  ldarg.0
+    IL_01b0:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_01b5:  stloc.3
+    IL_01b6:  ldarg.0
+    IL_01b7:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_01bc:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_01c2:  ldarg.0
+    IL_01c3:  ldc.i4.m1
+    IL_01c4:  dup
+    IL_01c5:  stloc.0
+    IL_01c6:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_01cb:  ldloca.s   V_3
+    IL_01cd:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_01d2:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_01d7:  stloc.s    V_4
+    IL_01d9:  ldloca.s   V_4
+    IL_01db:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_01e0:  stloc.3
+    IL_01e1:  ldloca.s   V_3
+    IL_01e3:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_01e8:  brtrue.s   IL_0226
+    IL_01ea:  ldarg.0
+    IL_01eb:  ldc.i4.4
+    IL_01ec:  dup
+    IL_01ed:  stloc.0
+    IL_01ee:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_01f3:  ldarg.0
+    IL_01f4:  ldloc.3
+    IL_01f5:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_01fa:  ldarg.0
+    IL_01fb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_0200:  ldloca.s   V_3
+    IL_0202:  ldarg.0
+    IL_0203:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_0208:  leave.s    IL_0263
     IL_020a:  ldarg.0
-    IL_020b:  ldc.i4.4
-    IL_020c:  dup
-    IL_020d:  stloc.0
-    IL_020e:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_0213:  ldarg.0
-    IL_0214:  ldloc.3
-    IL_0215:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_021a:  ldarg.0
-    IL_021b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
-    IL_0220:  ldloca.s   V_3
-    IL_0222:  ldarg.0
-    IL_0223:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
-    IL_0228:  leave.s    IL_028b
-    IL_022a:  ldarg.0
-    IL_022b:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_0230:  stloc.3
-    IL_0231:  ldarg.0
-    IL_0232:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
-    IL_0237:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_023d:  ldarg.0
-    IL_023e:  ldc.i4.m1
-    IL_023f:  dup
-    IL_0240:  stloc.0
-    IL_0241:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_0246:  ldloca.s   V_3
-    IL_0248:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_024d:  ldloca.s   V_3
-    IL_024f:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0255:  ldarg.0
-    IL_0256:  ldfld      ""int C.<F>d__2.<c>5__1""
-    IL_025b:  stloc.2
-    IL_025c:  leave.s    IL_0277
+    IL_020b:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_0210:  stloc.3
+    IL_0211:  ldarg.0
+    IL_0212:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_0217:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_021d:  ldarg.0
+    IL_021e:  ldc.i4.m1
+    IL_021f:  dup
+    IL_0220:  stloc.0
+    IL_0221:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0226:  ldloca.s   V_3
+    IL_0228:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_022d:  ldarg.0
+    IL_022e:  ldfld      ""int C.<F>d__2.<c>5__1""
+    IL_0233:  stloc.2
+    IL_0234:  leave.s    IL_024f
   }
   catch System.Exception
   {
-    IL_025e:  stloc.s    V_5
-    IL_0260:  ldarg.0
-    IL_0261:  ldc.i4.s   -2
-    IL_0263:  stfld      ""int C.<F>d__2.<>1__state""
-    IL_0268:  ldarg.0
-    IL_0269:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
-    IL_026e:  ldloc.s    V_5
-    IL_0270:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0275:  leave.s    IL_028b
+    IL_0236:  stloc.s    V_5
+    IL_0238:  ldarg.0
+    IL_0239:  ldc.i4.s   -2
+    IL_023b:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0240:  ldarg.0
+    IL_0241:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_0246:  ldloc.s    V_5
+    IL_0248:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_024d:  leave.s    IL_0263
   }
-  IL_0277:  ldarg.0
-  IL_0278:  ldc.i4.s   -2
-  IL_027a:  stfld      ""int C.<F>d__2.<>1__state""
-  IL_027f:  ldarg.0
-  IL_0280:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
-  IL_0285:  ldloc.2
-  IL_0286:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_028b:  ret
+  IL_024f:  ldarg.0
+  IL_0250:  ldc.i4.s   -2
+  IL_0252:  stfld      ""int C.<F>d__2.<>1__state""
+  IL_0257:  ldarg.0
+  IL_0258:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+  IL_025d:  ldloc.2
+  IL_025e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_0263:  ret
 }
 ");
 
@@ -1017,118 +1005,118 @@ IL_0082:  ldarg.0
 IL_0083:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
 IL_0091:  stloc.0
 IL_0092:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_00a7:  ldarg.0
-IL_00a8:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_009f:  ldarg.0
+IL_00a0:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_00b2:  ldarg.0
+IL_00b3:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
 IL_00ba:  ldarg.0
 IL_00bb:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_00c2:  ldarg.0
-IL_00c3:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_00cf:  ldnull
-IL_00d0:  stfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_00db:  callvirt   ""System.Collections.Generic.IEnumerator<S> System.Collections.Generic.IEnumerable<S>.GetEnumerator()""
-IL_00e0:  stfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
-IL_00ec:  ldarg.0
-IL_00ed:  ldfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
-IL_0110:  stloc.0
-IL_0111:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_0117:  ldloc.1
-IL_0118:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_011d:  ldarg.0
-IL_011e:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
-IL_0130:  ldarg.0
-IL_0131:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_0137:  ldarg.0
-IL_0138:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_0146:  stloc.0
-IL_0147:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_015c:  ldarg.0
-IL_015d:  ldfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
-IL_016f:  ldarg.0
-IL_0170:  ldfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
-IL_0177:  ldarg.0
-IL_0178:  ldfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
-IL_0184:  ldnull
-IL_0185:  stfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
-IL_0190:  callvirt   ""System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator()""
-IL_0195:  stfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_01a1:  ldarg.0
-IL_01a2:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_01c5:  stloc.0
-IL_01c6:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_01cc:  ldloc.1
-IL_01cd:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_01d2:  ldarg.0
-IL_01d3:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
-IL_01e5:  ldarg.0
-IL_01e6:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_01ec:  ldarg.0
-IL_01ed:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_01fb:  stloc.0
-IL_01fc:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_0211:  ldarg.0
-IL_0212:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_0224:  ldarg.0
-IL_0225:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_022c:  ldarg.0
-IL_022d:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_0239:  ldnull
-IL_023a:  stfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
-IL_0245:  callvirt   ""System.Collections.Generic.IEnumerator<U> System.Collections.Generic.IEnumerable<U>.GetEnumerator()""
-IL_024a:  stfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_0256:  ldarg.0
-IL_0257:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_027a:  stloc.0
-IL_027b:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_0281:  ldloc.1
-IL_0282:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_0287:  ldarg.0
-IL_0288:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
-IL_029a:  ldarg.0
-IL_029b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_02a1:  ldarg.0
-IL_02a2:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_02b0:  stloc.0
-IL_02b1:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_02c6:  ldarg.0
-IL_02c7:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_02d9:  ldarg.0
-IL_02da:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_02e1:  ldarg.0
-IL_02e2:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_02ee:  ldnull
-IL_02ef:  stfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_02fa:  callvirt   ""System.Collections.Generic.IEnumerator<U> System.Collections.Generic.IEnumerable<U>.GetEnumerator()""
-IL_02ff:  stfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_030b:  ldarg.0
-IL_030c:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_032f:  stloc.0
-IL_0330:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_0336:  ldloc.1
-IL_0337:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_033c:  ldarg.0
-IL_033d:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
-IL_034f:  ldarg.0
-IL_0350:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_0356:  ldarg.0
-IL_0357:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
-IL_0365:  stloc.0
-IL_0366:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_037b:  ldarg.0
-IL_037c:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_038e:  ldarg.0
-IL_038f:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_0396:  ldarg.0
-IL_0397:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_03a3:  ldnull
-IL_03a4:  stfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
-IL_03ad:  ldc.i4.s   -2
-IL_03af:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_03b4:  ldarg.0
-IL_03b5:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
-IL_03c3:  ldc.i4.s   -2
-IL_03c5:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
-IL_03ca:  ldarg.0
-IL_03cb:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
+IL_00c7:  ldnull
+IL_00c8:  stfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_00d3:  callvirt   ""System.Collections.Generic.IEnumerator<S> System.Collections.Generic.IEnumerable<S>.GetEnumerator()""
+IL_00d8:  stfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
+IL_00e4:  ldarg.0
+IL_00e5:  ldfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
+IL_0108:  stloc.0
+IL_0109:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_010f:  ldloc.1
+IL_0110:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_0115:  ldarg.0
+IL_0116:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
+IL_0128:  ldarg.0
+IL_0129:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_012f:  ldarg.0
+IL_0130:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_013e:  stloc.0
+IL_013f:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_014c:  ldarg.0
+IL_014d:  ldfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
+IL_015f:  ldarg.0
+IL_0160:  ldfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
+IL_0167:  ldarg.0
+IL_0168:  ldfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
+IL_0174:  ldnull
+IL_0175:  stfld      ""System.Collections.Generic.IEnumerator<S> Test<U>.<M>d__2<S, T>.<>7__wrap2""
+IL_0180:  callvirt   ""System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator()""
+IL_0185:  stfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_0191:  ldarg.0
+IL_0192:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_01b5:  stloc.0
+IL_01b6:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_01bc:  ldloc.1
+IL_01bd:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_01c2:  ldarg.0
+IL_01c3:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
+IL_01d5:  ldarg.0
+IL_01d6:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_01dc:  ldarg.0
+IL_01dd:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_01eb:  stloc.0
+IL_01ec:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_01f9:  ldarg.0
+IL_01fa:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_020c:  ldarg.0
+IL_020d:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_0214:  ldarg.0
+IL_0215:  ldfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_0221:  ldnull
+IL_0222:  stfld      ""System.Collections.Generic.IEnumerator<T> Test<U>.<M>d__2<S, T>.<>7__wrap1""
+IL_022d:  callvirt   ""System.Collections.Generic.IEnumerator<U> System.Collections.Generic.IEnumerable<U>.GetEnumerator()""
+IL_0232:  stfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_023e:  ldarg.0
+IL_023f:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_0262:  stloc.0
+IL_0263:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_0269:  ldloc.1
+IL_026a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_026f:  ldarg.0
+IL_0270:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
+IL_0282:  ldarg.0
+IL_0283:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_0289:  ldarg.0
+IL_028a:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_0298:  stloc.0
+IL_0299:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_02a6:  ldarg.0
+IL_02a7:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_02b9:  ldarg.0
+IL_02ba:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_02c1:  ldarg.0
+IL_02c2:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_02ce:  ldnull
+IL_02cf:  stfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_02da:  callvirt   ""System.Collections.Generic.IEnumerator<U> System.Collections.Generic.IEnumerable<U>.GetEnumerator()""
+IL_02df:  stfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_02eb:  ldarg.0
+IL_02ec:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_030f:  stloc.0
+IL_0310:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_0316:  ldloc.1
+IL_0317:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_031c:  ldarg.0
+IL_031d:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
+IL_032c:  ldarg.0
+IL_032d:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_0333:  ldarg.0
+IL_0334:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test<U>.<M>d__2<S, T>.<>u__1""
+IL_0342:  stloc.0
+IL_0343:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_0350:  ldarg.0
+IL_0351:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_0363:  ldarg.0
+IL_0364:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_036b:  ldarg.0
+IL_036c:  ldfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_0378:  ldnull
+IL_0379:  stfld      ""System.Collections.Generic.IEnumerator<U> Test<U>.<M>d__2<S, T>.<>7__wrap3""
+IL_0382:  ldc.i4.s   -2
+IL_0384:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_0389:  ldarg.0
+IL_038a:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
+IL_0398:  ldc.i4.s   -2
+IL_039a:  stfld      ""int Test<U>.<M>d__2<S, T>.<>1__state""
+IL_039f:  ldarg.0
+IL_03a0:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test<U>.<M>d__2<S, T>.<>t__builder""
 ", actual);
         }
 
@@ -1175,46 +1163,46 @@ IL_0072:  ldarg.0
 IL_0073:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<M>d__3.<>u__1""
 IL_0081:  stloc.0
 IL_0082:  stfld      ""int Test.<M>d__3.<>1__state""
-IL_0097:  ldarg.0
-IL_0098:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
+IL_008f:  ldarg.0
+IL_0090:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
+IL_00a2:  ldarg.0
+IL_00a3:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
 IL_00aa:  ldarg.0
 IL_00ab:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_00b2:  ldarg.0
-IL_00b3:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_00bf:  ldnull
-IL_00c0:  stfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_00cb:  callvirt   ""System.Collections.Generic.IEnumerator<object> System.Collections.Generic.IEnumerable<object>.GetEnumerator()""
-IL_00d0:  stfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_00dc:  ldarg.0
-IL_00dd:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_0100:  stloc.0
-IL_0101:  stfld      ""int Test.<M>d__3.<>1__state""
-IL_0107:  ldloc.1
-IL_0108:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<M>d__3.<>u__1""
-IL_010d:  ldarg.0
-IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<M>d__3.<>t__builder""
-IL_0120:  ldarg.0
-IL_0121:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<M>d__3.<>u__1""
-IL_0127:  ldarg.0
-IL_0128:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<M>d__3.<>u__1""
-IL_0136:  stloc.0
-IL_0137:  stfld      ""int Test.<M>d__3.<>1__state""
+IL_00b7:  ldnull
+IL_00b8:  stfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
+IL_00c3:  callvirt   ""System.Collections.Generic.IEnumerator<object> System.Collections.Generic.IEnumerable<object>.GetEnumerator()""
+IL_00c8:  stfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
+IL_00d4:  ldarg.0
+IL_00d5:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
+IL_00f8:  stloc.0
+IL_00f9:  stfld      ""int Test.<M>d__3.<>1__state""
+IL_00ff:  ldloc.1
+IL_0100:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<M>d__3.<>u__1""
+IL_0105:  ldarg.0
+IL_0106:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<M>d__3.<>t__builder""
+IL_0115:  ldarg.0
+IL_0116:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<M>d__3.<>u__1""
+IL_011c:  ldarg.0
+IL_011d:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<M>d__3.<>u__1""
+IL_012b:  stloc.0
+IL_012c:  stfld      ""int Test.<M>d__3.<>1__state""
+IL_0139:  ldarg.0
+IL_013a:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
 IL_014c:  ldarg.0
 IL_014d:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_015f:  ldarg.0
-IL_0160:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_0167:  ldarg.0
-IL_0168:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_0174:  ldnull
-IL_0175:  stfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
-IL_017e:  ldc.i4.s   -2
-IL_0180:  stfld      ""int Test.<M>d__3.<>1__state""
-IL_0185:  ldarg.0
-IL_0186:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<M>d__3.<>t__builder""
-IL_0194:  ldc.i4.s   -2
-IL_0196:  stfld      ""int Test.<M>d__3.<>1__state""
-IL_019b:  ldarg.0
-IL_019c:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<M>d__3.<>t__builder""
+IL_0154:  ldarg.0
+IL_0155:  ldfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
+IL_0161:  ldnull
+IL_0162:  stfld      ""System.Collections.Generic.IEnumerator<dynamic> Test.<M>d__3.<>7__wrap1""
+IL_016b:  ldc.i4.s   -2
+IL_016d:  stfld      ""int Test.<M>d__3.<>1__state""
+IL_0172:  ldarg.0
+IL_0173:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<M>d__3.<>t__builder""
+IL_0181:  ldc.i4.s   -2
+IL_0183:  stfld      ""int Test.<M>d__3.<>1__state""
+IL_0188:  ldarg.0
+IL_0189:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<M>d__3.<>t__builder""
 ", actual);
         }
 
@@ -1304,8 +1292,9 @@ class C
 }";
             var verifier = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput: @"1");
             verifier.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"{
-  // Code size      207 (0xcf)
+@"
+{
+  // Code size      199 (0xc7)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1367,7 +1356,7 @@ class C
     IL_0062:  ldloca.s   V_4
     IL_0064:  ldarg.0
     IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__0)""
-    IL_006a:  leave.s    IL_00ce
+    IL_006a:  leave.s    IL_00c6
     IL_006c:  ldarg.0
     IL_006d:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
     IL_0072:  stloc.s    V_4
@@ -1381,38 +1370,37 @@ class C
     IL_0084:  stfld      ""int C.<F>d__0.<>1__state""
     IL_0089:  ldloca.s   V_4
     IL_008b:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0090:  ldloca.s   V_4
-    IL_0092:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0098:  ldarg.0
-    IL_0099:  ldfld      ""int C.<F>d__0.<i>5__1""
-    IL_009e:  stloc.1
-    IL_009f:  leave.s    IL_00ba
+    IL_0090:  ldarg.0
+    IL_0091:  ldfld      ""int C.<F>d__0.<i>5__1""
+    IL_0096:  stloc.1
+    IL_0097:  leave.s    IL_00b2
   }
   catch System.Exception
   {
-    IL_00a1:  stloc.s    V_6
+    IL_0099:  stloc.s    V_6
+    IL_009b:  ldarg.0
+    IL_009c:  ldc.i4.s   -2
+    IL_009e:  stfld      ""int C.<F>d__0.<>1__state""
     IL_00a3:  ldarg.0
-    IL_00a4:  ldc.i4.s   -2
-    IL_00a6:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00ab:  ldarg.0
-    IL_00ac:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_00b1:  ldloc.s    V_6
-    IL_00b3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00b8:  leave.s    IL_00ce
+    IL_00a4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_00a9:  ldloc.s    V_6
+    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00b0:  leave.s    IL_00c6
   }
+  IL_00b2:  ldarg.0
+  IL_00b3:  ldc.i4.s   -2
+  IL_00b5:  stfld      ""int C.<F>d__0.<>1__state""
   IL_00ba:  ldarg.0
-  IL_00bb:  ldc.i4.s   -2
-  IL_00bd:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00c2:  ldarg.0
-  IL_00c3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00c8:  ldloc.1
-  IL_00c9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00ce:  ret
+  IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00c0:  ldloc.1
+  IL_00c1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00c6:  ret
 }");
             verifier = CompileAndVerify(text, options: TestOptions.UnsafeDebugExe, expectedOutput: @"1");
             verifier.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
-@"{
-  // Code size      224 (0xe0)
+@"
+{
+  // Code size      216 (0xd8)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1485,7 +1473,7 @@ class C
     IL_0070:  ldloca.s   V_6
     IL_0072:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__0)""
     IL_0077:  nop
-    IL_0078:  leave.s    IL_00df
+    IL_0078:  leave.s    IL_00d7
     IL_007a:  ldarg.0
     IL_007b:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
     IL_0080:  stloc.s    V_4
@@ -1500,35 +1488,33 @@ class C
     IL_0097:  ldloca.s   V_4
     IL_0099:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
     IL_009e:  nop
-    IL_009f:  ldloca.s   V_4
-    IL_00a1:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_00a7:  ldarg.0
-    IL_00a8:  ldfld      ""int C.<F>d__0.<i>5__1""
-    IL_00ad:  stloc.1
-    IL_00ae:  leave.s    IL_00ca
+    IL_009f:  ldarg.0
+    IL_00a0:  ldfld      ""int C.<F>d__0.<i>5__1""
+    IL_00a5:  stloc.1
+    IL_00a6:  leave.s    IL_00c2
   }
   catch System.Exception
   {
-    IL_00b0:  stloc.s    V_7
+    IL_00a8:  stloc.s    V_7
+    IL_00aa:  ldarg.0
+    IL_00ab:  ldc.i4.s   -2
+    IL_00ad:  stfld      ""int C.<F>d__0.<>1__state""
     IL_00b2:  ldarg.0
-    IL_00b3:  ldc.i4.s   -2
-    IL_00b5:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00ba:  ldarg.0
-    IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_00c0:  ldloc.s    V_7
-    IL_00c2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00c7:  nop
-    IL_00c8:  leave.s    IL_00df
+    IL_00b3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_00b8:  ldloc.s    V_7
+    IL_00ba:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00bf:  nop
+    IL_00c0:  leave.s    IL_00d7
   }
+  IL_00c2:  ldarg.0
+  IL_00c3:  ldc.i4.s   -2
+  IL_00c5:  stfld      ""int C.<F>d__0.<>1__state""
   IL_00ca:  ldarg.0
-  IL_00cb:  ldc.i4.s   -2
-  IL_00cd:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00d2:  ldarg.0
-  IL_00d3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00d8:  ldloc.1
-  IL_00d9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00de:  nop
-  IL_00df:  ret
+  IL_00cb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00d0:  ldloc.1
+  IL_00d1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00d6:  nop
+  IL_00d7:  ret
 }");
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -599,7 +599,7 @@ public class Test
 
             v.VerifyIL("Test.<F>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      300 (0x12c)
+  // Code size      290 (0x122)
   .maxstack  5
   .locals init (int V_0,
                 int V_1,
@@ -671,7 +671,7 @@ public class Test
     IL_007f:  ldloca.s   V_5
     IL_0081:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__2)""
     IL_0086:  nop
-    IL_0087:  leave      IL_012b
+    IL_0087:  leave      IL_0121
    >IL_008c:  ldarg.0
     IL_008d:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
     IL_0092:  stloc.s    V_4
@@ -683,64 +683,60 @@ public class Test
     IL_00a2:  dup
     IL_00a3:  stloc.0
     IL_00a4:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_00a9:  ldloca.s   V_4
-    IL_00ab:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00b0:  stloc.3
-    IL_00b1:  ldloca.s   V_4
-    IL_00b3:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00b9:  ldarg.0
-    IL_00ba:  ldloc.3
-    IL_00bb:  stfld      ""int Test.<F>d__2.<>s__3""
-    IL_00c0:  ldarg.0
-    IL_00c1:  ldarg.0
-    IL_00c2:  ldfld      ""int[] Test.<F>d__2.<>s__5""
-    IL_00c7:  ldc.i4.3
-    IL_00c8:  ldarg.0
-    IL_00c9:  ldfld      ""int Test.<F>d__2.<>s__2""
-    IL_00ce:  ldarg.0
-    IL_00cf:  ldfld      ""int Test.<F>d__2.<>s__3""
-    IL_00d4:  add
-    IL_00d5:  dup
-    IL_00d6:  stloc.3
-    IL_00d7:  stelem.i4
-    IL_00d8:  ldloc.3
-    IL_00d9:  stfld      ""int Test.<F>d__2.<>s__4""
-    IL_00de:  ldarg.0
-    IL_00df:  ldfld      ""int Test.<F>d__2.<>s__1""
-    IL_00e4:  ldarg.0
-    IL_00e5:  ldfld      ""int Test.<F>d__2.<>s__4""
-    IL_00ea:  ldc.i4.4
-    IL_00eb:  call       ""int Test.H(int, int, int)""
-    IL_00f0:  pop
-    IL_00f1:  ldarg.0
-    IL_00f2:  ldnull
-    IL_00f3:  stfld      ""int[] Test.<F>d__2.<>s__5""
-   -IL_00f8:  ldc.i4.1
-    IL_00f9:  stloc.1
-    IL_00fa:  leave.s    IL_0116
+    IL_00a9:  ldarg.0
+    IL_00aa:  ldloca.s   V_4
+    IL_00ac:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00b1:  stfld      ""int Test.<F>d__2.<>s__3""
+    IL_00b6:  ldarg.0
+    IL_00b7:  ldarg.0
+    IL_00b8:  ldfld      ""int[] Test.<F>d__2.<>s__5""
+    IL_00bd:  ldc.i4.3
+    IL_00be:  ldarg.0
+    IL_00bf:  ldfld      ""int Test.<F>d__2.<>s__2""
+    IL_00c4:  ldarg.0
+    IL_00c5:  ldfld      ""int Test.<F>d__2.<>s__3""
+    IL_00ca:  add
+    IL_00cb:  dup
+    IL_00cc:  stloc.3
+    IL_00cd:  stelem.i4
+    IL_00ce:  ldloc.3
+    IL_00cf:  stfld      ""int Test.<F>d__2.<>s__4""
+    IL_00d4:  ldarg.0
+    IL_00d5:  ldfld      ""int Test.<F>d__2.<>s__1""
+    IL_00da:  ldarg.0
+    IL_00db:  ldfld      ""int Test.<F>d__2.<>s__4""
+    IL_00e0:  ldc.i4.4
+    IL_00e1:  call       ""int Test.H(int, int, int)""
+    IL_00e6:  pop
+    IL_00e7:  ldarg.0
+    IL_00e8:  ldnull
+    IL_00e9:  stfld      ""int[] Test.<F>d__2.<>s__5""
+   -IL_00ee:  ldc.i4.1
+    IL_00ef:  stloc.1
+    IL_00f0:  leave.s    IL_010c
   }
   catch System.Exception
   {
-   ~IL_00fc:  stloc.s    V_6
-    IL_00fe:  ldarg.0
-    IL_00ff:  ldc.i4.s   -2
-    IL_0101:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_0106:  ldarg.0
-    IL_0107:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-    IL_010c:  ldloc.s    V_6
-    IL_010e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0113:  nop
-    IL_0114:  leave.s    IL_012b
+   ~IL_00f2:  stloc.s    V_6
+    IL_00f4:  ldarg.0
+    IL_00f5:  ldc.i4.s   -2
+    IL_00f7:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_00fc:  ldarg.0
+    IL_00fd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+    IL_0102:  ldloc.s    V_6
+    IL_0104:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0109:  nop
+    IL_010a:  leave.s    IL_0121
   }
- -IL_0116:  ldarg.0
-  IL_0117:  ldc.i4.s   -2
-  IL_0119:  stfld      ""int Test.<F>d__2.<>1__state""
- ~IL_011e:  ldarg.0
-  IL_011f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-  IL_0124:  ldloc.1
-  IL_0125:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_012a:  nop
-  IL_012b:  ret
+ -IL_010c:  ldarg.0
+  IL_010d:  ldc.i4.s   -2
+  IL_010f:  stfld      ""int Test.<F>d__2.<>1__state""
+ ~IL_0114:  ldarg.0
+  IL_0115:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+  IL_011a:  ldloc.1
+  IL_011b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_0120:  nop
+  IL_0121:  ret
 }", sequencePoints: "Test+<F>d__2.MoveNext");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -2013,7 +2013,7 @@ class Test
 
             c.VerifyIL("Test.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      188 (0xbc)
+  // Code size      180 (0xb4)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -2055,7 +2055,7 @@ class Test
     IL_0058:  ldloca.s   V_2
     IL_005a:  ldarg.0
     IL_005b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__0)""
-    IL_0060:  leave.s    IL_00bb
+    IL_0060:  leave.s    IL_00b3
     IL_0062:  ldarg.0
     IL_0063:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
     IL_0068:  stloc.2
@@ -2069,31 +2069,29 @@ class Test
     IL_0079:  stfld      ""int Test.<F>d__0.<>1__state""
     IL_007e:  ldloca.s   V_2
     IL_0080:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_008d:  stloc.1
-    IL_008e:  leave.s    IL_00a7
+    IL_0085:  stloc.1
+    IL_0086:  leave.s    IL_009f
   }
   catch System.Exception
   {
-    IL_0090:  stloc.3
+    IL_0088:  stloc.3
+    IL_0089:  ldarg.0
+    IL_008a:  ldc.i4.s   -2
+    IL_008c:  stfld      ""int Test.<F>d__0.<>1__state""
     IL_0091:  ldarg.0
-    IL_0092:  ldc.i4.s   -2
-    IL_0094:  stfld      ""int Test.<F>d__0.<>1__state""
-    IL_0099:  ldarg.0
-    IL_009a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-    IL_009f:  ldloc.3
-    IL_00a0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00a5:  leave.s    IL_00bb
+    IL_0092:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+    IL_0097:  ldloc.3
+    IL_0098:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_009d:  leave.s    IL_00b3
   }
+  IL_009f:  ldarg.0
+  IL_00a0:  ldc.i4.s   -2
+  IL_00a2:  stfld      ""int Test.<F>d__0.<>1__state""
   IL_00a7:  ldarg.0
-  IL_00a8:  ldc.i4.s   -2
-  IL_00aa:  stfld      ""int Test.<F>d__0.<>1__state""
-  IL_00af:  ldarg.0
-  IL_00b0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_00b5:  ldloc.1
-  IL_00b6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00bb:  ret
+  IL_00a8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_00ad:  ldloc.1
+  IL_00ae:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00b3:  ret
 }
 ");
 
@@ -2163,14 +2161,13 @@ class Test
 
             c.VerifyIL("Test.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      196 (0xc4)
+  // Code size      184 (0xb8)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
                 int V_2,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                int V_4,
-                System.Exception V_5)
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Test.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -2207,7 +2204,7 @@ class Test
     IL_0058:  ldloca.s   V_3
     IL_005a:  ldarg.0
     IL_005b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__0)""
-    IL_0060:  leave.s    IL_00c3
+    IL_0060:  leave.s    IL_00b7
     IL_0062:  ldarg.0
     IL_0063:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
     IL_0068:  stloc.3
@@ -2221,35 +2218,31 @@ class Test
     IL_0079:  stfld      ""int Test.<F>d__0.<>1__state""
     IL_007e:  ldloca.s   V_3
     IL_0080:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0085:  stloc.s    V_4
-    IL_0087:  ldloca.s   V_3
-    IL_0089:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_008f:  ldloc.s    V_4
-    IL_0091:  stloc.2
-    IL_0092:  ldloc.2
-    IL_0093:  stloc.1
-    IL_0094:  leave.s    IL_00af
+    IL_0085:  stloc.2
+    IL_0086:  ldloc.2
+    IL_0087:  stloc.1
+    IL_0088:  leave.s    IL_00a3
   }
   catch System.Exception
   {
-    IL_0096:  stloc.s    V_5
-    IL_0098:  ldarg.0
-    IL_0099:  ldc.i4.s   -2
-    IL_009b:  stfld      ""int Test.<F>d__0.<>1__state""
-    IL_00a0:  ldarg.0
-    IL_00a1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-    IL_00a6:  ldloc.s    V_5
-    IL_00a8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00ad:  leave.s    IL_00c3
+    IL_008a:  stloc.s    V_4
+    IL_008c:  ldarg.0
+    IL_008d:  ldc.i4.s   -2
+    IL_008f:  stfld      ""int Test.<F>d__0.<>1__state""
+    IL_0094:  ldarg.0
+    IL_0095:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+    IL_009a:  ldloc.s    V_4
+    IL_009c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00a1:  leave.s    IL_00b7
   }
-  IL_00af:  ldarg.0
-  IL_00b0:  ldc.i4.s   -2
-  IL_00b2:  stfld      ""int Test.<F>d__0.<>1__state""
-  IL_00b7:  ldarg.0
-  IL_00b8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_00bd:  ldloc.1
-  IL_00be:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00c3:  ret
+  IL_00a3:  ldarg.0
+  IL_00a4:  ldc.i4.s   -2
+  IL_00a6:  stfld      ""int Test.<F>d__0.<>1__state""
+  IL_00ab:  ldarg.0
+  IL_00ac:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_00b1:  ldloc.1
+  IL_00b2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00b7:  ret
 }
 ");
 
@@ -2322,14 +2315,13 @@ class Test
 
             c.VerifyIL("Test.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      216 (0xd8)
+  // Code size      205 (0xcd)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                int V_3,
-                Test.<F>d__0 V_4,
-                System.Exception V_5)
+                Test.<F>d__0 V_3,
+                System.Exception V_4)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Test.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -2338,7 +2330,7 @@ class Test
    ~IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_006c
+    IL_000c:  br.s       IL_006b
    -IL_000e:  nop
    -IL_000f:  call       ""System.Threading.Tasks.TaskFactory System.Threading.Tasks.Task.Factory.get""
     IL_0014:  ldsfld     ""System.Func<int> Test.<>c.<>9__0_0""
@@ -2355,7 +2347,7 @@ class Test
     IL_003d:  stloc.2
    ~IL_003e:  ldloca.s   V_2
     IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0045:  brtrue.s   IL_0088
+    IL_0045:  brtrue.s   IL_0087
     IL_0047:  ldarg.0
     IL_0048:  ldc.i4.0
     IL_0049:  dup
@@ -2365,60 +2357,56 @@ class Test
     IL_0051:  ldloc.2
     IL_0052:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
     IL_0057:  ldarg.0
-    IL_0058:  stloc.s    V_4
-    IL_005a:  ldarg.0
-    IL_005b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-    IL_0060:  ldloca.s   V_2
-    IL_0062:  ldloca.s   V_4
-    IL_0064:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__0)""
-    IL_0069:  nop
-    IL_006a:  leave.s    IL_00d7
-   >IL_006c:  ldarg.0
-    IL_006d:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
-    IL_0072:  stloc.2
-    IL_0073:  ldarg.0
-    IL_0074:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
-    IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007f:  ldarg.0
-    IL_0080:  ldc.i4.m1
-    IL_0081:  dup
-    IL_0082:  stloc.0
-    IL_0083:  stfld      ""int Test.<F>d__0.<>1__state""
+    IL_0058:  stloc.3
+    IL_0059:  ldarg.0
+    IL_005a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+    IL_005f:  ldloca.s   V_2
+    IL_0061:  ldloca.s   V_3
+    IL_0063:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__0)""
+    IL_0068:  nop
+    IL_0069:  leave.s    IL_00cc
+   >IL_006b:  ldarg.0
+    IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
+    IL_0071:  stloc.2
+    IL_0072:  ldarg.0
+    IL_0073:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
+    IL_0078:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007e:  ldarg.0
+    IL_007f:  ldc.i4.m1
+    IL_0080:  dup
+    IL_0081:  stloc.0
+    IL_0082:  stfld      ""int Test.<F>d__0.<>1__state""
+    IL_0087:  ldarg.0
     IL_0088:  ldloca.s   V_2
     IL_008a:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008f:  stloc.3
-    IL_0090:  ldloca.s   V_2
-    IL_0092:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0098:  ldarg.0
-    IL_0099:  ldloc.3
-    IL_009a:  stfld      ""int Test.<F>d__0.<>s__1""
-    IL_009f:  ldarg.0
-    IL_00a0:  ldfld      ""int Test.<F>d__0.<>s__1""
-    IL_00a5:  stloc.1
-    IL_00a6:  leave.s    IL_00c2
+    IL_008f:  stfld      ""int Test.<F>d__0.<>s__1""
+    IL_0094:  ldarg.0
+    IL_0095:  ldfld      ""int Test.<F>d__0.<>s__1""
+    IL_009a:  stloc.1
+    IL_009b:  leave.s    IL_00b7
   }
   catch System.Exception
   {
-   ~IL_00a8:  stloc.s    V_5
-    IL_00aa:  ldarg.0
-    IL_00ab:  ldc.i4.s   -2
-    IL_00ad:  stfld      ""int Test.<F>d__0.<>1__state""
-    IL_00b2:  ldarg.0
-    IL_00b3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-    IL_00b8:  ldloc.s    V_5
-    IL_00ba:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00bf:  nop
-    IL_00c0:  leave.s    IL_00d7
+   ~IL_009d:  stloc.s    V_4
+    IL_009f:  ldarg.0
+    IL_00a0:  ldc.i4.s   -2
+    IL_00a2:  stfld      ""int Test.<F>d__0.<>1__state""
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+    IL_00ad:  ldloc.s    V_4
+    IL_00af:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00b4:  nop
+    IL_00b5:  leave.s    IL_00cc
   }
- -IL_00c2:  ldarg.0
-  IL_00c3:  ldc.i4.s   -2
-  IL_00c5:  stfld      ""int Test.<F>d__0.<>1__state""
- ~IL_00ca:  ldarg.0
-  IL_00cb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
-  IL_00d0:  ldloc.1
-  IL_00d1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00d6:  nop
-  IL_00d7:  ret
+ -IL_00b7:  ldarg.0
+  IL_00b8:  ldc.i4.s   -2
+  IL_00ba:  stfld      ""int Test.<F>d__0.<>1__state""
+ ~IL_00bf:  ldarg.0
+  IL_00c0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__0.<>t__builder""
+  IL_00c5:  ldloc.1
+  IL_00c6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00cb:  nop
+  IL_00cc:  ret
 }
 ", sequencePoints: "Test+<F>d__0.MoveNext");
 
@@ -2483,7 +2471,7 @@ class Test
 ");
             c.VerifyIL("Test.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      194 (0xc2)
+  // Code size      186 (0xba)
   .maxstack  3
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_1,
@@ -2524,7 +2512,7 @@ class Test
     IL_0058:  ldloca.s   V_1
     IL_005a:  ldarg.0
     IL_005b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__0)""
-    IL_0060:  leave.s    IL_00c1
+    IL_0060:  leave.s    IL_00b9
     IL_0062:  ldarg.0
     IL_0063:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__0.<>u__1""
     IL_0068:  stloc.1
@@ -2539,31 +2527,29 @@ class Test
     IL_007e:  ldloca.s   V_1
     IL_0080:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0085:  pop
-    IL_0086:  ldloca.s   V_1
-    IL_0088:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_008e:  ldc.i4.s   42
-    IL_0090:  call       ""void System.Console.WriteLine(int)""
-    IL_0095:  leave.s    IL_00ae
+    IL_0086:  ldc.i4.s   42
+    IL_0088:  call       ""void System.Console.WriteLine(int)""
+    IL_008d:  leave.s    IL_00a6
   }
   catch System.Exception
   {
-    IL_0097:  stloc.2
+    IL_008f:  stloc.2
+    IL_0090:  ldarg.0
+    IL_0091:  ldc.i4.s   -2
+    IL_0093:  stfld      ""int Test.<F>d__0.<>1__state""
     IL_0098:  ldarg.0
-    IL_0099:  ldc.i4.s   -2
-    IL_009b:  stfld      ""int Test.<F>d__0.<>1__state""
-    IL_00a0:  ldarg.0
-    IL_00a1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
-    IL_00a6:  ldloc.2
-    IL_00a7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00ac:  leave.s    IL_00c1
+    IL_0099:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
+    IL_009e:  ldloc.2
+    IL_009f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00a4:  leave.s    IL_00b9
   }
+  IL_00a6:  ldarg.0
+  IL_00a7:  ldc.i4.s   -2
+  IL_00a9:  stfld      ""int Test.<F>d__0.<>1__state""
   IL_00ae:  ldarg.0
-  IL_00af:  ldc.i4.s   -2
-  IL_00b1:  stfld      ""int Test.<F>d__0.<>1__state""
-  IL_00b6:  ldarg.0
-  IL_00b7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
-  IL_00bc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_00c1:  ret
+  IL_00af:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Test.<F>d__0.<>t__builder""
+  IL_00b4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_00b9:  ret
 }
 ");
         }
@@ -2622,7 +2608,7 @@ class Test
 }
 ").VerifyIL("Test.<F>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      198 (0xc6)
+  // Code size      190 (0xbe)
   .maxstack  3
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter V_1,
@@ -2663,7 +2649,7 @@ class Test
     IL_0058:  ldloca.s   V_1
     IL_005a:  ldarg.0
     IL_005b:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, Test.<F>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter, ref Test.<F>d__1)""
-    IL_0060:  leave.s    IL_00c5
+    IL_0060:  leave.s    IL_00bd
     IL_0062:  ldarg.0
     IL_0063:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter Test.<F>d__1.<>u__1""
     IL_0068:  stloc.1
@@ -2677,33 +2663,31 @@ class Test
     IL_0079:  stfld      ""int Test.<F>d__1.<>1__state""
     IL_007e:  ldloca.s   V_1
     IL_0080:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
-    IL_0085:  ldloca.s   V_1
-    IL_0087:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_008d:  ldarg.0
-    IL_008e:  ldfld      ""System.Threading.AutoResetEvent Test.<F>d__1.handle""
-    IL_0093:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
-    IL_0098:  pop
-    IL_0099:  leave.s    IL_00b2
+    IL_0085:  ldarg.0
+    IL_0086:  ldfld      ""System.Threading.AutoResetEvent Test.<F>d__1.handle""
+    IL_008b:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
+    IL_0090:  pop
+    IL_0091:  leave.s    IL_00aa
   }
   catch System.Exception
   {
-    IL_009b:  stloc.2
+    IL_0093:  stloc.2
+    IL_0094:  ldarg.0
+    IL_0095:  ldc.i4.s   -2
+    IL_0097:  stfld      ""int Test.<F>d__1.<>1__state""
     IL_009c:  ldarg.0
-    IL_009d:  ldc.i4.s   -2
-    IL_009f:  stfld      ""int Test.<F>d__1.<>1__state""
-    IL_00a4:  ldarg.0
-    IL_00a5:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<F>d__1.<>t__builder""
-    IL_00aa:  ldloc.2
-    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
-    IL_00b0:  leave.s    IL_00c5
+    IL_009d:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<F>d__1.<>t__builder""
+    IL_00a2:  ldloc.2
+    IL_00a3:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
+    IL_00a8:  leave.s    IL_00bd
   }
+  IL_00aa:  ldarg.0
+  IL_00ab:  ldc.i4.s   -2
+  IL_00ad:  stfld      ""int Test.<F>d__1.<>1__state""
   IL_00b2:  ldarg.0
-  IL_00b3:  ldc.i4.s   -2
-  IL_00b5:  stfld      ""int Test.<F>d__1.<>1__state""
-  IL_00ba:  ldarg.0
-  IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<F>d__1.<>t__builder""
-  IL_00c0:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
-  IL_00c5:  ret
+  IL_00b3:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder Test.<F>d__1.<>t__builder""
+  IL_00b8:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
+  IL_00bd:  ret
 }
 ");
         }
@@ -4070,14 +4054,13 @@ class Test
 
             v.VerifyIL("Test.<F>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      235 (0xeb)
+  // Code size      224 (0xe0)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                int V_3,
-                Test.<F>d__2 V_4,
-                System.Exception V_5)
+                Test.<F>d__2 V_3,
+                System.Exception V_4)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Test.<F>d__2.<>1__state""
   IL_0006:  stloc.0
@@ -4086,7 +4069,7 @@ class Test
    ~IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_006e
+    IL_000c:  br.s       IL_006d
    -IL_000e:  nop
    -IL_000f:  ldarg.0
     IL_0010:  ldc.i4.s   10
@@ -4106,7 +4089,7 @@ class Test
     IL_003f:  stloc.2
    ~IL_0040:  ldloca.s   V_2
     IL_0042:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0047:  brtrue.s   IL_008a
+    IL_0047:  brtrue.s   IL_0089
     IL_0049:  ldarg.0
     IL_004a:  ldc.i4.0
     IL_004b:  dup
@@ -4116,65 +4099,61 @@ class Test
     IL_0053:  ldloc.2
     IL_0054:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
     IL_0059:  ldarg.0
-    IL_005a:  stloc.s    V_4
-    IL_005c:  ldarg.0
-    IL_005d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-    IL_0062:  ldloca.s   V_2
-    IL_0064:  ldloca.s   V_4
-    IL_0066:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__2)""
-    IL_006b:  nop
-    IL_006c:  leave.s    IL_00ea
-   >IL_006e:  ldarg.0
-    IL_006f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_0074:  stloc.2
-    IL_0075:  ldarg.0
-    IL_0076:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
-    IL_007b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0081:  ldarg.0
-    IL_0082:  ldc.i4.m1
-    IL_0083:  dup
-    IL_0084:  stloc.0
-    IL_0085:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_005a:  stloc.3
+    IL_005b:  ldarg.0
+    IL_005c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+    IL_0061:  ldloca.s   V_2
+    IL_0063:  ldloca.s   V_3
+    IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Test.<F>d__2>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Test.<F>d__2)""
+    IL_006a:  nop
+    IL_006b:  leave.s    IL_00df
+   >IL_006d:  ldarg.0
+    IL_006e:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_0073:  stloc.2
+    IL_0074:  ldarg.0
+    IL_0075:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Test.<F>d__2.<>u__1""
+    IL_007a:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0080:  ldarg.0
+    IL_0081:  ldc.i4.m1
+    IL_0082:  dup
+    IL_0083:  stloc.0
+    IL_0084:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_0089:  ldarg.0
     IL_008a:  ldloca.s   V_2
     IL_008c:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0091:  stloc.3
-    IL_0092:  ldloca.s   V_2
-    IL_0094:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_009a:  ldarg.0
-    IL_009b:  ldloc.3
-    IL_009c:  stfld      ""int Test.<F>d__2.<>s__2""
-    IL_00a1:  ldarg.0
-    IL_00a2:  ldfld      ""S[] Test.<F>d__2.<>s__3""
-    IL_00a7:  ldc.i4.1
-    IL_00a8:  ldelema    ""S""
-    IL_00ad:  ldarg.0
-    IL_00ae:  ldfld      ""int Test.<F>d__2.<>s__2""
-    IL_00b3:  call       ""int S.Mutate(int)""
-    IL_00b8:  stloc.1
-    IL_00b9:  leave.s    IL_00d5
+    IL_0091:  stfld      ""int Test.<F>d__2.<>s__2""
+    IL_0096:  ldarg.0
+    IL_0097:  ldfld      ""S[] Test.<F>d__2.<>s__3""
+    IL_009c:  ldc.i4.1
+    IL_009d:  ldelema    ""S""
+    IL_00a2:  ldarg.0
+    IL_00a3:  ldfld      ""int Test.<F>d__2.<>s__2""
+    IL_00a8:  call       ""int S.Mutate(int)""
+    IL_00ad:  stloc.1
+    IL_00ae:  leave.s    IL_00ca
   }
   catch System.Exception
   {
-   ~IL_00bb:  stloc.s    V_5
-    IL_00bd:  ldarg.0
-    IL_00be:  ldc.i4.s   -2
-    IL_00c0:  stfld      ""int Test.<F>d__2.<>1__state""
-    IL_00c5:  ldarg.0
-    IL_00c6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-    IL_00cb:  ldloc.s    V_5
-    IL_00cd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00d2:  nop
-    IL_00d3:  leave.s    IL_00ea
+   ~IL_00b0:  stloc.s    V_4
+    IL_00b2:  ldarg.0
+    IL_00b3:  ldc.i4.s   -2
+    IL_00b5:  stfld      ""int Test.<F>d__2.<>1__state""
+    IL_00ba:  ldarg.0
+    IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+    IL_00c0:  ldloc.s    V_4
+    IL_00c2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00c7:  nop
+    IL_00c8:  leave.s    IL_00df
   }
- -IL_00d5:  ldarg.0
-  IL_00d6:  ldc.i4.s   -2
-  IL_00d8:  stfld      ""int Test.<F>d__2.<>1__state""
- ~IL_00dd:  ldarg.0
-  IL_00de:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
-  IL_00e3:  ldloc.1
-  IL_00e4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00e9:  nop
-  IL_00ea:  ret
+ -IL_00ca:  ldarg.0
+  IL_00cb:  ldc.i4.s   -2
+  IL_00cd:  stfld      ""int Test.<F>d__2.<>1__state""
+ ~IL_00d2:  ldarg.0
+  IL_00d3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> Test.<F>d__2.<>t__builder""
+  IL_00d8:  ldloc.1
+  IL_00d9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00de:  nop
+  IL_00df:  ret
 }",
             sequencePoints: "Test+<F>d__2.MoveNext");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -14667,7 +14667,7 @@ class C
 
             CompileAndVerifyIL(source, "C.<>c__DisplayClass0_0.<<Main>b__0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      539 (0x21b)
+  // Code size      537 (0x219)
   .maxstack  10
   .locals init (int V_0,
                 C.<>c__DisplayClass0_0 V_1,
@@ -14799,7 +14799,7 @@ class C
     IL_0178:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, C.<>c__DisplayClass0_0.<<Main>b__0>d>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref C.<>c__DisplayClass0_0.<<Main>b__0>d)""
     IL_017d:  ldnull
     IL_017e:  stloc.s    V_4
-    IL_0180:  leave      IL_021a
+    IL_0180:  leave      IL_0218
     IL_0185:  ldarg.0
     IL_0186:  ldfld      ""object C.<>c__DisplayClass0_0.<<Main>b__0>d.<>u__1""
     IL_018b:  stloc.3
@@ -14834,31 +14834,29 @@ class C
     IL_01dd:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
     IL_01e2:  ldloc.3
     IL_01e3:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_01e8:  ldnull
-    IL_01e9:  stloc.3
-    IL_01ea:  stloc.2
-    IL_01eb:  leave.s    IL_0206
+    IL_01e8:  stloc.2
+    IL_01e9:  leave.s    IL_0204
   }
   catch System.Exception
   {
-    IL_01ed:  stloc.s    V_6
-    IL_01ef:  ldarg.0
-    IL_01f0:  ldc.i4.s   -2
-    IL_01f2:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
-    IL_01f7:  ldarg.0
-    IL_01f8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
-    IL_01fd:  ldloc.s    V_6
-    IL_01ff:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
-    IL_0204:  leave.s    IL_021a
+    IL_01eb:  stloc.s    V_6
+    IL_01ed:  ldarg.0
+    IL_01ee:  ldc.i4.s   -2
+    IL_01f0:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
+    IL_01f5:  ldarg.0
+    IL_01f6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
+    IL_01fb:  ldloc.s    V_6
+    IL_01fd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_0202:  leave.s    IL_0218
   }
-  IL_0206:  ldarg.0
-  IL_0207:  ldc.i4.s   -2
-  IL_0209:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
-  IL_020e:  ldarg.0
-  IL_020f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
-  IL_0214:  ldloc.2
-  IL_0215:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
-  IL_021a:  ret
+  IL_0204:  ldarg.0
+  IL_0205:  ldc.i4.s   -2
+  IL_0207:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
+  IL_020c:  ldarg.0
+  IL_020d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
+  IL_0212:  ldloc.2
+  IL_0213:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_0218:  ret
 }");
         }
 
@@ -15038,7 +15036,7 @@ class C
 }";
             CompileAndVerifyIL(source, "C.<M>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      859 (0x35b)
+  // Code size      855 (0x357)
   .maxstack  10
   .locals init (int V_0,
                 object V_1,
@@ -15055,7 +15053,7 @@ class C
     IL_0008:  brfalse    IL_013c
     IL_000d:  ldloc.0
     IL_000e:  ldc.i4.1
-    IL_000f:  beq        IL_02c6
+    IL_000f:  beq        IL_02c4
     IL_0014:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__0""
     IL_0019:  brtrue.s   IL_004b
     IL_001b:  ldc.i4.0
@@ -15148,7 +15146,7 @@ class C
     IL_0130:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, C.<M>d__1>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref C.<M>d__1)""
     IL_0135:  ldnull
     IL_0136:  stloc.3
-    IL_0137:  leave      IL_035a
+    IL_0137:  leave      IL_0356
     IL_013c:  ldarg.0
     IL_013d:  ldfld      ""object C.<M>d__1.<>u__1""
     IL_0142:  stloc.2
@@ -15183,160 +15181,156 @@ class C
     IL_0194:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__3""
     IL_0199:  ldloc.2
     IL_019a:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_019f:  ldnull
-    IL_01a0:  stloc.2
-    IL_01a1:  stloc.1
-    IL_01a2:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__4""
-    IL_01a7:  brtrue.s   IL_01d9
-    IL_01a9:  ldc.i4.0
-    IL_01aa:  ldstr      ""GetAwaiter""
-    IL_01af:  ldnull
-    IL_01b0:  ldtoken    ""C""
-    IL_01b5:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_01ba:  ldc.i4.1
-    IL_01bb:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_01c0:  dup
-    IL_01c1:  ldc.i4.0
-    IL_01c2:  ldc.i4.0
-    IL_01c3:  ldnull
-    IL_01c4:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_01c9:  stelem.ref
-    IL_01ca:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_01cf:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_01d4:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__4""
-    IL_01d9:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__4""
-    IL_01de:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
-    IL_01e3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__4""
-    IL_01e8:  ldloc.1
-    IL_01e9:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_01ee:  stloc.2
-    IL_01ef:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<M>d__1.<>o__1.<>p__6""
-    IL_01f4:  brtrue.s   IL_021b
-    IL_01f6:  ldc.i4.s   16
-    IL_01f8:  ldtoken    ""bool""
-    IL_01fd:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0202:  ldtoken    ""C""
-    IL_0207:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_020c:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-    IL_0211:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_0216:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<M>d__1.<>o__1.<>p__6""
-    IL_021b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<M>d__1.<>o__1.<>p__6""
-    IL_0220:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, bool> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>>.Target""
-    IL_0225:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<M>d__1.<>o__1.<>p__6""
-    IL_022a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__5""
-    IL_022f:  brtrue.s   IL_0260
-    IL_0231:  ldc.i4.0
-    IL_0232:  ldstr      ""IsCompleted""
-    IL_0237:  ldtoken    ""C""
-    IL_023c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0241:  ldc.i4.1
-    IL_0242:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_0247:  dup
-    IL_0248:  ldc.i4.0
-    IL_0249:  ldc.i4.0
-    IL_024a:  ldnull
-    IL_024b:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_0250:  stelem.ref
-    IL_0251:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.GetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_0256:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_025b:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__5""
-    IL_0260:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__5""
-    IL_0265:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
-    IL_026a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__5""
-    IL_026f:  ldloc.2
-    IL_0270:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_0275:  callvirt   ""bool System.Func<System.Runtime.CompilerServices.CallSite, object, bool>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_027a:  brtrue.s   IL_02dd
-    IL_027c:  ldarg.0
-    IL_027d:  ldc.i4.1
-    IL_027e:  dup
-    IL_027f:  stloc.0
-    IL_0280:  stfld      ""int C.<M>d__1.<>1__state""
-    IL_0285:  ldarg.0
-    IL_0286:  ldloc.2
-    IL_0287:  stfld      ""object C.<M>d__1.<>u__1""
-    IL_028c:  ldloc.2
-    IL_028d:  isinst     ""System.Runtime.CompilerServices.ICriticalNotifyCompletion""
-    IL_0292:  stloc.3
-    IL_0293:  ldloc.3
-    IL_0294:  brtrue.s   IL_02b1
-    IL_0296:  ldloc.2
-    IL_0297:  castclass  ""System.Runtime.CompilerServices.INotifyCompletion""
-    IL_029c:  stloc.s    V_4
-    IL_029e:  ldarg.0
-    IL_029f:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__1.<>t__builder""
-    IL_02a4:  ldloca.s   V_4
-    IL_02a6:  ldarg.0
-    IL_02a7:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted<System.Runtime.CompilerServices.INotifyCompletion, C.<M>d__1>(ref System.Runtime.CompilerServices.INotifyCompletion, ref C.<M>d__1)""
-    IL_02ac:  ldnull
-    IL_02ad:  stloc.s    V_4
-    IL_02af:  br.s       IL_02bf
-    IL_02b1:  ldarg.0
-    IL_02b2:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__1.<>t__builder""
-    IL_02b7:  ldloca.s   V_3
-    IL_02b9:  ldarg.0
-    IL_02ba:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, C.<M>d__1>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref C.<M>d__1)""
-    IL_02bf:  ldnull
-    IL_02c0:  stloc.3
-    IL_02c1:  leave      IL_035a
-    IL_02c6:  ldarg.0
-    IL_02c7:  ldfld      ""object C.<M>d__1.<>u__1""
-    IL_02cc:  stloc.2
-    IL_02cd:  ldarg.0
-    IL_02ce:  ldnull
-    IL_02cf:  stfld      ""object C.<M>d__1.<>u__1""
-    IL_02d4:  ldarg.0
-    IL_02d5:  ldc.i4.m1
-    IL_02d6:  dup
-    IL_02d7:  stloc.0
-    IL_02d8:  stfld      ""int C.<M>d__1.<>1__state""
-    IL_02dd:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__7""
-    IL_02e2:  brtrue.s   IL_0314
-    IL_02e4:  ldc.i4.0
-    IL_02e5:  ldstr      ""GetResult""
-    IL_02ea:  ldnull
-    IL_02eb:  ldtoken    ""C""
-    IL_02f0:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_02f5:  ldc.i4.1
-    IL_02f6:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_02fb:  dup
-    IL_02fc:  ldc.i4.0
-    IL_02fd:  ldc.i4.0
-    IL_02fe:  ldnull
-    IL_02ff:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_0304:  stelem.ref
-    IL_0305:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_030a:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_030f:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__7""
-    IL_0314:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__7""
-    IL_0319:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
-    IL_031e:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__7""
-    IL_0323:  ldloc.2
-    IL_0324:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_0329:  ldnull
-    IL_032a:  stloc.2
-    IL_032b:  pop
-    IL_032c:  leave.s    IL_0347
+    IL_019f:  stloc.1
+    IL_01a0:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__4""
+    IL_01a5:  brtrue.s   IL_01d7
+    IL_01a7:  ldc.i4.0
+    IL_01a8:  ldstr      ""GetAwaiter""
+    IL_01ad:  ldnull
+    IL_01ae:  ldtoken    ""C""
+    IL_01b3:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_01b8:  ldc.i4.1
+    IL_01b9:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_01be:  dup
+    IL_01bf:  ldc.i4.0
+    IL_01c0:  ldc.i4.0
+    IL_01c1:  ldnull
+    IL_01c2:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_01c7:  stelem.ref
+    IL_01c8:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_01cd:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_01d2:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__4""
+    IL_01d7:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__4""
+    IL_01dc:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
+    IL_01e1:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__4""
+    IL_01e6:  ldloc.1
+    IL_01e7:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_01ec:  stloc.2
+    IL_01ed:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<M>d__1.<>o__1.<>p__6""
+    IL_01f2:  brtrue.s   IL_0219
+    IL_01f4:  ldc.i4.s   16
+    IL_01f6:  ldtoken    ""bool""
+    IL_01fb:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_0200:  ldtoken    ""C""
+    IL_0205:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_020a:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+    IL_020f:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_0214:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<M>d__1.<>o__1.<>p__6""
+    IL_0219:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<M>d__1.<>o__1.<>p__6""
+    IL_021e:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, bool> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>>.Target""
+    IL_0223:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<M>d__1.<>o__1.<>p__6""
+    IL_0228:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__5""
+    IL_022d:  brtrue.s   IL_025e
+    IL_022f:  ldc.i4.0
+    IL_0230:  ldstr      ""IsCompleted""
+    IL_0235:  ldtoken    ""C""
+    IL_023a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_023f:  ldc.i4.1
+    IL_0240:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_0245:  dup
+    IL_0246:  ldc.i4.0
+    IL_0247:  ldc.i4.0
+    IL_0248:  ldnull
+    IL_0249:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_024e:  stelem.ref
+    IL_024f:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.GetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_0254:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_0259:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__5""
+    IL_025e:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__5""
+    IL_0263:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
+    IL_0268:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__5""
+    IL_026d:  ldloc.2
+    IL_026e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_0273:  callvirt   ""bool System.Func<System.Runtime.CompilerServices.CallSite, object, bool>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_0278:  brtrue.s   IL_02db
+    IL_027a:  ldarg.0
+    IL_027b:  ldc.i4.1
+    IL_027c:  dup
+    IL_027d:  stloc.0
+    IL_027e:  stfld      ""int C.<M>d__1.<>1__state""
+    IL_0283:  ldarg.0
+    IL_0284:  ldloc.2
+    IL_0285:  stfld      ""object C.<M>d__1.<>u__1""
+    IL_028a:  ldloc.2
+    IL_028b:  isinst     ""System.Runtime.CompilerServices.ICriticalNotifyCompletion""
+    IL_0290:  stloc.3
+    IL_0291:  ldloc.3
+    IL_0292:  brtrue.s   IL_02af
+    IL_0294:  ldloc.2
+    IL_0295:  castclass  ""System.Runtime.CompilerServices.INotifyCompletion""
+    IL_029a:  stloc.s    V_4
+    IL_029c:  ldarg.0
+    IL_029d:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__1.<>t__builder""
+    IL_02a2:  ldloca.s   V_4
+    IL_02a4:  ldarg.0
+    IL_02a5:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted<System.Runtime.CompilerServices.INotifyCompletion, C.<M>d__1>(ref System.Runtime.CompilerServices.INotifyCompletion, ref C.<M>d__1)""
+    IL_02aa:  ldnull
+    IL_02ab:  stloc.s    V_4
+    IL_02ad:  br.s       IL_02bd
+    IL_02af:  ldarg.0
+    IL_02b0:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__1.<>t__builder""
+    IL_02b5:  ldloca.s   V_3
+    IL_02b7:  ldarg.0
+    IL_02b8:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, C.<M>d__1>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref C.<M>d__1)""
+    IL_02bd:  ldnull
+    IL_02be:  stloc.3
+    IL_02bf:  leave      IL_0356
+    IL_02c4:  ldarg.0
+    IL_02c5:  ldfld      ""object C.<M>d__1.<>u__1""
+    IL_02ca:  stloc.2
+    IL_02cb:  ldarg.0
+    IL_02cc:  ldnull
+    IL_02cd:  stfld      ""object C.<M>d__1.<>u__1""
+    IL_02d2:  ldarg.0
+    IL_02d3:  ldc.i4.m1
+    IL_02d4:  dup
+    IL_02d5:  stloc.0
+    IL_02d6:  stfld      ""int C.<M>d__1.<>1__state""
+    IL_02db:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__7""
+    IL_02e0:  brtrue.s   IL_0312
+    IL_02e2:  ldc.i4.0
+    IL_02e3:  ldstr      ""GetResult""
+    IL_02e8:  ldnull
+    IL_02e9:  ldtoken    ""C""
+    IL_02ee:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_02f3:  ldc.i4.1
+    IL_02f4:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_02f9:  dup
+    IL_02fa:  ldc.i4.0
+    IL_02fb:  ldc.i4.0
+    IL_02fc:  ldnull
+    IL_02fd:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_0302:  stelem.ref
+    IL_0303:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_0308:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_030d:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__7""
+    IL_0312:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__7""
+    IL_0317:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
+    IL_031c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<M>d__1.<>o__1.<>p__7""
+    IL_0321:  ldloc.2
+    IL_0322:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_0327:  pop
+    IL_0328:  leave.s    IL_0343
   }
   catch System.Exception
   {
-    IL_032e:  stloc.s    V_5
-    IL_0330:  ldarg.0
-    IL_0331:  ldc.i4.s   -2
-    IL_0333:  stfld      ""int C.<M>d__1.<>1__state""
-    IL_0338:  ldarg.0
-    IL_0339:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__1.<>t__builder""
-    IL_033e:  ldloc.s    V_5
-    IL_0340:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
-    IL_0345:  leave.s    IL_035a
+    IL_032a:  stloc.s    V_5
+    IL_032c:  ldarg.0
+    IL_032d:  ldc.i4.s   -2
+    IL_032f:  stfld      ""int C.<M>d__1.<>1__state""
+    IL_0334:  ldarg.0
+    IL_0335:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__1.<>t__builder""
+    IL_033a:  ldloc.s    V_5
+    IL_033c:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
+    IL_0341:  leave.s    IL_0356
   }
-  IL_0347:  ldarg.0
-  IL_0348:  ldc.i4.s   -2
-  IL_034a:  stfld      ""int C.<M>d__1.<>1__state""
-  IL_034f:  ldarg.0
-  IL_0350:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__1.<>t__builder""
-  IL_0355:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
-  IL_035a:  ret
+  IL_0343:  ldarg.0
+  IL_0344:  ldc.i4.s   -2
+  IL_0346:  stfld      ""int C.<M>d__1.<>1__state""
+  IL_034b:  ldarg.0
+  IL_034c:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder C.<M>d__1.<>t__builder""
+  IL_0351:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
+  IL_0356:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -2090,7 +2090,7 @@ class C
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      191 (0xbf)
+  // Code size      183 (0xb7)
   .maxstack  3
   .locals init (int V_0,
                 T V_1,
@@ -2132,7 +2132,7 @@ class C
     IL_004e:  ldloca.s   V_2
     IL_0050:  ldarg.0
     IL_0051:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Test>d__1<T>>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Test>d__1<T>)""
-    IL_0056:  leave.s    IL_00be
+    IL_0056:  leave.s    IL_00b6
     IL_0058:  ldarg.0
     IL_0059:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1<T>.<>u__1""
     IL_005e:  stloc.2
@@ -2146,34 +2146,32 @@ class C
     IL_006f:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_0074:  ldloca.s   V_2
     IL_0076:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_007b:  ldloca.s   V_2
-    IL_007d:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0083:  ldarg.0
-    IL_0084:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__1""
-    IL_0089:  ldfld      ""T System.ValueTuple<T, T>.Item1""
-    IL_008e:  stloc.1
-    IL_008f:  leave.s    IL_00aa
+    IL_007b:  ldarg.0
+    IL_007c:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__1""
+    IL_0081:  ldfld      ""T System.ValueTuple<T, T>.Item1""
+    IL_0086:  stloc.1
+    IL_0087:  leave.s    IL_00a2
   }
   catch System.Exception
   {
-    IL_0091:  stloc.s    V_4
+    IL_0089:  stloc.s    V_4
+    IL_008b:  ldarg.0
+    IL_008c:  ldc.i4.s   -2
+    IL_008e:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_0093:  ldarg.0
-    IL_0094:  ldc.i4.s   -2
-    IL_0096:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-    IL_009b:  ldarg.0
-    IL_009c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
-    IL_00a1:  ldloc.s    V_4
-    IL_00a3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetException(System.Exception)""
-    IL_00a8:  leave.s    IL_00be
+    IL_0094:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
+    IL_0099:  ldloc.s    V_4
+    IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetException(System.Exception)""
+    IL_00a0:  leave.s    IL_00b6
   }
+  IL_00a2:  ldarg.0
+  IL_00a3:  ldc.i4.s   -2
+  IL_00a5:  stfld      ""int C.<Test>d__1<T>.<>1__state""
   IL_00aa:  ldarg.0
-  IL_00ab:  ldc.i4.s   -2
-  IL_00ad:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-  IL_00b2:  ldarg.0
-  IL_00b3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
-  IL_00b8:  ldloc.1
-  IL_00b9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetResult(T)""
-  IL_00be:  ret
+  IL_00ab:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
+  IL_00b0:  ldloc.1
+  IL_00b1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetResult(T)""
+  IL_00b6:  ret
 }
 ");
         }
@@ -2206,7 +2204,7 @@ class C
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      197 (0xc5)
+  // Code size      189 (0xbd)
   .maxstack  3
   .locals init (int V_0,
                 string V_1,
@@ -2248,7 +2246,7 @@ class C
     IL_004e:  ldloca.s   V_2
     IL_0050:  ldarg.0
     IL_0051:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Test>d__1<T>>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Test>d__1<T>)""
-    IL_0056:  leave.s    IL_00c4
+    IL_0056:  leave.s    IL_00bc
     IL_0058:  ldarg.0
     IL_0059:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1<T>.<>u__1""
     IL_005e:  stloc.2
@@ -2262,35 +2260,33 @@ class C
     IL_006f:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_0074:  ldloca.s   V_2
     IL_0076:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_007b:  ldloca.s   V_2
-    IL_007d:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0083:  ldarg.0
-    IL_0084:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__1""
-    IL_0089:  constrained. ""System.ValueTuple<T, T>""
-    IL_008f:  callvirt   ""string object.ToString()""
-    IL_0094:  stloc.1
-    IL_0095:  leave.s    IL_00b0
+    IL_007b:  ldarg.0
+    IL_007c:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__1""
+    IL_0081:  constrained. ""System.ValueTuple<T, T>""
+    IL_0087:  callvirt   ""string object.ToString()""
+    IL_008c:  stloc.1
+    IL_008d:  leave.s    IL_00a8
   }
   catch System.Exception
   {
-    IL_0097:  stloc.s    V_4
+    IL_008f:  stloc.s    V_4
+    IL_0091:  ldarg.0
+    IL_0092:  ldc.i4.s   -2
+    IL_0094:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_0099:  ldarg.0
-    IL_009a:  ldc.i4.s   -2
-    IL_009c:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-    IL_00a1:  ldarg.0
-    IL_00a2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string> C.<Test>d__1<T>.<>t__builder""
-    IL_00a7:  ldloc.s    V_4
-    IL_00a9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.SetException(System.Exception)""
-    IL_00ae:  leave.s    IL_00c4
+    IL_009a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string> C.<Test>d__1<T>.<>t__builder""
+    IL_009f:  ldloc.s    V_4
+    IL_00a1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.SetException(System.Exception)""
+    IL_00a6:  leave.s    IL_00bc
   }
+  IL_00a8:  ldarg.0
+  IL_00a9:  ldc.i4.s   -2
+  IL_00ab:  stfld      ""int C.<Test>d__1<T>.<>1__state""
   IL_00b0:  ldarg.0
-  IL_00b1:  ldc.i4.s   -2
-  IL_00b3:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-  IL_00b8:  ldarg.0
-  IL_00b9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string> C.<Test>d__1<T>.<>t__builder""
-  IL_00be:  ldloc.1
-  IL_00bf:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.SetResult(string)""
-  IL_00c4:  ret
+  IL_00b1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string> C.<Test>d__1<T>.<>t__builder""
+  IL_00b6:  ldloc.1
+  IL_00b7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<string>.SetResult(string)""
+  IL_00bc:  ret
 }
 ");
         }
@@ -2349,7 +2345,7 @@ namespace System
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      197 (0xc5)
+  // Code size      189 (0xbd)
   .maxstack  3
   .locals init (int V_0,
                 T V_1,
@@ -2391,7 +2387,7 @@ namespace System
     IL_004e:  ldloca.s   V_2
     IL_0050:  ldarg.0
     IL_0051:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Test>d__1<T>>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Test>d__1<T>)""
-    IL_0056:  leave.s    IL_00c4
+    IL_0056:  leave.s    IL_00bc
     IL_0058:  ldarg.0
     IL_0059:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1<T>.<>u__1""
     IL_005e:  stloc.2
@@ -2405,36 +2401,34 @@ namespace System
     IL_006f:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_0074:  ldloca.s   V_2
     IL_0076:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_007b:  ldloca.s   V_2
-    IL_007d:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0083:  ldarg.0
-    IL_0084:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__1""
-    IL_0089:  ldarg.0
-    IL_008a:  ldfld      ""T C.<Test>d__1<T>.a""
-    IL_008f:  call       ""T System.ValueTuple<T, T>.Test<T>(T)""
-    IL_0094:  stloc.1
-    IL_0095:  leave.s    IL_00b0
+    IL_007b:  ldarg.0
+    IL_007c:  ldflda     ""(T f1, T f2) C.<Test>d__1<T>.<x>5__1""
+    IL_0081:  ldarg.0
+    IL_0082:  ldfld      ""T C.<Test>d__1<T>.a""
+    IL_0087:  call       ""T System.ValueTuple<T, T>.Test<T>(T)""
+    IL_008c:  stloc.1
+    IL_008d:  leave.s    IL_00a8
   }
   catch System.Exception
   {
-    IL_0097:  stloc.s    V_4
+    IL_008f:  stloc.s    V_4
+    IL_0091:  ldarg.0
+    IL_0092:  ldc.i4.s   -2
+    IL_0094:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_0099:  ldarg.0
-    IL_009a:  ldc.i4.s   -2
-    IL_009c:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-    IL_00a1:  ldarg.0
-    IL_00a2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
-    IL_00a7:  ldloc.s    V_4
-    IL_00a9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetException(System.Exception)""
-    IL_00ae:  leave.s    IL_00c4
+    IL_009a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
+    IL_009f:  ldloc.s    V_4
+    IL_00a1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetException(System.Exception)""
+    IL_00a6:  leave.s    IL_00bc
   }
+  IL_00a8:  ldarg.0
+  IL_00a9:  ldc.i4.s   -2
+  IL_00ab:  stfld      ""int C.<Test>d__1<T>.<>1__state""
   IL_00b0:  ldarg.0
-  IL_00b1:  ldc.i4.s   -2
-  IL_00b3:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-  IL_00b8:  ldarg.0
-  IL_00b9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
-  IL_00be:  ldloc.1
-  IL_00bf:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetResult(T)""
-  IL_00c4:  ret
+  IL_00b1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
+  IL_00b6:  ldloc.1
+  IL_00b7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetResult(T)""
+  IL_00bc:  ret
 }
 ");
         }
@@ -2493,7 +2487,7 @@ namespace System
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      187 (0xbb)
+  // Code size      179 (0xb3)
   .maxstack  3
   .locals init (int V_0,
                 T V_1,
@@ -2533,7 +2527,7 @@ namespace System
     IL_0044:  ldloca.s   V_2
     IL_0046:  ldarg.0
     IL_0047:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Test>d__1<T>>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Test>d__1<T>)""
-    IL_004c:  leave.s    IL_00ba
+    IL_004c:  leave.s    IL_00b2
     IL_004e:  ldarg.0
     IL_004f:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1<T>.<>u__1""
     IL_0054:  stloc.2
@@ -2547,36 +2541,34 @@ namespace System
     IL_0065:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_006a:  ldloca.s   V_2
     IL_006c:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0071:  ldloca.s   V_2
-    IL_0073:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0079:  ldarg.0
-    IL_007a:  ldflda     ""(int f1, int f2) C.<Test>d__1<T>.<x>5__1""
-    IL_007f:  ldarg.0
-    IL_0080:  ldfld      ""T C.<Test>d__1<T>.a""
-    IL_0085:  call       ""T System.ValueTuple<int, int>.Test<T>(T)""
-    IL_008a:  stloc.1
-    IL_008b:  leave.s    IL_00a6
+    IL_0071:  ldarg.0
+    IL_0072:  ldflda     ""(int f1, int f2) C.<Test>d__1<T>.<x>5__1""
+    IL_0077:  ldarg.0
+    IL_0078:  ldfld      ""T C.<Test>d__1<T>.a""
+    IL_007d:  call       ""T System.ValueTuple<int, int>.Test<T>(T)""
+    IL_0082:  stloc.1
+    IL_0083:  leave.s    IL_009e
   }
   catch System.Exception
   {
-    IL_008d:  stloc.s    V_4
+    IL_0085:  stloc.s    V_4
+    IL_0087:  ldarg.0
+    IL_0088:  ldc.i4.s   -2
+    IL_008a:  stfld      ""int C.<Test>d__1<T>.<>1__state""
     IL_008f:  ldarg.0
-    IL_0090:  ldc.i4.s   -2
-    IL_0092:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-    IL_0097:  ldarg.0
-    IL_0098:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
-    IL_009d:  ldloc.s    V_4
-    IL_009f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetException(System.Exception)""
-    IL_00a4:  leave.s    IL_00ba
+    IL_0090:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
+    IL_0095:  ldloc.s    V_4
+    IL_0097:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetException(System.Exception)""
+    IL_009c:  leave.s    IL_00b2
   }
+  IL_009e:  ldarg.0
+  IL_009f:  ldc.i4.s   -2
+  IL_00a1:  stfld      ""int C.<Test>d__1<T>.<>1__state""
   IL_00a6:  ldarg.0
-  IL_00a7:  ldc.i4.s   -2
-  IL_00a9:  stfld      ""int C.<Test>d__1<T>.<>1__state""
-  IL_00ae:  ldarg.0
-  IL_00af:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
-  IL_00b4:  ldloc.1
-  IL_00b5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetResult(T)""
-  IL_00ba:  ret
+  IL_00a7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T> C.<Test>d__1<T>.<>t__builder""
+  IL_00ac:  ldloc.1
+  IL_00ad:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<T>.SetResult(T)""
+  IL_00b2:  ret
 }
 ");
         }
@@ -19264,7 +19256,7 @@ class C
             // NOTE: !!! There should be an IL local for  " (byte x, int y) v2 " , it should not be captured 
             verifier.VerifyIL("C.<Test>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      201 (0xc9)
+  // Code size      193 (0xc1)
   .maxstack  3
   .locals init (int V_0,
                 long V_1,
@@ -19311,7 +19303,7 @@ class C
     IL_0058:  ldloca.s   V_3
     IL_005a:  ldarg.0
     IL_005b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Test>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Test>d__1)""
-    IL_0060:  leave.s    IL_00c8
+    IL_0060:  leave.s    IL_00c0
     IL_0062:  ldarg.0
     IL_0063:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1.<>u__1""
     IL_0068:  stloc.3
@@ -19325,34 +19317,32 @@ class C
     IL_0079:  stfld      ""int C.<Test>d__1.<>1__state""
     IL_007e:  ldloca.s   V_3
     IL_0080:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0085:  ldloca.s   V_3
-    IL_0087:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_008d:  ldarg.0
-    IL_008e:  ldflda     ""(long a, int b) C.<Test>d__1.<v1>5__1""
-    IL_0093:  ldfld      ""long System.ValueTuple<long, int>.Item1""
-    IL_0098:  stloc.1
-    IL_0099:  leave.s    IL_00b4
+    IL_0085:  ldarg.0
+    IL_0086:  ldflda     ""(long a, int b) C.<Test>d__1.<v1>5__1""
+    IL_008b:  ldfld      ""long System.ValueTuple<long, int>.Item1""
+    IL_0090:  stloc.1
+    IL_0091:  leave.s    IL_00ac
   }
   catch System.Exception
   {
-    IL_009b:  stloc.s    V_5
+    IL_0093:  stloc.s    V_5
+    IL_0095:  ldarg.0
+    IL_0096:  ldc.i4.s   -2
+    IL_0098:  stfld      ""int C.<Test>d__1.<>1__state""
     IL_009d:  ldarg.0
-    IL_009e:  ldc.i4.s   -2
-    IL_00a0:  stfld      ""int C.<Test>d__1.<>1__state""
-    IL_00a5:  ldarg.0
-    IL_00a6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long> C.<Test>d__1.<>t__builder""
-    IL_00ab:  ldloc.s    V_5
-    IL_00ad:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long>.SetException(System.Exception)""
-    IL_00b2:  leave.s    IL_00c8
+    IL_009e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long> C.<Test>d__1.<>t__builder""
+    IL_00a3:  ldloc.s    V_5
+    IL_00a5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long>.SetException(System.Exception)""
+    IL_00aa:  leave.s    IL_00c0
   }
+  IL_00ac:  ldarg.0
+  IL_00ad:  ldc.i4.s   -2
+  IL_00af:  stfld      ""int C.<Test>d__1.<>1__state""
   IL_00b4:  ldarg.0
-  IL_00b5:  ldc.i4.s   -2
-  IL_00b7:  stfld      ""int C.<Test>d__1.<>1__state""
-  IL_00bc:  ldarg.0
-  IL_00bd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long> C.<Test>d__1.<>t__builder""
-  IL_00c2:  ldloc.1
-  IL_00c3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long>.SetResult(long)""
-  IL_00c8:  ret
+  IL_00b5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long> C.<Test>d__1.<>t__builder""
+  IL_00ba:  ldloc.1
+  IL_00bb:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long>.SetResult(long)""
+  IL_00c0:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -874,7 +874,7 @@ class C
 
                     diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      170 (0xaa)
+  // Code size      162 (0xa2)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -914,7 +914,7 @@ class C
     IL_003f:  ldloca.s   V_3
     IL_0041:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
     IL_0046:  nop
-    IL_0047:  leave.s    IL_00a9
+    IL_0047:  leave.s    IL_00a1
     IL_0049:  ldarg.0
     IL_004a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
     IL_004f:  stloc.2
@@ -929,39 +929,37 @@ class C
     IL_0065:  ldloca.s   V_2
     IL_0067:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_006c:  pop
-    IL_006d:  ldloca.s   V_2
-    IL_006f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0075:  ldc.i4.s   20
-    IL_0077:  stloc.1
-    IL_0078:  leave.s    IL_0094
+    IL_006d:  ldc.i4.s   20
+    IL_006f:  stloc.1
+    IL_0070:  leave.s    IL_008c
   }
   catch System.Exception
   {
-    IL_007a:  stloc.s    V_4
+    IL_0072:  stloc.s    V_4
+    IL_0074:  ldarg.0
+    IL_0075:  ldc.i4.s   -2
+    IL_0077:  stfld      ""int C.<F>d__0.<>1__state""
     IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.s   -2
-    IL_007f:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0084:  ldarg.0
-    IL_0085:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_008a:  ldloc.s    V_4
-    IL_008c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0091:  nop
-    IL_0092:  leave.s    IL_00a9
+    IL_007d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0082:  ldloc.s    V_4
+    IL_0084:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0089:  nop
+    IL_008a:  leave.s    IL_00a1
   }
+  IL_008c:  ldarg.0
+  IL_008d:  ldc.i4.s   -2
+  IL_008f:  stfld      ""int C.<F>d__0.<>1__state""
   IL_0094:  ldarg.0
-  IL_0095:  ldc.i4.s   -2
-  IL_0097:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_009c:  ldarg.0
-  IL_009d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00a2:  ldloc.1
-  IL_00a3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00a8:  nop
-  IL_00a9:  ret
+  IL_0095:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_009a:  ldloc.1
+  IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00a0:  nop
+  IL_00a1:  ret
 }
 ");
                     v0.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      168 (0xa8)
+  // Code size      160 (0xa0)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1001,7 +999,7 @@ class C
     IL_003e:  ldloca.s   V_3
     IL_0040:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
     IL_0045:  nop
-    IL_0046:  leave.s    IL_00a7
+    IL_0046:  leave.s    IL_009f
    >IL_0048:  ldarg.0
     IL_0049:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
     IL_004e:  stloc.2
@@ -1016,39 +1014,36 @@ class C
     IL_0064:  ldloca.s   V_2
     IL_0066:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_006b:  pop
-    IL_006c:  ldloca.s   V_2
-    IL_006e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-   -IL_0074:  ldc.i4.2
-    IL_0075:  stloc.1
-    IL_0076:  leave.s    IL_0092
+   -IL_006c:  ldc.i4.2
+    IL_006d:  stloc.1
+    IL_006e:  leave.s    IL_008a
   }
   catch System.Exception
   {
-   ~IL_0078:  stloc.s    V_4
+   ~IL_0070:  stloc.s    V_4
+    IL_0072:  ldarg.0
+    IL_0073:  ldc.i4.s   -2
+    IL_0075:  stfld      ""int C.<F>d__0.<>1__state""
     IL_007a:  ldarg.0
-    IL_007b:  ldc.i4.s   -2
-    IL_007d:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0082:  ldarg.0
-    IL_0083:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0088:  ldloc.s    V_4
-    IL_008a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_008f:  nop
-    IL_0090:  leave.s    IL_00a7
+    IL_007b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0080:  ldloc.s    V_4
+    IL_0082:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0087:  nop
+    IL_0088:  leave.s    IL_009f
   }
- -IL_0092:  ldarg.0
-  IL_0093:  ldc.i4.s   -2
-  IL_0095:  stfld      ""int C.<F>d__0.<>1__state""
- ~IL_009a:  ldarg.0
-  IL_009b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00a0:  ldloc.1
-  IL_00a1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00a6:  nop
-  IL_00a7:  ret
+ -IL_008a:  ldarg.0
+  IL_008b:  ldc.i4.s   -2
+  IL_008d:  stfld      ""int C.<F>d__0.<>1__state""
+ ~IL_0092:  ldarg.0
+  IL_0093:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_0098:  ldloc.1
+  IL_0099:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_009e:  nop
+  IL_009f:  ret
 }
 ", sequencePoints: "C+<F>d__0.MoveNext");
 
-                    v0.VerifyPdb("C+<F>d__0.MoveNext", @"
-<symbols>
+                    v0.VerifyPdb("C+<F>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;F&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1069,12 +1064,12 @@ class C
         <entry offset=""0xe"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
         <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""34"" />
         <entry offset=""0x1b"" hidden=""true"" />
-        <entry offset=""0x74"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" />
-        <entry offset=""0x78"" hidden=""true"" />
-        <entry offset=""0x92"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
-        <entry offset=""0x9a"" hidden=""true"" />
+        <entry offset=""0x6c"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""18"" />
+        <entry offset=""0x70"" hidden=""true"" />
+        <entry offset=""0x8a"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
+        <entry offset=""0x92"" hidden=""true"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xa8"">
+      <scope startOffset=""0x0"" endOffset=""0xa0"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
@@ -1083,8 +1078,7 @@ class C
       </asyncInfo>
     </method>
   </methods>
-</symbols>
-");
+</symbols>");
                 }
             }
         }
@@ -1889,7 +1883,7 @@ class C
 
             diff1.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      186 (0xba)
+  // Code size      178 (0xb2)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -1935,7 +1929,7 @@ class C
     IL_0050:  ldloca.s   V_3
     IL_0052:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
     IL_0057:  nop
-    IL_0058:  leave.s    IL_00b9
+    IL_0058:  leave.s    IL_00b1
     IL_005a:  ldarg.0
     IL_005b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
     IL_0060:  stloc.2
@@ -1950,34 +1944,32 @@ class C
     IL_0076:  ldloca.s   V_2
     IL_0078:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
     IL_007d:  nop
-    IL_007e:  ldloca.s   V_2
-    IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0086:  ldc.i4.1
-    IL_0087:  stloc.1
-    IL_0088:  leave.s    IL_00a4
+    IL_007e:  ldc.i4.1
+    IL_007f:  stloc.1
+    IL_0080:  leave.s    IL_009c
   }
   catch System.Exception
   {
-    IL_008a:  stloc.s    V_4
+    IL_0082:  stloc.s    V_4
+    IL_0084:  ldarg.0
+    IL_0085:  ldc.i4.s   -2
+    IL_0087:  stfld      ""int C.<F>d__0.<>1__state""
     IL_008c:  ldarg.0
-    IL_008d:  ldc.i4.s   -2
-    IL_008f:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0094:  ldarg.0
-    IL_0095:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_009a:  ldloc.s    V_4
-    IL_009c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00a1:  nop
-    IL_00a2:  leave.s    IL_00b9
+    IL_008d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0092:  ldloc.s    V_4
+    IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0099:  nop
+    IL_009a:  leave.s    IL_00b1
   }
+  IL_009c:  ldarg.0
+  IL_009d:  ldc.i4.s   -2
+  IL_009f:  stfld      ""int C.<F>d__0.<>1__state""
   IL_00a4:  ldarg.0
-  IL_00a5:  ldc.i4.s   -2
-  IL_00a7:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00ac:  ldarg.0
-  IL_00ad:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00b2:  ldloc.1
-  IL_00b3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00b8:  nop
-  IL_00b9:  ret
+  IL_00a5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00aa:  ldloc.1
+  IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00b0:  nop
+  IL_00b1:  ret
 }
 ");
             // 2 field defs added (both variables a1 and a2 of F changed their types) & 2 methods updated
@@ -1995,7 +1987,7 @@ class C
 
             diff2.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      186 (0xba)
+  // Code size      178 (0xb2)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -2041,7 +2033,7 @@ class C
     IL_0050:  ldloca.s   V_3
     IL_0052:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
     IL_0057:  nop
-    IL_0058:  leave.s    IL_00b9
+    IL_0058:  leave.s    IL_00b1
     IL_005a:  ldarg.0
     IL_005b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
     IL_0060:  stloc.2
@@ -2056,34 +2048,32 @@ class C
     IL_0076:  ldloca.s   V_2
     IL_0078:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
     IL_007d:  nop
-    IL_007e:  ldloca.s   V_2
-    IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-    IL_0086:  ldc.i4.1
-    IL_0087:  stloc.1
-    IL_0088:  leave.s    IL_00a4
+    IL_007e:  ldc.i4.1
+    IL_007f:  stloc.1
+    IL_0080:  leave.s    IL_009c
   }
   catch System.Exception
   {
-    IL_008a:  stloc.s    V_4
+    IL_0082:  stloc.s    V_4
+    IL_0084:  ldarg.0
+    IL_0085:  ldc.i4.s   -2
+    IL_0087:  stfld      ""int C.<F>d__0.<>1__state""
     IL_008c:  ldarg.0
-    IL_008d:  ldc.i4.s   -2
-    IL_008f:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0094:  ldarg.0
-    IL_0095:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_009a:  ldloc.s    V_4
-    IL_009c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00a1:  nop
-    IL_00a2:  leave.s    IL_00b9
+    IL_008d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0092:  ldloc.s    V_4
+    IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0099:  nop
+    IL_009a:  leave.s    IL_00b1
   }
+  IL_009c:  ldarg.0
+  IL_009d:  ldc.i4.s   -2
+  IL_009f:  stfld      ""int C.<F>d__0.<>1__state""
   IL_00a4:  ldarg.0
-  IL_00a5:  ldc.i4.s   -2
-  IL_00a7:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00ac:  ldarg.0
-  IL_00ad:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00b2:  ldloc.1
-  IL_00b3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00b8:  nop
-  IL_00b9:  ret
+  IL_00a5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00aa:  ldloc.1
+  IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00b0:  nop
+  IL_00b1:  ret
 }
 ");
             // 2 field defs added - variables of G and H changed their types; 4 methods updated: G, H kickoff and MoveNext
@@ -2634,7 +2624,7 @@ class C
             // Note that the new awaiter is allocated slot <>u__3 since <>u__1 and <>u__2 are taken.
             diff1.VerifyIL("C.<F>d__3.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      284 (0x11c)
+  // Code size      268 (0x10c)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -2655,7 +2645,7 @@ class C
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
     IL_0012:  br.s       IL_0055
-    IL_0014:  br         IL_00bb
+    IL_0014:  br         IL_00b3
     IL_0019:  nop
     IL_001a:  call       ""System.Threading.Tasks.Task<C> C.A3()""
     IL_001f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<C> System.Threading.Tasks.Task<C>.GetAwaiter()""
@@ -2679,7 +2669,7 @@ class C
     IL_0048:  ldloca.s   V_3
     IL_004a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<C>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<C>, ref C.<F>d__3)""
     IL_004f:  nop
-    IL_0050:  leave      IL_011b
+    IL_0050:  leave      IL_010b
     IL_0055:  ldarg.0
     IL_0056:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
     IL_005b:  stloc.2
@@ -2694,73 +2684,69 @@ class C
     IL_0071:  ldloca.s   V_2
     IL_0073:  call       ""C System.Runtime.CompilerServices.TaskAwaiter<C>.GetResult()""
     IL_0078:  pop
-    IL_0079:  ldloca.s   V_2
-    IL_007b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<C>""
-    IL_0081:  call       ""System.Threading.Tasks.Task<int> C.A2()""
-    IL_0086:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_008b:  stloc.s    V_4
-    IL_008d:  ldloca.s   V_4
-    IL_008f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0094:  brtrue.s   IL_00d8
-    IL_0096:  ldarg.0
-    IL_0097:  ldc.i4.1
-    IL_0098:  dup
-    IL_0099:  stloc.0
-    IL_009a:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0079:  call       ""System.Threading.Tasks.Task<int> C.A2()""
+    IL_007e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0083:  stloc.s    V_4
+    IL_0085:  ldloca.s   V_4
+    IL_0087:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_008c:  brtrue.s   IL_00d0
+    IL_008e:  ldarg.0
+    IL_008f:  ldc.i4.1
+    IL_0090:  dup
+    IL_0091:  stloc.0
+    IL_0092:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0097:  ldarg.0
+    IL_0098:  ldloc.s    V_4
+    IL_009a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
     IL_009f:  ldarg.0
-    IL_00a0:  ldloc.s    V_4
-    IL_00a2:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
-    IL_00a7:  ldarg.0
-    IL_00a8:  stloc.3
-    IL_00a9:  ldarg.0
-    IL_00aa:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_00af:  ldloca.s   V_4
-    IL_00b1:  ldloca.s   V_3
-    IL_00b3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__3)""
-    IL_00b8:  nop
-    IL_00b9:  leave.s    IL_011b
+    IL_00a0:  stloc.3
+    IL_00a1:  ldarg.0
+    IL_00a2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_00a7:  ldloca.s   V_4
+    IL_00a9:  ldloca.s   V_3
+    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__3)""
+    IL_00b0:  nop
+    IL_00b1:  leave.s    IL_010b
+    IL_00b3:  ldarg.0
+    IL_00b4:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
+    IL_00b9:  stloc.s    V_4
     IL_00bb:  ldarg.0
-    IL_00bc:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
-    IL_00c1:  stloc.s    V_4
-    IL_00c3:  ldarg.0
-    IL_00c4:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
-    IL_00c9:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00cf:  ldarg.0
-    IL_00d0:  ldc.i4.m1
-    IL_00d1:  dup
-    IL_00d2:  stloc.0
-    IL_00d3:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_00d8:  ldloca.s   V_4
-    IL_00da:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00df:  pop
-    IL_00e0:  ldloca.s   V_4
-    IL_00e2:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00e8:  ldc.i4.1
-    IL_00e9:  stloc.1
-    IL_00ea:  leave.s    IL_0106
+    IL_00bc:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__3.<>u__2""
+    IL_00c1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_00c7:  ldarg.0
+    IL_00c8:  ldc.i4.m1
+    IL_00c9:  dup
+    IL_00ca:  stloc.0
+    IL_00cb:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_00d0:  ldloca.s   V_4
+    IL_00d2:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00d7:  pop
+    IL_00d8:  ldc.i4.1
+    IL_00d9:  stloc.1
+    IL_00da:  leave.s    IL_00f6
   }
   catch System.Exception
   {
-    IL_00ec:  stloc.s    V_5
-    IL_00ee:  ldarg.0
-    IL_00ef:  ldc.i4.s   -2
-    IL_00f1:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_00f6:  ldarg.0
-    IL_00f7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_00fc:  ldloc.s    V_5
-    IL_00fe:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0103:  nop
-    IL_0104:  leave.s    IL_011b
+    IL_00dc:  stloc.s    V_5
+    IL_00de:  ldarg.0
+    IL_00df:  ldc.i4.s   -2
+    IL_00e1:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_00e6:  ldarg.0
+    IL_00e7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_00ec:  ldloc.s    V_5
+    IL_00ee:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00f3:  nop
+    IL_00f4:  leave.s    IL_010b
   }
-  IL_0106:  ldarg.0
-  IL_0107:  ldc.i4.s   -2
-  IL_0109:  stfld      ""int C.<F>d__3.<>1__state""
-  IL_010e:  ldarg.0
-  IL_010f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-  IL_0114:  ldloc.1
-  IL_0115:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_011a:  nop
-  IL_011b:  ret
+  IL_00f6:  ldarg.0
+  IL_00f7:  ldc.i4.s   -2
+  IL_00f9:  stfld      ""int C.<F>d__3.<>1__state""
+  IL_00fe:  ldarg.0
+  IL_00ff:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+  IL_0104:  ldloc.1
+  IL_0105:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_010a:  nop
+  IL_010b:  ret
 }
 ");
             // 1 field def added & 2 methods updated
@@ -2777,7 +2763,7 @@ class C
             // Note that the new awaiters are allocated slots <>u__4, <>u__5.
             diff2.VerifyIL("C.<F>d__3.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      284 (0x11c)
+  // Code size      268 (0x10c)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -2798,7 +2784,7 @@ class C
     IL_000e:  beq.s      IL_0014
     IL_0010:  br.s       IL_0019
     IL_0012:  br.s       IL_0055
-    IL_0014:  br         IL_00bb
+    IL_0014:  br         IL_00b3
     IL_0019:  nop
     IL_001a:  call       ""System.Threading.Tasks.Task<bool> C.A1()""
     IL_001f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<bool> System.Threading.Tasks.Task<bool>.GetAwaiter()""
@@ -2822,7 +2808,7 @@ class C
     IL_0048:  ldloca.s   V_3
     IL_004a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<bool>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<bool>, ref C.<F>d__3)""
     IL_004f:  nop
-    IL_0050:  leave      IL_011b
+    IL_0050:  leave      IL_010b
     IL_0055:  ldarg.0
     IL_0056:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<bool> C.<F>d__3.<>u__4""
     IL_005b:  stloc.2
@@ -2837,73 +2823,69 @@ class C
     IL_0071:  ldloca.s   V_2
     IL_0073:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<bool>.GetResult()""
     IL_0078:  pop
-    IL_0079:  ldloca.s   V_2
-    IL_007b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<bool>""
-    IL_0081:  call       ""System.Threading.Tasks.Task<C> C.A3()""
-    IL_0086:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<C> System.Threading.Tasks.Task<C>.GetAwaiter()""
-    IL_008b:  stloc.s    V_4
-    IL_008d:  ldloca.s   V_4
-    IL_008f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<C>.IsCompleted.get""
-    IL_0094:  brtrue.s   IL_00d8
-    IL_0096:  ldarg.0
-    IL_0097:  ldc.i4.1
-    IL_0098:  dup
-    IL_0099:  stloc.0
-    IL_009a:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0079:  call       ""System.Threading.Tasks.Task<C> C.A3()""
+    IL_007e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<C> System.Threading.Tasks.Task<C>.GetAwaiter()""
+    IL_0083:  stloc.s    V_4
+    IL_0085:  ldloca.s   V_4
+    IL_0087:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<C>.IsCompleted.get""
+    IL_008c:  brtrue.s   IL_00d0
+    IL_008e:  ldarg.0
+    IL_008f:  ldc.i4.1
+    IL_0090:  dup
+    IL_0091:  stloc.0
+    IL_0092:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_0097:  ldarg.0
+    IL_0098:  ldloc.s    V_4
+    IL_009a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
     IL_009f:  ldarg.0
-    IL_00a0:  ldloc.s    V_4
-    IL_00a2:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_00a7:  ldarg.0
-    IL_00a8:  stloc.3
-    IL_00a9:  ldarg.0
-    IL_00aa:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_00af:  ldloca.s   V_4
-    IL_00b1:  ldloca.s   V_3
-    IL_00b3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<C>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<C>, ref C.<F>d__3)""
-    IL_00b8:  nop
-    IL_00b9:  leave.s    IL_011b
+    IL_00a0:  stloc.3
+    IL_00a1:  ldarg.0
+    IL_00a2:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_00a7:  ldloca.s   V_4
+    IL_00a9:  ldloca.s   V_3
+    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<C>, C.<F>d__3>(ref System.Runtime.CompilerServices.TaskAwaiter<C>, ref C.<F>d__3)""
+    IL_00b0:  nop
+    IL_00b1:  leave.s    IL_010b
+    IL_00b3:  ldarg.0
+    IL_00b4:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
+    IL_00b9:  stloc.s    V_4
     IL_00bb:  ldarg.0
-    IL_00bc:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_00c1:  stloc.s    V_4
-    IL_00c3:  ldarg.0
-    IL_00c4:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
-    IL_00c9:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<C>""
-    IL_00cf:  ldarg.0
-    IL_00d0:  ldc.i4.m1
-    IL_00d1:  dup
-    IL_00d2:  stloc.0
-    IL_00d3:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_00d8:  ldloca.s   V_4
-    IL_00da:  call       ""C System.Runtime.CompilerServices.TaskAwaiter<C>.GetResult()""
-    IL_00df:  pop
-    IL_00e0:  ldloca.s   V_4
-    IL_00e2:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<C>""
-    IL_00e8:  ldc.i4.1
-    IL_00e9:  stloc.1
-    IL_00ea:  leave.s    IL_0106
+    IL_00bc:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<C> C.<F>d__3.<>u__3""
+    IL_00c1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<C>""
+    IL_00c7:  ldarg.0
+    IL_00c8:  ldc.i4.m1
+    IL_00c9:  dup
+    IL_00ca:  stloc.0
+    IL_00cb:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_00d0:  ldloca.s   V_4
+    IL_00d2:  call       ""C System.Runtime.CompilerServices.TaskAwaiter<C>.GetResult()""
+    IL_00d7:  pop
+    IL_00d8:  ldc.i4.1
+    IL_00d9:  stloc.1
+    IL_00da:  leave.s    IL_00f6
   }
   catch System.Exception
   {
-    IL_00ec:  stloc.s    V_5
-    IL_00ee:  ldarg.0
-    IL_00ef:  ldc.i4.s   -2
-    IL_00f1:  stfld      ""int C.<F>d__3.<>1__state""
-    IL_00f6:  ldarg.0
-    IL_00f7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-    IL_00fc:  ldloc.s    V_5
-    IL_00fe:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0103:  nop
-    IL_0104:  leave.s    IL_011b
+    IL_00dc:  stloc.s    V_5
+    IL_00de:  ldarg.0
+    IL_00df:  ldc.i4.s   -2
+    IL_00e1:  stfld      ""int C.<F>d__3.<>1__state""
+    IL_00e6:  ldarg.0
+    IL_00e7:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+    IL_00ec:  ldloc.s    V_5
+    IL_00ee:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00f3:  nop
+    IL_00f4:  leave.s    IL_010b
   }
-  IL_0106:  ldarg.0
-  IL_0107:  ldc.i4.s   -2
-  IL_0109:  stfld      ""int C.<F>d__3.<>1__state""
-  IL_010e:  ldarg.0
-  IL_010f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
-  IL_0114:  ldloc.1
-  IL_0115:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_011a:  nop
-  IL_011b:  ret
+  IL_00f6:  ldarg.0
+  IL_00f7:  ldc.i4.s   -2
+  IL_00f9:  stfld      ""int C.<F>d__3.<>1__state""
+  IL_00fe:  ldarg.0
+  IL_00ff:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__3.<>t__builder""
+  IL_0104:  ldloc.1
+  IL_0105:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_010a:  nop
+  IL_010b:  ret
 }
 ");
             // 2 field defs added - G and H awaiters & 4 methods updated: G, H kickoff and MoveNext

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2969,7 +2969,7 @@ class C
 
             v0.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      254 (0xfe)
+  // Code size      246 (0xf6)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -3047,7 +3047,7 @@ class C
     IL_0094:  ldloca.s   V_3
     IL_0096:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__0)""
     IL_009b:  nop
-    IL_009c:  leave.s    IL_00fd
+    IL_009c:  leave.s    IL_00f5
    >IL_009e:  ldarg.0
     IL_009f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__0.<>u__1""
     IL_00a4:  stloc.2
@@ -3062,34 +3062,32 @@ class C
     IL_00ba:  ldloca.s   V_2
     IL_00bc:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_00c1:  pop
-    IL_00c2:  ldloca.s   V_2
-    IL_00c4:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-   -IL_00ca:  ldc.i4.1
-    IL_00cb:  stloc.1
-    IL_00cc:  leave.s    IL_00e8
+   -IL_00c2:  ldc.i4.1
+    IL_00c3:  stloc.1
+    IL_00c4:  leave.s    IL_00e0
   }
   catch System.Exception
   {
-   ~IL_00ce:  stloc.s    V_4
+   ~IL_00c6:  stloc.s    V_4
+    IL_00c8:  ldarg.0
+    IL_00c9:  ldc.i4.s   -2
+    IL_00cb:  stfld      ""int C.<F>d__0.<>1__state""
     IL_00d0:  ldarg.0
-    IL_00d1:  ldc.i4.s   -2
-    IL_00d3:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00d8:  ldarg.0
-    IL_00d9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_00de:  ldloc.s    V_4
-    IL_00e0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00e5:  nop
-    IL_00e6:  leave.s    IL_00fd
+    IL_00d1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_00d6:  ldloc.s    V_4
+    IL_00d8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00dd:  nop
+    IL_00de:  leave.s    IL_00f5
   }
- -IL_00e8:  ldarg.0
-  IL_00e9:  ldc.i4.s   -2
-  IL_00eb:  stfld      ""int C.<F>d__0.<>1__state""
- ~IL_00f0:  ldarg.0
-  IL_00f1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00f6:  ldloc.1
-  IL_00f7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00fc:  nop
-  IL_00fd:  ret
+ -IL_00e0:  ldarg.0
+  IL_00e1:  ldc.i4.s   -2
+  IL_00e3:  stfld      ""int C.<F>d__0.<>1__state""
+ ~IL_00e8:  ldarg.0
+  IL_00e9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00ee:  ldloc.1
+  IL_00ef:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00f4:  nop
+  IL_00f5:  ret
 }
 ", sequencePoints: "C+<F>d__0.MoveNext");
 

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBAsyncTests.cs
@@ -58,14 +58,13 @@ class Driver
 
             v.VerifyIL("TestCase.<Run>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      301 (0x12d)
+  // Code size      289 (0x121)
   .maxstack  3
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_1,
-                int V_2,
-                TestCase.<Run>d__1 V_3,
-                bool V_4,
-                System.Exception V_5)
+                TestCase.<Run>d__1 V_2,
+                bool V_3,
+                System.Exception V_4)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int TestCase.<Run>d__1.<>1__state""
   IL_0006:  stloc.0
@@ -110,14 +109,14 @@ class Driver
     IL_006e:  ldloc.1
     IL_006f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
     IL_0074:  ldarg.0
-    IL_0075:  stloc.3
+    IL_0075:  stloc.2
     IL_0076:  ldarg.0
     IL_0077:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
     IL_007c:  ldloca.s   V_1
-    IL_007e:  ldloca.s   V_3
+    IL_007e:  ldloca.s   V_2
     IL_0080:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, TestCase.<Run>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref TestCase.<Run>d__1)""
     IL_0085:  nop
-    IL_0086:  leave      IL_012c
+    IL_0086:  leave      IL_0120
    >IL_008b:  ldarg.0
     IL_008c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> TestCase.<Run>d__1.<>u__1""
     IL_0091:  stloc.1
@@ -129,59 +128,55 @@ class Driver
     IL_00a0:  dup
     IL_00a1:  stloc.0
     IL_00a2:  stfld      ""int TestCase.<Run>d__1.<>1__state""
-    IL_00a7:  ldloca.s   V_1
-    IL_00a9:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00ae:  stloc.2
-    IL_00af:  ldloca.s   V_1
-    IL_00b1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00b7:  ldarg.0
-    IL_00b8:  ldloc.2
-    IL_00b9:  stfld      ""int TestCase.<Run>d__1.<>s__3""
-    IL_00be:  ldarg.0
-    IL_00bf:  ldarg.0
-    IL_00c0:  ldfld      ""int TestCase.<Run>d__1.<>s__3""
-    IL_00c5:  stfld      ""int TestCase.<Run>d__1.<rez2>5__2""
-   -IL_00ca:  ldarg.0
-    IL_00cb:  ldfld      ""int TestCase.<Run>d__1.<rez2>5__2""
-    IL_00d0:  ldc.i4.3
-    IL_00d1:  ceq
-    IL_00d3:  stloc.s    V_4
-   ~IL_00d5:  ldloc.s    V_4
-    IL_00d7:  brfalse.s  IL_00e5
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldloca.s   V_1
+    IL_00aa:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00af:  stfld      ""int TestCase.<Run>d__1.<>s__3""
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldarg.0
+    IL_00b6:  ldfld      ""int TestCase.<Run>d__1.<>s__3""
+    IL_00bb:  stfld      ""int TestCase.<Run>d__1.<rez2>5__2""
+   -IL_00c0:  ldarg.0
+    IL_00c1:  ldfld      ""int TestCase.<Run>d__1.<rez2>5__2""
+    IL_00c6:  ldc.i4.3
+    IL_00c7:  ceq
+    IL_00c9:  stloc.3
+   ~IL_00ca:  ldloc.3
+    IL_00cb:  brfalse.s  IL_00d9
+   -IL_00cd:  ldsfld     ""int TestCase.Count""
+    IL_00d2:  ldc.i4.1
+    IL_00d3:  add
+    IL_00d4:  stsfld     ""int TestCase.Count""
    -IL_00d9:  ldsfld     ""int TestCase.Count""
     IL_00de:  ldc.i4.1
-    IL_00df:  add
-    IL_00e0:  stsfld     ""int TestCase.Count""
-   -IL_00e5:  ldsfld     ""int TestCase.Count""
-    IL_00ea:  ldc.i4.1
-    IL_00eb:  sub
-    IL_00ec:  stsfld     ""int Driver.Result""
-   -IL_00f1:  ldsfld     ""System.Threading.AutoResetEvent Driver.CompletedSignal""
-    IL_00f6:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
-    IL_00fb:  pop
-   ~IL_00fc:  leave.s    IL_0118
+    IL_00df:  sub
+    IL_00e0:  stsfld     ""int Driver.Result""
+   -IL_00e5:  ldsfld     ""System.Threading.AutoResetEvent Driver.CompletedSignal""
+    IL_00ea:  callvirt   ""bool System.Threading.EventWaitHandle.Set()""
+    IL_00ef:  pop
+   ~IL_00f0:  leave.s    IL_010c
   }
   catch System.Exception
   {
-  ~$IL_00fe:  stloc.s    V_5
-    IL_0100:  ldarg.0
-    IL_0101:  ldc.i4.s   -2
-    IL_0103:  stfld      ""int TestCase.<Run>d__1.<>1__state""
-    IL_0108:  ldarg.0
-    IL_0109:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-    IL_010e:  ldloc.s    V_5
-    IL_0110:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
-    IL_0115:  nop
-    IL_0116:  leave.s    IL_012c
+  ~$IL_00f2:  stloc.s    V_4
+    IL_00f4:  ldarg.0
+    IL_00f5:  ldc.i4.s   -2
+    IL_00f7:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+    IL_00fc:  ldarg.0
+    IL_00fd:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+    IL_0102:  ldloc.s    V_4
+    IL_0104:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException(System.Exception)""
+    IL_0109:  nop
+    IL_010a:  leave.s    IL_0120
   }
- -IL_0118:  ldarg.0
-  IL_0119:  ldc.i4.s   -2
-  IL_011b:  stfld      ""int TestCase.<Run>d__1.<>1__state""
- ~IL_0120:  ldarg.0
-  IL_0121:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
-  IL_0126:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
-  IL_012b:  nop
-  IL_012c:  ret
+ -IL_010c:  ldarg.0
+  IL_010d:  ldc.i4.s   -2
+  IL_010f:  stfld      ""int TestCase.<Run>d__1.<>1__state""
+ ~IL_0114:  ldarg.0
+  IL_0115:  ldflda     ""System.Runtime.CompilerServices.AsyncVoidMethodBuilder TestCase.<Run>d__1.<>t__builder""
+  IL_011a:  call       ""void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetResult()""
+  IL_011f:  nop
+  IL_0120:  ret
 }",
 sequencePoints: "TestCase+<Run>d__1.MoveNext");
 
@@ -264,13 +259,12 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
       <customDebugInfo>
         <forward declaringType=""TestCase"" methodName="".cctor"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x12d"" />
-          <slot startOffset=""0x0"" endOffset=""0x12d"" />
+          <slot startOffset=""0x0"" endOffset=""0x121"" />
+          <slot startOffset=""0x0"" endOffset=""0x121"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
           <slot kind=""33"" offset=""146"" />
-          <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""1"" offset=""173"" />
           <slot kind=""temp"" />
@@ -284,18 +278,18 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         <entry offset=""0x1a"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""71"" />
         <entry offset=""0x45"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""37"" />
         <entry offset=""0x5b"" hidden=""true"" />
-        <entry offset=""0xca"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""23"" />
-        <entry offset=""0xd5"" hidden=""true"" />
-        <entry offset=""0xd9"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""32"" />
-        <entry offset=""0xe5"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" />
-        <entry offset=""0xf1"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" />
-        <entry offset=""0xfc"" hidden=""true"" />
-        <entry offset=""0xfe"" hidden=""true"" />
-        <entry offset=""0x118"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" />
-        <entry offset=""0x120"" hidden=""true"" />
+        <entry offset=""0xc0"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""23"" />
+        <entry offset=""0xca"" hidden=""true"" />
+        <entry offset=""0xcd"" startLine=""18"" startColumn=""24"" endLine=""18"" endColumn=""32"" />
+        <entry offset=""0xd9"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""44"" />
+        <entry offset=""0xe5"" startLine=""22"" startColumn=""9"" endLine=""22"" endColumn=""38"" />
+        <entry offset=""0xf0"" hidden=""true"" />
+        <entry offset=""0xf2"" hidden=""true"" />
+        <entry offset=""0x10c"" startLine=""23"" startColumn=""5"" endLine=""23"" endColumn=""6"" />
+        <entry offset=""0x114"" hidden=""true"" />
       </sequencePoints>
       <asyncInfo>
-        <catchHandler offset=""0xfe"" />
+        <catchHandler offset=""0xf2"" />
         <kickoffMethod declaringType=""TestCase"" methodName=""Run"" />
         <await yield=""0x6d"" resume=""0x8b"" declaringType=""TestCase+&lt;Run&gt;d__1"" methodName=""MoveNext"" />
       </asyncInfo>
@@ -317,10 +311,10 @@ sequencePoints: "TestCase+<Run>d__1.MoveNext");
         <entry offset=""0xe"" startLine=""16"" startColumn=""32"" endLine=""16"" endColumn=""33"" />
         <entry offset=""0xf"" startLine=""16"" startColumn=""34"" endLine=""16"" endColumn=""58"" />
         <entry offset=""0x1f"" hidden=""true"" />
-        <entry offset=""0x78"" startLine=""16"" startColumn=""59"" endLine=""16"" endColumn=""68"" />
-        <entry offset=""0x7c"" hidden=""true"" />
-        <entry offset=""0x96"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" />
-        <entry offset=""0x9e"" hidden=""true"" />
+        <entry offset=""0x70"" startLine=""16"" startColumn=""59"" endLine=""16"" endColumn=""68"" />
+        <entry offset=""0x74"" hidden=""true"" />
+        <entry offset=""0x8e"" startLine=""16"" startColumn=""69"" endLine=""16"" endColumn=""70"" />
+        <entry offset=""0x96"" hidden=""true"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""TestCase+&lt;&gt;c"" methodName=""&lt;Run&gt;b__1_0"" />
@@ -370,8 +364,7 @@ namespace ConsoleApplication1
     }
 }";
             var compilation = CreateCompilationWithMscorlib45(text, options: TestOptions.DebugDll).VerifyDiagnostics();
-            compilation.VerifyPdb(@"
-<symbols>
+            compilation.VerifyPdb(@"<symbols>
   <methods>
     <method containingType=""ConsoleApplication1.Program"" name=""Main"" parameterNames=""args"">
       <customDebugInfo>
@@ -446,13 +439,13 @@ namespace ConsoleApplication1
         <entry offset=""0xe"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
         <entry offset=""0xf"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""26"" />
         <entry offset=""0x20"" hidden=""true"" />
-        <entry offset=""0x79"" hidden=""true"" />
-        <entry offset=""0x7b"" hidden=""true"" />
-        <entry offset=""0x93"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" />
-        <entry offset=""0x9b"" hidden=""true"" />
+        <entry offset=""0x71"" hidden=""true"" />
+        <entry offset=""0x73"" hidden=""true"" />
+        <entry offset=""0x8b"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" />
+        <entry offset=""0x93"" hidden=""true"" />
       </sequencePoints>
       <asyncInfo>
-        <catchHandler offset=""0x7b"" />
+        <catchHandler offset=""0x73"" />
         <kickoffMethod declaringType=""ConsoleApplication1.Program"" methodName=""QBar"" />
         <await yield=""0x32"" resume=""0x4d"" declaringType=""ConsoleApplication1.Program+&lt;QBar&gt;d__2"" methodName=""MoveNext"" />
       </asyncInfo>
@@ -461,17 +454,16 @@ namespace ConsoleApplication1
       <customDebugInfo>
         <forward declaringType=""ConsoleApplication1.Program"" methodName=""Main"" parameterNames=""args"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x14f"" />
+          <slot startOffset=""0x0"" endOffset=""0x144"" />
           <slot />
           <slot />
-          <slot startOffset=""0x41"" endOffset=""0xee"" />
-          <slot startOffset=""0x54"" endOffset=""0xee"" />
+          <slot startOffset=""0x41"" endOffset=""0xe3"" />
+          <slot startOffset=""0x54"" endOffset=""0xe3"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
           <slot kind=""20"" offset=""0"" />
           <slot kind=""33"" offset=""141"" />
-          <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
@@ -488,18 +480,18 @@ namespace ConsoleApplication1
         <entry offset=""0x54"" startLine=""23"" startColumn=""13"" endLine=""23"" endColumn=""14"" />
         <entry offset=""0x55"" startLine=""24"" startColumn=""17"" endLine=""24"" endColumn=""55"" />
         <entry offset=""0x6b"" hidden=""true"" />
-        <entry offset=""0xdb"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""39"" />
-        <entry offset=""0xed"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" />
-        <entry offset=""0xee"" hidden=""true"" />
-        <entry offset=""0xfc"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""30"" />
-        <entry offset=""0x116"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""30"" />
-        <entry offset=""0x11f"" hidden=""true"" />
-        <entry offset=""0x139"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" />
-        <entry offset=""0x141"" hidden=""true"" />
+        <entry offset=""0xd0"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""39"" />
+        <entry offset=""0xe2"" startLine=""26"" startColumn=""13"" endLine=""26"" endColumn=""14"" />
+        <entry offset=""0xe3"" hidden=""true"" />
+        <entry offset=""0xf1"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""30"" />
+        <entry offset=""0x10b"" startLine=""27"" startColumn=""13"" endLine=""27"" endColumn=""30"" />
+        <entry offset=""0x114"" hidden=""true"" />
+        <entry offset=""0x12e"" startLine=""28"" startColumn=""9"" endLine=""28"" endColumn=""10"" />
+        <entry offset=""0x136"" hidden=""true"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""ConsoleApplication1.Program"" methodName=""ZBar"" />
-        <await yield=""0x7d"" resume=""0x9c"" declaringType=""ConsoleApplication1.Program+&lt;ZBar&gt;d__3"" methodName=""MoveNext"" />
+        <await yield=""0x7d"" resume=""0x9b"" declaringType=""ConsoleApplication1.Program+&lt;ZBar&gt;d__3"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -525,8 +517,7 @@ class TestCase
                     references: new[] { SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929, CSharpRef })
                 .VerifyDiagnostics();
 
-            compilation.VerifyPdb(@"
-<symbols>
+            compilation.VerifyPdb(@"<symbols>
   <methods>
     <method containingType=""TestCase"" name=""Await"" parameterNames=""d"">
       <customDebugInfo>
@@ -545,12 +536,11 @@ class TestCase
           <namespace usingCount=""0"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x262"" />
+          <slot startOffset=""0x0"" endOffset=""0x25d"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
           <slot kind=""33"" offset=""21"" />
-          <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
@@ -563,15 +553,15 @@ class TestCase
         <entry offset=""0x11"" startLine=""5"" startColumn=""5"" endLine=""5"" endColumn=""6"" />
         <entry offset=""0x12"" startLine=""6"" startColumn=""9"" endLine=""6"" endColumn=""27"" />
         <entry offset=""0xae"" hidden=""true"" />
-        <entry offset=""0x231"" hidden=""true"" />
-        <entry offset=""0x233"" hidden=""true"" />
-        <entry offset=""0x24d"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
-        <entry offset=""0x255"" hidden=""true"" />
+        <entry offset=""0x22c"" hidden=""true"" />
+        <entry offset=""0x22e"" hidden=""true"" />
+        <entry offset=""0x248"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""6"" />
+        <entry offset=""0x250"" hidden=""true"" />
       </sequencePoints>
       <asyncInfo>
-        <catchHandler offset=""0x233"" />
+        <catchHandler offset=""0x22e"" />
         <kickoffMethod declaringType=""TestCase"" methodName=""Await"" parameterNames=""d"" />
-        <await yield=""0x148"" resume=""0x190"" declaringType=""TestCase+&lt;Await&gt;d__0"" methodName=""MoveNext"" />
+        <await yield=""0x148"" resume=""0x18f"" declaringType=""TestCase+&lt;Await&gt;d__0"" methodName=""MoveNext"" />
       </asyncInfo>
     </method>
   </methods>
@@ -624,7 +614,7 @@ sequencePoints: "C.F");
 
             v.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext", @"
 {
-  // Code size      168 (0xa8)
+  // Code size      160 (0xa0)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
@@ -664,7 +654,7 @@ sequencePoints: "C.F");
     IL_003e:  ldloca.s   V_3
     IL_0040:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter, ref C.<F>d__0)""
     IL_0045:  nop
-    IL_0046:  leave.s    IL_00a7
+    IL_0046:  leave.s    IL_009f
    >IL_0048:  ldarg.0
     IL_0049:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter C.<F>d__0.<>u__1""
     IL_004e:  stloc.2
@@ -679,34 +669,32 @@ sequencePoints: "C.F");
     IL_0064:  ldloca.s   V_2
     IL_0066:  call       ""void System.Runtime.CompilerServices.TaskAwaiter.GetResult()""
     IL_006b:  nop
-    IL_006c:  ldloca.s   V_2
-    IL_006e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter""
-   -IL_0074:  ldc.i4.1
-    IL_0075:  stloc.1
-    IL_0076:  leave.s    IL_0092
+   -IL_006c:  ldc.i4.1
+    IL_006d:  stloc.1
+    IL_006e:  leave.s    IL_008a
   }
   catch System.Exception
   {
-   ~IL_0078:  stloc.s    V_4
+   ~IL_0070:  stloc.s    V_4
+    IL_0072:  ldarg.0
+    IL_0073:  ldc.i4.s   -2
+    IL_0075:  stfld      ""int C.<F>d__0.<>1__state""
     IL_007a:  ldarg.0
-    IL_007b:  ldc.i4.s   -2
-    IL_007d:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0082:  ldarg.0
-    IL_0083:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0088:  ldloc.s    V_4
-    IL_008a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_008f:  nop
-    IL_0090:  leave.s    IL_00a7
+    IL_007b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0080:  ldloc.s    V_4
+    IL_0082:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0087:  nop
+    IL_0088:  leave.s    IL_009f
   }
- -IL_0092:  ldarg.0
-  IL_0093:  ldc.i4.s   -2
-  IL_0095:  stfld      ""int C.<F>d__0.<>1__state""
- ~IL_009a:  ldarg.0
-  IL_009b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00a0:  ldloc.1
-  IL_00a1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00a6:  nop
-  IL_00a7:  ret
+ -IL_008a:  ldarg.0
+  IL_008b:  ldc.i4.s   -2
+  IL_008d:  stfld      ""int C.<F>d__0.<>1__state""
+ ~IL_0092:  ldarg.0
+  IL_0093:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_0098:  ldloc.1
+  IL_0099:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_009e:  nop
+  IL_009f:  ret
 }
 ", sequencePoints: "C+<F>d__0.MoveNext");
         }
@@ -747,8 +735,7 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"
-<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -764,14 +751,14 @@ class C
         <entry offset=""0x25"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
         <entry offset=""0x36"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" />
         <entry offset=""0x55"" hidden=""true"" />
-        <entry offset=""0xa9"" hidden=""true"" />
-        <entry offset=""0xab"" hidden=""true"" />
-        <entry offset=""0xc2"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
-        <entry offset=""0xca"" hidden=""true"" />
+        <entry offset=""0xa1"" hidden=""true"" />
+        <entry offset=""0xa3"" hidden=""true"" />
+        <entry offset=""0xba"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0xc2"" hidden=""true"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xd6"">
-        <scope startOffset=""0xa"" endOffset=""0xab"">
-          <local name=""CS$&lt;&gt;8__locals0"" il_index=""1"" il_start=""0xa"" il_end=""0xab"" attributes=""0"" />
+      <scope startOffset=""0x0"" endOffset=""0xce"">
+        <scope startOffset=""0xa"" endOffset=""0xa3"">
+          <local name=""CS$&lt;&gt;8__locals0"" il_index=""1"" il_start=""0xa"" il_end=""0xa3"" attributes=""0"" />
         </scope>
       </scope>
       <asyncInfo>
@@ -832,14 +819,13 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"
-<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x10e"" />
+          <slot startOffset=""0x0"" endOffset=""0x106"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -859,10 +845,10 @@ class C
         <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
         <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""31"" />
         <entry offset=""0x86"" hidden=""true"" />
-        <entry offset=""0xdf"" hidden=""true"" />
-        <entry offset=""0xe1"" hidden=""true"" />
-        <entry offset=""0xf9"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
-        <entry offset=""0x101"" hidden=""true"" />
+        <entry offset=""0xd7"" hidden=""true"" />
+        <entry offset=""0xd9"" hidden=""true"" />
+        <entry offset=""0xf1"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
+        <entry offset=""0xf9"" hidden=""true"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -928,14 +914,13 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"
-<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0xec"" />
+          <slot startOffset=""0x0"" endOffset=""0xe4"" />
         </hoistedLocalScopes>
       </customDebugInfo>
       <sequencePoints>
@@ -948,11 +933,11 @@ class C
         <entry offset=""0x39"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
         <entry offset=""0x4f"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" />
         <entry offset=""0x5b"" hidden=""true"" />
-        <entry offset=""0xaf"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" />
-        <entry offset=""0xbf"" hidden=""true"" />
-        <entry offset=""0xc1"" hidden=""true"" />
-        <entry offset=""0xd8"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
-        <entry offset=""0xe0"" hidden=""true"" />
+        <entry offset=""0xa7"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" />
+        <entry offset=""0xb7"" hidden=""true"" />
+        <entry offset=""0xb9"" hidden=""true"" />
+        <entry offset=""0xd0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
+        <entry offset=""0xd8"" hidden=""true"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -1011,14 +996,13 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"
-<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
         <forward declaringType=""C+&lt;&gt;c__DisplayClass0_0"" methodName=""&lt;M&gt;b__0"" />
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0xfd"" />
+          <slot startOffset=""0x0"" endOffset=""0xf5"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1038,11 +1022,11 @@ class C
         <entry offset=""0x41"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""47"" />
         <entry offset=""0x58"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""29"" />
         <entry offset=""0x64"" hidden=""true"" />
-        <entry offset=""0xbd"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" />
-        <entry offset=""0xce"" hidden=""true"" />
-        <entry offset=""0xd0"" hidden=""true"" />
-        <entry offset=""0xe8"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
-        <entry offset=""0xf0"" hidden=""true"" />
+        <entry offset=""0xb5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""31"" />
+        <entry offset=""0xc6"" hidden=""true"" />
+        <entry offset=""0xc8"" hidden=""true"" />
+        <entry offset=""0xe0"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
+        <entry offset=""0xe8"" hidden=""true"" />
       </sequencePoints>
       <asyncInfo>
         <kickoffMethod declaringType=""C"" methodName=""M"" parameterNames=""b"" />
@@ -1103,8 +1087,7 @@ class C
 
             // CHANGE: Dev12 emits a <dynamiclocal> entry for "d", but gives it slot "-1", preventing it from matching
             // any locals when consumed by the EE (i.e. it has no effect).  See FUNCBRECEE::IsLocalDynamic.
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"
-<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1112,7 +1095,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x10a"" />
+          <slot startOffset=""0x0"" endOffset=""0x102"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1128,13 +1111,13 @@ class C
         <entry offset=""0xf"" startLine=""8"" startColumn=""9"" endLine=""8"" endColumn=""23"" />
         <entry offset=""0x1b"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""29"" />
         <entry offset=""0x27"" hidden=""true"" />
-        <entry offset=""0x83"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" />
-        <entry offset=""0xdb"" hidden=""true"" />
-        <entry offset=""0xdd"" hidden=""true"" />
-        <entry offset=""0xf5"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
-        <entry offset=""0xfd"" hidden=""true"" />
+        <entry offset=""0x7b"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""22"" />
+        <entry offset=""0xd3"" hidden=""true"" />
+        <entry offset=""0xd5"" hidden=""true"" />
+        <entry offset=""0xed"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0xf5"" hidden=""true"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x10a"">
+      <scope startOffset=""0x0"" endOffset=""0x102"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
@@ -1190,8 +1173,7 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"
-<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1209,15 +1191,15 @@ class C
         <entry offset=""0x14"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" />
         <entry offset=""0x64"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" />
         <entry offset=""0x70"" hidden=""true"" />
-        <entry offset=""0xc4"" hidden=""true"" />
-        <entry offset=""0xc6"" hidden=""true"" />
-        <entry offset=""0xdd"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
-        <entry offset=""0xe5"" hidden=""true"" />
+        <entry offset=""0xbc"" hidden=""true"" />
+        <entry offset=""0xbe"" hidden=""true"" />
+        <entry offset=""0xd5"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+        <entry offset=""0xdd"" hidden=""true"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0xf1"">
+      <scope startOffset=""0x0"" endOffset=""0xe9"">
         <namespace name=""System.Threading.Tasks"" />
-        <scope startOffset=""0xd"" endOffset=""0xc6"">
-          <local name=""d"" il_index=""1"" il_start=""0xd"" il_end=""0xc6"" attributes=""0"" />
+        <scope startOffset=""0xd"" endOffset=""0xbe"">
+          <local name=""d"" il_index=""1"" il_start=""0xd"" il_end=""0xbe"" attributes=""0"" />
         </scope>
       </scope>
       <asyncInfo>
@@ -1272,8 +1254,7 @@ class C
                 }, module.GetFieldNames("C.<M>d__0"));
             });
 
-            v.VerifyPdb("C+<M>d__0.MoveNext", @"
-<symbols>
+            v.VerifyPdb("C+<M>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;M&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1281,7 +1262,7 @@ class C
           <namespace usingCount=""1"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x10a"" />
+          <slot startOffset=""0x0"" endOffset=""0x102"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
           <slot kind=""27"" offset=""0"" />
@@ -1298,12 +1279,12 @@ class C
         <entry offset=""0x1e"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""22"" />
         <entry offset=""0x76"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""29"" />
         <entry offset=""0x82"" hidden=""true"" />
-        <entry offset=""0xdb"" hidden=""true"" />
-        <entry offset=""0xdd"" hidden=""true"" />
-        <entry offset=""0xf5"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
-        <entry offset=""0xfd"" hidden=""true"" />
+        <entry offset=""0xd3"" hidden=""true"" />
+        <entry offset=""0xd5"" hidden=""true"" />
+        <entry offset=""0xed"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
+        <entry offset=""0xf5"" hidden=""true"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x10a"">
+      <scope startOffset=""0x0"" endOffset=""0x102"">
         <namespace name=""System.Threading.Tasks"" />
       </scope>
       <asyncInfo>
@@ -1430,15 +1411,14 @@ class C
 
             v.VerifyIL("C.<G>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      286 (0x11e)
+  // Code size      274 (0x112)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
                 object V_2,
                 System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                int V_4,
-                C.<G>d__0 V_5,
-                System.Exception V_6)
+                C.<G>d__0 V_4,
+                System.Exception V_5)
  ~IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<G>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1488,14 +1468,14 @@ class C
     IL_0052:  ldloc.3
     IL_0053:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<G>d__0.<>u__1""
     IL_0058:  ldarg.0
-    IL_0059:  stloc.s    V_5
+    IL_0059:  stloc.s    V_4
     IL_005b:  ldarg.0
     IL_005c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
     IL_0061:  ldloca.s   V_3
-    IL_0063:  ldloca.s   V_5
+    IL_0063:  ldloca.s   V_4
     IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<G>d__0>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<G>d__0)""
     IL_006a:  nop
-    IL_006b:  leave      IL_011d
+    IL_006b:  leave      IL_0111
    >IL_0070:  ldarg.0
     IL_0071:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<G>d__0.<>u__1""
     IL_0076:  stloc.3
@@ -1507,72 +1487,67 @@ class C
     IL_0085:  dup
     IL_0086:  stloc.0
     IL_0087:  stfld      ""int C.<G>d__0.<>1__state""
-    IL_008c:  ldloca.s   V_3
-    IL_008e:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0093:  stloc.s    V_4
-    IL_0095:  ldloca.s   V_3
-    IL_0097:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_009d:  ldarg.0
-    IL_009e:  ldloc.s    V_4
-    IL_00a0:  stfld      ""int C.<G>d__0.<>s__4""
-    IL_00a5:  ldarg.0
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldfld      ""int C.<G>d__0.<>s__4""
-    IL_00ac:  stfld      ""int C.<G>d__0.<x>5__1""
-   -IL_00b1:  nop
-   ~IL_00b2:  ldarg.0
-    IL_00b3:  ldfld      ""object C.<G>d__0.<>s__2""
-    IL_00b8:  stloc.2
-    IL_00b9:  ldloc.2
-    IL_00ba:  brfalse.s  IL_00d7
+    IL_008c:  ldarg.0
+    IL_008d:  ldloca.s   V_3
+    IL_008f:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0094:  stfld      ""int C.<G>d__0.<>s__4""
+    IL_0099:  ldarg.0
+    IL_009a:  ldarg.0
+    IL_009b:  ldfld      ""int C.<G>d__0.<>s__4""
+    IL_00a0:  stfld      ""int C.<G>d__0.<x>5__1""
+   -IL_00a5:  nop
+   ~IL_00a6:  ldarg.0
+    IL_00a7:  ldfld      ""object C.<G>d__0.<>s__2""
+    IL_00ac:  stloc.2
+    IL_00ad:  ldloc.2
+    IL_00ae:  brfalse.s  IL_00cb
+    IL_00b0:  ldloc.2
+    IL_00b1:  isinst     ""System.Exception""
+    IL_00b6:  stloc.s    V_5
+    IL_00b8:  ldloc.s    V_5
+    IL_00ba:  brtrue.s   IL_00be
     IL_00bc:  ldloc.2
-    IL_00bd:  isinst     ""System.Exception""
-    IL_00c2:  stloc.s    V_6
-    IL_00c4:  ldloc.s    V_6
-    IL_00c6:  brtrue.s   IL_00ca
-    IL_00c8:  ldloc.2
-    IL_00c9:  throw
-    IL_00ca:  ldloc.s    V_6
-    IL_00cc:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
-    IL_00d1:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
-    IL_00d6:  nop
-    IL_00d7:  ldarg.0
-    IL_00d8:  ldfld      ""int C.<G>d__0.<>s__3""
-    IL_00dd:  pop
-    IL_00de:  ldarg.0
-    IL_00df:  ldnull
-    IL_00e0:  stfld      ""object C.<G>d__0.<>s__2""
-   -IL_00e5:  ldarg.0
-    IL_00e6:  ldfld      ""int C.<G>d__0.<x>5__1""
-    IL_00eb:  stloc.1
-    IL_00ec:  leave.s    IL_0108
+    IL_00bd:  throw
+    IL_00be:  ldloc.s    V_5
+    IL_00c0:  call       ""System.Runtime.ExceptionServices.ExceptionDispatchInfo System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(System.Exception)""
+    IL_00c5:  callvirt   ""void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()""
+    IL_00ca:  nop
+    IL_00cb:  ldarg.0
+    IL_00cc:  ldfld      ""int C.<G>d__0.<>s__3""
+    IL_00d1:  pop
+    IL_00d2:  ldarg.0
+    IL_00d3:  ldnull
+    IL_00d4:  stfld      ""object C.<G>d__0.<>s__2""
+   -IL_00d9:  ldarg.0
+    IL_00da:  ldfld      ""int C.<G>d__0.<x>5__1""
+    IL_00df:  stloc.1
+    IL_00e0:  leave.s    IL_00fc
   }
   catch System.Exception
   {
-   ~IL_00ee:  stloc.s    V_6
-    IL_00f0:  ldarg.0
-    IL_00f1:  ldc.i4.s   -2
-    IL_00f3:  stfld      ""int C.<G>d__0.<>1__state""
-    IL_00f8:  ldarg.0
-    IL_00f9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
-    IL_00fe:  ldloc.s    V_6
-    IL_0100:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_0105:  nop
-    IL_0106:  leave.s    IL_011d
+   ~IL_00e2:  stloc.s    V_5
+    IL_00e4:  ldarg.0
+    IL_00e5:  ldc.i4.s   -2
+    IL_00e7:  stfld      ""int C.<G>d__0.<>1__state""
+    IL_00ec:  ldarg.0
+    IL_00ed:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
+    IL_00f2:  ldloc.s    V_5
+    IL_00f4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00f9:  nop
+    IL_00fa:  leave.s    IL_0111
   }
- -IL_0108:  ldarg.0
-  IL_0109:  ldc.i4.s   -2
-  IL_010b:  stfld      ""int C.<G>d__0.<>1__state""
- ~IL_0110:  ldarg.0
-  IL_0111:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
-  IL_0116:  ldloc.1
-  IL_0117:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_011c:  nop
-  IL_011d:  ret
+ -IL_00fc:  ldarg.0
+  IL_00fd:  ldc.i4.s   -2
+  IL_00ff:  stfld      ""int C.<G>d__0.<>1__state""
+ ~IL_0104:  ldarg.0
+  IL_0105:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<G>d__0.<>t__builder""
+  IL_010a:  ldloc.1
+  IL_010b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_0110:  nop
+  IL_0111:  ret
 }", sequencePoints: "C+<G>d__0.MoveNext");
 
-            v.VerifyPdb("C+<G>d__0.MoveNext", @"
-<symbols>
+            v.VerifyPdb("C+<G>d__0.MoveNext", @"<symbols>
   <methods>
     <method containingType=""C+&lt;G&gt;d__0"" name=""MoveNext"">
       <customDebugInfo>
@@ -1580,7 +1555,7 @@ class C
           <namespace usingCount=""2"" />
         </using>
         <hoistedLocalScopes>
-          <slot startOffset=""0x0"" endOffset=""0x11e"" />
+          <slot startOffset=""0x0"" endOffset=""0x112"" />
           <slot startOffset=""0x29"" endOffset=""0x33"" />
         </hoistedLocalScopes>
         <encLocalSlotMap>
@@ -1588,7 +1563,6 @@ class C
           <slot kind=""20"" offset=""0"" />
           <slot kind=""temp"" />
           <slot kind=""33"" offset=""105"" />
-          <slot kind=""temp"" />
           <slot kind=""temp"" />
           <slot kind=""temp"" />
         </encLocalSlotMap>
@@ -1606,14 +1580,14 @@ class C
         <entry offset=""0x33"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
         <entry offset=""0x34"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""27"" />
         <entry offset=""0x3f"" hidden=""true"" />
-        <entry offset=""0xb1"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0xb2"" hidden=""true"" />
-        <entry offset=""0xe5"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""18"" />
-        <entry offset=""0xee"" hidden=""true"" />
-        <entry offset=""0x108"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" />
-        <entry offset=""0x110"" hidden=""true"" />
+        <entry offset=""0xa5"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
+        <entry offset=""0xa6"" hidden=""true"" />
+        <entry offset=""0xd9"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""18"" />
+        <entry offset=""0xe2"" hidden=""true"" />
+        <entry offset=""0xfc"" startLine=""20"" startColumn=""5"" endLine=""20"" endColumn=""6"" />
+        <entry offset=""0x104"" hidden=""true"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x11e"">
+      <scope startOffset=""0x0"" endOffset=""0x112"">
         <namespace name=""System"" />
         <namespace name=""System.Threading.Tasks"" />
       </scope>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAwaitTests.cs
@@ -1894,11 +1894,11 @@ class C
             var calls = actualIL.Split(new[] { '\n', '\r' }, System.StringSplitOptions.RemoveEmptyEntries).Where(s => s.Contains("OnCompleted")).ToArray();
             Assert.Equal(calls.Length, 6);
             Assert.Equal("    IL_0056:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted<T1, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T1, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[0]);
-            Assert.Equal("    IL_00c1:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T2, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T2, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[1]);
-            Assert.Equal("    IL_012c:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T3, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T3, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[2]);
-            Assert.Equal("    IL_019a:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted<T4, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T4, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[3]);
-            Assert.Equal("    IL_020a:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T5, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T5, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[4]);
-            Assert.Equal("    IL_027a:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T6, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T6, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[5]);
+            Assert.Equal("    IL_00b9:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T2, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T2, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[1]);
+            Assert.Equal("    IL_011c:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T3, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T3, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[2]);
+            Assert.Equal("    IL_0182:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitOnCompleted<T4, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T4, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[3]);
+            Assert.Equal("    IL_01ea:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T5, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T5, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[4]);
+            Assert.Equal("    IL_0252:  call       \"void System.Runtime.CompilerServices.AsyncVoidMethodBuilder.AwaitUnsafeOnCompleted<T6, C.<F>d__0<T1, T2, T3, T4, T5, T6>>(ref T6, ref C.<F>d__0<T1, T2, T3, T4, T5, T6>)\"", calls[5]);
         }
 
         [Fact]

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -1050,7 +1050,7 @@ class C
                 var methodData = testData.GetMethodData("<>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()");
                 methodData.VerifyIL(@"
 {
-  // Code size      544 (0x220)
+  // Code size      542 (0x21e)
   .maxstack  10
   .locals init (int V_0,
                 <>x.<>c__DisplayClass0_0 V_1,
@@ -1183,7 +1183,7 @@ class C
     IL_017d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d)""
     IL_0182:  ldnull
     IL_0183:  stloc.s    V_4
-    IL_0185:  leave      IL_021f
+    IL_0185:  leave      IL_021d
     IL_018a:  ldarg.0
     IL_018b:  ldfld      ""object <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>u__1""
     IL_0190:  stloc.3
@@ -1218,31 +1218,29 @@ class C
     IL_01e2:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
     IL_01e7:  ldloc.3
     IL_01e8:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-    IL_01ed:  ldnull
-    IL_01ee:  stloc.3
-    IL_01ef:  stloc.2
-    IL_01f0:  leave.s    IL_020b
+    IL_01ed:  stloc.2
+    IL_01ee:  leave.s    IL_0209
   }
   catch System.Exception
   {
-    IL_01f2:  stloc.s    V_6
-    IL_01f4:  ldarg.0
-    IL_01f5:  ldc.i4.s   -2
-    IL_01f7:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
-    IL_01fc:  ldarg.0
-    IL_01fd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
-    IL_0202:  ldloc.s    V_6
-    IL_0204:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
-    IL_0209:  leave.s    IL_021f
+    IL_01f0:  stloc.s    V_6
+    IL_01f2:  ldarg.0
+    IL_01f3:  ldc.i4.s   -2
+    IL_01f5:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
+    IL_01fa:  ldarg.0
+    IL_01fb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
+    IL_0200:  ldloc.s    V_6
+    IL_0202:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_0207:  leave.s    IL_021d
   }
-  IL_020b:  ldarg.0
-  IL_020c:  ldc.i4.s   -2
-  IL_020e:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
-  IL_0213:  ldarg.0
-  IL_0214:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
-  IL_0219:  ldloc.2
-  IL_021a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
-  IL_021f:  ret
+  IL_0209:  ldarg.0
+  IL_020a:  ldc.i4.s   -2
+  IL_020c:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
+  IL_0211:  ldarg.0
+  IL_0212:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
+  IL_0217:  ldloc.2
+  IL_0218:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_021d:  ret
 }
 ");
             });

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -2108,10 +2108,9 @@ class C
   .maxstack  1
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
-                object V_2,
-                C.<M>d__1 V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
-                System.Exception V_5)
+                C.<M>d__1 V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.x""
   IL_0006:  ret
@@ -2122,10 +2121,9 @@ class C
   .maxstack  1
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
-                object V_2,
-                C.<M>d__1 V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
-                System.Exception V_5)
+                C.<M>d__1 V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.<y>5__1""
   IL_0006:  ret
@@ -2180,12 +2178,11 @@ class C
   .maxstack  1
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
-                object V_2,
-                C.<M>d__1 V_3,
+                C.<M>d__1 V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_3,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                System.Exception V_7)
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.x""
   IL_0006:  ret
@@ -2196,12 +2193,11 @@ class C
   .maxstack  1
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
-                object V_2,
-                C.<M>d__1 V_3,
+                C.<M>d__1 V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_3,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                System.Exception V_7)
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<M>d__1.<y>5__1""
   IL_0006:  ret
@@ -2221,28 +2217,27 @@ class C
   .maxstack  1
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
-                object V_2,
-                C.<M>d__1 V_3,
+                C.<M>d__1 V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_3,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                System.Exception V_7)
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""object C.<M>d__1.x""
   IL_0006:  ret
-}");
+}
+");
                 VerifyLocal(testData, "<>x", locals[1], "<>m1", "y", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
   .locals init (int V_0,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_1,
-                object V_2,
-                C.<M>d__1 V_3,
+                C.<M>d__1 V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<object> V_3,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_4,
                 System.Runtime.CompilerServices.TaskAwaiter<object> V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<object> V_6,
-                System.Exception V_7)
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""long C.<M>d__1.<y>5__3""
   IL_0006:  ret


### PR DESCRIPTION
I was looking through our async codegen and noticed that we are zeroing out the awaiter local after fetching its Result, often right before exiting the MoveNext method. 
We also allocate unnecessary temp while doing this.

This pattern would repeat for every `await` and just makes the state machine method bigger. It is generally not necessary to zero-out locals. 

Basically a very simple `await` like ` Console.WriteLine(await Somehthing())` 
will end with 

```cs
                ...   some code here to handle suspending/resuming if necessary ...

		int temp = taskAwaiter.GetResult();
                // the following erasing of taskAwaiter seems unnecessary.
                // taskAwaiter is just a local variable.
		taskAwaiter = default(TaskAwaiter<int>);   
		Console.WriteLine(temp);
```

Where it can be just:

```cs
                ...   some code here to handle suspending/resuming if necessary ...

		Console.WriteLine(taskAwaiter.GetResult());
```


**Risk**

The risk is low. 
Storing a value into a regular (unpinned) local variable without ever reading it is not observable. The change essentially removes a dead store.

The only possible case where this can go wrong is if we are running with conservative GC that does not track liveness of stack roots (not common) + when containing async method is active for a very long time - like spinning in a loop or blocked on an IO. 
If GC is to happen after we are done with the given awaiter, GC may still consider the awaiter as rooted.

This would be a problem for any ref-containing local that went out of scope without being zeroed out, which is very common.  
So, basically either this change does not cause a problem or we have bigger problems (conservative GC). 

**Performance impact**

We are removing a dead local store here (which JIT might also be able to remove), so perf impact should be none or positive (possibly very slightly).
As evident from the the test changes, IL does get smaller.

I will look for any async benchmarks to run here.

**Is this a regression from a previous update?**

No. This is technically not a bug and we emitted such code for quite some time.

We have numerous tests that verify the behavior and codegen of async code. Most of this change is actually updating the IL baselines.