### PR TITLE
Fix release builds

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -28,8 +28,8 @@
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$(RepoRoot)Binaries\</BaseOutputPath>
     <OutDir>$(BaseOutputPath)$(Configuration)\</OutDir>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RepoRoot)Binaries\Obj\</BaseIntermediateOutputPath>
-    <BaseIntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
+    <BaseIntermediateOutputPath>$(BaseIntermediateOutputPath)$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</IntermediateOutputPath>
 
     <NetStandard20RefPath>$(NuGetPackageRoot)/NETStandard.Library/$(NETStandardLibraryFixedVersion)/build/netstandard2.0/ref/</NetStandard20RefPath>
     <MicrosoftCSharpRefPath>$(NuGetPackageRoot)/Microsoft.CSharp/$(MicrosoftCSharpVersion)/ref/netstandard1.0/</MicrosoftCSharpRefPath>


### PR DESCRIPTION
The content produced by NuGet restore is independent of build
configuration.  Hence it needs to be stored in a folder that is
accessible to both Debug and Release.

This didn't work with the present structure of our Obj directory
because it put project folders under configuration directories.  That
mean there is no common parent for a project across all configurations.
To fix this we need to change our Obj structure:

- Old: `Obj\<Configuration>\<Project Name>`
- New: `Obj\<Project Name>\<Configuration>`
