### PR TITLE
Classify 'var' in patterns as a keyword.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -2290,5 +2290,40 @@ namespace ConsoleApplication1
     }
 }", Class("Debug"));
         }
+
+        [WorkItem(18956, "https://github.com/dotnet/roslyn/issues/18956")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestVarInPattern1()
+        {
+            await TestAsync(
+@"
+class Program
+{
+    void Main(string s)
+    {
+        if (s is var v)
+        {
+        }
+    }
+}", Keyword("var"));
+        }
+
+        [WorkItem(18956, "https://github.com/dotnet/roslyn/issues/18956")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TestVarInPattern2()
+        {
+            await TestAsync(
+@"
+class Program
+{
+    void Main(string s)
+    {
+        switch (s)
+        {
+            case var v:
+        }
+    }
+}", Keyword("var"));
+        }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
@@ -49,7 +49,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 _owner = owner;
                 _textView = textView;
                 _textView.Closed += OnTextViewClosed;
-
                 _subjectBuffer = textBuffer;
                 _registration = Workspace.GetWorkspaceRegistration(textBuffer.AsTextContainer());
 

--- a/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
@@ -180,8 +180,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
         {
             return
                 name.CheckParent<RefTypeSyntax>(v => v.Type == name) ||
-                name.CheckParent<VariableDeclarationSyntax>(v => v.Type == name) ||
                 name.CheckParent<ForEachStatementSyntax>(f => f.Type == name) ||
+                name.CheckParent<DeclarationPatternSyntax>(v => v.Type == name) ||
+                name.CheckParent<VariableDeclarationSyntax>(v => v.Type == name) ||
                 name.CheckParent<DeclarationExpressionSyntax>(f => f.Type == name);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/18956