### PR TITLE
Upgrade Roslyn to consume newer Microsoft.Net.RoslynDiagnostics

### DIFF
--- a/build/Rulesets/Roslyn_BuildRules.ruleset
+++ b/build/Rulesets/Roslyn_BuildRules.ruleset
@@ -20,6 +20,7 @@
     <Rule Id="CA1054" Action="None" />
     <Rule Id="CA1055" Action="None" />
     <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1061" Action="None" /> <!-- "do not hide base class methods": currently violations in the compiler -->
     <Rule Id="CA1064" Action="None" />
     <Rule Id="CA1065" Action="None" />
     <Rule Id="CA1066" Action="None" />
@@ -35,9 +36,19 @@
     <Rule Id="CA1720" Action="None" />
     <Rule Id="CA1721" Action="None" />
     <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1801" Action="None" /> <!-- unused parameters: broken due to https://github.com/dotnet/roslyn/issues/8884 -->
+    <Rule Id="CA1802" Action="None" /> <!-- broken due to https://github.com/dotnet/roslyn-analyzers/issues/1175 -->
+    <Rule Id="CA1804" Action="None" /> <!-- broken due to incomplete IOperation support -->
+    <Rule Id="CA1806" Action="None" /> <!-- "do not ignore results": we do this in many places, for example fire-and-forget async or HRESULTs we don't care about -->
+    <Rule Id="CA1812" Action="None" /> <!-- disabled as we create many internal types via reflection-based mechanisms -->
+    <Rule Id="CA1814" Action="None" /> <!-- prefer jagged arrays to multidimensional: a silly piece of advice -->
     <Rule Id="CA1815" Action="None" />
+    <Rule Id="CA1821" Action="None" /> <!-- broken due to https://github.com/dotnet/roslyn-analyzers/issues/1176 -->
+    <Rule Id="CA1823" Action="None" /> <!-- "avoid unused private fields": many issues including https://github.com/dotnet/roslyn-analyzers/issues/933 -->
+    <Rule Id="CA1824" Action="None" /> <!-- mark assemblies with NeutralResourcesLanguageAttribute -->
     <Rule Id="CA2007" Action="Warning" />
     <Rule Id="CA2211" Action="None" />
+    <Rule Id="CA2214" Action="None" /> <!-- do not call overridable methods in constructors: done in various places -->
     <Rule Id="CA2218" Action="None" />
     <Rule Id="CA2222" Action="None" />
     <Rule Id="CA2224" Action="None" />
@@ -45,6 +56,8 @@
     <Rule Id="CA2227" Action="None" />
     <Rule Id="CA2231" Action="None" />
     <Rule Id="CA2234" Action="None" />
+    <Rule Id="CA5350" Action="None" /> <!-- in some cases we must use legacy cryptographic hashes, so disable for now -->
+    <Rule Id="CA5351" Action="None" /> <!-- in some cases we must use legacy cryptographic hashes, so disable for now -->
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
     <Rule Id="RS1001" Action="None" />

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -18,7 +18,7 @@
     <ToolsetCompilerPackageVersion>2.0.1</ToolsetCompilerPackageVersion>
     <VSIXExpInstallerPackageName>RoslynTools.Microsoft.VSIXExpInstaller</VSIXExpInstallerPackageName>
     <VSIXExpInstallerPackageVersion>0.2.1-beta</VSIXExpInstallerPackageVersion>
-    <RoslynDiagnosticsNugetPackageVersion>1.2.0-beta2</RoslynDiagnosticsNugetPackageVersion>
+    <RoslynDiagnosticsNugetPackageVersion>2.0.0-beta1-61628-06</RoslynDiagnosticsNugetPackageVersion>
     <RoslynDiagnosticsPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.RoslynDiagnostics\$(RoslynDiagnosticsNugetPackageVersion)\build\Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
     <RoslynBuildUtilFilePath>$(NuGetPackageRoot)\Roslyn.Build.Util\0.9.4-portable\lib\dotnet\Roslyn.MSBuild.Util.dll</RoslynBuildUtilFilePath>
     <AdditionalFileItemNames>$(AdditionalFileItemNames);PublicAPI</AdditionalFileItemNames>

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -7,7 +7,7 @@
     "Microsoft.NETCore.Platforms": "1.1.0",
     "Microsoft.DiaSymReader.Native": "1.5.0",
     "Microsoft.Net.Compilers": "2.0.1",
-    "Microsoft.Net.RoslynDiagnostics": "1.2.0-beta2",
+    "Microsoft.Net.RoslynDiagnostics": "2.0.0-beta1-61628-06",
     "FakeSign": "0.9.2",
     "xunit": "2.2.0-beta4-build3444",
     "xunit.runner.console": "2.2.0-beta4-build3444",

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -678,12 +678,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                                     await computeTask.ConfigureAwait(false);
                                 }
-                                catch (OperationCanceledException ex)
+                                catch (OperationCanceledException)
                                 {
                                     cancellationToken.ThrowIfCancellationRequested();
                                     if (!cts.IsCancellationRequested)
                                     {
-                                        throw ex;
+                                        throw;
                                     }
 
                                     suspendend = true;


### PR DESCRIPTION
My motivation for doing this is to pick up the new PublicAPI checker
that understands type forwards. In doing so I disabled a bunch of new
warnings that are either broken or not really applicable to Roslyn.
One new warning (don't rethrow exceptions with throw ex;) seemed useful
enough to keep on so I left it on and fixed the one offense in the
codebase.