### PR TITLE
Add workaround for AsyncSemaphore disposal problems

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -48,7 +48,7 @@ namespace Roslyn.Test.Utilities.Remote
         {
             _inprocServices = inprocServices;
 
-            _rpc = new JsonRpc(stream, stream, target: this);
+            _rpc = new JsonRpc(new JsonRpcMessageHandler(stream, stream), target: this);
             _rpc.JsonSerializer.Converters.Add(AggregateJsonConverter.Instance);
 
             // handle disconnected situation

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             var target = useThisAsCallback ? this : callbackTarget;
             _cancellationToken = cancellationToken;
 
-            _rpc = new JsonRpc(stream, stream, target);
+            _rpc = new JsonRpc(new JsonRpcMessageHandler(stream, stream), target);
             _rpc.JsonSerializer.Converters.Add(AggregateJsonConverter.Instance);
 
             _rpc.Disconnected += OnDisconnected;

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcMessageHandler.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcMessageHandler.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
+using StreamJsonRpc;
+
+namespace Microsoft.VisualStudio.LanguageServices.Remote
+{
+    // This is a workaround for a limitation in vs-threading.
+    // https://github.com/dotnet/roslyn/issues/19042
+    internal class JsonRpcMessageHandler : HeaderDelimitedMessageHandler
+    {
+        public JsonRpcMessageHandler(Stream sendingStream, Stream receivingStream)
+            : base(sendingStream, receivingStream)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // Do not call base.Dispose. We do not want the AsyncSemaphore instances to be disposed due to a race
+            // condition.
+
+            if (disposing)
+            {
+                ReceivingStream?.Dispose();
+                SendingStream?.Dispose();
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             _hostGroup = hostGroup;
             _timeout = TimeSpan.FromMilliseconds(workspace.Options.GetOption(RemoteHostOptions.RequestServiceTimeoutInMS));
 
-            _rpc = new JsonRpc(stream, stream, target: this);
+            _rpc = new JsonRpc(new JsonRpcMessageHandler(stream, stream), target: this);
             _rpc.JsonSerializer.Converters.Add(AggregateJsonConverter.Instance);
 
             // handle disconnected situation

--- a/src/VisualStudio/Core/Next/ServicesVisualStudio.Next.csproj
+++ b/src/VisualStudio/Core/Next/ServicesVisualStudio.Next.csproj
@@ -105,6 +105,7 @@
     <Compile Include="FindReferences\ToolTips\LazyToolTip.cs" />
     <Compile Include="ProjectSystem\DeferredProjectWorkspaceService.cs" />
     <Compile Include="Remote\JsonRpcClient.cs" />
+    <Compile Include="Remote\JsonRpcMessageHandler.cs" />
     <Compile Include="Remote\JsonRpcSession.cs" />
     <Compile Include="Remote\RemoteHostClientFactory.cs" />
     <Compile Include="Remote\ServiceHubRemoteHostClient.WorkspaceHost.cs" />

--- a/src/Workspaces/Remote/Razor/RazorServiceHub.csproj
+++ b/src/Workspaces/Remote/Razor/RazorServiceHub.csproj
@@ -44,6 +44,9 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <Compile Include="..\..\..\VisualStudio\Core\Next\Remote\JsonRpcMessageHandler.cs">
+      <Link>Shared\JsonRpcMessageHandler.cs</Link>
+    </Compile>
     <Compile Include="..\ServiceHub\Shared\RoslynJsonConverter.cs">
       <Link>Shared\RoslynJsonConverter.cs</Link>
     </Compile>

--- a/src/Workspaces/Remote/ServiceHub/ServiceHub.csproj
+++ b/src/Workspaces/Remote/ServiceHub/ServiceHub.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\..\..\VisualStudio\Core\Def\Telemetry\VSTelemetryLogger.cs">
       <Link>Telemetry\VSTelemetryLogger.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\VisualStudio\Core\Next\Remote\JsonRpcMessageHandler.cs">
+      <Link>Shared\JsonRpcMessageHandler.cs</Link>
+    </Compile>
     <Compile Include="Services\CodeAnalysisService_CodeLens.cs" />
     <Compile Include="Services\CodeAnalysisService_DesignerAttributes.cs" />
     <Compile Include="Services\CodeAnalysisService_TodoComments.cs" />

--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.VisualStudio.LanguageServices.Remote;
 using Roslyn.Utilities;
 using StreamJsonRpc;
 
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Remote
             // due to this issue - https://github.com/dotnet/roslyn/issues/16900#issuecomment-277378950
             // all sub type must explicitly start JsonRpc once everything is
             // setup
-            Rpc = new JsonRpc(stream, stream, this);
+            Rpc = new JsonRpc(new JsonRpcMessageHandler(stream, stream), this);
             Rpc.JsonSerializer.Converters.Add(AggregateJsonConverter.Instance);
             Rpc.Disconnected += OnRpcDisconnected;
         }


### PR DESCRIPTION
This is a workaround for #18563. See #19042 for a follow-up task to remove
this workaround.

## Ask Mode

**Customer scenario**

Rare but definitely observable crash in OOP scenarios (Navigate To, etc.).

**Bugs this fixes:**

This works around #18563 prior to the proper fix being incorporated from Microsoft/vs-threading#105.

**Workarounds, if any**

None.

**Risk**

Low. This change is intended to be functionally equivalent to Microsoft/vs-threading#105, both before and after that change is incorporated.

**Performance impact**

Aside from a small additional type existing, none.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Failure to strictly adhere to MSDN documentation for a concurrency primitive (`SemaphoreSlim`). This is an exceptionally hard to reproduce race condition bug in a dependency.

**How was the bug found?**

Internal customer reported.
