### PR TITLE
Fix build issues around SDK change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ UnitTestResults.html
 *.nuget.props
 *.nuget.targets
 project.lock.json
+msbuild.binlog
 *.project.lock.json
 
 *_i.c

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -103,6 +103,7 @@
     <NoStdLib>true</NoStdLib>
     <FrameworkPathOverride>$(NuGetPackageRoot)\Microsoft.NetFX20\$(MicrosoftNetFX20Version)\lib\net20</FrameworkPathOverride>
     <ExecuteAsTool>false</ExecuteAsTool>
+    <GenerateResourceMSBuildRuntime>CurrentRuntime</GenerateResourceMSBuildRuntime>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DevEnvDir)' == ''">

--- a/src/Test/DeployCoreClrTestRuntime/DeployCoreClrTestRuntime.csproj
+++ b/src/Test/DeployCoreClrTestRuntime/DeployCoreClrTestRuntime.csproj
@@ -12,7 +12,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;osx.10.12-x64</RuntimeIdentifiers>
     <PackageTargetFallback>portable-net452;dotnet;netstandard1.6</PackageTargetFallback>
-    <SelfContained>true</SelfContained>
+    <SelfContained Condition="'$(JenkinsBuild)' == 'true'" >true</SelfContained>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />


### PR DESCRIPTION
Fixes the following issues:

1. Remove dependency on Net Framework 3.5 in our builds.
1. Suppress errors around `<SelfContained>` on developer machines while we work on the correct fix. 