### PR TITLE
[DO NOT MERGE] Add IOperation APIs for string interpolation

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -2099,18 +2099,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundInterpolatedString
+    internal partial class BoundInterpolatedString : IInterpolatedStringExpression
     {
-        protected override OperationKind ExpressionKind => OperationKind.None;
+        protected override OperationKind ExpressionKind => OperationKind.InterpolatedStringExpression;
+
+        ImmutableArray<IOperation> IInterpolatedStringExpression.Parts => this.Parts.As<IOperation>();
 
         public override void Accept(OperationVisitor visitor)
         {
-            visitor.VisitNoneOperation(this);
+            visitor.VisitInterpolatedStringExpression(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
-            return visitor.VisitNoneOperation(this, argument);
+            return visitor.VisitInterpolatedStringExpression(this, argument);
         }
     }
 
@@ -2144,18 +2146,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundStringInsert
+    internal partial class BoundStringInsert : IInterpolation
     {
-        protected override OperationKind ExpressionKind => OperationKind.None;
+        protected override OperationKind ExpressionKind => OperationKind.Interpolation;
+
+        IOperation IInterpolation.Alignment => this.Alignment;
+
+        IOperation IInterpolation.Expression => this.Value;
+
+        IOperation IInterpolation.FormatString => this.Format;
 
         public override void Accept(OperationVisitor visitor)
         {
-            visitor.VisitNoneOperation(this);
+            visitor.VisitInterpolation(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
-            return visitor.VisitNoneOperation(this, argument);
+            return visitor.VisitInterpolation(this, argument);
         }
     }
 

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -79,6 +79,8 @@
     <Compile Include="Operations\IIncrementExpression.cs" />
     <Compile Include="Operations\IIndexedPropertyReferenceExpression.cs" />
     <Compile Include="Operations\IInstanceReferenceExpression.cs" />
+    <Compile Include="Operations\IInterpolatedStringExpression.cs" />
+    <Compile Include="Operations\IInterpolation.cs" />
     <Compile Include="Operations\IInvalidExpression.cs" />
     <Compile Include="Operations\IInvalidStatement.cs" />
     <Compile Include="Operations\IInvocationExpression.cs" />
@@ -100,7 +102,7 @@
     <Compile Include="Operations\IOmittedArgumentExpression.cs" />
     <Compile Include="Operations\ObjectCreationExpression_IHasArgumentsExpression.cs" />
     <Compile Include="Operations\Operation.cs" />
-    <Compile Include="Operations\IOperationKind.cs" />
+    <Compile Include="Operations\OperationKind.cs" />
     <Compile Include="Operations\IParameterInitializer.cs" />
     <Compile Include="Operations\IParameterReferenceExpression.cs" />
     <Compile Include="Operations\IParenthesizedExpression.cs" />

--- a/src/Compilers/Core/Portable/Operations/IInterpolatedStringExpression.cs
+++ b/src/Compilers/Core/Portable/Operations/IInterpolatedStringExpression.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Semantics
+{
+    /// <summary>
+    /// Represents an interpolated string expression.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface IInterpolatedStringExpression : IOperation
+    {
+        /// <summary>
+        /// Constituent parts of interpolated string, each can be a string <see cref="ILiteralExpression"/> or an <see cref="IInterpolation"/>.
+        /// </summary>
+        ImmutableArray<IOperation> Parts { get; }
+    }
+}
+

--- a/src/Compilers/Core/Portable/Operations/IInterpolation.cs
+++ b/src/Compilers/Core/Portable/Operations/IInterpolation.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Semantics
+{
+    /// <summary>
+    /// Represents a constituent interpolation part of an interpolated string expression.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface IInterpolation : IOperation
+    {
+        /// <summary>
+        /// Expression
+        /// </summary>
+        IOperation Expression { get; }
+
+        /// <summary>
+        /// Optional alignment
+        /// </summary>
+        IOperation Alignment { get; }
+
+        /// <summary>
+        /// Optional format string.
+        /// </summary>
+        IOperation FormatString { get; }
+    }
+}
+

--- a/src/Compilers/Core/Portable/Operations/OperationKind.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationKind.cs
@@ -126,6 +126,10 @@ namespace Microsoft.CodeAnalysis
         ConditionalAccessExpression = 0x11c,
         /// <summary>Indicates an <see cref="IConditionalAccessInstanceExpression"/>.</summary>
         ConditionalAccessInstanceExpression = 0x11d,
+        /// <summary>Indicates an <see cref="IInterpolatedStringExpression"/>.</summary>
+        InterpolatedStringExpression = 0x11e,
+        /// <summary>Indicates an <see cref="IInterpolation"/>.</summary>
+        Interpolation = 0x11f,
 
         // Expressions that occur only in C#.
 

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -394,6 +394,16 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             DefaultVisit(operation);
         }
+
+        public virtual void VisitInterpolatedStringExpression(IInterpolatedStringExpression operation)
+        {
+            DefaultVisit(operation);
+        }
+
+        public virtual void VisitInterpolation(IInterpolation operation)
+        {
+            DefaultVisit(operation);
+        }
     }
 
     /// <summary>
@@ -791,6 +801,16 @@ namespace Microsoft.CodeAnalysis.Semantics
         }
 
         public virtual TResult VisitLocalFunctionStatement(IOperation operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitInterpolatedStringExpression(IInterpolatedStringExpression operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitInterpolation(IInterpolation operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Core/Portable/Operations/OperationWalker.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationWalker.cs
@@ -412,5 +412,17 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             VisitArray(operation.Children);
         }
+
+        public override void VisitInterpolatedStringExpression(IInterpolatedStringExpression operation)
+        {
+            VisitArray(operation.Parts);
+        }
+
+        public override void VisitInterpolation(IInterpolation operation)
+        {
+            Visit(operation.Expression);
+            Visit(operation.Alignment);
+            Visit(operation.FormatString);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -73,6 +73,8 @@ Microsoft.CodeAnalysis.OperationKind.IfStatement = 5 -> Microsoft.CodeAnalysis.O
 Microsoft.CodeAnalysis.OperationKind.IncrementExpression = 518 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.IndexedPropertyReferenceExpression = 267 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.InstanceReferenceExpression = 277 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.OperationKind.InterpolatedStringExpression = 286 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.OperationKind.Interpolation = 287 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.InvalidExpression = 256 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.InvalidStatement = 1 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.InvocationExpression = 259 -> Microsoft.CodeAnalysis.OperationKind
@@ -410,6 +412,12 @@ Microsoft.CodeAnalysis.Semantics.IIncrementExpression.IncrementOperationKind.get
 Microsoft.CodeAnalysis.Semantics.IIndexedPropertyReferenceExpression
 Microsoft.CodeAnalysis.Semantics.IInstanceReferenceExpression
 Microsoft.CodeAnalysis.Semantics.IInstanceReferenceExpression.InstanceReferenceKind.get -> Microsoft.CodeAnalysis.Semantics.InstanceReferenceKind
+Microsoft.CodeAnalysis.Semantics.IInterpolatedStringExpression
+Microsoft.CodeAnalysis.Semantics.IInterpolatedStringExpression.Parts.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation>
+Microsoft.CodeAnalysis.Semantics.IInterpolation
+Microsoft.CodeAnalysis.Semantics.IInterpolation.Alignment.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.Semantics.IInterpolation.Expression.get -> Microsoft.CodeAnalysis.IOperation
+Microsoft.CodeAnalysis.Semantics.IInterpolation.FormatString.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.IInvalidExpression
 Microsoft.CodeAnalysis.Semantics.IInvalidExpression.Children.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation>
 Microsoft.CodeAnalysis.Semantics.IInvalidStatement
@@ -690,6 +698,8 @@ override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitIfStatement(Micro
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitIncrementExpression(Microsoft.CodeAnalysis.Semantics.IIncrementExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitIndexedPropertyReferenceExpression(Microsoft.CodeAnalysis.Semantics.IIndexedPropertyReferenceExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitInstanceReferenceExpression(Microsoft.CodeAnalysis.Semantics.IInstanceReferenceExpression operation) -> void
+override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitInterpolatedStringExpression(Microsoft.CodeAnalysis.Semantics.IInterpolatedStringExpression operation) -> void
+override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitInterpolation(Microsoft.CodeAnalysis.Semantics.IInterpolation operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitInvalidExpression(Microsoft.CodeAnalysis.Semantics.IInvalidExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitInvalidStatement(Microsoft.CodeAnalysis.Semantics.IInvalidStatement operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitInvocationExpression(Microsoft.CodeAnalysis.Semantics.IInvocationExpression operation) -> void
@@ -788,6 +798,8 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitIfStatement(Micro
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitIncrementExpression(Microsoft.CodeAnalysis.Semantics.IIncrementExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitIndexedPropertyReferenceExpression(Microsoft.CodeAnalysis.Semantics.IIndexedPropertyReferenceExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitInstanceReferenceExpression(Microsoft.CodeAnalysis.Semantics.IInstanceReferenceExpression operation) -> void
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitInterpolatedStringExpression(Microsoft.CodeAnalysis.Semantics.IInterpolatedStringExpression operation) -> void
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitInterpolation(Microsoft.CodeAnalysis.Semantics.IInterpolation operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitInvalidExpression(Microsoft.CodeAnalysis.Semantics.IInvalidExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitInvalidStatement(Microsoft.CodeAnalysis.Semantics.IInvalidStatement operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitInvocationExpression(Microsoft.CodeAnalysis.Semantics.IInvocationExpression operation) -> void
@@ -864,6 +876,8 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.Vi
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitIncrementExpression(Microsoft.CodeAnalysis.Semantics.IIncrementExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitIndexedPropertyReferenceExpression(Microsoft.CodeAnalysis.Semantics.IIndexedPropertyReferenceExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitInstanceReferenceExpression(Microsoft.CodeAnalysis.Semantics.IInstanceReferenceExpression operation, TArgument argument) -> TResult
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitInterpolatedStringExpression(Microsoft.CodeAnalysis.Semantics.IInterpolatedStringExpression operation, TArgument argument) -> TResult
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitInterpolation(Microsoft.CodeAnalysis.Semantics.IInterpolation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitInvalidExpression(Microsoft.CodeAnalysis.Semantics.IInvalidExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitInvalidStatement(Microsoft.CodeAnalysis.Semantics.IInvalidStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitInvocationExpression(Microsoft.CodeAnalysis.Semantics.IInvocationExpression operation, TArgument argument) -> TResult

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_InterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_InterpolatedString.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function BindInterpolatedStringExpression(syntax As InterpolatedStringExpressionSyntax, diagnostics As DiagnosticBag) As BoundExpression
 
-            Dim contentBuilder = ArrayBuilder(Of BoundNode).GetInstance()
+            Dim contentBuilder = ArrayBuilder(Of BoundExpression).GetInstance()
 
             For Each item In syntax.Contents
 
@@ -65,7 +65,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                   CreateStringLiteral(syntax.FormatClause, syntax.FormatClause.FormatStringToken.ValueText, compilerGenerated:=False, diagnostics:=diagnostics),
                                   Nothing)
 
-            Return New BoundInterpolation(syntax, expression, alignmentOpt, formatStringOpt)
+            Return New BoundInterpolation(syntax, expression, alignmentOpt, formatStringOpt, type:=Nothing)
 
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -1897,13 +1897,13 @@
   <Node Name="BoundInterpolatedStringExpression" Base="BoundExpression" HasValidate="true">
     <!-- Type is required for this node type; may not be null -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-    <Field Name="Contents" Type="ImmutableArray(Of BoundNode)"/>
+    <Field Name="Contents" Type="ImmutableArray(Of BoundExpression)"/>
     <Field Name="Binder" Type="Binder" Null="disallow" />
   </Node>
   
   <!-- There is no BoundInterpolatedStringText because we use BoundLiteral of type string for this purpose. -->
   
-  <Node Name="BoundInterpolation" Base="BoundNode">
+  <Node Name="BoundInterpolation" Base="BoundExpression" HasValidate="true">
     <Field Name="Expression" Type="BoundExpression" Null="disallow"/>
     <Field Name="AlignmentOpt" Type="BoundExpression" Null="allow"/>
     <Field Name="FormatStringOpt" Type="BoundLiteral" Null="allow"/>

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -2846,17 +2846,59 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
     End Class
 
-    Friend Partial Class BoundInterpolatedStringExpression
+    Partial Friend Class BoundInterpolatedStringExpression
+        Implements IInterpolatedStringExpression
+
         Protected Overrides Function ExpressionKind() As OperationKind
-            Return OperationKind.None
+            Return OperationKind.InterpolatedStringExpression
         End Function
 
+        Public ReadOnly Property IInterpolatedStringExpression_Parts As ImmutableArray(Of IOperation) Implements IInterpolatedStringExpression.Parts
+            Get
+                Return Me.Contents.As(Of IOperation)()
+            End Get
+        End Property
+
         Public Overrides Sub Accept(visitor As OperationVisitor)
-            visitor.VisitNoneOperation(Me)
+            visitor.VisitInterpolatedStringExpression(Me)
         End Sub
 
         Public Overrides Function Accept(Of TArgument, TResult)(visitor As OperationVisitor(Of TArgument, TResult), argument As TArgument) As TResult
-            Return visitor.VisitNoneOperation(Me, argument)
+            Return visitor.VisitInterpolatedStringExpression(Me, argument)
+        End Function
+    End Class
+
+    Partial Friend Class BoundInterpolation
+        Implements IInterpolation
+
+        Private ReadOnly Property IInterpolation_Expression As IOperation Implements IInterpolation.Expression
+            Get
+                Return Me.Expression
+            End Get
+        End Property
+
+        Public ReadOnly Property IInterpolation_Alignment As IOperation Implements IInterpolation.Alignment
+            Get
+                Return Me.AlignmentOpt
+            End Get
+        End Property
+
+        Public ReadOnly Property IInterpolation_FormatString As IOperation Implements IInterpolation.FormatString
+            Get
+                Return Me.FormatStringOpt
+            End Get
+        End Property
+
+        Protected Overrides Function ExpressionKind() As OperationKind
+            Return OperationKind.Interpolation
+        End Function
+
+        Public Overrides Sub Accept(visitor As OperationVisitor)
+            visitor.VisitInterpolation(Me)
+        End Sub
+
+        Public Overrides Function Accept(Of TArgument, TResult)(visitor As OperationVisitor(Of TArgument, TResult), argument As TArgument) As TResult
+            Return visitor.VisitInterpolation(Me, argument)
         End Function
     End Class
 

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1090,6 +1090,24 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Visit(operation.MaximumValue, "Max");
         }
 
+        public override void VisitInterpolatedStringExpression(IInterpolatedStringExpression operation)
+        {
+            LogString(nameof(IInterpolatedStringExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            VisitArray(operation.Parts, "Parts", logElementCount: true);
+        }
+
+        public override void VisitInterpolation(IInterpolation operation)
+        {
+            LogString(nameof(IInterpolation));
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Expression, "Expression");
+            Visit(operation.Alignment, "Alignment");
+            Visit(operation.FormatString, "FormatString");
+        }
+
         #endregion
     }
 }

--- a/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
@@ -512,5 +512,15 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             base.VisitInvalidExpression(operation);
         }
+
+        public override void VisitInterpolatedStringExpression(IInterpolatedStringExpression operation)
+        {
+            base.VisitInterpolatedStringExpression(operation);
+        }
+
+        public override void VisitInterpolation(IInterpolation operation)
+        {
+            base.VisitInterpolation(operation);
+        }
     }
 }


### PR DESCRIPTION
This is a proposal PR for https://github.com/dotnet/roslyn/issues/18300#issuecomment-294631382. We will discuss the proposal at the next IOperation Design meeting. Subsequently, I will add unit tests for string interpolation operation trees.

Fixes #18300 

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
