### PR TITLE
Disabling tests due to flakiness

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListDesktop.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListDesktop.cs
@@ -14,13 +14,13 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.ErrorList)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18996"), Trait(Traits.Feature, Traits.Features.ErrorList)]
         public override void ErrorList()
         {
             base.ErrorList();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.ErrorList)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18996"), Trait(Traits.Feature, Traits.Features.ErrorList)]
         public override void ErrorLevelWarning()
         {
             base.ErrorLevelWarning();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListNetCore.cs
@@ -14,14 +14,14 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.ErrorList)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18996"), Trait(Traits.Feature, Traits.Features.ErrorList)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         public override void ErrorList()
         {
             base.ErrorList();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.ErrorList)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18996"), Trait(Traits.Feature, Traits.Features.ErrorList)]
         [Trait(Traits.Feature, Traits.Features.NetCore)]
         public override void ErrorLevelWarning()
         {


### PR DESCRIPTION
 https://github.com/dotnet/roslyn/issues/18996

Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpErrorListNetCore.ErrorList
Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpErrorListNetCore.ErrorLevelWarning
Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpErrorListDesktop.ErrorList
Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpErrorListDesktop.ErrorLevelWarning

