### PR TITLE
Add .mvid section to PE and remove dependency on MetadataReader

### DIFF
--- a/docs/compilers/CSharp/CommandLine.md
+++ b/docs/compilers/CSharp/CommandLine.md
@@ -4,6 +4,7 @@
 | ---- | ---- |
 | **OUTPUT FILES** |
 | `/out:`*file* | Specify output file name (default: base name of file with main class or first file)
+| `/refout:`*file* | Specify the reference assembly's output file name
 | `/target:exe` |  Build a console executable (default) (Short form: `/t:exe`)
 | `/target:winexe` | Build a Windows executable (Short form: `/t:winexe` )
 | `/target:library` | Build a library (Short form: `/t:library`)
@@ -32,6 +33,7 @@
 | `/debug`:{`full`&#124;`pdbonly`&#124;`portable`} | Specify debugging type (`full` is default, and  enables attaching a debugger to a running program. `portable` is a cross-platform format)
 | `/optimize`{`+`&#124;`-`} | Enable optimizations (Short form: `/o`)
 | `/deterministic` | Produce a deterministic assembly (including module version GUID and timestamp)
+| `/refonly | Produce a reference assembly, instead of a full assembly, as the primary output 
 | **ERRORS AND WARNINGS**
 | `/warnaserror`{`+`&#124;`-`} | Report all warnings as errors
 | `/warnaserror`{`+`&#124;`-`}`:`*warn list* | Report specific warnings as errors

--- a/docs/compilers/Visual Basic/CommandLine.md
+++ b/docs/compilers/Visual Basic/CommandLine.md
@@ -4,6 +4,7 @@
 | ---- | ---- |
 | **OUTPUT FILE**
 | `/out:`*file* | Specifies the output file name.
+| `/refout:`*file* | Specify the reference assembly's output file name
 | `/target:exe` | Create a console application (default). (Short form: `/t`)
 | `/target:winexe` | Create a Windows application.
 | `/target:library` | Create a library assembly.
@@ -34,6 +35,7 @@
 | `/debug:portable` | Emit debugging information in the portable format.
 | `/debug:pdbonly` | Emit PDB file only.
 | `/deterministic` | Produce a deterministic assembly (including module version GUID and timestamp)
+| `/refonly | Produce a reference assembly, instead of a full assembly, as the primary output 
 | **ERRORS AND WARNINGS**
 | `/nowarn` | Disable all warnings.
 | `/nowarn:`*number_list* | Disable a list of individual warnings.

--- a/docs/features/refout.md
+++ b/docs/features/refout.md
@@ -43,7 +43,6 @@ When the compiler produces documentation, the contents produced will match the A
 
 The compilation from the command-line will either produce both assemblies (implementation and ref) or neither. There is no "partial success" scenario.
 
-
 ### CscTask/CoreCompile
 The `CoreCompile` target will support a new output, called `IntermediateRefAssembly`, which parallels the existing `IntermediateAssembly`.
 The `Csc` task will support a new output, called `OutputRefAssembly`, which parallels the existing `OutputAssembly`.

--- a/docs/features/refout.md
+++ b/docs/features/refout.md
@@ -37,10 +37,12 @@ The `/refout` parameter specifies a file path where the ref assembly should be o
 The `/refonly` parameter is a flag that indicates that a ref assembly should be output instead of an implementation assembly. 
 The `/refonly` parameter is not allowed together with the `/refout` parameter, as it doesn't make sense to have both the primary and secondary outputs be ref assemblies. Also, the `/refonly` parameter silently disables outputting PDBs, as ref assemblies cannot be executed. 
 The `/refonly` parameter translates to `EmitMetadataOnly` being `true`, and `IncludePrivateMembers` being `false` in the `Emit` API (see details below).
+Neither `/refonly` nor `/refout` are permitted with `/target:module` or `/addmodule` options.
 
 When the compiler produces documentation, the contents produced will match the APIs that go into the primary output. In other words, the documentation will be filtered down when using the `/refonly` parameter.
 
 The compilation from the command-line will either produce both assemblies (implementation and ref) or neither. There is no "partial success" scenario.
+
 
 ### CscTask/CoreCompile
 The `CoreCompile` target will support a new output, called `IntermediateRefAssembly`, which parallels the existing `IntermediateAssembly`.
@@ -68,10 +70,9 @@ As mentioned above, there may be further refinements after C# 7.1:
 - produce ref assemblies even when there are errors outside method bodies (emitting error types when `EmitOptions.TolerateErrors` is set)
 
 ## Open questions
-- should explicit method implementations be included in ref assemblies? (answer: no. The interfaces that are declared as implemented are what matter to consuming compilations)
+- should explicit method implementations be included in ref assemblies?
 - Non-public attributes on public APIs (emit attribute based on accessibility rule)
 - ref assemblies and NoPia
-- `/refout` and `/addmodule`, should we disallow this combination? (answer: yes. This will not be supported in C# 7.1)
 
 ## Related issues
 - Produce ref assemblies from command-line and msbuild (https://github.com/dotnet/roslyn/issues/2184)

--- a/docs/features/refout.md
+++ b/docs/features/refout.md
@@ -32,7 +32,7 @@ Two mutually exclusive command-line parameters will be added to `csc.exe` and `v
 - `/refout`
 - `/refonly`
 
-The `/refout` parameter specifies a file path where the ref assembly should be output. This translates to `metadataPeStream` in the `Emit` API (see details below).
+The `/refout` parameter specifies a file path where the ref assembly should be output. This translates to `metadataPeStream` in the `Emit` API (see details below). The filename for the ref assembly should generally match that of the primary assembly, but it can be in a different folder.
 
 The `/refonly` parameter is a flag that indicates that a ref assembly should be output instead of an implementation assembly. 
 The `/refonly` parameter is not allowed together with the `/refout` parameter, as it doesn't make sense to have both the primary and secondary outputs be ref assemblies. Also, the `/refonly` parameter silently disables outputting PDBs, as ref assemblies cannot be executed. 
@@ -47,13 +47,14 @@ The `CoreCompile` target will support a new output, called `IntermediateRefAssem
 The `Csc` task will support a new output, called `OutputRefAssembly`, which parallels the existing `OutputAssembly`.
 Both of those basically map to the `/refout` command-line parameter.
 
-An additional task, called `CopyRefAssembly`, will be provided along with the existing `Csc` task. It takes a `SourcePath` and a `DestinationPath` and generally copies the file from the source over to the destination. But if it can determine that the contents of those two files match, then the destination file is left untouched.
+An additional task, called `CopyRefAssembly`, will be provided along with the existing `Csc` task. It takes a `SourcePath` and a `DestinationPath` and generally copies the file from the source over to the destination. But if it can determine that the contents of those two files match (by comparing their MVIDs, see details below), then the destination file is left untouched.
 
 ### CodeAnalysis APIs
 It is already possible to produce metadata-only assemblies by using `EmitOptions.EmitMetadataOnly`, which is used in IDE scenarios with cross-language dependencies.
 The compiler will be updated to honour the `EmitOptions.IncludePrivateMembers` flag as well. When combined with `EmitMetadataOnly` or a `metadataPeStream` in `Emit`, a ref assembly will be produced.
-The diagnostic check for emitting methods lacking a body (`void M();`) will be moved from declaration diagnostics to regular diagnostics, so that code will successfully emit with `EmitMetadataOnly`.
+The diagnostic check for emitting methods lacking a body (`void M();`) will be filtered from declaration diagnostics, so that code will successfully emit with `EmitMetadataOnly`.
 Later on, the `EmitOptions.TolerateErrors` flag will allow emitting error types as well.
+`Emit` is also modified to produce a new PE section called ".mvid" containing a copy of the MVID, when producing ref assemblies. This makes it easy for `CopyRefAssembly` to extract and compare MVIDs from ref assemblies.
 
 Going back to the 4 driving scenarios:
 1. For a regular compilation, `EmitMetadataOnly` is left to `false` and no `metadataPeStream` is passed into `Emit`.
@@ -67,10 +68,10 @@ As mentioned above, there may be further refinements after C# 7.1:
 - produce ref assemblies even when there are errors outside method bodies (emitting error types when `EmitOptions.TolerateErrors` is set)
 
 ## Open questions
-- should explicit method implementations be included in ref assemblies?
+- should explicit method implementations be included in ref assemblies? (answer: no. The interfaces that are declared as implemented are what matter to consuming compilations)
 - Non-public attributes on public APIs (emit attribute based on accessibility rule)
 - ref assemblies and NoPia
-- `/refout` and `/addmodule`, should we disallow this combination?
+- `/refout` and `/addmodule`, should we disallow this combination? (answer: yes. This will not be supported in C# 7.1)
 
 ## Related issues
 - Produce ref assemblies from command-line and msbuild (https://github.com/dotnet/roslyn/issues/2184)

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -55,6 +55,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="..\..\..\Core\MSBuildTask\MvidReader.cs">
+      <Link>Emit\MvidReader.cs</Link>
+    </Compile>
     <Compile Include="Attributes\AttributeTests.cs" />
     <Compile Include="Attributes\AttributeTests_Assembly.cs" />
     <Compile Include="Attributes\AttributeTests_CallerInfoAttributes.cs" />

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -343,13 +343,15 @@ public class C
             peBlob.WriteContentTo(peStream);
 
             peStream.Position = 0;
-            var peReader = new PEReader(peStream);
-            AssertEx.Equal(new[] { ".text", ".rsrc", ".reloc", ".mvid" },
-                peReader.PEHeaders.SectionHeaders.Select(h => h.Name));
+            using (var peReader = new PEReader(peStream))
+            {
+                AssertEx.Equal(new[] { ".text", ".rsrc", ".reloc", ".mvid" },
+                    peReader.PEHeaders.SectionHeaders.Select(h => h.Name));
 
-            peStream.Position = 0;
-            var mvid = BuildTasks.MvidReader.ReadAssemblyMvidOrEmpty(peStream);
-            Assert.Equal(TestPEBuilder.s_mvid, mvid);
+                peStream.Position = 0;
+                var mvid = BuildTasks.MvidReader.ReadAssemblyMvidOrEmpty(peStream);
+                Assert.Equal(TestPEBuilder.s_mvid, mvid);
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -262,11 +262,11 @@ public class C
 
                 VerifyEntryPoint(output, expectZero: false);
                 VerifyMethods(output, new[] { "void C.Main()", "C..ctor()" });
-                VerifyMVID(output, hasMvidSection: false);
+                VerifyMvid(output, hasMvidSection: false);
 
                 VerifyEntryPoint(metadataOutput, expectZero: true);
                 VerifyMethods(metadataOutput, new[] { "C..ctor()" });
-                VerifyMVID(metadataOutput, hasMvidSection: true);
+                VerifyMvid(metadataOutput, hasMvidSection: true);
             }
 
             void VerifyEntryPoint(MemoryStream stream, bool expectZero)
@@ -281,7 +281,7 @@ public class C
         /// Extract the MVID using two different methods (PEReader and MvidReader) and compare them. 
         /// We only expect an .mvid section in ref assemblies.
         /// </summary>
-        void VerifyMVID(MemoryStream stream, bool hasMvidSection)
+        private void VerifyMvid(MemoryStream stream, bool hasMvidSection)
         {
             Guid mvidFromModuleDefinition;
             stream.Position = 0;
@@ -291,7 +291,7 @@ public class C
                 mvidFromModuleDefinition = metadataReader.GetGuid(metadataReader.GetModuleDefinition().Mvid);
 
                 stream.Position = 0;
-                var mvidFromMvidReader = BuildTasks.MvidReader.ReadAssemblyMvid(stream);
+                var mvidFromMvidReader = BuildTasks.MvidReader.ReadAssemblyMvidOrEmpty(stream);
 
                 if (hasMvidSection)
                 {
@@ -326,8 +326,8 @@ public class C
                 VerifyMethods(output, new[] { "System.Int32 C.<PrivateSetter>k__BackingField", "System.Int32 C.PrivateSetter.get", "void C.PrivateSetter.set",
                     "C..ctor()", "System.Int32 C.PrivateSetter { get; private set; }" });
                 VerifyMethods(metadataOutput, new[] { "System.Int32 C.PrivateSetter.get", "C..ctor()", "System.Int32 C.PrivateSetter { get; }" });
-                VerifyMVID(output, hasMvidSection: false);
-                VerifyMVID(metadataOutput, hasMvidSection: true);
+                VerifyMvid(output, hasMvidSection: false);
+                VerifyMvid(metadataOutput, hasMvidSection: true);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -49,7 +49,6 @@ class X
                 Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "x"));
         }
 
-
         [Fact]
         public void CompilationEmitWithQuotedMainType()
         {

--- a/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
+++ b/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.IO;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -85,10 +83,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         private Guid ExtractMvid(string path)
         {
             using (FileStream source = File.OpenRead(path))
-            using (var reader = new PEReader(source))
             {
-                var metadataReader = reader.GetMetadataReader();
-                return metadataReader.GetGuid(metadataReader.GetModuleDefinition().Mvid);
+                return MvidReader.ReadAssemblyMvid(source);
             }
         }
     }

--- a/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
+++ b/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             using (FileStream source = File.OpenRead(path))
             {
-                return MvidReader.ReadAssemblyMvid(source);
+                return MvidReader.ReadAssemblyMvidOrEmpty(source);
             }
         }
     }

--- a/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/MSBuildTask.csproj
@@ -55,6 +55,7 @@
     </Compile>
     <Compile Include="AssemblyResolution.cs" />
     <Compile Include="CanonicalError.cs" />
+    <Compile Include="MvidReader.cs" />
     <Compile Include="CopyRefAssembly.cs" />
     <Compile Include="ValidateBootstrap.cs" />
     <Compile Include="CommandLineBuilderExtension.cs" />

--- a/src/Compilers/Core/MSBuildTask/MvidReader.cs
+++ b/src/Compilers/Core/MSBuildTask/MvidReader.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 // Section: Name (8)
                 byte[] name = ReadBytes(8);
                 if (name.Length == 8 && name[0] == '.' &&
-                    name[1] == 'm' && name[2] == 'v' && name[3] == 'i' && name[4] == 'd')
+                    name[1] == 'm' && name[2] == 'v' && name[3] == 'i' && name[4] == 'd' && name[5] == '\0')
                 {
                     // Section: VirtualSize (4)
                     uint virtualSize = ReadUInt32();
@@ -104,13 +104,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                     return new Guid(guidBytes);
                 }
-                else
-                {
-                    // Section: VirtualSize (4), VirtualAddress (4), SizeOfRawData (4),
-                    // PointerToRawData (4), PointerToRelocations (4), PointerToLineNumbers (4),
-                    // NumberOfRelocations (2), NumberOfLineNumbers (2), Characteristics (4)
-                    Skip(4 + 4 + 4 + 4 + 4 + 4 + 2 + 2 + 4);
-                }
+
+                // Section: VirtualSize (4), VirtualAddress (4), SizeOfRawData (4),
+                // PointerToRawData (4), PointerToRelocations (4), PointerToLineNumbers (4),
+                // NumberOfRelocations (2), NumberOfLineNumbers (2), Characteristics (4)
+                Skip(4 + 4 + 4 + 4 + 4 + 4 + 2 + 2 + 4);
             }
 
             return Guid.Empty;

--- a/src/Compilers/Core/MSBuildTask/MvidReader.cs
+++ b/src/Compilers/Core/MSBuildTask/MvidReader.cs
@@ -28,13 +28,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 return s_empty;
             }
-            if (!ReadUInt32(reader, out uint lfanew))
+            if (!ReadUInt32(reader, out uint pointerToPeSignature))
             {
                 return s_empty;
             }
 
             // jump over the MS DOS Stub to the PE Signature
-            if (!MoveTo(lfanew, reader))
+            if (!MoveTo(pointerToPeSignature, reader))
             {
                 return s_empty;
             }

--- a/src/Compilers/Core/MSBuildTask/project.json
+++ b/src/Compilers/Core/MSBuildTask/project.json
@@ -15,7 +15,6 @@
     "System.IO.Pipes": "4.3.0",
     "System.Linq": "4.3.0",
     "System.Reflection": "4.3.0",
-    "System.Reflection.Metadata": "1.4.2",
     "System.Security.AccessControl": "4.3.0",
     "System.Security.Cryptography.Algorithms": "4.3.0",
     "System.Security.Principal.Windows": "4.3.0",

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Emit\AsyncMoveNextBodyDebugInfo.cs" />
     <Compile Include="Emit\IteratorMoveNextBodyDebugInfo.cs" />
     <Compile Include="Emit\StateMachineMoveNextDebugInfo.cs" />
+    <Compile Include="PEWriter\ExtendedPEBuilder.cs" />
     <Compile Include="Serialization\IObjectWritable.cs" />
     <Compile Include="Serialization\ObjectBinder.cs" />
     <Compile Include="Serialization\ObjectBinderSnapshot.cs" />

--- a/src/Compilers/Core/Portable/PEWriter/ExtendedPEBuilder.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ExtendedPEBuilder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Cci
         private Blob _mvidSectionFixup = default(Blob);
 
         // Only include the .mvid section in ref assemblies
-        private bool _withMvidSection;
+        private readonly bool _withMvidSection;
 
         public ExtendedPEBuilder(
             PEHeaderBuilder header,

--- a/src/Compilers/Core/Portable/PEWriter/ExtendedPEBuilder.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ExtendedPEBuilder.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Cci
+{
+    /// <summary>
+    /// This PEBuilder adds an .mvid section.
+    /// </summary>
+    internal sealed class ExtendedPEBuilder
+        : ManagedPEBuilder
+    {
+        private const string MvidSectionName = ".mvid";
+        public const int SizeOfGuid = 16;
+
+        // When the section is built with a placeholder, the placeholder blob is saved for later fixing up.
+        private Blob _mvidSectionFixup = default(Blob);
+
+        // Only include the .mvid section in ref assemblies
+        private bool _withMvidSection;
+
+        public ExtendedPEBuilder(
+            PEHeaderBuilder header,
+            MetadataRootBuilder metadataRootBuilder,
+            BlobBuilder ilStream,
+            BlobBuilder mappedFieldData,
+            BlobBuilder managedResources,
+            ResourceSectionBuilder nativeResources,
+            DebugDirectoryBuilder debugDirectoryBuilder,
+            int strongNameSignatureSize,
+            MethodDefinitionHandle entryPoint,
+            CorFlags flags,
+            Func<IEnumerable<Blob>, BlobContentId> deterministicIdProvider,
+            bool withMvidSection)
+            : base(header, metadataRootBuilder, ilStream, mappedFieldData, managedResources, nativeResources,
+                  debugDirectoryBuilder, strongNameSignatureSize, entryPoint, flags, deterministicIdProvider)
+        {
+            _withMvidSection = withMvidSection;
+        }
+
+        protected override ImmutableArray<Section> CreateSections()
+        {
+            var baseSections = base.CreateSections();
+
+            if (_withMvidSection)
+            {
+                var builder = ArrayBuilder<Section>.GetInstance(baseSections.Length + 1);
+
+                builder.Add(new Section(MvidSectionName, SectionCharacteristics.MemRead |
+                    SectionCharacteristics.ContainsInitializedData |
+                    SectionCharacteristics.MemDiscardable));
+
+                builder.AddRange(baseSections);
+                return builder.ToImmutableAndFree();
+            }
+            else
+            {
+                return baseSections;
+            }
+        }
+
+        protected override BlobBuilder SerializeSection(string name, SectionLocation location)
+        {
+            if (name.Equals(MvidSectionName, StringComparison.Ordinal))
+            {
+                Debug.Assert(_withMvidSection);
+                return SerializeMvidSection(location);
+            }
+
+            return base.SerializeSection(name, location);
+        }
+
+        internal BlobContentId Serialize(BlobBuilder peBlob, out Blob mvidSectionFixup)
+        {
+            var result = base.Serialize(peBlob);
+            mvidSectionFixup = _mvidSectionFixup;
+            return result;
+        }
+
+        private BlobBuilder SerializeMvidSection(SectionLocation location)
+        {
+            var sectionBuilder = new BlobBuilder();
+
+            // The guid will be filled in later:
+            _mvidSectionFixup = sectionBuilder.ReserveBytes(SizeOfGuid);
+            var mvidWriter = new BlobWriter(_mvidSectionFixup);
+            mvidWriter.WriteBytes(0, _mvidSectionFixup.Length);
+            Debug.Assert(mvidWriter.RemainingBytes == 0);
+
+            return sectionBuilder;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Cci
             MethodDefinitionHandle entryPointHandle;
             MethodDefinitionHandle debugEntryPointHandle;
             mdWriter.GetEntryPoints(out entryPointHandle, out debugEntryPointHandle);
-            
+
             if (!debugEntryPointHandle.IsNil)
             {
                 nativePdbWriterOpt?.SetEntryPoint((uint)MetadataTokens.GetToken(debugEntryPointHandle));
@@ -186,7 +186,7 @@ namespace Microsoft.Cci
                 debugDirectoryBuilder = null;
             }
 
-            var peBuilder = new ManagedPEBuilder(
+            var peBuilder = new ExtendedPEBuilder(
                 peHeaderBuilder,
                 metadataRootBuilder,
                 ilBuilder,
@@ -197,12 +197,13 @@ namespace Microsoft.Cci
                 CalculateStrongNameSignatureSize(context.Module),
                 entryPointHandle,
                 properties.CorFlags,
-                deterministicIdProvider);
+                deterministicIdProvider,
+                metadataOnly && !context.IncludePrivateMembers);
 
             var peBlob = new BlobBuilder();
-            var peContentId = peBuilder.Serialize(peBlob);
+            var peContentId = peBuilder.Serialize(peBlob, out Blob mvidSectionFixup);
 
-            PatchModuleVersionIds(mvidFixup, mvidStringFixup, peContentId.Guid);
+            PatchModuleVersionIds(mvidFixup, mvidSectionFixup, mvidStringFixup, peContentId.Guid);
 
             try
             {
@@ -216,11 +217,18 @@ namespace Microsoft.Cci
             return true;
         }
 
-        private static void PatchModuleVersionIds(Blob guidFixup, Blob stringFixup, Guid mvid)
+        private static void PatchModuleVersionIds(Blob guidFixup, Blob guidSectionFixup, Blob stringFixup, Guid mvid)
         {
             if (!guidFixup.IsDefault)
             {
                 var writer = new BlobWriter(guidFixup);
+                writer.WriteGuid(mvid);
+                Debug.Assert(writer.RemainingBytes == 0);
+            }
+
+            if (!guidSectionFixup.IsDefault)
+            {
+                var writer = new BlobWriter(guidSectionFixup);
                 writer.WriteGuid(mvid);
                 Debug.Assert(writer.RemainingBytes == 0);
             }
@@ -321,6 +329,92 @@ namespace Microsoft.Cci
             }
 
             return (keySize < 128 + 32) ? 128 : keySize - 32;
+        }
+
+        /// <summary>
+        /// This PEBuilder adds an .mvid section.
+        /// </summary>
+        private class ExtendedPEBuilder : ManagedPEBuilder
+        {
+            private const string MvidSectionName = ".mvid";
+            public const int SizeOfGuid = 16;
+
+            // When the section is built with a placeholder, the placeholder blob is saved for later fixing up.
+            private Blob _mvidSectionFixup = default(Blob);
+
+            // Only include the .mvid section in ref assemblies
+            private bool _withMvidSection;
+
+            public ExtendedPEBuilder(
+                PEHeaderBuilder header,
+                MetadataRootBuilder metadataRootBuilder,
+                BlobBuilder ilStream,
+                BlobBuilder mappedFieldData,
+                BlobBuilder managedResources,
+                ResourceSectionBuilder nativeResources,
+                DebugDirectoryBuilder debugDirectoryBuilder,
+                int strongNameSignatureSize,
+                MethodDefinitionHandle entryPoint,
+                CorFlags flags,
+                Func<IEnumerable<Blob>, BlobContentId> deterministicIdProvider,
+                bool withMvidSection)
+                : base(header, metadataRootBuilder, ilStream, mappedFieldData, managedResources, nativeResources,
+                      debugDirectoryBuilder, strongNameSignatureSize, entryPoint, flags, deterministicIdProvider)
+            {
+                _withMvidSection = withMvidSection;
+            }
+
+            protected override ImmutableArray<Section> CreateSections()
+            {
+                var baseSections = base.CreateSections();
+
+                if (_withMvidSection)
+                {
+                    var builder = ArrayBuilder<Section>.GetInstance(baseSections.Length + 1);
+
+                    builder.Add(new Section(MvidSectionName, SectionCharacteristics.MemRead |
+                        SectionCharacteristics.ContainsInitializedData |
+                        SectionCharacteristics.MemDiscardable));
+
+                    builder.AddRange(baseSections);
+                    return builder.ToImmutableAndFree();
+                }
+                else
+                {
+                    return baseSections;
+                }
+            }
+
+            protected override BlobBuilder SerializeSection(string name, SectionLocation location)
+            {
+                if (name.Equals(MvidSectionName, StringComparison.Ordinal))
+                {
+                    Debug.Assert(_withMvidSection);
+                    return SerializeMvidSection(location);
+                }
+
+                return base.SerializeSection(name, location);
+            }
+
+            internal BlobContentId Serialize(BlobBuilder peBlob, out Blob mvidSectionFixup)
+            {
+                var result = base.Serialize(peBlob);
+                mvidSectionFixup = _mvidSectionFixup;
+                return result;
+            }
+
+            private BlobBuilder SerializeMvidSection(SectionLocation location)
+            {
+                var sectionBuilder = new BlobBuilder();
+
+                // The guid will be filled in later:
+                _mvidSectionFixup = sectionBuilder.ReserveBytes(SizeOfGuid);
+                var mvidWriter = new BlobWriter(_mvidSectionFixup);
+                mvidWriter.WriteBytes(0, _mvidSectionFixup.Length);
+                Debug.Assert(mvidWriter.RemainingBytes == 0);
+
+                return sectionBuilder;
+            }
         }
     }
 }


### PR DESCRIPTION
The dependency on MetadataReader is causing troubles for MSBuild integration. But the MVID is in a difficult place to extract in the PE and we don't want to replicate much MetadataReader logic.

So, for ref assemblies, we make another copy of the MVID in a new Section (".mvid"). Sections can be extracted much more easily. This PR includes a simple PE reader that finds the MVID in this new location in the binary.

@tmat @dotnet/roslyn-compiler for review.