### PR TITLE
Fix setup authoring for Microsoft.DiaSymReader.Native

### DIFF
--- a/build/scripts/check-toolset-insertion.ps1
+++ b/build/scripts/check-toolset-insertion.ps1
@@ -21,6 +21,11 @@ try
         "Microsoft.Build.Utilities.Core.dll",
         "Microsoft.DiaSymReader.Native.arm.dll"
     )
+
+    $exludedFromVsix = @(    
+        "Microsoft.DiaSymReader.Native.x86.dll", # installed by msbuild setup component
+        "Microsoft.DiaSymReader.Native.amd64.dll"  # installed by msbuild setup component
+    )
     
     $deploymentPath = join-path $binariesPath "Exes\Toolset"
     $deployedFiles = 
@@ -92,7 +97,7 @@ try
     foreach ($file in $deployedFiles)
     {
         write-host "`t$file"
-        if ($msbuildroslynfiles.Contains($file))
+        if ($msbuildroslynfiles.Contains($file) -or $exludedFromVsix.Contains($file))
         {
             continue;
         }

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -98,14 +98,15 @@ Public Class BuildDevDivInsertionFiles
     ' the src/NuGet/Microsoft.Net.Compilers.nuspec file, the
     ' src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr file,
     ' and src/Compilers/Extension/CompilerExtension.csproj file.
+    '
+    ' Note: Microsoft.DiaSymReader.Native.amd64.dll and Microsoft.DiaSymReader.Native.x86.dll
+    ' are installed by msbuild setup, not Roslyn.
     Private ReadOnly CompilerFiles As String() = {
         "Microsoft.CodeAnalysis.dll",
         "Microsoft.CodeAnalysis.CSharp.dll",
         "Microsoft.CodeAnalysis.Scripting.dll",
         "Microsoft.CodeAnalysis.CSharp.Scripting.dll",
         "Microsoft.CodeAnalysis.VisualBasic.dll",
-        "Microsoft.DiaSymReader.Native.amd64.dll",
-        "Microsoft.DiaSymReader.Native.x86.dll",
         "System.AppContext.dll",
         "System.Console.dll",
         "System.Diagnostics.FileVersionInfo.dll",

--- a/src/Setup/DevDivPackages/Roslyn/project.json
+++ b/src/Setup/DevDivPackages/Roslyn/project.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "Microsoft.DiaSymReader": "1.1.0",
-    "Microsoft.DiaSymReader.Native": "1.5.0",
     "Microsoft.CodeAnalysis.Elfie": "0.10.6-rc2",
     "System.Collections.Immutable": "1.3.1",
     "System.Reflection.Metadata": "1.4.2",

--- a/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
+++ b/src/Setup/DevDivVsix/CompilersPackage/Microsoft.CodeAnalysis.Compilers.swr
@@ -34,9 +34,6 @@ folder InstallDir:\MSBuild\15.0\Bin\Roslyn
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Reflection.Metadata.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Exes\csi\System.ValueTuple.dll vs.file.ngenArchitecture=all
 
-    file source=$(OutputPath)\Vsix\CompilerExtension\Microsoft.DiaSymReader.Native.amd64.dll
-    file source=$(OutputPath)\Vsix\CompilerExtension\Microsoft.DiaSymReader.Native.x86.dll
-
     file source=$(OutputPath)\Vsix\CompilerExtension\System.AppContext.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Console.dll vs.file.ngenArchitecture=all
     file source=$(OutputPath)\Vsix\CompilerExtension\System.Diagnostics.FileVersionInfo.dll vs.file.ngenArchitecture=all

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -229,10 +229,6 @@
           <IncludeInVSIX>true</IncludeInVSIX>
       </Content>
   </ItemGroup>
-  <ItemGroup>
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.DiaSymReader.Native.amd64.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.DiaSymReader.Native.x86.dll" />
-  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup>

--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -48,5 +48,6 @@
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.DiaSymReader.Native" Version="[15.0,16.0)" DisplayName="Windows PDB reader/writer" />
   </Prerequisites>
 </PackageManifest>

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
@@ -14,6 +16,7 @@ using Microsoft.CodeAnalysis.Remote.Telemetry;
 using Microsoft.CodeAnalysis.Storage;
 using Microsoft.VisualStudio.LanguageServices.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
+using Roslyn.Utilities;
 using RoslynLogger = Microsoft.CodeAnalysis.Internal.Log.Logger;
 
 namespace Microsoft.CodeAnalysis.Remote
@@ -41,6 +44,8 @@ namespace Microsoft.CodeAnalysis.Remote
             // this should let us to freely try to use all resources possible without worrying about affecting
             // host's work such as responsiveness or build.
             Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
+
+            SetNativeDllSearchDirectories();
         }
 
         public RemoteHostService(Stream stream, IServiceProvider serviceProvider) :
@@ -218,6 +223,24 @@ namespace Microsoft.CodeAnalysis.Remote
             var workspace = new AdhocWorkspace(RoslynServices.HostServices);
             var persistentStorageService = workspace.Services.GetService<IPersistentStorageService>() as AbstractPersistentStorageService;
             return persistentStorageService;
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr AddDllDirectory(string directory);
+
+        private static void SetNativeDllSearchDirectories()
+        {
+            // Set LoadLibrary search directory to %VSINSTALLDIR%\Common7\IDE so that the compiler 
+            // can P/Invoke to Microsoft.DiaSymReader.Native when emitting Windows PDBs.
+
+            Contract.Assert(string.Equals(Path.GetFileName(
+                AppDomain.CurrentDomain.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)), "IDE", StringComparison.OrdinalIgnoreCase));
+
+            var cookie = AddDllDirectory(AppDomain.CurrentDomain.BaseDirectory);
+            if (cookie == IntPtr.Zero)
+            {
+                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
         }
     }
 }


### PR DESCRIPTION
Needs to be inserted into vsuml branch along with VSO PR 65254

**Customer scenario**

Not observable to customer.

This change addresses two issues with Microsoft.DiaSymReader.Native:

1) Microsoft.DiaSymReader.Native is built from WinC TFS branch and inserted into redist directory of a VS release branch by C++ team. Currently these bits are not directly picked up by the VS setup. Instead we first package them to nupkg and then insert them during Roslyn insertion process as a Roslyn dependency. This leads to a problem when finalizing a release -- if C++ team inserts their final binaries after we insert ours we are gonna end up with non-final binaries in the shipping layout. To avoid this race the setup authoring should pick the binaries up directly from the redist directory without going thru Roslyn.

2) VS components other than Roslyn that might potentially use Microsoft.DiaSymReader.Native can't currently do so without taking a dependency on Roslyn.

The binaries are now inserted into ```msbuild\Bin\Roslyn``` directory by msbuild setup package and to ```Common7\IDE``` directory by a new Willow package built in VS branch. This change removes the binaries from Roslyn Willow setup authoring. 

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

None.

**Risk**

Small.

**Performance impact**

None.

**Is this a regression from a previous update?**

Setup authoring was incorrect in Dev15 RTM, we shipped wrong build of Microsoft.DiaSymReader.Native binaries.

**Root cause analysis:**

**How was the bug found?**
