### PR TITLE
Don't call into sqlite on platforms where we havne't provided support for it yet.

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -96,13 +96,21 @@ namespace Microsoft.CodeAnalysis.SQLite
         {
             // Attempt to load the correct version of e_sqlite.dll.  That way when we call
             // into SQLitePCL.Batteries_V2.Init it will be able to find it.
-            var myFolder = Path.GetDirectoryName(
-                typeof(SQLitePersistentStorage).Assembly.Location);
+            //
+            // Only do this on Windows when we can safely do the LoadLibrary call to this
+            // direct dll.  On other platforms, it is the responsibility of the host to ensure
+            // that the necessary sqlite library has already been loaded such that SQLitePCL.Batteries_V2
+            // will be able to call into it.
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                var myFolder = Path.GetDirectoryName(
+                    typeof(SQLitePersistentStorage).Assembly.Location);
 
-            var is64 = IntPtr.Size == 8;
-            var subfolder = is64 ? "x64" : "x86";
+                var is64 = IntPtr.Size == 8;
+                var subfolder = is64 ? "x64" : "x86";
 
-            LoadLibrary(Path.Combine(myFolder, subfolder, "e_sqlite3.dll"));
+                LoadLibrary(Path.Combine(myFolder, subfolder, "e_sqlite3.dll"));
+            }
 
             // Necessary to initialize SQLitePCL.
             SQLitePCL.Batteries_V2.Init();


### PR DESCRIPTION
This is for clients that want to use Workspaces.Desktop, but which run on non-Windows.  Right now our sqlite work is Windows-only.  I'd like to relax that in the future, but it will have to come in a later milestone.
