### PR TITLE
Update Language Feature Status.md

### DIFF
--- a/docs/Language Feature Status.md
+++ b/docs/Language Feature Status.md
@@ -13,7 +13,7 @@ efforts behind them.
 | [Async Main](https://github.com/dotnet/csharplang/blob/master/proposals/async-main.md) | [async-main](https://github.com/dotnet/roslyn/tree/features/async-main)  | Prototype | [tyoverby](https://github.com/tyoverby) | [vsadov](https://github.com/vsadov) | [stephentoub](https://github.com/stephentoub) |
 | [Default Expressions](https://github.com/dotnet/csharplang/blob/master/proposals/target-typed-default.md) | master  | Merged | [jcouv](https://github.com/jcouv) | [cston](https://github.com/cston) | [jcouv](https://github.com/jcouv) |
 | [Ref Assemblies](https://github.com/dotnet/roslyn/blob/features/refout/docs/features/refout.md) | [refout](https://github.com/dotnet/roslyn/tree/features/refout)  | Integration & validation | [jcouv](https://github.com/jcouv) | [gafter](https://github.com/gafter) | N/A |
-| [Infer tuple names](https://github.com/dotnet/csharplang/blob/master/proposals/target-typed-default.md) | [tuple-names](https://github.com/dotnet/roslyn/tree/features/tuple-names)  | Implementation | [jcouv](https://github.com/jcouv) | [gafter](https://github.com/gafter) | [jcouv](https://github.com/jcouv) |
+| [Infer tuple names](https://github.com/dotnet/csharplang/blob/master/proposals/tuple-names.md) | [tuple-names](https://github.com/dotnet/roslyn/tree/features/tuple-names)  | Implementation | [jcouv](https://github.com/jcouv) | [gafter](https://github.com/gafter) | [jcouv](https://github.com/jcouv) |
 
 # C# 7.2
 


### PR DESCRIPTION
Doc-only change to feature status. The link for tuple-names feature was incorrectly pointing to proposal for "default". I fixed the link, but I yet have to populate such a proposal for tuple-names. I will do that this week (then the link will work).

CC @marek-safar @jaredpar 