### PR TITLE
Allow properties to be passed with DefinitionItems for FAR.

### DIFF
--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.DocumentLocationDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.DocumentLocationDefinitionItem.cs
@@ -20,10 +20,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 ImmutableArray<TaggedText> displayParts,
                 ImmutableArray<TaggedText> nameDisplayParts,
                 ImmutableArray<DocumentSpan> sourceSpans,
+                ImmutableDictionary<string, string> properties,
                 bool displayIfNoReferences)
                 : base(tags, displayParts, nameDisplayParts,
-                      ImmutableArray.Create(new TaggedText(TextTags.Text, sourceSpans[0].Document.Project.Name)),
-                      sourceSpans, displayIfNoReferences)
+                       ImmutableArray.Create(new TaggedText(TextTags.Text, sourceSpans[0].Document.Project.Name)),
+                       sourceSpans, properties, displayIfNoReferences)
             {
             }
 

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.NonNavigatingDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.NonNavigatingDefinitionItem.cs
@@ -19,10 +19,11 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 ImmutableArray<string> tags,
                 ImmutableArray<TaggedText> displayParts,
                 ImmutableArray<TaggedText> originationParts,
+                ImmutableDictionary<string, string> properties,
                 bool displayIfNoReferences)
                 : base(tags, displayParts, ImmutableArray<TaggedText>.Empty,
-                      originationParts, ImmutableArray<DocumentSpan>.Empty,
-                      displayIfNoReferences)
+                       originationParts, ImmutableArray<DocumentSpan>.Empty,
+                       properties, displayIfNoReferences)
             {
             }
 

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.SymbolDefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.SymbolDefinitionItem.cs
@@ -31,11 +31,13 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 ImmutableArray<string> tags,
                 ImmutableArray<TaggedText> displayParts,
                 ImmutableArray<TaggedText> nameDisplayParts,
+                ImmutableDictionary<string, string> properties,
                 bool displayIfNoReferences,
                 Solution solution, ISymbol definition)
                 : base(tags, displayParts, nameDisplayParts,
                        GetOriginationParts(definition),
                        ImmutableArray<DocumentSpan>.Empty,
+                       properties,
                        displayIfNoReferences)
             {
                 _workspace = solution.Workspace;

--- a/src/Features/Core/Portable/FindUsages/IDefinitionsAndReferencesFactory.cs
+++ b/src/Features/Core/Portable/FindUsages/IDefinitionsAndReferencesFactory.cs
@@ -180,6 +180,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 showMetadataSymbolsWithoutReferences: false);
 
             var sourceLocations = ArrayBuilder<DocumentSpan>.GetInstance();
+            ImmutableDictionary<string, string> properties = null;
 
             // If it's a namespace, don't create any normal location.  Namespaces
             // come from many different sources, but we'll only show a single 
@@ -192,7 +193,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
                     {
                         return DefinitionItem.CreateMetadataDefinition(
                             tags, displayParts, nameDisplayParts, solution, 
-                            definition, displayIfNoReferences);
+                            definition, properties, displayIfNoReferences);
                     }
                     else if (location.IsInSource)
                     {
@@ -230,12 +231,12 @@ namespace Microsoft.CodeAnalysis.FindUsages
                 return DefinitionItem.CreateNonNavigableItem(
                     tags, displayParts,
                     DefinitionItem.GetOriginationParts(definition),
-                    displayIfNoReferences);
+                    properties, displayIfNoReferences);
             }
 
             return DefinitionItem.Create(
                 tags, displayParts, sourceLocations.ToImmutableAndFree(),
-                nameDisplayParts, displayIfNoReferences);
+                nameDisplayParts, properties, displayIfNoReferences);
         }
 
         public static SourceReferenceItem TryCreateSourceReferenceItem(

--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
@@ -93,7 +93,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.FindReferences
                 string filePath,
                 int lineNumber,
                 int charOffset) 
-                : base(tags, displayParts, ImmutableArray<TaggedText>.Empty)
+                : base(tags, displayParts, ImmutableArray<TaggedText>.Empty,
+                       originationParts: default(ImmutableArray<TaggedText>),
+                       sourceSpans: default(ImmutableArray<DocumentSpan>),
+                       properties: null,
+                       displayIfNoReferences: true)
             {
                 _serviceProvider = serviceProvider;
                 _filePath = filePath;


### PR DESCRIPTION
This will be used so that we can shuttle the RQName along with a definition-item when we compute the results in the OOP server.  We can then use the RQName on the VS side to see if any extensions want to add any more results to the FAR results.  This allows us to avoid having to get back to a symbol on the VS side in order to notify 3rd parties of what we're searching for.
