### PR TITLE
support CasePatternSwitchLabel in StatementSyntaxComparer

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -1483,7 +1483,6 @@ var x = $""Hello{123:N2}"";
             edits.VerifyEdits("Update [x = $\"Hello{123:N1}\"]@8 -> [x = $\"Hello{123:N2}\"]@8");
         }
 
-        [WorkItem(18970, "https://github.com/dotnet/roslyn/issues/18970")]
         [Fact]
         public void MatchCasePattern_UpdateDelete()
         {
@@ -1507,9 +1506,9 @@ switch(shape)
 
             var expected = new MatchingPairs {
                 { "switch(shape) {     case Point p: return 0;     case Circle c: return 1; }", "switch(shape) {     case Circle circle: return 1; }" },
-                { "p", "circle" },
                 { "case Circle c: return 1;", "case Circle circle: return 1;" },
                 { "case Circle c:", "case Circle circle:" },
+                { "c", "circle" },
                 { "return 1;", "return 1;" }
             };
 
@@ -1716,7 +1715,6 @@ var (a1, a3) = (1, () => { return 8; });
                 "Update [case 1: f(); break;]@18 -> [case 2: f(); break;]@18");
         }
 
-        [WorkItem(18970, "https://github.com/dotnet/roslyn/issues/18970")]
         [Fact]
         public void CasePatternLabel_UpdateDelete()
         {
@@ -1739,12 +1737,11 @@ switch(shape)
 
             edits.VerifyEdits(
                 "Update [case Circle c: return 1;]@55 -> [case Circle circle: return 1;]@26",
-                "Update [p]@37 -> [circle]@38",
-                "Move [p]@37 -> @38",
+                "Update [c]@67 -> [circle]@38",
                 "Delete [case Point p: return 0;]@26",
                 "Delete [case Point p:]@26",
-                "Delete [return 0;]@40",
-                "Delete [c]@67");
+                "Delete [p]@37",
+                "Delete [return 0;]@40");
         }
 
         #endregion
@@ -8347,12 +8344,11 @@ switch(shape)
             edits.VerifyEdits(
                 "Update [case Circle c: A(c); break;]@55 -> [case Circle c1: A(c1); break;]@26",
                 "Update [A(c);]@70 -> [A(c1);]@42",
-                "Update [p]@37 -> [c1]@38",
-                "Move [p]@37 -> @38",
+                "Update [c]@67 -> [c1]@38",
                 "Delete [case Point p: return 0;]@26",
                 "Delete [case Point p:]@26",
-                "Delete [return 0;]@40",
-                "Delete [c]@67");
+                "Delete [p]@37",
+                "Delete [return 0;]@40");
         }
 
         [Fact]

--- a/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/StatementSyntaxComparer.cs
@@ -681,6 +681,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     distance = (leftNode.RawKind == rightNode.RawKind) ? 0.0 : 0.1;
                     return true;
 
+                case SyntaxKind.SingleVariableDesignation:
+                    distance = ComputeWeightedDistance((SingleVariableDesignationSyntax)leftNode, (SingleVariableDesignationSyntax)rightNode);
+                    return true;
+
                 default:
                     distance = 0;
                     return false;
@@ -835,6 +839,25 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 default:
                     throw ExceptionUtilities.UnexpectedValue(leftBlock.Parent.Kind());
             }
+        }
+
+        private double ComputeWeightedDistance(SingleVariableDesignationSyntax leftNode, SingleVariableDesignationSyntax rightNode)
+        {
+            double distance = ComputeDistance(leftNode, rightNode);
+            double parentDistance;
+
+            if (leftNode.Parent != null && 
+                rightNode.Parent != null &&
+                GetLabel(leftNode.Parent) == GetLabel(rightNode.Parent))
+            {
+                parentDistance = ComputeDistance(leftNode.Parent, rightNode.Parent);
+            }
+            else
+            {
+                parentDistance = 1;
+            }
+
+            return 0.5 * parentDistance + 0.5 * distance;
         }
 
         private static double ComputeWeightedBlockDistance(BlockSyntax leftBlock, BlockSyntax rightBlock)

--- a/src/Workspaces/Core/Portable/Differencing/Match.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Match.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         private const double EpsilonDistance = 0.00001;
         private const double MatchingDistance1 = 0.25;
         private const double MatchingDistance2 = 0.5;
+        private const double MatchingDistance3 = 0.75;
         private const double MaxDistance = 1.0;
 
         private readonly TreeComparer<TNode> _comparer;
@@ -153,6 +154,7 @@ namespace Microsoft.CodeAnalysis.Differencing
             ComputeMatchForLabel(s1, s2, tiedToAncestor, EpsilonDistance);     // almost exact match
             ComputeMatchForLabel(s1, s2, tiedToAncestor, MatchingDistance1);   // ok match
             ComputeMatchForLabel(s1, s2, tiedToAncestor, MatchingDistance2);   // ok match
+            ComputeMatchForLabel(s1, s2, tiedToAncestor, MatchingDistance3);   // ok match
             ComputeMatchForLabel(s1, s2, tiedToAncestor, MaxDistance);         // any match
         }
 


### PR DESCRIPTION
**Customer scenario**

Variables declared by patterns within switch statements are matched incorrectly by StatementSyntaxComparer. Fixing this. Have to add one more pass for the matcher. It does not affect the performance. However, it would be nice to re-consider this. Created #19163.

**Bugs this fixes:**

Fixes #18970

**Workarounds, if any**

**Risk**

Low

**Performance impact**
Low 

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

Planned