### PR TITLE
Use refasm-only items for compilation

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
@@ -23,6 +23,8 @@
              AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
   <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"
              AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly"
+             AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll" />
   <PropertyGroup>
     <!-- By default don't use the compiler server in Visual Studio. -->
     <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">false</UseSharedCompilation>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -1,13 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
+          BeforeTargets="CoreCompile"
+          Condition="'@(ReferencePathWithRefAssemblies)' == ''">
+    <!-- Common targets should populate this item from dev15.3, but this file
+         may be used (via NuGet package) on earlier MSBuilds. If the
+         adjusted-for-reference-assemblies item is not populated, just use
+         the older item's contents. -->
+    <ItemGroup>
+      <ReferencePathWithRefAssemblies Include="@(ReferencePath)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
                   @(Compile);
                   @(_CoreCompileResourceInputs);
                   $(ApplicationIcon);
                   $(AssemblyOriginatorKeyFile);
-                  @(ReferencePath);
+                  @(ReferencePathWithRefAssemblies);
                   @(CompiledLicenseFile);
                   @(LinkResource);
                   @(EmbeddedDocumentation);
@@ -38,9 +50,9 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetingClr2Framework)' == 'true'">
-      <ReferencePath>
+      <ReferencePathWithRefAssemblies>
         <EmbedInteropTypes />
-      </ReferencePath>
+      </ReferencePathWithRefAssemblies>
     </ItemGroup>
 
     <PropertyGroup>
@@ -117,7 +129,7 @@
          Prefer32Bit="$(Prefer32Bit)"
          PreferredUILang="$(PreferredUILang)"
          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
-         References="@(ReferencePath)"
+         References="@(ReferencePathWithRefAssemblies)"
          ReportAnalyzer="$(ReportAnalyzer)"
          Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
          ResponseFiles="$(CompilerResponseFile)"

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -1,13 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="ShimReferencePathsWhenCommonTargetsDoesNotUnderstandReferenceAssemblies"
+          BeforeTargets="CoreCompile"
+          Condition="'@(ReferencePathWithRefAssemblies)' == ''">
+    <!-- Common targets should populate this item from dev15.3, but this file
+         may be used (via NuGet package) on earlier MSBuilds. If the
+         adjusted-for-reference-assemblies item is not populated, just use
+         the older item's contents. -->
+    <ItemGroup>
+      <ReferencePathWithRefAssemblies Include="@(ReferencePath)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
                   @(Compile);
                   @(_CoreCompileResourceInputs);
                   $(ApplicationIcon);
                   $(AssemblyOriginatorKeyFile);
-                  @(ReferencePath);
+                  @(ReferencePathWithRefAssemblies);
                   @(CompiledLicenseFile);
                   @(LinkResource);
                   @(EmbeddedDocumentation);
@@ -36,9 +48,9 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetingClr2Framework)' == 'true'">
-      <ReferencePath>
+      <ReferencePathWithRefAssemblies>
         <EmbedInteropTypes />
-      </ReferencePath>
+      </ReferencePathWithRefAssemblies>
     </ItemGroup>
 
     <!-- Prefer32Bit was introduced in .NET 4.5. Set it to false if we are targeting 4.0 -->
@@ -109,7 +121,7 @@
          Prefer32Bit="$(Prefer32Bit)"
          PreferredUILang="$(PreferredUILang)"
          ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
-         References="@(ReferencePath)"
+         References="@(ReferencePathWithRefAssemblies)"
          RemoveIntegerChecks="$(RemoveIntegerChecks)"
          ReportAnalyzer="$(ReportAnalyzer)"
          Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"


### PR DESCRIPTION
Use the new item provided by common targets to avoid recompiling a
project when a reference has changed only in implementation, not
interface.

Include a shim so that these targets can continue to work on older
MSBuild distributions. That keeps the NuGet-package-for-downlevel
scenario working, as well as making an easy transition period to the new
logic.

Requires Microsoft/msbuild#2039.