### PR TITLE
Avoid allocations due to use of Keys/Values instead of GetEnumerator

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -564,13 +564,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Check constraints within named aliases.
 
             // Force resolution of named aliases.
-            foreach (var alias in UsingAliases.Values)
+            foreach (var (_, alias) in UsingAliases)
             {
                 alias.Alias.GetAliasTarget(basesBeingResolved: null);
                 semanticDiagnostics.AddRange(alias.Alias.AliasTargetDiagnostics);
             }
 
-            foreach (var alias in UsingAliases.Values)
+            foreach (var (_, alias) in UsingAliases)
             {
                 alias.Alias.CheckConstraints(semanticDiagnostics);
             }
@@ -823,7 +823,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal void AddLookupSymbolsInfoInAliases(LookupSymbolsInfo result, LookupOptions options, Binder originalBinder)
         {
-            foreach (var usingAlias in this.UsingAliases.Values)
+            foreach (var (_, usingAlias) in this.UsingAliases)
             {
                 AddAliasSymbolToResult(result, usingAlias.Alias, options, originalBinder);
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -402,7 +402,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             if (_lazyAnalyzerActionCountsMap == null)
             {
                 var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, AnalyzerActionCounts>();
-                foreach (var analyzer in _analyzerStateMap.Keys)
+                foreach (var (analyzer, _) in _analyzerStateMap)
                 {
                     var actionCounts = await driver.GetAnalyzerActionCountsAsync(analyzer, _compilationOptions, cancellationToken).ConfigureAwait(false);
                     builder.Add(analyzer, actionCounts);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var reportedError = false;
 
                 // Add language specific analyzers.
-                foreach (var language in analyzerTypeNameMap.Keys)
+                foreach (var (language, _) in analyzerTypeNameMap)
                 {
                     if (language == null)
                     {

--- a/src/Compilers/Core/Portable/InternalUtilities/KeyValuePair.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/KeyValuePair.cs
@@ -10,5 +10,11 @@ namespace Roslyn.Utilities
         {
             return new KeyValuePair<K, V>(key, value);
         }
+
+        public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> keyValuePair, out TKey key, out TValue value)
+        {
+            key = keyValuePair.Key;
+            value = keyValuePair.Value;
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
@@ -617,7 +617,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
 
                 If staticLocals IsNot Nothing Then
-                    For Each array In staticLocals.Values
+                    For Each nameToArray In staticLocals
+                        Dim array = nameToArray.Value
                         If array.Count > 1 Then
                             Dim lexicallyFirst As LocalSymbol = array(0)
 

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ProduceTags.cs
@@ -600,28 +600,28 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 var bufferToChanges = new Dictionary<ITextBuffer, DiffResult>();
                 using (Logger.LogBlock(FunctionId.Tagger_TagSource_ProcessNewTags, cancellationToken))
                 {
-                    foreach (var latestBuffer in newTagTrees.Keys)
+                    foreach (var (latestBuffer, latestSpans) in newTagTrees)
                     {
                         var snapshot = spansToTag.First(s => s.SnapshotSpan.Snapshot.TextBuffer == latestBuffer).SnapshotSpan.Snapshot;
 
                         if (oldTagTrees.TryGetValue(latestBuffer, out var previousSpans))
                         {
-                            var difference = ComputeDifference(snapshot, newTagTrees[latestBuffer], previousSpans);
+                            var difference = ComputeDifference(snapshot, latestSpans, previousSpans);
                             bufferToChanges[latestBuffer] = difference;
                         }
                         else
                         {
                             // It's a new buffer, so report all spans are changed
-                            bufferToChanges[latestBuffer] = new DiffResult(added: newTagTrees[latestBuffer].GetSpans(snapshot).Select(t => t.Span), removed: null);
+                            bufferToChanges[latestBuffer] = new DiffResult(added: latestSpans.GetSpans(snapshot).Select(t => t.Span), removed: null);
                         }
                     }
 
-                    foreach (var oldBuffer in oldTagTrees.Keys)
+                    foreach (var (oldBuffer, previousSpans) in oldTagTrees)
                     {
                         if (!newTagTrees.ContainsKey(oldBuffer))
                         {
                             // This buffer disappeared, so let's notify that the old tags are gone
-                            bufferToChanges[oldBuffer] = new DiffResult(added: null, removed: oldTagTrees[oldBuffer].GetSpans(oldBuffer.CurrentSnapshot).Select(t => t.Span));
+                            bufferToChanges[oldBuffer] = new DiffResult(added: null, removed: previousSpans.GetSpans(oldBuffer.CurrentSnapshot).Select(t => t.Span));
                         }
                     }
                 }

--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public void ClearAnalyzerDiagnostics(ProjectId projectId)
         {
-            foreach (var analyzer in _analyzerHostDiagnosticsMap.Keys)
+            foreach (var (analyzer, _) in _analyzerHostDiagnosticsMap)
             {
                 ClearAnalyzerDiagnostics(analyzer, projectId);
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         }
 
                         // TODO: for now, this is static, but in future, we might consider making this a dynamic so that we process cheaper analyzer first.
-                        foreach (var set in _map.Values)
+                        foreach (var (_, set) in _map)
                         {
                             yield return set;
                         }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 {
@@ -95,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                             yield return _compilerAnalyzer;
                         }
 
-                        foreach (var analyzer in _map.Keys)
+                        foreach (var (analyzer, _) in _map)
                         {
                             yield return analyzer;
                         }

--- a/src/Features/Core/Portable/SolutionCrawler/AggregateIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/AggregateIncrementalAnalyzer.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Options;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
@@ -21,7 +22,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public async Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
         {
-            foreach (var analyzer in this.Analyzers.Values)
+            foreach (var (_, analyzer) in this.Analyzers)
             {
                 if (analyzer.IsValueCreated)
                 {
@@ -98,7 +99,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public void RemoveDocument(DocumentId documentId)
         {
-            foreach (var analyzer in this.Analyzers.Values)
+            foreach (var (_, analyzer) in this.Analyzers)
             {
                 if (analyzer.IsValueCreated)
                 {
@@ -109,7 +110,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public void RemoveProject(ProjectId projectId)
         {
-            foreach (var analyzer in this.Analyzers.Values)
+            foreach (var (_, analyzer) in this.Analyzers)
             {
                 if (analyzer.IsValueCreated)
                 {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -276,7 +276,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
 
                 // We have different suppression fixers for every language.
                 // So we need to group diagnostics by the containing project language and apply fixes separately.
-                languages = new HashSet<string>(projectDiagnosticsToFixMap.Keys.Select(p => p.Language).Concat(documentDiagnosticsToFixMap.Select(kvp => kvp.Key.Project.Language)));
+                languages = new HashSet<string>(projectDiagnosticsToFixMap.Select(p => p.Key.Language).Concat(documentDiagnosticsToFixMap.Select(kvp => kvp.Key.Project.Language)));
 
                 foreach (var language in languages)
                 {

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllLogger.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllLogger.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesComputation_Diagnostics, KeyValueLogMessage.Create(m =>
             {
-                m[s_documentsWithDiagnosticsToFix] = documentsAndDiagnosticsToFixMap.Keys.Count();
+                m[s_documentsWithDiagnosticsToFix] = documentsAndDiagnosticsToFixMap.Count;
                 m[s_totalDiagnosticsToFix] = documentsAndDiagnosticsToFixMap.Values.Sum(v => v.Length);
             }));
         }
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             Logger.Log(FunctionId.CodeFixes_FixAllOccurrencesComputation_Diagnostics, KeyValueLogMessage.Create(m =>
             {
-                m[s_projectsWithDiagnosticsToFix] = projectsAndDiagnosticsToFixMap.Keys.Count();
+                m[s_projectsWithDiagnosticsToFix] = projectsAndDiagnosticsToFixMap.Count;
                 m[s_totalDiagnosticsToFix] = projectsAndDiagnosticsToFixMap.Values.Sum(v => v.Length);
             }));
         }

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -174,7 +174,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, DiagnosticAnalysisResultBuilder>();
 
             ImmutableArray<Diagnostic> diagnostics;
-            ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>> diagnosticsByAnalyzerMap;
 
             foreach (var analyzer in analyzers)
             {
@@ -182,20 +181,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 var result = new DiagnosticAnalysisResultBuilder(project, version);
 
-                foreach (var tree in analysisResult.SyntaxDiagnostics.Keys)
+                foreach (var (tree, diagnosticsByAnalyzerMap) in analysisResult.SyntaxDiagnostics)
                 {
-                    if (analysisResult.SyntaxDiagnostics.TryGetValue(tree, out diagnosticsByAnalyzerMap) &&
-                        diagnosticsByAnalyzerMap.TryGetValue(analyzer, out diagnostics))
+                    if (diagnosticsByAnalyzerMap.TryGetValue(analyzer, out diagnostics))
                     {
                         Contract.Requires(diagnostics.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation).Count());
                         result.AddSyntaxDiagnostics(tree, diagnostics);
                     }
                 }
 
-                foreach (var tree in analysisResult.SemanticDiagnostics.Keys)
+                foreach (var (tree, diagnosticsByAnalyzerMap) in analysisResult.SemanticDiagnostics)
                 {
-                    if (analysisResult.SemanticDiagnostics.TryGetValue(tree, out diagnosticsByAnalyzerMap) &&
-                        diagnosticsByAnalyzerMap.TryGetValue(analyzer, out diagnostics))
+                    if (diagnosticsByAnalyzerMap.TryGetValue(analyzer, out diagnostics))
                     {
                         Contract.Requires(diagnostics.Length == CompilationWithAnalyzers.GetEffectiveDiagnostics(diagnostics, compilation).Count());
                         result.AddSemanticDiagnostics(tree, diagnostics);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -420,7 +420,7 @@ namespace Microsoft.CodeAnalysis
             // update parse options for all documents too
             var docMap = _documentStates;
 
-            foreach (var docId in _documentStates.Keys)
+            foreach (var (docId, _) in _documentStates)
             {
                 var oldDocState = this.GetDocumentState(docId);
                 var newDocState = oldDocState.UpdateParseOptions(options);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis
         {
             // this may produce a version that is out of sync with the actual Document versions.
             var latestVersion = VersionStamp.Default;
-            foreach (var doc in documentStates.Values)
+            foreach (var (_, doc) in documentStates)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            foreach (var additionalDoc in additionalDocumentStates.Values)
+            foreach (var (_, additionalDoc) in additionalDocumentStates)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis
         {
             // this may produce a version that is out of sync with the actual Document versions.
             var latestVersion = VersionStamp.Default;
-            foreach (var doc in documentStates.Values)
+            foreach (var (_, doc) in documentStates)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis
                 latestVersion = version.GetNewerVersion(latestVersion);
             }
 
-            foreach (var additionalDoc in additionalDocumentStates.Values)
+            foreach (var (_, additionalDoc) in additionalDocumentStates)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -372,7 +372,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             // TODO: Remove this loop when we add source assembly symbols to s_assemblyOrModuleSymbolToProjectMap
-            foreach (var state in _projectIdToProjectStateMap.Values)
+            foreach (var (_, state) in _projectIdToProjectStateMap)
             {
                 if (this.TryGetCompilation(state.Id, out var compilation))
                 {


### PR DESCRIPTION
`ImmutableDictionary<TKey, TValue>` provides a non-allocating implementation of `GetEnumerator()`, but does not offer non-allocating implementations of the `Keys` or `Values` properties (dotnet/corefx#249 and linked issues). This pull request adds a `Deconstruct` extension method for `KeyValuePair<TKey, TValue>`, leveraging a new C# feature to provide almost identical use-site code for these properties without actually incurring the allocation overhead.

:memo: This pull request builds on the change in #19125 to avoid merge conflicts (~~the first commit in the branch overlaps~~) (edit: no longer applies).

## Ask Mode

**Customer scenario**

No observable changes.

* Use `GetEnumerator()` instead of `Keys` where applicable
* Use `GetEnumerator()` instead of `Values` where applicable
* Add a `Deconstruct` extension method so the above changes can be implemented with minimal changes to the actual code structure

**Bugs this fixes:**

N/A

**Workarounds, if any**

None needed.

**Risk**

Low (no behavior changes).

**Performance impact**

Performance is improved by eliminating unnecessary allocations.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Missed during code review?

**How was the bug found?**

Internal code review.
