### PR TITLE
[Analyzer] Improve performance of SimplifyTypeNamesDiagnosticAnalyzer

### DIFF
--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -35,7 +35,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            foreach (var node in context.Node.Ancestors(ascendOutOfTrivia: false)) {
+            foreach (var node in context.Node.Ancestors(ascendOutOfTrivia: false))
+            {
                 // Bail out early because we have already simplified an ancestor of this node (except in the QualifiedCref case).
                 // We need to keep going in case this node is under a QualifiedCref because it is possible to have multiple simplifications within the same QualifiedCref.
                 // For example, consider <see cref="A.M(Nullable{int})"/>. The 'A.M(Nullable{int})' here is represented by a single QualifiedCref node in the syntax tree.
@@ -43,7 +44,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
                 // to 'int?' in the GenericName for the 'Nullable{T}' that is nested inside this QualifiedCref. We need to keep going so that the latter simplification can be
                 // made available.
                 if (!node.IsKind(SyntaxKind.QualifiedCref) && s_kindsOfInterest.Contains(node.Kind()))
+                {
                     return;
+                }
             }
 
             Diagnostic diagnostic;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -35,15 +35,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            if (context.Node.Ancestors(ascendOutOfTrivia: false).Any(n => !n.IsKind(SyntaxKind.QualifiedCref) && s_kindsOfInterest.Contains(n.Kind())))
-            {
+            foreach (var node in context.Node.Ancestors(ascendOutOfTrivia: false)) {
                 // Bail out early because we have already simplified an ancestor of this node (except in the QualifiedCref case).
                 // We need to keep going in case this node is under a QualifiedCref because it is possible to have multiple simplifications within the same QualifiedCref.
                 // For example, consider <see cref="A.M(Nullable{int})"/>. The 'A.M(Nullable{int})' here is represented by a single QualifiedCref node in the syntax tree.
                 // It is possible to have a simplification to remove the 'A.' qualification for the QualifiedCref itself as well as another simplification to change 'Nullable{int}'
                 // to 'int?' in the GenericName for the 'Nullable{T}' that is nested inside this QualifiedCref. We need to keep going so that the latter simplification can be
                 // made available.
-                return;
+                if (!node.IsKind(SyntaxKind.QualifiedCref) && s_kindsOfInterest.Contains(node.Kind()))
+                    return;
             }
 
             Diagnostic diagnostic;


### PR DESCRIPTION
This avoids creating lambda captures for the analyzer.

**Bugs this fixes:**

None.

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

No risk, just a refactor.

**Performance impact**

Improves performance by not creating a lambda capture.

**Is this a regression from a previous update?**

**Root cause analysis:**

Probably has been there forever.

**How was the bug found?**

Caught via profiling.