### PR TITLE
Remove unused private method

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
@@ -162,18 +162,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return asset;
             }
 
-            private CompilationWithAnalyzers CreateAnalyzerDriver(CompilationWithAnalyzers analyzerDriver, Func<DiagnosticAnalyzer, bool> predicate)
-            {
-                var analyzers = analyzerDriver.Analyzers.Where(predicate).ToImmutableArray();
-                if (analyzers.Length == 0)
-                {
-                    // we can't create analyzer driver with 0 analyzers
-                    return null;
-                }
-
-                return analyzerDriver.Compilation.WithAnalyzers(analyzers, analyzerDriver.AnalysisOptions);
-            }
-
             private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> GetCompilerAnalysisResultAsync(Stream stream, Dictionary<string, DiagnosticAnalyzer> analyzerMap, Project project, CancellationToken cancellationToken)
             {
                 // handling of cancellation and exception


### PR DESCRIPTION
## Ask Mode

**Customer scenario**

No observable changes. A `private` unreferenced method is deleted.

**Bugs this fixes:**

N/A

**Workarounds, if any**

None needed.

**Risk**

Low (no behavior changes).

**Performance impact**

Trivial (slightly smaller assembly, no change to executed code).

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

No readily-available code coverage reports.

**How was the bug found?**

Internal code review.
