### PR TITLE
ENC support for C# 7.0 features

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -5936,6 +5936,96 @@ class C
 
         #endregion
 
+        #region OutVar
+
+        [Fact]
+        public void SyntaxOffset_OutVarInConstructor()
+        {
+            var source = @"
+class B
+{
+    B(out int z) { z = 2; } 
+}
+
+class C
+{
+    int F = G(out var v1);    
+    int P => G(out var v2);    
+
+    C() 
+    : base(out var v3)
+    { 
+        G(out var v4);
+    }
+
+    int G(out int x) 
+    {
+        x = 1;
+        return 2;
+    }
+}
+";
+
+            var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            c.VerifyDiagnostics(
+                // (9,19): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
+                //     int F = G(out var v1);    
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "var v1").WithLocation(9, 19),
+                // (9,13): error CS0236: A field initializer cannot reference the non-static field, method, or property 'C.G(out int)'
+                //     int F = G(out var v1);    
+                Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "G(out var v1)").WithArguments("C.G(out int)").WithLocation(9, 13),
+                // (13,16): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
+                //     : base(out var v3)
+                Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "var v3").WithLocation(13, 16),
+                // (13,7): error CS1729: 'object' does not contain a constructor that takes 1 arguments
+                //     : base(out var v3)
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "base").WithArguments("object", "1").WithLocation(13, 7));
+        }
+
+
+        [Fact]
+        public void SyntaxOffset_OutVarInMethod()
+        {
+            var source = @"class C { int G(out int x) { int z = 1; G(out var y); G(out var w); return x = y; } }";
+
+            var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            c.VerifyPdb("C.G", @"
+<symbols>
+  <methods>
+    <method containingType=""C"" name=""G"" parameterNames=""x"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""0"" offset=""6"" />
+          <slot kind=""0"" offset=""23"" />
+          <slot kind=""0"" offset=""37"" />
+          <slot kind=""temp"" />
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""1"" startColumn=""28"" endLine=""1"" endColumn=""29"" />
+        <entry offset=""0x1"" startLine=""1"" startColumn=""30"" endLine=""1"" endColumn=""40"" />
+        <entry offset=""0x3"" startLine=""1"" startColumn=""41"" endLine=""1"" endColumn=""54"" />
+        <entry offset=""0xc"" startLine=""1"" startColumn=""55"" endLine=""1"" endColumn=""68"" />
+        <entry offset=""0x15"" startLine=""1"" startColumn=""69"" endLine=""1"" endColumn=""82"" />
+        <entry offset=""0x1f"" startLine=""1"" startColumn=""83"" endLine=""1"" endColumn=""84"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x22"">
+        <local name=""z"" il_index=""0"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
+        <local name=""y"" il_index=""1"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
+        <local name=""w"" il_index=""2"" il_start=""0x0"" il_end=""0x22"" attributes=""0"" />
+      </scope>
+    </method>
+  </methods>
+</symbols>
+");
+        }
+
+        #endregion
+
         [Fact, WorkItem(4370, "https://github.com/dotnet/roslyn/issues/4370")]
         public void HeadingHiddenSequencePointsPickUpDocumentFromVisibleSequencePoint()
         {

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -5982,7 +5982,6 @@ class C
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "base").WithArguments("object", "1").WithLocation(13, 7));
         }
 
-
         [Fact]
         public void SyntaxOffset_OutVarInMethod()
         {

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -905,6 +905,529 @@ catch (Exception e) when (filter(e)) { Console.WriteLine(30); }
         }
 
         [Fact]
+        public void MatchTuple()
+        {
+            var src1 = @"
+return (1, 2);
+return (d, 6);
+return (10, e, 22);
+return (2, () => { 
+    int a = 6;
+    return 1;
+});";
+
+            var src2 = @"
+return (1, 2, 3);
+return (d, 5);
+return (10, e);
+return (2, () => {
+    int a = 6;
+    return 5;
+});";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "return (1, 2);", "return (1, 2, 3);" },
+                { "return (d, 6);", "return (d, 5);" },
+                { "return (10, e, 22);", "return (10, e);" },
+                { "return (2, () => {      int a = 6;     return 1; });", "return (2, () => {     int a = 6;     return 5; });" },
+                { "() => {      int a = 6;     return 1; }", "() => {     int a = 6;     return 5; }" },
+                { "{      int a = 6;     return 1; }", "{     int a = 6;     return 5; }" },
+                { "int a = 6;", "int a = 6;" },
+                { "int a = 6", "int a = 6" },
+                { "a = 6", "a = 6" },
+                { "return 1;", "return 5;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchLocalFunctionDefinitions()
+        {
+            var src1 = @"
+(int a, string c) F1(int i) { return null; }
+(int a, int b) F2(int i) { return null; }
+(int a, int b, int c) F3(int i) { return null; }
+";
+
+            var src2 = @"
+(int a, int b) F1(int i) { return null; }
+(int a, int b, string c) F2(int i) { return null; }
+(int a, int b) F3(int i) { return null; }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "(int a, string c) F1(int i) { return null; }", "(int a, int b) F1(int i) { return null; }" },
+                { "{ return null; }", "{ return null; }" },
+                { "return null;", "return null;" },
+                { "(int a, int b) F2(int i) { return null; }", "(int a, int b, string c) F2(int i) { return null; }" },
+                { "{ return null; }", "{ return null; }" },
+                { "return null;", "return null;" },
+                { "(int a, int b, int c) F3(int i) { return null; }", "(int a, int b) F3(int i) { return null; }" },
+                { "{ return null; }", "{ return null; }" },
+                { "return null;", "return null;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchVariableDesignations()
+        {
+            var src1 = @"
+M(out int z);
+N(out var a);
+";
+
+            var src2 = @"
+M(out var z);
+N(out var b);
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "M(out int z);", "M(out var z);" },
+                { "z", "z" },
+                { "N(out var a);", "N(out var b);" },
+                { "a", "b" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchParenthesizedVariable_Update()
+        {
+            var src1 = @"
+var (x1, (x2, x3)) = (1, (2, true));
+var (a1, a2) = (1, () => { return 7; });
+";
+
+            var src2 = @"
+var (x1, (x3, x4)) = (1, (2, true));
+var (a1, a3) = (1, () => { return 8; });
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "var (x1, (x2, x3)) = (1, (2, true));", "var (x1, (x3, x4)) = (1, (2, true));" },
+                { "x1", "x1" },
+                { "x2", "x4" },
+                { "x3", "x3" },
+                { "var (a1, a2) = (1, () => { return 7; });", "var (a1, a3) = (1, () => { return 8; });" },
+                { "a1", "a1" },
+                { "a2", "a3" },
+                { "() => { return 7; }", "() => { return 8; }" },
+                { "{ return 7; }", "{ return 8; }" },
+                { "return 7;", "return 8;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchParenthesizedVariable_Insert()
+        {
+            var src1 = @"var (z1, z2) = (1, 2);";
+            var src2 = @"var (z1, z2, z3) = (1, 2, 5);";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "var (z1, z2) = (1, 2);", "var (z1, z2, z3) = (1, 2, 5);" },
+                { "z1", "z1" },
+                { "z2", "z2" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchParenthesizedVariable_Delete()
+        {
+            var src1 = @"var (y1, y2, y3) = (1, 2, 7);";
+            var src2 = @"var (y1, y2) = (1, 4);";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "var (y1, y2, y3) = (1, 2, 7);", "var (y1, y2) = (1, 4);" },
+                { "y1", "y1" },
+                { "y2", "y2" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchForeachVariable_Update1()
+        {
+            var src1 = @"
+foreach (var (a1, a2) in e) { A1(); }
+foreach ((var b1, var b2) in e) { A2(); }
+";
+
+            var src2 = @"
+foreach (var (a1, a3) in e) { A1(); }
+foreach ((var b3, int b2) in e) { A2(); }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "foreach (var (a1, a2) in e) { A1(); }", "foreach (var (a1, a3) in e) { A1(); }" },
+                { "a1", "a1" },
+                { "a2", "a3" },
+                { "{ A1(); }", "{ A1(); }" },
+                { "A1();", "A1();" },
+                { "foreach ((var b1, var b2) in e) { A2(); }", "foreach ((var b3, int b2) in e) { A2(); }" },
+                { "b1", "b3" },
+                { "b2", "b2" },
+                { "{ A2(); }", "{ A2(); }" },
+                { "A2();", "A2();" },
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchForeachVariable_Update2()
+        {
+            var src1 = @"
+foreach (_ in e2) { yield return 4; }
+foreach (_ in e3) { A(); }
+";
+
+            var src2 = @"
+foreach (_ in e4) { A(); }
+foreach (var b in e2) { yield return 4; }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "foreach (_ in e2) { yield return 4; }", "foreach (var b in e2) { yield return 4; }" },
+                { "{ yield return 4; }", "{ yield return 4; }" },
+                { "yield return 4;", "yield return 4;" },
+                { "foreach (_ in e3) { A(); }", "foreach (_ in e4) { A(); }" },
+                { "{ A(); }", "{ A(); }" },
+                { "A();", "A();" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchForeachVariable_Insert()
+        {
+            var src1 = @"
+foreach (var (a3, a4) in e) { }
+foreach ((var b4, var b5) in e) { }
+";
+
+            var src2 = @"
+foreach (var (a3, a5, a4) in e) { }
+foreach ((var b6, var b4, var b5) in e) { }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "foreach (var (a3, a4) in e) { }", "foreach (var (a3, a5, a4) in e) { }" },
+                { "a3", "a3" },
+                { "a4", "a4" },
+                { "{ }", "{ }" },
+                { "foreach ((var b4, var b5) in e) { }", "foreach ((var b6, var b4, var b5) in e) { }" },
+                { "b4", "b4" },
+                { "b5", "b5" },
+                { "{ }", "{ }" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchForeachVariable_Delete()
+        {
+            var src1 = @"
+foreach (var (a11, a12, a13) in e) { A1(); }
+foreach ((var b7, var b8, var b9) in e) { A2(); }
+";
+
+            var src2 = @"
+foreach (var (a12, a13) in e1) { A1(); }
+foreach ((var b7, var b9) in e) { A2(); }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "foreach (var (a11, a12, a13) in e) { A1(); }", "foreach (var (a12, a13) in e1) { A1(); }" },
+                { "a12", "a12" },
+                { "a13", "a13" },
+                { "{ A1(); }", "{ A1(); }" },
+                { "A1();", "A1();" },
+                { "foreach ((var b7, var b8, var b9) in e) { A2(); }", "foreach ((var b7, var b9) in e) { A2(); }" },
+                { "b7", "b7" },
+                { "b9", "b9" },
+                { "{ A2(); }", "{ A2(); }" },
+                { "A2();", "A2();" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchConstantPattern()
+        {
+            var src1 = @"
+if ((o is null) && (y == 7)) return 3;
+if (a is 7) return 5;
+";
+
+            var src2 = @"
+if ((o1 is null) && (y == 7)) return 3;
+if (a is 77) return 5;
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs {
+                { "if ((o is null) && (y == 7)) return 3;", "if ((o1 is null) && (y == 7)) return 3;" },
+                { "return 3;", "return 3;" },
+                { "if (a is 7) return 5;", "if (a is 77) return 5;" },
+                { "return 5;", "return 5;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchDeclarationPattern()
+        {
+            var src1 = @"
+if (!(o is int i) && (y == 7)) return;
+if (!(a is string s)) return;
+if (!(b is string t)) return;
+if (!(c is int j)) return;
+";
+
+            var src2 = @"
+if (!(b is string t1)) return;
+if (!(o1 is int i) && (y == 7)) return;
+if (!(c is int)) return;
+if (!(a is int s)) return;
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs {
+                { "if (!(o is int i) && (y == 7)) return;", "if (!(o1 is int i) && (y == 7)) return;" },
+                { "i", "i" },
+                { "return;", "return;" },
+                { "if (!(a is string s)) return;", "if (!(a is int s)) return;" },
+                { "s", "s" },
+                { "return;", "return;" },
+                { "if (!(b is string t)) return;", "if (!(b is string t1)) return;" },
+                { "t", "t1" },
+                { "return;", "return;" },
+                { "if (!(c is int j)) return;", "if (!(c is int)) return;" },
+                { "return;", "return;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchCasePattern_UpdateInsert()
+        {
+            var src1 = @"
+switch(shape)
+{
+    case Circle c: return 1;
+    default: return 4;
+}
+";
+
+            var src2 = @"
+switch(shape)
+{
+    case Circle c1: return 1;
+    case Point p: return 0;
+    default: return 4;
+}
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs {
+                { "switch(shape) {     case Circle c: return 1;     default: return 4; }", "switch(shape) {     case Circle c1: return 1;     case Point p: return 0;     default: return 4; }" },
+                { "case Circle c: return 1;", "case Circle c1: return 1;" },
+                { "case Circle c:", "case Circle c1:" },
+                { "c", "c1" },
+                { "return 1;", "return 1;" },
+                { "default: return 4;", "default: return 4;" },
+                { "return 4;", "return 4;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchWhenCondition()
+        {
+            var src1 = @"
+switch(shape)
+{
+    case Circle c when (c < 10): return 1;
+    case Circle c when (c > 100): return 2;
+}
+";
+
+            var src2 = @"
+switch(shape)
+{
+    case Circle c when (c < 5): return 1;
+    case Circle c2 when (c2 > 100): return 2;
+}
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "switch(shape) {     case Circle c when (c < 10): return 1;     case Circle c when (c > 100): return 2; }", "switch(shape) {     case Circle c when (c < 5): return 1;     case Circle c2 when (c2 > 100): return 2; }" },
+                { "case Circle c when (c < 10): return 1;", "case Circle c when (c < 5): return 1;" },
+                { "case Circle c when (c < 10):", "case Circle c when (c < 5):" },
+                { "c", "c" },
+                { "when (c < 10)", "when (c < 5)" },
+                { "return 1;", "return 1;" },
+                { "case Circle c when (c > 100): return 2;", "case Circle c2 when (c2 > 100): return 2;" },
+                { "case Circle c when (c > 100):", "case Circle c2 when (c2 > 100):" },
+                { "c", "c2" },
+                { "when (c > 100)", "when (c2 > 100)" },
+                { "return 2;", "return 2;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchRef()
+        {
+            var src1 = @"
+ref int a = ref G(new int[] { 1, 2 });
+    ref int G(int[] p)
+    {
+        return ref p[1];
+    }
+";
+
+            var src2 = @"
+ref int32 a = ref G1(new int[] { 1, 2 });
+    ref int G1(int[] p)
+    {
+        return ref p[2];
+    }
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "ref int a = ref G(new int[] { 1, 2 });", "ref int32 a = ref G1(new int[] { 1, 2 });" },
+                { "ref int a = ref G(new int[] { 1, 2 })", "ref int32 a = ref G1(new int[] { 1, 2 })" },
+                { "a = ref G(new int[] { 1, 2 })", "a = ref G1(new int[] { 1, 2 })" },
+                { "ref int G(int[] p)     {         return ref p[1];     }", "ref int G1(int[] p)     {         return ref p[2];     }" },
+                { "{         return ref p[1];     }", "{         return ref p[2];     }" },
+                { "return ref p[1];", "return ref p[2];" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchThrowException_UpdateInsert()
+        {
+            var src1 = @"
+return a > 3 ? a : throw new Exception();
+return c > 7 ? c : 7;
+";
+
+            var src2 = @"
+return a > 3 ? a : throw new ArgumentException();
+return c > 7 ? c : throw new IndexOutOfRangeException();
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "return a > 3 ? a : throw new Exception();", "return a > 3 ? a : throw new ArgumentException();" },
+                { "return c > 7 ? c : 7;", "return c > 7 ? c : throw new IndexOutOfRangeException();" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void MatchThrowException_UpdateDelete()
+        {
+            var src1 = @"
+return a > 3 ? a : throw new Exception();
+return b > 5 ? b : throw new OperationCanceledException();
+";
+
+            var src2 = @"
+return a > 3 ? a : throw new ArgumentException();
+return b > 5 ? b : 5;
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs
+            {
+                { "return a > 3 ? a : throw new Exception();", "return a > 3 ? a : throw new ArgumentException();" },
+                { "return b > 5 ? b : throw new OperationCanceledException();", "return b > 5 ? b : 5;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
         public void StringLiteral_update()
         {
             var src1 = @"
@@ -960,6 +1483,7 @@ var x = $""Hello{123:N2}"";
             edits.VerifyEdits("Update [x = $\"Hello{123:N1}\"]@8 -> [x = $\"Hello{123:N2}\"]@8");
         }
 
+        [WorkItem(18970, "https://github.com/dotnet/roslyn/issues/18970")]
         [Fact]
         public void MatchCasePattern_UpdateDelete()
         {
@@ -983,7 +1507,9 @@ switch(shape)
 
             var expected = new MatchingPairs {
                 { "switch(shape) {     case Point p: return 0;     case Circle c: return 1; }", "switch(shape) {     case Circle circle: return 1; }" },
+                { "p", "circle" },
                 { "case Circle c: return 1;", "case Circle circle: return 1;" },
+                { "case Circle c:", "case Circle circle:" },
                 { "return 1;", "return 1;" }
             };
 
@@ -1019,6 +1545,131 @@ switch(shape)
             edits.VerifyEdits(
                 "Update [x = F(1)]@6 -> [x = F(3)]@6",
                 "Update [y = G(2)]@16 -> [y = G(4)]@16");
+        }
+
+        [Fact]
+        public void ParenthesizedVariableDeclaration_Update()
+        {
+            var src1 = @"
+var (x1, (x2, x3)) = (1, (2, true));
+var (a1, a2) = (1, () => { return 7; });
+";
+           var src2 = @"
+var (x1, (x2, x4)) = (1, (2, true));
+var (a1, a3) = (1, () => { return 8; });
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [x3]@18 -> [x4]@18",
+                "Update [a2]@51 -> [a3]@51");
+        }
+
+        [Fact]
+        public void ParenthesizedVariableDeclaration_Insert()
+        {
+            var src1 = @"var (z1, z2) = (1, 2);";
+            var src2 = @"var (z1, z2, z3) = (1, 2, 5);";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [var (z1, z2) = (1, 2);]@2 -> [var (z1, z2, z3) = (1, 2, 5);]@2",
+                "Insert [z3]@15");
+        }
+
+        [Fact]
+        public void ParenthesizedVariableDeclaration_Delete()
+        {
+            var src1 = @"var (y1, y2, y3) = (1, 2, 7);";
+            var src2 = @"var (y1, y2) = (1, 4);";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [var (y1, y2, y3) = (1, 2, 7);]@2 -> [var (y1, y2) = (1, 4);]@2",
+                "Delete [y3]@15");
+        }
+
+        [Fact]
+        public void VariableDeclaraions_Reorder()
+        {
+            var src1 = @"var (a, b) = (1, 2); var (c, d) = (3, 4);";
+            var src2 = @"var (c, d) = (3, 4); var (a, b) = (1, 2);";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Reorder [var (c, d) = (3, 4);]@23 -> @2");
+        }
+
+        [Fact]
+        public void VariableNames_Reorder()
+        {
+            var src1 = @"var (a, b) = (1, 2);";
+            var src2 = @"var (b, a) = (2, 1);";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [var (a, b) = (1, 2);]@2 -> [var (b, a) = (2, 1);]@2",
+                "Reorder [b]@10 -> @7");
+        }
+
+        [Fact]
+        public void VariableNamesAndDeclaraions_Reorder()
+        {
+            var src1 = @"var (a, b) = (1, 2); var (c, d) = (3, 4);";
+            var src2 = @"var (d, c) = (3, 4); var (a, b) = (1, 2);";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Reorder [var (c, d) = (3, 4);]@23 -> @2",
+                "Reorder [d]@31 -> @7");
+        }
+
+        [Fact]
+        public void ParenthesizedVariableDeclaration_Reorder()
+        {
+            var src1 = @"var (a, (b, c)) = (1, (2, 3));";
+            var src2 = @"var ((b, c), a) = ((2, 3), 1);";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [var (a, (b, c)) = (1, (2, 3));]@2 -> [var ((b, c), a) = ((2, 3), 1);]@2",
+                "Reorder [a]@7 -> @15");
+        }
+
+        [Fact]
+        public void ParenthesizedVariableDeclaration_DoubleReorder()
+        {
+            var src1 = @"var (a, (b, c)) = (1, (2, 3));";
+            var src2 = @"var ((c, b), a) = ((2, 3), 1);";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [var (a, (b, c)) = (1, (2, 3));]@2 -> [var ((c, b), a) = ((2, 3), 1);]@2",
+                "Reorder [b]@11 -> @11",
+                "Reorder [c]@14 -> @8");
+        }
+
+        [Fact]
+        public void ParenthesizedVariableDeclaration_ComplexReorder()
+        {
+            var src1 = @"var (a, (b, c)) = (1, (2, 3)); var (x, (y, z)) = (4, (5, 6));";
+            var src2 = @"var (x, (y, z)) = (4, (5, 6)); var ((c, b), a) = (1, (2, 3)); ";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Reorder [var (x, (y, z)) = (4, (5, 6));]@33 -> @2",
+                "Update [var (a, (b, c)) = (1, (2, 3));]@2 -> [var ((c, b), a) = (1, (2, 3));]@33",
+                "Reorder [b]@11 -> @42",
+                "Reorder [c]@14 -> @39");
         }
 
         #endregion
@@ -1065,6 +1716,7 @@ switch(shape)
                 "Update [case 1: f(); break;]@18 -> [case 2: f(); break;]@18");
         }
 
+        [WorkItem(18970, "https://github.com/dotnet/roslyn/issues/18970")]
         [Fact]
         public void CasePatternLabel_UpdateDelete()
         {
@@ -1087,8 +1739,12 @@ switch(shape)
 
             edits.VerifyEdits(
                 "Update [case Circle c: return 1;]@55 -> [case Circle circle: return 1;]@26",
+                "Update [p]@37 -> [circle]@38",
+                "Move [p]@37 -> @38",
                 "Delete [case Point p: return 0;]@26",
-                "Delete [return 0;]@40");
+                "Delete [case Point p:]@26",
+                "Delete [return 0;]@40",
+                "Delete [c]@67");
         }
 
         #endregion
@@ -1867,6 +2523,134 @@ try { Console.WriteLine(); } catch (E e) { /*1*/ } finally { /*3*/ }";
                 "Insert [foreach (var a in b) { Foo(); }]@2",
                 "Move [{ Foo(); }]@2 -> @23");
         }
+
+        [Fact]
+        public void ForeachVariable_Update1()
+        {
+            var src1 = @"
+foreach (var (a1, a2) in e) { }
+foreach ((var b1, var b2) in e) { }
+foreach (var a in e1) { yield return 7; }
+";
+
+            var src2 = @"
+foreach (var (a1, a3) in e) { }
+foreach ((var b3, int b2) in e) { }
+foreach (_ in e1) { yield return 7; }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [foreach ((var b1, var b2) in e) { }]@37 -> [foreach ((var b3, int b2) in e) { }]@37",
+                "Update [foreach (var a in e1) { yield return 7; }]@74 -> [foreach (_ in e1) { yield return 7; }]@74",
+                "Update [a2]@22 -> [a3]@22",
+                "Update [b1]@51 -> [b3]@51");
+        }
+
+        [Fact]
+        public void ForeachVariable_Update2()
+        {
+            var src1 = @"
+foreach (_ in e2) { yield return 5; }
+foreach (_ in e3) {  A(); }
+";
+
+            var src2 = @"
+foreach (var b in e2) { yield return 5; }
+foreach (_ in e4) { A(); }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [foreach (_ in e2) { yield return 5; }]@4 -> [foreach (var b in e2) { yield return 5; }]@4",
+                "Update [foreach (_ in e3) {  A(); }]@43 -> [foreach (_ in e4) { A(); }]@47");
+        }
+
+        [Fact]
+        public void ForeachVariable_Insert()
+        {
+            var src1 = @"
+foreach (var (a3, a4) in e) { }
+foreach ((var b4, var b5) in e) { }
+";
+
+            var src2 = @"
+foreach (var (a3, a5, a4) in e) { }
+foreach ((var b6, var b4, var b5) in e) { }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [foreach (var (a3, a4) in e) { }]@4 -> [foreach (var (a3, a5, a4) in e) { }]@4",
+                "Update [foreach ((var b4, var b5) in e) { }]@37 -> [foreach ((var b6, var b4, var b5) in e) { }]@41",
+                "Insert [a5]@22",
+                "Insert [b6]@55");
+        }
+
+        [Fact]
+        public void ForeachVariable_Delete()
+        {
+            var src1 = @"
+foreach (var (a11, a12, a13) in e) { F(); }
+foreach ((var b7, var b8, var b9) in e) { G(); }
+";
+
+            var src2 = @"
+foreach (var (a12, a13) in e1) { F(); }
+foreach ((var b7, var b9) in e) { G(); }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [foreach (var (a11, a12, a13) in e) { F(); }]@4 -> [foreach (var (a12, a13) in e1) { F(); }]@4",
+                "Update [foreach ((var b7, var b8, var b9) in e) { G(); }]@49 -> [foreach ((var b7, var b9) in e) { G(); }]@45",
+                "Delete [a11]@18",
+                "Delete [b8]@71");
+        }
+
+        [Fact]
+        public void ForeachVariable_Reorder()
+        {
+            var src1 = @"
+foreach (var (a, b) in e1) { }
+foreach ((var x, var y) in e2) { }
+";
+
+            var src2 = @"
+foreach ((var x, var y) in e2) { }
+foreach (var (a, b) in e1) { }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Reorder [foreach ((var x, var y) in e2) { }]@36 -> @4");
+        }
+
+        [Fact]
+        public void ForeachVariableEmbedded_Reorder()
+        {
+            var src1 = @"
+foreach (var (a, b) in e1) { 
+    foreach ((var x, var y) in e2) { }
+}
+";
+
+            var src2 = @"
+foreach ((var x, var y) in e2) { }
+foreach (var (a, b) in e1) { }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Move [foreach ((var x, var y) in e2) { }]@39 -> @4");
+        }
+
 
         #endregion
 
@@ -7376,5 +8160,408 @@ class C
         }
 
         #endregion
+
+        #region Out Var
+
+        [Fact]
+        public void OutVarType_Update()
+        {
+            var src1 = @"
+M(out var y);
+";
+            var src2 = @"
+M(out int y);
+";
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [M(out var y);]@4 -> [M(out int y);]@4");
+        }
+
+        [Fact]
+        public void OutVarNameAndType_Update()
+        {
+            var src1 = @"
+M(out var y);
+";
+            var src2 = @"
+M(out int z);
+";
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [M(out var y);]@4 -> [M(out int z);]@4",
+                "Update [y]@14 -> [z]@14");
+        }
+
+        [Fact]
+        public void OutVar_Insert()
+        {
+            var src1 = @"
+M();
+";
+            var src2 = @"
+M(out int y);
+";
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [M();]@4 -> [M(out int y);]@4",
+                "Insert [y]@14");
+        }
+
+        [Fact]
+        public void OutVar_Delete()
+        {
+            var src1 = @"
+M(out int y);
+";
+
+            var src2 = @"
+M();
+";
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [M(out int y);]@4 -> [M();]@4",
+                "Delete [y]@14");
+        }
+
+        #endregion
+
+        #region Pattern
+
+        [Fact]
+        public void ConstantPattern_Update()
+        {
+            var src1 = @"
+if ((o is null) && (y == 7)) return 3;
+if (a is 7) return 5;
+";
+
+            var src2 = @"
+if ((o1 is null) && (y == 7)) return 3;
+if (a is 77) return 5;
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [if ((o is null) && (y == 7)) return 3;]@4 -> [if ((o1 is null) && (y == 7)) return 3;]@4",
+                "Update [if (a is 7) return 5;]@44 -> [if (a is 77) return 5;]@45");
+        }
+
+        [Fact]
+        public void DeclarationPattern_Update()
+        {
+            var src1 = @"
+if (!(o is int i) && (y == 7)) return;
+if (!(a is string s)) return;
+if (!(b is string t)) return;
+if (!(c is int j)) return;
+";
+
+            var src2 = @"
+if (!(o1 is int i) && (y == 7)) return;
+if (!(a is int s)) return;
+if (!(b is string t1)) return;
+if (!(c is int)) return;
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [if (!(o is int i) && (y == 7)) return;]@4 -> [if (!(o1 is int i) && (y == 7)) return;]@4",
+                "Update [if (!(a is string s)) return;]@44 -> [if (!(a is int s)) return;]@45",
+                "Update [if (!(c is int j)) return;]@106 -> [if (!(c is int)) return;]@105",
+                "Update [t]@93 -> [t1]@91",
+                "Delete [j]@121");
+        }
+
+        [Fact]
+        public void DeclarationPattern_Reorder()
+        {
+            var src1 = @"if ((a is int i) && (b is int j)) { A(); }";
+            var src2 = @"if ((b is int j) && (a is int i)) { A(); }";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [if ((a is int i) && (b is int j)) { A(); }]@2 -> [if ((b is int j) && (a is int i)) { A(); }]@2",
+                "Reorder [j]@32 -> @16");
+        }
+
+        [Fact]
+        public void CasePattern_UpdateInsert()
+        {
+            var src1 = @"
+switch(shape)
+{
+    case Circle c: return 1;
+    default: return 4;
+}
+";
+
+            var src2 = @"
+switch(shape)
+{
+    case Circle c1: return 1;
+    case Point p: return 0;
+    default: return 4;
+}
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [case Circle c: return 1;]@26 -> [case Circle c1: return 1;]@26",
+                "Insert [case Point p: return 0;]@57",
+                "Insert [case Point p:]@57",
+                "Insert [return 0;]@71",
+                "Update [c]@38 -> [c1]@38",
+                "Insert [p]@68");
+        }
+
+        [Fact]
+        public void CasePattern_UpdateDelete()
+        {
+            var src1 = @"
+switch(shape)
+{
+    case Point p: return 0;
+    case Circle c: A(c); break;
+    default: return 4;
+}
+";
+
+            var src2 = @"
+switch(shape)
+{
+    case Circle c1: A(c1); break;
+    default: return 4;
+}
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [case Circle c: A(c); break;]@55 -> [case Circle c1: A(c1); break;]@26",
+                "Update [A(c);]@70 -> [A(c1);]@42",
+                "Update [p]@37 -> [c1]@38",
+                "Move [p]@37 -> @38",
+                "Delete [case Point p: return 0;]@26",
+                "Delete [case Point p:]@26",
+                "Delete [return 0;]@40",
+                "Delete [c]@67");
+        }
+
+        [Fact]
+        public void WhenCondition_Update()
+        {
+            var src1 = @"
+switch(shape)
+{
+    case Circle c when (c < 10): return 1;
+    case Circle c when (c > 100): return 2;
+}
+";
+
+            var src2 = @"
+switch(shape)
+{
+    case Circle c when (c < 5): return 1;
+    case Circle c2 when (c2 > 100): return 2;
+}
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [case Circle c when (c < 10): return 1;]@26 -> [case Circle c when (c < 5): return 1;]@26",
+                "Update [case Circle c when (c > 100): return 2;]@70 -> [case Circle c2 when (c2 > 100): return 2;]@69",
+                "Update [when (c < 10)]@40 -> [when (c < 5)]@40",
+                "Update [c]@82 -> [c2]@81",
+                "Update [when (c > 100)]@84 -> [when (c2 > 100)]@84");
+        }
+
+        [Fact]
+        public void CasePatternWithWhenCondition_UpdateReorder()
+        {
+            var src1 = @"
+switch(shape)
+{
+    case Rectangle r: return 0;
+    case Circle c when (c.Radius < 10): return 1;
+    case Circle c when (c.Radius > 100): return 2;
+}
+";
+
+            var src2 = @"
+switch(shape)
+{
+    case Circle c when (c.Radius > 99): return 2;
+    case Circle c when (c.Radius < 10): return 1;
+    case Rectangle r: return 0;
+}
+";
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Reorder [case Circle c when (c.Radius < 10): return 1;]@59 -> @77",
+                "Reorder [case Circle c when (c.Radius > 100): return 2;]@110 -> @26",
+                "Update [case Circle c when (c.Radius > 100): return 2;]@110 -> [case Circle c when (c.Radius > 99): return 2;]@26",
+                "Move [c]@71 -> @38",
+                "Update [when (c.Radius > 100)]@124 -> [when (c.Radius > 99)]@40",
+                "Move [c]@122 -> @89");
+        }
+
+        #endregion
+
+        #region Ref
+
+        [Fact]
+        public void Ref_Update()
+        {
+            var src1 = @"
+ref int a = ref G(new int[] { 1, 2 });
+ref int G(int[] p) { return ref p[1];  }
+";
+
+            var src2 = @"
+ref int32 a = ref G1(new int[] { 1, 2 });
+ref int G1(int[] p) { return ref p[2]; }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [ref int G(int[] p) { return ref p[1];  }]@44 -> [ref int G1(int[] p) { return ref p[2]; }]@47",
+                "Update [ref int a = ref G(new int[] { 1, 2 })]@4 -> [ref int32 a = ref G1(new int[] { 1, 2 })]@4",
+                "Update [a = ref G(new int[] { 1, 2 })]@12 -> [a = ref G1(new int[] { 1, 2 })]@14");
+        }
+
+        [Fact]
+        public void Ref_Insert()
+        {
+            var src1 = @"
+int a = G(new int[] { 1, 2 });
+int G(int[] p) { return p[1];  }
+";
+
+            var src2 = @"
+ref int32 a = ref G1(new int[] { 1, 2 });
+ref int G1(int[] p) { return ref p[2]; }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [int G(int[] p) { return p[1];  }]@36 -> [ref int G1(int[] p) { return ref p[2]; }]@47",
+                "Update [int a = G(new int[] { 1, 2 })]@4 -> [ref int32 a = ref G1(new int[] { 1, 2 })]@4",
+                "Update [a = G(new int[] { 1, 2 })]@8 -> [a = ref G1(new int[] { 1, 2 })]@14");
+        }
+
+        [Fact]
+        public void Ref_Delete()
+        {
+            var src1 = @"
+ref int a = ref G(new int[] { 1, 2 });
+ref int G(int[] p) { return ref p[1];  }
+";
+
+            var src2 = @"
+int32 a = G1(new int[] { 1, 2 });
+int G1(int[] p) { return p[2]; }
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [ref int G(int[] p) { return ref p[1];  }]@44 -> [int G1(int[] p) { return p[2]; }]@39",
+                "Update [ref int a = ref G(new int[] { 1, 2 })]@4 -> [int32 a = G1(new int[] { 1, 2 })]@4",
+                "Update [a = ref G(new int[] { 1, 2 })]@12 -> [a = G1(new int[] { 1, 2 })]@10");
+        }
+
+        #endregion
+
+        #region Tuples
+
+        [Fact]
+        public void TupleType_LocalVariables()
+        {
+            var src1 = @"
+(int a, string c) x = (a, string2);
+(int a, int b) y = (3, 4);
+(int a, int b, int c) z = (5, 6, 7);
+";
+
+            var src2 = @"
+(int a, int b)  x = (a, string2);
+(int a, int b, string c) z1 = (5, 6, 7);
+(int a, int b) y2 = (3, 4);
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Reorder [(int a, int b, int c) z = (5, 6, 7);]@69 -> @39",
+                "Update [(int a, string c) x = (a, string2)]@4 -> [(int a, int b)  x = (a, string2)]@4",
+                "Update [(int a, int b, int c) z = (5, 6, 7)]@69 -> [(int a, int b, string c) z1 = (5, 6, 7)]@39",
+                "Update [z = (5, 6, 7)]@91 -> [z1 = (5, 6, 7)]@64",
+                "Update [y = (3, 4)]@56 -> [y2 = (3, 4)]@96");
+        }
+
+        [Fact]
+        public void TupleElementName()
+        {
+            var src1 = @"(int a, int b) F();";
+            var src2 = @"(int x, int b) F();";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [(int a, int b) F();]@0 -> [(int x, int b) F();]@0");
+        }
+
+        [Fact]
+        public void TupleInField()
+        {
+            var src1 = @"private (int, int) _x = (1, 2);";
+            var src2 = @"private (int, string) _y = (1, 2);";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [(int, int) _x = (1, 2)]@8 -> [(int, string) _y = (1, 2)]@8",
+                "Update [_x = (1, 2)]@19 -> [_y = (1, 2)]@22");
+        }
+
+        [Fact]
+        public void TupleInProperty()
+        {
+            var src1 = @"public (int, int) Property1 { get { return (1, 2); } }";
+            var src2 = @"public (int, string) Property2 { get { return (1, string.Empty); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [public (int, int) Property1 { get { return (1, 2); } }]@0 -> [public (int, string) Property2 { get { return (1, string.Empty); } }]@0",
+                "Update [get { return (1, 2); }]@30 -> [get { return (1, string.Empty); }]@33");
+        }
+
+        [Fact]
+        public void TupleInDelegate()
+        {
+            var src1 = @"public delegate void EventHandler1((int, int) x);";
+            var src2 = @"public delegate void EventHandler2((int, int) y);";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [public delegate void EventHandler1((int, int) x);]@0 -> [public delegate void EventHandler2((int, int) y);]@0",
+                "Update [(int, int) x]@35 -> [(int, int) y]@35");
+        }
+
+        #endregion 
     }
 }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
@@ -6709,6 +6709,36 @@ class C
         }
 
         [Fact]
+        public void TupleElementDelete()
+        {
+            var src1 = "class C { (int, int, int a) M() { return (1, 2, 3); } }";
+            var src2 = "class C { (int, int) M() { return (1, 2); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [(int, int, int a) M() { return (1, 2, 3); }]@10 -> [(int, int) M() { return (1, 2); }]@10");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.TypeUpdate, "(int, int) M()", "method"));
+        }
+
+        [Fact]
+        public void TupleElementAdd()
+        {
+            var src1 = "class C { (int, int) M() { return (1, 2); } }";
+            var src2 = "class C { (int, int, int a) M() { return (1, 2, 3); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [(int, int) M() { return (1, 2); }]@10 -> [(int, int, int a) M() { return (1, 2, 3); }]@10");
+
+            edits.VerifyRudeDiagnostics(
+                Diagnostic(RudeEditKind.TypeUpdate, "(int, int, int a) M()", "method"));
+        }
+
+        [Fact]
         public void Indexer_ParameterUpdate()
         {
             var src1 = "class C { int this[int a] { get; set; } }";

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -416,7 +416,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
     {
         public static void VerifyEdits<TNode>(this EditScript<TNode> actual, params string[] expected)
         {
-            AssertEx.Equal(expected, actual.Edits.Select(e => e.GetDebuggerDisplay()), itemSeparator: ",\r\n");
+            AssertEx.Equal(
+                expected.Select(s => string.Format("\"{0}\"",s)), 
+                actual.Edits.Select(e => string.Format("\"{0}\"", e.GetDebuggerDisplay())), itemSeparator: ",\r\n");
         }
     }
 }

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -1353,6 +1353,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.RefExpression:
                 case SyntaxKind.DeclarationPattern:
                 case SyntaxKind.SimpleAssignmentExpression:
+                case SyntaxKind.WhenClause:
+                case SyntaxKind.SingleVariableDesignation:
+                case SyntaxKind.CasePatternSwitchLabel:
                     return node.Span;
 
                 default:

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -163,7 +163,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             ForStatement,
             ForStatementPart,                 // tied to parent
             ForEachStatement,
-            ForEachComponentStatement,
             UsingStatement,
             FixedStatement,
             LockStatement,
@@ -174,6 +173,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             SwitchStatement,
             SwitchSection,
+            CasePatternSwitchLabel,            // tied to parent
+            WhenClause,                  
 
             YieldStatement,                    // tied to parent
             GotoStatement,
@@ -184,6 +185,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
             LabeledStatement,
 
+            LocalFunction,
+
             // TODO: 
             // Ideally we could declare LocalVariableDeclarator tied to the first enclosing node that defines local scope (block, foreach, etc.)
             // Also consider handling LocalDeclarationStatement as just a bag of variable declarators,
@@ -192,10 +195,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             LocalVariableDeclaration,          // tied to parent
             LocalVariableDeclarator,           // tied to parent
 
+            SingleVariableDesignation,
             AwaitExpression,
-
-            LocalFunction,
-
             Lambda,
 
             FromClause,
@@ -243,6 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case Label.JoinIntoClause:
                 case Label.GroupClauseLambda:
                 case Label.QueryContinuation:
+                case Label.CasePatternSwitchLabel:
                     return 1;
 
                 default:
@@ -291,6 +293,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.VariableDeclarator:
                     return Label.LocalVariableDeclarator;
 
+                case SyntaxKind.SingleVariableDesignation:
+                    return Label.SingleVariableDesignation;
+
                 case SyntaxKind.LabeledStatement:
                     return Label.LabeledStatement;
 
@@ -332,11 +337,9 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.ForStatement:
                     return Label.ForStatement;
 
+                case SyntaxKind.ForEachVariableStatement:
                 case SyntaxKind.ForEachStatement:
                     return Label.ForEachStatement;
-
-                case SyntaxKind.ForEachVariableStatement:
-                    return Label.ForEachComponentStatement;
 
                 case SyntaxKind.UsingStatement:
                     return Label.UsingStatement;
@@ -372,6 +375,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     // We don't need to analyze case expressions.
                     isLeaf = true;
                     return Label.Ignored;
+
+                case SyntaxKind.WhenClause:
+                    return Label.WhenClause;
+
+                case SyntaxKind.CasePatternSwitchLabel:
+                    return Label.CasePatternSwitchLabel;
 
                 case SyntaxKind.TryStatement:
                     return Label.TryStatement;
@@ -456,6 +465,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.ArrayRankSpecifier:
                 case SyntaxKind.PointerType:
                 case SyntaxKind.NullableType:
+                case SyntaxKind.TupleType:
+                case SyntaxKind.RefType:
                 case SyntaxKind.OmittedTypeArgument:
                 case SyntaxKind.NameColon:
                 case SyntaxKind.StackAllocArrayCreationExpression:
@@ -472,6 +483,8 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.TypeOfExpression:
                 case SyntaxKind.SizeOfExpression:
                 case SyntaxKind.DefaultExpression:
+                case SyntaxKind.ConstantPattern:
+                case SyntaxKind.DiscardDesignation:
                     // can't contain a lambda/await/anonymous type:
                     isLeaf = true;
                     return Label.Ignored;
@@ -581,9 +594,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return true;
 
                 case SyntaxKind.ForEachStatement:
+                case SyntaxKind.ForEachVariableStatement:
                     {
-                        var leftForEach = (ForEachStatementSyntax)leftNode;
-                        var rightForEach = (ForEachStatementSyntax)rightNode;
+
+                        var leftForEach = (CommonForEachStatementSyntax)leftNode;
+                        var rightForEach = (CommonForEachStatementSyntax)rightNode;
                         distance = ComputeWeightedDistance(leftForEach, rightForEach);
                         return true;
                     }
@@ -758,7 +773,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 return true;
             }
 
-            if (leftBlock.Parent.Kind() != rightBlock.Parent.Kind())
+            if (GetLabel(leftBlock.Parent) != GetLabel(rightBlock.Parent))
             {
                 distance = 0.2 + 0.8 * ComputeWeightedBlockDistance(leftBlock, rightBlock);
                 return true;
@@ -839,14 +854,22 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return AdjustForLocalsInBlock(distance, left.Block, right.Block, localsWeight: 0.3);
         }
 
-        private static double ComputeWeightedDistance(ForEachStatementSyntax left, ForEachStatementSyntax right)
+        private static double ComputeWeightedDistance(
+            CommonForEachStatementSyntax leftCommonForEach,
+            CommonForEachStatementSyntax rightCommonForEach)
         {
-            double statementDistance = ComputeDistance(left.Statement, right.Statement);
-            double expressionDistance = ComputeDistance(left.Expression, right.Expression);
-            double identifierDistance = ComputeDistance(left.Identifier, right.Identifier);
+            double statementDistance = ComputeDistance(leftCommonForEach.Statement, rightCommonForEach.Statement);
+            double expressionDistance = ComputeDistance(leftCommonForEach.Expression, rightCommonForEach.Expression);
 
-            double distance = identifierDistance * 0.7 + expressionDistance * 0.2 + statementDistance * 0.1;
-            return AdjustForLocalsInBlock(distance, left.Statement, right.Statement, localsWeight: 0.6);
+            List<SyntaxToken> leftLocals = null; 
+            List<SyntaxToken> rightLocals = null;
+            GetLocalNames(leftCommonForEach, ref leftLocals);
+            GetLocalNames(rightCommonForEach, ref rightLocals);
+
+            double localNamesDistance = ComputeDistance(leftLocals, rightLocals);
+
+            double distance = localNamesDistance * 0.6 + expressionDistance * 0.2 + statementDistance * 0.2;
+            return AdjustForLocalsInBlock(distance, leftCommonForEach.Statement, rightCommonForEach.Statement, localsWeight: 0.6);
         }
 
         private static double ComputeWeightedDistance(ForStatementSyntax left, ForStatementSyntax right)
@@ -979,13 +1002,79 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         {
             foreach (var local in localDeclaration.Variables)
             {
-                if (result == null)
-                {
-                    result = new List<SyntaxToken>();
-                }
-
-                result.Add(local.Identifier);
+                GetLocalNames(local.Identifier, ref result);
             }
+        }
+
+        private static void GetLocalNames(CommonForEachStatementSyntax commonForEach, ref List<SyntaxToken> result)
+        {
+            switch (commonForEach.Kind())
+            {
+                case SyntaxKind.ForEachStatement:
+                    GetLocalNames(((ForEachStatementSyntax)commonForEach).Identifier, ref result);
+                    return;
+
+                case SyntaxKind.ForEachVariableStatement:
+                    var forEachVariable = (ForEachVariableStatementSyntax)commonForEach;
+                    GetLocalNames(forEachVariable.Variable, ref result);
+                    return;
+
+                default: throw ExceptionUtilities.UnexpectedValue(commonForEach.Kind());
+            }
+        }
+
+        private static void GetLocalNames(ExpressionSyntax expression, ref List<SyntaxToken> result)
+        {
+            switch (expression.Kind())
+            {
+                case SyntaxKind.DeclarationExpression:
+                    var declarationExpression = (DeclarationExpressionSyntax)expression;
+                    var localDeclaration = declarationExpression.Designation;
+                    GetLocalNames(localDeclaration, ref result);
+                    return;
+
+                case SyntaxKind.TupleExpression:
+                    var tupleExpression = (TupleExpressionSyntax)expression;
+                    foreach(var argument in tupleExpression.Arguments)
+                    {
+                        GetLocalNames(argument.Expression, ref result);
+                    }
+                    return;
+
+                default: 
+                    // Do nothing for node that cannot have variable declarations inside.
+                    return;
+            }
+        }
+
+        private static void GetLocalNames(VariableDesignationSyntax designation, ref List<SyntaxToken> result)
+        {
+            switch (designation.Kind())
+            {
+                case SyntaxKind.SingleVariableDesignation:
+                    GetLocalNames(((SingleVariableDesignationSyntax)designation).Identifier, ref result);
+                    return;
+
+                case SyntaxKind.ParenthesizedVariableDesignation:
+                    var parenthesizedVariableDesignation = (ParenthesizedVariableDesignationSyntax)designation;
+                    foreach(var variableDesignation in parenthesizedVariableDesignation.Variables)
+                    {
+                        GetLocalNames(variableDesignation, ref result);
+                    }
+                    return;
+
+                default: throw ExceptionUtilities.UnexpectedValue(designation.Kind());
+            }
+        }
+
+        private static void GetLocalNames(SyntaxToken syntaxToken, ref List<SyntaxToken> result)
+        {
+            if (result == null)
+            {
+                result = new List<SyntaxToken>();
+            }
+
+            result.Add(syntaxToken);
         }
 
         private static double CombineOptional(


### PR DESCRIPTION
Preemptively tagging @MattGertz for ask mode approval, contingent on test green.

**Customer scenario**

This change provides a support of C# 7.0 features by matching and labeling algorithms within ENC.

**Bugs this fixes:**

Contributes to all issues mentioned in #17891.

**Workarounds, if any**

none

**Risk**

low

**Performance impact**
N/A

**Is this a regression from a previous update?**

No

Root cause analysis:

N/A

How was the bug found?

planned