### PR TITLE
Use MicrosoftSHA2 cert for signing

### DIFF
--- a/build/config/SignToolData.json
+++ b/build/config/SignToolData.json
@@ -1,7 +1,7 @@
 ﻿{
   "sign": [
     {
-      "certificate": "Microsoft402",
+      "certificate": "MicrosoftSHA2",
       "strongName": "MsSharedLib72",
       "values": [
         "Dlls\\BasicCodeAnalysis\\Microsoft.CodeAnalysis.VisualBasic.dll",


### PR DESCRIPTION
**Customer scenario**

Using SHA2 instead of SHA1 for signing.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/18088

**Workarounds, if any**



**Risk**



**Performance impact**


**Is this a regression from a previous update?**

**Root cause analysis:**



**How was the bug found?**

