### PR TITLE
NullReferenceException in CheckFeatureAvailability which Discard and SpeculativeSemanticModel

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1223,7 +1223,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool isDiscard = containingDeconstruction != null || IsOutVarDiscardIdentifier(node);
             if (isDiscard)
             {
-                CheckFeatureAvailability(node.Location, MessageID.IDS_FeatureTuples, diagnostics);
+                CheckFeatureAvailability(node, MessageID.IDS_FeatureTuples, diagnostics);
             }
 
             return isDiscard;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1350,7 +1350,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression BindNameofOperatorInternal(InvocationExpressionSyntax node, DiagnosticBag diagnostics)
         {
-            CheckFeatureAvailability(node.GetLocation(), MessageID.IDS_FeatureNameof, diagnostics);
+            CheckFeatureAvailability(node, MessageID.IDS_FeatureNameof, diagnostics);
             var argument = node.ArgumentList.Arguments[0].Expression;
             string name = "";
             // We relax the instance-vs-static requirement for top-level member access expressions by creating a NameofBinder binder.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -189,8 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (isVar)
                 {
-                    // GetLocation() so that it also works in speculative contexts.
-                    CheckFeatureAvailability(syntax.GetLocation(), MessageID.IDS_FeatureImplicitLocal, diagnostics);
+                    CheckFeatureAvailability(syntax, MessageID.IDS_FeatureImplicitLocal, diagnostics);
                 }
 
                 return symbol;
@@ -2067,22 +2066,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal static void CheckFeatureAvailability(Location location, MessageID feature, DiagnosticBag diagnostics)
+        internal static void CheckFeatureAvailability(SyntaxNode syntax, MessageID feature, DiagnosticBag diagnostics, Location locationOpt = null)
         {
-            var options = (CSharpParseOptions)location.SourceTree.Options;
+            var options = (CSharpParseOptions)syntax.SyntaxTree.Options;
             if (options.IsFeatureEnabled(feature))
             {
                 return;
             }
 
+            var location = locationOpt ?? syntax.GetLocation();
             string requiredFeature = feature.RequiredFeature();
             if (requiredFeature != null)
             {
-                if (!options.IsFeatureEnabled(feature))
-                {
-                    diagnostics.Add(ErrorCode.ERR_FeatureIsExperimental, location, feature.Localize(), requiredFeature);
-                }
-
+                diagnostics.Add(ErrorCode.ERR_FeatureIsExperimental, location, feature.Localize(), requiredFeature);
                 return;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -438,8 +438,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // time, so it doesn't really matter.
                     if (switchGoverningType.SpecialType == SpecialType.System_Boolean)
                     {
-                        // GetLocation() so that it also works in speculative contexts.
-                        CheckFeatureAvailability(node.GetLocation(), MessageID.IDS_FeatureSwitchOnBool, diagnostics);
+                        CheckFeatureAvailability(node, MessageID.IDS_FeatureSwitchOnBool, diagnostics);
                     }
 
                     return switchExpression;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -183,10 +183,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (notRegularProperty)
                 {
-                    Binder.CheckFeatureAvailability(location,
-                                                    isReadOnly ? MessageID.IDS_FeatureReadonlyAutoImplementedProperties :
-                                                                 MessageID.IDS_FeatureAutoImplementedProperties,
-                                                    diagnostics);
+                    Binder.CheckFeatureAvailability(
+                        syntax,
+                        isReadOnly ? MessageID.IDS_FeatureReadonlyAutoImplementedProperties : MessageID.IDS_FeatureAutoImplementedProperties,
+                        diagnostics,
+                        location);
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -31456,6 +31456,37 @@ class C
             var symbol = (ILocalSymbol)model.GetDeclaredSymbol(decl.Designation);
             Assert.Equal("System.Int32", symbol.Type.ToTestDisplayString());
         }
+
+        [Fact]
+        [WorkItem(388744, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=388744")]
+        public void SpeculativeSemanticModelWithOutDiscard()
+        {
+            var source =
+@"class C
+{
+    static void F()
+    {
+        C.G(out _);
+    }
+    static void G(out object o)
+    {
+        o = null;
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(source);
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var identifierBefore = GetReferences(tree, "G").Single();
+            Assert.Equal(tree, identifierBefore.Location.SourceTree);
+            var statementBefore = identifierBefore.Ancestors().OfType<StatementSyntax>().First();
+            var statementAfter = SyntaxFactory.ParseStatement(@"G(out _);");
+            bool success = model.TryGetSpeculativeSemanticModel(statementBefore.SpanStart, statementAfter, out model);
+            Assert.True(success);
+            var identifierAfter = statementAfter.DescendantNodes().OfType<IdentifierNameSyntax>().Single(id => id.Identifier.ValueText == "G");
+            Assert.Null(identifierAfter.Location.SourceTree);
+            var info = model.GetSymbolInfo(identifierAfter);
+            Assert.Equal("void C.G(out System.Object o)", info.Symbol.ToTestDisplayString());
+        }
     }
 
     internal static class OutVarTestsExtensions

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.SimplifyTypeNames;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -3763,6 +3764,66 @@ class Program
                 diagnosticCount: 1,
                 diagnosticId: IDEDiagnosticIds.RemoveQualificationDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Warning);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [WorkItem(388744, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=388744")]
+        public async Task SimplifyTypeNameWithOutDiscard()
+        {
+            await TestAsync(
+@"class C
+{
+    static void F()
+    {
+        [|C.G|](out _);
+    }
+    static void G(out object o)
+    {
+        o = null;
+    }
+}",
+@"class C
+{
+    static void F()
+    {
+        G(out _);
+    }
+    static void G(out object o)
+    {
+        o = null;
+    }
+}",
+                parseOptions: CSharpParseOptions.Default);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)]
+        [WorkItem(388744, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=388744")]
+        public async Task SimplifyTypeNameWithOutDiscard_FeatureDisabled()
+        {
+            await TestAsync(
+@"class C
+{
+    static void F()
+    {
+        [|C.G|](out _);
+    }
+    static void G(out object o)
+    {
+        o = null;
+    }
+}",
+@"class C
+{
+    static void F()
+    {
+        G(out _);
+    }
+    static void G(out object o)
+    {
+        o = null;
+    }
+}",
+                parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6));
         }
 
         private async Task TestWithPredefinedTypeOptionsAsync(string code, string expected, int index = 0)


### PR DESCRIPTION
This is cherry-picking https://github.com/dotnet/roslyn/pull/17544 to the dev15.2 branch.

Conflicts:
	src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs

**Customer scenario**
Rename a local `_old` to `_new`. When you type the `_` for `_new`, VS will crash.

**Bugs this fixes:**
Fixes VSO #388744 (Watson, will be submitted for shiproom approval for dev15.2)
Fixes GitHub #17229 (VS crash)
Fixes GitHub #18117 (analyzer crash)

**Risk**
**Performance impact**
Low. 
The discard logic is conditional on the feature being enabled (ie you're using langver > 7.0), but the check for feature availability was using a `Location` to get a syntax tree to get the current options. But in speculative analysis scenario, a `Location` will have no syntax tree attached. 
The code was modified to directly pass in a `SyntaxNode` to that method instead. A `SyntaxNode` always belongs to a syntax tree and therefore always has options.

**Is this a regression from a previous update?**
This is a new problem, introduced by the discard feature in C# 7.0.

**Root cause analysis:**
Although I did an IDE test pass, I did not catch this issue. I'm not sure why. The Rename use case is in the checklist, I must have tested renaming `_` to `name`, but not the reverse path.

**How was the bug found?**
Watson crash and multiple user reports.