### PR TITLE
Fix failures to dispose PinnedRemotableDataScope

### DIFF
--- a/src/Compilers/Core/Portable/Optional.cs
+++ b/src/Compilers/Core/Portable/Optional.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
@@ -33,7 +35,14 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Gets the value of the current object.
         /// </summary>
-        /// <returns></returns>
+        /// <remarks>
+        /// <para>Unlike <see cref="Nullable{T}.Value"/>, this property does not throw an exception when
+        /// <see cref="HasValue"/> is <see langword="false"/>.</para>
+        /// </remarks>
+        /// <returns>
+        /// <para>The value if <see cref="HasValue"/> is <see langword="true"/>; otherwise, the default value for type
+        /// <typeparamref name="T"/>.</para>
+        /// </returns>
         public T Value
         {
             get { return _value; }

--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -59,7 +59,7 @@ namespace Roslyn.Test.Utilities.Remote
 
         public AssetStorage AssetStorage => _inprocServices.AssetStorage;
 
-        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
+        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, Optional<Func<CancellationToken, Task<PinnedRemotableDataScope>>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host

--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -63,7 +63,7 @@ namespace Roslyn.Test.Utilities.Remote
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host
-            var snapshotStream = await _inprocServices.RequestServiceAsync(WellKnownServiceHubServices.SnapshotService, cancellationToken).ConfigureAwait(false);
+            var snapshotStream = getSnapshotAsync.Value == null ? null : await _inprocServices.RequestServiceAsync(WellKnownServiceHubServices.SnapshotService, cancellationToken).ConfigureAwait(false);
 
             // get stream from service hub to communicate service specific information
             // this is what consumer actually use to communicate information

--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -59,7 +59,7 @@ namespace Roslyn.Test.Utilities.Remote
 
         public AssetStorage AssetStorage => _inprocServices.AssetStorage;
 
-        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
+        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host
@@ -69,7 +69,7 @@ namespace Roslyn.Test.Utilities.Remote
             // this is what consumer actually use to communicate information
             var serviceStream = await _inprocServices.RequestServiceAsync(serviceName, cancellationToken).ConfigureAwait(false);
 
-            return await JsonRpcSession.CreateAsync(snapshot, callbackTarget, serviceStream, snapshotStream, cancellationToken).ConfigureAwait(false);
+            return await JsonRpcSession.CreateAsync(getSnapshotAsync, callbackTarget, serviceStream, snapshotStream, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void OnConnected()

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using StreamJsonRpc;
 using Microsoft.CodeAnalysis.Remote;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Remote
 {
@@ -22,6 +23,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         public JsonRpcClient(
             Stream stream, object callbackTarget, bool useThisAsCallback, CancellationToken cancellationToken)
         {
+            Contract.Requires(stream != null);
+
             var target = useThisAsCallback ? this : callbackTarget;
             _cancellationToken = cancellationToken;
 

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
@@ -72,6 +72,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             CancellationToken cancellationToken) :
             base(snapshot, cancellationToken)
         {
+            Contract.Requires((snapshot == null) == (snapshotStreamOpt == null));
+
             // get session id
             _currentSessionId = Interlocked.Increment(ref s_sessionId);
 

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
@@ -31,13 +31,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         private readonly CancellationTokenRegistration _cancellationRegistration;
 
         public static async Task<JsonRpcSession> CreateAsync(
-            Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync,
+            Optional<Func<CancellationToken, Task<PinnedRemotableDataScope>>> getSnapshotAsync,
             object callbackTarget,
             Stream serviceStream,
             Stream snapshotStreamOpt,
             CancellationToken cancellationToken)
         {
-            var snapshot = getSnapshotAsync == null ? null : await getSnapshotAsync(cancellationToken).ConfigureAwait(false);
+            var snapshot = getSnapshotAsync.Value == null ? null : await getSnapshotAsync.Value(cancellationToken).ConfigureAwait(false);
 
             JsonRpcSession session;
             try

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Execution;
@@ -114,11 +115,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             _rpc.StartListening();
         }
 
-        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
+        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, Optional<Func<CancellationToken, Task<PinnedRemotableDataScope>>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host for solution related information
-            var snapshotStream = getSnapshotAsync == null ? null : await RequestServiceAsync(_hubClient, WellKnownServiceHubServices.SnapshotService, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
+            var snapshotStream = getSnapshotAsync.Value != null ? null : await RequestServiceAsync(_hubClient, WellKnownServiceHubServices.SnapshotService, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
             // get stream from service hub to communicate service specific information
             // this is what consumer actually use to communicate information

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -114,17 +114,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             _rpc.StartListening();
         }
 
-        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
+        protected override async Task<Session> TryCreateServiceSessionAsync(string serviceName, Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host for solution related information
-            var snapshotStream = snapshot == null ? null : await RequestServiceAsync(_hubClient, WellKnownServiceHubServices.SnapshotService, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
+            var snapshotStream = getSnapshotAsync == null ? null : await RequestServiceAsync(_hubClient, WellKnownServiceHubServices.SnapshotService, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
             // get stream from service hub to communicate service specific information
             // this is what consumer actually use to communicate information
             var serviceStream = await RequestServiceAsync(_hubClient, serviceName, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
-            return await JsonRpcSession.CreateAsync(snapshot, callbackTarget, serviceStream, snapshotStream, cancellationToken).ConfigureAwait(false);
+            return await JsonRpcSession.CreateAsync(getSnapshotAsync, callbackTarget, serviceStream, snapshotStream, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void OnConnected()

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         {
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host for solution related information
-            var snapshotStream = getSnapshotAsync.Value != null ? null : await RequestServiceAsync(_hubClient, WellKnownServiceHubServices.SnapshotService, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
+            var snapshotStream = getSnapshotAsync.Value == null ? null : await RequestServiceAsync(_hubClient, WellKnownServiceHubServices.SnapshotService, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
             // get stream from service hub to communicate service specific information
             // this is what consumer actually use to communicate information

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
@@ -30,7 +30,7 @@ namespace myNamespace
     }
 }";
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18879"), Trait(Traits.Feature, Traits.Features.EncapsulateField)]
+        [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField)]
         public void EncapsulateThroughCommand()
         {
             SetUpEditor(TestSource);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpNavigateTo.cs
@@ -20,7 +20,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870"), Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public void NavigateTo()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
@@ -61,7 +61,7 @@ Del<C, System");
             VisualStudio.InteractiveWindow.Verify.CompletionItemsExist("C:");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18877")]
+        [Fact]
         public void VerifyNoCrashOnEnter()
         {
             VisualStudio.Workspace.SetUseSuggestionMode(false);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
@@ -214,7 +214,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.Workspace.WaitForAsyncOperations(FeatureAttribute.SolutionCrawler);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18880")]
+        [Fact]
         public void ResetInteractiveFromProjectAndVerify()
         {
             var assembly = new ProjectUtils.AssemblyReference("System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicNavigateTo.cs
@@ -18,7 +18,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
         {
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18870"), Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public void NavigateTo()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/Workspaces/Core/Portable/Execution/PinnedRemotableDataScope.cs
+++ b/src/Workspaces/Core/Portable/Execution/PinnedRemotableDataScope.cs
@@ -12,10 +12,11 @@ namespace Microsoft.CodeAnalysis.Execution
     /// <summary>
     /// checksum scope that one can use to pin assets in memory while working on remote host
     /// </summary>
-    internal class PinnedRemotableDataScope : IDisposable
+    internal sealed class PinnedRemotableDataScope : IDisposable
     {
         private readonly AssetStorages _storages;
         private readonly AssetStorages.Storage _storage;
+        private bool _disposed;
 
         public readonly Checksum SolutionChecksum;
 
@@ -63,7 +64,12 @@ namespace Microsoft.CodeAnalysis.Execution
 
         public void Dispose()
         {
-            _storages.UnregisterSnapshot(this);
+            if (!_disposed)
+            {
+                _disposed = true;
+                _storages.UnregisterSnapshot(this);
+            }
+
             GC.SuppressFinalize(this);
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_SourceDeclarations.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder_SourceDeclarations.cs
@@ -118,17 +118,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static async Task<(bool, ImmutableArray<SymbolAndProjectId>)> TryFindSourceDeclarationsWithNormalQueryInRemoteProcessAsync(
             Solution solution, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            var session = await SymbolFinder.TryGetRemoteSessionAsync(solution, cancellationToken).ConfigureAwait(false);
-            if (session != null)
+            using (var session = await SymbolFinder.TryGetRemoteSessionAsync(solution, cancellationToken).ConfigureAwait(false))
             {
-                var result = await session.InvokeAsync<SerializableSymbolAndProjectId[]>(
-                    nameof(IRemoteSymbolFinder.FindSolutionSourceDeclarationsWithNormalQueryAsync),
-                    name, ignoreCase, criteria).ConfigureAwait(false);
+                if (session != null)
+                {
+                    var result = await session.InvokeAsync<SerializableSymbolAndProjectId[]>(
+                        nameof(IRemoteSymbolFinder.FindSolutionSourceDeclarationsWithNormalQueryAsync),
+                        name, ignoreCase, criteria).ConfigureAwait(false);
 
-                var rehydrated = await RehydrateAsync(
-                    solution, result, cancellationToken).ConfigureAwait(false);
+                    var rehydrated = await RehydrateAsync(
+                        solution, result, cancellationToken).ConfigureAwait(false);
 
-                return (true, rehydrated);
+                    return (true, rehydrated);
+                }
             }
 
             return (false, ImmutableArray<SymbolAndProjectId>.Empty);
@@ -137,17 +139,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static async Task<(bool, ImmutableArray<SymbolAndProjectId>)> TryFindSourceDeclarationsWithNormalQueryInRemoteProcessAsync(
             Project project, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            var session = await SymbolFinder.TryGetRemoteSessionAsync(project.Solution, cancellationToken).ConfigureAwait(false);
-            if (session != null)
+            using (var session = await SymbolFinder.TryGetRemoteSessionAsync(project.Solution, cancellationToken).ConfigureAwait(false))
             {
-                var result = await session.InvokeAsync<SerializableSymbolAndProjectId[]>(
-                    nameof(IRemoteSymbolFinder.FindProjectSourceDeclarationsWithNormalQueryAsync),
-                    project.Id, name, ignoreCase, criteria).ConfigureAwait(false);
+                if (session != null)
+                {
+                    var result = await session.InvokeAsync<SerializableSymbolAndProjectId[]>(
+                        nameof(IRemoteSymbolFinder.FindProjectSourceDeclarationsWithNormalQueryAsync),
+                        project.Id, name, ignoreCase, criteria).ConfigureAwait(false);
 
-                var rehydrated = await RehydrateAsync(
-                    project.Solution, result, cancellationToken).ConfigureAwait(false);
+                    var rehydrated = await RehydrateAsync(
+                        project.Solution, result, cancellationToken).ConfigureAwait(false);
 
-                return (true, rehydrated);
+                    return (true, rehydrated);
+                }
             }
 
             return (false, ImmutableArray<SymbolAndProjectId>.Empty);
@@ -156,17 +160,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static async Task<(bool, ImmutableArray<SymbolAndProjectId>)> TryFindSourceDeclarationsWithPatternInRemoteProcessAsync(
             Project project, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
-            var session = await SymbolFinder.TryGetRemoteSessionAsync(project.Solution, cancellationToken).ConfigureAwait(false);
-            if (session != null)
+            using (var session = await SymbolFinder.TryGetRemoteSessionAsync(project.Solution, cancellationToken).ConfigureAwait(false))
             {
-                var result = await session.InvokeAsync<SerializableSymbolAndProjectId[]>(
-                    nameof(IRemoteSymbolFinder.FindProjectSourceDeclarationsWithPatternAsync),
-                    project.Id, pattern, criteria).ConfigureAwait(false);
+                if (session != null)
+                {
+                    var result = await session.InvokeAsync<SerializableSymbolAndProjectId[]>(
+                        nameof(IRemoteSymbolFinder.FindProjectSourceDeclarationsWithPatternAsync),
+                        project.Id, pattern, criteria).ConfigureAwait(false);
 
-                var rehydrated = await RehydrateAsync(
-                    project.Solution, result, cancellationToken).ConfigureAwait(false);
+                    var rehydrated = await RehydrateAsync(
+                        project.Solution, result, cancellationToken).ConfigureAwait(false);
 
-                return (true, rehydrated);
+                    return (true, rehydrated);
+                }
             }
 
             return (false, ImmutableArray<SymbolAndProjectId>.Empty);

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
             {
                 // PERF: Avoid string.Split allocations when the pattern doesn't contain a dot.
                 _dotSeparatedPatternSegments = pattern.Length > 0
-                    ? new PatternSegment[1] { _fullPatternSegment }
+                    ? new PatternSegment[1] { new PatternSegment(pattern.Trim(), allowFuzzyMatching) }
                     : Array.Empty<PatternSegment>();
             }
             else

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -24,30 +24,6 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public event EventHandler<bool> ConnectionChanged;
 
-        [Obsolete("use TryCreateServiceSessionAsync instead")]
-        public Task<Session> CreateServiceSessionAsync(string serviceName, CancellationToken cancellationToken)
-        {
-            return CreateServiceSessionAsync(serviceName, callbackTarget: null, cancellationToken: cancellationToken);
-        }
-
-        [Obsolete("use TryCreateServiceSessionAsync instead")]
-        public Task<Session> CreateServiceSessionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
-        {
-            return TryCreateServiceSessionAsync(serviceName, snapshot: null, callbackTarget: callbackTarget, cancellationToken: cancellationToken);
-        }
-
-        [Obsolete("use TryCreateServiceSessionAsync instead")]
-        public Task<Session> CreateServiceSessionAsync(string serviceName, Solution solution, CancellationToken cancellationToken)
-        {
-            return CreateServiceSessionAsync(serviceName, solution, callbackTarget: null, cancellationToken: cancellationToken);
-        }
-
-        [Obsolete("use TryCreateServiceSessionAsync instead")]
-        public Task<Session> CreateServiceSessionAsync(string serviceName, Solution solution, object callbackTarget, CancellationToken cancellationToken)
-        {
-            return TryCreateServiceSessionAsync(serviceName, solution, callbackTarget, cancellationToken);
-        }
-
         /// <summary>
         /// Create <see cref="RemoteHostClient.Session"/> for the <paramref name="serviceName"/> if possible.
         /// otherwise, return null.
@@ -69,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         public Task<Session> TryCreateServiceSessionAsync(string serviceName, object callbackTarget, CancellationToken cancellationToken)
         {
-            return TryCreateServiceSessionAsync(serviceName, snapshot: null, callbackTarget: callbackTarget, cancellationToken: cancellationToken);
+            return TryCreateServiceSessionAsync(serviceName, getSnapshotAsync: null, callbackTarget: callbackTarget, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -93,36 +69,15 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         public async Task<Session> TryCreateServiceSessionAsync(string serviceName, Solution solution, object callbackTarget, CancellationToken cancellationToken)
         {
-            var snapshot = await GetPinnedScopeAsync(solution, cancellationToken).ConfigureAwait(false);
-
-            try
-            {
-                return await TryCreateServiceSessionAsync(serviceName, snapshot, callbackTarget, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                snapshot?.Dispose();
-                throw;
-            }
+            Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync = ct => GetPinnedScopeAsync(solution, ct);
+            return await TryCreateServiceSessionAsync(serviceName, getSnapshotAsync, callbackTarget, cancellationToken).ConfigureAwait(false);
         }
 
         protected abstract void OnConnected();
 
         protected abstract void OnDisconnected();
 
-        [Obsolete]
-        protected virtual Task<Session> CreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
-        {
-            snapshot?.Dispose();
-            return SpecializedTasks.Default<Session>();
-        }
-
-        protected virtual Task<Session> TryCreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
-        {
-#pragma warning disable CS0612 // leave it for now to not break backward compatibility
-            return CreateServiceSessionAsync(serviceName, snapshot, callbackTarget, cancellationToken);
-#pragma warning restore CS0612 // Type or member is obsolete
-        }
+        protected abstract Task<Session> TryCreateServiceSessionAsync(string serviceName, Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken);
 
         internal void Shutdown()
         {
@@ -220,9 +175,8 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             protected override Task<Session> TryCreateServiceSessionAsync(
-                string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
+                string serviceName, Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
             {
-                snapshot?.Dispose();
                 return SpecializedTasks.Default<Session>();
             }
 

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         protected abstract void OnDisconnected();
 
-        protected abstract Task<Session> TryCreateServiceSessionAsync(string serviceName, Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken);
+        protected abstract Task<Session> TryCreateServiceSessionAsync(string serviceName, Optional<Func<CancellationToken, Task<PinnedRemotableDataScope>>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken);
 
         internal void Shutdown()
         {
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
 
             protected override Task<Session> TryCreateServiceSessionAsync(
-                string serviceName, Func<CancellationToken, Task<PinnedRemotableDataScope>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
+                string serviceName, Optional<Func<CancellationToken, Task<PinnedRemotableDataScope>>> getSnapshotAsync, object callbackTarget, CancellationToken cancellationToken)
             {
                 return SpecializedTasks.Default<Session>();
             }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -94,7 +94,16 @@ namespace Microsoft.CodeAnalysis.Remote
         public async Task<Session> TryCreateServiceSessionAsync(string serviceName, Solution solution, object callbackTarget, CancellationToken cancellationToken)
         {
             var snapshot = await GetPinnedScopeAsync(solution, cancellationToken).ConfigureAwait(false);
-            return await TryCreateServiceSessionAsync(serviceName, snapshot, callbackTarget, cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                return await TryCreateServiceSessionAsync(serviceName, snapshot, callbackTarget, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                snapshot?.Dispose();
+                throw;
+            }
         }
 
         protected abstract void OnConnected();
@@ -104,6 +113,7 @@ namespace Microsoft.CodeAnalysis.Remote
         [Obsolete]
         protected virtual Task<Session> CreateServiceSessionAsync(string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
         {
+            snapshot?.Dispose();
             return SpecializedTasks.Default<Session>();
         }
 
@@ -212,6 +222,7 @@ namespace Microsoft.CodeAnalysis.Remote
             protected override Task<Session> TryCreateServiceSessionAsync(
                 string serviceName, PinnedRemotableDataScope snapshot, object callbackTarget, CancellationToken cancellationToken)
             {
+                snapshot?.Dispose();
                 return SpecializedTasks.Default<Session>();
             }
 


### PR DESCRIPTION
### Ask Mode

**Customer scenario**

* Attempt to use the Find All References feature.
* Type in the Navigate To feature.

The widespread use of `PatternMatcher` suggests other places, including but not limited to Code Completion, may be producing inconsistent behavior.

**Bugs this fixes:**

#18870
#18877
#18879
#18880

**Workarounds, if any**

None.

**Risk**

Without this change, there appears to be a high likelihood of user-observable misbehavior (possibly including application crashes) associated with the use of Navigate To, code completion, and/or Find All References.

**Performance impact**

This change should not negatively impact performance.

**Is this a regression from a previous update?**

The bugs appear to be introduced in 3755cc5fa4c83519a22451c530646de0d2912357, df9f330c3462101a45fa308e82b4ce15b93fcf9b, and 556ca2bf86301fb44083f61a02bcc08bee86cf6b. This corrects them prior to shipping to customers.

**Root cause analysis:**

We do not have any code in place to ensure pooled objects are not used after they are returned to a pool (including the special case of attempting to return the object twice). The nature of these failures makes it difficult to trace individual test failures back to the cause. A proof of concept solution was used to aid in root cause analysis and will be proposed separately.

**How was the bug found?**

Integration tests.
