### PR TITLE
Mark compiler scripts executable on non-Windows systems

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.NETCore.Compilers.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" InitialTargets="MakeCompilerScriptsExecutable" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Always use the local build task, even if we just shell out to an exe in case there are
        new properties in the local build task. -->
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"
@@ -23,4 +23,11 @@
     <VbcToolExe Condition="'$(OS)' == 'Windows_NT'">RunVbc.cmd</VbcToolExe>
     <VbcToolExe Condition="'$(OS)' != 'Windows_NT'">RunVbc</VbcToolExe>
   </PropertyGroup>
+
+  <!-- If packaged on Windows, the RunCsc and RunVbc scripts may not be marked
+       executable. If we're not running on Windows, mark them as such, just in case -->
+  <Target Name="MakeCompilerScriptsExecutable"
+          Condition="'$(BuildingProject)' == 'true' AND '$(OS)' != 'Windows_NT'">
+    <Exec Command="chmod +x &quot;$(CscToolPath)/$(CscToolExe)&quot; &quot;$(VbcToolPath)/$(VbcToolExe)&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
One more change needed to build on Linux