### PR TITLE
Add a language service to find entry points that can be accessed from the CPS project system.

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpVisualStudio.csproj
+++ b/src/VisualStudio/CSharp/Impl/CSharpVisualStudio.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Options\NamingStylesOptionPage.cs" />
     <Compile Include="Options\AdvancedOptionPageStrings.cs" />
     <Compile Include="Options\IntelliSenseOptionPageStrings.cs" />
+    <Compile Include="ProjectSystemShim\CSharpEntryPointFinderService.cs" />
     <Compile Include="Venus\CSharpAdditionalFormattingRuleLanguageService.cs" />
     <Compile Include="CSharpPackage.cs" />
     <Compile Include="CSharpVSResources.Designer.cs">

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpEntryPointFinderService.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpEntryPointFinderService.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+
+namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
+{
+    [ExportLanguageService(typeof(IEntryPointFinderService), LanguageNames.CSharp), Shared]
+    internal class CSharpEntryPointFinderService : IEntryPointFinderService
+    {
+        public IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol, bool findFormsOnly)
+        {
+            return EntryPointFinder.FindEntryPoints(symbol);
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IEntryPointFinderService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IEntryPointFinderService.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+{
+    internal interface IEntryPointFinderService : ILanguageService
+    {
+        /// <summary>
+        /// Finds the types that contain entry points like the Main method in a give namespace.
+        /// </summary>
+        /// <param name="symbol">The namespace to search.</param>
+        /// <param name="findFormsOnly">Restrict the search to only Windows Forms classes. Note that this is only implemented for VisualBasic</param>
+        IEnumerable<INamedTypeSymbol> FindEntryPoints(INamespaceSymbol symbol, bool findFormsOnly);
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Implementation\Preview\ReferenceChange.cs" />
     <Compile Include="Implementation\ProjectSystem\CPS\ICodeModelFactory.cs" />
     <Compile Include="Implementation\ProjectSystem\IDeferredProjectWorkspaceService.cs" />
+    <Compile Include="Implementation\ProjectSystem\IEntryPointFinderService.cs" />
     <Compile Include="Implementation\ProjectSystem\Legacy\AbstractLegacyProject_ICompilerOptionsHostObject.cs" />
     <Compile Include="Implementation\ProjectSystem\Legacy\AbstractLegacyProject_IIntellisenseBuildTarget.cs" />
     <Compile Include="Implementation\ProjectSystem\CPS\IWorkspaceProjectContextFactory.cs" />

--- a/src/VisualStudio/VisualBasic/Impl/BasicVisualStudio.vbproj
+++ b/src/VisualStudio/VisualBasic/Impl/BasicVisualStudio.vbproj
@@ -134,6 +134,7 @@
     <Compile Include="Options\StyleViewModel.vb" />
     <Compile Include="Progression\VisualBasicGraphProvider.vb" />
     <Compile Include="Progression\VisualBasicProgressionLanguageService.vb" />
+    <Compile Include="ProjectSystemShim\VisualBasicEntryPointFinderService.vb" />
     <Compile Include="ProjectSystemShim\VisualBasicProjectOptionsHelper.vb" />
     <Compile Include="ProjectSystemShim\EntryPointFinder.vb" />
     <Compile Include="ProjectSystemShim\Interop\IVbBuildStatusCallback.vb" />

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicEntryPointFinderService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicEntryPointFinderService.vb
@@ -6,7 +6,7 @@ Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
-    <ExportLanguageService(GetType(IEntryPointFinderService), LanguageNames.CSharp), [Shared]>
+    <ExportLanguageService(GetType(IEntryPointFinderService), LanguageNames.VisualBasic), [Shared]>
     Friend Class VisualBasicEntryPointFinderService
         Implements IEntryPointFinderService
 

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicEntryPointFinderService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicEntryPointFinderService.vb
@@ -1,0 +1,17 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+
+Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
+    <ExportLanguageService(GetType(IEntryPointFinderService), LanguageNames.CSharp), [Shared]>
+    Friend Class VisualBasicEntryPointFinderService
+        Implements IEntryPointFinderService
+
+        Public Function FindEntryPoints(symbol As INamespaceSymbol, findFormsOnly As Boolean) As IEnumerable(Of INamedTypeSymbol) Implements IEntryPointFinderService.FindEntryPoints
+            Return EntryPointFinder.FindEntryPoints(symbol, findFormsOnly)
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
**Customer scenario**

For .NET Core Projects, the Startup Object property in the Application property page is not populated. There is a walker in Roslyn to find the entry points that the old project system calls into. There are C#\VB specific implementations but we don't have NuGet packages for those dlls since they have no APIs. This change, therefore, adds a language service that we could get access from the project system to get the language specific implementation.

**Bugs this fixes:**

https://github.com/dotnet/project-system/issues/763

**Workarounds, if any**

None.

**Risk**

Low. Just adds a new service.

**Performance impact**

Low. Just adds a new service.

**Is this a regression from a previous update?**
No

**Root cause analysis:**

Unimplemented.

**How was the bug found?**

Backlog item.

@jasonmalinowski @dotnet/roslyn-ide @dotnet/project-system 
