### PR TITLE
Use Capacity instead of Count to identify large ArrayBuilder instances

### DIFF
--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis
                 // while the chance that we will need their size is diminishingly small.
                 // It makes sense to constrain the size to some "not too small" number. 
                 // Overall perf does not seem to be very sensitive to this number, so I picked 128 as a limit.
-                if (this.Count < 128)
+                if (_builder.Capacity < 128)
                 {
                     if (this.Count != 0)
                     {


### PR DESCRIPTION
**Customer scenario**

This is not an observable behavioral change.

**Bugs this fixes:**

N/A

**Workarounds, if any**

The current code is functionally correct, but could be less efficient than intended in some scenarios.

**Risk**

Low. This change will reject some items from a cache that were previously not being rejected, but rejection is never an error for these pools.

**Performance impact**

In some situations, this change will allow larger than expected `ArrayBuilder<T>` instances to be garbage collected rather than holding them in an object pool (potentially indefinitely).

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This is a subtle detail. The new implementation appears to be the intended behavior the whole time but the actual implementation is observably equivalent.

**How was the bug found?**

Manual code review.
