### PR TITLE
workaround for Microsoft.CodeAnalysis.Differencing.Match makes not optimal matches

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -960,6 +960,36 @@ var x = $""Hello{123:N2}"";
             edits.VerifyEdits("Update [x = $\"Hello{123:N1}\"]@8 -> [x = $\"Hello{123:N2}\"]@8");
         }
 
+        [Fact]
+        public void MatchCasePattern_UpdateDelete()
+        {
+            var src1 = @"
+switch(shape)
+{
+    case Point p: return 0;
+    case Circle c: return 1;
+}
+";
+
+            var src2 = @"
+switch(shape)
+{
+    case Circle circle: return 1;
+}
+";
+
+            var match = GetMethodMatches(src1, src2, kind: MethodKind.Regular);
+            var actual = ToMatchingPairs(match);
+
+            var expected = new MatchingPairs {
+                { "switch(shape) {     case Point p: return 0;     case Circle c: return 1; }", "switch(shape) {     case Circle circle: return 1; }" },
+                { "case Circle c: return 1;", "case Circle circle: return 1;" },
+                { "return 1;", "return 1;" }
+            };
+
+            expected.AssertEqual(actual);
+        }
+
         #endregion
 
         #region Variable Declaration
@@ -1033,6 +1063,32 @@ var x = $""Hello{123:N2}"";
 
             edits.VerifyEdits(
                 "Update [case 1: f(); break;]@18 -> [case 2: f(); break;]@18");
+        }
+
+        [Fact]
+        public void CasePatternLabel_UpdateDelete()
+        {
+            var src1 = @"
+switch(shape)
+{
+    case Point p: return 0;
+    case Circle c: return 1;
+}
+";
+
+            var src2 = @"
+switch(shape)
+{
+    case Circle circle: return 1;
+}
+";
+
+            var edits = GetMethodEdits(src1, src2);
+
+            edits.VerifyEdits(
+                "Update [case Circle c: return 1;]@55 -> [case Circle circle: return 1;]@26",
+                "Delete [case Point p: return 0;]@26",
+                "Delete [return 0;]@40");
         }
 
         #endregion

--- a/src/Workspaces/Core/Portable/Differencing/Match.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Match.cs
@@ -14,8 +14,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         private const double EpsilonDistance = 0.00001;
         private const double MatchingDistance1 = 0.25;
         private const double MatchingDistance2 = 0.5;
-        private const double MatchingDistance3 = 1;
-        private const double MaxDistance = 2.0;
+        private const double MaxDistance = 1.0;
 
         private readonly TreeComparer<TNode> _comparer;
         private readonly TNode _root1;
@@ -154,7 +153,6 @@ namespace Microsoft.CodeAnalysis.Differencing
             ComputeMatchForLabel(s1, s2, tiedToAncestor, EpsilonDistance);     // almost exact match
             ComputeMatchForLabel(s1, s2, tiedToAncestor, MatchingDistance1);   // ok match
             ComputeMatchForLabel(s1, s2, tiedToAncestor, MatchingDistance2);   // ok match
-            ComputeMatchForLabel(s1, s2, tiedToAncestor, MatchingDistance3);   // ok match 
             ComputeMatchForLabel(s1, s2, tiedToAncestor, MaxDistance);         // any match
         }
 
@@ -168,6 +166,7 @@ namespace Microsoft.CodeAnalysis.Differencing
             // So in the case of totally matching sequences, we process them in O(n) - 
             // both node1 and firstNonMatch2 will be advanced simultaneously.
 
+            Debug.Assert(maxAcceptableDistance >= ExactMatchDistance && maxAcceptableDistance <= MaxDistance);
             int count1 = s1.Count;
             int count2 = s2.Count;
             int firstNonMatch2 = 0;
@@ -184,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Differencing
 
                 // Find node2 that matches node1 the best, i.e. has minimal distance.
 
-                double bestDistance = MaxDistance;
+                double bestDistance = MaxDistance * 2;
                 TNode bestMatch = default(TNode);
                 bool matched = false;
                 int i2;

--- a/src/Workspaces/Core/Portable/Differencing/Match.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Match.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.Differencing
     {
         private const double ExactMatchDistance = 0.0;
         private const double EpsilonDistance = 0.00001;
-        private const double MatchingDistance1 = 0.5;
-        private const double MatchingDistance2 = 1.0;
-        private const double MatchingDistance3 = 1.5;
+        private const double MatchingDistance1 = 0.25;
+        private const double MatchingDistance2 = 0.5;
+        private const double MatchingDistance3 = 1;
         private const double MaxDistance = 2.0;
 
         private readonly TreeComparer<TNode> _comparer;
@@ -257,6 +257,11 @@ namespace Microsoft.CodeAnalysis.Differencing
                     if (i2 == firstNonMatch2)
                     {
                         firstNonMatch2 = i2 + 1;
+                    }
+
+                    if (firstNonMatch2 == count2)
+                    {
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
Preemptively tagging @MattGertz for ask mode approval, contingent on test green.

**Customer scenario**

This work around was need to continue on ENC support for C# 7 feature

**Bugs this fixes:**

Fixes #18801

**Workarounds, if any**

none

**Risk**

low

**Performance impact**
N/A

**Is this a regression from a previous update?**

No

Root cause analysis:

N/A

How was the bug found?

test