### PR TITLE
Allow the 'params' keyword in indexers

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/ParamsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ParamsKeywordRecommenderTests.cs
@@ -221,9 +221,9 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotAfterIndexer()
+        public async Task TestAfterIndexer()
         {
-            await VerifyAbsenceAsync(
+            await VerifyKeywordAsync(
 @"class C {
     int this[$$");
         }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ParamsKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ParamsKeywordRecommender.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         protected override bool IsValidContext(int position, CSharpSyntaxContext context, CancellationToken cancellationToken)
         {
-            return context.SyntaxTree.IsParameterModifierContext(context.Position, context.LeftToken, cancellationToken);
+            return context.SyntaxTree.IsParamsModifierContext(context.Position, context.LeftToken, cancellationToken);
         }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1042,6 +1042,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return false;
         }
 
+        public static bool IsParamsModifierContext(
+            this SyntaxTree syntaxTree,
+            int position,
+            SyntaxToken tokenOnLeftOfPosition,
+            CancellationToken cancellationToken)
+        {
+            var token = tokenOnLeftOfPosition;
+            token = token.GetPreviousTokenIfTouchingWord(position);
+
+            if (syntaxTree.IsParameterModifierContext(position, tokenOnLeftOfPosition, cancellationToken))
+                return true;
+
+            if ((token.IsKind(SyntaxKind.OpenBracketToken) || token.IsKind(SyntaxKind.CommaToken)) &&
+                token.Parent.IsKind(SyntaxKind.BracketedParameterList) &&
+                token.Parent.IsParentKind(SyntaxKind.IndexerDeclaration))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         public static bool IsDelegateReturnTypeContext(
             this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1048,17 +1048,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             SyntaxToken tokenOnLeftOfPosition,
             CancellationToken cancellationToken)
         {
+            if (syntaxTree.IsParameterModifierContext(position, tokenOnLeftOfPosition, cancellationToken))
+            {
+                return true;
+            }
+
             var token = tokenOnLeftOfPosition;
             token = token.GetPreviousTokenIfTouchingWord(position);
 
-            if (syntaxTree.IsParameterModifierContext(position, tokenOnLeftOfPosition, cancellationToken))
-                return true;
-
-            if ((token.IsKind(SyntaxKind.OpenBracketToken) || token.IsKind(SyntaxKind.CommaToken)) &&
-                token.Parent.IsKind(SyntaxKind.BracketedParameterList) &&
-                token.Parent.IsParentKind(SyntaxKind.IndexerDeclaration))
+            if (token.IsKind(SyntaxKind.OpenBracketToken) || token.IsKind(SyntaxKind.CommaToken))
             {
-                return true;
+                return token.Parent.IsKind(SyntaxKind.BracketedParameterList);
             }
 
             return false;


### PR DESCRIPTION
**Bugs this fixes:**

#17384 - Autocompletion list misses params for indexers

**Risk**

Low.

**Performance impact**

Low.

**Is this a regression from a previous update?**

No.