### PR TITLE
Disable OOP for several features until they are appropriately reviewed

### DIFF
--- a/src/Features/Core/Portable/NavigateTo/NavigateToOptions.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private const string LocalRegistryPath = @"Roslyn\Features\NavigateTo\";
 
         public static readonly Option<bool> OutOfProcessAllowed = new Option<bool>(
-            nameof(NavigateToOptions), nameof(OutOfProcessAllowed), defaultValue: true,
+            nameof(NavigateToOptions), nameof(OutOfProcessAllowed), defaultValue: false,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OutOfProcessAllowed)));
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinderOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinderOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private const string LocalRegistryPath = @"Roslyn\Features\SymbolFinder\";
 
         public static readonly Option<bool> OutOfProcessAllowed = new Option<bool>(
-            nameof(SymbolFinderOptions), nameof(OutOfProcessAllowed), defaultValue: true,
+            nameof(SymbolFinderOptions), nameof(OutOfProcessAllowed), defaultValue: false,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OutOfProcessAllowed)));
     }
 }


### PR DESCRIPTION
Tagging @Pilchie @dotnet/roslyn-ide 

These features were accidently enabled as part of my sqlite work.  I didn't intend to check that in until there was adequate testing/perf information.   Turning off until that happens.  