### PR TITLE
Fix Windows build correctness leg

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26323.1
+VisualStudioVersion = 15.0.26405.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysisTest", "src\Compilers\Core\CodeAnalysisTest\CodeAnalysisTest.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject
@@ -129,6 +129,34 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "csi", "src\Interactive\csi\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities.CoreClr", "src\Test\Utilities\CoreClr\TestUtilities.CoreClr.csproj", "{67CA3EEE-37F1-4EDF-BD9B-C11911748F37}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workspace", "Workspace", "{D9591377-7868-4D64-9314-83E0C92A871B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Workspaces", "src\Workspaces\Core\Portable\Workspaces.csproj", "{5F8D2414-064A-4B3A-9B42-8E2A04246BE5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpWorkspace", "src\Workspaces\CSharp\Portable\CSharpWorkspace.csproj", "{21B239D0-D144-430F-A394-C066D58EE267}"
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "BasicWorkspace", "src\Workspaces\VisualBasic\Portable\BasicWorkspace.vbproj", "{57CA988D-F010-4BF2-9A2E-07D6DCD2FF2C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeStyle", "CodeStyle", "{B20208C3-D3A6-4020-A274-6BE3786D29FB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeStyle", "src\CodeStyle\Core\Analyzers\CodeStyle.csproj", "{275812EE-DEDB-4232-9439-91C9757D2AE4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeStyleFixes", "src\CodeStyle\Core\CodeFixes\CodeStyleFixes.csproj", "{5FF1E493-69CC-4D0B-83F2-039F469A04E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeStyleTests", "src\CodeStyle\Core\Tests\CodeStyleTests.csproj", "{9FF1205F-1D7C-4EE4-B038-3456FE6EBEAF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpCodeStyle", "src\CodeStyle\CSharp\Analyzers\CSharpCodeStyle.csproj", "{AA87BFED-089A-4096-B8D5-690BDC7D5B24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpCodeStyleFixes", "src\CodeStyle\CSharp\CodeFixes\CSharpCodeStyleFixes.csproj", "{A07ABCF5-BC43-4EE9-8FD8-B2D77FD54D73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpCodeStyleTests", "src\CodeStyle\CSharp\Tests\CSharpCodeStyleTests.csproj", "{5018D049-5870-465A-889B-C742CE1E31CB}"
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "BasicCodeStyle", "src\CodeStyle\VisualBasic\Analyzers\BasicCodeStyle.vbproj", "{2531A8C4-97DD-47BC-A79C-B7846051E137}"
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "BasicCodeStyleFixes", "src\CodeStyle\VisualBasic\CodeFixes\BasicCodeStyleFixes.vbproj", "{0141285D-8F6C-42C7-BAF3-3C0CCD61C716}"
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "BasicCodeStyleTests", "src\CodeStyle\VisualBasic\Tests\BasicCodeStyleTests.vbproj", "{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{06b26dcb-7a12-48ef-ae50-708593abd05f}*SharedItemsImports = 4
@@ -139,6 +167,7 @@ Global
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
 		src\Compilers\Server\ServerShared\ServerShared.projitems*{32691768-af9c-4cae-9d0f-10721091b9aa}*SharedItemsImports = 13
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 4
+		src\Dependencies\PooledObjects\Microsoft.CodeAnalysis.PooledObjects.projitems*{5f8d2414-064a-4b3a-9b42-8e2a04246be5}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{8ce3a581-2969-4864-a803-013e9d977c3a}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
@@ -358,6 +387,54 @@ Global
 		{67CA3EEE-37F1-4EDF-BD9B-C11911748F37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{67CA3EEE-37F1-4EDF-BD9B-C11911748F37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{67CA3EEE-37F1-4EDF-BD9B-C11911748F37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F8D2414-064A-4B3A-9B42-8E2A04246BE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F8D2414-064A-4B3A-9B42-8E2A04246BE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F8D2414-064A-4B3A-9B42-8E2A04246BE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F8D2414-064A-4B3A-9B42-8E2A04246BE5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21B239D0-D144-430F-A394-C066D58EE267}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21B239D0-D144-430F-A394-C066D58EE267}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21B239D0-D144-430F-A394-C066D58EE267}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21B239D0-D144-430F-A394-C066D58EE267}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57CA988D-F010-4BF2-9A2E-07D6DCD2FF2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57CA988D-F010-4BF2-9A2E-07D6DCD2FF2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57CA988D-F010-4BF2-9A2E-07D6DCD2FF2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57CA988D-F010-4BF2-9A2E-07D6DCD2FF2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{275812EE-DEDB-4232-9439-91C9757D2AE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{275812EE-DEDB-4232-9439-91C9757D2AE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{275812EE-DEDB-4232-9439-91C9757D2AE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{275812EE-DEDB-4232-9439-91C9757D2AE4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FF1E493-69CC-4D0B-83F2-039F469A04E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FF1E493-69CC-4D0B-83F2-039F469A04E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FF1E493-69CC-4D0B-83F2-039F469A04E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FF1E493-69CC-4D0B-83F2-039F469A04E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FF1205F-1D7C-4EE4-B038-3456FE6EBEAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FF1205F-1D7C-4EE4-B038-3456FE6EBEAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FF1205F-1D7C-4EE4-B038-3456FE6EBEAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FF1205F-1D7C-4EE4-B038-3456FE6EBEAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA87BFED-089A-4096-B8D5-690BDC7D5B24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA87BFED-089A-4096-B8D5-690BDC7D5B24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA87BFED-089A-4096-B8D5-690BDC7D5B24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA87BFED-089A-4096-B8D5-690BDC7D5B24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A07ABCF5-BC43-4EE9-8FD8-B2D77FD54D73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A07ABCF5-BC43-4EE9-8FD8-B2D77FD54D73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A07ABCF5-BC43-4EE9-8FD8-B2D77FD54D73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A07ABCF5-BC43-4EE9-8FD8-B2D77FD54D73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5018D049-5870-465A-889B-C742CE1E31CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5018D049-5870-465A-889B-C742CE1E31CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5018D049-5870-465A-889B-C742CE1E31CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5018D049-5870-465A-889B-C742CE1E31CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2531A8C4-97DD-47BC-A79C-B7846051E137}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2531A8C4-97DD-47BC-A79C-B7846051E137}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2531A8C4-97DD-47BC-A79C-B7846051E137}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2531A8C4-97DD-47BC-A79C-B7846051E137}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0141285D-8F6C-42C7-BAF3-3C0CCD61C716}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0141285D-8F6C-42C7-BAF3-3C0CCD61C716}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0141285D-8F6C-42C7-BAF3-3C0CCD61C716}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0141285D-8F6C-42C7-BAF3-3C0CCD61C716}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -418,5 +495,17 @@ Global
 		{57557F32-0635-421A-BCF8-549AED50F764} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 		{14118347-ED06-4608-9C45-18228273C712} = {3FF38FD4-DF16-44B0-924F-0D5AE155495B}
 		{67CA3EEE-37F1-4EDF-BD9B-C11911748F37} = {6F016299-BA96-45BA-9BFF-6C0793979177}
+		{5F8D2414-064A-4B3A-9B42-8E2A04246BE5} = {D9591377-7868-4D64-9314-83E0C92A871B}
+		{21B239D0-D144-430F-A394-C066D58EE267} = {D9591377-7868-4D64-9314-83E0C92A871B}
+		{57CA988D-F010-4BF2-9A2E-07D6DCD2FF2C} = {D9591377-7868-4D64-9314-83E0C92A871B}
+		{275812EE-DEDB-4232-9439-91C9757D2AE4} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{5FF1E493-69CC-4D0B-83F2-039F469A04E1} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{9FF1205F-1D7C-4EE4-B038-3456FE6EBEAF} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{AA87BFED-089A-4096-B8D5-690BDC7D5B24} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{A07ABCF5-BC43-4EE9-8FD8-B2D77FD54D73} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{5018D049-5870-465A-889B-C742CE1E31CB} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{2531A8C4-97DD-47BC-A79C-B7846051E137} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{0141285D-8F6C-42C7-BAF3-3C0CCD61C716} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
+		{E512C6C1-F085-4AD7-B0D9-E8F1A0A2A510} = {B20208C3-D3A6-4020-A274-6BE3786D29FB}
 	EndGlobalSection
 EndGlobal

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -11,21 +11,27 @@ $ErrorActionPreference="Stop"
 # fails.  
 # 
 # Original sample came from: http://jameskovacs.com/2010/02/25/the-exec-problem/
-function Exec([scriptblock]$cmd, [string]$errorMessage = "Error executing command: " + $cmd) { 
-    # Clear LastExitCode before invoking the script so a windows command failure
-    # before doesn't carry over.  Can happen if the expression is pure powershell
-    # and not wrapping a windows command.
-    $lastexitcode = 0
-
-    $output = & $cmd 
+function Exec([scriptblock]$cmd, [switch]$echo = $false) {
+    if ($echo) {
+        & $cmd
+    }
+    else {
+        $output = & $cmd 
+    }
 
     # Need to check both of these cases for errors as they represent different items
     # - $?: did the powershell script block throw an error
     # - $lastexitcode: did a windows command executed by the script block end in error
     if ((-not $?) -or ($lastexitcode -ne 0)) {
-        Write-Host $output
-        throw $errorMessage 
+        if (-not $echo) { 
+            Write-Host $output
+        }
+        throw "Command failed to execute: $cmd"
     } 
+}
+
+function Exec-Echo([scriptblock]$cmd) {
+    Exec $cmd -echo:$true
 }
 
 # Handy function for executing Invoke-Expression and reliably throwing an 
@@ -33,7 +39,7 @@ function Exec([scriptblock]$cmd, [string]$errorMessage = "Error executing comman
 # 
 # Original sample came from: http://jameskovacs.com/2010/02/25/the-exec-problem/
 function Exec-Expression([string]$expr) {
-    Exec { Invoke-Expression $expr }
+    Exec { Invoke-Expression $expr } -echo:$true
 }
 
 # Ensure that NuGet is installed and return the path to the 

--- a/build/scripts/cibuild-legacy.ps1
+++ b/build/scripts/cibuild-legacy.ps1
@@ -25,4 +25,7 @@ Write-Host "!!!This script is legacy and will be deleted.  Please call build/scr
 Write-Host "New Args are $newArgs"
 $script = Join-Path $PSScriptRoot "cibuild.ps1"
 Invoke-Expression "$script $newArgs"
+if ((-not $?) -or ($lastexitcode -ne 0)) {
+    exit 1
+} 
 Write-Host "!!!This script is legacy and will be deleted.  Please call build/scripts/cibuild.cmd directly!!!"

--- a/build/scripts/cibuild.ps1
+++ b/build/scripts/cibuild.ps1
@@ -87,7 +87,7 @@ try {
     Redirect-Temp
 
     if ($testBuildCorrectness) {
-        Exec { & ".\build\scripts\test-build-correctness.ps1" $repoDir $configDir }
+        Exec-Echo { & ".\build\scripts\test-build-correctness.ps1" -config $buildConfiguration }
         exit 0
     }
 

--- a/build/scripts/test-build-correctness.ps1
+++ b/build/scripts/test-build-correctness.ps1
@@ -11,51 +11,47 @@
 
 [CmdletBinding(PositionalBinding=$false)]
 param(
-    [string]$sourcePath = $null,
-    [string]$binariesPath = $null
+    [string]$config = "",
+    [string]$msbuild = ""
 )
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
 
-function Get-PackagesPath {
-    $packagesPath = $env:NUGET_PACKAGES
-    if ($packagesPath -eq $null) {
-        $packagesPath = Join-Path $env:UserProfile ".nuget\packages\"
-    }
-
-    return $packagesPath
-}
-
-Push-Location $sourcePath
 try {
+    . (Join-Path $PSScriptRoot "build-utils.ps1")
+    Push-Location $repoDir
 
     # Need to parse out the current NuGet package version of Structured Logger
-    [xml]$deps = Get-Content (Join-Path $sourcePath "build\Targets\Dependencies.props")
+    [xml]$deps = Get-Content (Join-Path $repoDir "build\Targets\Dependencies.props")
     $structuredLoggerVersion = $deps.Project.PropertyGroup.MicrosoftBuildLoggingStructuredLoggerVersion
-    $packagesPath = Get-PackagesPath
-    $structuredLoggerPath = Join-Path $packagesPath "Microsoft.Build.Logging.StructuredLogger\$structuredLoggerVersion\lib\net46\StructuredLogger.dll"
-    $logPath = Join-Path $binariesPath "build.xml"
+    $structuredLoggerPath = Join-Path (Get-PackagesDir) "Microsoft.Build.Logging.StructuredLogger\$structuredLoggerVersion\lib\net46\StructuredLogger.dll"
+    $configDir = Join-Path $binariesDir $config
+    $logPath = Join-Path $configDir "build.xml"
+
+    if ($msbuild -eq "") {
+        $msbuild = Ensure-MSBuild
+    }
 
     Write-Host "Building Roslyn.sln with logging support"
-    Exec { & msbuild /v:m /m /logger:StructuredLogger`,$structuredLoggerPath`;$logPath /nodeReuse:false /p:DeployExtension=false Roslyn.sln }
+    Exec-Echo { & $msbuild /v:m /m /logger:StructuredLogger`,$structuredLoggerPath`;$logPath /nodeReuse:false /p:DeployExtension=false Roslyn.sln }
     Write-Host ""
 
     # Verify the state of our various build artifacts
     Write-Host "Running BuildBoss"
-    $buildBossPath = Join-Path $binariesPath "Exes\BuildBoss\BuildBoss.exe"
-    Exec { & $buildBossPath Roslyn.sln Compilers.sln src\Samples\Samples.sln CrossPlatform.sln "build\Targets" $logPath }
+    $buildBossPath = Join-Path $configDir "Exes\BuildBoss\BuildBoss.exe"
+    Exec-Echo { & $buildBossPath Roslyn.sln Compilers.sln src\Samples\Samples.sln CrossPlatform.sln "build\Targets" $logPath }
     Write-Host ""
 
     # Verify the state of our project.jsons
     Write-Host "Running RepoUtil"
-    $repoUtilPath = Join-Path $binariesPath "Exes\RepoUtil\RepoUtil.exe"
-    Exec { & $repoUtilPath verify }
+    $repoUtilPath = Join-Path $configDir "Exes\RepoUtil\RepoUtil.exe"
+    Exec-Echo { & $repoUtilPath verify }
     Write-Host ""
 
     # Verify the state of our generated syntax files
     Write-Host "Checking generated compiler files"
-    Exec { & (Join-Path $PSScriptRoot "generate-compiler-code.ps1") -test }
+    Exec-Echo { & (Join-Path $PSScriptRoot "generate-compiler-code.ps1") -test }
 
     exit 0
 }

--- a/build/scripts/test-determinism.ps1
+++ b/build/scripts/test-determinism.ps1
@@ -39,10 +39,10 @@ function Run-Build() {
         Write-Host "Cleaning the Binaries"
         Remove-Item -re -fo $debugDir
         Remove-Item -re -fo $objDir
-        Exec {& msbuild /nologo /v:m /nodeReuse:false /t:clean $sln }
+        Exec {& $msbuild /nologo /v:m /nodeReuse:false /t:clean $sln }
 
         Write-Host "Building the Solution"
-        Exec { & msbuild /nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:buildDir '/p:Features="debug-determinism;pdb-path-determinism"' /p:UseRoslynAnalyzers=false $pathMapBuildOption $sln }
+        Exec { & $msbuild /nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:buildDir '/p:Features="debug-determinism;pdb-path-determinism"' /p:UseRoslynAnalyzers=false $pathMapBuildOption $sln }
     }
     finally {
         Pop-Location
@@ -173,6 +173,7 @@ function Run-Test() {
 try {
     . (Join-Path $PSScriptRoot "build-utils.ps1")
 
+    $msbuild = Ensure-MSBuild
     if (-not ([IO.Path]::IsPathRooted($script:buildDir))) {
         Write-Host "The build path must be absolute"
         exit 1

--- a/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/BoundNodes.xml.Generated.vb
@@ -651,11 +651,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function Update(resultKind As LookupResultKind, symbols As ImmutableArray(Of Symbol), childBoundNodes As ImmutableArray(Of BoundExpression), type As TypeSymbol) As BoundBadExpression
             If resultKind <> Me.ResultKind OrElse symbols <> Me.Symbols OrElse childBoundNodes <> Me.ChildBoundNodes OrElse type IsNot Me.Type Then
                 Dim result = New BoundBadExpression(Me.Syntax, resultKind, symbols, childBoundNodes, type, Me.HasErrors)
-
+                
                 If Me.WasCompilerGenerated Then
                     result.SetWasCompilerGenerated()
                 End If
-
+                
                 Return result
             End If
             Return Me

--- a/src/Tools/BuildBoss/Program.cs
+++ b/src/Tools/BuildBoss/Program.cs
@@ -36,6 +36,11 @@ namespace BuildBoss
                 }
             }
 
+            if (!allGood)
+            {
+                Console.WriteLine("Failed");
+            }
+
             return allGood ? 0 : 1;
         }
 

--- a/src/Tools/BuildBoss/StructuredLoggerCheckerUtil.cs
+++ b/src/Tools/BuildBoss/StructuredLoggerCheckerUtil.cs
@@ -50,6 +50,12 @@ namespace BuildBoss
             var allGood = true;
             foreach (var pair in _copyMap.OrderBy(x => x.Key))
             {
+                // Issue https://github.com/dotnet/roslyn/issues/18753
+                if (Path.GetFileName(pair.Key) == "xunit.abstractions.dll")
+                {
+                    continue;
+                }
+
                 var list = pair.Value;
                 if (list.Count > 1)
                 {
@@ -57,7 +63,6 @@ namespace BuildBoss
                     foreach (var item in list)
                     {
                         textWriter.WriteLine($"\t{item}");
-
                     }
                     textWriter.WriteLine("");
 


### PR DESCRIPTION
There were a couple of powershell problems that caused us to suppress failures in the windows build correctness leg:

1. Invoke-Expression calls must always check $LastExitCode even when invoking a powershell script.  It's possible the script exits with the exit command and that won't propagate to $? 
1. Stop clearing $LastExitCode before invoking commands inside Exec.  This is causing errors to be suppressed for reasons I don't quite understand.  It's a paranoid check anyways so removing it. 

Once those were fixed it revealed a number of violations that had gone unnoticed.  This PR also corrects them. 