### PR TITLE
Repair an InvalidCastException caused by unnecessarily tight coupling.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(this.IsDefinition);
             Debug.Assert(ReferenceEquals(newOwner.OriginalDefinition, this.ContainingSymbol.OriginalDefinition));
-            return (newOwner == this.ContainingSymbol) ? this : new SubstitutedMethodSymbol((SubstitutedNamedTypeSymbol)newOwner, this);
+            return (newOwner == this.ContainingSymbol) ? this : new SubstitutedMethodSymbol(newOwner, this);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -38,9 +38,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private int _hashCode; // computed on demand
 
-        internal SubstitutedMethodSymbol(SubstitutedNamedTypeSymbol containingSymbol, MethodSymbol originalDefinition)
+        internal SubstitutedMethodSymbol(NamedTypeSymbol containingSymbol, MethodSymbol originalDefinition)
             : this(containingSymbol, containingSymbol.TypeSubstitution, originalDefinition, constructedFrom: null)
         {
+            Debug.Assert(containingSymbol is SubstitutedNamedTypeSymbol || containingSymbol is SubstitutedErrorTypeSymbol);
         }
 
         protected SubstitutedMethodSymbol(NamedTypeSymbol containingSymbol, TypeMap map, MethodSymbol originalDefinition, MethodSymbol constructedFrom)

--- a/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SubstitutedMethodSymbol.cs
@@ -42,6 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             : this(containingSymbol, containingSymbol.TypeSubstitution, originalDefinition, constructedFrom: null)
         {
             Debug.Assert(containingSymbol is SubstitutedNamedTypeSymbol || containingSymbol is SubstitutedErrorTypeSymbol);
+            Debug.Assert(originalDefinition.ContainingType == containingSymbol.OriginalDefinition);
         }
 
         protected SubstitutedMethodSymbol(NamedTypeSymbol containingSymbol, TypeMap map, MethodSymbol originalDefinition, MethodSymbol constructedFrom)

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Attributes\AttributeTests_Tuples.cs" />
     <Compile Include="Attributes\AttributeTests_WellKnownAttributes.cs" />
     <Compile Include="CodeGen\CodeGenCapturing.cs" />
+    <Compile Include="CodeGen\PatternTests.cs" />
     <Compile Include="Emit\BinaryCompatibility.cs" />
     <Compile Include="Emit\DesktopStrongNameProviderTests.cs" />
     <Compile Include="Attributes\InternalsVisibleToAndStrongNameTests.cs" />

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class PatternTests : EmitMetadataTestBase
     {
         [Fact, WorkItem(18811, "https://github.com/dotnet/roslyn/issues/18811")]
-        public void MissingNullable()
+        public void MissingNullable_01()
         {
             var source = @"namespace System {
     public class Object { }
@@ -41,6 +41,35 @@ static class C {
                 // (9,48): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
                 //     public static bool M() => ((object)123) is int i;
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(9, 48)
+                );
+        }
+
+        [Fact, WorkItem(18811, "https://github.com/dotnet/roslyn/issues/18811")]
+        public void MissingNullable_02()
+        {
+            var source = @"namespace System {
+    public class Object { }
+    public abstract class ValueType { }
+    public struct Void { }
+    public struct Boolean { }
+    public struct Int32 { }
+    public struct Nullable<T> where T : struct { }
+}
+static class C {
+    public static bool M() => ((object)123) is int i;
+}
+";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.GetDiagnostics().Verify();
+            compilation.GetEmitDiagnostics().Verify(
+                // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
+                Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion),
+                // (10,48): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //     public static bool M() => ((object)123) is int i;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(10, 48),
+                // (10,48): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
+                //     public static bool M() => ((object)123) is int i;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(10, 48)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    public class PatternTests : EmitMetadataTestBase
+    {
+        [Fact, WorkItem(18811, "https://github.com/dotnet/roslyn/issues/18811")]
+        public void MissingNullable()
+        {
+            var source = @"namespace System {
+    public class Object { }
+    public abstract class ValueType { }
+    public struct Void { }
+    public struct Boolean { }
+    public struct Int32 { }
+}
+static class C {
+    public static bool M() => ((object)123) is int i;
+}
+";
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseDll);
+            compilation.GetDiagnostics().Verify();
+            compilation.GetEmitDiagnostics().Verify(
+                // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
+                Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1),
+                // (9,48): error CS0518: Predefined type 'System.Nullable`1' is not defined or imported
+                //     public static bool M() => ((object)123) is int i;
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "int i").WithArguments("System.Nullable`1").WithLocation(9, 48),
+                // (9,48): error CS0656: Missing compiler required member 'System.Nullable`1.GetValueOrDefault'
+                //     public static bool M() => ((object)123) is int i;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "GetValueOrDefault").WithLocation(9, 48),
+                // (9,48): error CS0656: Missing compiler required member 'System.Nullable`1.get_HasValue'
+                //     public static bool M() => ((object)123) is int i;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "int i").WithArguments("System.Nullable`1", "get_HasValue").WithLocation(9, 48)
+                );
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**

Use pattern-matching when compiling (or compiling against) a core library that lacks Nullable`1. Compiler crashes.

**Bugs this fixes:**

Fixes #18811

**Workarounds, if any**

Don't do that.

**Risk**

Tiny. The bug was in error recovery code.

**Performance impact**

None expected.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

The improper tight coupling (depending on particular implementation types) bug has been latent, undetected, for years. We just found a symptom.

**How was the bug found?**

Customer reported.
