### PR TITLE
Ensure linked files are kept in sync in the workspace

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceChangeEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceChangeEventArgs.cs
@@ -4,11 +4,32 @@ using System;
 
 namespace Microsoft.CodeAnalysis
 {
+    /// <summary>
+    /// The <see cref="EventArgs"/> describing any kind of workspace change.
+    /// </summary>
+    /// <remarks>
+    /// When linked files are edited, one document change event is fired per linked file. All of
+    /// these events contain the same <see cref="OldSolution"/>, and they all contain the same
+    /// <see cref="NewSolution"/>. This is so that we can trigger document change events on all
+    /// affected documents without reporting intermediate states in which the linked file contents
+    /// do not match.
+    /// </remarks>
     public class WorkspaceChangeEventArgs : EventArgs
     {
         public WorkspaceChangeKind Kind { get; }
+
+        /// <remarks>
+        /// If linked documents are being changed, there may be multiple events with the same
+        /// <see cref="OldSolution"/> and <see cref="NewSolution"/>.
+        /// </remarks>
         public Solution OldSolution { get; }
+
+        /// <remarks>
+        /// If linked documents are being changed, there may be multiple events with the same
+        /// <see cref="OldSolution"/> and <see cref="NewSolution"/>.
+        /// </remarks>
         public Solution NewSolution { get; }
+
         public ProjectId ProjectId { get; }
         public DocumentId DocumentId { get; }
 

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceChangeKind.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceChangeKind.cs
@@ -68,6 +68,14 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// A document in the current solution was changed.
         /// </summary>
+        /// <remarks>
+        /// When linked files are edited, one <see cref="DocumentChanged"/> event is fired per
+        /// linked file. All of these events contain the same OldSolution, and they all contain
+        /// the same NewSolution. This is so that we can trigger document change events on all
+        /// affected documents without reporting intermediate states in which the linked file
+        /// contents do not match. Each <see cref="DocumentChanged"/> event does not represent
+        /// an incremental update from the previous event in this special case.
+        /// </remarks>
         DocumentChanged = 12,
 
         /// <summary>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299

For additional documents, this makes no semantic change. For regular
documents, there are slight semantic changes. Previously, each changed
document *incrementally* caused a synchronous `OnDocumentTextChanged`
call (with Workspace.CurrentSolution only partially updated, leaving
linked files with content discrepancies) and then an asynchronous
`RaiseWorkspaceChangedEventAsync` (again with Workspace.CurrentSolution
only partially updated).

Now, all of the synchronous `OnDocumentTextChange` events happen after
the Workspace.CurrentSolution is fully updated, and the
`RaiseWorkspaceChangedEventAsync` calls to indicate that a document was
updated actually contain before/after solutions with *all* of the linked
files updated.

Ask Mode Template
=============

**Customer scenario**: The customer is using linked files (or Shared Projects or multi-targeted .net core projects) in the IDE, and the IDE will occasionally crash. It's a relatively high-hit Watson that we've been trying to track down for a while.

**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems?id=209299 (also https://github.com/dotnet/roslyn/issues/18041 and https://developercommunity.visualstudio.com/content/problem/43706/random-visual-studio-crash.html)

**Workarounds, if any**: None.

**Risk**: Medium. This impacts typing in linked files.

**Performance impact**: Low-to-none. We are doing a few more (extremely cheap) version checks than before, but the same number of expensive operations.

**Is this a regression from a previous update?** No.

**Root cause analysis:** It's a race in the handling of regular edits of linked files that was overlooked, likely from the beginning of Roslyn. There is now a unit test to ensure it behaves as we expect.

**How was the bug found?**: Watson and customer reports.