### PR TITLE
Don't run CoreClr tests on Microbuild

### DIFF
--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -38,7 +38,7 @@
     <MSBuild Projects="$(RepoRoot)src\NuGet\NuGet.proj" />
     <MSBuild Projects="$(RepoRoot)src\Setup\SetupStep2.proj" Properties="$(SetupStep2Properties);DeployExtension=false" />
 
-    <MSBuild Projects="$(RepoRoot)BuildAndTest.proj" Targets="Test" Condition="'$(SkipTest)' != 'true'" />
+    <MSBuild Projects="$(RepoRoot)BuildAndTest.proj" Targets="Test" Condition="'$(SkipTest)' != 'true'" Properties="SkipCoreClrTests=true" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)..\..\..\build\scripts\check-toolset-insertion.ps1 &quot;$(MSBuildThisFileDirectory)..\..\..&quot; &quot;$(BinariesPath)&quot;" />
     


### PR DESCRIPTION
These tests are still being worked on for reliability.  Should not be in Microbuild. 