### PR TITLE
Warn for self-assignment in deconstruction

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -7,3 +7,5 @@ In C# 7, the compiler accepted a pattern of the form `dynamic identifier`, e.g. 
 - https://github.com/dotnet/roslyn/issues/17674 In C# 7, the compiler accepted an assignment statement of the form `_ = M();` where M is a `void` method. The compiler now rejects that.
 
 - https://github.com/dotnet/roslyn/issues/17173 Before C# 7.1, `csc` would accept leading zeroes in the `/langversion` option. Now it should reject it. Example: `csc.exe source.cs /langversion:07`.
+
+- https://github.com/dotnet/roslyn/issues/16870 In C# 7.0 and before C# 7.1, the compiler accepted self-assignments in deconstruction-assignment. The compiler now produces a warning for that. For instance, in `(x, y) = (x, 2);`.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     /// <summary>
     /// This portion of the binder converts deconstruction-assignment syntax (AssignmentExpressionSyntax nodes with the left
-    /// being a tuple expression or declaration expression) into a BoundAssignmentOperator (or bad node).
-    /// The BoundAssignmentOperator will have:
+    /// being a tuple expression or declaration expression) into a BoundDeconstructionAssignmentOperator (or bad node).
+    /// The BoundDeconstructionAssignmentOperator will have:
     /// - a BoundTupleLiteral as its Left,
     /// - a BoundConversion as its Right, holding:
     ///     - a tree of Conversion objects with Kind=Deconstruction, information about a Deconstruct method (optional) and

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -112,9 +112,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
+        {
+            if (!node.HasAnyErrors)
+            {
+                CheckForDeconstructionAssignmentToSelf((BoundTupleLiteral)node.Left, node.Right);
+            }
+
+            return base.VisitDeconstructionAssignmentOperator(node);
+        }
+
         public override BoundNode VisitAssignmentOperator(BoundAssignmentOperator node)
         {
             CheckForAssignmentToSelf(node);
+
             if (_inExpressionLambda && node.Left.Kind != BoundKind.ObjectInitializerMember && node.Left.Kind != BoundKind.DynamicObjectInitializerMember)
             {
                 Error(ErrorCode.ERR_ExpressionTreeContainsAssignment, node);

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -863,7 +864,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             while (right.Kind == BoundKind.Conversion)
             {
-                right = ((BoundConversion)right).Operand;
+
+                var conversion = (BoundConversion)right;
+                switch(conversion.ConversionKind)
+                {
+                    case ConversionKind.Deconstruction:
+                    case ConversionKind.ImplicitTupleLiteral:
+                    case ConversionKind.Identity:
+                        right = conversion.Operand;
+                        break;
+                    case var c:
+                        throw ExceptionUtilities.UnexpectedValue(c);
+                }
             }
 
             if (right.Kind != BoundKind.ConvertedTupleLiteral && right.Kind != BoundKind.TupleLiteral)

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
@@ -866,12 +866,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 right = ((BoundConversion)right).Operand;
             }
 
-            if (right.Kind != BoundKind.ConvertedTupleLiteral)
+            if (right.Kind != BoundKind.ConvertedTupleLiteral && right.Kind != BoundKind.TupleLiteral)
             {
                 return;
             }
 
-            var rightTuple = (BoundConvertedTupleLiteral)right;
+            var rightTuple = (BoundTupleExpression)right;
             var leftArguments = leftTuple.Arguments;
             int length = leftArguments.Length;
             Debug.Assert(length == rightTuple.Arguments.Length);

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
@@ -864,7 +864,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             while (right.Kind == BoundKind.Conversion)
             {
-
                 var conversion = (BoundConversion)right;
                 switch(conversion.ConversionKind)
                 {
@@ -873,8 +872,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case ConversionKind.Identity:
                         right = conversion.Operand;
                         break;
-                    case var c:
-                        throw ExceptionUtilities.UnexpectedValue(c);
+                    default:
+                        return;
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6682,7 +6682,7 @@ class C
     void M()
     {
         object z = 3;
-        (x, (y, z)) = (y, x);
+        (x, (y, z)) = (x, y);
     }
 }
 static class Extensions
@@ -6695,7 +6695,11 @@ static class Extensions
 }";
 
             var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (9,10): warning CS1717: Assignment made to same variable; did you mean to assign something else?
+                //         (x, (y, z)) = (x, y);
+                Diagnostic(ErrorCode.WRN_AssignmentToSelf, "x").WithLocation(9, 10)
+                );
         }
 
         [Fact, WorkItem(17756, "https://github.com/dotnet/roslyn/issues/17756")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -6694,9 +6694,34 @@ class C
 
             var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
-                // (9,14): warning CS1717: Assignment made to same variable; did you mean to assign something else?
+                // (14,14): warning CS1717: Assignment made to same variable; did you mean to assign something else?
                 //         (_, (x, y)) = (1, (x, b));
-                Diagnostic(ErrorCode.WRN_AssignmentToSelf, "x").WithLocation(9, 14)
+                Diagnostic(ErrorCode.WRN_AssignmentToSelf, "x").WithLocation(14, 14)
+                );
+        }
+
+        [Fact]
+        public void DeconstructionWarnsForSelfAssignment_WithExplicitTupleConversion()
+        {
+            var source =
+@"
+class C
+{
+    int y = 2;
+    byte b = 3;
+    void M()
+    {
+        // The conversions on the right-hand-side:
+        // - a deconstruction conversion on the entire right-hand-side
+        // - an identity conversion as its operand
+        // - an explicit tuple literal conversion as its operand
+        (y, _) = ((int, int))(y, b);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib45(source, references: s_valueTupleRefs, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(
                 );
         }
 


### PR DESCRIPTION
**Customer scenario**
Give a warning for likely code error in `(x, y) = (x, 1);`.
Although we allowed it in C# 7.0 deconstructions, LDM and compat council approved introducing this warning in C# 7.1.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/16870

**Risk**
**Performance impact**
Low. In the diagnostics pass, where self-assignment was already checked for simple assignments (`x=x;`), we now also drill into deconstructions and perform a similar check.

**Is this a regression from a previous update?**
No, but this is introducing a compat break (new warning) for likely bad code.
The compat council approved taking this compat break for dev15.3 mostly for two reasons: (1) the code very likely does not reflect the user intent, (2) the window of time since C# 7.0 shipped is relatively small (that minimizes the number of affected customers).

**Root cause analysis:**
We missed this scenario in language and compiler design for deconstructions.

**How was the bug found?**
This warning was suggested by @alrz (thanks!)

@dotnet/roslyn-compiler for review.