### PR TITLE
Recommend var keyword in patterns

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
@@ -251,5 +251,22 @@ $$"));
 @"class C {
      void M1(out $$");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestVarPatternInSwitch()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"switch(o)
+    {
+        case $$
+    }
+"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestVarPatternInIs()
+        {
+            await VerifyKeywordAsync(AddInsideMethod("var b = o is $$ "));
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/VarKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/VarKeywordRecommender.cs
@@ -19,7 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         {
             if (context.IsStatementContext ||
                 context.IsGlobalStatementContext ||
-                context.IsPossibleTupleContext)
+                context.IsPossibleTupleContext ||
+                context.IsPatternContext)
             {
                 return true;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -98,13 +98,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             bool isCatchFilterContext,
             bool isDestructorTypeContext,
             bool isPossibleTupleContext,
+            bool isPatternContext,
             CancellationToken cancellationToken)
             : base(workspace, semanticModel, position, leftToken, targetToken,
                    isTypeContext, isNamespaceContext, isNamespaceDeclarationNameContext,
                    isPreProcessorDirectiveContext,
                    isRightOfDotOrArrowOrColonColon, isStatementContext, isAnyExpressionContext,
                    isAttributeNameContext, isEnumTypeMemberAccessContext, isNameOfContext,
-                   isInQuery, isInImportsDirective, IsWithinAsyncMethod(), isPossibleTupleContext, cancellationToken)
+                   isInQuery, isInImportsDirective, IsWithinAsyncMethod(), isPossibleTupleContext,
+                   isPatternContext, cancellationToken)
         {
             this.ContainingTypeDeclaration = containingTypeDeclaration;
             this.ContainingTypeOrEnumDeclaration = containingTypeOrEnumDeclaration;
@@ -242,6 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 syntaxTree.IsCatchFilterContext(position, leftToken),
                 isDestructorTypeContext,
                 syntaxTree.IsPossibleTupleContext(leftToken, position),
+                syntaxTree.IsPatternContext(leftToken, position),
                 cancellationToken);
         }
 

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1260,6 +1260,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return false;
         }
 
+        public static bool IsPatternContext(this SyntaxTree syntaxTree, SyntaxToken leftToken, int position)
+        {
+            leftToken = leftToken.GetPreviousTokenIfTouchingWord(position);
+
+            // case $$
+            // is $$
+            if (leftToken.IsKind(SyntaxKind.CaseKeyword, SyntaxKind.IsKeyword))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         private static SyntaxToken FindTokenOnLeftOfNode(SyntaxNode node)
         {
             return node.FindTokenOnLeftOfPosition(node.SpanStart);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/SyntaxContext.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/SyntaxContext.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             bool isInImportsDirective,
             bool isWithinAsyncMethod,
             bool isPossibleTupleContext,
+            bool isPatternContext,
             CancellationToken cancellationToken)
         {
             this.Workspace = workspace;
@@ -54,6 +55,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             this.IsInImportsDirective = isInImportsDirective;
             this.IsWithinAsyncMethod = isWithinAsyncMethod;
             this.IsPossibleTupleContext = isPossibleTupleContext;
+            this.IsPatternContext = isPatternContext;
             this.InferredTypes = ComputeInferredTypes(workspace, semanticModel, position, cancellationToken);
         }
 
@@ -83,6 +85,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
         public bool IsInImportsDirective { get; }
         public bool IsWithinAsyncMethod { get; }
         public bool IsPossibleTupleContext { get; }
+        public bool IsPatternContext { get; }
 
         public IEnumerable<ITypeSymbol> InferredTypes { get; }
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
@@ -97,6 +97,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 isInImportsDirective:=isInImportsDirective,
                 isWithinAsyncMethod:=IsWithinAsyncMethod(targetToken, cancellationToken),
                 isPossibleTupleContext:=isPossibleTupleContext,
+                isPatternContext:=False,
                 cancellationToken:=cancellationToken)
 
             Dim syntaxTree = semanticModel.SyntaxTree


### PR DESCRIPTION
**Customer scenario**

Type a var pattern, `o is var x` or `case var x:`.
Auto-completion gets in the way and forces an actual type, instead of the `var` keyword.

**Workarounds, if any**
Cancel the completion.

**Risk**
**Performance impact**
Low. This is just adding one more context where the `var` keyword recommender will trigger (in C#).

**Root cause analysis:**
This was probably missed in the validation of IDE scenarios for the new patterns feature.

**How was the bug found?**
I noticed this in @BillWagner's recent NDC talk.

FYI @gafter
