### PR TITLE
Fix fix all behavior

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -87,6 +87,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
             }
 
+            private static bool s_UseOldCode = true;
+
             /// <summary>
             /// Return all diagnostics that belong to given project for the given StateSets (analyzers) either from cache or by calculating them
             /// </summary>
@@ -108,9 +110,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         }
 
                         // perf optimization. check whether we want to analyze this project or not.
-                        if (!await FullAnalysisEnabledAsync(project, ignoreFullAnalysisOptions, cancellationToken).ConfigureAwait(false))
+                        if (!ignoreFullAnalysisOptions || s_UseOldCode)
                         {
-                            return new ProjectAnalysisData(project.Id, VersionStamp.Default, existingData.Result, ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty);
+                            if (!await FullAnalysisEnabledAsync(project, ignoreFullAnalysisOptions, cancellationToken).ConfigureAwait(false))
+                            {
+                                return new ProjectAnalysisData(project.Id, VersionStamp.Default, existingData.Result, ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty);
+                            }
                         }
 
                         var result = await ComputeDiagnosticsAsync(analyzerDriverOpt, project, stateSets, existingData.Result, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
@heejaechang Can you do an initial review of this change? I was able to demonstrate that the change fixed the totally broken behavior of Fix All observed in several cases, but it's unclear whether or not this will negatively impact scenarios I was not able to test.

The root cause appears to be `HasSuccessfullyLoadedAsync` returning false because the `HasSuccessfullyLoadedTransitively` property of the compilation tracker is false. I have no idea how this occurred, but it seems that we do not want to skip the code that finds diagnostics either way.

The bug was most readily reproduced in large solutions (especially e.g. Roslyn.sln), but it's not clear if that is a prerequisite for failure or why it would make a difference.

## Ask Mode

**Customer scenario**

Apply a Fix All operation using the light bulb. The scenario may, but does not always, occur regardless of the scope specified for the Fix All operation.

**Bugs this fixes:**

#17943
#18124

**Workarounds, if any**

The bug does not always occur. Retrying the operation and/or restarting the IDE before retrying the operation in some cases provides a workaround, though the workaround has been observed to be sporadically incomplete.

**Risk**

In the absence of additional work to address the readily-observable performance problems in Fix All operations, this change has a **very high risk** of causing customer machines to either hang or crash. However, the current inconsistent behavior makes the necessary performance evaluations difficult to impossible.

**Performance impact**

This change has been observed to incur substantial overhead when Fix All is used, including very long blocking operations on the UI thread without a wait dialog. However, it appears that the cause of these performance problems was already part of the code and not directly attributed to this change. This change restores consistently correct behavior of Fix All, providing the necessary basis for ongoing performance improvements.

Edit: The performance overhead which caused the UI thread to hang appears to have been caused by code within a `#if DEBUG` section. I'll attempt to narrow this down tomorrow.

**Is this a regression from a previous update?**

This appears to be a regression affecting Visual Studio 2017 to a greater degree than Visual Studio 2015. However, various problems of this form have long been observed in the product.

**Root cause analysis:**

@heejaechang Can you provide more details for the root cause analysis based on my initial comments above?

**How was the bug found?**

Multiple customer and internal reports.