### PR TITLE
Always show snippets should not exclude non-snippet items

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2615,6 +2615,34 @@ End Class
             End Using
         End Function
 
+                <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSnippetsNotExclusiveWhenAlwaysShowing() As Task
+            Dim snippetProvider As CompletionProvider =
+                New VisualStudio.LanguageServices.VisualBasic.Snippets.
+                    SnippetCompletionProvider(editorAdaptersFactoryService:=Nothing)
+
+            Using state = TestState.CreateVisualBasicTestState(
+                  <Document><![CDATA[
+Class C
+    Public Sub Foo()
+        Dim x as Integer = 3
+        Dim t = $$
+    End Sub
+End Class
+}]]></Document>,
+                  extraCompletionProviders:={snippetProvider},
+                  extraExportedTypes:={GetType(MockSnippetInfoService)}.ToList())
+
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(CompletionOptions.SnippetsBehavior,
+                                                                                    LanguageNames.VisualBasic,
+                                                                                    SnippetsRule.AlwaysInclude)
+
+                state.SendInvokeCompletionList()
+                await state.WaitForAsynchronousOperationsAsync()
+                Assert.True(state.CompletionItemsContainsAll({"x", "Shortcut"}))
+            End Using
+        End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestBuiltInTypesKeywordInTupleLiteral() As Task
             Using state = TestState.CreateVisualBasicTestState(

--- a/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetCompletionProvider.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetCompletionProvider.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets
         End Function
 
         Private Function ShouldBeExclusive(options As OptionSet) As Boolean
-            Return not options.GetOption(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic) = SnippetsRule.AlwaysInclude
+            Return options.GetOption(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic) = SnippetsRule.IncludeAfterTypingIdentifierQuestionTab
         End Function
 
         Private Shared ReadOnly s_commitChars As Char() = {" "c, ";"c, "("c, ")"c, "["c, "]"c, "{"c, "}"c, "."c, ","c, ":"c, "+"c, "-"c, "*"c, "/"c, "\"c, "^"c, "<"c, ">"c, "'"c, "="c}

--- a/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetCompletionProvider.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Snippets/SnippetCompletionProvider.vb
@@ -52,8 +52,12 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets
             Dim syntaxFacts = document.GetLanguageService(Of ISyntaxFactsService)()
             Dim isPossibleTupleContext = syntaxFacts.IsPossibleTupleContext(syntaxTree, position, cancellationToken)
 
-            context.IsExclusive = True
+            context.IsExclusive = ShouldBeExclusive(context.Options)
             context.AddItems(CreateCompletionItems(snippets, isPossibleTupleContext))
+        End Function
+
+        Private Function ShouldBeExclusive(options As OptionSet) As Boolean
+            Return not options.GetOption(CompletionOptions.SnippetsBehavior, LanguageNames.VisualBasic) = SnippetsRule.AlwaysInclude
         End Function
 
         Private Shared ReadOnly s_commitChars As Char() = {" "c, ";"c, "("c, ")"c, "["c, "]"c, "{"c, "}"c, "."c, ","c, ":"c, "+"c, "-"c, "*"c, "/"c, "\"c, "^"c, "<"c, ">"c, "'"c, "="c}


### PR DESCRIPTION
**Customer scenario**

The customer sets the VB option to always show snippets in the completion list, which mimics the C# behavior. Now the completion list contains *only* snippets.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/17951

**Workarounds, if any**

This option is essentially unusable in VB.

**Risk**

Extremely low. This only affects snippets.

**Performance impact**

None

**Is this a regression from a previous update?**

No, but only because we didn't offer this option before.

**Root cause analysis:**

This option was not tested in VB when the same set of completion options were made available for both langauges.

**How was the bug found?**

Dogfooding.
