### PR TITLE
Fix logic that was making us unify different local functions if their signatures matched.

### DIFF
--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -191,6 +191,7 @@
     <Compile Include="Diagnostics\UseAutoProperty\UseAutoPropertyTests.vb" />
     <Compile Include="Expansion\LambdaParameterExpansionTests.vb" />
     <Compile Include="FindReferences\FindReferencesTests.Literals.vb" />
+    <Compile Include="FindReferences\FindReferencesTests.LocalFunctions.vb" />
     <Compile Include="FindReferences\FindReferencesTests.Tuples.vb" />
     <Compile Include="GoToImplementation\GoToImplementationTests.vb" />
     <Compile Include="IntelliSense\CompletionServiceTests.vb" />

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LocalFunctions.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LocalFunctions.vb
@@ -1,0 +1,196 @@
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
+    Partial Public Class FindReferencesTests
+        <WorkItem(18761, "https://github.com/dotnet/roslyn/issues/18761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestLocalFunction1() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Test
+{
+    void Main()
+    {
+        {
+            int x = 1;
+            [|$$Print|](x);
+            void {|Definition:Print|}(int y) { }
+        }
+
+        {
+            int z = 1;
+            Print(z);
+            void Print(int y) { }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(18761, "https://github.com/dotnet/roslyn/issues/18761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestLocalFunction2() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Test
+{
+    void Main()
+    {
+        {
+            int x = 1;
+            [|Print|](x);
+            void {|Definition:$$Print|}(int y) { }
+        }
+
+        {
+            int z = 1;
+            Print(z);
+            void Print(int y) { }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(18761, "https://github.com/dotnet/roslyn/issues/18761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestLocalFunction3() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Test
+{
+    void Main()
+    {
+        {
+            int x = 1;
+            Print(x);
+            void Print(int y) { }
+        }
+
+        {
+            int z = 1;
+            [|$$Print|](z);
+            void {|Definition:Print|}(int y) { }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(18761, "https://github.com/dotnet/roslyn/issues/18761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestLocalFunction4() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Test
+{
+    void Main()
+    {
+        {
+            int x = 1;
+            Print(x);
+            void Print(int y) { }
+        }
+
+        {
+            int z = 1;
+            [|Print|](z);
+            void {|Definition:$$Print|}(int y) { }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(18761, "https://github.com/dotnet/roslyn/issues/18761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestGenericLocalFunction1() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Test
+{
+    void Main()
+    {
+        int x = 1;
+        [|Print|](x);
+        [|Print|]&lt;int&gt;(x);
+        void {|Definition:$$Print|}&lt;T&gt;(T y) { }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(18761, "https://github.com/dotnet/roslyn/issues/18761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestGenericLocalFunction2() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Test
+{
+    void Main()
+    {
+        int x = 1;
+        [|Print|](x);
+        [|$$Print|]&lt;int&gt;(x);
+        void {|Definition:Print|}&lt;T&gt;(T y) { }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(18761, "https://github.com/dotnet/roslyn/issues/18761")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestGenericLocalFunction3() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+class Test
+{
+    void Main()
+    {
+        int x = 1;
+        [|$$Print|](x);
+        [|Print|]&lt;int&gt;(x);
+        void {|Definition:Print|}&lt;T&gt;(T y) { }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+    End Class
+End Namespace

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -211,8 +211,11 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                 }
                 else
                 {
-                    if (x.MethodKind == MethodKind.AnonymousFunction)
+                    if (x.MethodKind == MethodKind.AnonymousFunction ||
+                        x.MethodKind == MethodKind.LocalFunction)
                     {
+                        // Treat local and anonymous functions just like we do ILocalSymbols.  
+                        // They're only equivalent if they have the same location.
                         return HaveSameLocation(x, y);
                     }
 
@@ -351,7 +354,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                         return false;
                     }
 
-                    for(int i = 0; i < xElements.Length; i++)
+                    for (int i = 0; i < xElements.Length; i++)
                     {
                         if (!AreEquivalent(xElements[i].Type, yElements[i].Type, equivalentTypesWithDifferingAssemblies))
                         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/18761
