### PR TITLE
Pass LangVersion thru ICompilerOptionsHostObject.SetCompilerOptions when above 15 (VB)

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -82,12 +82,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return _store.GetOrDefault(nameof(GenerateFullPaths), false); }
         }
 
-        public string LangVersion
-        {
-            set { _store[nameof(LangVersion)] = value; }
-            get { return (string)_store[nameof(LangVersion)]; }
-        }
-
         public string ModuleAssemblyName
         {
             set { _store[nameof(ModuleAssemblyName)] = value; }

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -382,6 +382,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
         }
 
+        public string LangVersion
+        {
+            set { _store[nameof(LangVersion)] = value; }
+            get { return (string)_store[nameof(LangVersion)]; }
+        }
+
         #endregion
 
         /// <summary>
@@ -733,6 +739,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             commandLine.AppendSwitchIfNotNull("/checksumalgorithm:", ChecksumAlgorithm);
             commandLine.AppendSwitchWithSplitting("/instrument:", Instrument, ",", ';', ',');
             commandLine.AppendSwitchIfNotNull("/sourcelink:", SourceLink);
+            commandLine.AppendSwitchIfNotNull("/langversion:", LangVersion);
 
             AddFeatures(commandLine, Features);
             AddEmbeddedFilesToCommandLine(commandLine);

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -980,12 +980,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 "15", "15.0"
             };
 
-            for (int i = 0; i < supportedList.Length; i++)
+            if (Array.IndexOf(supportedList, langVersion) >= 0)
             {
-                if (supportedList[i].Equals(langVersion, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
+                return false;
             }
 
             return true;

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -969,7 +969,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 return false;
             }
 
-            // CVbcMSBuildHostObject::SetLanguageVersion can handle version below 15
+            // CVbcMSBuildHostObject::SetLanguageVersion can handle versions up to 15
             var supportedList = new[]
             {
                 "9", "9.0",
@@ -980,12 +980,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 "15", "15.0"
             };
 
-            if (Array.IndexOf(supportedList, langVersion) >= 0)
-            {
-                return false;
-            }
-
-            return true;
+            return Array.IndexOf(supportedList, langVersion) < 0;
         }
 
         /// <summary>

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -79,12 +79,6 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (ITaskItem[])_store[nameof(Imports)]; }
         }
 
-        public string LangVersion
-        {
-            set { _store[nameof(LangVersion)] = value; }
-            get { return (string)_store[nameof(LangVersion)]; }
-        }
-
         public string ModuleAssemblyName
         {
             set { _store[nameof(ModuleAssemblyName)] = value; }
@@ -909,7 +903,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
 
                 // Check for support of the LangVersion property
-                if (vbcHostObject is IVbcHostObject3)
+                if (vbcHostObject is IVbcHostObject3 && VbcHostObjectSupports(LangVersion))
                 {
                     IVbcHostObject3 vbcHostObject3 = (IVbcHostObject3)vbcHostObject;
                     CheckHostObjectSupport(param = nameof(LangVersion), vbcHostObject3.SetLanguageVersion(LangVersion));
@@ -958,6 +952,37 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
 
             return true;
+        }
+
+        // VbcHostObject doesn't support VB versions beyond 15,
+        // so the LangVersion will be passed through ICompilerOptionsHostObject.SetCompilerOptions instead
+        private static bool VbcHostObjectSupports(string langVersion)
+        {
+            if (langVersion == null)
+            {
+                return true;
+            }
+
+            var supportedList = new[]
+            {
+                "9", "9.0",
+                "10", "10.0",
+                "11", "11.0",
+                "12", "12.0",
+                "14", "14.0",
+                "15", "15.0"
+            };
+
+            int length = supportedList.Length;
+            for (int i = 0; i < length; i++)
+            {
+                if (supportedList[i].Equals(langVersion, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
@@ -56,6 +56,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
                 Dim supported As Boolean
                 compilerOptionsHost.SetCompilerOptions("/langversion:14", supported)
+                Assert.True(supported)
 
                 Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
@@ -77,6 +78,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
                 Dim supported As Boolean
                 compilerOptionsHost.SetCompilerOptions("/langversion:15", supported)
+                Assert.True(supported)
 
                 Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
@@ -97,6 +99,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
                 Dim supported As Boolean
                 compilerOptionsHost.SetCompilerOptions("/langversion:Default", supported)
+                Assert.True(supported)
 
                 Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
@@ -117,6 +120,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
                 Dim supported As Boolean
                 compilerOptionsHost.SetCompilerOptions("/langversion:15.3", supported)
+                Assert.True(supported)
 
                 Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
@@ -137,6 +141,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
                 Dim supported As Boolean
                 compilerOptionsHost.SetCompilerOptions("/langversion:latest", supported)
+                Assert.True(supported)
 
                 Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
@@ -49,6 +49,44 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
         <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
+        Public Sub SetCompilerOptions_LangVersion15_3()
+            Using environment = New TestEnvironment()
+                Dim project = CreateVisualBasicProject(environment, "Test")
+
+                Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
+                Dim supported As Boolean
+                compilerOptionsHost.SetCompilerOptions("/langversion:15.3", supported)
+
+                Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
+                Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
+
+                Assert.Equal(LanguageVersion.VisualBasic15_3, options.LanguageVersion)
+
+                project.Disconnect()
+            End Using
+        End Sub
+
+        <WpfFact()>
+        <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
+        Public Sub SetCompilerOptions_LangVersionLatest()
+            Using environment = New TestEnvironment()
+                Dim project = CreateVisualBasicProject(environment, "Test")
+
+                Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
+                Dim supported As Boolean
+                compilerOptionsHost.SetCompilerOptions("/langversion:latest", supported)
+
+                Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
+                Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
+
+                Assert.Equal(LanguageVersion.VisualBasic15_3, options.LanguageVersion)
+
+                project.Disconnect()
+            End Using
+        End Sub
+
+        <WpfFact()>
+        <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         <WorkItem(530980, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530980")>
         Public Sub DocumentationModeSetToParseIfNotProducingDocFile()
             Using environment = New TestEnvironment()

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
@@ -49,6 +49,67 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
         <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
+        Public Sub SetCompilerOptions_LangVersion14()
+            Using environment = New TestEnvironment()
+                Dim project = CreateVisualBasicProject(environment, "Test")
+
+                Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
+                Dim supported As Boolean
+                compilerOptionsHost.SetCompilerOptions("/langversion:14", supported)
+
+                Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
+                Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
+
+                ' SetCompilerOptions only handles versions 15.3 and up
+                Assert.Equal(LanguageVersion.VisualBasic15, options.LanguageVersion)
+                Assert.Equal(LanguageVersion.VisualBasic15, options.SpecifiedLanguageVersion)
+
+                project.Disconnect()
+            End Using
+        End Sub
+
+        <WpfFact()>
+        <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
+        Public Sub SetCompilerOptions_LangVersion15()
+            Using environment = New TestEnvironment()
+                Dim project = CreateVisualBasicProject(environment, "Test")
+
+                Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
+                Dim supported As Boolean
+                compilerOptionsHost.SetCompilerOptions("/langversion:15", supported)
+
+                Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
+                Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
+
+                Assert.Equal(LanguageVersion.VisualBasic15, options.LanguageVersion)
+                Assert.Equal(LanguageVersion.VisualBasic15, options.SpecifiedLanguageVersion)
+
+                project.Disconnect()
+            End Using
+        End Sub
+
+        <WpfFact()>
+        <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
+        Public Sub SetCompilerOptions_LangVersionDefault()
+            Using environment = New TestEnvironment()
+                Dim project = CreateVisualBasicProject(environment, "Test")
+
+                Dim compilerOptionsHost = DirectCast(project, Implementation.ProjectSystem.Interop.ICompilerOptionsHostObject)
+                Dim supported As Boolean
+                compilerOptionsHost.SetCompilerOptions("/langversion:Default", supported)
+
+                Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
+                Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
+
+                Assert.Equal(LanguageVersion.Default.MapSpecifiedToEffectiveVersion(), options.LanguageVersion)
+                Assert.Equal(LanguageVersion.Default.MapSpecifiedToEffectiveVersion(), options.SpecifiedLanguageVersion)
+
+                project.Disconnect()
+            End Using
+        End Sub
+
+        <WpfFact()>
+        <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub SetCompilerOptions_LangVersion15_3()
             Using environment = New TestEnvironment()
                 Dim project = CreateVisualBasicProject(environment, "Test")
@@ -61,6 +122,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
 
                 Assert.Equal(LanguageVersion.VisualBasic15_3, options.LanguageVersion)
+                Assert.Equal(LanguageVersion.VisualBasic15_3, options.SpecifiedLanguageVersion)
 
                 project.Disconnect()
             End Using
@@ -79,7 +141,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim workspaceProject = environment.Workspace.CurrentSolution.Projects.Single()
                 Dim options = DirectCast(workspaceProject.ParseOptions, VisualBasicParseOptions)
 
-                Assert.Equal(LanguageVersion.VisualBasic15_3, options.LanguageVersion)
+                Assert.Equal(LanguageVersion.Latest.MapSpecifiedToEffectiveVersion(), options.LanguageVersion)
+                Assert.Equal(LanguageVersion.Latest.MapSpecifiedToEffectiveVersion(), options.SpecifiedLanguageVersion)
 
                 project.Disconnect()
             End Using

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -397,6 +397,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
             Dim commandLineOptions = DirectCast(commandLineArguments.ParseOptions, VisualBasicParseOptions)
             If commandLineOptions.LanguageVersion > LanguageVersion.VisualBasic15 Then
+                ' For language versions after VB 15, we expect the version to be passed from MSBuild to the IDE
+                ' via command-line arguments (`ICompilerOptionsHostObject.SetCompilerOptions`)
+                ' instead of using `IVbcHostObject3.SetLanguageVersion`
                 resultParseOptions = resultParseOptions.WithLanguageVersion(commandLineOptions.LanguageVersion)
             End If
 

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -392,7 +392,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
         Protected Overrides Function CreateParseOptions(commandLineArguments As CommandLineArguments) As ParseOptions
             Dim baseParseOptions = DirectCast(MyBase.CreateParseOptions(commandLineArguments), VisualBasicParseOptions)
-            Return VisualBasicProjectOptionsHelper.CreateParseOptions(baseParseOptions, _rawOptions)
+
+            Dim resultParseOptions = VisualBasicProjectOptionsHelper.CreateParseOptions(baseParseOptions, _rawOptions)
+
+            Dim commandLineOptions = DirectCast(commandLineArguments.ParseOptions, VisualBasicParseOptions)
+            If commandLineOptions.LanguageVersion > LanguageVersion.VisualBasic15 Then
+                resultParseOptions = resultParseOptions.WithLanguageVersion(commandLineOptions.LanguageVersion)
+            End If
+
+            Return resultParseOptions
         End Function
 
         Private Shadows Sub UpdateOptions()

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
@@ -880,7 +880,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic
                 {
                     if (!string.IsNullOrWhiteSpace(languageVersion))
                     {
-                        _commandLineArgs.Add("/languageversion:" + languageVersion);
+                        _commandLineArgs.Add("/langversion:" + languageVersion);
                     }
 
                     return true;

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -581,6 +581,27 @@ class C1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestOpenProject_VisualBasic_WithLanguageVersion15_3()
+        {
+            CreateFiles(GetMultiProjectSolutionFiles()
+                .ReplaceFileElement(@"VisualBasicProject\VisualBasicProject.vbproj", "LangVersion", "15.3"));
+
+            var project = MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj")).Result;
+            Assert.Equal(VB.LanguageVersion.VisualBasic15_3, ((VB.VisualBasicParseOptions)project.ParseOptions).LanguageVersion);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        public void TestOpenProject_VisualBasic_WithLatestLanguageVersion()
+        {
+            CreateFiles(GetMultiProjectSolutionFiles()
+                .ReplaceFileElement(@"VisualBasicProject\VisualBasicProject.vbproj", "LangVersion", "Latest"));
+
+            var project = MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj")).Result;
+            Assert.Equal(VB.LanguageVersion.VisualBasic15_3, ((VB.VisualBasicParseOptions)project.ParseOptions).LanguageVersion);
+            Assert.Equal(VB.LanguageVersion.Latest, ((VB.VisualBasicParseOptions)project.ParseOptions).SpecifiedLanguageVersion);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
         public void TestOpenProject_VisualBasic_WithoutAssemblyName()
         {
             CreateFiles(GetMultiProjectSolutionFiles()

--- a/src/Workspaces/CoreTestUtilities/TestFiles/VisualBasicProject_VisualBasicProject.vbproj
+++ b/src/Workspaces/CoreTestUtilities/TestFiles/VisualBasicProject_VisualBasicProject.vbproj
@@ -38,6 +38,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OptionExplicit>On</OptionExplicit>
+    <LangVersion>15</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <OptionCompare>Binary</OptionCompare>


### PR DESCRIPTION
Currently, if you set your project to VB 15.3 and use inferred tuple names in VB, you will get red squiggles ("Please use version 15.3"). But building works fine.
The problem is that the IDE builds a compilation using the language version communicated by MSBuild, but that communication channel (`IVbcHostObject3.SetLanguageVersion`) doesn't work for 15.3. That's because it has a hardcoded list of known versions.
This PR bypasses this channel for VB versions above 15, and uses `ICompilerOptionsHostObject.SetCompilerOptions` instead.

@jasonmalinowski @tmeschter 
I'm not sure what was causing my troubles debugging, but I was eventually able to step through.
I validated a couple of scenarios by hand, but I'm not sure how to test this more systematically. Please advise.

FYI @dotnet/roslyn-compiler 

Relates to https://github.com/dotnet/project-system/issues/2088