### PR TITLE
Preventing crash when a local function with iterators is using an out/ref parameter

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode.cs
@@ -88,8 +88,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                var syntax = Syntax;
-                return syntax == null ? null : syntax.SyntaxTree;
+                return Syntax?.SyntaxTree;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -166,13 +166,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.State = pending.State;
                 BoundNode branch = pending.Branch;
 
-                // No need to check the parameters if we dont know the branch
-                if (branch != null)
-                {
-                    LeaveParameters(localFuncSymbol.Parameters, branch?.Syntax,
-                                    branch?.WasCompilerGenerated == true
-                                        ? location : null);
-                }
+                // If the branch syntax is null we can take the localFunc syntax.
+                // This will only be used incase of any diagnostics need to be created and the location is null
+                var syntax = branch?.Syntax ?? localFunc.Syntax; 
+                LeaveParameters(localFuncSymbol.Parameters, syntax, branch?.WasCompilerGenerated == true ? location : null);
 
                 IntersectWith(ref stateAtReturn, ref this.State);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -166,8 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // If the branch syntax is null we can take the localFunc syntax.
                 // This will only be used incase of any diagnostics need to be created and the location is null
-                var syntax = branch?.Syntax ?? localFunc.Syntax;
-                LeaveParameters(localFuncSymbol.Parameters, syntax, location);
+                LeaveParameters(localFuncSymbol.Parameters, branch?.Syntax ?? localFunc.Syntax, location);
 
                 IntersectWith(ref stateAtReturn, ref this.State);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -164,10 +164,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.State = pending.State;
                 BoundNode branch = pending.Branch;
 
-                // If the branch syntax is null we can take the localFunc syntax.
-                // This will only be used incase of any diagnostics need to be created and the location is null
-                var syntax = branch?.Syntax ?? localFunc.Syntax;
-                LeaveParameters(localFuncSymbol.Parameters, syntax, branch?.WasCompilerGenerated == true ? location : null);
+                // Pass the local function identifier as a location if the branch
+                // is null or compiler generated.
+                LeaveParameters(localFuncSymbol.Parameters,
+                  branch?.Syntax,
+                  branch?.WasCompilerGenerated == false ? null : location);
 
                 IntersectWith(ref stateAtReturn, ref this.State);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.State = pending.State;
                 BoundNode branch = pending.Branch;
 
-                //No need to check the parameters if we dont know the branch
+                // No need to check the parameters if we dont know the branch
                 if (branch != null)
                 {
                     LeaveParameters(localFuncSymbol.Parameters, branch?.Syntax,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -141,8 +141,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // of the function where the enumerable is returned.
             if (localFuncSymbol.IsIterator)
             {
-                //This causes an exception later if one of the parameters is out or ref
-                //Added the check bellow if (branch != null) to not check for LeaveParameters
+                // This causes an exception later if one of the parameters is out or ref
+                // Added the check bellow if (branch != null) to not check for LeaveParameters
                 PendingBranches.Add(new PendingBranch(null, this.State));
             }
 
@@ -166,7 +166,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.State = pending.State;
                 BoundNode branch = pending.Branch;
 
-                if (branch != null)//No need to check the parameters if we dont know the branch
+                //No need to check the parameters if we dont know the branch
+                if (branch != null)
                 {
                     LeaveParameters(localFuncSymbol.Parameters, branch?.Syntax,
                                     branch?.WasCompilerGenerated == true

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this.State = pending.State;
                 BoundNode branch = pending.Branch;
 
-                if (branch != null)//No need to check the parameters if we dont know the branch -> Causes NullReferenceException in ReportUnassignedOutParameter location = new SourceLocation(node);
+                if (branch != null)//No need to check the parameters if we dont know the branch
                 {
                     LeaveParameters(localFuncSymbol.Parameters, branch?.Syntax,
                                     branch?.WasCompilerGenerated == true

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -166,7 +166,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // If the branch syntax is null we can take the localFunc syntax.
                 // This will only be used incase of any diagnostics need to be created and the location is null
-                LeaveParameters(localFuncSymbol.Parameters, branch?.Syntax ?? localFunc.Syntax, location);
 
                 IntersectWith(ref stateAtReturn, ref this.State);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -141,8 +141,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // of the function where the enumerable is returned.
             if (localFuncSymbol.IsIterator)
             {
-                // This causes an exception later if one of the parameters is out or ref
-                // Added the check bellow if (branch != null) to not check for LeaveParameters
                 PendingBranches.Add(new PendingBranch(null, this.State));
             }
 
@@ -168,8 +166,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // If the branch syntax is null we can take the localFunc syntax.
                 // This will only be used incase of any diagnostics need to be created and the location is null
-                var syntax = branch?.Syntax ?? localFunc.Syntax; 
-                LeaveParameters(localFuncSymbol.Parameters, syntax, branch?.WasCompilerGenerated == true ? location : null);
+                var syntax = branch?.Syntax ?? localFunc.Syntax;
+                LeaveParameters(localFuncSymbol.Parameters, syntax, location);
 
                 IntersectWith(ref stateAtReturn, ref this.State);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -141,6 +141,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // of the function where the enumerable is returned.
             if (localFuncSymbol.IsIterator)
             {
+                //This causes an exception later if one of the parameters is out or ref
+                //Added the check bellow if (branch != null) to not check for LeaveParameters
                 PendingBranches.Add(new PendingBranch(null, this.State));
             }
 
@@ -163,9 +165,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 this.State = pending.State;
                 BoundNode branch = pending.Branch;
-                LeaveParameters(localFuncSymbol.Parameters, branch?.Syntax,
-                                branch?.WasCompilerGenerated == true
-                                    ? location : null);
+
+                if (branch != null)//No need to check the parameters if we dont know the branch -> Causes NullReferenceException in ReportUnassignedOutParameter location = new SourceLocation(node);
+                {
+                    LeaveParameters(localFuncSymbol.Parameters, branch?.Syntax,
+                                    branch?.WasCompilerGenerated == true
+                                        ? location : null);
+                }
+
                 IntersectWith(ref stateAtReturn, ref this.State);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -166,6 +166,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // If the branch syntax is null we can take the localFunc syntax.
                 // This will only be used incase of any diagnostics need to be created and the location is null
+                var syntax = branch?.Syntax ?? localFunc.Syntax;
+                LeaveParameters(localFuncSymbol.Parameters, syntax, branch?.WasCompilerGenerated == true ? location : null);
 
                 IntersectWith(ref stateAtReturn, ref this.State);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -271,14 +271,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected virtual void ReportUnassignedOutParameter(ParameterSymbol parameter, SyntaxNode node, Location location)
         {
-            if (!_requireOutParamsAssigned && topLevelMethod == currentMethodOrLambda) return;
+            if (!_requireOutParamsAssigned && topLevelMethod == currentMethodOrLambda &&
+                node == null && location == null)
+            {
+                return;
+            }
+
             if (Diagnostics != null && this.State.Reachable)
             {
                 if (location == null)
                 {
                     location = new SourceLocation(node);
                 }
-
+                
                 bool reported = false;
                 if (parameter.IsThis)
                 {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -272,7 +272,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected virtual void ReportUnassignedOutParameter(ParameterSymbol parameter, SyntaxNode node, Location location)
         {
             if (!_requireOutParamsAssigned && topLevelMethod == currentMethodOrLambda)
+            {
                 return;
+            }
 
             // If node and location are null "new SourceLocation(node);" will throw a NullReferenceException
             Debug.Assert(node != null || location != null);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -283,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     location = new SourceLocation(node);
                 }
-                
+
                 bool reported = false;
                 if (parameter.IsThis)
                 {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -271,11 +271,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected virtual void ReportUnassignedOutParameter(ParameterSymbol parameter, SyntaxNode node, Location location)
         {
-            if (!_requireOutParamsAssigned && topLevelMethod == currentMethodOrLambda ||
-                node == null && location == null)
-            {
+            if (!_requireOutParamsAssigned && topLevelMethod == currentMethodOrLambda)
                 return;
-            }
+
+            // If node and location are null "new SourceLocation(node);" will throw a NullReferenceException
+            Debug.Assert(node != null || location != null);
 
             if (Diagnostics != null && this.State.Reachable)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected virtual void ReportUnassignedOutParameter(ParameterSymbol parameter, SyntaxNode node, Location location)
         {
-            if (!_requireOutParamsAssigned && topLevelMethod == currentMethodOrLambda &&
+            if (!_requireOutParamsAssigned && topLevelMethod == currentMethodOrLambda ||
                 node == null && location == null)
             {
                 return;

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -1322,6 +1322,7 @@ struct S
 
         [Fact]
         [WorkItem(18813, "https://github.com/dotnet/roslyn/issues/18813")]
+        public void LocalIEnumerableFunctionWithOutParameter()
         {
             var comp = CreateStandardCompilation(@"
 class c

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -1319,7 +1319,6 @@ struct S
                 Diagnostic(ErrorCode.ERR_UseDefViolationField, "Local()").WithArguments("_x").WithLocation(14, 9));
         }
 
-
         [Fact]
         [WorkItem(18813, "https://github.com/dotnet/roslyn/issues/18813")]
         public void LocalIEnumerableFunctionWithOutParameter1()
@@ -1329,9 +1328,9 @@ class c
 {
     static void Main(string[] args)
     {
-        System.Collections.Generic.IEnumerable<string> getFoo(int count, out bool foobar)
+        System.Collections.Generic.IEnumerable<string> getFoo(int count, out bool output)
         {
-            foobar = true;
+            output = true;
             yield return ""foo"";
         }
 
@@ -1342,10 +1341,10 @@ class c
             comp.VerifyDiagnostics(
                 // (6,83): error CS1623: Iterators cannot have ref or out parameters
                 //         System.Collections.Generic.IEnumerable<string> getFoo(int count, out bool foobar)
-                Diagnostic(ErrorCode.ERR_BadIteratorArgType, "foobar"),
+                Diagnostic(ErrorCode.ERR_BadIteratorArgType, "output"),
                 // (6,56): error CS0177: The out parameter 'foobar' must be assigned to before control leaves the current method
                 //         System.Collections.Generic.IEnumerable<string> getFoo(int count, out bool foobar)
-                Diagnostic(ErrorCode.ERR_ParamUnassigned, "getFoo").WithArguments("foobar").WithLocation(6, 56));
+                Diagnostic(ErrorCode.ERR_ParamUnassigned, "getFoo").WithArguments("output").WithLocation(6, 56));
         }
 
         [Fact]
@@ -1357,9 +1356,9 @@ class c
 {
     static void Main(string[] args)
     {
-        System.Collections.Generic.IEnumerable<string> getFoo(int count, out bool foobar)
+        System.Collections.Generic.IEnumerable<string> getFoo(int count, out bool output)
         {
-            foobar = false;
+            output = false;
             for (int i = 0; i < count; i++)
             {
                 foreach (var val in getFoo(3, out var bar))
@@ -1375,10 +1374,10 @@ class c
             comp.VerifyDiagnostics(
                 // (6,83): error CS1623: Iterators cannot have ref or out parameters
                 //         System.Collections.Generic.IEnumerable<string> getFoo(int count, out bool foobar)
-                Diagnostic(ErrorCode.ERR_BadIteratorArgType, "foobar"),
+                Diagnostic(ErrorCode.ERR_BadIteratorArgType, "output"),
                 // (6,56): error CS0177: The out parameter 'foobar' must be assigned to before control leaves the current method
                 //         System.Collections.Generic.IEnumerable<string> getFoo(int count, out bool foobar)
-                Diagnostic(ErrorCode.ERR_ParamUnassigned, "getFoo").WithArguments("foobar").WithLocation(6, 56));
+                Diagnostic(ErrorCode.ERR_ParamUnassigned, "getFoo").WithArguments("output").WithLocation(6, 56));
         }
     }
 }


### PR DESCRIPTION
When the localfunction has IsIterator == true, then a PendingBranch is
being added with a branch as null. This later causes a
NullReferenceException in ReportUnassignedOutParameter

Fixes #18813

**Customer scenario**
When creating a local function(with Iterators) and it has out/ref parameters, Visual Studio just crashes.

**Bugs this fixes:**
https://github.com/dotnet/roslyn/issues/18813

**Workarounds, if any**
None.

**Risk**
Affects Local functions when they have ref/out parameters

**Performance impact**
Low

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
~~No tests found in the area of DataFlowPass.LocalFunctions.cs and other methods involved in this issue~~
~~What tests are we adding to guard against it in the future?~~
~~Might need a new issue to track the missing tests for this area.~~

Since the changes did trigger a failed build, my previous assumption, that there aren't tests covering the affected methods is wrong.

**How was the bug found?**
https://github.com/dotnet/roslyn/issues/18813
