### PR TITLE
Catch and report FileNotFoundException loading compiler assemblies

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -20,7 +18,6 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Debugging;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -9031,7 +9028,31 @@ class C {
                 // warning CS2029: Invalid value for '/define'; '5' is not a valid identifier
                 Diagnostic(ErrorCode.WRN_DefineIdentifierRequired).WithArguments("5"));
         }
-        
+
+        [WorkItem(406649, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=406649")]
+        [ConditionalFact(typeof(IsEnglishLocal))]
+        public void MissingCompilerAssembly()
+        {
+            var dir = Temp.CreateDirectory();
+            var cscPath = dir.CopyFile(typeof(Csc).Assembly.Location).Path;
+
+            // Missing Microsoft.CodeAnalysis.CSharp.dll.
+            var result = ProcessUtilities.Run(cscPath, arguments: "/nologo /t:library unknown.cs", workingDirectory: dir.Path);
+            Assert.Equal(1, result.ExitCode);
+            Assert.Equal(
+                $"Could not load file or assembly '{typeof(CSharpCompilation).Assembly.FullName}' or one of its dependencies. The system cannot find the file specified.",
+                result.Output.Trim());
+
+            // Missing System.Collections.Immutable.dll.
+            dir.CopyFile(typeof(Compilation).Assembly.Location);
+            dir.CopyFile(typeof(CSharpCompilation).Assembly.Location);
+            result = ProcessUtilities.Run(cscPath, arguments: "/nologo /t:library unknown.cs", workingDirectory: dir.Path);
+            Assert.Equal(1, result.ExitCode);
+            Assert.Equal(
+                $"Could not load file or assembly '{typeof(ImmutableArray).Assembly.FullName}' or one of its dependencies. The system cannot find the file specified.",
+                result.Output.Trim());
+        }
+
         public class QuotedArgumentTests
         {
             private void VerifyQuotedValid<T>(string name, string value, T expected, Func<CSharpCommandLineArguments, T> getValue)

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -1,19 +1,30 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.CodeAnalysis.CommandLine;
-using Roslyn.Utilities;
-using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine
 {
     public class Program
     {
         public static int Main(string[] args)
-            => Main(args, Array.Empty<string>());
+        {
+            try
+            {
+                return MainCore(args);
+            }
+            catch (FileNotFoundException e)
+            {
+                // Catch exception from missing compiler assembly.
+                // Report the exception message and terminate the process.
+                Console.WriteLine(e.Message);
+                return CommonCompiler.Failed;
+            }
+        }
 
-        public static int Main(string[] args, string[] extraArgs)
-            => DesktopBuildClient.Run(args, extraArgs, RequestLanguage.CSharpCompile, Csc.Run, new DesktopAnalyzerAssemblyLoader());
+        private static int MainCore(string[] args)
+            => DesktopBuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, new DesktopAnalyzerAssemblyLoader());
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)
             => Csc.Run(args, new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: sdkDir, tempDir: tempDir), textWriter, analyzerLoader);

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -128,14 +128,14 @@ namespace Microsoft.CodeAnalysis.CommandLine
             cancellationToken.ThrowIfCancellationRequested();
 
             // Read the full request
-            var responseBuffer = new byte[length];
-            await ReadAllAsync(inStream, responseBuffer, length, cancellationToken).ConfigureAwait(false);
+            var requestBuffer = new byte[length];
+            await ReadAllAsync(inStream, requestBuffer, length, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
 
             Log("Parsing request");
             // Parse the request into the Request data structure.
-            using (var reader = new BinaryReader(new MemoryStream(responseBuffer), Encoding.Unicode))
+            using (var reader = new BinaryReader(new MemoryStream(requestBuffer), Encoding.Unicode))
             {
                 var protocolVersion = reader.ReadUInt32();
                 var language = (RequestLanguage)reader.ReadUInt32();

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -508,7 +508,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal int RunCore(TextWriter consoleOutput, ErrorLogger errorLogger, CancellationToken cancellationToken)
+        private int RunCore(TextWriter consoleOutput, ErrorLogger errorLogger, CancellationToken cancellationToken)
         {
             Debug.Assert(!Arguments.IsScriptRunner);
 

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -31,13 +31,22 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 var controller = new DesktopBuildServerController(appSettings);
                 return controller.Run(args);
             }
-            catch (TypeInitializationException ex) when (ex.InnerException is FileNotFoundException)
+            catch (FileNotFoundException e)
             {
-                // Assume FileNotFoundException was the result of a missing
-                // compiler assembly. Log the exception and terminate the process.
-                CompilerServerLogger.LogException(ex, "File not found");
-                return CommonCompiler.Failed;
+                // Assume the exception was the result of a missing compiler assembly.
+                LogException(e);
             }
+            catch (TypeInitializationException e) when (e.InnerException is FileNotFoundException)
+            {
+                // Assume the exception was the result of a missing compiler assembly.
+                LogException((FileNotFoundException)e.InnerException);
+            }
+            return CommonCompiler.Failed;
+        }
+
+        private static void LogException(FileNotFoundException e)
+        {
+            CompilerServerLogger.LogException(e, "File not found");
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -3,20 +3,15 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Pipes;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.Win32;
-using Roslyn.Test.Utilities;
-using Xunit;
-using System.Xml;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CommandLine;
-using Moq;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 {
@@ -112,7 +107,7 @@ End Module")
 
         #region Helpers
 
-        private IEnumerable<KeyValuePair<string, string>> AddForLoggingEnvironmentVars(IEnumerable<KeyValuePair<string, string>> vars)
+        private static IEnumerable<KeyValuePair<string, string>> AddForLoggingEnvironmentVars(IEnumerable<KeyValuePair<string, string>> vars)
         {
             vars = vars ?? new KeyValuePair<string, string>[] { };
             if (!vars.Where(kvp => kvp.Key == "RoslynCommandLineLogFile").Any())
@@ -162,13 +157,7 @@ End Module")
             }
         }
 
-        public Process StartProcess(string fileName, string arguments, string workingDirectory = null)
-        {
-            CheckForBadShared(arguments);
-            return ProcessUtilities.StartProcess(fileName, arguments, workingDirectory);
-        }
-
-        private ProcessResult RunCommandLineCompiler(
+        private static ProcessResult RunCommandLineCompiler(
             string compilerPath,
             string arguments,
             string currentDirectory,
@@ -182,7 +171,7 @@ End Module")
                 additionalEnvironmentVars: AddForLoggingEnvironmentVars(additionalEnvironmentVars));
         }
 
-        private ProcessResult RunCommandLineCompiler(
+        private static ProcessResult RunCommandLineCompiler(
             string compilerPath,
             string arguments,
             TempDirectory currentDirectory,
@@ -1406,6 +1395,42 @@ class Program
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal(0, result.ExitCode);
                 await serverData.Verify(connections: 2, completed: 2).ConfigureAwait(true);
+            }
+        }
+
+        [WorkItem(406649, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=406649")]
+        [Fact]
+        public void MissingCompilerAssembly_CompilerServer()
+        {
+            var dir = Temp.CreateDirectory();
+            var workingDirectory = dir.Path;
+            var serverExe = dir.CopyFile(CompilerServerExecutable).Path;
+            dir.CopyFile(typeof(System.Collections.Immutable.ImmutableArray).Assembly.Location);
+
+            // Missing Microsoft.CodeAnalysis.dll launching server.
+            var result = ProcessUtilities.Run(serverExe, arguments: $"-pipename:{GetUniqueName()}", workingDirectory: workingDirectory);
+            Assert.Equal(1, result.ExitCode);
+            // Exception is logged rather than written to output/error streams.
+            Assert.Equal("", result.Output.Trim());
+        }
+
+        [WorkItem(406649, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=406649")]
+        [WorkItem(19213, "https://github.com/dotnet/roslyn/issues/19213")]
+        [Fact(Skip = "19213")]
+        public async Task MissingCompilerAssembly_CompilerServerHost()
+        {
+            var host = new TestableCompilerServerHost((request, cancellationToken) =>
+            {
+                throw new FileNotFoundException();
+            });
+            using (var serverData = ServerUtil.CreateServer(compilerServerHost: host))
+            {
+                var request = new BuildRequest(1, RequestLanguage.CSharpCompile, new BuildRequest.Argument[0]);
+                var compileTask = ServerUtil.Send(serverData.PipeName, request);
+                var response = await compileTask;
+                Assert.Equal(BuildResponse.ResponseType.Completed, response.Type);
+                Assert.Equal(0, ((CompletedBuildResponse)response).ReturnCode);
+                await serverData.Verify(connections: 1, completed: 1).ConfigureAwait(true);
             }
         }
     }

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -5,12 +5,9 @@ extern alias vbc;
 
 using Microsoft.CodeAnalysis.CommandLine;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;

--- a/src/Compilers/Shared/Csc.cs
+++ b/src/Compilers/Shared/Csc.cs
@@ -3,9 +3,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.CommandLine;
 
 namespace Microsoft.CodeAnalysis.CSharp.CommandLine

--- a/src/Compilers/Shared/DesktopBuildClient.cs
+++ b/src/Compilers/Shared/DesktopBuildClient.cs
@@ -2,20 +2,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.IO.Pipes;
-using System.Runtime.InteropServices;
-using System.Security.Principal;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using static Microsoft.CodeAnalysis.CommandLine.CompilerServerLogger;
-using static Microsoft.CodeAnalysis.CommandLine.NativeMethods;
 using System.Reflection;
-using System.Security.AccessControl;
-using System.Security.Cryptography;
 
 namespace Microsoft.CodeAnalysis.CommandLine
 {
@@ -37,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             _analyzerAssemblyLoader = analyzerAssemblyLoader;
         }
 
-        internal static int Run(IEnumerable<string> arguments, IEnumerable<string> extraArguments, RequestLanguage language, CompileFunc compileFunc, IAnalyzerAssemblyLoader analyzerAssemblyLoader)
+        internal static int Run(IEnumerable<string> arguments, RequestLanguage language, CompileFunc compileFunc, IAnalyzerAssemblyLoader analyzerAssemblyLoader)
         {
             var client = new DesktopBuildClient(language, compileFunc, analyzerAssemblyLoader);
             var clientDir = AppContext.BaseDirectory;
@@ -45,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var workingDir = Directory.GetCurrentDirectory();
             var tempDir = BuildServerConnection.GetTempPath(workingDir);
             var buildPaths = new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: sdkDir, tempDir: tempDir);
-            var originalArguments = BuildClient.GetCommandLineArgs(arguments).Concat(extraArguments).ToArray();
+            var originalArguments = GetCommandLineArgs(arguments).ToArray();
             return client.RunCompilation(originalArguments, buildPaths).ExitCode;
         }
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -8264,6 +8264,29 @@ End Module
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_InvalidSwitchValue).WithArguments("langversion", "1000").WithLocation(1, 1))
         End Sub
 
+        <WorkItem(406649, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=406649")>
+        <ConditionalFact(GetType(IsEnglishLocal))>
+        Public Sub MissingCompilerAssembly()
+            Dim dir = Temp.CreateDirectory()
+            Dim vbcPath = dir.CopyFile(GetType(Vbc).Assembly.Location).Path
+
+            ' Missing Microsoft.CodeAnalysis.VisualBasic.dll.
+            Dim result = ProcessUtilities.Run(vbcPath, arguments:="/nologo /t:library unknown.vb", workingDirectory:=dir.Path)
+            Assert.Equal(1, result.ExitCode)
+            Assert.Equal(
+                $"Could not load file or assembly '{GetType(VisualBasicCompilation).Assembly.FullName}' or one of its dependencies. The system cannot find the file specified.",
+                result.Output.Trim())
+
+            ' Missing System.Collections.Immutable.dll.
+            dir.CopyFile(GetType(Compilation).Assembly.Location)
+            dir.CopyFile(GetType(VisualBasicCompilation).Assembly.Location)
+            result = ProcessUtilities.Run(vbcPath, arguments:="/nologo /t:library unknown.vb", workingDirectory:=dir.Path)
+            Assert.Equal(1, result.ExitCode)
+            Assert.Equal(
+                $"Could not load file or assembly '{GetType(ImmutableArray).Assembly.FullName}' or one of its dependencies. The system cannot find the file specified.",
+                result.Output.Trim())
+        End Sub
+
         Private Function MakeTrivialExe(Optional directory As String = Nothing) As String
             Return Temp.CreateFile(directory:=directory, prefix:="", extension:=".vb").WriteAllText("
 Class Program

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -1,19 +1,30 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.CodeAnalysis.CommandLine;
-using Roslyn.Utilities;
-using System;
 
 namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
 {
     public class Program
     {
         public static int Main(string[] args)
-            => Main(args, Array.Empty<string>());
+        {
+            try
+            {
+                return MainCore(args);
+            }
+            catch (FileNotFoundException e)
+            {
+                // Catch exception from missing compiler assembly.
+                // Report the exception message and terminate the process.
+                Console.WriteLine(e.Message);
+                return CommonCompiler.Failed;
+            }
+        }
 
-        public static int Main(string[] args, string[] extraArgs)
-            => DesktopBuildClient.Run(args, extraArgs, RequestLanguage.VisualBasicCompile, Vbc.Run, new DesktopAnalyzerAssemblyLoader());
+        private static int MainCore(string[] args)
+            => DesktopBuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, new DesktopAnalyzerAssemblyLoader());
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)
             => Vbc.Run(args, new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: sdkDir, tempDir: tempDir), textWriter, analyzerLoader);

--- a/src/Test/Utilities/Desktop/AppDomainUtils.cs
+++ b/src/Test/Utilities/Desktop/AppDomainUtils.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public static AppDomain Create(string name = null, string basePath = null)
         {
-            name = name ?? "Custtom AppDomain";
+            name = name ?? "Custom AppDomain";
             basePath = basePath ?? Path.GetDirectoryName(typeof(AppDomainUtils).Assembly.Location);
 
             lock (s_lock)


### PR DESCRIPTION
**Customer scenario**
Copy and run compiler exe without copying all dependencies.

**Bugs this fixes:**
[406649](https://devdiv.visualstudio.com/DevDiv/_workitems?id=406649)

**Workarounds, if any**
Copy missing compiler assemblies.

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**How was the bug found?**
Customer reports