### PR TITLE
Update usage string for VBC and update checklist for new LangVersion

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4467,7 +4467,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
  /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short 
                                form: /d)
  /langversion:&lt;string&gt;         Specify language version mode: ISO-1, ISO-2, 3, 
-                               4, 5, 6, Default, or Latest
+                               4, 5, 6, 7, 7.1, Default, or Latest
 
                         - SECURITY -
  /delaysign[+|-]               Delay-sign the assembly using only the public 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -55,9 +55,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal const string RestFieldName = "Rest";
 
         private TupleTypeSymbol(Location locationOpt, NamedTypeSymbol underlyingType, ImmutableArray<Location> elementLocations,
-            ImmutableArray<string> elementNames, ImmutableArray<TypeSymbol> elementTypes, ImmutableArray<bool> inferredNamesPositions)
+            ImmutableArray<string> elementNames, ImmutableArray<TypeSymbol> elementTypes, ImmutableArray<bool> errorPositions)
             : this(locationOpt == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create(locationOpt),
-                  underlyingType, elementLocations, elementNames, elementTypes, inferredNamesPositions)
+                  underlyingType, elementLocations, elementNames, elementTypes, errorPositions)
         {
         }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1403,10 +1403,12 @@ d.cs
             Assert.True(rangeEnd > rangeStart);
 
             string helpRange = help.Substring(rangeStart, rangeEnd - rangeStart).ToLowerInvariant();
-
+            var acceptableFollowingChar = new[] { '\r', '\n', ',' };
             foreach (var version in expected)
             {
-                Assert.True(helpRange.Contains(version), $"Missing version '{version}'");
+                var foundIndex = helpRange.IndexOf(version);
+                Assert.True(foundIndex > 0, $"Missing version '{version}'");
+                Assert.True(Array.IndexOf(acceptableFollowingChar, helpRange[foundIndex + version.Length]) >= 0);
             }
 
             // The canary check is a reminder that this test needs to be updated when a language version is added

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1395,7 +1395,9 @@ d.cs
         [Fact]
         public void LanguageVersion_CommandLineUsage()
         {
-            var expected = Enum.GetValues(typeof(LanguageVersion)).Cast<LanguageVersion>().Select(v => v.ToDisplayString());
+            var expected = Enum.GetValues(typeof(LanguageVersion)).Cast<LanguageVersion>()
+                .Where(v => v != LanguageVersion.CSharp1 && v != LanguageVersion.CSharp2)
+                .Select(v => v.ToDisplayString());
             string help = CSharpResources.IDS_CSCHelp;
 
             var rangeStart = help.IndexOf("/langversion");
@@ -1403,12 +1405,13 @@ d.cs
             Assert.True(rangeEnd > rangeStart);
 
             string helpRange = help.Substring(rangeStart, rangeEnd - rangeStart).ToLowerInvariant();
-            var acceptableFollowingChar = new[] { '\r', '\n', ',' };
+            var acceptableSurroundingChar = new[] { '\r', '\n', ',' , ' '};
             foreach (var version in expected)
             {
                 var foundIndex = helpRange.IndexOf(version);
                 Assert.True(foundIndex > 0, $"Missing version '{version}'");
-                Assert.True(Array.IndexOf(acceptableFollowingChar, helpRange[foundIndex + version.Length]) >= 0);
+                Assert.True(Array.IndexOf(acceptableSurroundingChar, helpRange[foundIndex - 1]) >= 0);
+                Assert.True(Array.IndexOf(acceptableSurroundingChar, helpRange[foundIndex + version.Length]) >= 0);
             }
 
             // The canary check is a reminder that this test needs to be updated when a language version is added

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1393,6 +1393,27 @@ d.cs
         }
 
         [Fact]
+        public void LanguageVersion_CommandLineUsage()
+        {
+            var expected = Enum.GetValues(typeof(LanguageVersion)).Cast<LanguageVersion>().Select(v => v.ToDisplayString());
+            string help = CSharpResources.IDS_CSCHelp;
+
+            var rangeStart = help.IndexOf("/langversion");
+            var rangeEnd = help.IndexOf("/delaysign");
+            Assert.True(rangeEnd > rangeStart);
+
+            string helpRange = help.Substring(rangeStart, rangeEnd - rangeStart).ToLowerInvariant();
+
+            foreach (var version in expected)
+            {
+                Assert.True(helpRange.Contains(version), $"Missing version '{version}'");
+            }
+
+            // The canary check is a reminder that this test needs to be updated when a language version is added
+            LanguageVersionAdded_Canary();
+        }
+
+        [Fact]
         [WorkItem(546961, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546961")]
         public void Define()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3838,7 +3838,8 @@ class C2
             var model = compilation.GetSemanticModel(tree);
             var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
 
-            // PROTOTYPE(tuple-names) The type for int? was not picked up
+            // The type for int? was not picked up
+            // Follow-up issue: https://github.com/dotnet/roslyn/issues/19144
             var yTuple = nodes.OfType<TupleExpressionSyntax>().ElementAt(0);
             Assert.Equal("(? e, (System.Int32 e, System.Int32, System.Int32, System.Int32))",
                 model.GetTypeInfo(yTuple).Type.ToTestDisplayString());

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Class TupleFieldSymbol
         Inherits WrappedFieldSymbol
 
-        Protected _containingTuple As TupleTypeSymbol
+        Protected ReadOnly _containingTuple As TupleTypeSymbol
 
         ''' <summary>
         ''' If this field represents a tuple element with index X, the field contains
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         '''  2X + 1  if this field represents a Friendly-named element
         ''' Otherwise, (-1 - [index in members array]);
         ''' </summary>
-        Private _tupleElementIndex As Integer
+        Private ReadOnly _tupleElementIndex As Integer
 
         Public Overrides ReadOnly Property IsTupleField As Boolean
             Get
@@ -123,7 +123,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Class TupleElementFieldSymbol
         Inherits TupleFieldSymbol
 
-        Private _locations As ImmutableArray(Of Location)
+        Private ReadOnly _locations As ImmutableArray(Of Location)
 
         ' default tuple elements like Item1 Or Item20 could be provided by the user or
         ' otherwise implicitly declared by compiler
@@ -209,8 +209,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend NotInheritable Class TupleVirtualElementFieldSymbol
         Inherits TupleElementFieldSymbol
 
-        Private _name As String
-        Private _cannotUse As Boolean ' With LanguageVersion 15, we will produce named elements that should not be used
+        Private ReadOnly _name As String
+        Private ReadOnly _cannotUse As Boolean ' With LanguageVersion 15, we will produce named elements that should not be used
 
         Public Sub New(container As TupleTypeSymbol,
                        underlyingField As FieldSymbol,

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5130,7 +5130,7 @@
                                   import_list:namespace,...
 /langversion:&lt;number&gt;             Specify language version: 
                                   9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|default|latest
+                                  15.0|15.3|default|latest
 /optionexplicit[+|-]              Require explicit declaration of variables.
 /optioninfer[+|-]                 Allow type inference of variables.
 /rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1616,8 +1616,10 @@ End Module").Path
         <Fact>
         Public Sub LanguageVersionAdded_Canary()
             ' When a new version is added, this test will break. This list must be checked:
+            ' - update the command-line error for bad /langver flag (<see cref="ERRID.IDS_VBCHelp"/>)
             ' - update the "UpgradeProject" codefixer
             ' - update the IDE drop-down for selecting Language Version
+            ' - update legacy project system to pass Language Version from MSBuild to IDE (see CVbcMSBuildHostObject::SetLanguageVersion)
             ' - update all the tests that call this canary
             ' - update the command-line documentation (CommandLine.md)
             AssertEx.SetEqual({"default", "9", "10", "11", "12", "14", "15", "15.3", "latest"},

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1706,9 +1706,12 @@ End Module").Path
             Assert.True(rangeEnd > rangeStart)
 
             Dim helpRange = help.Substring(rangeStart, rangeEnd - rangeStart).ToLowerInvariant()
+            Dim acceptableFollowingChar = {CChar(vbCr), CChar(vbLf), "|"c}
 
             For Each v In expected
-                Assert.True(helpRange.Contains(v), $"Missing version '{v}'")
+                Dim foundIndex = helpRange.IndexOf(v)
+                Assert.True(foundIndex > 0, $"Missing version '{v}'")
+                Assert.True(Array.IndexOf(acceptableFollowingChar, helpRange(foundIndex + v.Length)) >= 0)
             Next
 
             ' The canary check is a reminder that this test needs to be updated when a language version is added

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1626,6 +1626,7 @@ End Module").Path
                 System.Enum.GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString()))
             ' For minor versions, the format should be "x.y", such as "15.3"
         End Sub
+
         <Fact>
         Public Sub LanguageVersion_GetErrorCode()
             Dim versions = System.Enum.GetValues(GetType(LanguageVersion)).
@@ -1690,6 +1691,25 @@ End Module").Path
             Dim version As LanguageVersion
             Assert.Equal(success, input.TryParse(version))
             Assert.Equal(expected, version)
+
+            ' The canary check is a reminder that this test needs to be updated when a language version is added
+            LanguageVersionAdded_Canary()
+        End Sub
+
+        <Fact>
+        Public Sub LanguageVersion_CommandLineUsage()
+            Dim expected = [Enum].GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString())
+            Dim help = VBResources.IDS_VBCHelp
+
+            Dim rangeStart = help.IndexOf("/langversion")
+            Dim rangeEnd = help.IndexOf("/optionexplicit")
+            Assert.True(rangeEnd > rangeStart)
+
+            Dim helpRange = help.Substring(rangeStart, rangeEnd - rangeStart).ToLowerInvariant()
+
+            For Each v In expected
+                Assert.True(helpRange.Contains(v), $"Missing version '{v}'")
+            Next
 
             ' The canary check is a reminder that this test needs to be updated when a language version is added
             LanguageVersionAdded_Canary()

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1706,12 +1706,13 @@ End Module").Path
             Assert.True(rangeEnd > rangeStart)
 
             Dim helpRange = help.Substring(rangeStart, rangeEnd - rangeStart).ToLowerInvariant()
-            Dim acceptableFollowingChar = {CChar(vbCr), CChar(vbLf), "|"c}
+            Dim acceptableSurroundingChar = {CChar(vbCr), CChar(vbLf), "|"c, " "c}
 
             For Each v In expected
                 Dim foundIndex = helpRange.IndexOf(v)
                 Assert.True(foundIndex > 0, $"Missing version '{v}'")
-                Assert.True(Array.IndexOf(acceptableFollowingChar, helpRange(foundIndex + v.Length)) >= 0)
+                Assert.True(Array.IndexOf(acceptableSurroundingChar, helpRange(foundIndex - 1)) >= 0)
+                Assert.True(Array.IndexOf(acceptableSurroundingChar, helpRange(foundIndex + v.Length)) >= 0)
             Next
 
             ' The canary check is a reminder that this test needs to be updated when a language version is added


### PR DESCRIPTION
**Customer scenario**
Type `vbc -?`
The usage string doesn't list language version 15.3 (but should).

Also addresses some suggestions from previous PR (making fields read-only, adjusting name of parameter). (FYI @cston)

**Risk**
**Performance impact**
Low. Just changing a resource string.

**Root cause analysis:**
I'd missed this when adding the new language version. This PR also updates the checklist for new language version, to avoid missing this in the future.

**How was the bug found?**
Ad-hoc testing.

@dotnet/roslyn-compiler for review.