### PR TITLE
C# symbol matcher changes and test to support tuples and ref

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -704,6 +704,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 other = SubstituteTypeParameters(other);
 
                 return _comparer.Equals(method.ReturnType, other.ReturnType) &&
+                    method.RefKind.Equals(other.RefKind) &&
                     method.Parameters.SequenceEqual(other.Parameters, AreParametersEqual) &&
                     method.TypeParameters.SequenceEqual(other.TypeParameters, AreTypesEqual);
             }
@@ -757,6 +758,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             {
                 Debug.Assert(StringOrdinalComparer.Equals(property.Name, other.Name));
                 return _comparer.Equals(property.Type, other.Type) &&
+                    property.RefKind.Equals(other.RefKind) &&
                     property.Parameters.SequenceEqual(other.Parameters, AreParametersEqual);
             }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -760,7 +760,6 @@ public struct Vector
             Assert.NotNull(other);
         }
 
-
         [Fact]
         public void TupleDelegate_TypeChange()
         {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/SymbolMatcherTests.cs
@@ -519,5 +519,432 @@ class C
             Assert.Equal("x1", mappedX1.Name);
             Assert.Null(mappedX2);
         }
+
+        [Fact]
+        public void TupleField_TypeChange()
+        {
+            var source0 = @"
+class C
+{  
+    public (int a, int b) x;
+}";
+            var source1 = @"
+class C
+{
+    public (int a, bool b) x;
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<FieldSymbol>("C.x");
+            var other = matcher.MapDefinition(member);
+            // If a type changes within a tuple, we do not expect types to match.
+            Assert.Null(other);
+        }
+
+        [Fact]
+        public void TupleField_NameChange()
+        {
+            var source0 = @"
+class C
+{  
+    public (int a, int b) x;
+}";
+            var source1 = @"
+class C
+{
+    public (int a, int c) x;
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<FieldSymbol>("C.x");
+            var other = matcher.MapDefinition(member);
+            // Types must match because just an element name was changed.
+            Assert.NotNull(other);
+        }
+
+        [Fact]
+        public void TupleMethod_TypeChange()
+        {
+            var source0 = @"
+class C
+{  
+    public (int a, int b) X() { return null };
+}";
+            var source1 = @"
+class C
+{
+    public (int a, bool b) X() { return null };
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<MethodSymbol>("C.X");
+            var other = matcher.MapDefinition(member);
+            // If a type changes within a tuple, we do not expect types to match.
+            Assert.Null(other);
+        }
+
+        [Fact]
+        public void TupleMethod_NameChange()
+        {
+            var source0 = @"
+class C
+{  
+    public (int a, int b) X() { return null };
+}";
+            var source1 = @"
+class C
+{
+    public (int a, int c) X() { return null };
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<MethodSymbol>("C.X");
+            var other = matcher.MapDefinition(member);
+            // Types must match because just an element name was changed.
+            Assert.NotNull(other);
+        }
+
+        [Fact]
+        public void TupleProperty_TypeChange()
+        {
+            var source0 = @"
+class C
+{  
+    public (int a, int b) X { get { return null; } };
+}";
+            var source1 = @"
+class C
+{
+    public (int a, bool b) X { get { return null; } };
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<PropertySymbol>("C.X");
+            var other = matcher.MapDefinition(member);
+            // If a type changes within a tuple, we do not expect types to match.
+            Assert.Null(other);
+        }
+
+        [Fact]
+        public void TupleProperty_NameChange()
+        {
+            var source0 = @"
+class C
+{  
+    public (int a, int b) X { get { return null; } };
+}";
+            var source1 = @"
+class C
+{
+    public (int a, int c) X { get { return null; } };
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<PropertySymbol>("C.X");
+            var other = matcher.MapDefinition(member);
+            // Types must match because just an element name was changed.
+            Assert.NotNull(other);
+        }
+
+        [Fact]
+        public void TupleStructField_TypeChange()
+        {
+            var source0 = @"
+public struct Vector
+{
+    public (int x, int y) Coordinates;
+}";
+            var source1 = @"
+public struct Vector
+{
+    public (int x, int y, int z) Coordinates;
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<FieldSymbol>("Vector.Coordinates");
+            var other = matcher.MapDefinition(member);
+            // If a type changes within a tuple, we do not expect types to match.
+            Assert.Null(other);
+        }
+
+        [Fact]
+        public void TupleStructField_NameChange()
+        {
+            var source0 = @"
+public struct Vector
+{
+    public (int x, int y) Coordinates;
+}";
+            var source1 = @"
+public struct Vector
+{
+    public (int x, int z) Coordinates;
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<FieldSymbol>("Vector.Coordinates");
+            var other = matcher.MapDefinition(member);
+            // Types must match because just an element name was changed.
+            Assert.NotNull(other);
+        }
+
+
+        [Fact]
+        public void TupleDelegate_TypeChange()
+        {
+            var source0 = @"
+public class C
+{
+    public delegate (int, int) F();
+}";
+            var source1 = @"
+public struct C
+{
+    public delegate (int, bool) F();
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<SourceNamedTypeSymbol>("C.F");
+            var other = matcher.MapDefinition(member);
+            // Tuple delegate defines a type. We should be able to match old and new types by name.
+            Assert.NotNull(other);
+        }
+
+        [Fact]
+        public void TupleDeletagate_NameChange()
+        {
+            var source0 = @"
+public class C
+{
+    public delegate (int, int) F();
+}";
+            var source1 = @"
+public struct C
+{
+    public delegate (int x, int y) F();
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<SourceNamedTypeSymbol>("C.F");
+            var other = matcher.MapDefinition(member);
+            // Types must match because just an element name was changed.
+            Assert.NotNull(other);
+        }
+
+        [Fact]
+        public void RefMethod_TypeChange()
+        {
+            var source0 = @"
+class C
+{  
+    public ref int GetFirst(int[] numbers, bool[] bools) { return ref numbers[0]; } };
+}";
+            var source1 = @"
+class C
+{
+    public ref bool GetFirst(int[] numbers, bool[] bools) { return ref bools[0]; } };
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<MethodSymbol>("C.GetFirst");
+            var other = matcher.MapDefinition(member);
+            // If a type changes, we do not expect types to match.
+            Assert.Null(other);
+        }
+
+        [Fact]
+        public void RefMethod_RefChange()
+        {
+            var source0 = @"
+class C
+{  
+    public ref bool GetFirst(bool[] bools) { return ref bools[0]; } };
+}";
+            var source1 = @"
+class C
+{
+    public bool GetFirst(bool[] bools) { return bools[0]; } };
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<MethodSymbol>("C.GetFirst");
+            var other = matcher.MapDefinition(member);
+            // If a type changes, we do not expect types to match.
+            Assert.Null(other);
+        }
+
+        [Fact]
+        public void RefProperty_TypeChange()
+        {
+            var source0 = @"
+struct S
+{
+    int[] ints;
+    bool[] bools;
+    public ref int X { get => ref ints[0]; }
+}";
+            var source1 = @"
+struct S
+{
+    int[] ints;
+    bool[] bools;
+    public ref bool X { get => ref bools[0]; }
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<PropertySymbol>("S.X");
+            var other = matcher.MapDefinition(member);
+            // If a type changes, we do not expect types to match.
+            Assert.Null(other);
+        }
+
+        [Fact]
+        public void RefProperty_RefChange()
+        {
+            var source0 = @"
+struct S
+{
+    int[] ints;
+    public ref int X { get => ref ints[0]; }
+}";
+            var source1 = @"
+struct S
+{
+    int[] ints;
+    public int X { get => ints[0]; }
+}";
+            var compilation0 = CreateStandardCompilation(source0, options: TestOptions.DebugDll);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var matcher = new CSharpSymbolMatcher(
+                null,
+                compilation1.SourceAssembly,
+                default(EmitContext),
+                compilation0.SourceAssembly,
+                default(EmitContext),
+                null);
+
+            var member = compilation1.GetMember<PropertySymbol>("S.X");
+            var other = matcher.MapDefinition(member);
+            // If a type changes, we do not expect types to match.
+            Assert.Null(other);
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

Support C# 7.0 features in EnC:
 - tests for tuples  
- fix to support ref

**Bugs this fixes:**

Works towards to #17891

**Workarounds, if any**


**Risk**

Low

**Performance impact**

Low

**Is this a regression from a previous update?**

**Root cause analysis:**


**How was the bug found?**

Planned