### PR TITLE
Removed AssemblySymbol.GetWellKnownType

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -475,11 +475,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return CorLibrary.GetDeclaredSpecialType(type);
         }
 
-        internal NamedTypeSymbol GetWellKnownType(WellKnownType type)
-        {
-            return this.GetTypeByMetadataName(WellKnownTypes.GetMetadataName(type));
-        }
-
         internal static TypeSymbol DynamicType
         {
             get

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AssemblyAndNamespaceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AssemblyAndNamespaceTests.cs
@@ -431,9 +431,7 @@ class App
             Assert.Equal("System.Threading.Tasks.Task", taskType.ToTestDisplayString());
 
             // When we look in a single assembly, we don't consider referenced assemblies.
-            Assert.Null(comp.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
             Assert.Null(comp.Assembly.GetTypeByMetadataName("System.Threading.Tasks.Task"));
-            Assert.Equal(taskType, comp.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
             Assert.Equal(taskType, comp.Assembly.CorLibrary.GetTypeByMetadataName("System.Threading.Tasks.Task"));
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AssemblyAndNamespaceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AssemblyAndNamespaceTests.cs
@@ -431,9 +431,9 @@ class App
             Assert.Equal("System.Threading.Tasks.Task", taskType.ToTestDisplayString());
 
             // When we look in a single assembly, we don't consider referenced assemblies.
-            Assert.Null(comp.Assembly.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
+            Assert.Null(comp.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
             Assert.Null(comp.Assembly.GetTypeByMetadataName("System.Threading.Tasks.Task"));
-            Assert.Equal(taskType, comp.Assembly.CorLibrary.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
+            Assert.Equal(taskType, comp.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task));
             Assert.Equal(taskType, comp.Assembly.CorLibrary.GetTypeByMetadataName("System.Threading.Tasks.Task"));
         }
     }


### PR DESCRIPTION
**Bugs this fixes:**
https://github.com/dotnet/roslyn/issues/18700

**Risk**
Unknown. Presumably low.

Since its the first time commiting to the roslyn repository I'm unsure if the adjustements to the test are correct or not. Since the method was removed I removed it from the tests aswell.