### PR TITLE
Don't crash in NavigateTo with methods that have __arglist parameters.

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -1095,5 +1095,23 @@ class D
                 VerifyNavigateToResultItem(item, "ToError", "ToError()", MatchKind.Regular, NavigateToItemKind.Method);
             });
         }
+
+        [WorkItem(18843, "https://github.com/dotnet/roslyn/issues/18843")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NavigateTo)]
+        public async Task Test__arglist()
+        {
+            await TestAsync(
+@"class C
+{
+    public void ToError(__arglist)
+    {
+    }
+}", async w =>
+{
+    SetupVerifiableGlyph(StandardGlyphGroup.GlyphGroupMethod, StandardGlyphItem.GlyphItemPublic);
+    var item = (await _aggregator.GetItemsAsync("ToError")).Single();
+    VerifyNavigateToResultItem(item, "ToError", "[|ToError|](__arglist)", MatchKind.Exact, NavigateToItemKind.Method);
+});
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -1014,7 +1014,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     builder.Append(' ');
                 }
 
-                AppendTokens(parameter.Type, builder);
+                if (parameter.Type != null)
+                {
+                    AppendTokens(parameter.Type, builder);
+                }
+                else
+                {
+                    builder.Append(parameter.Identifier.Text);
+                }
 
                 first = false;
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/18843

