### PR TITLE
Introduce Exec-Command

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -464,7 +464,7 @@
              Targets="GetTargetPath"
              BuildInParallel="true">
 
-        <Output TaskParameter="TargetOutputs" ItemName="ReferenceCopyLocalPaths" />
+        <Output TaskParameter="TargetOutputs" ItemName="ReferenceCopyLocalPaths" Condition="Exists(@TargetOutputs)" />
     </MSBuild>
   </Target>
 

--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -9,15 +9,15 @@ $ErrorActionPreference="Stop"
 
 # Handy function for executing a command in powershell and throwing if it 
 # fails.  
+#
+# Use this when the full command is known at script authoring time and 
+# doesn't require any dynamic argument build up.  Example:
+#
+#   Exec-Block { & $msbuild Test.proj }
 # 
 # Original sample came from: http://jameskovacs.com/2010/02/25/the-exec-problem/
-function Exec([scriptblock]$cmd, [switch]$echo = $false) {
-    if ($echo) {
-        & $cmd
-    }
-    else {
-        $output = & $cmd 
-    }
+function Exec-Block([scriptblock]$cmd) {
+    & $cmd
 
     # Need to check both of these cases for errors as they represent different items
     # - $?: did the powershell script block throw an error
@@ -30,22 +30,71 @@ function Exec([scriptblock]$cmd, [switch]$echo = $false) {
     } 
 }
 
-function Exec-Echo([scriptblock]$cmd) {
-    Exec $cmd -echo:$true
+# Handy function for executing a windows command which needs to go through 
+# windows command line parsing.  
+#
+# Use this when the command arguments are stored in a variable.  Particularly 
+# when the variable needs reparsing by the windows command line. Example:
+#
+#   $args = "/p:ManualBuild=true Test.proj"
+#   Exec-Command $msbuild $args
+# 
+function Exec-Command([string]$command, [string]$commandArgs) {
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = $command
+    $startInfo.Arguments = $commandArgs
+
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
+    $process.StartInfo.RedirectStandardOutput = $true;
+    $process.Start() | Out-Null
+
+    $finished = $false
+    try {
+        # The OutputDataReceived event doesn't fire as events are sent by the 
+        # process in powershell.  Possibly due to subtlties of how Powershell
+        # manages the thread pool that I'm not aware of.  Using blocking
+        # reading here as an alternative which is fine since this blocks 
+        # on completion already.
+        $out = $process.StandardOutput
+        while (-not $out.EndOfStream) {
+            $line = $out.ReadLine()
+            Write-Output $line
+        }
+
+        while (-not $process.WaitForExit(100)) { 
+            # Non-blocking loop done to allow ctr-c interrupts
+        }
+
+        $finished = $true
+        if ($process.ExitCode -ne 0) { 
+            throw "Command failed to execute: $command $commandArgs" 
+        }
+    }
+    finally {
+        # If we didn't finish then an error occured or the user hit ctrl-c.  Either
+        # way kill the process
+        if (-not $finished) {
+            $process.Kill()
+        }
+    }
 }
 
-# Handy function for executing Invoke-Expression and reliably throwing an 
-# error if the expression, or the command it invoked, fails
-# 
-# Original sample came from: http://jameskovacs.com/2010/02/25/the-exec-problem/
-function Exec-Expression([string]$expr) {
-    Exec { Invoke-Expression $expr } -echo:$true
+# Handy function for executing a powershell script in a clean environment with 
+# arguments.  Prefer this over & sourcing a script as it will both use a clean
+# environment and do proper error checking
+function Exec-Script([string]$script, [string]$scriptArgs = "") {
+    Exec-Command "powershell" "-noprofile -executionPolicy RemoteSigned -file `"$script`" $scriptArgs"
 }
 
 # Ensure that NuGet is installed and return the path to the 
 # executable to use.
 function Ensure-NuGet() {
-    Exec { & (Join-Path $PSScriptRoot "download-nuget.ps1") }
+    Exec-Block { & (Join-Path $PSScriptRoot "download-nuget.ps1") } | Out-Host
     $nuget = Join-Path $repoDir "NuGet.exe"
     return $nuget
 }
@@ -56,7 +105,7 @@ function Ensure-BasicTool([string]$name, [string]$version) {
     $p = Join-Path (Get-PackagesDir) "$($name).$($version)"
     if (-not (Test-Path $p)) {
         $nuget = Ensure-NuGet
-        Exec { & $nuget install $name -OutputDirectory (Get-PackagesDir) -Version $version }
+        Exec-Block { & $nuget install $name -OutputDirectory (Get-PackagesDir) -Version $version } | Out-Null
     }
     
     return $p
@@ -206,14 +255,14 @@ function Get-VisualStudioDir() {
 # Clear out the NuGet package cache
 function Clear-PackageCache() {
     $nuget = Ensure-NuGet
-    Exec { & $nuget locals all -clear }
+    Exec-Block { & $nuget locals all -clear } | Out-Host
 }
 
 # Restore a single project
 function Restore-Project([string]$fileName, [string]$nuget, [string]$msbuildDir) {
     $nugetConfig = Join-Path $repoDir "nuget.config"
     $filePath = Join-Path $repoDir $fileName
-    Exec { & $nuget restore -verbosity quiet -configfile $nugetConfig -MSBuildPath $msbuildDir -Project2ProjectTimeOut 1200 $filePath }
+    Exec-Block { & $nuget restore -verbosity quiet -configfile $nugetConfig -MSBuildPath $msbuildDir -Project2ProjectTimeOut 1200 $filePath } | Out-Null
 }
 
 # Restore all of the projects that the repo consumes

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -33,12 +33,12 @@ function Run-Build() {
     $target = if ($project -ne "") { $project } else { Join-Path $repoDir "Roslyn.sln" }
     $buildArgs = "$buildArgs $target"
 
-    Exec-Expression "& `"$msbuild`" $buildArgs"
+    Exec-Command $msbuild $buildArgs | Out-Host
 }
 
 function Run-Test() {
     $proj = Join-Path $repoDir "BuildAndTest.proj"
-    Exec-Expression "& `"$msbuild`" /v:m /p:SkipCoreClr=true /t:Test $proj"
+    Exec-Command $msbuild "/v:m /p:SkipCoreClr=true /t:Test $proj" | Out-Host
 }
 
 try {

--- a/build/scripts/generate-compiler-code.ps1
+++ b/build/scripts/generate-compiler-code.ps1
@@ -14,10 +14,7 @@ function Run-Tool($tool, $toolArgs) {
         throw "$tool does not exist"
     }
 
-    Exec-Expression "& `"$coreRun`" `"$tool`" $toolArgs"
-    if ((-not $?) -or ($lastexitcode -ne 0)) {
-        throw "Failed"
-    }
+    Exec-Command "$coreRun" "`"$tool`" $toolArgs" | Out-Host
 }
 
 function Run-LanguageCore($language, $languageSuffix, $languageDir, $syntaxTool, $errorFactsTool, $generatedDir, $generatedTestDir) {

--- a/build/scripts/test-build-correctness.ps1
+++ b/build/scripts/test-build-correctness.ps1
@@ -34,24 +34,24 @@ try {
     }
 
     Write-Host "Building Roslyn.sln with logging support"
-    Exec-Echo { & $msbuild /v:m /m /logger:StructuredLogger`,$structuredLoggerPath`;$logPath /nodeReuse:false /p:DeployExtension=false Roslyn.sln }
+    Exec-Command $msbuild "/v:m /m /logger:StructuredLogger,$structuredLoggerPath;$logPath /nodeReuse:false /p:DeployExtension=false Roslyn.sln"
     Write-Host ""
 
     # Verify the state of our various build artifacts
     Write-Host "Running BuildBoss"
     $buildBossPath = Join-Path $configDir "Exes\BuildBoss\BuildBoss.exe"
-    Exec-Echo { & $buildBossPath Roslyn.sln Compilers.sln src\Samples\Samples.sln CrossPlatform.sln "build\Targets" $logPath }
+    Exec-Command $buildBossPath "Roslyn.sln Compilers.sln src\Samples\Samples.sln CrossPlatform.sln build\Targets $logPath"
     Write-Host ""
 
     # Verify the state of our project.jsons
     Write-Host "Running RepoUtil"
     $repoUtilPath = Join-Path $configDir "Exes\RepoUtil\RepoUtil.exe"
-    Exec-Echo { & $repoUtilPath verify }
+    Exec-Command $repoUtilPath verify 
     Write-Host ""
 
     # Verify the state of our generated syntax files
     Write-Host "Checking generated compiler files"
-    Exec-Echo { & (Join-Path $PSScriptRoot "generate-compiler-code.ps1") -test }
+    Exec-Block { & (Join-Path $PSScriptRoot "generate-compiler-code.ps1") -test }
 
     exit 0
 }

--- a/build/scripts/test-determinism.ps1
+++ b/build/scripts/test-determinism.ps1
@@ -37,12 +37,10 @@ function Run-Build() {
 
         # Clean out the previous run
         Write-Host "Cleaning the Binaries"
-        Remove-Item -re -fo $debugDir
-        Remove-Item -re -fo $objDir
-        Exec {& $msbuild /nologo /v:m /nodeReuse:false /t:clean $sln }
+        Exec-Command $msbuild "/nologo /v:m /nodeReuse:false /t:clean $sln"
 
         Write-Host "Building the Solution"
-        Exec { & $msbuild /nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:buildDir '/p:Features="debug-determinism;pdb-path-determinism"' /p:UseRoslynAnalyzers=false $pathMapBuildOption $sln }
+        Exec-Command $msbuild "/nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:buildDir /p:Features=`"debug-determinism;pdb-path-determinism`" /p:UseRoslynAnalyzers=false $pathMapBuildOption $sln"
     }
     finally {
         Pop-Location

--- a/docs/contributing/Powershell Guidelines.md
+++ b/docs/contributing/Powershell Guidelines.md
@@ -88,26 +88,28 @@ to the invocation and removes the need for error prone if checking after every c
 # DO NOT
 & msbuild /v:m /m Roslyn.sln
 # DO 
-Exec { & msbuild /v:m /m Roslyn.sln }
+Exec-Block { & msbuild /v:m /m Roslyn.sln }
 ```
 
 Note this will not work for the rare Windows commands which use 0 as an exit code on failure.  For 
 example robocopy and corflags.
 
 In some cases windows commands need to have their argument list built up dynamically.  When that 
-happens do not use Invoke-Expression to execute the command, instead use Exec-Expression.  The former
-does not fail when the windows command fails and can lead to silent errors.  The Exec-Expression 
-will throw if the underlying expression or windows command fails.
+happens do not use Invoke-Expression to execute the command, instead use Exec-Command.  The former
+does not fail when the windows command fails, can invoke powershell argument parsing and doesn't 
+have a mechanism for echoing output to console.  The Exec-Command uses Process directly and can support
+the major functionality needed.
 
 
 ``` powershell
-$command = "& msbuild /v:m Roslyn.sln"
+$command = "C:\Program Files (x86)\Microsoft Visual Studio\Preview\Dogfood\MSBuild\15.0\Bin\MSBuild.exe"
+$args = "/v:m Roslyn.sln"
 if (...) { 
-    $command += " /fl /flp:v=diag"
+    $args += " /fl /flp:v=diag"
 }
 # DO NOT
-Invoke-Expression $command
+Invoke-Expression "& $command $args"
 # DO
-Exec-Expression $command
+Exec-Command $command $args
 ```
 

--- a/src/Tools/MicroBuild/cibuild.ps1
+++ b/src/Tools/MicroBuild/cibuild.ps1
@@ -15,19 +15,17 @@ function Terminate-BuildProcesses() {
 }
 
 try {
+    Write-Host "${env:Userprofile}"
     . (Join-Path $PSScriptRoot "..\..\..\build\scripts\build-utils.ps1")
     Push-Location $PSScriptRoot
 
     $nuget = Ensure-NuGet
-    Exec { & $nuget locals all -clear }
+    Exec-Block { & $nuget locals all -clear } | Out-Host
 
     $msbuild = Ensure-MSBuild
 
     # The /nowarn exception can be removed once we fix https://github.com/dotnet/roslyn/issues/17325
-    & $msbuild /nodereuse:false /p:Configuration=Release /p:SkipTest=true Build.proj /warnaserror /nowarn:MSB3277
-    if (-not $?) { 
-        throw "Build failed"
-    }
+    Exec-Block { & $msbuild /nodereuse:false /p:Configuration=Release /p:SkipTest=true Build.proj /warnaserror /nowarn:MSB3277 } | Out-Host
 
     exit 0
 }


### PR DESCRIPTION
There is no good method today for executing windows commands with
dynamically built argument lists in Powershell.  This change attempts
to address that by introducing Exec-Command which uses the .NET
Process API directly.  This makes it straight forward to build windows
commands that rely on windows style parsing and output

