### PR TITLE
Disable unusably slow diagnostic check in DEBUG builds

### DIFF
--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
                 return;
             }
 
-#if DEBUG
+#if DEBUG && false
             var documentErrorLookup = new HashSet<DocumentId>();
             foreach (var project in workspace.CurrentSolution.Projects)
             {


### PR DESCRIPTION
This change avoids a performance issue that makes DEBUG builds _impossible_ to debug when working on code fix and/or refactoring features.
