### PR TITLE
Fix analyzer exceptions when WorkspaceAnalyzerOptions not available

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -79,6 +79,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.PreferFrameworkType
             var syntaxTree = context.Node.SyntaxTree;
             var cancellationToken = context.CancellationToken;
             var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
 
             var semanticModel = context.SemanticModel;
             var language = semanticModel.Language;

--- a/src/Features/Core/Portable/Diagnostics/SymbolAnalysisContextExtensions.cs
+++ b/src/Features/Core/Portable/Diagnostics/SymbolAnalysisContextExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             }
 
             var optionSet = await context.Options.GetDocumentOptionSetAsync(location.SourceTree, context.CancellationToken).ConfigureAwait(false);
-            return optionSet.GetOption(SimplificationOptions.NamingPreferences, context.Compilation.Language);
+            return optionSet?.GetOption(SimplificationOptions.NamingPreferences, context.Compilation.Language);
         }
     }
 }

--- a/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -64,7 +64,12 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
             var tree = context.SemanticModel.SyntaxTree;
             var cancellationToken = context.CancellationToken;
 
-            var workspace = ((WorkspaceAnalyzerOptions)context.Options).Workspace;
+            if (!(context.Options is WorkspaceAnalyzerOptions workspaceOptions))
+            {
+                return;
+            }
+
+            var workspace = workspaceOptions.Workspace;
             var service = workspace.Services.GetLanguageServices(context.SemanticModel.Compilation.Language)
                                             .GetService<IUnnecessaryImportsService>();
 

--- a/src/Workspaces/Core/Portable/NamingStyles/Serialization/NamingStylePreferences.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/Serialization/NamingStylePreferences.cs
@@ -82,12 +82,24 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
         public bool Equals(NamingStylePreferences other)
         {
-            return !ReferenceEquals(other, null) &&
-                   CreateXElement().ToString() == other.CreateXElement().ToString();
+            return other == null
+                ? false
+                : CreateXElement().ToString() == other.CreateXElement().ToString();
         }
 
         public static bool operator ==(NamingStylePreferences left, NamingStylePreferences right)
-            => left?.Equals(right) == true;
+        {
+            if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
+            {
+                return true;
+            }
+            else if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
+            {
+                return false;
+            }
+
+            return left.Equals(right);
+        }
 
         public static bool operator !=(NamingStylePreferences left, NamingStylePreferences right)
             => !(left == right);


### PR DESCRIPTION
Fixes #16644

**Customer scenario**: The user tries to run the Roslyn analyzers in an AdHoc workspace that doesn't have options of type WorkspaceAnalyzerOptions, and the analyzers throw exceptions instead of simply not reporting diagnostics, making the resulting list of diagnostics noisy.

**Bugs this fixes:** Fixes #16644

**Workarounds, if any**: None.

**Risk**: Very low. This is in top-level features with nothing depending on them, and just adds some null checks.

**Performance impact**: Very low. Just some null checks.

**Is this a regression from a previous update?**: No.

**Root cause analysis:** We didn't consider this use case when starting to use the WorkspaceAnalyzerOptions

**How was the bug found?** Customer reported in https://github.com/dotnet/roslyn/issues/16644