### PR TITLE
Check for prefix match before hard selecting when backspacing

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -371,8 +371,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
                 if (bestFilterResult != null)
                 {
+                    // Only hard select this result if it's a prefix match
+                    var prefixLength = bestFilterResult.Value.CompletionItem.FilterText.GetCaseInsensitivePrefixLength(model.FilterText);
+                    var hardSelect =  prefixLength == bestFilterResult.Value.CompletionItem.FilterText.Length;
                     return model.WithSelectedItem(bestFilterResult.Value.CompletionItem)
-                                .WithHardSelection(true)
+                                .WithHardSelection(hardSelect)
                                 .WithIsUnique(matchCount == 1);
                 }
                 else

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -372,6 +372,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 if (bestFilterResult != null)
                 {
                     // Only hard select this result if it's a prefix match
+                    // We need to do this so that 
+                    // * deleting a retyping a dot in a member access does not change the 
+                    //   text that originally appeared before the dot
+                    // * deleting through a word from the end keeps that word selected
+                    // This also preserves the behavior the VB had through Dev12.
                     var hardSelect = bestFilterResult.Value.CompletionItem.FilterText.StartsWith(model.FilterText, StringComparison.CurrentCultureIgnoreCase);
                     return model.WithSelectedItem(bestFilterResult.Value.CompletionItem)
                                 .WithHardSelection(hardSelect)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 {
                     // Only hard select this result if it's a prefix match
                     // We need to do this so that 
-                    // * deleting a retyping a dot in a member access does not change the 
+                    // * deleting and retyping a dot in a member access does not change the 
                     //   text that originally appeared before the dot
                     // * deleting through a word from the end keeps that word selected
                     // This also preserves the behavior the VB had through Dev12.

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -372,8 +372,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 if (bestFilterResult != null)
                 {
                     // Only hard select this result if it's a prefix match
-                    var prefixLength = bestFilterResult.Value.CompletionItem.FilterText.GetCaseInsensitivePrefixLength(model.FilterText);
-                    var hardSelect =  prefixLength == bestFilterResult.Value.CompletionItem.FilterText.Length;
+                    var hardSelect = bestFilterResult.Value.CompletionItem.FilterText.StartsWith(model.FilterText, StringComparison.CurrentCultureIgnoreCase);
                     return model.WithSelectedItem(bestFilterResult.Value.CompletionItem)
                                 .WithHardSelection(hardSelect)
                                 .WithIsUnique(matchCount == 1);

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -494,7 +494,7 @@ class Variable
                 state.SendBackspace()
                 ' This completion is hard-selected because the suggestion mode never triggers on backspace
                 ' See issue https://github.com/dotnet/roslyn/issues/15302
-                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
 
                 state.SendTypeChars(", var as")
                 state.SendBackspace()
@@ -502,7 +502,7 @@ class Variable
 
                 state.SendTypeChars(")")
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("(var a, var a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("(var as, var a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 
@@ -524,7 +524,7 @@ class Variable
                 state.SendBackspace()
                 ' This completion is hard-selected because the suggestion mode never triggers on backspace
                 ' See issue https://github.com/dotnet/roslyn/issues/15302
-                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
 
                 state.SendTypeChars(", var as")
                 state.SendBackspace()
@@ -532,7 +532,7 @@ class Variable
 
                 state.SendReturn()
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("(var a, var a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("(var as, var a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 
@@ -2911,7 +2911,7 @@ class Program
                 state.Workspace.Options = state.Workspace.Options.WithChangedOption(key, True)
 
                 state.SendBackspace()
-                Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=False)
+                Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=True)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -494,7 +494,7 @@ class Variable
                 state.SendBackspace()
                 ' This completion is hard-selected because the suggestion mode never triggers on backspace
                 ' See issue https://github.com/dotnet/roslyn/issues/15302
-                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=False)
 
                 state.SendTypeChars(", var as")
                 state.SendBackspace()
@@ -502,7 +502,7 @@ class Variable
 
                 state.SendTypeChars(")")
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("(var as, var a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("(var a, var a)", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 
@@ -524,7 +524,7 @@ class Variable
                 state.SendBackspace()
                 ' This completion is hard-selected because the suggestion mode never triggers on backspace
                 ' See issue https://github.com/dotnet/roslyn/issues/15302
-                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="as", isHardSelected:=False)
 
                 state.SendTypeChars(", var as")
                 state.SendBackspace()
@@ -532,7 +532,7 @@ class Variable
 
                 state.SendReturn()
                 Await state.AssertNoCompletionSession()
-                Assert.Contains("(var as, var a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("(var a, var a", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 
@@ -2911,7 +2911,7 @@ class Program
                 state.Workspace.Options = state.Workspace.Options.WithChangedOption(key, True)
 
                 state.SendBackspace()
-                Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="Environment", isHardSelected:=False)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2845,6 +2845,27 @@ End Class
             End Using
         End Function
 
+        <WorkItem(18785, "https://github.com/dotnet/roslyn/issues/18785")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function BackspaceSoftSelectionIfNotPrefixMatch() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+Class C
+    Sub Do()
+        Dim x = new System.Collections.Generic.List(Of String)()
+        x.$$Add("stuff")
+    End Sub
+End Class
+]]></Document>)
+
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem("x", isSoftSelected:=True)
+                state.SendTypeChars(".")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Assert.Contains("x.Add", state.GetLineTextFromCaretPosition())
+            End Using
+        End Function
+
         <ExportLanguageService(GetType(ISnippetInfoService), LanguageNames.VisualBasic), System.Composition.Shared>
 		Friend Class MockSnippetInfoService
 			Implements ISnippetInfoService


### PR DESCRIPTION
**Customer scenario**

Customer deletes and retypes a dot character expecting that the original text after the dot will be preserved (which is the Dev12 behavior). Instead, the item that best matches the combined text from before and after the dot is inserted.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/18785

**Workarounds, if any**

Customers could disable intellisense on deletion, which further regresses the experience in VB.

**Risk**

Low--the change only affects how the best match when the user types backspace is selected.

**Performance impact**

Low--we will do one extra string comparison each time the user types backspace.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

A regression test for this behavior is added.

**How was the bug found?**

Customer reported.
