### PR TITLE
Removing zero initialization of locals upon entering a scope. (for locals captured by a local function).

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -635,25 +635,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var prologue = ArrayBuilder<BoundExpression>.GetInstance();
 
-            BoundExpression newFrame;
-            if (frame.Constructor == null)
-            {
-                Debug.Assert(frame.TypeKind == TypeKind.Struct);
-                newFrame = new BoundDefaultExpression(syntax: syntax, type: frameType);
-            }
-            else
+            if (frame.Constructor != null)
             {
                 MethodSymbol constructor = frame.Constructor.AsMember(frameType);
                 Debug.Assert(frameType == constructor.ContainingType);
-                newFrame = new BoundObjectCreationExpression(
-                syntax: syntax,
-                constructor: constructor);
-            }
 
-            prologue.Add(new BoundAssignmentOperator(syntax,
-                new BoundLocal(syntax, framePointer, null, frameType),
-                newFrame,
-                frameType));
+                prologue.Add(new BoundAssignmentOperator(syntax,
+                    new BoundLocal(syntax, framePointer, null, frameType),
+                    new BoundObjectCreationExpression(syntax: syntax, constructor: constructor),
+                    frameType));
+            }
 
             CapturedSymbolReplacement oldInnermostFrameProxy = null;
             if ((object)_innermostFramePointer != null)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -1529,82 +1529,80 @@ public class C
                 parseOptions: _localFunctionParseOptions,
                 expectedOptimizedIL: @"
 {
-  // Code size      250 (0xfa)
+  // Code size      242 (0xf2)
   .maxstack  7
   .locals init (C.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
                 object V_1, //d
                 object V_2) //l3
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    ""C.<>c__DisplayClass0_0""
-  IL_0008:  ldloca.s   V_0
-  IL_000a:  ldc.i4.0
-  IL_000b:  stfld      ""int C.<>c__DisplayClass0_0.capture1""
-  IL_0010:  ldc.i4.2
-  IL_0011:  box        ""int""
-  IL_0016:  stloc.1
-  IL_0017:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
-  IL_001c:  brtrue.s   IL_0042
-  IL_001e:  ldc.i4.0
-  IL_001f:  ldtoken    ""int""
-  IL_0024:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0029:  ldtoken    ""C""
-  IL_002e:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0033:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-  IL_0038:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_003d:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
-  IL_0042:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
-  IL_0047:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>>.Target""
-  IL_004c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
-  IL_0051:  ldloc.1
-  IL_0052:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, object, int>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-  IL_0057:  call       ""void C.<Main>g__L10_0(int)""
-  IL_005c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
-  IL_0061:  brtrue.s   IL_0087
-  IL_0063:  ldc.i4.0
-  IL_0064:  ldtoken    ""int""
-  IL_0069:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_006e:  ldtoken    ""C""
-  IL_0073:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0078:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-  IL_007d:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_0082:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
-  IL_0087:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
-  IL_008c:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>>.Target""
-  IL_0091:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
-  IL_0096:  ldloc.1
-  IL_0097:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, object, int>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-  IL_009c:  ldloca.s   V_0
-  IL_009e:  call       ""System.Action<int> C.<Main>g__L20_1(int, ref C.<>c__DisplayClass0_0)""
-  IL_00a3:  stloc.2
-  IL_00a4:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
-  IL_00a9:  brtrue.s   IL_00e3
-  IL_00ab:  ldc.i4     0x100
-  IL_00b0:  ldtoken    ""C""
-  IL_00b5:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_00ba:  ldc.i4.2
-  IL_00bb:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-  IL_00c0:  dup
-  IL_00c1:  ldc.i4.0
-  IL_00c2:  ldc.i4.0
-  IL_00c3:  ldnull
-  IL_00c4:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00c9:  stelem.ref
-  IL_00ca:  dup
-  IL_00cb:  ldc.i4.1
-  IL_00cc:  ldc.i4.0
-  IL_00cd:  ldnull
-  IL_00ce:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_00d3:  stelem.ref
-  IL_00d4:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Invoke(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-  IL_00d9:  call       ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_00de:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
-  IL_00e3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
-  IL_00e8:  ldfld      ""System.Action<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
-  IL_00ed:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
-  IL_00f2:  ldloc.2
-  IL_00f3:  ldloc.1
-  IL_00f4:  callvirt   ""void System.Action<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
-  IL_00f9:  ret
+  IL_0002:  ldc.i4.0
+  IL_0003:  stfld      ""int C.<>c__DisplayClass0_0.capture1""
+  IL_0008:  ldc.i4.2
+  IL_0009:  box        ""int""
+  IL_000e:  stloc.1
+  IL_000f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
+  IL_0014:  brtrue.s   IL_003a
+  IL_0016:  ldc.i4.0
+  IL_0017:  ldtoken    ""int""
+  IL_001c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0021:  ldtoken    ""C""
+  IL_0026:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_002b:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0030:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_0035:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
+  IL_003a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
+  IL_003f:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>>.Target""
+  IL_0044:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__0""
+  IL_0049:  ldloc.1
+  IL_004a:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, object, int>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+  IL_004f:  call       ""void C.<Main>g__L10_0(int)""
+  IL_0054:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
+  IL_0059:  brtrue.s   IL_007f
+  IL_005b:  ldc.i4.0
+  IL_005c:  ldtoken    ""int""
+  IL_0061:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0066:  ldtoken    ""C""
+  IL_006b:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0070:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0075:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_007a:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
+  IL_007f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
+  IL_0084:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, int> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>>.Target""
+  IL_0089:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, int>> C.<>o__0.<>p__1""
+  IL_008e:  ldloc.1
+  IL_008f:  callvirt   ""int System.Func<System.Runtime.CompilerServices.CallSite, object, int>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+  IL_0094:  ldloca.s   V_0
+  IL_0096:  call       ""System.Action<int> C.<Main>g__L20_1(int, ref C.<>c__DisplayClass0_0)""
+  IL_009b:  stloc.2
+  IL_009c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
+  IL_00a1:  brtrue.s   IL_00db
+  IL_00a3:  ldc.i4     0x100
+  IL_00a8:  ldtoken    ""C""
+  IL_00ad:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_00b2:  ldc.i4.2
+  IL_00b3:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_00b8:  dup
+  IL_00b9:  ldc.i4.0
+  IL_00ba:  ldc.i4.0
+  IL_00bb:  ldnull
+  IL_00bc:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00c1:  stelem.ref
+  IL_00c2:  dup
+  IL_00c3:  ldc.i4.1
+  IL_00c4:  ldc.i4.0
+  IL_00c5:  ldnull
+  IL_00c6:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_00cb:  stelem.ref
+  IL_00cc:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Invoke(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_00d1:  call       ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_00d6:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
+  IL_00db:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
+  IL_00e0:  ldfld      ""System.Action<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
+  IL_00e5:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Action<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__2""
+  IL_00ea:  ldloc.2
+  IL_00eb:  ldloc.1
+  IL_00ec:  callvirt   ""void System.Action<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object, object)""
+  IL_00f1:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -4000,47 +4000,41 @@ class Program
         }
     }", expectedOutput: "6");
 
-            //BUG: the "initobj" instructions in the following code are redundant.
+            //NOTE: the following code should not have "initobj" instructions.
 
             c.VerifyIL("Program.Main", @"
 {
-  // Code size       87 (0x57)
+  // Code size       63 (0x3f)
   .maxstack  3
   .locals init (Program.<>c__DisplayClass0_0 V_0, //CS$<>8__locals0
                 Program.<>c__DisplayClass0_1 V_1, //CS$<>8__locals1
                 Program.<>c__DisplayClass0_2 V_2) //CS$<>8__locals2
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    ""Program.<>c__DisplayClass0_0""
-  IL_0008:  ldloca.s   V_0
-  IL_000a:  ldc.i4.1
-  IL_000b:  stfld      ""int Program.<>c__DisplayClass0_0.q""
-  IL_0010:  ldloc.0
-  IL_0011:  ldfld      ""int Program.<>c__DisplayClass0_0.q""
-  IL_0016:  ldc.i4.0
-  IL_0017:  ble.s      IL_0056
-  IL_0019:  ldloca.s   V_1
-  IL_001b:  initobj    ""Program.<>c__DisplayClass0_1""
-  IL_0021:  ldloca.s   V_1
-  IL_0023:  ldc.i4.2
-  IL_0024:  stfld      ""int Program.<>c__DisplayClass0_1.w""
-  IL_0029:  ldloc.1
-  IL_002a:  ldfld      ""int Program.<>c__DisplayClass0_1.w""
-  IL_002f:  ldc.i4.0
-  IL_0030:  ble.s      IL_0056
-  IL_0032:  ldloca.s   V_2
-  IL_0034:  initobj    ""Program.<>c__DisplayClass0_2""
-  IL_003a:  ldloca.s   V_2
-  IL_003c:  ldc.i4.3
-  IL_003d:  stfld      ""int Program.<>c__DisplayClass0_2.e""
-  IL_0042:  ldloc.2
-  IL_0043:  ldfld      ""int Program.<>c__DisplayClass0_2.e""
-  IL_0048:  ldc.i4.0
-  IL_0049:  ble.s      IL_0056
-  IL_004b:  ldloca.s   V_0
-  IL_004d:  ldloca.s   V_1
-  IL_004f:  ldloca.s   V_2
-  IL_0051:  call       ""void Program.<Main>g__Print0_0(ref Program.<>c__DisplayClass0_0, ref Program.<>c__DisplayClass0_1, ref Program.<>c__DisplayClass0_2)""
-  IL_0056:  ret
+  IL_0002:  ldc.i4.1
+  IL_0003:  stfld      ""int Program.<>c__DisplayClass0_0.q""
+  IL_0008:  ldloc.0
+  IL_0009:  ldfld      ""int Program.<>c__DisplayClass0_0.q""
+  IL_000e:  ldc.i4.0
+  IL_000f:  ble.s      IL_003e
+  IL_0011:  ldloca.s   V_1
+  IL_0013:  ldc.i4.2
+  IL_0014:  stfld      ""int Program.<>c__DisplayClass0_1.w""
+  IL_0019:  ldloc.1
+  IL_001a:  ldfld      ""int Program.<>c__DisplayClass0_1.w""
+  IL_001f:  ldc.i4.0
+  IL_0020:  ble.s      IL_003e
+  IL_0022:  ldloca.s   V_2
+  IL_0024:  ldc.i4.3
+  IL_0025:  stfld      ""int Program.<>c__DisplayClass0_2.e""
+  IL_002a:  ldloc.2
+  IL_002b:  ldfld      ""int Program.<>c__DisplayClass0_2.e""
+  IL_0030:  ldc.i4.0
+  IL_0031:  ble.s      IL_003e
+  IL_0033:  ldloca.s   V_0
+  IL_0035:  ldloca.s   V_1
+  IL_0037:  ldloca.s   V_2
+  IL_0039:  call       ""void Program.<Main>g__Print0_0(ref Program.<>c__DisplayClass0_0, ref Program.<>c__DisplayClass0_1, ref Program.<>c__DisplayClass0_2)""
+  IL_003e:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -1599,22 +1599,20 @@ class Program
 
             CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: false).VerifyIL("Program.M()", @"
 {
-  // Code size       34 (0x22)
+  // Code size       26 (0x1a)
   .maxstack  5
   .locals init (Program.<>c__DisplayClass0_0 V_0) //CS$<>8__locals0
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    ""Program.<>c__DisplayClass0_0""
-  IL_0008:  ldloca.s   V_0
-  IL_000a:  ldc.i4.1
-  IL_000b:  newarr     ""int""
-  IL_0010:  dup
-  IL_0011:  ldc.i4.0
-  IL_0012:  ldc.i4.s   40
-  IL_0014:  stelem.i4
-  IL_0015:  stfld      ""int[] Program.<>c__DisplayClass0_0.arr""
-  IL_001a:  ldloca.s   V_0
-  IL_001c:  call       ""ref int Program.<M>g__N0_0(ref Program.<>c__DisplayClass0_0)""
-  IL_0021:  ret
+  IL_0002:  ldc.i4.1
+  IL_0003:  newarr     ""int""
+  IL_0008:  dup
+  IL_0009:  ldc.i4.0
+  IL_000a:  ldc.i4.s   40
+  IL_000c:  stelem.i4
+  IL_000d:  stfld      ""int[] Program.<>c__DisplayClass0_0.arr""
+  IL_0012:  ldloca.s   V_0
+  IL_0014:  call       ""ref int Program.<M>g__N0_0(ref Program.<>c__DisplayClass0_0)""
+  IL_0019:  ret
 }").VerifyIL("Program.<M>g__N0_0", @"
 {
   // Code size       24 (0x18)


### PR DESCRIPTION
Fixes :#19119

While working on a blog article about Local Functions, I noticed a codegen artifact whose purpose I could not quite explain. We are zeroing out variables when entering a scope if the variables happen to be captured in a struct closure. 

See: bug #19119

The reason why this is happening is likely because the behavior was copied from the older codepath when closure is a class and we do have to `new` a new instance. We do not need to `new` the struct though.  
The code does not really create a new instance. It only clears the old state, which is not observable anyways by the guarantees provided by the Definite Assignment Analysis. 

== Risk

The risk is low.

If this zero-out is observable, we have a much bigger problem. It would indicate a Definite Assignment Analysis failure.

== Performance impact

We are removing redundant code.
In simple cases it is removed by the JIT as well, so we are mostly just making the IL a bit cleaner.

I could imagine that in more complicated cases - bigger display structs or a JIT that is not as smart, zeroing out would incur run-time penalties.

== Is this a regression from a previous update?

No. We had that redundancy since we have shipped the feature.