### PR TITLE
Fix the double write of xunit.abstractions.dll

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -367,6 +367,7 @@
 
   <PropertyGroup>
     <PrepareResourcesDependsOn>DeployPortableOnDeveloperBuild;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
+    <PrepareForBuildDependsOn>RemoveDuplicateXUnitContent;$(PrepareForBuildDependsOn)</PrepareForBuildDependsOn>
     <TargetFrameworkMonikerAssemblyAttributesPath>$(IntermediateOutputPath)$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)</TargetFrameworkMonikerAssemblyAttributesPath>
     <PostCompileBinaryModificationSentinelFile>$(IntermediateOutputPath)$(TargetFileName).pcbm</PostCompileBinaryModificationSentinelFile>
     <OptimizationDataFolderPath>$(NuGetPackageRoot)\RoslynDependencies.OptimizationData\2.0.0-rc-61101-16\content\OptimizationData</OptimizationDataFolderPath>
@@ -470,4 +471,23 @@
 
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->
   <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />
+
+  <!-- 
+    In order to leverage LUT testing we need to have both of the follownig packages in 
+    our build.  
+
+        - xunit.runner.desktop
+        - xunit
+
+    Both of these include xunit.abstractions.dll in different forms: content and reference
+    respectively.  This creates a double write violation in our build.  The content item
+    is unnecessary for us since we reference the xunit package hence remove it here. 
+
+    https://github.com/dotnet/roslyn/issues/18753
+  -->
+  <Target Name="RemoveDuplicateXUnitContent">
+    <ItemGroup>
+      <Content Remove="@(Content)" Condition="'%(Filename)%(Extension)' == 'xunit.abstractions.dll'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/build/Targets/Roslyn.Toolsets.Xunit.targets
+++ b/build/Targets/Roslyn.Toolsets.Xunit.targets
@@ -32,7 +32,5 @@
         <Link>app.config</Link>
       </None>
     </ItemGroup>
-
   </Target>
-
 </Project>

--- a/src/Tools/BuildBoss/StructuredLoggerCheckerUtil.cs
+++ b/src/Tools/BuildBoss/StructuredLoggerCheckerUtil.cs
@@ -50,12 +50,6 @@ namespace BuildBoss
             var allGood = true;
             foreach (var pair in _copyMap.OrderBy(x => x.Key))
             {
-                // Issue https://github.com/dotnet/roslyn/issues/18753
-                if (Path.GetFileName(pair.Key) == "xunit.abstractions.dll")
-                {
-                    continue;
-                }
-
                 var list = pair.Value;
                 if (list.Count > 1)
                 {


### PR DESCRIPTION
Infrastructure change

In order to leverage LUT testing we need to have both of the
follownig packages in our build.

- xunit.runner.desktop
- xunit

Both of these include xunit.abstractions.dll in different forms: content
and reference respectively.  This creates a double write violation in our
build.

I've spoken with the xunit team and at this point they believe the
feature is executing as designed.  The content use in xunit.runner.desktop
is meant to support 1.X clients who can't reference the package.

I'm still working with them to find a better way to exclude this but
for now this will remove the race in our build.

Issue #18573 will remain open to track the handling here and find
a better solution.
