### PR TITLE
Remove invalid powershell variable

### DIFF
--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -23,9 +23,6 @@ function Exec-Block([scriptblock]$cmd) {
     # - $?: did the powershell script block throw an error
     # - $lastexitcode: did a windows command executed by the script block end in error
     if ((-not $?) -or ($lastexitcode -ne 0)) {
-        if (-not $echo) { 
-            Write-Host $output
-        }
         throw "Command failed to execute: $cmd"
     } 
 }


### PR DESCRIPTION
This wasn't previously flagged because this only comes into play if there is an error.  As
written the code will display "$echo isn't a variable" instaed of the actual error.

]