### PR TITLE
Address issue that was causing a double-free in the pattern matcher code

### DIFF
--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatcher.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
             {
                 // PERF: Avoid string.Split allocations when the pattern doesn't contain a dot.
                 _dotSeparatedPatternSegments = pattern.Length > 0
-                    ? new PatternSegment[1] { _fullPatternSegment }
+                    ? new PatternSegment[1] { new PatternSegment(pattern, allowFuzzyMatching) }
                     : Array.Empty<PatternSegment>();
             }
             else


### PR DESCRIPTION
**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
