### PR TITLE
Fixing crash with refout on private setter on public property

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PropertySymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PropertySymbolAdapter.cs
@@ -14,32 +14,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         #region IPropertyDefinition Members
 
-        IEnumerable<Cci.IMethodReference> Cci.IPropertyDefinition.Accessors
+        IEnumerable<Cci.IMethodReference> Cci.IPropertyDefinition.GetAccessors(EmitContext context)
         {
-            get
+            CheckDefinitionInvariant();
+
+            Cci.IMethodReference getMethod = this.GetMethod;
+            if (getMethod != null && Cci.Extensions.ShouldInclude(getMethod.GetResolvedMethod(context), context))
             {
-                CheckDefinitionInvariant();
+                yield return getMethod;
+            }
 
-                var getMethod = this.GetMethod;
-                if ((object)getMethod != null)
-                {
-                    yield return getMethod;
-                }
+            Cci.IMethodReference setMethod = this.SetMethod;
+            if (setMethod != null && Cci.Extensions.ShouldInclude(setMethod.GetResolvedMethod(context), context))
+            {
+                yield return setMethod;
+            }
 
-                var setMethod = this.SetMethod;
-                if ((object)setMethod != null)
+            SourcePropertySymbol sourceProperty = this as SourcePropertySymbol;
+            if ((object)sourceProperty != null)
+            {
+                SynthesizedSealedPropertyAccessor synthesizedAccessor = sourceProperty.SynthesizedSealedAccessorOpt;
+                if ((object)synthesizedAccessor != null)
                 {
-                    yield return setMethod;
-                }
-
-                SourcePropertySymbol sourceProperty = this as SourcePropertySymbol;
-                if ((object)sourceProperty != null)
-                {
-                    SynthesizedSealedPropertyAccessor synthesizedAccessor = sourceProperty.SynthesizedSealedAccessorOpt;
-                    if ((object)synthesizedAccessor != null)
-                    {
-                        yield return synthesizedAccessor;
-                    }
+                    yield return synthesizedAccessor;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PropertySymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PropertySymbolAdapter.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.Cci;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.Emit;
@@ -10,22 +11,22 @@ using Microsoft.CodeAnalysis.Emit;
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal partial class PropertySymbol :
-        Cci.IPropertyDefinition
+        IPropertyDefinition
     {
         #region IPropertyDefinition Members
 
-        IEnumerable<Cci.IMethodReference> Cci.IPropertyDefinition.GetAccessors(EmitContext context)
+        IEnumerable<IMethodReference> IPropertyDefinition.GetAccessors(EmitContext context)
         {
             CheckDefinitionInvariant();
 
-            Cci.IMethodReference getMethod = this.GetMethod;
-            if (getMethod != null && Cci.Extensions.ShouldInclude(getMethod.GetResolvedMethod(context), context))
+            IMethodReference getMethod = this.GetMethod;
+            if (getMethod != null && getMethod.GetResolvedMethod(context).ShouldInclude(context))
             {
                 yield return getMethod;
             }
 
-            Cci.IMethodReference setMethod = this.SetMethod;
-            if (setMethod != null && Cci.Extensions.ShouldInclude(setMethod.GetResolvedMethod(context), context))
+            IMethodReference setMethod = this.SetMethod;
+            if (setMethod != null && setMethod.GetResolvedMethod(context).ShouldInclude(context))
             {
                 yield return setMethod;
             }
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        MetadataConstant Cci.IPropertyDefinition.DefaultValue
+        MetadataConstant IPropertyDefinition.DefaultValue
         {
             get
             {
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        Cci.IMethodReference Cci.IPropertyDefinition.Getter
+        IMethodReference IPropertyDefinition.Getter
         {
             get
             {
@@ -65,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        bool Cci.IPropertyDefinition.HasDefaultValue
+        bool IPropertyDefinition.HasDefaultValue
         {
             get
             {
@@ -74,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        bool Cci.IPropertyDefinition.IsRuntimeSpecial
+        bool IPropertyDefinition.IsRuntimeSpecial
         {
             get
             {
@@ -92,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        bool Cci.IPropertyDefinition.IsSpecialName
+        bool IPropertyDefinition.IsSpecialName
         {
             get
             {
@@ -101,16 +102,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        ImmutableArray<Cci.IParameterDefinition> Cci.IPropertyDefinition.Parameters
+        ImmutableArray<IParameterDefinition> IPropertyDefinition.Parameters
         {
             get
             {
                 CheckDefinitionInvariant();
-                return StaticCast<Cci.IParameterDefinition>.From(this.Parameters);
+                return StaticCast<IParameterDefinition>.From(this.Parameters);
             }
         }
 
-        Cci.IMethodReference Cci.IPropertyDefinition.Setter
+        IMethodReference IPropertyDefinition.Setter
         {
             get
             {
@@ -139,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(this.ContainingModule is SourceModuleSymbol || this.ContainingAssembly.IsLinked);
         }
 
-        Cci.CallingConvention Cci.ISignature.CallingConvention
+        CallingConvention ISignature.CallingConvention
         {
             get
             {
@@ -148,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        ushort Cci.ISignature.ParameterCount
+        ushort ISignature.ParameterCount
         {
             get
             {
@@ -157,31 +158,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        ImmutableArray<Cci.IParameterTypeInformation> Cci.ISignature.GetParameters(EmitContext context)
+        ImmutableArray<IParameterTypeInformation> ISignature.GetParameters(EmitContext context)
         {
             CheckDefinitionInvariant();
-            return StaticCast<Cci.IParameterTypeInformation>.From(this.Parameters);
+            return StaticCast<IParameterTypeInformation>.From(this.Parameters);
         }
 
-        ImmutableArray<Cci.ICustomModifier> Cci.ISignature.ReturnValueCustomModifiers
+        ImmutableArray<ICustomModifier> ISignature.ReturnValueCustomModifiers
         {
             get
             {
                 CheckDefinitionInvariantAllowEmbedded();
-                return this.TypeCustomModifiers.As<Cci.ICustomModifier>();
+                return this.TypeCustomModifiers.As<ICustomModifier>();
             }
         }
 
-        ImmutableArray<Cci.ICustomModifier> Cci.ISignature.RefCustomModifiers
+        ImmutableArray<ICustomModifier> ISignature.RefCustomModifiers
         {
             get
             {
                 CheckDefinitionInvariantAllowEmbedded();
-                return this.RefCustomModifiers.As<Cci.ICustomModifier>();
+                return this.RefCustomModifiers.As<ICustomModifier>();
             }
         }
 
-        bool Cci.ISignature.ReturnValueIsByRef
+        bool ISignature.ReturnValueIsByRef
         {
             get
             {
@@ -190,7 +191,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        Cci.ITypeReference Cci.ISignature.GetType(EmitContext context)
+        ITypeReference ISignature.GetType(EmitContext context)
         {
             CheckDefinitionInvariantAllowEmbedded();
             return ((PEModuleBuilder)context.Module).Translate(this.Type,
@@ -202,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region ITypeDefinitionMember Members
 
-        Cci.ITypeDefinition Cci.ITypeDefinitionMember.ContainingTypeDefinition
+        ITypeDefinition ITypeDefinitionMember.ContainingTypeDefinition
         {
             get
             {
@@ -211,7 +212,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        Cci.TypeMemberVisibility Cci.ITypeDefinitionMember.Visibility
+        TypeMemberVisibility ITypeDefinitionMember.Visibility
         {
             get
             {
@@ -224,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region ITypeMemberReference Members
 
-        Cci.ITypeReference Cci.ITypeMemberReference.GetContainingType(EmitContext context)
+        ITypeReference ITypeMemberReference.GetContainingType(EmitContext context)
         {
             CheckDefinitionInvariant();
             return this.ContainingType;
@@ -234,13 +235,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region IReference Members
 
-        void Cci.IReference.Dispatch(Cci.MetadataVisitor visitor)
+        void IReference.Dispatch(MetadataVisitor visitor)
         {
             CheckDefinitionInvariant();
-            visitor.Visit((Cci.IPropertyDefinition)this);
+            visitor.Visit((IPropertyDefinition)this);
         }
 
-        Cci.IDefinition Cci.IReference.AsDefinition(EmitContext context)
+        IDefinition IReference.AsDefinition(EmitContext context)
         {
             CheckDefinitionInvariant();
             return this;
@@ -250,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region INamedEntity Members
 
-        string Cci.INamedEntity.Name
+        string INamedEntity.Name
         {
             get
             {
@@ -261,7 +262,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #endregion
 
-        private Cci.IMethodReference GetSynthesizedSealedAccessor(MethodKind targetMethodKind)
+        private IMethodReference GetSynthesizedSealedAccessor(MethodKind targetMethodKind)
         {
             SourcePropertySymbol sourceProperty = this as SourcePropertySymbol;
             if ((object)sourceProperty != null)

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -379,8 +378,7 @@ public class C
 
             AssertEx.Equal(
                 expectedMethods,
-                ((NamedTypeSymbol)compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last()
-                    .GlobalNamespace.GetMember("C")).GetMembers().Select(m => m.ToTestDisplayString()));
+                compWithMetadata.GetMember<NamedTypeSymbol>("C").GetMembers().Select(m => m.ToTestDisplayString()));
         }
 
         [Fact]
@@ -772,20 +770,21 @@ public class PublicClass
             var compWithReal = CreateCompilation("", references: new[] { MscorlibRef, realImage },
                 options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
             AssertEx.Equal(
-                compWithReal.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()),
-                new[] { "<Module>", "<>f__AnonymousType0<<anonymous>j__TPar>", "PublicClass" });
+                new[] { "<Module>", "<>f__AnonymousType0<<anonymous>j__TPar>", "PublicClass" },
+                compWithReal.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
 
             AssertEx.Equal(
-                ((NamedTypeSymbol)compWithReal.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMember("PublicClass")).GetMembers()
-                    .Select(m => m.ToTestDisplayString()),
                 new[] { "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
                     "void PublicClass.ProtectedMethod()", "void PublicClass.InternalMethod()",
-                    "PublicClass..ctor()" });
+                    "PublicClass..ctor()" },
+                compWithReal.GetMember<NamedTypeSymbol>("PublicClass").GetMembers()
+                    .Select(m => m.ToTestDisplayString()));
 
-            AssertEx.Equal(compWithReal.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()),
+            AssertEx.Equal(
                 new[] { "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
                     "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
-                    "System.Diagnostics.DebuggableAttribute" });
+                    "System.Diagnostics.DebuggableAttribute" },
+                compWithReal.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()));
 
             // verify metadata (types, members, attributes) of the metadata-only assembly
             var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
@@ -795,20 +794,20 @@ public class PublicClass
             var compWithMetadata = CreateCompilation("", references: new[] { MscorlibRef, metadataImage },
                 options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
             AssertEx.Equal(
-                compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()),
-                new[] { "<Module>", "PublicClass" });
+                new[] { "<Module>", "PublicClass" },
+                compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
 
             AssertEx.Equal(
-                ((NamedTypeSymbol)compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMember("PublicClass")).GetMembers()
-                    .Select(m => m.ToTestDisplayString()),
                 new[] { "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
                     "void PublicClass.ProtectedMethod()", "void PublicClass.InternalMethod()",
-                    "PublicClass..ctor()" });
+                    "PublicClass..ctor()" },
+                compWithMetadata.GetMember<NamedTypeSymbol>("PublicClass").GetMembers().Select(m => m.ToTestDisplayString()));
 
-            AssertEx.Equal(compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()),
+            AssertEx.Equal(
                 new[] { "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
                     "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
-                    "System.Diagnostics.DebuggableAttribute" });
+                    "System.Diagnostics.DebuggableAttribute" },
+                compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()));
 
             MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitMetadataOnly));
 
@@ -820,20 +819,20 @@ public class PublicClass
             var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
                 options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
             AssertEx.Equal(
-                compWithRef.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()),
-                new[] { "<Module>", "PublicClass" });
+                new[] { "<Module>", "PublicClass" },
+                compWithRef.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
 
             AssertEx.Equal(
-                ((NamedTypeSymbol)compWithRef.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMember("PublicClass")).GetMembers()
-                    .Select(m => m.ToTestDisplayString()),
-                new[] { "void PublicClass.PublicMethod()", "void PublicClass.ProtectedMethod()", "PublicClass..ctor()" });
+                new[] { "void PublicClass.PublicMethod()", "void PublicClass.ProtectedMethod()", "PublicClass..ctor()" },
+                compWithRef.GetMember<NamedTypeSymbol>("PublicClass").GetMembers().Select(m => m.ToTestDisplayString()));
 
-            AssertEx.Equal(compWithRef.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()),
+            AssertEx.Equal(
                 new[] {
                     "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
                     "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
                     "System.Diagnostics.DebuggableAttribute",
-                    "System.Runtime.CompilerServices.ReferenceAssemblyAttribute" });
+                    "System.Runtime.CompilerServices.ReferenceAssemblyAttribute" },
+                compWithRef.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()));
 
             MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitRefOnly));
         }

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedProperty.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedProperty.cs
@@ -81,19 +81,16 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 get { return _setter; }
             }
 
-            IEnumerable<Cci.IMethodReference> Cci.IPropertyDefinition.Accessors
+            IEnumerable<Cci.IMethodReference> Cci.IPropertyDefinition.GetAccessors(EmitContext context)
             {
-                get
+                if (_getter != null)
                 {
-                    if (_getter != null)
-                    {
-                        yield return _getter;
-                    }
+                    yield return _getter;
+                }
 
-                    if (_setter != null)
-                    {
-                        yield return _setter;
-                    }
+                if (_setter != null)
+                {
+                    yield return _setter;
                 }
             }
 

--- a/src/Compilers/Core/Portable/PEWriter/Members.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Members.cs
@@ -984,6 +984,11 @@ namespace Microsoft.Cci
         /// </summary>
         public static bool ShouldInclude(this ITypeDefinitionMember member, EmitContext context)
         {
+            if (context.IncludePrivateMembers)
+            {
+                return true;
+            }
+
             var method = member as IMethodDefinition;
             if (method != null && method.IsVirtual)
             {

--- a/src/Compilers/Core/Portable/PEWriter/Members.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Members.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
 using EmitContext = Microsoft.CodeAnalysis.Emit.EmitContext;
 
 namespace Microsoft.Cci
@@ -714,7 +713,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// A list of methods that are associated with the property.
         /// </summary>
-        IEnumerable<IMethodReference> Accessors { get; }
+        IEnumerable<IMethodReference> GetAccessors(EmitContext context);
 
         /// <summary>
         /// A compile time constant value that provides the default value for the property. (Who uses this and why?)

--- a/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
@@ -464,7 +464,7 @@ namespace Microsoft.Cci
 
         public virtual void Visit(IPropertyDefinition propertyDefinition)
         {
-            this.Visit(propertyDefinition.Accessors);
+            this.Visit(propertyDefinition.GetAccessors(Context));
             this.Visit(propertyDefinition.Parameters);
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2579,7 +2579,7 @@ namespace Microsoft.Cci
             foreach (IPropertyDefinition propertyDef in this.GetPropertyDefs())
             {
                 var association = GetPropertyDefIndex(propertyDef);
-                foreach (IMethodReference accessorMethod in propertyDef.Accessors)
+                foreach (IMethodReference accessorMethod in propertyDef.GetAccessors(Context))
                 {
                     MethodSemanticsAttributes semantics;
                     if (accessorMethod == propertyDef.Setter)

--- a/src/Compilers/VisualBasic/Portable/Emit/PropertySymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PropertySymbolAdapter.vb
@@ -11,21 +11,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Partial Class PropertySymbol
         Implements IPropertyDefinition
 
-        Private ReadOnly Property IPropertyDefinitionAccessors As IEnumerable(Of IMethodReference) Implements IPropertyDefinition.Accessors
-            Get
-                CheckDefinitionInvariant()
+        Private Iterator Function IPropertyDefinitionAccessors(context As EmitContext) As IEnumerable(Of IMethodReference) Implements IPropertyDefinition.GetAccessors
+            CheckDefinitionInvariant()
 
-                If Me.GetMethod IsNot Nothing And Me.SetMethod IsNot Nothing Then
-                    Return {Me.GetMethod, Me.SetMethod}
-                ElseIf Me.GetMethod IsNot Nothing Then
-                    Return SpecializedCollections.SingletonEnumerable(Me.GetMethod)
-                ElseIf Me.SetMethod IsNot Nothing Then
-                    Return SpecializedCollections.SingletonEnumerable(Me.SetMethod)
-                Else
-                    Return SpecializedCollections.EmptyEnumerable(Of IMethodReference)()
-                End If
-            End Get
-        End Property
+            Dim getter As IMethodReference = Me.GetMethod
+            If getter IsNot Nothing AndAlso getter.GetResolvedMethod(context).ShouldInclude(context) Then
+                Yield getter
+            End If
+
+            Dim setter As IMethodReference = Me.SetMethod
+            If setter IsNot Nothing AndAlso setter.GetResolvedMethod(context).ShouldInclude(context) Then
+                Yield setter
+            End If
+        End Function
 
         Private ReadOnly Property IPropertyDefinitionDefaultValue As MetadataConstant Implements IPropertyDefinition.DefaultValue
             Get

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -361,8 +361,7 @@ End Class"
                                                      options:=TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All))
 
             AssertEx.Equal(expectedMethods,
-                           DirectCast(compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMember("C"), NamedTypeSymbol).
-                               GetMembers().Select(Function(m) m.ToTestDisplayString()))
+                           compWithMetadata.GetMember(Of NamedTypeSymbol)("C").GetMembers().Select(Function(m) m.ToTestDisplayString()))
         End Sub
 
         <Fact>
@@ -802,20 +801,22 @@ End Class"
             Dim compWithReal = CreateCompilation("", references:={MscorlibRef, realImage},
                             options:=TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All))
             Dim realAssembly = compWithReal.SourceModule.GetReferencedAssemblySymbols().Last()
-            AssertEx.SetEqual(realAssembly.GlobalNamespace.GetMembers().Select(Function(m) m.ToDisplayString()),
-                {"<Module>", "PublicClass"})
+            AssertEx.SetEqual(
+                {"<Module>", "PublicClass"},
+                realAssembly.GlobalNamespace.GetMembers().Select(Function(m) m.ToDisplayString()))
 
             AssertEx.SetEqual(
-                DirectCast(realAssembly.GlobalNamespace.GetMember("PublicClass"), NamedTypeSymbol).GetMembers().
-                                Select(Function(m) m.ToTestDisplayString()),
-                            {"Sub PublicClass.PublicMethod()", "Sub PublicClass.PrivateMethod()",
-                                "Sub PublicClass.InternalMethod()", "Sub PublicClass.ProtectedMethod()",
-                                "Sub PublicClass.AbstractMethod()", "Sub PublicClass..ctor()"})
+                {"Sub PublicClass.PublicMethod()", "Sub PublicClass.PrivateMethod()",
+                    "Sub PublicClass.InternalMethod()", "Sub PublicClass.ProtectedMethod()",
+                    "Sub PublicClass.AbstractMethod()", "Sub PublicClass..ctor()"},
+                compWithReal.GetMember(Of NamedTypeSymbol)("PublicClass").GetMembers().
+                    Select(Function(m) m.ToTestDisplayString()))
 
-            AssertEx.SetEqual(realAssembly.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()),
+            AssertEx.SetEqual(
                 {"System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
                     "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
-                    "System.Diagnostics.DebuggableAttribute"})
+                    "System.Diagnostics.DebuggableAttribute"},
+                realAssembly.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()))
 
             ' verify metadata (types, members, attributes) of the metadata-only assembly
             Dim emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(True)
@@ -825,20 +826,22 @@ End Class"
             Dim compWithMetadata = CreateCompilation("", references:={MscorlibRef, metadataImage},
                             options:=TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All))
             Dim metadataAssembly As AssemblySymbol = compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last()
-            AssertEx.SetEqual(metadataAssembly.GlobalNamespace.GetMembers().Select(Function(m) m.ToDisplayString()),
-                {"<Module>", "PublicClass"})
+            AssertEx.SetEqual(
+                {"<Module>", "PublicClass"},
+                metadataAssembly.GlobalNamespace.GetMembers().Select(Function(m) m.ToDisplayString()))
 
             AssertEx.SetEqual(
-                DirectCast(metadataAssembly.GlobalNamespace.GetMember("PublicClass"), NamedTypeSymbol).GetMembers().
-                                Select(Function(m) m.ToTestDisplayString()),
-                            {"Sub PublicClass.PublicMethod()", "Sub PublicClass.PrivateMethod()",
-                                "Sub PublicClass.InternalMethod()", "Sub PublicClass.ProtectedMethod()",
-                                "Sub PublicClass.AbstractMethod()", "Sub PublicClass..ctor()"})
+                {"Sub PublicClass.PublicMethod()", "Sub PublicClass.PrivateMethod()",
+                    "Sub PublicClass.InternalMethod()", "Sub PublicClass.ProtectedMethod()",
+                    "Sub PublicClass.AbstractMethod()", "Sub PublicClass..ctor()"},
+                compWithMetadata.GetMember(Of NamedTypeSymbol)("PublicClass").GetMembers().
+                    Select(Function(m) m.ToTestDisplayString()))
 
-            AssertEx.SetEqual(metadataAssembly.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()),
+            AssertEx.SetEqual(
                 {"System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
                     "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
-                    "System.Diagnostics.DebuggableAttribute"})
+                    "System.Diagnostics.DebuggableAttribute"},
+                metadataAssembly.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()))
 
             MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitMetadataOnly))
 
@@ -850,20 +853,22 @@ End Class"
             Dim compWithRef = CreateCompilation("", references:={MscorlibRef, refImage},
                             options:=TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All))
             Dim refAssembly As AssemblySymbol = compWithRef.SourceModule.GetReferencedAssemblySymbols().Last()
-            AssertEx.SetEqual(refAssembly.GlobalNamespace.GetMembers().Select(Function(m) m.ToDisplayString()),
-                {"<Module>", "PublicClass"})
+            AssertEx.SetEqual(
+                {"<Module>", "PublicClass"},
+                refAssembly.GlobalNamespace.GetMembers().Select(Function(m) m.ToDisplayString()))
 
             AssertEx.SetEqual(
-                DirectCast(refAssembly.GlobalNamespace.GetMember("PublicClass"), NamedTypeSymbol).GetMembers().
-                                Select(Function(m) m.ToTestDisplayString()),
-                            {"Sub PublicClass..ctor()", "Sub PublicClass.PublicMethod()",
-                                "Sub PublicClass.ProtectedMethod()", "Sub PublicClass.AbstractMethod()"})
+                {"Sub PublicClass..ctor()", "Sub PublicClass.PublicMethod()",
+                    "Sub PublicClass.ProtectedMethod()", "Sub PublicClass.AbstractMethod()"},
+                compWithRef.GetMember(Of NamedTypeSymbol)("PublicClass").GetMembers().
+                    Select(Function(m) m.ToTestDisplayString()))
 
-            AssertEx.SetEqual(refAssembly.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()),
+            AssertEx.SetEqual(
                 {"System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
                     "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
                     "System.Diagnostics.DebuggableAttribute",
-                    "System.Runtime.CompilerServices.ReferenceAssemblyAttribute"})
+                    "System.Runtime.CompilerServices.ReferenceAssemblyAttribute"},
+                refAssembly.GetAttributes().Select(Function(a) a.AttributeClass.ToTestDisplayString()))
 
             MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitRefOnly))
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -298,6 +298,74 @@ End Class
         End Sub
 
         <Fact>
+        Private Sub EmitRefAssembly_PrivatePropertyGetter()
+            Dim source As String = "
+Public Class C
+    Property P As Integer
+        Private Get
+            Return 0
+        End Get
+        Set
+        End Set
+    End Property
+End Class"
+
+            Dim comp = CreateCompilationWithMscorlib(source, options:=TestOptions.DebugDll.WithDeterministic(True))
+
+            Using output As New MemoryStream()
+                Using metadataOutput As New MemoryStream()
+                    Dim emitResult = comp.Emit(output, metadataPEStream:=metadataOutput,
+                                               options:=EmitOptions.Default.WithIncludePrivateMembers(False))
+                    Assert.True(emitResult.Success)
+                    emitResult.Diagnostics.Verify()
+
+                    VerifyMethod(output, {"Sub C..ctor()", "Function C.get_P() As System.Int32", "Sub C.set_P(Value As System.Int32)", "Property C.P As System.Int32"})
+                    VerifyMethod(metadataOutput, {"Sub C..ctor()", "Sub C.set_P(Value As System.Int32)", "WriteOnly Property C.P As System.Int32"})
+                End Using
+            End Using
+        End Sub
+
+        <Fact>
+        Private Sub EmitRefAssembly_PrivatePropertySetter()
+            Dim source As String = "
+Public Class C
+    Property P As Integer
+        Get
+            Return 0
+        End Get
+        Private Set
+        End Set
+    End Property
+End Class"
+
+            Dim comp = CreateCompilationWithMscorlib(source, options:=TestOptions.DebugDll.WithDeterministic(True))
+
+            Using output As New MemoryStream()
+                Using metadataOutput As New MemoryStream()
+                    Dim emitResult = comp.Emit(output, metadataPEStream:=metadataOutput,
+                                               options:=EmitOptions.Default.WithIncludePrivateMembers(False))
+                    Assert.True(emitResult.Success)
+                    emitResult.Diagnostics.Verify()
+
+                    VerifyMethod(output, {"Sub C..ctor()", "Function C.get_P() As System.Int32", "Sub C.set_P(Value As System.Int32)", "Property C.P As System.Int32"})
+                    VerifyMethod(metadataOutput, {"Sub C..ctor()", "Function C.get_P() As System.Int32", "ReadOnly Property C.P As System.Int32"})
+                End Using
+            End Using
+        End Sub
+
+        Private Shared Sub VerifyMethod(stream As MemoryStream, expectedMethods As String())
+            stream.Position = 0
+            Dim metadataRef = AssemblyMetadata.CreateFromImage(stream.ToArray()).GetReference()
+
+            Dim compWithMetadata = CreateCompilation("", references:={MscorlibRef, metadataRef},
+                                                     options:=TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All))
+
+            AssertEx.Equal(expectedMethods,
+                           DirectCast(compWithMetadata.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMember("C"), NamedTypeSymbol).
+                               GetMembers().Select(Function(m) m.ToTestDisplayString()))
+        End Sub
+
+        <Fact>
         Public Sub RefAssembly_HasReferenceAssemblyAttribute()
             Dim emitRefAssembly = EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)
 


### PR DESCRIPTION
Another issue discovered by Domino integration.
The crash was in `PopulateMethodSemanticsTableRows`, which iterates over all the property definitions (that is filtered by refout logic) and then iterates over the accessors of those properties, which are not filtered by refout logic. Trying to find the handle for a private accessor would fail.

As part of this fix, I did a review of all the Cci APIs in `Members.cs` for other such "leaks". But I couldn't find other ones. The one I scrutinized the most was events and their accessors, but apparently we don't allow accessibility modifiers on such accessors.
Let me know if you have other ideas.

@AlekseyTs @gafter @dotnet/roslyn-compiler for review. Thanks