### PR TITLE
Disabled more flakey tests which fail on a trivial PR.

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
@@ -30,7 +30,7 @@ namespace myNamespace
     }
 }";
 
-        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870"), Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateThroughCommand()
         {
             SetUpEditor(TestSource);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
@@ -30,7 +30,7 @@ namespace myNamespace
     }
 }";
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870"), Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18879"), Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateThroughCommand()
         {
             SetUpEditor(TestSource);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpNavigateTo.cs
@@ -20,7 +20,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870"), Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public void NavigateTo()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
@@ -61,7 +61,7 @@ Del<C, System");
             VisualStudio.InteractiveWindow.Verify.CompletionItemsExist("C:");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18877")]
         public void VerifyNoCrashOnEnter()
         {
             VisualStudio.Workspace.SetUseSuggestionMode(false);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
@@ -61,7 +61,7 @@ Del<C, System");
             VisualStudio.InteractiveWindow.Verify.CompletionItemsExist("C:");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870")]
         public void VerifyNoCrashOnEnter()
         {
             VisualStudio.Workspace.SetUseSuggestionMode(false);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
@@ -214,7 +214,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.SolutionCrawler);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870")]
         public void ResetInteractiveFromProjectAndVerify()
         {
             var assembly = new ProjectUtils.AssemblyReference("System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
@@ -214,7 +214,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.SolutionCrawler);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18880")]
         public void ResetInteractiveFromProjectAndVerify()
         {
             var assembly = new ProjectUtils.AssemblyReference("System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicNavigateTo.cs
@@ -18,7 +18,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870"), Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public void NavigateTo()
         {
             var project = new ProjectUtils.Project(ProjectName);


### PR DESCRIPTION
Make Position/Green/Parent all implemented in the same style.
Added comments.

=== Disabled tests:
NavigateTo because of https://github.com/dotnet/roslyn/issues/18870
EncapsulateThroughCommand  because of https://github.com/dotnet/roslyn/issues/18879
VerifyNoCrashOnEnter  because of https://github.com/dotnet/roslyn/issues/18877
ResetInteractiveFromProjectAndVerify  because of https://github.com/dotnet/roslyn/issues/18880
