### PR TITLE
Avoid inefficient use of ContainsKey

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -215,9 +215,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var isSuppressed = !diag.IsEnabledByDefault;
 
                 // If the user said something about it, that overrides the author.
-                if (diagnosticOptions.ContainsKey(diag.Id))
+                if (diagnosticOptions.TryGetValue(diag.Id, out var severity))
                 {
-                    isSuppressed = diagnosticOptions[diag.Id] == ReportDiagnostic.Suppress;
+                    isSuppressed = severity == ReportDiagnostic.Suppress;
                 }
 
                 if (!isSuppressed)

--- a/src/Compilers/Core/Portable/InternalUtilities/ImmutableSetWithInsertionOrder`1.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ImmutableSetWithInsertionOrder`1.cs
@@ -44,13 +44,14 @@ namespace Roslyn.Utilities
 
         public ImmutableSetWithInsertionOrder<T> Remove(T value)
         {
-            // no reason to cause allocations if value is missing
-            if (!_map.ContainsKey(value))
+            var modifiedMap = _map.Remove(value);
+            if (modifiedMap == _map)
             {
+                // no reason to cause allocations if value is missing
                 return this;
             }
 
-            return this.Count == 1 ? Empty : new ImmutableSetWithInsertionOrder<T>(_map.Remove(value), _nextElementValue);
+            return this.Count == 1 ? Empty : new ImmutableSetWithInsertionOrder<T>(modifiedMap, _nextElementValue);
         }
 
         public IEnumerable<T> InInsertionOrder

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1916,20 +1916,14 @@ lVbRuntimePlus:
                             End If
 
                             ' Expression evaluated successfully --> add to 'defines'
-                            If defines.ContainsKey(symbolName) Then
-                                defines = defines.Remove(symbolName)
-                            End If
-                            defines = defines.Add(symbolName, value)
+                            defines = defines.SetItem(symbolName, value)
 
                         ElseIf tokens.Current.Kind = SyntaxKind.CommaToken OrElse
                             tokens.Current.Kind = SyntaxKind.ColonToken OrElse
                             tokens.Current.Kind = SyntaxKind.EndOfFileToken Then
                             ' We have no value being assigned, so we'll just assign it to true
 
-                            If defines.ContainsKey(symbolName) Then
-                                defines = defines.Remove(symbolName)
-                            End If
-                            defines = defines.Add(symbolName, InternalSyntax.CConst.Create(True))
+                            defines = defines.SetItem(symbolName, InternalSyntax.CConst.Create(True))
 
                         ElseIf tokens.Current.Kind = SyntaxKind.BadToken Then
                             GetErrorStringForRemainderOfConditionalCompilation(tokens, parsedTokensAsString)

--- a/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs
@@ -150,7 +150,24 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             {
                 // sort the result to the order defined by the fixers
                 var priorityMap = _fixerPriorityMap[document.Project.Language].Value;
-                result.Sort((d1, d2) => priorityMap.ContainsKey((CodeFixProvider)d1.Provider) ? (priorityMap.ContainsKey((CodeFixProvider)d2.Provider) ? priorityMap[(CodeFixProvider)d1.Provider] - priorityMap[(CodeFixProvider)d2.Provider] : -1) : 1);
+                result.Sort((d1, d2) =>
+                {
+                    if (priorityMap.TryGetValue((CodeFixProvider)d1.Provider, out int priority1))
+                    {
+                        if (priorityMap.TryGetValue((CodeFixProvider)d2.Provider, out int priority2))
+                        {
+                            return priority1 - priority2;
+                        }
+                        else
+                        {
+                            return -1;
+                        }
+                    }
+                    else
+                    {
+                        return 1;
+                    }
+                });
             }
 
             // TODO (https://github.com/dotnet/roslyn/issues/4932): Don't restrict CodeFixes in Interactive

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -604,9 +604,9 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                     {
                         var snapshot = spansToTag.First(s => s.SnapshotSpan.Snapshot.TextBuffer == latestBuffer).SnapshotSpan.Snapshot;
 
-                        if (oldTagTrees.ContainsKey(latestBuffer))
+                        if (oldTagTrees.TryGetValue(latestBuffer, out var previousSpans))
                         {
-                            var difference = ComputeDifference(snapshot, newTagTrees[latestBuffer], oldTagTrees[latestBuffer]);
+                            var difference = ComputeDifference(snapshot, newTagTrees[latestBuffer], previousSpans);
                             bufferToChanges[latestBuffer] = difference;
                         }
                         else


### PR DESCRIPTION
## Ask Mode

**Customer scenario**

No observable changes.

* Use `TryGetValue` instead of `ContainsKey`&rarr;indexer
* Use `Remove` instead of `ContainsKey`&rarr;`Remove`
* Use `SetItem` instead of `ContainsKey`&rarr;`Remove`&rarr;`Add`

**Bugs this fixes:**

N/A

**Workarounds, if any**

None needed.

**Risk**

Low (no behavior changes).

**Performance impact**

Performance is improved by eliminating duplicated dictionary operations.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Missed during code review.

**How was the bug found?**

Internal code review.
