### PR TITLE
Update DSRP to 1.3.0-beta1-61619-01

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -19,6 +19,7 @@
     <add key="dotnet.myget.org symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />
     <add key="dotnet.myget.org symreader-portable" value="https://dotnet.myget.org/F/symreader-portable/api/v3/index.json" />
     <add key="dotnet.myget.org symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+    <add key="dotnet.myget.org symreader-native" value="https://dotnet.myget.org/F/symreader-native/api/v3/index.json" />
     <add key="dotnet.myget.org metadata-tools" value="https://dotnet.myget.org/F/metadata-tools/api/v3/index.json" />
     <add key="dotnet.myget.org interactive-window" value="https://dotnet.myget.org/F/interactive-window/api/v3/index.json" />
     <add key="dotnet.myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />

--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -23,7 +23,7 @@
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.1.0</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderConverterXmlVersion>1.0.0-beta1-61624-01</MicrosoftDiaSymReaderConverterXmlVersion>
-    <MicrosoftDiaSymReaderNativeVersion>1.5.0</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>1.6.0-beta2-25219</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.3.0-beta1-61619-01</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-61531-03</MicrosoftMetadataVisualizerVersion>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>1.1.0</MicrosoftNETCoreRuntimeCoreCLRVersion>

--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -22,7 +22,7 @@
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.1.0</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderConverterXmlVersion>1.0.0-beta1-61618-01</MicrosoftDiaSymReaderConverterXmlVersion>
+    <MicrosoftDiaSymReaderConverterXmlVersion>1.0.0-beta1-61624-01</MicrosoftDiaSymReaderConverterXmlVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.5.0</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.3.0-beta1-61619-01</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-61531-03</MicrosoftMetadataVisualizerVersion>

--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -24,7 +24,7 @@
     <MicrosoftDiaSymReaderVersion>1.1.0</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderConverterXmlVersion>1.0.0-beta1-61618-01</MicrosoftDiaSymReaderConverterXmlVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.5.0</MicrosoftDiaSymReaderNativeVersion>
-    <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0</MicrosoftDiaSymReaderPortablePdbVersion>
+    <MicrosoftDiaSymReaderPortablePdbVersion>1.3.0-beta1-61619-01</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-61531-03</MicrosoftMetadataVisualizerVersion>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>1.1.0</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -5,7 +5,7 @@
     "MicroBuild.Core": "0.2.0",
     "MicroBuild.Plugins.SwixBuild": "1.1.0-g0701ee829f",
     "Microsoft.NETCore.Platforms": "1.1.0",
-    "Microsoft.DiaSymReader.Native": "1.5.0",
+    "Microsoft.DiaSymReader.Native": "1.6.0-beta2-25219",
     "Microsoft.Net.Compilers": "2.0.1",
     "Microsoft.Net.RoslynDiagnostics": "1.2.0-beta2",
     "FakeSign": "0.9.2",

--- a/src/Compilers/CSharp/csc/project.json
+++ b/src/Compilers/CSharp/csc/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DiaSymReader.Native": "1.5.0"
+    "Microsoft.DiaSymReader.Native": "1.6.0-beta2-25219"
   },
   "frameworks": {
     "net46": { }

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -1298,11 +1298,20 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows PDB writer doesn&apos;t support deterministic compilation -- could not find Microsoft.DiaSymReader.Native.{0}.dll.
+        ///   Looks up a localized string similar to Windows PDB writer doesn&apos;t support deterministic compilation: &apos;{0}&apos;.
         /// </summary>
         internal static string SymWriterNotDeterministic {
             get {
                 return ResourceManager.GetString("SymWriterNotDeterministic", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The version of Windows PDB writer is older than required: &apos;{0}&apos;.
+        /// </summary>
+        internal static string SymWriterOlderVersionThanRequired {
+            get {
+                return ResourceManager.GetString("SymWriterOlderVersionThanRequired", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -1289,7 +1289,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows PDB writer is not available -- could not find Microsoft.DiaSymReader.Native.{0}.dll.
+        ///   Looks up a localized string similar to Windows PDB writer is not available -- could not find &apos;{0}&apos;.
         /// </summary>
         internal static string SymWriterNotAvailable {
             get {
@@ -1298,7 +1298,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows PDB writer doesn&apos;t support deterministic compilation: &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Windows PDB writer doesn&apos;t support deterministic compilation: &apos;{0}&apos;. .
         /// </summary>
         internal static string SymWriterNotDeterministic {
             get {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -465,10 +465,13 @@
     <value>Invalid data at offset {0}: {1}{2}*{3}{4}</value>
   </data>
   <data name="SymWriterNotDeterministic" xml:space="preserve">
-    <value>Windows PDB writer doesn't support deterministic compilation -- could not find Microsoft.DiaSymReader.Native.{0}.dll</value>
+    <value>Windows PDB writer doesn't support deterministic compilation: '{0}'</value>
   </data>
   <data name="SymWriterNotAvailable" xml:space="preserve">
-    <value>Windows PDB writer is not available -- could not find Microsoft.DiaSymReader.Native.{0}.dll</value>
+    <value>Windows PDB writer is not available -- could not find '{0}'</value>
+  </data>
+  <data name="SymWriterOlderVersionThanRequired" xml:space="preserve">
+    <value>The version of Windows PDB writer is older than required: '{0}'</value>
   </data>
   <data name="RuleSetBadAttributeValue" xml:space="preserve">
     <value>The attribute {0} has an invalid value of {1}.</value>

--- a/src/Compilers/VisualBasic/vbc/project.json
+++ b/src/Compilers/VisualBasic/vbc/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DiaSymReader.Native": "1.5.0"
+    "Microsoft.DiaSymReader.Native": "1.6.0-beta2-25219"
   },
   "frameworks": {
     "net46": { }

--- a/src/Setup/DevDivPackages/Debugger/project.json
+++ b/src/Setup/DevDivPackages/Debugger/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
+    "Microsoft.DiaSymReader.PortablePdb": "1.3.0-beta1-61619-01",
     "System.Diagnostics.Process": "4.3.0",
     "System.IO.FileSystem": "4.3.0",
     "System.IO.FileSystem.Primitives": "4.3.0",

--- a/src/Setup/DevDivPackages/Roslyn/project.json
+++ b/src/Setup/DevDivPackages/Roslyn/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.DiaSymReader": "1.1.0",
-    "Microsoft.DiaSymReader.Native": "1.5.0",
+    "Microsoft.DiaSymReader.Native": "1.6.0-beta2-25219",
     "Microsoft.CodeAnalysis.Elfie": "0.10.6-rc2",
     "System.Collections.Immutable": "1.3.1",
     "System.Reflection.Metadata": "1.4.2",
@@ -34,7 +34,7 @@
     "System.Xml.XDocument": "4.3.0",
     "System.Xml.XmlDocument": "4.3.0",
     "System.Xml.XPath.XDocument": "4.3.0",
-    "System.ValueTuple": "4.3.0",
+    "System.ValueTuple": "4.3.0"
   },
   "frameworks": {
     "net46": {}

--- a/src/Test/PdbUtilities/project.json
+++ b/src/Test/PdbUtilities/project.json
@@ -2,7 +2,7 @@
   "supports": {},
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
-    "Microsoft.DiaSymReader.Native": "1.5.0",
+    "Microsoft.DiaSymReader.Native": "1.6.0-beta2-25219",
     "Microsoft.DiaSymReader": "1.1.0",
     "Microsoft.DiaSymReader.PortablePdb": "1.3.0-beta1-61619-01",
     "Microsoft.Metadata.Visualizer": "1.0.0-beta1-61531-03",

--- a/src/Test/PdbUtilities/project.json
+++ b/src/Test/PdbUtilities/project.json
@@ -4,7 +4,7 @@
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "Microsoft.DiaSymReader.Native": "1.5.0",
     "Microsoft.DiaSymReader": "1.1.0",
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
+    "Microsoft.DiaSymReader.PortablePdb": "1.3.0-beta1-61619-01",
     "Microsoft.Metadata.Visualizer": "1.0.0-beta1-61531-03",
     "System.Collections.Immutable": "1.3.1",
     "System.Reflection.Metadata": "1.4.2",

--- a/src/Test/Utilities/Desktop/project.json
+++ b/src/Test/Utilities/Desktop/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "2.0.0-pre-20160714",
-    "Microsoft.DiaSymReader.Native": "1.5.0",
+    "Microsoft.DiaSymReader.Native": "1.6.0-beta2-25219",
     "Microsoft.DiaSymReader": "1.1.0",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",

--- a/src/Test/Utilities/Portable/project.json
+++ b/src/Test/Utilities/Portable/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "2.0.0-pre-20160714",
     "Microsoft.CSharp": "4.3.0",
-    "Microsoft.DiaSymReader.Converter.Xml": "1.0.0-beta1-61618-01",
+    "Microsoft.DiaSymReader.Converter.Xml": "1.0.0-beta1-61624-01",
     "Microsoft.Metadata.Visualizer": "1.0.0-beta1-61531-03",
     "Microsoft.NETCore.Platforms": "1.1.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",

--- a/src/VisualStudio/Setup.Dependencies/project.json
+++ b/src/VisualStudio/Setup.Dependencies/project.json
@@ -3,7 +3,7 @@
     "Microsoft.VisualStudio.Shell.Framework": "15.0.26201-alpha",
     "Microsoft.VisualStudio.Shell.15.0": "15.0.26201-alpha",
     "Microsoft.DiaSymReader": "1.1.0",
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
+    "Microsoft.DiaSymReader.PortablePdb": "1.3.0-beta1-61619-01",
     "System.Collections.Immutable": "1.3.1",
     "System.Collections": "4.3.0",
     "System.Collections.Concurrent": "4.3.0",

--- a/src/VisualStudio/Setup/project.json
+++ b/src/VisualStudio/Setup/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.DiaSymReader.PortablePdb": "1.2.0",
+    "Microsoft.DiaSymReader.PortablePdb": "1.3.0-beta1-61619-01",
     "ManagedEsent": "1.9.4"
   },
   "frameworks": {


### PR DESCRIPTION
**Customer scenario**

When using portable PDBs + EnC, if breakpoints are set in unedited methods, the line deltas aren't being applied. So the symbol reader seems to return the old line numbers causing breakpoints to be set on the wrong line (or not bind at all if the is no associated code with this bogus line number). This issue doesn't repo if using Windows PDBs.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/17539

**Workarounds, if any**

None.

**Risk**

Small.

**Performance impact**

None

**Is this a regression from a previous update?**

Regression vs Windows PDBs.

**Root cause analysis:**

Missing test case. Added test covering the code.

**How was the bug found?**

Reported by a partner team.
