### PR TITLE
Update our VS SDK generation scripts

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--Generated file, do not directly edit.  Run "RepoUtil change" to regenerate-->
   <PropertyGroup>
+    <FakeSignVersion>0.9.2</FakeSignVersion>
     <GitLinkVersion>3.0.0-unstable0085</GitLinkVersion>
     <ManagedEsentVersion>1.9.4</ManagedEsentVersion>
     <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>

--- a/build/config/RepoUtilData.json
+++ b/build/config/RepoUtilData.json
@@ -50,7 +50,8 @@
         "GitLink",
         "Microsoft.NETCore.Runtime.CoreCLR",
         "Microsoft.VSSDK.BuildTools",
-        "NETStandard.Library"
+        "NETStandard.Library",
+        "FakeSign"
       ]
     }
   },

--- a/src/Tools/GenerateSdkPackages/README.md
+++ b/src/Tools/GenerateSdkPackages/README.md
@@ -1,8 +1,48 @@
 # Generate SDK Packages
 
-This is a collection of tools for generating a set of NuGet packages for the VS SDK and updating our repo to consume them.  This is a temporary solution until we work with the VS SDK team to help address a couple of issues with how their packages are produced.
+This is a collection of tools for generating a set of NuGet packages for the VS SDK and updating our repo to consume 
+them.  This is a temporary solution until we work with the VS SDK team to help address a couple of issues with how their 
+packages are produced.
 
 - make-all.ps1: Generates all of the NuGet packages we need for the VS SDK
 - change-all.ps1: Changes all our project.json files to reference a new VS SDK version 
+
+## Example workflow
+
+Here is an example of building, testing and uploading the packages for the 26418.00 build of d15prerel.  First step is 
+to make the packages for the build.
+
+``` powershell 
+> .\make-all.ps1 -version "26418.00" -branch "d15prerel"  -outpath c:\users\jaredpar\temp\nuget
+```
+
+This will create all of the packages with the version string 15.0.26418-alpha.  Next the build needs to be updated 
+to reflect this change in version for the packages we are consuming. 
+
+``` powershell
+> .\change-all.ps1 -version "26418.00" 
+```
+
+Before uploading the packages to myget please do a local build to validate the changes.  In order to do this the 
+following line needs to be added to NuGet.config.  Do not merge this change, it is for testing only.  
+
+``` xml
+<add key="DO NOT MERGE" value="c:\users\jaredpar\temp\nuget" />
+```
+
+Given this entry we can quickly run the following developer flow to validate the changes:
+
+``` cmd
+> cd <roslyn root>
+> Restore.cmd
+> Build.cmd
+> Test.cmd
+```
+
+Assuming this all passes then revert the change to NuGet.config, upload the packages to the roslyn-tools feed of 
+myget and submit the result of `change-all.ps1` as a PR. 
+
+
+
 
 

--- a/src/Tools/GenerateSdkPackages/change-all.ps1
+++ b/src/Tools/GenerateSdkPackages/change-all.ps1
@@ -1,45 +1,44 @@
-Param(
-    [string]$version = ""
-)
+[CmdletBinding(PositionalBinding=$false)]
+Param([string]$version = "")
 
-set-strictmode -version 2.0
-$ErrorActionPreference="Stop"
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
 
 try {
     if ($version -eq "") { 
-        write-host "Need a -version"
+        Write-Host "Need a -version"
         exit 1
     }
 
-    $rootPath = resolve-path (join-path $PSScriptRoot "..\..\..\")
-    $repoUtil = join-path $rootPath "Binaries\Debug\Exes\RepoUtil\RepoUtil.exe"
-    if (-not (test-path $repoUtil)) { 
-        write-host "RepoUtil not found $repoUtil"
+    $rootPath = Resolve-Path (Join-Path $PSScriptRoot "..\..\..\")
+    $repoUtil = Join-Path $rootPath "Binaries\Debug\Exes\RepoUtil\RepoUtil.exe"
+    if (-not (Test-Path $repoUtil)) { 
+        Write-Host "RepoUtil not found $repoUtil"
         exit 1
     }
 
-    $fileList = gc (join-path $PSScriptRoot "files.txt")
+    $fileList = Get-Content (Join-Path $PSScriptRoot "files.txt")
     $shortVersion = $version.Substring(0, $version.IndexOf('.'))
     $packageVersion = "15.0.$shortVersion-alpha"
     $changeList = @()
 
-    write-host "Moving version to $packageVersion"
+    Write-Host "Moving version to $packageVersion"
     foreach ($item in $fileList) { 
-        $name = split-path -leaf $item
+        $name = Split-Path -leaf $item
         $simpleName = [IO.Path]::GetFileNameWithoutExtension($name) 
         $changeList += "$simpleName $packageVersion"
     }
 
     $changeFilePath = [IO.Path]::GetTempFileName()
-    $changeList -join [Environment]::NewLine | out-file $changeFilePath
-    write-host (gc -raw $changeFilePath)
+    $changeList -join [Environment]::NewLine | Out-File $changeFilePath
+    Write-Host (gc -raw $changeFilePath)
 
-    $fullSln = join-path $rootPath "..\Roslyn.sln"
-    if (test-path $fullSln) {
+    $fullSln = Join-Path $rootPath "..\Roslyn.sln"
+    if (Test-Path $fullSln) {
         # Running as a part of the full enlisment.  Need to add some extra paramteers
-        $sourcesPath = resolve-path (join-path $rootPath "..")
+        $sourcesPath = Resolve-Path (Join-Path $rootPath "..")
         $generatePath = $rootPath
-        $configPath = join-path $rootPath "build\config\RepoUtilData.json"
+        $configPath = Join-Path $rootPath "build\config\RepoUtilData.json"
         & $repoUtil -sourcesPath $sourcesPath -generatePath $generatePath -config $configPath change -version $changeFilePath
     }
     else {
@@ -48,7 +47,8 @@ try {
     }
 
 }
-catch [exception] {
-    write-host $_.Exception
-    exit -1
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    exit 1
 }

--- a/src/Tools/GenerateSdkPackages/engine.nuspec
+++ b/src/Tools/GenerateSdkPackages/engine.nuspec
@@ -17,8 +17,8 @@
     <tags>VSSDK</tags>
   </metadata>
   <files>
-    <file src="$debuggerPath$\net20\Microsoft.VisualStudio.Debugger.Engine.dll" target="lib\net20" />
-    <file src="$debuggerPath$\net45\Microsoft.VisualStudio.Debugger.Engine.dll" target="lib\net45" />
+    <file src="$debuggerPath$\v2.0\Microsoft.VisualStudio.Debugger.Engine.dll" target="lib\net20" />
+    <file src="$debuggerPath$\v4.5\Microsoft.VisualStudio.Debugger.Engine.dll" target="lib\net45" />
     <file src="$debuggerPath$\portable\Microsoft.VisualStudio.Debugger.Engine.dll" target="lib\portable-net45+win8" />
   </files>
 </package>

--- a/src/Tools/GenerateSdkPackages/make-all.ps1
+++ b/src/Tools/GenerateSdkPackages/make-all.ps1
@@ -1,25 +1,29 @@
-Param(
-    [string]$version = "26014.00",
+[CmdletBinding(PositionalBinding=$false)]
+Param( [string]$version = "26014.00",
     [string]$branch = "d15rel",
     [string]$outPath = $null,
     [string]$fakeSign = $null
 )
 
-set-strictmode -version 2.0
-$ErrorActionPreference="Stop"
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+function Create-Directory([string]$name) {
+    [IO.Directory]::CreateDirectory($name)
+}
 
 # Package a normal DLL into a nuget.  Default used for packages that have a simple 1-1
 # relationship between DLL and NuGet for only Net46.
 function package-normal() {
-    $baseNuspecPath = join-path $PSScriptRoot "base.nuspec"
-    $sourceFilePath = join-path $dropPath $item
-    $filePath = join-path $dllPath $name
-    if (-not (test-path $sourceFilePath)) {
-        write-host "Could not locate $sourceFilePath"
+    $baseNuspecPath = Join-Path $PSScriptRoot "base.nuspec"
+    $sourceFilePath = Join-Path $dropPath $item
+    $filePath = Join-Path $dllPath $name
+    if (-not (Test-Path $sourceFilePath)) {
+        Write-Host "Could not locate $sourceFilePath"
         continue;
     }
 
-    cp $sourceFilePath $filePath
+    Copy-Item $sourceFilePath $filePath
     & $fakeSign -f $filePath
     & $nuget pack $baseNuspecPath -OutputDirectory $packagePath -Properties name=$simpleName`;version=$packageVersion`;filePath=$filePath
 }
@@ -27,75 +31,75 @@ function package-normal() {
 # The debugger DLLs have a more complex structure and it's easier to special case
 # copying them over.
 function copy-debugger() { 
-    $refRootPath = [IO.Path]::GetFullPath((join-path $dropPath "..\..\Debugger\ReferenceDLL"))
-    $debuggerDllPath = join-path $dllPath "debugger"
-    $net20Path = join-path $debuggerDllPath "net20"
-    $net45Path = join-path $debuggerDllPath "net45"
-    $portablePath = join-path $debuggerDllPath "portable"
+    $refRootPath = [IO.Path]::GetFullPath((Join-Path $dropPath "..\..\Debugger\ReferenceDLL"))
+    $debuggerDllPath = Join-Path $dllPath "debugger"
+    $net20Path = Join-Path $debuggerDllPath "net20"
+    $net45Path = Join-Path $debuggerDllPath "net45"
+    $portablePath = Join-Path $debuggerDllPath "portable"
 
-    mkdir $debuggerDllPath -ErrorAction SilentlyContinue | out-null
-    mkdir $net20Path -ErrorAction SilentlyContinue | out-null
-    mkdir $net45Path -ErrorAction SilentlyContinue | out-null
-    mkdir $portablePath -ErrorAction SilentlyContinue | out-null
+    Create-Directory $debuggerDllPath
+    Create-Directory $net20Path
+    Create-Directory $net45Path
+    Create-Directory $portablePath
 
-    pushd $debuggerDllPath
+    Push-Location $debuggerDllPath
     try {
-        $d = join-path $dropPath "..\..\Debugger"
-        cp (join-path $d "RemoteDebugger\Microsoft.VisualStudio.Debugger.Engine.dll") $net20Path
-        cp (join-path $d "IDE\Microsoft.VisualStudio.Debugger.Engine.dll") $net45Path
-        cp (join-path $d "x-plat\coreclr.windows\mcg\Microsoft.VisualStudio.Debugger.Engine.dll") $portablePath
-        cp (join-path $dropPath "Microsoft.VisualStudio.Debugger.Metadata.dll") $net20Path
-        cp (join-path $dropPath "Microsoft.VisualStudio.Debugger.Metadata.dll") $portablePath
-        gci -re -in *.dll | %{ & $fakeSign -f $_ }
+        $d = Join-Path $dropPath "..\..\Debugger"
+        Copy-Item (Join-Path $d "RemoteDebugger\Microsoft.VisualStudio.Debugger.Engine.dll") $net20Path
+        Copy-Item (Join-Path $d "IDE\Microsoft.VisualStudio.Debugger.Engine.dll") $net45Path
+        Copy-Item (Join-Path $d "x-plat\coreclr.windows\mcg\Microsoft.VisualStudio.Debugger.Engine.dll") $portablePath
+        Copy-Item (Join-Path $dropPath "Microsoft.VisualStudio.Debugger.Metadata.dll") $net20Path
+        Copy-Item (Join-Path $dropPath "Microsoft.VisualStudio.Debugger.Metadata.dll") $portablePath
+        Get-ChildItem -re -in *.dll | %{ & $fakeSign -f $_ }
     }
     finally {
-        popd
+        Pop-Location
     }
 }
 
 # Used to package debugger nugets
 function package-debugger() {
     param( [string]$kind )
-    $debuggerPath = join-path $dllPath "debugger"
-    $nuspecPath = join-path $PSScriptRoot "$kind.nuspec"
+    $debuggerPath = Join-Path $dllPath "debugger"
+    $nuspecPath = Join-Path $PSScriptRoot "$kind.nuspec"
     & $nuget pack $nuspecPath -OutputDirectory $packagePath -Properties version=$packageVersion`;debuggerPath=$debuggerPath
 }
 
 try {
     if ($outPath -eq "") {
-        write-host "Need an -outPath value"
+        Write-Host "Need an -outPath value"
         exit 1
     }
 
     if ($fakeSign -eq "") {
-        write-host "Need a -fakeSign value"
+        Write-Host "Need a -fakeSign value"
         exit 1
     }
 
-    $list = gc (join-path $PSScriptRoot "files.txt")
+    $list = Get-Content (Join-Path $PSScriptRoot "files.txt")
     $dropPath = "\\cpvsbuild\drops\VS\$branch\raw\$version\binaries.x86ret\bin\i386"
-    $nuget = join-path $PSScriptRoot "..\..\..\nuget.exe"
+    $nuget = Join-Path $PSScriptRoot "..\..\..\nuget.exe"
 
     $shortVersion = $version.Substring(0, $version.IndexOf('.'))
     $packageVersion = "15.0.$shortVersion-alpha"
-    $dllPath = join-path $outPath "Dlls"
-    $packagePath = join-path $outPath "Packages"
+    $dllPath = Join-Path $outPath "Dlls"
+    $packagePath = Join-Path $outPath "Packages"
 
-    write-host "Drop path is $dropPath"
-    write-host "Package version $packageVersion"
-    write-host "Out path is $outPath"
+    Write-Host "Drop path is $dropPath"
+    Write-Host "Package version $packageVersion"
+    Write-Host "Out path is $outPath"
 
-    mkdir $outPath -ErrorAction SilentlyContinue | out-null
-    mkdir $dllPath -ErrorAction SilentlyContinue | out-null
-    mkdir $packagePath -ErrorAction SilentlyContinue | out-null
-    pushd $outPath
+    Create-Directory $outPath
+    Create-Directory $dllPath
+    Create-Directory $packagePath
+    Push-Location $outPath
     try {
         copy-debugger
 
         foreach ($item in $list) {
-            $name = split-path -leaf $item
+            $name = Split-Path -leaf $item
             $simpleName = [IO.Path]::GetFileNameWithoutExtension($name) 
-            write-host "Packing $simpleName"
+            Write-Host "Packing $simpleName"
             switch ($simpleName) {
                 "Microsoft.VisualStudio.Debugger.Engine" { package-debugger "engine" }
                 "Microsoft.VisualStudio.Debugger.Metadata" { package-debugger "metadata" }
@@ -104,10 +108,10 @@ try {
         }
     }
     finally {
-        popd
+        Pop-Location
     }
 }
-catch [exception] {
-    write-host $_.Exception
-    exit -1
+catch {
+    Write-Host $_
+    exit 1
 }

--- a/src/Tools/GenerateSdkPackages/metadata.nuspec
+++ b/src/Tools/GenerateSdkPackages/metadata.nuspec
@@ -17,7 +17,7 @@
     <tags>VSSDK</tags>
   </metadata>
   <files>
-    <file src="$debuggerPath$\net20\Microsoft.VisualStudio.Debugger.Metadata.dll" target="lib\net20" />
+    <file src="$debuggerPath$\v2.0\Microsoft.VisualStudio.Debugger.Metadata.dll" target="lib\net20" />
     <file src="$debuggerPath$\portable\Microsoft.VisualStudio.Debugger.Metadata.dll" target="lib\portable-net45+win8" />
   </files>
 </package>


### PR DESCRIPTION
Infrastructure change

This change updates the scripts used to generate our VS SDK packages:

- Bring scripts up to date with powershell guidelines 
- Make them easier to run by removing fakesign argument 
- Added a full developer work flow example to README.md