### PR TITLE
Eliminate delegate allocations in PooledObject.Create

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/ObjectPools/PooledObject.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ObjectPools/PooledObject.cs
@@ -36,32 +36,50 @@ namespace Roslyn.Utilities
         #region factory
         public static PooledObject<StringBuilder> Create(ObjectPool<StringBuilder> pool)
         {
-            return new PooledObject<StringBuilder>(pool, Allocator, Releaser);
+            return new PooledObject<StringBuilder>(
+                pool,
+                p => Allocator(p),
+                (p, sb) => Releaser(p, sb));
         }
 
         public static PooledObject<Stack<TItem>> Create<TItem>(ObjectPool<Stack<TItem>> pool)
         {
-            return new PooledObject<Stack<TItem>>(pool, Allocator, Releaser);
+            return new PooledObject<Stack<TItem>>(
+                pool,
+                p => Allocator(p),
+                (p, sb) => Releaser(p, sb));
         }
 
         public static PooledObject<Queue<TItem>> Create<TItem>(ObjectPool<Queue<TItem>> pool)
         {
-            return new PooledObject<Queue<TItem>>(pool, Allocator, Releaser);
+            return new PooledObject<Queue<TItem>>(
+                pool,
+                p => Allocator(p),
+                (p, sb) => Releaser(p, sb));
         }
 
         public static PooledObject<HashSet<TItem>> Create<TItem>(ObjectPool<HashSet<TItem>> pool)
         {
-            return new PooledObject<HashSet<TItem>>(pool, Allocator, Releaser);
+            return new PooledObject<HashSet<TItem>>(
+                pool,
+                p => Allocator(p),
+                (p, sb) => Releaser(p, sb));
         }
 
         public static PooledObject<Dictionary<TKey, TValue>> Create<TKey, TValue>(ObjectPool<Dictionary<TKey, TValue>> pool)
         {
-            return new PooledObject<Dictionary<TKey, TValue>>(pool, Allocator, Releaser);
+            return new PooledObject<Dictionary<TKey, TValue>>(
+                pool,
+                p => Allocator(p),
+                (p, sb) => Releaser(p, sb));
         }
 
         public static PooledObject<List<TItem>> Create<TItem>(ObjectPool<List<TItem>> pool)
         {
-            return new PooledObject<List<TItem>>(pool, Allocator, Releaser);
+            return new PooledObject<List<TItem>>(
+                pool,
+                p => Allocator(p),
+                (p, sb) => Releaser(p, sb));
         }
         #endregion
 


### PR DESCRIPTION
**Customer scenario**

No observable behavior change.

**Bugs this fixes:**

N/A

**Workarounds, if any**

The current code is functionally correct, but less efficient than required.

**Risk**

Low.

**Performance impact**

This change improves performance by eliminating allocations on a code path which is expected to be (amortized) non-allocating.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Observed during code review. It is possible that at the time this was implemented, the developer either wasn't aware that method group conversions are not cached (a subtle detail most people don't need to care about), or believed that #6642 would be merged earlier.

**How was the bug found?**

Manual code review.
