### PR TITLE
Tolerate null LocalName when serializing tuple names for locals

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -1285,6 +1285,27 @@ Sum: 10, Count: 4")
         End Sub
 
         <Fact>
+        <WorkItem(18762, "https://github.com/dotnet/roslyn/issues/18762")>
+        Public Sub UnnamedTempShouldNotCrashPbdEncoding()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Imports System.Threading.Tasks
+
+Module Module1
+    Private Async Function DoAllWorkAsync() As Task(Of (FistValue As String, SecondValue As String))
+        Return (Nothing, Nothing)
+    End Function
+End Module
+    </file>
+</compilation>,
+additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, useLatestFramework:=True, options:=TestOptions.DebugDll)
+
+        End Sub
+
+        <Fact>
         Public Sub Overloading001()
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -1286,7 +1286,7 @@ Sum: 10, Count: 4")
 
         <Fact>
         <WorkItem(18762, "https://github.com/dotnet/roslyn/issues/18762")>
-        Public Sub UnnamedTempShouldNotCrashPbdEncoding()
+        Public Sub UnnamedTempShouldNotCrashPdbEncoding()
 
             Dim verifier = CompileAndVerify(
 <compilation>
@@ -1295,7 +1295,7 @@ Imports System
 Imports System.Threading.Tasks
 
 Module Module1
-    Private Async Function DoAllWorkAsync() As Task(Of (FistValue As String, SecondValue As String))
+    Private Async Function DoAllWorkAsync() As Task(Of (FirstValue As String, SecondValue As String))
         Return (Nothing, Nothing)
     End Function
 End Module

--- a/src/Dependencies/CodeAnalysis.Metadata/CustomDebugInfoEncoder.cs
+++ b/src/Dependencies/CodeAnalysis.Metadata/CustomDebugInfoEncoder.cs
@@ -194,7 +194,10 @@ namespace Microsoft.CodeAnalysis.Debugging
                         builder.WriteInt32(info.SlotIndex);
                         builder.WriteInt32(info.ScopeStart);
                         builder.WriteInt32(info.ScopeEnd);
-                        builder.WriteUTF8(info.LocalName);
+                        if (info.LocalName != null)
+                        {
+                            builder.WriteUTF8(info.LocalName);
+                        }
                         builder.WriteByte(0);
                     }
                 });


### PR DESCRIPTION
@tmat @cston @dotnet/roslyn-compiler for review. 
The crash occurred because the method that saved tuple element names into PDBs didn't handle `null` `LocalName`. The local in question only occurs in VB (it's a FunctionLocal).

**Customer scenario**

In a VB project, write an async method that returns a tuple type with element names. The compiler crashes when compiling with PDB output.

**Bugs this fixes:**
https://github.com/dotnet/roslyn/issues/18762

**Workarounds, if any**
Don't use tuple names in the return type.

**Risk**
**Performance impact**
Low. One-line null check.

**Root cause analysis:**

We do have a test with such scenario, but it uses release (not debug) options, so that specific local is elided and the crash avoided.

**How was the bug found?**

Customer reported.