### PR TITLE
Unresolvable conflict not indicated when renaming identifier.

### DIFF
--- a/src/EditorFeatures/Test2/Rename/CSharp/LocalConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/LocalConflictTests.vb
@@ -466,5 +466,140 @@ namespace ConsoleApplication1
                 result.AssertLabeledSpansAre("stmt2", "this.list = list.ToList();", RelatedLocationType.ResolvedReferenceConflict)
             End Using
         End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(17177, "https://github.com/dotnet/roslyn/issues/17177")>
+        Public Sub ConflictsBetweenSwitchCaseStatementsWithoutBlocks()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Test
+{
+    static void Main()
+    {
+        switch (true)
+        {
+            case true:
+                object {|stmt1:$$i|} = null;
+                break;
+            case false:
+                object {|stmt2:j|} = null;
+                break;
+        }
+    }
+}
+                            </Document>
+                    </Project>
+                </Workspace>, renameTo:="j")
+
+                result.AssertLabeledSpansAre("stmt1", "j", RelatedLocationType.NoConflict)
+                result.AssertLabeledSpansAre("stmt2", "j", RelatedLocationType.UnresolvableConflict)
+            End Using
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(17177, "https://github.com/dotnet/roslyn/issues/17177")>
+        Public Sub NoConflictsBetweenSwitchCaseStatementsWithBlocks()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Test
+{
+    static void Main()
+    {
+        switch (true)
+        {
+            case true:
+                {
+                    object {|stmt1:$$i|} = null;
+                    break;
+                }
+            case false:
+                {
+                    object j = null;
+                    break;
+                }
+        }
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="j")
+
+                result.AssertLabeledSpansAre("stmt1", "j", RelatedLocationType.NoConflict)
+            End Using
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(17177, "https://github.com/dotnet/roslyn/issues/17177")>
+        Public Sub NoConflictsBetweenSwitchCaseStatementFirstStatementWithBlock()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Test
+{
+    static void Main()
+    {
+        switch (true)
+        {
+            case true:
+                {
+                    object {|stmt1:$$i|} = null;
+                    break;
+                }
+            case false:
+                object {|stmt2:j|} = null;
+                break;
+        }
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="j")
+
+                result.AssertLabeledSpansAre("stmt1", "j", RelatedLocationType.NoConflict)
+                result.AssertLabeledSpansAre("stmt2", "j", RelatedLocationType.UnresolvableConflict)
+            End Using
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(17177, "https://github.com/dotnet/roslyn/issues/17177")>
+        Public Sub NoConflictsBetweenSwitchCaseStatementSecondStatementWithBlock()
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+class Test
+{
+    static void Main()
+    {
+        switch (true)
+        {
+            case true:
+                object {|stmt1:$$i|} = null;
+                break;
+            case false:
+                {
+                    object {|stmt2:j|} = null;
+                    break;
+                }
+        }
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>, renameTo:="j")
+
+                result.AssertLabeledSpansAre("stmt1", "j", RelatedLocationType.NoConflict)
+                result.AssertLabeledSpansAre("stmt2", "j", RelatedLocationType.UnresolvableConflict)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Rename/LocalConflictVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/LocalConflictVisitor.cs
@@ -187,19 +187,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
         {
             var tokens = new List<SyntaxToken>();
 
-            var statements = node.ChildNodes()
-                                 .Where(x => x.IsKind(SyntaxKind.SwitchSection))
-                                 .SelectMany(x => x.ChildNodes().Where(n => n.IsKind(SyntaxKind.LocalDeclarationStatement)));
+            var statements = node.ChildNodes().Where(x => x.IsKind(SyntaxKind.SwitchSection)).SelectMany(x => x.ChildNodes());
 
-            // We want to collect any variable declarations that are in the block
-            // before visiting nested statements
             foreach (var statement in statements)
             {
-                var declarationStatement = (LocalDeclarationStatementSyntax)statement;
-
-                foreach (var declarator in declarationStatement.Declaration.Variables)
+                if (statement.Kind() == SyntaxKind.LocalDeclarationStatement)
                 {
-                    tokens.Add(declarator.Identifier);
+                    var declarationStatement = (LocalDeclarationStatementSyntax)statement;
+
+                    foreach (var declarator in declarationStatement.Declaration.Variables)
+                    {
+                        tokens.Add(declarator.Identifier);
+                    }
                 }
             }
 


### PR DESCRIPTION
**Customer scenario**

The user tries to rename variable in switch-case statement (to existing one from another case-statement), but Visual Studio doesn't find any conflicts.

**Bugs this fixes:**

#17177

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

Low. Only processing of SwitchStatement is changes in LocalConflictVisitor.

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

No, reproducible in Visual Studio 2015.

**Root cause analysis:**

`LocalConflictVisitor` doesn't check switch-case statement (as it is done for: using, foreach, catch and etc.). So, it cannot find conflicts between different case statements.

**How was the bug found?**

Customer reported.
