### PR TITLE
support of C# 7.0 foreach in ENC

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -7853,5 +7853,229 @@ class C
 }
 ");
         }
+
+        [Fact]
+        public void ForeachStatement()
+        {
+            var source0 = MarkedSource(@"
+class C
+{
+    public static (int, (bool, double))[] F() => new[] { (1, (true, 2.0)) };
+
+    public static void G()
+    {        
+        foreach (var (<N:0>x</N:0>, (<N:1>y</N:1>, <N:2>z</N:2>)) in F())
+        {
+            System.Console.WriteLine(x);
+        }
+    }
+}");
+            var source1 = MarkedSource(@"
+class C
+{
+    public static (int, (bool, double))[] F() => new[] { (1, (true, 2.0)) };
+
+    public static void G()
+    {        
+        foreach (var (<N:0>x1</N:0>, (<N:1>y</N:1>, <N:2>z</N:2>)) in F())
+        {
+            System.Console.WriteLine(x1);
+        }
+    }
+}");
+
+            var source2 = MarkedSource(@"
+class C
+{
+    public static (int, (bool, double))[] F() => new[] { (1, (true, 2.0)) };
+
+    public static void G()
+    {        
+        foreach (var (<N:0>x1</N:0>, <N:1>yz</N:1>) in F())
+        {
+            System.Console.WriteLine(x1);
+        }
+    }
+}");
+
+            var compilation0 = CreateStandardCompilation(source0.Tree, options: ComSafeDebugDll, references: s_valueTupleRefs);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+            var compilation2 = compilation1.WithSource(source2.Tree);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.G");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.G");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.G");
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyIL("C.G", @"
+{
+  // Code size       72 (0x48)
+  .maxstack  2
+  .locals init ((int, (bool, double))[] V_0,
+                int V_1,
+                int V_2, //x
+                bool V_3, //y
+                double V_4, //z
+                System.ValueTuple<bool, double> V_5)
+  IL_0000:  nop
+  IL_0001:  nop
+  IL_0002:  call       ""(int, (bool, double))[] C.F()""
+  IL_0007:  stloc.0
+  IL_0008:  ldc.i4.0
+  IL_0009:  stloc.1
+  IL_000a:  br.s       IL_0041
+  IL_000c:  ldloc.0
+  IL_000d:  ldloc.1
+  IL_000e:  ldelem     ""System.ValueTuple<int, (bool, double)>""
+  IL_0013:  dup
+  IL_0014:  ldfld      ""(bool, double) System.ValueTuple<int, (bool, double)>.Item2""
+  IL_0019:  stloc.s    V_5
+  IL_001b:  dup
+  IL_001c:  ldfld      ""int System.ValueTuple<int, (bool, double)>.Item1""
+  IL_0021:  stloc.2
+  IL_0022:  ldloc.s    V_5
+  IL_0024:  ldfld      ""bool System.ValueTuple<bool, double>.Item1""
+  IL_0029:  stloc.3
+  IL_002a:  ldloc.s    V_5
+  IL_002c:  ldfld      ""double System.ValueTuple<bool, double>.Item2""
+  IL_0031:  stloc.s    V_4
+  IL_0033:  pop
+  IL_0034:  nop
+  IL_0035:  ldloc.2
+  IL_0036:  call       ""void System.Console.WriteLine(int)""
+  IL_003b:  nop
+  IL_003c:  nop
+  IL_003d:  ldloc.1
+  IL_003e:  ldc.i4.1
+  IL_003f:  add
+  IL_0040:  stloc.1
+  IL_0041:  ldloc.1
+  IL_0042:  ldloc.0
+  IL_0043:  ldlen
+  IL_0044:  conv.i4
+  IL_0045:  blt.s      IL_000c
+  IL_0047:  ret
+}
+");
+
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifyIL("C.G", @"
+{
+  // Code size       80 (0x50)
+  .maxstack  2
+  .locals init ([unchanged] V_0,
+                [int] V_1,
+                int V_2, //x1
+                bool V_3, //y
+                double V_4, //z
+                [unchanged] V_5,
+                (int, (bool, double))[] V_6,
+                int V_7,
+                System.ValueTuple<bool, double> V_8)
+  IL_0000:  nop
+  IL_0001:  nop
+  IL_0002:  call       ""(int, (bool, double))[] C.F()""
+  IL_0007:  stloc.s    V_6
+  IL_0009:  ldc.i4.0
+  IL_000a:  stloc.s    V_7
+  IL_000c:  br.s       IL_0047
+  IL_000e:  ldloc.s    V_6
+  IL_0010:  ldloc.s    V_7
+  IL_0012:  ldelem     ""System.ValueTuple<int, (bool, double)>""
+  IL_0017:  dup
+  IL_0018:  ldfld      ""(bool, double) System.ValueTuple<int, (bool, double)>.Item2""
+  IL_001d:  stloc.s    V_8
+  IL_001f:  dup
+  IL_0020:  ldfld      ""int System.ValueTuple<int, (bool, double)>.Item1""
+  IL_0025:  stloc.2
+  IL_0026:  ldloc.s    V_8
+  IL_0028:  ldfld      ""bool System.ValueTuple<bool, double>.Item1""
+  IL_002d:  stloc.3
+  IL_002e:  ldloc.s    V_8
+  IL_0030:  ldfld      ""double System.ValueTuple<bool, double>.Item2""
+  IL_0035:  stloc.s    V_4
+  IL_0037:  pop
+  IL_0038:  nop
+  IL_0039:  ldloc.2
+  IL_003a:  call       ""void System.Console.WriteLine(int)""
+  IL_003f:  nop
+  IL_0040:  nop
+  IL_0041:  ldloc.s    V_7
+  IL_0043:  ldc.i4.1
+  IL_0044:  add
+  IL_0045:  stloc.s    V_7
+  IL_0047:  ldloc.s    V_7
+  IL_0049:  ldloc.s    V_6
+  IL_004b:  ldlen
+  IL_004c:  conv.i4
+  IL_004d:  blt.s      IL_000e
+  IL_004f:  ret
+}
+");
+
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifyIL("C.G", @"
+{
+  // Code size       66 (0x42)
+  .maxstack  2
+  .locals init ([unchanged] V_0,
+                [int] V_1,
+                int V_2, //x1
+                [bool] V_3,
+                [unchanged] V_4,
+                [unchanged] V_5,
+                [unchanged] V_6,
+                [int] V_7,
+                [unchanged] V_8,
+                (int, (bool, double))[] V_9,
+                int V_10,
+                System.ValueTuple<bool, double> V_11, //yz
+                System.ValueTuple<int, (bool, double)> V_12)
+  IL_0000:  nop
+  IL_0001:  nop
+  IL_0002:  call       ""(int, (bool, double))[] C.F()""
+  IL_0007:  stloc.s    V_9
+  IL_0009:  ldc.i4.0
+  IL_000a:  stloc.s    V_10
+  IL_000c:  br.s       IL_0039
+  IL_000e:  ldloc.s    V_9
+  IL_0010:  ldloc.s    V_10
+  IL_0012:  ldelem     ""System.ValueTuple<int, (bool, double)>""
+  IL_0017:  stloc.s    V_12
+  IL_0019:  ldloc.s    V_12
+  IL_001b:  ldfld      ""int System.ValueTuple<int, (bool, double)>.Item1""
+  IL_0020:  stloc.2
+  IL_0021:  ldloc.s    V_12
+  IL_0023:  ldfld      ""(bool, double) System.ValueTuple<int, (bool, double)>.Item2""
+  IL_0028:  stloc.s    V_11
+  IL_002a:  nop
+  IL_002b:  ldloc.2
+  IL_002c:  call       ""void System.Console.WriteLine(int)""
+  IL_0031:  nop
+  IL_0032:  nop
+  IL_0033:  ldloc.s    V_10
+  IL_0035:  ldc.i4.1
+  IL_0036:  add
+  IL_0037:  stloc.s    V_10
+  IL_0039:  ldloc.s    V_10
+  IL_003b:  ldloc.s    V_9
+  IL_003d:  ldlen
+  IL_003e:  conv.i4
+  IL_003f:  blt.s      IL_000e
+  IL_0041:  ret
+}
+");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -3436,7 +3436,6 @@ class C
 ", methodToken: diff1.UpdatedMethods.Single());
         }
 
-
         [Fact]
         public void ForEachStatement_Deconstruction()
         {

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -3185,6 +3185,41 @@ class Test
         }
 
         [Fact]
+        public void ForEachVariableBody_Update_ExpressionActive()
+        {
+            string src1 = @"
+class Test
+{
+    private static (string, int) F() { <AS:0>return null;</AS:0> }
+
+    static void Main(string[] args)
+    {
+        foreach ((string s, int i) in <AS:1>F()</AS:1>)
+        {
+            System.Console.Write(0);
+        }
+    }
+}";
+            string src2 = @"
+class Test
+{
+    private static (string, int) F() { <AS:0>return null;</AS:0> }
+
+    static void Main(string[] args)
+    {
+        foreach ((string s, int i) in <AS:1>F()</AS:1>)
+        {
+            System.Console.Write(1);
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
         public void ForEachBody_Update_InKeywordActive()
         {
             string src1 = @"
@@ -3208,6 +3243,41 @@ class Test
     static void Main(string[] args)
     {
         foreach (char c <AS:1>in</AS:1> F())
+        {
+            System.Console.Write(1);
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void ForEachVariableBody_Update_InKeywordActive()
+        {
+            string src1 = @"
+class Test
+{
+    private static (string, int) F() { <AS:0>return null;</AS:0> }
+
+    static void Main(string[] args)
+    {
+        foreach ((string s, int i) <AS:1>in</AS:1> F())
+        {
+            System.Console.Write(0);
+        }
+    }
+}";
+            string src2 = @"
+class Test
+{
+    private static (string, int) F() { <AS:0>return null;</AS:0> }
+
+    static void Main(string[] args)
+    {
+        foreach ((string s, int i) <AS:1>in</AS:1> F())
         {
             System.Console.Write(1);
         }
@@ -3255,6 +3325,41 @@ class Test
         }
 
         [Fact]
+        public void ForEachVariableBody_Update_VariableActive()
+        {
+            string src1 = @"
+class Test
+{
+    private static (string, int) F() { <AS:0>return null;</AS:0> }
+
+    static void Main(string[] args)
+    {
+        foreach (<AS:1>(string s, int i)</AS:1> in F())
+        {
+            System.Console.Write(0);
+        }
+    }
+}";
+            string src2 = @"
+class Test
+{
+    private static (string, int) F() { <AS:0>return null;</AS:0> }
+
+    static void Main(string[] args)
+    {
+        foreach (<AS:1>(string s, int i)</AS:1> in F())
+        {
+            System.Console.Write(1);
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
         public void ForEachBody_Update_ForeachKeywordActive()
         {
             string src1 = @"
@@ -3278,6 +3383,41 @@ class Test
     static void Main(string[] args)
     {
         <AS:1>foreach</AS:1> (char c in F())
+        {
+            System.Console.Write(1);
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void ForEachVariableBody_Update_ForeachKeywordActive()
+        {
+            string src1 = @"
+class Test
+{
+    private static (string, int) F() { <AS:0>return null;</AS:0> }
+
+    static void Main(string[] args)
+    {
+        <AS:1>foreach</AS:1> ((string s, int i) in F())
+        {
+            System.Console.Write(0);
+        }
+    }
+}";
+            string src2 = @"
+class Test
+{
+    private static (string, int) F() { <AS:0>return null;</AS:0> }
+
+    static void Main(string[] args)
+    {
+        <AS:1>foreach</AS:1> ((string s, int i) in F())
         {
             System.Console.Write(1);
         }
@@ -3361,11 +3501,11 @@ class Test
 
             edits.VerifyRudeDiagnostics(active,
                 Diagnostic(RudeEditKind.ActiveStatementUpdate, "(int i, (var b, double d))"),
-                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "(int i, (var b, double d))", "deconstruction"));
+                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "foreach (      (int i, (var b, double d))        in F())", CSharpFeaturesResources.foreach_statement));
         }
 
         [Fact]
-        public void ForEach_Reorder_Leaf1()
+        public void ForEach_Reorder_Leaf()
         {
             string src1 = @"
 class Test
@@ -3414,56 +3554,7 @@ class Test
         }
 
         [Fact]
-        public void ForEach_Update_Leaf1()
-        {
-            string src1 = @"
-class Test
-{
-    public static int[] e1 = new int[1];
-    public static int[] e2 = new int[1];
-    
-    static void Main(string[] args)
-    {
-        foreach (var a in e1)
-        {
-            foreach (var b in e1)
-            {
-                foreach (var c in e1)
-                {
-                    <AS:0>System.Console.Write();</AS:0>
-                }
-            }
-        }
-    }
-}";
-            string src2 = @"
-class Test
-{
-    public static int[] e1 = new int[1];
-    public static int[] e2 = new int[1];
-    
-    static void Main(string[] args)
-    {
-        foreach (var b in e1)
-        {
-            foreach (var c in e1)
-            {
-                foreach (var a in e1)
-                {
-                    <AS:0>System.Console.Write();</AS:0>
-                }
-            }
-        }
-    }
-}";
-            var edits = GetTopEdits(src1, src2);
-            var active = GetActiveStatements(src1, src2);
-
-            edits.VerifyRudeDiagnostics(active);
-        }
-
-        [Fact]
-        public void ForEachVariable_Update_Leaf1()
+        public void ForEachVariable_Reorder_Leaf()
         {
             string src1 = @"
 class Test
@@ -3512,7 +3603,7 @@ class Test
         }
 
         [Fact]
-        public void ForEach_Update_Leaf2()
+        public void ForEach_Update_Leaf()
         {
             string src1 = @"
 class Test
@@ -3555,7 +3646,7 @@ class Test
         }
 
         [Fact]
-        public void ForEachVariable_Update_Leaf2()
+        public void ForEachVariable_Update_Leaf()
         {
             string src1 = @"
 class Test
@@ -3592,9 +3683,9 @@ class Test
             var active = GetActiveStatements(src1, src2);
 
             edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "foreach (var c in e1)", "foreach statement"),
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "(int b1, bool b2)", "deconstruction"),
-                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "(var a1, var a2)", "deconstruction"));
+                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "foreach (var c in e1)", CSharpFeaturesResources.foreach_statement),
+                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "foreach ((int b1, bool b2) in e1)", CSharpFeaturesResources.foreach_statement),
+                Diagnostic(RudeEditKind.InsertAroundActiveStatement, "foreach ((var a1, var a2) in e1)", CSharpFeaturesResources.foreach_statement));
         }
 
         [Fact]
@@ -3631,6 +3722,52 @@ class Test
         foreach (var a in e1)
         {
             foreach (var b in e1)
+            {
+                <AS:0>System.Console.Write();</AS:0>
+            }
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void ForEachVariable_Delete_Leaf1()
+        {
+            string src1 = @"
+class Test
+{
+    public static (int, bool)[] e1 = new (int, bool)[1];
+    public static (int, bool)[] e2 = new (int, bool)[1];
+    
+    static void Main(string[] args)
+    {
+        foreach ((var a1, var a2) in e1)
+        {
+            foreach ((int b1, bool b2) in e1)
+            {
+                foreach (var c in e1)
+                {
+                    <AS:0>System.Console.Write();</AS:0>
+                }
+            }
+        }
+    }
+}";
+            string src2 = @"
+class Test
+{
+    public static (int, bool)[] e1 = new (int, bool)[1];
+    public static (int, bool)[] e2 = new (int, bool)[1];
+    
+    static void Main(string[] args)
+    {
+        foreach ((var a1, var a2) in e1)
+        {
+            foreach ((int b1, bool b2) in e1)
             {
                 <AS:0>System.Console.Write();</AS:0>
             }
@@ -3690,6 +3827,52 @@ class Test
         }
 
         [Fact]
+        public void ForEachVariable_Delete_Leaf2()
+        {
+            string src1 = @"
+class Test
+{
+    public static (int, bool)[] e1 = new (int, bool)[1];
+    public static (int, bool)[] e2 = new (int, bool)[1];
+    
+    static void Main(string[] args)
+    {
+        foreach ((var a1, var a2) in e1)
+        {
+            foreach ((int b1, bool b2) in e1)
+            {
+                foreach (var c in e1)
+                {
+                    <AS:0>System.Console.Write();</AS:0>
+                }
+            }
+        }
+    }
+}";
+            string src2 = @"
+class Test
+{
+    public static (int, bool)[] e1 = new (int, bool)[1];
+    public static (int, bool)[] e2 = new (int, bool)[1];
+    
+    static void Main(string[] args)
+    {
+        foreach ((int b1, bool b2) in e1)
+        {
+            foreach (var c in e1)
+            {
+                <AS:0>System.Console.Write();</AS:0>
+            }
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
         public void ForEach_Delete_Leaf3()
         {
             string src1 = @"
@@ -3721,6 +3904,52 @@ class Test
     static void Main(string[] args)
     {
         foreach (var a in e1)
+        {
+            foreach (var c in e1)
+            {
+                <AS:0>System.Console.Write();</AS:0>
+            }
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void ForEachVariable_Delete_Leaf3()
+        {
+            string src1 = @"
+class Test
+{
+    public static int[] e1 = new int[1];
+    public static int[] e2 = new int[1];
+    
+    static void Main(string[] args)
+    {
+        foreach ((var a1, var a2) in e1)
+        {
+            foreach ((int b1, bool b2) in e1)
+            {
+                foreach (var c in e1)
+                {
+                    <AS:0>System.Console.Write();</AS:0>
+                }
+            }
+        }
+    }
+}";
+            string src2 = @"
+class Test
+{
+    public static int[] e1 = new int[1];
+    public static int[] e2 = new int[1];
+    
+    static void Main(string[] args)
+    {
+        foreach ((var a1, var a2) in e1)
         {
             foreach (var c in e1)
             {

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -3463,6 +3463,55 @@ class Test
         }
 
         [Fact]
+        public void ForEachVariable_Update_Leaf1()
+        {
+            string src1 = @"
+class Test
+{
+    public static (int, bool)[] e1 = new (int, bool)[1];
+    public static (int, bool)[] e2 = new (int, bool)[1];
+    
+    static void Main(string[] args)
+    {
+        foreach ((var a1, var a2) in e1)
+        {
+            foreach ((int b1, bool b2) in e1)
+            {
+                foreach (var c in e1)
+                {
+                    <AS:0>System.Console.Write();</AS:0>
+                }
+            }
+        }
+    }
+}";
+            string src2 = @"
+class Test
+{
+    public static (int, bool)[] e1 = new (int, bool)[1];
+    public static (int, bool)[] e2 = new (int, bool)[1];
+    
+    static void Main(string[] args)
+    {
+        foreach ((int b1, bool b2) in e1)
+        {
+            foreach (var c in e1)
+            {
+                foreach ((var a1, var a2) in e1)
+                {
+                    <AS:0>System.Console.Write();</AS:0>
+                }
+            }
+        }
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
         public void ForEach_Update_Leaf2()
         {
             string src1 = @"

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -8182,8 +8182,7 @@ class C
             var edits = GetTopEdits(src1, src2);
             var active = GetActiveStatements(src1, src2);
 
-            edits.VerifyRudeDiagnostics(active,
-                Diagnostic(RudeEditKind.UpdateAroundActiveStatement, "var (x, y)", CSharpFeaturesResources.deconstruction));
+            edits.VerifyRudeDiagnostics(active);
         }
 
         [Fact]

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -3108,7 +3108,6 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         {
             switch (n.Kind())
             {
-                case SyntaxKind.ForEachVariableStatement:
                 case SyntaxKind.LocalFunctionStatement:
                     return true;
                 default:

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -3227,15 +3227,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             // 
             // Unlike exception regions matching where we use LCS, we allow reordering of the statements.
 
-            ReportUnmatchedStatements<LockStatementSyntax>(diagnostics, match, new [] { (int)SyntaxKind.LockStatement }, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements<LockStatementSyntax>(diagnostics, match, new[] { (int)SyntaxKind.LockStatement }, oldActiveStatement, newActiveStatement,
                 areEquivalent: AreEquivalentActiveStatements,
                 areSimilar: null);
 
-            ReportUnmatchedStatements<FixedStatementSyntax>(diagnostics, match, new [] { (int)SyntaxKind.FixedStatement }, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements<FixedStatementSyntax>(diagnostics, match, new[] { (int)SyntaxKind.FixedStatement }, oldActiveStatement, newActiveStatement,
                 areEquivalent: AreEquivalentActiveStatements,
                 areSimilar: (n1, n2) => DeclareSameIdentifiers(n1.Declaration.Variables, n2.Declaration.Variables));
 
-            ReportUnmatchedStatements<UsingStatementSyntax>(diagnostics, match, new [] { (int)SyntaxKind.UsingStatement }, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements<UsingStatementSyntax>(diagnostics, match, new[] { (int)SyntaxKind.UsingStatement }, oldActiveStatement, newActiveStatement,
                 areEquivalent: AreEquivalentActiveStatements,
                 areSimilar: (using1, using2) =>
                 {
@@ -3243,7 +3243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         DeclareSameIdentifiers(using1.Declaration.Variables, using2.Declaration.Variables);
                 });
 
-            ReportUnmatchedStatements<CommonForEachStatementSyntax>(diagnostics, match, new [] { (int)SyntaxKind.ForEachStatement, (int)SyntaxKind.ForEachVariableStatement }, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements<CommonForEachStatementSyntax>(diagnostics, match, new[] { (int)SyntaxKind.ForEachStatement, (int)SyntaxKind.ForEachVariableStatement }, oldActiveStatement, newActiveStatement,
                 areEquivalent: AreEquivalentActiveStatements,
                 areSimilar: AreSimilarActiveStatements);
         }

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -3227,15 +3227,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             // 
             // Unlike exception regions matching where we use LCS, we allow reordering of the statements.
 
-            ReportUnmatchedStatements<LockStatementSyntax>(diagnostics, match, (int)SyntaxKind.LockStatement, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements<LockStatementSyntax>(diagnostics, match, new [] { (int)SyntaxKind.LockStatement }, oldActiveStatement, newActiveStatement,
                 areEquivalent: AreEquivalentActiveStatements,
                 areSimilar: null);
 
-            ReportUnmatchedStatements<FixedStatementSyntax>(diagnostics, match, (int)SyntaxKind.FixedStatement, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements<FixedStatementSyntax>(diagnostics, match, new [] { (int)SyntaxKind.FixedStatement }, oldActiveStatement, newActiveStatement,
                 areEquivalent: AreEquivalentActiveStatements,
                 areSimilar: (n1, n2) => DeclareSameIdentifiers(n1.Declaration.Variables, n2.Declaration.Variables));
 
-            ReportUnmatchedStatements<UsingStatementSyntax>(diagnostics, match, (int)SyntaxKind.UsingStatement, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements<UsingStatementSyntax>(diagnostics, match, new [] { (int)SyntaxKind.UsingStatement }, oldActiveStatement, newActiveStatement,
                 areEquivalent: AreEquivalentActiveStatements,
                 areSimilar: (using1, using2) =>
                 {
@@ -3243,7 +3243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                         DeclareSameIdentifiers(using1.Declaration.Variables, using2.Declaration.Variables);
                 });
 
-            ReportUnmatchedStatements<CommonForEachStatementSyntax>(diagnostics, match, new int[] { (int)SyntaxKind.ForEachStatement, (int)SyntaxKind.ForEachVariableStatement }, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements<CommonForEachStatementSyntax>(diagnostics, match, new [] { (int)SyntaxKind.ForEachStatement, (int)SyntaxKind.ForEachVariableStatement }, oldActiveStatement, newActiveStatement,
                 areEquivalent: AreEquivalentActiveStatements,
                 areSimilar: AreSimilarActiveStatements);
         }

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             }
         }
 
-        private static void GetLocalNames(CommonForEachStatementSyntax commonForEach, ref List<SyntaxToken> result)
+        internal static void GetLocalNames(CommonForEachStatementSyntax commonForEach, ref List<SyntaxToken> result)
         {
             switch (commonForEach.Kind())
             {

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1703,9 +1703,22 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             Func<TSyntaxNode, TSyntaxNode, bool> areSimilar)
             where TSyntaxNode : SyntaxNode
         {
+            ReportUnmatchedStatements(diagnostics, match, new[] { syntaxKind }, oldActiveStatement, newActiveStatement, areEquivalent, areSimilar);
+        }
+
+            protected void ReportUnmatchedStatements<TSyntaxNode>(
+            List<RudeEditDiagnostic> diagnostics,
+            Match<SyntaxNode> match,
+            int[] syntaxKinds,
+            SyntaxNode oldActiveStatement,
+            SyntaxNode newActiveStatement,
+            Func<TSyntaxNode, TSyntaxNode, bool> areEquivalent,
+            Func<TSyntaxNode, TSyntaxNode, bool> areSimilar)
+            where TSyntaxNode : SyntaxNode
+        {
             List<SyntaxNode> oldNodes = null, newNodes = null;
-            GetAncestors(GetEncompassingAncestor(match.OldRoot), oldActiveStatement, syntaxKind, ref oldNodes);
-            GetAncestors(GetEncompassingAncestor(match.NewRoot), newActiveStatement, syntaxKind, ref newNodes);
+            GetAncestors(GetEncompassingAncestor(match.OldRoot), oldActiveStatement, syntaxKinds, ref oldNodes);
+            GetAncestors(GetEncompassingAncestor(match.NewRoot), newActiveStatement, syntaxKinds, ref newNodes);
 
             if (newNodes != null)
             {
@@ -1836,11 +1849,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return -1;
         }
 
-        private static void GetAncestors(SyntaxNode root, SyntaxNode node, int syntaxKind, ref List<SyntaxNode> list)
+        private static void GetAncestors(SyntaxNode root, SyntaxNode node, int[] syntaxKinds, ref List<SyntaxNode> list)
         {
             while (node != root)
             {
-                if (node.RawKind == syntaxKind)
+                if (syntaxKinds.Contains(node.RawKind))
                 {
                     if (list == null)
                     {

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -1696,19 +1696,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         protected void ReportUnmatchedStatements<TSyntaxNode>(
             List<RudeEditDiagnostic> diagnostics,
             Match<SyntaxNode> match,
-            int syntaxKind,
-            SyntaxNode oldActiveStatement,
-            SyntaxNode newActiveStatement,
-            Func<TSyntaxNode, TSyntaxNode, bool> areEquivalent,
-            Func<TSyntaxNode, TSyntaxNode, bool> areSimilar)
-            where TSyntaxNode : SyntaxNode
-        {
-            ReportUnmatchedStatements(diagnostics, match, new[] { syntaxKind }, oldActiveStatement, newActiveStatement, areEquivalent, areSimilar);
-        }
-
-            protected void ReportUnmatchedStatements<TSyntaxNode>(
-            List<RudeEditDiagnostic> diagnostics,
-            Match<SyntaxNode> match,
             int[] syntaxKinds,
             SyntaxNode oldActiveStatement,
             SyntaxNode newActiveStatement,

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -3155,19 +3155,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
             ' 
             ' Unlike exception regions matching where we use LCS, we allow reordering of the statements.
 
-            ReportUnmatchedStatements(Of SyncLockBlockSyntax)(diagnostics, match, SyntaxKind.SyncLockBlock, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements(Of SyncLockBlockSyntax)(diagnostics, match, New Integer() {SyntaxKind.SyncLockBlock}, oldActiveStatement, newActiveStatement,
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.SyncLockStatement.Expression, n2.SyncLockStatement.Expression),
                 areSimilar:=Nothing)
 
-            ReportUnmatchedStatements(Of WithBlockSyntax)(diagnostics, match, SyntaxKind.WithBlock, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements(Of WithBlockSyntax)(diagnostics, match, New Integer() {SyntaxKind.WithBlock}, oldActiveStatement, newActiveStatement,
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.WithStatement.Expression, n2.WithStatement.Expression),
                 areSimilar:=Nothing)
 
-            ReportUnmatchedStatements(Of UsingBlockSyntax)(diagnostics, match, SyntaxKind.UsingBlock, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements(Of UsingBlockSyntax)(diagnostics, match, New Integer() {SyntaxKind.UsingBlock}, oldActiveStatement, newActiveStatement,
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.UsingStatement.Expression, n2.UsingStatement.Expression),
                 areSimilar:=Nothing)
 
-            ReportUnmatchedStatements(Of ForOrForEachBlockSyntax)(diagnostics, match, SyntaxKind.ForEachBlock, oldActiveStatement, newActiveStatement,
+            ReportUnmatchedStatements(Of ForOrForEachBlockSyntax)(diagnostics, match, New Integer() {SyntaxKind.ForEachBlock}, oldActiveStatement, newActiveStatement,
                 areEquivalent:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(n1.ForOrForEachStatement, n2.ForOrForEachStatement),
                 areSimilar:=Function(n1, n2) AreEquivalentIgnoringLambdaBodies(DirectCast(n1.ForOrForEachStatement, ForEachStatementSyntax).ControlVariable,
                                                                          DirectCast(n2.ForOrForEachStatement, ForEachStatementSyntax).ControlVariable))


### PR DESCRIPTION
**Customer scenario**

Enabling support of C#7.0 foreach statemets by ENC: tuples and deconstructions.
Also verified enabling manually. The only issue I see to consider is when we change tuple to deconstruction (or the opposite) as a foreach variable, it displays a rude edit saying "ENC0060	Adding 'foreach statement' around an active statement will prevent the debug session from continuing." Should we consider fixing this?

**Bugs this fixes:**

Works towards to fix #17891

**Workarounds, if any**

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**
Planned