### PR TITLE
Guard access to shared resource WordSimilarityChecker.s_pool

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SpellChecker.cs
@@ -140,7 +140,10 @@ namespace Roslyn.Utilities
             _source = null;
             _editDistance = null;
             _lastAreSimilarResult = default(CacheResult);
-            s_pool.Push(this);
+            lock (s_poolGate)
+            {
+                s_pool.Push(this);
+            }
         }
 
         public static bool AreSimilar(string originalText, string candidateText)


### PR DESCRIPTION
## Ask Mode

**Customer scenario**

Repeatedly use Navigate To. Visual Studio will eventually crash.

**Bugs this fixes:**

N/A

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

Essentially none. If the access was concurrent previously then it was also erroneous.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Race condition in access to a shared variable. Should have been caught during code review but we missed it.

**How was the bug found?**

Found while manual testing.
