### PR TITLE
Disabling some ReferenceHighlighting tests due to flakiness

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReferenceHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReferenceHighlighting.cs
@@ -42,7 +42,7 @@ class {|definition:C|}
             VerifyNone("void");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19059"), Trait(Traits.Feature, Traits.Features.Classification)]
         public void WrittenReference()
         {
             var markup = @"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicReferenceHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicReferenceHighlighting.cs
@@ -23,7 +23,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Basic
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19059"), Trait(Traits.Feature, Traits.Features.Classification)]
         public void Highlighting()
         {
             var markup = @"


### PR DESCRIPTION
The following tests have been failing sporadically recently.

CSharpReferenceHighlighting.WrittenReference
BasicReferenceHighlighting.Highlighting

One example where they both failed is:
https://ci.dot.net/job/dotnet_roslyn/job/master/job/windows_release_vs-integration_prtest/3340/

Tracked by: https://github.com/dotnet/roslyn/issues/19059
