### PR TITLE
Simplify how we go from a text-snapshot to a document in lightbulbs.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 using (Logger.LogBlock(FunctionId.SuggestedActions_GetSuggestedActions, cancellationToken))
                 {
-                    var document = GetMatchingDocumentAsync(range.Snapshot, cancellationToken).WaitAndGetResult(cancellationToken);
+                    var document = range.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
                     if (document == null)
                     {
                         // this is here to fail test and see why it is failed.
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (!action.PerformFinalApplicabilityCheck)
                 {
                     // If we don't even need to perform the final applicability check,
-                    // then the code actoin is applicable.
+                    // then the code action is applicable.
                     return true;
                 }
 
@@ -588,7 +588,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     applicableSpan);
             }
 
-            public async Task<bool> HasSuggestedActionsAsync(ISuggestedActionCategorySet requestedActionCategories, SnapshotSpan range, CancellationToken cancellationToken)
+            public async Task<bool> HasSuggestedActionsAsync(
+                ISuggestedActionCategorySet requestedActionCategories,
+                SnapshotSpan range,
+                CancellationToken cancellationToken)
             {
                 // Explicitly hold onto below fields in locals and use these locals throughout this code path to avoid crashes
                 // if these fields happen to be cleared by Dispose() below. This is required since this code path involves
@@ -604,7 +607,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 using (var asyncToken = provider.OperationListener.BeginAsyncOperation("HasSuggestedActionsAsync"))
                 {
-                    var document = await GetMatchingDocumentAsync(range.Snapshot, cancellationToken).ConfigureAwait(false);
+                    var document = range.Snapshot.GetOpenDocumentInCurrentContextWithChanges();
                     if (document == null)
                     {
                         // this is here to fail test and see why it is failed.
@@ -720,44 +723,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 }
 
                 return translatedSpan.Span.ToTextSpan();
-            }
-
-            private static async Task<Document> GetMatchingDocumentAsync(ITextSnapshot givenSnapshot, CancellationToken cancellationToken)
-            {
-                var buffer = givenSnapshot.TextBuffer;
-                if (buffer == null)
-                {
-                    return null;
-                }
-
-                var workspace = buffer.GetWorkspace();
-                if (workspace == null)
-                {
-                    return null;
-                }
-
-                var documentId = workspace.GetDocumentIdInCurrentContext(buffer.AsTextContainer());
-                if (documentId == null)
-                {
-                    return null;
-                }
-
-                var document = workspace.CurrentSolution.GetDocument(documentId);
-                if (document == null)
-                {
-                    return null;
-                }
-
-                var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var snapshot = sourceText.FindCorrespondingEditorTextSnapshot();
-                if (snapshot == null || snapshot.Version.ReiteratedVersionNumber != givenSnapshot.Version.ReiteratedVersionNumber)
-                {
-                    return null;
-                }
-
-                return document;
             }
 
             private void OnTextViewClosed(object sender, EventArgs e)


### PR DESCRIPTION
After investigating with jason, we've concluded this strange code was written
back in the days where roslyn workspaces and VS documents were not something
you could trust to be in sync.  So we had to have a lot of painful code to try
to detect and bail out when that happened.  This is definitely not necessary
now, and we can just use the simple and correct function we already hve for this
task.

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
