### PR TITLE
Use Interlocked exchange on some MetadataReferences to guarantee reference equality

### DIFF
--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -488,6 +488,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 
         private static readonly ImmutableArray<MetadataReference> s_desktopRefsToRemove = ImmutableArray.Create(SystemRef, SystemCoreRef);
 
+        private class MetadataReferenceEqualityComparer : IEqualityComparer<MetadataReference>
+        {
+            private MetadataReferenceEqualityComparer() { }
+
+            public bool Equals(MetadataReference x, MetadataReference y) => x.Display == y.Display;
+
+            public int GetHashCode(MetadataReference obj) => obj.Display?.GetHashCode() ?? 0;
+
+            private static readonly MetadataReferenceEqualityComparer s_instance = new MetadataReferenceEqualityComparer();
+            public static MetadataReferenceEqualityComparer Instance => s_instance;
+        }
+
         public static CSharpCompilation CreateStandardCompilation(
             IEnumerable<SyntaxTree> trees,
             IEnumerable<MetadataReference> references = null,
@@ -496,7 +508,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         {
             if (CoreClrShim.IsRunningOnCoreClr)
             {
-                references = references?.Except(s_desktopRefsToRemove);
+                references = references?.Except(s_desktopRefsToRemove, MetadataReferenceEqualityComparer.Instance);
             }
             return CreateCompilation(trees, (references != null) ? s_stdRefs.Concat(references) : s_stdRefs, options, assemblyName);
         }

--- a/src/Test/Utilities/Portable/TestBase.cs
+++ b/src/Test/Utilities/Portable/TestBase.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -147,7 +148,10 @@ namespace Roslyn.Test.Utilities
             {
                 if (s_systemCoreRef == null)
                 {
-                    s_systemCoreRef = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.System_Core).GetReference(display: "System.Core.v4_0_30319.dll");
+                    Interlocked.CompareExchange(
+                        ref s_systemCoreRef,
+                        AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.System_Core).GetReference(display: "System.Core.v4_0_30319.dll"),
+                        null);
                 }
 
                 return s_systemCoreRef;
@@ -414,7 +418,10 @@ namespace Roslyn.Test.Utilities
             {
                 if (s_systemRef == null)
                 {
-                    s_systemRef = AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.System).GetReference(display: "System.v4_0_30319.dll");
+                    Interlocked.CompareExchange(
+                        ref s_systemRef,
+                        AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.System).GetReference(display: "System.v4_0_30319.dll"),
+                        null);
                 }
 
                 return s_systemRef;

--- a/src/Test/Utilities/Portable/TestBase.cs
+++ b/src/Test/Utilities/Portable/TestBase.cs
@@ -148,6 +148,8 @@ namespace Roslyn.Test.Utilities
             {
                 if (s_systemCoreRef == null)
                 {
+                    // We rely on reference equality in CreateSharedCompilation, so
+                    // we must use a CompareExchange here.
                     Interlocked.CompareExchange(
                         ref s_systemCoreRef,
                         AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.System_Core).GetReference(display: "System.Core.v4_0_30319.dll"),
@@ -418,6 +420,8 @@ namespace Roslyn.Test.Utilities
             {
                 if (s_systemRef == null)
                 {
+                    // We rely on reference equality in CreateSharedCompilation, so
+                    // we must use a CompareExchange here.
                     Interlocked.CompareExchange(
                         ref s_systemRef,
                         AssemblyMetadata.CreateFromImage(TestResources.NetFX.v4_0_30319.System).GetReference(display: "System.v4_0_30319.dll"),


### PR DESCRIPTION
It seems like the reference set for CoreCLR tests is sometimes different, resulting
in CI failures. This is likely due to the lazy initialization of static MetadataReferences
in TestBase without thread synchronization. This change adds Interlocked calls where
necessary and adds a comment warning about when more Interlocked calls may be
needed.

This is a test-only change.