### PR TITLE
Provide an async codepath for sqlite writes.

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/SQLite/SQLitePersistentStorage.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.SQLite
         {
             // Flush all pending writes so that all data our features wanted written
             // are definitely persisted to the DB.
-            FlushAllPendingWrites();
+            FlushAllPendingWritesAsync(CancellationToken.None).Wait();
 
             lock (_connectionGate)
             {


### PR DESCRIPTION
While investigating what was happening in the OOP server, i noticed a case while my disk was under load, where there were many more threads that i expected in the OOP server waiting to grab a lock in the sqlite persistence layer before they could proceed.

The reason for the lock is so that buffered writes will be seen by any subequent reads.  However, even though we buffer writes, performing the actual write of that data may still always take time (since IO is involved).  Even though sqlite is fast, it can't do anythign i the OS is literally not serving its IO requests.  To ameliorate this issue, i've moved the internal lock to a SemaphoreSlim that can be acquired asynchronously.  With this, all backed up requests that need to use the persistence layer, can now relinquish their thread if they're waiting on one actual thread that is trying to get through the write-queue.  

