### PR TITLE
Misleading constant diagnostics

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2650,7 +2650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // we suggest different actions
                 var errorCode = boundFilter.ConstantValue.BooleanValue
                     ? ErrorCode.WRN_FilterIsConstantTrue
-                    : (filter.Parent.Parent as TryStatementSyntax).Catches.Count == 1
+                    : ((filter.Parent.Parent as TryStatementSyntax).Catches.Count == 1) && ((filter.Parent.Parent as TryStatementSyntax).Finally != null)
                         ? ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch
                         : ErrorCode.WRN_FilterIsConstantFalse;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2650,7 +2650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // we suggest different actions
                 var errorCode = boundFilter.ConstantValue.BooleanValue
                     ? ErrorCode.WRN_FilterIsConstantTrue
-                    : ((filter.Parent.Parent as TryStatementSyntax).Catches.Count == 1) && ((filter.Parent.Parent as TryStatementSyntax).Finally != null)
+                    : ((filter.Parent.Parent as TryStatementSyntax).Catches.Count == 1) && ((filter.Parent.Parent as TryStatementSyntax).Finally == null)
                         ? ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch
                         : ErrorCode.WRN_FilterIsConstantFalse;
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2650,7 +2650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // we suggest different actions
                 var errorCode = boundFilter.ConstantValue.BooleanValue
                     ? ErrorCode.WRN_FilterIsConstantTrue
-                    : ((filter.Parent.Parent as TryStatementSyntax).Catches.Count == 1) && ((filter.Parent.Parent as TryStatementSyntax).Finally == null)
+                    : (filter.Parent.Parent is TryStatementSyntax s && s.Catches.Count == 1 && s.Finally == null)
                         ? ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch
                         : ErrorCode.WRN_FilterIsConstantFalse;
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -13104,7 +13104,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter expression is a constant &apos;{0}&apos;, consider removing the catch clause.
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;false&apos;, consider removing the catch clause.
         /// </summary>
         internal static string WRN_FilterIsConstantFalse {
             get {
@@ -13122,25 +13122,25 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter expression is a constant &apos;{0}&apos;, consider removing the try-catch block.
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;false&apos;, consider removing the try-catch block.
         /// </summary>
-        internal static string WRN_FilterIsConstantRedundantTryCatch {
+        internal static string WRN_FilterIsConstantFalseRedundantTryCatch {
             get {
-                return ResourceManager.GetString("WRN_FilterIsConstantRedundantTryCatch", resourceCulture);
+                return ResourceManager.GetString("WRN_FilterIsConstantFalseRedundantTryCatch", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Filter expression is a constant &apos;false&apos;. .
         /// </summary>
-        internal static string WRN_FilterIsConstantRedundantTryCatch_Title {
+        internal static string WRN_FilterIsConstantFalseRedundantTryCatch_Title {
             get {
-                return ResourceManager.GetString("WRN_FilterIsConstantRedundantTryCatch_Title", resourceCulture);
+                return ResourceManager.GetString("WRN_FilterIsConstantFalseRedundantTryCatch_Title", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter expression is a constant &apos;{0}&apos;, consider removing the filter.
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;true&apos;, consider removing the filter.
         /// </summary>
         internal static string WRN_FilterIsConstantTrue {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -13104,20 +13104,56 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter expression is a constant, consider removing the filter.
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;{0}&apos;, consider removing the catch clause.
         /// </summary>
-        internal static string WRN_FilterIsConstant {
+        internal static string WRN_FilterIsConstantFalse {
             get {
-                return ResourceManager.GetString("WRN_FilterIsConstant", resourceCulture);
+                return ResourceManager.GetString("WRN_FilterIsConstantFalse", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filter expression is a constant.
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;false&apos;.
         /// </summary>
-        internal static string WRN_FilterIsConstant_Title {
+        internal static string WRN_FilterIsConstantFalse_Title {
             get {
-                return ResourceManager.GetString("WRN_FilterIsConstant_Title", resourceCulture);
+                return ResourceManager.GetString("WRN_FilterIsConstantFalse_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;{0}&apos;, consider removing the try-catch block.
+        /// </summary>
+        internal static string WRN_FilterIsConstantRedundantTryCatch {
+            get {
+                return ResourceManager.GetString("WRN_FilterIsConstantRedundantTryCatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;false&apos;. .
+        /// </summary>
+        internal static string WRN_FilterIsConstantRedundantTryCatch_Title {
+            get {
+                return ResourceManager.GetString("WRN_FilterIsConstantRedundantTryCatch_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;{0}&apos;, consider removing the filter.
+        /// </summary>
+        internal static string WRN_FilterIsConstantTrue {
+            get {
+                return ResourceManager.GetString("WRN_FilterIsConstantTrue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter expression is a constant &apos;true&apos;.
+        /// </summary>
+        internal static string WRN_FilterIsConstantTrue_Title {
+            get {
+                return ResourceManager.GetString("WRN_FilterIsConstantTrue_Title", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -759,11 +759,11 @@
   <data name="ERR_UnreachableCatch" xml:space="preserve">
     <value>A previous catch clause already catches all exceptions of this or of a super type ('{0}')</value>
   </data>
-  <data name="WRN_FilterIsConstant" xml:space="preserve">
-    <value>Filter expression is a constant, consider removing the filter</value>
+  <data name="WRN_FilterIsConstantTrue" xml:space="preserve">
+    <value>Filter expression is a constant '{0}', consider removing the filter</value>
   </data>
-  <data name="WRN_FilterIsConstant_Title" xml:space="preserve">
-    <value>Filter expression is a constant</value>
+  <data name="WRN_FilterIsConstantTrue_Title" xml:space="preserve">
+    <value>Filter expression is a constant 'true'</value>
   </data>
   <data name="ERR_ReturnExpected" xml:space="preserve">
     <value>'{0}': not all code paths return a value</value>
@@ -5222,5 +5222,17 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ICompoundAssignmentOperationIsNotCSharpCompoundAssignment" xml:space="preserve">
     <value>{0} is not a valid C# compound assignment operation</value>
+  </data>
+  <data name="WRN_FilterIsConstantFalse" xml:space="preserve">
+    <value>Filter expression is a constant '{0}', consider removing the catch clause</value>
+  </data>
+  <data name="WRN_FilterIsConstantFalse_Title" xml:space="preserve">
+    <value>Filter expression is a constant 'false'</value>
+  </data>
+  <data name="WRN_FilterIsConstantRedundantTryCatch" xml:space="preserve">
+    <value>Filter expression is a constant '{0}', consider removing the try-catch block</value>
+  </data>
+  <data name="WRN_FilterIsConstantRedundantTryCatch_Title" xml:space="preserve">
+    <value>Filter expression is a constant 'false'. </value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -760,7 +760,7 @@
     <value>A previous catch clause already catches all exceptions of this or of a super type ('{0}')</value>
   </data>
   <data name="WRN_FilterIsConstantTrue" xml:space="preserve">
-    <value>Filter expression is a constant '{0}', consider removing the filter</value>
+    <value>Filter expression is a constant 'true', consider removing the filter</value>
   </data>
   <data name="WRN_FilterIsConstantTrue_Title" xml:space="preserve">
     <value>Filter expression is a constant 'true'</value>
@@ -5224,15 +5224,15 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>{0} is not a valid C# compound assignment operation</value>
   </data>
   <data name="WRN_FilterIsConstantFalse" xml:space="preserve">
-    <value>Filter expression is a constant '{0}', consider removing the catch clause</value>
+    <value>Filter expression is a constant 'false', consider removing the catch clause</value>
   </data>
   <data name="WRN_FilterIsConstantFalse_Title" xml:space="preserve">
     <value>Filter expression is a constant 'false'</value>
   </data>
-  <data name="WRN_FilterIsConstantRedundantTryCatch" xml:space="preserve">
-    <value>Filter expression is a constant '{0}', consider removing the try-catch block</value>
+  <data name="WRN_FilterIsConstantFalseRedundantTryCatch" xml:space="preserve">
+    <value>Filter expression is a constant 'false', consider removing the try-catch block</value>
   </data>
-  <data name="WRN_FilterIsConstantRedundantTryCatch_Title" xml:space="preserve">
+  <data name="WRN_FilterIsConstantFalseRedundantTryCatch_Title" xml:space="preserve">
     <value>Filter expression is a constant 'false'. </value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1242,7 +1242,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_MutuallyExclusiveOptions = 7102,
         ERR_InvalidDebugInfo = 7103,
         WRN_FilterIsConstantFalse = 7104,
-        WRN_FilterIsConstantRedundantTryCatch = 7105,
+        WRN_FilterIsConstantFalseRedundantTryCatch = 7105,
         #endregion diagnostics introduced in C# 6
 
         // huge gap here; unused 7106-8000

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1241,11 +1241,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_EncReferenceToAddedMember = 7101,
         ERR_MutuallyExclusiveOptions = 7102,
         ERR_InvalidDebugInfo = 7103,
-        WRN_FilterIsConstantFalse = 7104,
-        WRN_FilterIsConstantFalseRedundantTryCatch = 7105,
         #endregion diagnostics introduced in C# 6
 
-        // huge gap here; unused 7106-8000
+        // huge gap here; unused 7104-8000
 
         #region more diagnostics introduced in Roslyn (C# 6)
         WRN_UnimplementedCommandLineSwitch = 8001,
@@ -1545,5 +1543,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_InvalidVersionFormatDeterministic = 8357,
 
         ERR_AttributeCtorInParameter = 8358,
+
+        #region diagnostics for FilterIsConstant warning message fix
+        WRN_FilterIsConstantFalse = 8355,
+        WRN_FilterIsConstantFalseRedundantTryCatch = 8356,
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1232,7 +1232,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FixedBufferTooManyDimensions = 7092,
         ERR_CantReadConfigFile = 7093,
         ERR_BadAwaitInCatchFilter = 7094,
-        WRN_FilterIsConstant = 7095,
+        // WRN_FilterIsConstant = 7095,   // replaced by FilterIsConstantFalse and FilterIsConstantTrue
         ERR_EncNoPIAReference = 7096,
         //ERR_EncNoDynamicOperation = 7097,   // dynamic operations are now allowed
         ERR_LinkedNetmoduleMetadataMustProvideFullPEImage = 7098,
@@ -1241,9 +1241,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_EncReferenceToAddedMember = 7101,
         ERR_MutuallyExclusiveOptions = 7102,
         ERR_InvalidDebugInfo = 7103,
+        WRN_FilterIsConstantFalse = 7104,
+        WRN_FilterIsConstantTrue = 7105,
+        WRN_FilterIsConstantRedundantTryCatch = 7106,
         #endregion diagnostics introduced in C# 6
 
-        // huge gap here; unused 7104-8000
+        // huge gap here; unused 7107-8000
 
         #region more diagnostics introduced in Roslyn (C# 6)
         WRN_UnimplementedCommandLineSwitch = 8001,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1545,8 +1545,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AttributeCtorInParameter = 8358,
 
         #region diagnostics for FilterIsConstant warning message fix
-        WRN_FilterIsConstantFalse = 8357,
-        WRN_FilterIsConstantFalseRedundantTryCatch = 8358,
+        WRN_FilterIsConstantFalse = 8358,
+        WRN_FilterIsConstantFalseRedundantTryCatch = 8359,
         #endregion diagnostics for FilterIsConstant warning message fix
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1545,8 +1545,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AttributeCtorInParameter = 8358,
 
         #region diagnostics for FilterIsConstant warning message fix
-        WRN_FilterIsConstantFalse = 8358,
-        WRN_FilterIsConstantFalseRedundantTryCatch = 8359,
+        WRN_FilterIsConstantFalse = 8359,
+        WRN_FilterIsConstantFalseRedundantTryCatch = 8360,
         #endregion diagnostics for FilterIsConstant warning message fix
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1547,6 +1547,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         #region diagnostics for FilterIsConstant warning message fix
         WRN_FilterIsConstantFalse = 8355,
         WRN_FilterIsConstantFalseRedundantTryCatch = 8356,
-        #endregion
+        #endregion diagnostics for FilterIsConstant warning message fix
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1545,8 +1545,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AttributeCtorInParameter = 8358,
 
         #region diagnostics for FilterIsConstant warning message fix
-        WRN_FilterIsConstantFalse = 8355,
-        WRN_FilterIsConstantFalseRedundantTryCatch = 8356,
+        WRN_FilterIsConstantFalse = 8357,
+        WRN_FilterIsConstantFalseRedundantTryCatch = 8358,
         #endregion diagnostics for FilterIsConstant warning message fix
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1232,7 +1232,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_FixedBufferTooManyDimensions = 7092,
         ERR_CantReadConfigFile = 7093,
         ERR_BadAwaitInCatchFilter = 7094,
-        // WRN_FilterIsConstant = 7095,   // replaced by FilterIsConstantFalse and FilterIsConstantTrue
+        WRN_FilterIsConstantTrue = 7095,
         ERR_EncNoPIAReference = 7096,
         //ERR_EncNoDynamicOperation = 7097,   // dynamic operations are now allowed
         ERR_LinkedNetmoduleMetadataMustProvideFullPEImage = 7098,
@@ -1242,11 +1242,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_MutuallyExclusiveOptions = 7102,
         ERR_InvalidDebugInfo = 7103,
         WRN_FilterIsConstantFalse = 7104,
-        WRN_FilterIsConstantTrue = 7105,
-        WRN_FilterIsConstantRedundantTryCatch = 7106,
+        WRN_FilterIsConstantRedundantTryCatch = 7105,
         #endregion diagnostics introduced in C# 6
 
-        // huge gap here; unused 7107-8000
+        // huge gap here; unused 7106-8000
 
         #region more diagnostics introduced in Roslyn (C# 6)
         WRN_UnimplementedCommandLineSwitch = 8001,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -312,9 +312,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_BadUILang:
                 case ErrorCode.WRN_RefCultureMismatch:
                 case ErrorCode.WRN_ConflictingMachineAssembly:
-                case ErrorCode.WRN_FilterIsConstantFalse:
                 case ErrorCode.WRN_FilterIsConstantTrue:
-                case ErrorCode.WRN_FilterIsConstantRedundantTryCatch:
+                case ErrorCode.WRN_FilterIsConstantFalse:
+                case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
                 case ErrorCode.WRN_IdentifierOrNumericLiteralExpected:
                 case ErrorCode.WRN_ReferencedAssemblyDoesNotHaveStrongName:
                 case ErrorCode.WRN_AlignmentMagnitude:

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -312,7 +312,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_BadUILang:
                 case ErrorCode.WRN_RefCultureMismatch:
                 case ErrorCode.WRN_ConflictingMachineAssembly:
-                case ErrorCode.WRN_FilterIsConstant:
+                case ErrorCode.WRN_FilterIsConstantFalse:
+                case ErrorCode.WRN_FilterIsConstantTrue:
+                case ErrorCode.WRN_FilterIsConstantRedundantTryCatch:
                 case ErrorCode.WRN_IdentifierOrNumericLiteralExpected:
                 case ErrorCode.WRN_ReferencedAssemblyDoesNotHaveStrongName:
                 case ErrorCode.WRN_AlignmentMagnitude:

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -158,7 +158,9 @@
                 case ErrorCode.WRN_CallerLineNumberPreferredOverCallerMemberName:
                 case ErrorCode.WRN_CallerLineNumberPreferredOverCallerFilePath:
                 case ErrorCode.WRN_AssemblyAttributeFromModuleIsOverridden:
-                case ErrorCode.WRN_FilterIsConstant:
+                case ErrorCode.WRN_FilterIsConstantFalse:
+                case ErrorCode.WRN_FilterIsConstantTrue:
+                case ErrorCode.WRN_FilterIsConstantRedundantTryCatch:
                 case ErrorCode.WRN_UnimplementedCommandLineSwitch:
                 case ErrorCode.WRN_ReferencedAssemblyDoesNotHaveStrongName:
                 case ErrorCode.WRN_RefCultureMismatch:

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -159,8 +159,6 @@
                 case ErrorCode.WRN_CallerLineNumberPreferredOverCallerFilePath:
                 case ErrorCode.WRN_AssemblyAttributeFromModuleIsOverridden:
                 case ErrorCode.WRN_FilterIsConstantTrue:
-                case ErrorCode.WRN_FilterIsConstantFalse:
-                case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
                 case ErrorCode.WRN_UnimplementedCommandLineSwitch:
                 case ErrorCode.WRN_ReferencedAssemblyDoesNotHaveStrongName:
                 case ErrorCode.WRN_RefCultureMismatch:
@@ -178,6 +176,8 @@
                 case ErrorCode.WRN_Experimental:
                 case ErrorCode.WRN_DefaultInSwitch:
                 case ErrorCode.WRN_UnreferencedLocalFunction:
+                case ErrorCode.WRN_FilterIsConstantFalse:
+                case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -158,9 +158,9 @@
                 case ErrorCode.WRN_CallerLineNumberPreferredOverCallerMemberName:
                 case ErrorCode.WRN_CallerLineNumberPreferredOverCallerFilePath:
                 case ErrorCode.WRN_AssemblyAttributeFromModuleIsOverridden:
-                case ErrorCode.WRN_FilterIsConstantFalse:
                 case ErrorCode.WRN_FilterIsConstantTrue:
-                case ErrorCode.WRN_FilterIsConstantRedundantTryCatch:
+                case ErrorCode.WRN_FilterIsConstantFalse:
+                case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
                 case ErrorCode.WRN_UnimplementedCommandLineSwitch:
                 case ErrorCode.WRN_ReferencedAssemblyDoesNotHaveStrongName:
                 case ErrorCode.WRN_RefCultureMismatch:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5280,7 +5280,7 @@ class Program
         }
 
         [Fact]
-        public void CS7103WRN_FilterIsConstantFalse1()
+        public void CS7104WRN_FilterIsConstantFalse1()
         {
             var text = @"
 using System;
@@ -5298,16 +5298,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
-                // (12,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS7103WRN_FilterIsConstantFalse2()
+        public void CS7104WRN_FilterIsConstantFalse2()
         {
             var text = @"
 using System;
@@ -5325,16 +5325,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "(1+1)!=2").WithLocation(11, 25),
-                // (12,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS7104WRN_FilterIsConstantRedundantTryCatch1()
+        public void CS7105WRN_FilterIsConstantRedundantTryCatch1()
         {
             var text = @"
 using System;
@@ -5350,13 +5350,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS7104WRN_FilterIsConstantRedundantTryCatch2()
+        public void CS7105WRN_FilterIsConstantRedundantTryCatch2()
         {
             var text = @"
 using System;
@@ -5372,7 +5372,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "(1+1)!=2").WithLocation(10, 25));
         }
@@ -5423,7 +5423,7 @@ class Program
                 // (10,19): warning CS7095: Filter expression is a constant 'true', consider removing the filter
                 //         catch when (true) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 21),
-                // (12,19): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,19): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 21));
         }
@@ -5472,7 +5472,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the catch clause
+    // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
     //         catch (A) when (false) 
     Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
     // (13,13): warning CS0162: Unreachable code detected
@@ -5505,7 +5505,7 @@ class Program
             // is to make conditional compilation easier. Such scenario doesn't apply to filters.
 
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (10,33): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
+    // (10,33): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
     //         catch (Exception) when (false) 
     Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 33),
     // (12,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5280,7 +5280,7 @@ class Program
         }
 
         [Fact]
-        public void CS8355WRN_FilterIsConstantFalse_NonBoolean()
+        public void CS8357WRN_FilterIsConstantFalse_NonBoolean()
         {
             // Non-boolean constant filters are not considered for WRN_FilterIsConstant warnings. 
 
@@ -5311,13 +5311,13 @@ class Program
                 // (13,25): error CS0029: Cannot implicitly convert type 'string' to 'bool'
                 //         catch (B) when ("false") { }
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""false""").WithArguments("string", "bool").WithLocation(13, 25),
-                // (14,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                // (14,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(14, 25));
         }
 
         [Fact]
-        public void CS8355WRN_FilterIsConstantFalse1()
+        public void CS8357WRN_FilterIsConstantFalse1()
         {
             var text = @"
 using System;
@@ -5335,16 +5335,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
-                // (12,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS8355WRN_FilterIsConstantFalse2()
+        public void CS8357WRN_FilterIsConstantFalse2()
         {
             var text = @"
 using System;
@@ -5362,16 +5362,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "(1+1)!=2").WithLocation(11, 25),
-                // (12,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS8355WRN_FilterIsConstantFalse3()
+        public void CS8357WRN_FilterIsConstantFalse3()
         {
             var text = @"
 using System;
@@ -5388,13 +5388,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS8356WRN_FilterIsConstantRedundantTryCatch1()
+        public void CS8358WRN_FilterIsConstantRedundantTryCatch1()
         {
             var text = @"
 using System;
@@ -5410,13 +5410,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8356: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS8356WRN_FilterIsConstantRedundantTryCatch2()
+        public void CS8358WRN_FilterIsConstantRedundantTryCatch2()
         {
             var text = @"
 using System;
@@ -5432,7 +5432,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8356: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "(1+1)!=2").WithLocation(10, 25));
         }
@@ -5483,7 +5483,7 @@ class Program
                 // (10,19): warning CS7095: Filter expression is a constant 'true', consider removing the filter
                 //         catch when (true) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 21),
-                // (12,19): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,19): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 21));
         }
@@ -5532,7 +5532,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (11,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+    // (11,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
     //         catch (A) when (false) 
     Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
     // (13,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5334,6 +5334,29 @@ class Program
         }
 
         [Fact]
+        public void CS7104WRN_FilterIsConstantFalse3()
+        {
+            var text = @"
+using System;
+class A : Exception { }
+
+class Program
+{
+    static void M()
+    {
+        try { }
+        catch (A) when (false) { }
+        finally { }
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+                //         catch (A) when (false) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(10, 25));
+        }
+
+        [Fact]
         public void CS7105WRN_FilterIsConstantRedundantTryCatch1()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5280,7 +5280,56 @@ class Program
         }
 
         [Fact]
-        public void CS7095WRN_FilterIsConstant1()
+        public void CS7103WRN_FilterIsConstantFalse1()
+        {
+            var text = @"
+using System;
+class A : Exception { }
+class B : A { }
+
+class Program
+{
+    static void M()
+    {
+        try { }
+        catch (A) when (false) { }
+        catch (B) when (false) { }
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (11,25): warning CS7103: Filter expression is a constant 'true', consider removing the filter
+                //         catch (A) when (false) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(11, 25),
+                // (12,25): warning CS7103: Filter expression is a constant 'true', consider removing the filter
+                //         catch (B) when (false) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(12, 25));
+        }
+
+        [Fact]
+        public void CS7103WRN_FilterIsConstantFalse2()
+        {
+            var text = @"
+using System;
+class A : Exception { }
+
+class Program
+{
+    static void M()
+    {
+        try { }
+        catch (A) when (false) { }
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+                //         catch (A) when (false) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "false").WithArguments("false").WithLocation(10, 25));
+        }
+
+        [Fact]
+        public void CS7104WRN_FilterIsConstantTrue1()
         {
             var text = @"
 using System;
@@ -5298,13 +5347,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,23): warning CS7095: Filter expression is a constant, consider removing the filter
+                // (11,25): warning CS7104: Filter expression is a constant 'true', consider removing the filter
                 //         catch (A) when (true) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstant, "true").WithLocation(11, 25));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithArguments("true").WithLocation(11, 25));
         }
 
         [Fact]
-        public void CS7095WRN_FilterIsConstant2()
+        public void CS7104WRN_FilterIsConstantTrue2()
         {
             var text = @"
 using System;
@@ -5322,12 +5371,12 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (10,19): warning CS7095: Filter expression is a constant, consider removing the filter
+                // (10,19): warning CS7104: Filter expression is a constant 'true', consider removing the filter
                 //         catch when (true) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstant, "true").WithLocation(10, 21),
-                // (12,19): warning CS7095: Filter expression is a constant, consider removing the filter
+                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithArguments("true").WithLocation(10, 21),
+                // (12,19): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstant, "false").WithLocation(12, 21));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(12, 21));
         }
 
         [Fact]
@@ -5352,9 +5401,9 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (11,25): warning CS7095: Filter expression is a constant, consider removing the filter
+    // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
     //         catch (A) when (false) 
-    Diagnostic(ErrorCode.WRN_FilterIsConstant, "false").WithLocation(11, 25),
+    Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "false").WithArguments("false").WithLocation(11, 25),
     // (13,13): warning CS0162: Unreachable code detected
     //             Console.WriteLine(1); 
     Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(13, 13)
@@ -5385,9 +5434,9 @@ class Program
             // is to make conditional compilation easier. Such scenario doesn't apply to filters.
 
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (10,33): warning CS7095: Filter expression is a constant, consider removing the filter
+    // (10,33): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
     //         catch (Exception) when (false) 
-    Diagnostic(ErrorCode.WRN_FilterIsConstant, "false").WithLocation(10, 33),
+    Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "false").WithArguments("false").WithLocation(10, 33),
     // (12,13): warning CS0162: Unreachable code detected
     //             Console.WriteLine(x);
     Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(12, 13)
@@ -5418,9 +5467,9 @@ class Program
             // is to make conditional compilation easier. Such scenario doesn't apply to filters.
 
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (10,33): warning CS7095: Filter expression is a constant, consider removing the filter
+    // (10,33): warning CS7104: Filter expression is a constant 'true', consider removing the filter
     //         catch (Exception) when (true) 
-    Diagnostic(ErrorCode.WRN_FilterIsConstant, "true").WithLocation(10, 33),
+    Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithArguments("true").WithLocation(10, 33),
     // (12,31): error CS0165: Use of unassigned local variable 'x'
     //             Console.WriteLine(x);
     Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(12, 31)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5280,7 +5280,7 @@ class Program
         }
 
         [Fact]
-        public void CS7103WRN_FilterIsConstantFalse1()
+        public void CS7103WRN_FilterIsConstantFalse()
         {
             var text = @"
 using System;
@@ -5307,7 +5307,7 @@ class Program
         }
 
         [Fact]
-        public void CS7103WRN_FilterIsConstantFalse2()
+        public void CS7105WRN_FilterIsConstantRedundantTryCatch()
         {
             var text = @"
 using System;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5280,7 +5280,44 @@ class Program
         }
 
         [Fact]
-        public void CS7104WRN_FilterIsConstantFalse1()
+        public void CS8355WRN_FilterIsConstantFalse_NonBoolean()
+        {
+            // Non-boolean constant filters are not considered for WRN_FilterIsConstant warnings. 
+
+            var text = @"
+using System;
+class A : Exception { }
+class B : A { }
+
+class Program
+{
+    static void M()
+    {
+        try { }
+        catch (A) when (1) { }
+        catch (B) when (0) { }
+        catch (B) when (""false"") { }
+        catch (B) when (false) { }
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (11,25): error CS0029: Cannot implicitly convert type 'int' to 'bool'
+                //         catch (A) when (1) { }
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "1").WithArguments("int", "bool").WithLocation(11, 25),
+                // (12,25): error CS0029: Cannot implicitly convert type 'int' to 'bool'
+                //         catch (B) when (0) { }
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "0").WithArguments("int", "bool").WithLocation(12, 25),
+                // (13,25): error CS0029: Cannot implicitly convert type 'string' to 'bool'
+                //         catch (B) when ("false") { }
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""false""").WithArguments("string", "bool").WithLocation(13, 25),
+                // (14,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                //         catch (B) when (false) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(14, 25));
+        }
+
+        [Fact]
+        public void CS8355WRN_FilterIsConstantFalse1()
         {
             var text = @"
 using System;
@@ -5298,16 +5335,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
-                // (12,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS7104WRN_FilterIsConstantFalse2()
+        public void CS8355WRN_FilterIsConstantFalse2()
         {
             var text = @"
 using System;
@@ -5325,16 +5362,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "(1+1)!=2").WithLocation(11, 25),
-                // (12,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS7104WRN_FilterIsConstantFalse3()
+        public void CS8355WRN_FilterIsConstantFalse3()
         {
             var text = @"
 using System;
@@ -5351,13 +5388,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS7105WRN_FilterIsConstantRedundantTryCatch1()
+        public void CS8356WRN_FilterIsConstantRedundantTryCatch1()
         {
             var text = @"
 using System;
@@ -5373,13 +5410,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS8356: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS7105WRN_FilterIsConstantRedundantTryCatch2()
+        public void CS8356WRN_FilterIsConstantRedundantTryCatch2()
         {
             var text = @"
 using System;
@@ -5395,7 +5432,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS8356: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "(1+1)!=2").WithLocation(10, 25));
         }
@@ -5446,7 +5483,7 @@ class Program
                 // (10,19): warning CS7095: Filter expression is a constant 'true', consider removing the filter
                 //         catch when (true) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 21),
-                // (12,19): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,19): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 21));
         }
@@ -5495,7 +5532,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+    // (11,25): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
     //         catch (A) when (false) 
     Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
     // (13,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5403,7 +5403,7 @@ class Program
             CreateStandardCompilation(text).VerifyDiagnostics(
     // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
     //         catch (A) when (false) 
-    Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "false").WithArguments("false").WithLocation(11, 25),
+    Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(11, 25),
     // (13,13): warning CS0162: Unreachable code detected
     //             Console.WriteLine(1); 
     Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(13, 13)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5280,7 +5280,7 @@ class Program
         }
 
         [Fact]
-        public void CS7103WRN_FilterIsConstantFalse()
+        public void CS7103WRN_FilterIsConstantFalse1()
         {
             var text = @"
 using System;
@@ -5298,16 +5298,43 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7103: Filter expression is a constant 'true', consider removing the filter
+                // (11,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(11, 25),
-                // (12,25): warning CS7103: Filter expression is a constant 'true', consider removing the filter
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
+                // (12,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(12, 25));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS7105WRN_FilterIsConstantRedundantTryCatch()
+        public void CS7103WRN_FilterIsConstantFalse2()
+        {
+            var text = @"
+using System;
+class A : Exception { }
+class B : A { }
+
+class Program
+{
+    static void M()
+    {
+        try { }
+        catch (A) when ((1+1)!=2) { }
+        catch (B) when (false) { }
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (11,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
+                //         catch (A) when (false) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
+                // (12,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
+                //         catch (B) when (false) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
+        }
+
+        [Fact]
+        public void CS7104WRN_FilterIsConstantRedundantTryCatch1()
         {
             var text = @"
 using System;
@@ -5323,13 +5350,35 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "false").WithArguments("false").WithLocation(10, 25));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS7104WRN_FilterIsConstantTrue1()
+        public void CS7104WRN_FilterIsConstantRedundantTryCatch2()
+        {
+            var text = @"
+using System;
+class A : Exception { }
+
+class Program
+{
+    static void M()
+    {
+        try { }
+        catch (A) when ((1+1)!=2) { }
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
+                //         catch (A) when (false) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 25));
+        }
+
+        [Fact]
+        public void CS7095WRN_FilterIsConstantTrue1()
         {
             var text = @"
 using System;
@@ -5347,13 +5396,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS7104: Filter expression is a constant 'true', consider removing the filter
+                // (11,25): warning CS7095: Filter expression is a constant 'true', consider removing the filter
                 //         catch (A) when (true) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithArguments("true").WithLocation(11, 25));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(11, 25));
         }
 
         [Fact]
-        public void CS7104WRN_FilterIsConstantTrue2()
+        public void CS7095WRN_FilterIsConstantTrue2()
         {
             var text = @"
 using System;
@@ -5371,12 +5420,34 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (10,19): warning CS7104: Filter expression is a constant 'true', consider removing the filter
+                // (10,19): warning CS7095: Filter expression is a constant 'true', consider removing the filter
                 //         catch when (true) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithArguments("true").WithLocation(10, 21),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 21),
                 // (12,19): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(12, 21));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 21));
+        }
+
+        [Fact]
+        public void CS7095WRN_FilterIsConstantTrue3()
+        {
+            var text = @"
+using System;
+class A : Exception { }
+
+class Program
+{
+    static void M()
+    {
+        try { }
+        catch when ((1+1)==2) { }
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (10,19): warning CS7095: Filter expression is a constant 'true', consider removing the filter
+                //         catch when (true) { }
+                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 21));
         }
 
         [Fact]
@@ -5401,9 +5472,9 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+    // (11,25): warning CS7105: Filter expression is a constant 'false', consider removing the catch clause
     //         catch (A) when (false) 
-    Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(11, 25),
+    Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
     // (13,13): warning CS0162: Unreachable code detected
     //             Console.WriteLine(1); 
     Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(13, 13)
@@ -5434,9 +5505,9 @@ class Program
             // is to make conditional compilation easier. Such scenario doesn't apply to filters.
 
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (10,33): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+    // (10,33): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
     //         catch (Exception) when (false) 
-    Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "false").WithArguments("false").WithLocation(10, 33),
+    Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 33),
     // (12,13): warning CS0162: Unreachable code detected
     //             Console.WriteLine(x);
     Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(12, 13)
@@ -5467,9 +5538,9 @@ class Program
             // is to make conditional compilation easier. Such scenario doesn't apply to filters.
 
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (10,33): warning CS7104: Filter expression is a constant 'true', consider removing the filter
+    // (10,33): warning CS7095: Filter expression is a constant 'true', consider removing the filter
     //         catch (Exception) when (true) 
-    Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithArguments("true").WithLocation(10, 33),
+    Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 33),
     // (12,31): error CS0165: Use of unassigned local variable 'x'
     //             Console.WriteLine(x);
     Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(12, 31)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5327,7 +5327,7 @@ class Program
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (11,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "(1+1)!=2").WithLocation(11, 25),
                 // (12,25): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
@@ -5374,7 +5374,7 @@ class Program
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (11,25): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 25));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "(1+1)!=2").WithLocation(10, 25));
         }
 
         [Fact]
@@ -5447,7 +5447,7 @@ class Program
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (10,19): warning CS7095: Filter expression is a constant 'true', consider removing the filter
                 //         catch when (true) { }
-                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 21));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "(1+1)==2").WithLocation(10, 21));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5280,7 +5280,7 @@ class Program
         }
 
         [Fact]
-        public void CS8357WRN_FilterIsConstantFalse_NonBoolean()
+        public void CS8358WRN_FilterIsConstantFalse_NonBoolean()
         {
             // Non-boolean constant filters are not considered for WRN_FilterIsConstant warnings. 
 
@@ -5311,13 +5311,13 @@ class Program
                 // (13,25): error CS0029: Cannot implicitly convert type 'string' to 'bool'
                 //         catch (B) when ("false") { }
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""false""").WithArguments("string", "bool").WithLocation(13, 25),
-                // (14,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+                // (14,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(14, 25));
         }
 
         [Fact]
-        public void CS8357WRN_FilterIsConstantFalse1()
+        public void CS8358WRN_FilterIsConstantFalse1()
         {
             var text = @"
 using System;
@@ -5335,16 +5335,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
-                // (12,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS8357WRN_FilterIsConstantFalse2()
+        public void CS8358WRN_FilterIsConstantFalse2()
         {
             var text = @"
 using System;
@@ -5362,16 +5362,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "(1+1)!=2").WithLocation(11, 25),
-                // (12,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS8357WRN_FilterIsConstantFalse3()
+        public void CS8358WRN_FilterIsConstantFalse3()
         {
             var text = @"
 using System;
@@ -5388,13 +5388,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS8358WRN_FilterIsConstantRedundantTryCatch1()
+        public void CS8359WRN_FilterIsConstantRedundantTryCatch1()
         {
             var text = @"
 using System;
@@ -5410,13 +5410,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS8359: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS8358WRN_FilterIsConstantRedundantTryCatch2()
+        public void CS8359WRN_FilterIsConstantRedundantTryCatch2()
         {
             var text = @"
 using System;
@@ -5432,7 +5432,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS8359: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "(1+1)!=2").WithLocation(10, 25));
         }
@@ -5483,7 +5483,7 @@ class Program
                 // (10,19): warning CS7095: Filter expression is a constant 'true', consider removing the filter
                 //         catch when (true) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 21),
-                // (12,19): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,19): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 21));
         }
@@ -5532,7 +5532,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (11,25): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+    // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
     //         catch (A) when (false) 
     Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
     // (13,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5280,7 +5280,7 @@ class Program
         }
 
         [Fact]
-        public void CS8358WRN_FilterIsConstantFalse_NonBoolean()
+        public void CS8359WRN_FilterIsConstantFalse_NonBoolean()
         {
             // Non-boolean constant filters are not considered for WRN_FilterIsConstant warnings. 
 
@@ -5311,13 +5311,13 @@ class Program
                 // (13,25): error CS0029: Cannot implicitly convert type 'string' to 'bool'
                 //         catch (B) when ("false") { }
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""false""").WithArguments("string", "bool").WithLocation(13, 25),
-                // (14,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+                // (14,25): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(14, 25));
         }
 
         [Fact]
-        public void CS8358WRN_FilterIsConstantFalse1()
+        public void CS8359WRN_FilterIsConstantFalse1()
         {
             var text = @"
 using System;
@@ -5335,16 +5335,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
-                // (12,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS8358WRN_FilterIsConstantFalse2()
+        public void CS8359WRN_FilterIsConstantFalse2()
         {
             var text = @"
 using System;
@@ -5362,16 +5362,16 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "(1+1)!=2").WithLocation(11, 25),
-                // (12,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,25): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (B) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 25));
         }
 
         [Fact]
-        public void CS8358WRN_FilterIsConstantFalse3()
+        public void CS8359WRN_FilterIsConstantFalse3()
         {
             var text = @"
 using System;
@@ -5388,13 +5388,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+                // (11,25): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS8359WRN_FilterIsConstantRedundantTryCatch1()
+        public void CS8360WRN_FilterIsConstantRedundantTryCatch1()
         {
             var text = @"
 using System;
@@ -5410,13 +5410,13 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8359: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS8360: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 25));
         }
 
         [Fact]
-        public void CS8359WRN_FilterIsConstantRedundantTryCatch2()
+        public void CS8360WRN_FilterIsConstantRedundantTryCatch2()
         {
             var text = @"
 using System;
@@ -5432,7 +5432,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,25): warning CS8359: Filter expression is a constant 'false', consider removing the try-catch block
+                // (11,25): warning CS8360: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (A) when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "(1+1)!=2").WithLocation(10, 25));
         }
@@ -5483,7 +5483,7 @@ class Program
                 // (10,19): warning CS7095: Filter expression is a constant 'true', consider removing the filter
                 //         catch when (true) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantTrue, "true").WithLocation(10, 21),
-                // (12,19): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+                // (12,19): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) { }
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(12, 21));
         }
@@ -5532,7 +5532,7 @@ class Program
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-    // (11,25): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+    // (11,25): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
     //         catch (A) when (false) 
     Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(11, 25),
     // (13,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1232,7 +1232,7 @@ class C
                 // (12,37): error CS8310: Operator '|' cannot be applied to operand 'default'
                 //             System.Console.Write($"{true | default} {i} {b}");
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
-                // (15,40): warning CS8356: Filter expression is a constant 'false', consider removing the try-catch block
+                // (15,40): warning CS8358: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(15, 40),
                 // (17,13): warning CS0162: Unreachable code detected
@@ -1262,7 +1262,7 @@ class C
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (10,40): warning CS8356: Filter expression is a constant 'false', consider removing the try-catch block
+                // (10,40): warning CS8358: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (false)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(10, 40),
                 // (12,13): warning CS0162: Unreachable code detected
@@ -1308,7 +1308,7 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (26,40): warning CS8356: Filter expression is a constant, consider removing the filter
+                // (26,40): warning CS8358: Filter expression is a constant, consider removing the filter
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(26, 40),
                 // (28,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1232,9 +1232,9 @@ class C
                 // (12,37): error CS8310: Operator '|' cannot be applied to operand 'default'
                 //             System.Console.Write($"{true | default} {i} {b}");
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
-                // (15,40): warning CS7095: Filter expression is a constant, consider removing the filter
+                // (15,40): warning CS7105: Filter expression is a constant 'default', consider removing the try-catch block
                 //         catch (System.Exception) when (default)
-                Diagnostic(ErrorCode.WRN_FilterIsConstant, "default").WithLocation(15, 40),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "default").WithArguments("default").WithLocation(15, 40),
                 // (17,13): warning CS0162: Unreachable code detected
                 //             System.Console.Write("catch");
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(17, 13)
@@ -1262,9 +1262,9 @@ class C
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (10,40): warning CS7095: Filter expression is a constant, consider removing the filter
+                // (10,40): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (false)
-                Diagnostic(ErrorCode.WRN_FilterIsConstant, "default").WithLocation(10, 40),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "false").WithArguments("false").WithLocation(10, 40),
                 // (12,13): warning CS0162: Unreachable code detected
                 //             System.Console.Write("catch");
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(12, 13)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1232,7 +1232,7 @@ class C
                 // (12,37): error CS8310: Operator '|' cannot be applied to operand 'default'
                 //             System.Console.Write($"{true | default} {i} {b}");
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
-                // (15,40): warning CS8359: Filter expression is a constant 'false', consider removing the try-catch block
+                // (15,40): warning CS8360: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(15, 40),
                 // (17,13): warning CS0162: Unreachable code detected
@@ -1262,7 +1262,7 @@ class C
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (10,40): warning CS8359: Filter expression is a constant 'false', consider removing the try-catch block
+                // (10,40): warning CS8360: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (false)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(10, 40),
                 // (12,13): warning CS0162: Unreachable code detected
@@ -1308,7 +1308,7 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (26,40): warning CS8359: Filter expression is a constant, consider removing the filter
+                // (26,40): warning CS8360: Filter expression is a constant, consider removing the filter
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(26, 40),
                 // (28,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1264,7 +1264,7 @@ class C
             comp.VerifyDiagnostics(
                 // (10,40): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (false)
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 40),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(10, 40),
                 // (12,13): warning CS0162: Unreachable code detected
                 //             System.Console.Write("catch");
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(12, 13)
@@ -1310,7 +1310,7 @@ class C
             comp.VerifyDiagnostics(
                 // (26,40): warning CS7095: Filter expression is a constant, consider removing the filter
                 //         catch (System.Exception) when (false)
-                Diagnostic(ErrorCode.WRN_FilterIsConstant, "default").WithLocation(26, 40),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(26, 40),
                 // (28,13): warning CS0162: Unreachable code detected
                 //             System.Console.Write("catch");
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(28, 13)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1232,7 +1232,7 @@ class C
                 // (12,37): error CS8310: Operator '|' cannot be applied to operand 'default'
                 //             System.Console.Write($"{true | default} {i} {b}");
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
-                // (15,40): warning CS8358: Filter expression is a constant 'false', consider removing the try-catch block
+                // (15,40): warning CS8359: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(15, 40),
                 // (17,13): warning CS0162: Unreachable code detected
@@ -1262,7 +1262,7 @@ class C
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (10,40): warning CS8358: Filter expression is a constant 'false', consider removing the try-catch block
+                // (10,40): warning CS8359: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (false)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(10, 40),
                 // (12,13): warning CS0162: Unreachable code detected
@@ -1308,7 +1308,7 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (26,40): warning CS8358: Filter expression is a constant, consider removing the filter
+                // (26,40): warning CS8359: Filter expression is a constant, consider removing the filter
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(26, 40),
                 // (28,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1232,9 +1232,9 @@ class C
                 // (12,37): error CS8310: Operator '|' cannot be applied to operand 'default'
                 //             System.Console.Write($"{true | default} {i} {b}");
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
-                // (15,40): warning CS7105: Filter expression is a constant 'default', consider removing the try-catch block
+                // (15,40): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (default)
-                Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "default").WithArguments("default").WithLocation(15, 40),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(15, 40),
                 // (17,13): warning CS0162: Unreachable code detected
                 //             System.Console.Write("catch");
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(17, 13)
@@ -1262,9 +1262,9 @@ class C
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (10,40): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+                // (10,40): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (false)
-                Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "false").WithArguments("false").WithLocation(10, 40),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "false").WithLocation(10, 40),
                 // (12,13): warning CS0162: Unreachable code detected
                 //             System.Console.Write("catch");
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(12, 13)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1232,7 +1232,7 @@ class C
                 // (12,37): error CS8310: Operator '|' cannot be applied to operand 'default'
                 //             System.Console.Write($"{true | default} {i} {b}");
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
-                // (15,40): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+                // (15,40): warning CS8356: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(15, 40),
                 // (17,13): warning CS0162: Unreachable code detected
@@ -1262,7 +1262,7 @@ class C
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (10,40): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
+                // (10,40): warning CS8356: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (false)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(10, 40),
                 // (12,13): warning CS0162: Unreachable code detected
@@ -1308,8 +1308,8 @@ class C
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (26,40): warning CS7095: Filter expression is a constant, consider removing the filter
-                //         catch (System.Exception) when (false)
+                // (26,40): warning CS8356: Filter expression is a constant, consider removing the filter
+                //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(26, 40),
                 // (28,13): warning CS0162: Unreachable code detected
                 //             System.Console.Write("catch");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1232,7 +1232,7 @@ class C
                 // (12,37): error CS8310: Operator '|' cannot be applied to operand 'default'
                 //             System.Console.Write($"{true | default} {i} {b}");
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
-                // (15,40): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
+                // (15,40): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(15, 40),
                 // (17,13): warning CS0162: Unreachable code detected
@@ -1262,7 +1262,7 @@ class C
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (10,40): warning CS7104: Filter expression is a constant 'false', consider removing the try-catch block
+                // (10,40): warning CS7105: Filter expression is a constant 'false', consider removing the try-catch block
                 //         catch (System.Exception) when (false)
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch, "default").WithLocation(10, 40),
                 // (12,13): warning CS0162: Unreachable code detected

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1234,7 +1234,7 @@ class C
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
                 // (15,40): warning CS7105: Filter expression is a constant 'default', consider removing the try-catch block
                 //         catch (System.Exception) when (default)
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "default").WithArguments("default").WithLocation(15, 40),
+                Diagnostic(ErrorCode.WRN_FilterIsConstantRedundantTryCatch, "default").WithArguments("default").WithLocation(15, 40),
                 // (17,13): warning CS0162: Unreachable code detected
                 //             System.Console.Write("catch");
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(17, 13)

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -241,9 +241,9 @@ class X
                         case ErrorCode.WRN_AssemblyAttributeFromModuleIsOverridden:
                         case ErrorCode.WRN_RefCultureMismatch:
                         case ErrorCode.WRN_ConflictingMachineAssembly:
-                        case ErrorCode.WRN_FilterIsConstantTrue:
                         case ErrorCode.WRN_FilterIsConstantFalse:
-                        case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
+                        case ErrorCode.WRN_FilterIsConstantTrue:
+                        case ErrorCode.WRN_FilterIsConstantRedundantTryCatch:
                         case ErrorCode.WRN_AnalyzerCannotBeCreated:
                         case ErrorCode.WRN_NoAnalyzerInAssembly:
                         case ErrorCode.WRN_UnableToLoadAnalyzer:

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -241,9 +241,9 @@ class X
                         case ErrorCode.WRN_AssemblyAttributeFromModuleIsOverridden:
                         case ErrorCode.WRN_RefCultureMismatch:
                         case ErrorCode.WRN_ConflictingMachineAssembly:
-                        case ErrorCode.WRN_FilterIsConstantFalse:
                         case ErrorCode.WRN_FilterIsConstantTrue:
-                        case ErrorCode.WRN_FilterIsConstantRedundantTryCatch:
+                        case ErrorCode.WRN_FilterIsConstantFalse:
+                        case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
                         case ErrorCode.WRN_AnalyzerCannotBeCreated:
                         case ErrorCode.WRN_NoAnalyzerInAssembly:
                         case ErrorCode.WRN_UnableToLoadAnalyzer:

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -241,7 +241,9 @@ class X
                         case ErrorCode.WRN_AssemblyAttributeFromModuleIsOverridden:
                         case ErrorCode.WRN_RefCultureMismatch:
                         case ErrorCode.WRN_ConflictingMachineAssembly:
-                        case ErrorCode.WRN_FilterIsConstant:
+                        case ErrorCode.WRN_FilterIsConstantFalse:
+                        case ErrorCode.WRN_FilterIsConstantTrue:
+                        case ErrorCode.WRN_FilterIsConstantRedundantTryCatch:
                         case ErrorCode.WRN_AnalyzerCannotBeCreated:
                         case ErrorCode.WRN_NoAnalyzerInAssembly:
                         case ErrorCode.WRN_UnableToLoadAnalyzer:

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -243,7 +243,7 @@ class X
                         case ErrorCode.WRN_ConflictingMachineAssembly:
                         case ErrorCode.WRN_FilterIsConstantFalse:
                         case ErrorCode.WRN_FilterIsConstantTrue:
-                        case ErrorCode.WRN_FilterIsConstantRedundantTryCatch:
+                        case ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch:
                         case ErrorCode.WRN_AnalyzerCannotBeCreated:
                         case ErrorCode.WRN_NoAnalyzerInAssembly:
                         case ErrorCode.WRN_UnableToLoadAnalyzer:

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2020,7 +2020,7 @@ public class mine {
                 // (18,9): error CS1017: Catch clauses cannot follow the general catch clause of a try statement
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.ERR_TooManyCatches, "catch").WithLocation(18, 9),
-                // (18,21): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
+                // (18,21): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(18, 21));
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2020,7 +2020,7 @@ public class mine {
                 // (18,9): error CS1017: Catch clauses cannot follow the general catch clause of a try statement
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.ERR_TooManyCatches, "catch").WithLocation(18, 9),
-                // (18,21): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
+                // (18,21): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(18, 21));
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2020,9 +2020,9 @@ public class mine {
                 // (18,9): error CS1017: Catch clauses cannot follow the general catch clause of a try statement
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.ERR_TooManyCatches, "catch").WithLocation(18, 9),
-                // (18,21): warning CS7095: Filter expression is a constant, consider removing the filter
+                // (18,21): warning CS7095: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) {}
-                Diagnostic(ErrorCode.WRN_FilterIsConstant, "false").WithLocation(18, 21));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(18, 21));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2020,7 +2020,7 @@ public class mine {
                 // (18,9): error CS1017: Catch clauses cannot follow the general catch clause of a try statement
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.ERR_TooManyCatches, "catch").WithLocation(18, 9),
-                // (18,21): warning CS8358: Filter expression is a constant 'false', consider removing the catch clause
+                // (18,21): warning CS8359: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(18, 21));
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2020,7 +2020,7 @@ public class mine {
                 // (18,9): error CS1017: Catch clauses cannot follow the general catch clause of a try statement
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.ERR_TooManyCatches, "catch").WithLocation(18, 9),
-                // (18,21): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
+                // (18,21): warning CS7104: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(18, 21));
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2020,9 +2020,9 @@ public class mine {
                 // (18,9): error CS1017: Catch clauses cannot follow the general catch clause of a try statement
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.ERR_TooManyCatches, "catch").WithLocation(18, 9),
-                // (18,21): warning CS7095: Filter expression is a constant 'false', consider removing the catch clause
+                // (18,21): warning CS7103: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) {}
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(18, 21));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(18, 21));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2022,7 +2022,7 @@ public class mine {
                 Diagnostic(ErrorCode.ERR_TooManyCatches, "catch").WithLocation(18, 9),
                 // (18,21): warning CS7095: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) {}
-                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(18, 21));
+                Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithArguments("false").WithLocation(18, 21));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2020,7 +2020,7 @@ public class mine {
                 // (18,9): error CS1017: Catch clauses cannot follow the general catch clause of a try statement
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.ERR_TooManyCatches, "catch").WithLocation(18, 9),
-                // (18,21): warning CS8355: Filter expression is a constant 'false', consider removing the catch clause
+                // (18,21): warning CS8357: Filter expression is a constant 'false', consider removing the catch clause
                 //         catch when (false) {}
                 Diagnostic(ErrorCode.WRN_FilterIsConstantFalse, "false").WithLocation(18, 21));
         }


### PR DESCRIPTION
**Bugs this fixes:**

#18750 

Replaced WRN_FilterIsConstant warning with three separate warnings with different suggestions. 
* `WRN_FilterIsConstantTrue`: suggest removing the filter
* `WRN_FilterIsConstantFalse`: suggest removing the catch clause
* `WRN_FilterIsConstantRedundantTryCatch`: suggest removing the try-catch block, if the catch filter expression is 'false'/'default' and there is only one catch clause for the try-catch block. 
