### PR TITLE
Include generic interfaces in implements clause completion

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
@@ -739,5 +739,22 @@ Class B
 
             Await VerifyNoItemsExistAsync(text)
         End Function
+
+        <WorkItem(18006, "https://github.com/dotnet/roslyn/issues/18006")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function ShowGenericTypes() As Task
+            Dim text = <text>Interface I(Of T)
+    Sub Foo()
+End Interface
+
+Class B
+    Implements I(Of Integer)
+
+    Public Sub Foo() Implements $$
+
+   </text>.Value
+
+            Await VerifyItemExistsAsync(text, "I(Of Integer)")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
@@ -756,5 +756,43 @@ Class B
 
             Await VerifyItemExistsAsync(text, "I(Of Integer)")
         End Function
+
+        <WorkItem(18006, "https://github.com/dotnet/roslyn/issues/18006")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function ShowGenericTypes2() As Task
+            Dim text = <text>Interface I(Of T)
+    Sub Foo()
+End Interface
+
+Class B(Of T)
+    Implements I(Of T)
+
+    Public Sub Foo() Implements $$
+    End Sub
+End Class
+
+   </text>.Value
+
+            Await VerifyItemExistsAsync(text, "I(Of T)")
+        End Function
+
+        <WorkItem(18006, "https://github.com/dotnet/roslyn/issues/18006")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function ShowGenericTypes3() As Task
+            Dim text = <text>Interface I(Of T)
+    Sub Foo()
+End Interface
+
+Class B(Of T)
+    Implements I(Of Integer)
+
+    Public Sub Foo() Implements  
+    End Sub
+End Class
+
+   </text>.Value
+
+            Await VerifyItemExistsAsync(text, "I(Of T)")
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
@@ -162,7 +162,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             End If
 
             Dim interfaceWithUnimplementedMembers = containingType.GetAllUnimplementedMembersInThis(containingType.Interfaces, AddressOf interfaceMemberGetter, cancellationToken) _
-                                                .Where(Function(i) i.Item2.Any(Function(s) MatchesMemberKind(s, kind))) _
+                                                .Where(Function(i) i.Item2.Any(Function(interfaceOrContainer) MatchesMemberKind(interfaceOrContainer, kind))) _
                                                 .Select(Function(i) i.Item1)
 
             Dim interfacesAndContainers = New HashSet(Of ISymbol)(interfaceWithUnimplementedMembers)
@@ -170,8 +170,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 AddAliasesAndContainers(i, interfacesAndContainers, node, semanticModel)
             Next
 
-            Dim symbols = semanticModel.LookupSymbols(position)
-            Dim availableInterfacesAndContainers = interfacesAndContainers.Where(Function(s) symbols.Contains(s.OriginalDefinition)).ToImmutableArray()
+            Dim symbols = New HashSet(Of ISymbol)(semanticModel.LookupSymbols(position))
+            Dim availableInterfacesAndContainers = interfacesAndContainers.Where(
+                Function(interfaceOrContainer) symbols.Contains(interfaceOrContainer.OriginalDefinition)).ToImmutableArray()
 
             Dim result = TryAddGlobalTo(availableInterfacesAndContainers)
 

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
@@ -171,8 +171,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Next
 
             Dim symbols = semanticModel.LookupSymbols(position)
+            Dim availableInterfacesAndContainers = interfacesAndContainers.Where(Function(s) symbols.Contains(s.OriginalDefinition)).ToImmutableArray()
 
-            Dim result = TryAddGlobalTo(interfacesAndContainers.Intersect(symbols.ToArray()).ToImmutableArray())
+            Dim result = TryAddGlobalTo(availableInterfacesAndContainers)
 
             ' Even if there's not anything left to implement, we'll show the list of interfaces, 
             ' the global namespace, and the project root namespace (if any), as long as the class implements something.


### PR DESCRIPTION
**Customer scenario**

Customer is trying to type an implements clause to implement a member of a generic interface. The generic interface is not listed in the completion list.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/18006

**Workarounds, if any**

None

**Risk**

Low, this is only a change in how we show completion within implements clauses in VB.

**Performance impact**

Low, for each symbol we might suggest we now check to see if its original definition was returned by lookup symbols (instead of the symbol itself).

**Is this a regression from a previous update?**

No

**Root cause analysis:**
Test hole, regression test has been added.

**How was the bug found?**

Customer reported.
