### PR TITLE
Address additional feedback on PR #18771

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PropertySymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PropertySymbolAdapter.cs
@@ -19,20 +19,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             CheckDefinitionInvariant();
 
-            IMethodReference getMethod = this.GetMethod;
-            if (getMethod != null && getMethod.GetResolvedMethod(context).ShouldInclude(context))
+            MethodSymbol getMethod = this.GetMethod;
+            if (getMethod != null && getMethod.ShouldInclude(context))
             {
                 yield return getMethod;
             }
 
-            IMethodReference setMethod = this.SetMethod;
-            if (setMethod != null && setMethod.GetResolvedMethod(context).ShouldInclude(context))
+            MethodSymbol setMethod = this.SetMethod;
+            if (setMethod != null && setMethod.ShouldInclude(context))
             {
                 yield return setMethod;
             }
 
             SourcePropertySymbol sourceProperty = this as SourcePropertySymbol;
-            if ((object)sourceProperty != null)
+            if ((object)sourceProperty != null && sourceProperty.ShouldInclude(context))
             {
                 SynthesizedSealedPropertyAccessor synthesizedAccessor = sourceProperty.SynthesizedSealedAccessorOpt;
                 if ((object)synthesizedAccessor != null)

--- a/src/Compilers/VisualBasic/Portable/Emit/PropertySymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PropertySymbolAdapter.vb
@@ -14,13 +14,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Iterator Function IPropertyDefinitionAccessors(context As EmitContext) As IEnumerable(Of IMethodReference) Implements IPropertyDefinition.GetAccessors
             CheckDefinitionInvariant()
 
-            Dim getter As IMethodReference = Me.GetMethod
-            If getter IsNot Nothing AndAlso getter.GetResolvedMethod(context).ShouldInclude(context) Then
+            Dim getter As MethodSymbol = Me.GetMethod
+            If getter IsNot Nothing AndAlso getter.ShouldInclude(context) Then
                 Yield getter
             End If
 
-            Dim setter As IMethodReference = Me.SetMethod
-            If setter IsNot Nothing AndAlso setter.GetResolvedMethod(context).ShouldInclude(context) Then
+            Dim setter As MethodSymbol = Me.SetMethod
+            If setter IsNot Nothing AndAlso setter.ShouldInclude(context) Then
                 Yield setter
             End If
         End Function


### PR DESCRIPTION
Follow-up feedback on https://github.com/dotnet/roslyn/pull/18771 (thanks Aleksey)
It turns out the scenario where an accessor needs to be synthesized to be sealed worked, but I added a test and also the `ShouldInclude` filter for consistency (it will not filter virtual methods, so no observable change).

@AlekseyTs @dotnet/roslyn-compiler for review.