### PR TITLE
removed /bugreport from csc /help output (closes #14171)

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4488,7 +4488,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
 
                         - ADVANCED -
  /baseaddress:&lt;address&gt;        Base address for the library to be built
- /bugreport:&lt;file&gt;             Create a 'Bug Report' file
  /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file 
                                checksum stored in PDB. Supported values are:
                                SHA1 (default) or SHA256.

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5154,7 +5154,6 @@
                                   - ADVANCED -
 /baseaddress:&lt;number&gt;             The base address for a library or module 
                                   (hex).
-/bugreport:&lt;file&gt;                 Create bug report file.
 /checksumalgorithm:&lt;alg&gt;          Specify algorithm for calculating source file 
                                   checksum stored in PDB. Supported values are:
                                   SHA1 (default) or SHA256.


### PR DESCRIPTION
**Customer scenario**

Removes unsupported parameter from compiler output. 

**Bugs this fixes:**

#14171

**Risk**

Very low
