### PR TITLE
Don't show completionlist completion after dot

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
@@ -399,6 +399,26 @@ End Class
             Await VerifyNoItemsExistAsync(markup)
         End Function
 
+        <WorkItem(18787, "https://github.com/dotnet/roslyn/issues/18787")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function NotAfterDot() As Task
+            Dim markup = <Text><![CDATA[
+Public Class Program
+     Private Shared field1 As Integer
+ 
+    ''' <summary>
+    ''' </summary>
+    ''' <completionList cref="Program"></completionList>
+    Public Class Program2
+Public Async Function TestM() As Task
+            Dim obj As Program2 = Program.$$
+        End Sub
+    End Class
+End Class
+]]></Text>.Value
+            Await VerifyNoItemsExistAsync(markup)
+        End Function
+
         Friend Overrides Function CreateCompletionProvider() As CompletionProvider
             Return New CompletionListTagCompletionProvider()
         End Function

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CompletionListTagCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CompletionListTagCompletionProvider.vb
@@ -19,6 +19,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 Return SpecializedTasks.EmptyImmutableArray(Of ISymbol)()
             End If
 
+            If context.TargetToken.IsKind(SyntaxKind.DotToken) Then
+                Return SpecializedTasks.EmptyImmutableArray(Of ISymbol)()
+            End If
+
             Dim typeInferenceService = context.GetLanguageService(Of ITypeInferenceService)()
             Dim inferredType = typeInferenceService.InferType(context.SemanticModel, position, objectAsDefault:=True, cancellationToken:=cancellationToken)
             If inferredType Is Nothing Then


### PR DESCRIPTION
**Customer scenario**

Customer starts using a member from `System.Pens`, `System.Brushes`, etc. (Any type that uses the `completionlist` XML documentation tag). They insert one item but want to replace it with a different item. Intellisense gets in their way and inserts `Pens.Blah` again instead of `Blah`

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/18787

**Workarounds, if any**

None

**Risk**

Very low, we now just check to see if the target token is a dot token.

**Performance impact**

Very low, we actually will show completionlist completion less than we did before.

**Is this a regression from a previous update?**

No

**Root cause analysis:**
This was a test hole, a test has been added to cover the scenario.

**How was the bug found?**

Customer reported
