### PR TITLE
Update Elfie version to be 0.10.6

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -26,7 +26,7 @@
     <MicrosoftCodeAnalysisCSharpVersion>1.0.1</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>1.0.1</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisEditorFeaturesTextVersion>1.0.1</MicrosoftCodeAnalysisEditorFeaturesTextVersion>
-    <MicrosoftCodeAnalysisElfieVersion>0.10.6-rc2</MicrosoftCodeAnalysisElfieVersion>
+    <MicrosoftCodeAnalysisElfieVersion>0.10.6</MicrosoftCodeAnalysisElfieVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftCodeAnalysisVisualBasicVersion>1.0.1</MicrosoftCodeAnalysisVisualBasicVersion>
     <MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>1.0.1</MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>


### PR DESCRIPTION
This was reverted as a part of 5fe4adb3ada293fe4 but should have been
put back.

*Review:* @tannergooding, @brettfo, @jaredpar 

@MattGertz This is a packaging change we made in our 15.1 and 15.2 branches but it didn't quite correctly make it to 15.3. It doesn't impact shipping binaries, just our NuGet packages.
