### PR TITLE
Avoid calling GetDiagnostics on compilation during EnC analysis

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
@@ -19,6 +19,107 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         Inherits EditAndContinueTestBase
 
         <Fact>
+        Public Sub SemanticErrors_MethodBody()
+            Dim source0 = MarkedSource("
+Class C
+    Shared Sub E()
+        Dim x As Integer = 1
+        System.Console.WriteLine(x)
+    End Sub
+
+    Shared Sub G()
+        System.Console.WriteLine(1)
+    End Sub
+End Class
+")
+            Dim source1 = MarkedSource("
+Class C
+    Shared Sub E()
+        Dim x = Unknown(2)
+        System.Console.WriteLine(x)
+    End Sub
+
+    Shared Sub G()
+        System.Console.WriteLine(2)
+    End Sub
+End Class
+")
+            Dim compilation0 = CreateCompilationWithMscorlib(source0.Tree, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim e0 = compilation0.GetMember(Of MethodSymbol)("C.E")
+            Dim e1 = compilation1.GetMember(Of MethodSymbol)("C.E")
+            Dim g0 = compilation0.GetMember(Of MethodSymbol)("C.G")
+            Dim g1 = compilation1.GetMember(Of MethodSymbol)("C.G")
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+            ' Semantic errors are reported only for the bodies of members being emitted.
+            Dim diffError = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, e0, e1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diffError.EmitResult.Diagnostics.Verify(
+                Diagnostic(ERRID.ERR_NameNotDeclared1, "Unknown").WithArguments("Unknown").WithLocation(4, 17))
+
+            Dim diffGood = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, g0, g1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diffGood.EmitResult.Diagnostics.Verify()
+            diffGood.VerifyIL("C.G", "
+{
+  // Code size        9 (0x9)
+  .maxstack  1
+  IL_0000:  nop
+  IL_0001:  ldc.i4.2
+  IL_0002:  call       ""Sub System.Console.WriteLine(Integer)""
+  IL_0007:  nop
+  IL_0008:  ret
+}")
+        End Sub
+
+        <Fact>
+        Public Sub SemanticErrors_Declaration()
+            Dim source0 = MarkedSource("
+Class C
+    Sub G() 
+        System.Console.WriteLine(1)
+    End Sub
+End Class
+")
+            Dim source1 = MarkedSource("
+Class C
+    Sub G() 
+        System.Console.WriteLine(1)
+    End Sub
+End Class
+
+Class Bad 
+  Inherits Bad
+End Class
+")
+            Dim compilation0 = CreateCompilationWithMscorlib(source0.Tree, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim g0 = compilation0.GetMember(Of MethodSymbol)("C.G")
+            Dim g1 = compilation1.GetMember(Of MethodSymbol)("C.G")
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+            Dim diff = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, g0, g1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff.EmitResult.Diagnostics.Verify(
+                Diagnostic(ERRID.ERR_TypeInItsInheritsClause1, "Bad").WithArguments("Bad").WithLocation(9, 12))
+        End Sub
+
+        <Fact>
         Public Sub ModifyMethod_WithTuples()
             Dim source0 =
 "
@@ -5183,5 +5284,8 @@ End Class")
 }
 ")
         End Sub
+
+
+
     End Class
 End Namespace

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/Extensions.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/Extensions.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Differencing;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.EditAndContinue.UnitTests;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditAndContinue;
+using Microsoft.CodeAnalysis.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
 {
@@ -58,7 +59,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             this EditScript<SyntaxNode> editScript,
             params RudeEditDiagnosticDescription[] expectedDiagnostics)
         {
-            VerifySemantics(editScript, ActiveStatementsDescription.Empty, null, expectedDiagnostics);
+            VerifySemanticDiagnostics(editScript, null, expectedDiagnostics);
+        }
+
+        internal static void VerifySemanticDiagnostics(
+            this EditScript<SyntaxNode> editScript,
+            DiagnosticDescription expectedDeclarationError,
+            params RudeEditDiagnosticDescription[] expectedDiagnostics)
+        {
+            VerifySemantics(editScript, ActiveStatementsDescription.Empty, null, expectedDeclarationError, expectedDiagnostics);
         }
 
         internal static void VerifySemantics(
@@ -67,7 +76,17 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             SemanticEditDescription[] expectedSemanticEdits,
             params RudeEditDiagnosticDescription[] expectedDiagnostics)
         {
-            VerifySemantics(editScript, activeStatements, null, null, expectedSemanticEdits, expectedDiagnostics);
+            VerifySemantics(editScript, activeStatements, expectedSemanticEdits, null, expectedDiagnostics);
+        }
+
+        internal static void VerifySemantics(
+            this EditScript<SyntaxNode> editScript,
+            ActiveStatementsDescription activeStatements,
+            SemanticEditDescription[] expectedSemanticEdits,
+            DiagnosticDescription expectedDeclarationError,
+            params RudeEditDiagnosticDescription[] expectedDiagnostics)
+        {
+            VerifySemantics(editScript, activeStatements, null, null, expectedSemanticEdits, expectedDeclarationError, expectedDiagnostics);
         }
 
         internal static void VerifySemantics(
@@ -76,6 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             IEnumerable<string> additionalOldSources,
             IEnumerable<string> additionalNewSources,
             SemanticEditDescription[] expectedSemanticEdits,
+            DiagnosticDescription expectedDeclarationError,
             params RudeEditDiagnosticDescription[] expectedDiagnostics)
         {
             CSharpEditAndContinueTestHelpers.Instance.VerifySemantics(
@@ -84,6 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
                 additionalOldSources,
                 additionalNewSources,
                 expectedSemanticEdits,
+                expectedDeclarationError,
                 expectedDiagnostics);
         }
     }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditTopLevelTests.cs
@@ -3853,13 +3853,14 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                new[]
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: new[]
                 {
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").StaticConstructors.Single())
-                });
+                },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -3874,13 +3875,14 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                new[]
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: new[]
                 {
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single())
-                });
+                },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -3895,13 +3897,14 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                new[]
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: new[]
                 {
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single())
-                });
+                },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -3916,11 +3919,12 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                null,
-                Diagnostic(RudeEditKind.Delete, "partial class C", FeaturesResources.constructor));
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: null,
+                expectedDiagnostics: new[] { Diagnostic(RudeEditKind.Delete, "partial class C", FeaturesResources.constructor) },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -3935,13 +3939,14 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                new[]
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: new[]
                 {
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").StaticConstructors.Single(), preserveLocalVariables: true)
-                });
+                },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -3956,13 +3961,14 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                new[]
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: new[]
                 {
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
-                });
+                },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -3977,13 +3983,14 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                new[]
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: new[]
                 {
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
-                });
+                },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -3998,13 +4005,14 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                new[]
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: new[]
                 {
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").InstanceConstructors.Single(), preserveLocalVariables: true)
-                });
+                },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -4019,11 +4027,12 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                null,
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "public C()"));
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits: null,
+                expectedDiagnostics: new[] { Diagnostic(RudeEditKind.ChangingConstructorVisibility, "public C()") },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -4038,11 +4047,12 @@ class B
             var edits = GetTopEdits(srcA1, srcA2);
 
             edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                new[] { srcB1 },
-                new[] { srcB2 },
-                null,
-                Diagnostic(RudeEditKind.ChangingConstructorVisibility, "internal C()"));
+                activeStatements: ActiveStatementsDescription.Empty,
+                additionalOldSources: new[] { srcB1 },
+                additionalNewSources: new[] { srcB2 },
+                expectedSemanticEdits:null,
+                expectedDiagnostics: new[] { Diagnostic(RudeEditKind.ChangingConstructorVisibility, "internal C()") },
+                expectedDeclarationError: null);
         }
 
         [Fact]
@@ -4311,6 +4321,76 @@ partial class C
 
             edits.VerifyRudeDiagnostics(
                 Diagnostic(RudeEditKind.InsertExtern, "public extern C()", FeaturesResources.constructor));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/18940")]
+        public void ParameterlessConstructor_SemanticError_Delete1()
+        {
+            string src1 = @"
+class C
+{
+    D() {}
+}
+";
+            string src2 = @"
+class C
+{
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/pull/18940")]
+        public void ParameterlessConstructor_SemanticError_Delete_OutsideOfClass1()
+        {
+            string src1 = @"
+C() {}
+";
+            string src2 = @"
+";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifyRudeDiagnostics();
+        }
+
+        [Fact]
+        public void Constructor_SemanticError_Partial()
+        {
+            string src1 = @"
+partial class C
+{
+    partial void C(int x);
+}
+
+partial class C
+{
+    partial void C(int x)
+    {
+        System.Console.WriteLine(1);
+    }
+}
+";
+            string src2 = @"
+partial class C
+{
+    partial void C(int x);
+}
+
+partial class C
+{
+    partial void C(int x)
+    {
+        System.Console.WriteLine(2);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                // (4,18): error CS0542: 'C': member names cannot be the same as their enclosing type
+                //     partial void C(int x);
+                Diagnostic(ErrorCode.ERR_MemberNameSameAsType, "C").WithArguments("C").WithLocation(4, 18));
         }
 
         #endregion
@@ -5620,6 +5700,40 @@ class C
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[0], syntaxMap[0]),
                     SemanticEdit(SemanticEditKind.Update, c => c.GetMember<NamedTypeSymbol>("C").Constructors[1], syntaxMap[0]),
                 });
+        }
+
+        [Fact]
+        public void PropertyWithInitializer_SemanticError_Partial()
+        {
+            string src1 = @"
+partial class C
+{
+    partial int P => 1;
+}
+
+partial class C
+{
+    partial int P => 1;
+}
+";
+            string src2 = @"
+partial class C
+{
+    partial int P => 1;
+}
+
+partial class C
+{
+    partial int P => 1;
+
+    public C() { }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            edits.VerifySemanticDiagnostics(
+                // (4,17): error CS0753: Only methods, classes, structs, or interfaces may be partial
+                //     partial int P => 1;
+                Diagnostic(ErrorCode.ERR_PartialMethodOnlyMethods, "P").WithLocation(4, 17));
         }
 
         #endregion

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -205,6 +205,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             IEnumerable<string> additionalOldSources = null,
             IEnumerable<string> additionalNewSources = null,
             SemanticEditDescription[] expectedSemanticEdits = null,
+            DiagnosticDescription expectedDeclarationError = null,
             RudeEditDiagnosticDescription[] expectedDiagnostics = null)
         {
             var editMap = Analyzer.BuildEditMap(editScript);
@@ -233,18 +234,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             var oldCompilation = CreateLibraryCompilation("Old", oldTrees);
             var newCompilation = CreateLibraryCompilation("New", newTrees);
-
-            if (oldCompilation is CSharpCompilation)
-            {
-                oldCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).Verify();
-                newCompilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).Verify();
-            }
-            else
-            {
-                // TODO: verify all compilation diagnostics like C# does (tests need to be updated)
-                oldTrees.SelectMany(tree => tree.GetDiagnostics()).Where(d => d.Severity == DiagnosticSeverity.Error).Verify();
-                newTrees.SelectMany(tree => tree.GetDiagnostics()).Where(d => d.Severity == DiagnosticSeverity.Error).Verify();
-            }
 
             var oldModel = oldCompilation.GetSemanticModel(oldRoot.SyntaxTree);
             var newModel = newCompilation.GetSemanticModel(newRoot.SyntaxTree);
@@ -297,7 +286,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 newModel,
                 actualSemanticEdits,
                 diagnostics,
+                out var firstDeclarationErrorOpt,
                 default(CancellationToken));
+
+            var actualDeclarationErrors = (firstDeclarationErrorOpt != null) ? new[] { firstDeclarationErrorOpt } : Array.Empty<Diagnostic>();
+            var expectedDeclarationErrors = (expectedDeclarationError != null) ? new[] { expectedDeclarationError } : Array.Empty<DiagnosticDescription>();
+            actualDeclarationErrors.Verify(expectedDeclarationErrors);
 
             diagnostics.Verify(newSource, expectedDiagnostics);
 

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/Extensions.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/Extensions.vb
@@ -5,6 +5,7 @@ Imports Microsoft.CodeAnalysis.Differencing
 Imports Microsoft.CodeAnalysis.EditAndContinue
 Imports Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EditAndContinue
+Imports Microsoft.CodeAnalysis.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
 
@@ -47,7 +48,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
         <Extension>
         Friend Sub VerifySemanticDiagnostics(editScript As EditScript(Of SyntaxNode),
                                              ParamArray expectedDiagnostics As RudeEditDiagnosticDescription())
-            VerifySemantics(editScript, ActiveStatementsDescription.Empty, Nothing, expectedDiagnostics)
+            VerifySemanticDiagnostics(editScript, Nothing, expectedDiagnostics)
+        End Sub
+
+        <Extension>
+        Friend Sub VerifySemanticDiagnostics(editScript As EditScript(Of SyntaxNode),
+                                             expectedDeclarationError As DiagnosticDescription,
+                                             ParamArray expectedDiagnostics As RudeEditDiagnosticDescription())
+            VerifySemantics(editScript, ActiveStatementsDescription.Empty, Nothing, expectedDeclarationError, expectedDiagnostics)
         End Sub
 
         <Extension>
@@ -55,7 +63,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
                                    activeStatements As ActiveStatementsDescription,
                                    expectedSemanticEdits As SemanticEditDescription(),
                                    ParamArray expectedDiagnostics As RudeEditDiagnosticDescription())
-            VerifySemantics(editScript, activeStatements, Nothing, Nothing, expectedSemanticEdits, expectedDiagnostics)
+            VerifySemantics(editScript, activeStatements, Nothing, Nothing, expectedSemanticEdits, Nothing, expectedDiagnostics)
+        End Sub
+
+        <Extension>
+        Friend Sub VerifySemantics(editScript As EditScript(Of SyntaxNode),
+                                   activeStatements As ActiveStatementsDescription,
+                                   expectedSemanticEdits As SemanticEditDescription(),
+                                   expectedDeclarationError As DiagnosticDescription,
+                                   ParamArray expectedDiagnostics As RudeEditDiagnosticDescription())
+            VerifySemantics(editScript, activeStatements, Nothing, Nothing, expectedSemanticEdits, expectedDeclarationError, expectedDiagnostics)
         End Sub
 
         <Extension>
@@ -65,12 +82,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
                                    additionalNewSources As IEnumerable(Of String),
                                    expectedSemanticEdits As SemanticEditDescription(),
                                    ParamArray expectedDiagnostics As RudeEditDiagnosticDescription())
+            VerifySemantics(editScript, activeStatements, additionalOldSources, additionalNewSources, expectedSemanticEdits, Nothing, expectedDiagnostics)
+        End Sub
+
+        <Extension>
+        Friend Sub VerifySemantics(editScript As EditScript(Of SyntaxNode),
+                                   activeStatements As ActiveStatementsDescription,
+                                   additionalOldSources As IEnumerable(Of String),
+                                   additionalNewSources As IEnumerable(Of String),
+                                   expectedSemanticEdits As SemanticEditDescription(),
+                                   expectedDeclarationError As DiagnosticDescription,
+                                   ParamArray expectedDiagnostics As RudeEditDiagnosticDescription())
             VisualBasicEditAndContinueTestHelpers.Instance.VerifySemantics(
                 editScript,
                 activeStatements,
                 additionalOldSources,
                 additionalNewSources,
                 expectedSemanticEdits,
+                expectedDeclarationError,
                 expectedDiagnostics)
         End Sub
     End Module

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditStatementTests.vb
@@ -4497,6 +4497,40 @@ End Class
             edits.VerifySemanticDiagnostics(
                 Diagnostic(RudeEditKind.RenamingCapturedVariable, "y", "x", "y"))
         End Sub
+
+        <Fact>
+        Public Sub Lambdas_Signature_SemanticErrors()
+            Dim src1 = "
+Imports System
+
+Class C
+
+    Sub G(f As Func(Of Unknown, Unknown))
+    End Sub
+
+    Sub F()
+        G(Function(a) 1)
+    End Sub
+End Class
+"
+            Dim src2 = "
+Imports System
+
+Class C
+
+    Sub G(f As Func(Of Unknown, Unknown))
+    End Sub
+
+    Sub F()
+        G(Function(a) 2)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(ERRID.ERR_UndefinedType1, "Unknown").WithArguments("Unknown").WithLocation(6, 24))
+        End Sub
+
 #End Region
 
 #Region "Queries"
@@ -5976,12 +6010,13 @@ End Class
 "
             Dim edits = GetTopEdits(src1, src2)
             VisualBasicEditAndContinueTestHelpers.Instance40.VerifySemantics(
-                edits,
-                ActiveStatementsDescription.Empty,
-                Nothing,
-                Nothing,
-                Nothing,
-                {Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "Shared Iterator Function F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute")})
+                editScript:=edits,
+                activeStatements:=ActiveStatementsDescription.Empty,
+                additionalOldSources:=Nothing,
+                additionalNewSources:=Nothing,
+                expectedSemanticEdits:=Nothing,
+                expectedDiagnostics:={Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "Shared Iterator Function F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute")},
+                expectedDeclarationError:=Nothing)
         End Sub
 
         <Fact>
@@ -6006,12 +6041,13 @@ End Class
 "
             Dim edits = GetTopEdits(src1, src2)
             VisualBasicEditAndContinueTestHelpers.Instance40.VerifySemantics(
-                edits,
-                ActiveStatementsDescription.Empty,
-                Nothing,
-                Nothing,
-                Nothing,
-                Nothing)
+                editScript:=edits,
+                activeStatements:=ActiveStatementsDescription.Empty,
+                additionalOldSources:=Nothing,
+                additionalNewSources:=Nothing,
+                expectedSemanticEdits:=Nothing,
+                expectedDiagnostics:=Nothing,
+                expectedDeclarationError:=Nothing)
         End Sub
 
 #End Region
@@ -6092,12 +6128,13 @@ End Class
 "
             Dim edits = GetTopEdits(src1, src2)
             VisualBasicEditAndContinueTestHelpers.InstanceMinAsync.VerifySemantics(
-                edits,
-                ActiveStatementsDescription.Empty,
-                Nothing,
-                Nothing,
-                Nothing,
-                {Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "Shared Async Function F()", "System.Runtime.CompilerServices.AsyncStateMachineAttribute")})
+                editScript:=edits,
+                activeStatements:=ActiveStatementsDescription.Empty,
+                additionalOldSources:=Nothing,
+                additionalNewSources:=Nothing,
+                expectedSemanticEdits:=Nothing,
+                expectedDiagnostics:={Diagnostic(RudeEditKind.UpdatingStateMachineMethodMissingAttribute, "Shared Async Function F()", "System.Runtime.CompilerServices.AsyncStateMachineAttribute")},
+                expectedDeclarationError:=Nothing)
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditStatementTests.vb
@@ -3418,7 +3418,7 @@ End Class
             Dim src1 = "
 Imports System
 Class C
-    Property Item(a1 As Integer, a2 As Integer) As Func(Of Integer, Integer)
+    Readonly Property Item(a1 As Integer, a2 As Integer) As Func(Of Integer, Integer)
         Get
             Return New Func(Of Integer, Integer)(Function(a3) a1 + a2)
         End Get
@@ -3428,7 +3428,7 @@ End Class
             Dim src2 = "
 Imports System
 Class C
-    Property Item(a1 As Integer, a2 As Integer) As Func(Of Integer, Integer)
+    Readonly Property Item(a1 As Integer, a2 As Integer) As Func(Of Integer, Integer)
         Get
             Return New Func(Of Integer, Integer)(Function(a3) a2)
         End Get
@@ -3714,7 +3714,7 @@ End Class
             Dim src1 = "
 Imports System
 Class C
-    Property Item(a1 As Integer, a2 As Integer) As Func(Of Integer, Integer)
+    Readonly Property Item(a1 As Integer, a2 As Integer) As Func(Of Integer, Integer)
         Get
             Return New Func(Of Integer, Integer)(Function(a3) a2)
         End Get
@@ -3724,7 +3724,7 @@ End Class
             Dim src2 = "
 Imports System
 Class C
-    Property Item(a1 As Integer, a2 As Integer) As Func(Of Integer, Integer)
+    Readonly Property Item(a1 As Integer, a2 As Integer) As Func(Of Integer, Integer)
         Get
             Return New Func(Of Integer, Integer)(Function(a3) a1 + a2)
         End Get
@@ -4041,12 +4041,12 @@ Imports System
 
 Partial Class C
     Dim x As Integer = 1
-    Partial Sub F() ' def
+    Private Partial Sub F() ' def
     End Sub
 End Class
 
 Partial Class C
-    Partial Sub F() ' impl
+    Private Sub F() ' impl
         Dim f = New Func(Of Integer, Integer)(Function(a) a)
     End Sub
 End Class
@@ -4056,19 +4056,19 @@ Imports System
 
 Partial Class C
     Dim x As Integer = 1
-    Partial Sub F() ' def
+    Private Partial Sub F() ' def
     End Sub
 End Class
 
 Partial Class C
-    Partial Sub F() ' impl
+    Private Sub F() ' impl
         Dim f = New Func(Of Integer, Integer)(Function(a) a + x)
     End Sub
 End Class
 "
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics(
-                Diagnostic(RudeEditKind.CapturingVariable, "F", "Me").WithFirstLine("Partial Sub F() ' impl"))
+                Diagnostic(RudeEditKind.CapturingVariable, "F", "Me").WithFirstLine("Private Sub F() ' impl"))
         End Sub
 
         <Fact>

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
@@ -1308,7 +1308,7 @@ End Class
         <Fact>
         Public Sub NestedClass_InsertMemberWithInitializer1()
             Dim src1 = "Public Class C : End Class"
-            Dim src2 = "Public Class C : Private Class D : Public Property P As New List(Of String) : End Class : End Class"
+            Dim src2 = "Public Class C : Private Class D : Public Property P As New Object : End Class : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
@@ -1318,7 +1318,7 @@ End Class
         <Fact>
         Public Sub NestedClass_InsertMemberWithInitializer2()
             Dim src1 = "Public Module C : End Module"
-            Dim src2 = "Public Module C : Private Class D : Property P As New List(Of String) : End Class : End Module"
+            Dim src2 = "Public Module C : Private Class D : Property P As New Object : End Class : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
@@ -1767,14 +1767,14 @@ End Class
         <Fact>
         Public Sub MethodInsert_PrivateWithAttribute()
             Dim src1 = "Class C : End Class"
-            Dim src2 = "Class C : " & vbLf & "<A>Private Sub F : End Sub : End Class"
+            Dim src2 = "Class C : " & vbLf & "<System.Obsolete>Private Sub F : End Sub : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Insert [<A>Private Sub F : End Sub]@11",
-                "Insert [<A>Private Sub F]@11",
-                "Insert [<A>]@11",
-                "Insert [A]@12")
+                "Insert [<System.Obsolete>Private Sub F : End Sub]@11",
+                "Insert [<System.Obsolete>Private Sub F]@11",
+                "Insert [<System.Obsolete>]@11",
+                "Insert [System.Obsolete]@12")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember(Of NamedTypeSymbol)("C").GetMember("F"))})
@@ -2926,7 +2926,8 @@ Partial Class C
         Return 0
     End Function
 
-    Dim A1(F(<N:0.0>Function(a1) a1 + 1</N:0.0>)), A2 As Integer = F(<N:0.1>Function(a2) a2 + 1</N:0.1>)
+    Dim A1(F(<N:0.0>Function(a1) a1 + 1</N:0.0>))
+    Dim A2 As Integer = F(<N:0.1>Function(a2) a2 + 1</N:0.1>)
     Dim A3, A4 As New Func(Of Integer, Integer)(<N:0.2>Function(a34) a34 + 1</N:0.2>)
     Dim A5(F(<N:0.3>Function(a51) a51 + 1</N:0.3>), F(<N:0.4>Function(a52) a52 + 1</N:0.4>)) As Integer
 End Class
@@ -2947,7 +2948,8 @@ Partial Class C
         Return 0
     End Function
 
-    Dim A1(F(<N:0.0>Function(a1) a1 + 1</N:0.0>)), A2 As Integer = F(<N:0.1>Function(a2) a2 + 1</N:0.1>)
+    Dim A1(F(<N:0.0>Function(a1) a1 + 1</N:0.0>))
+    Dim A2 As Integer = F(<N:0.1>Function(a2) a2 + 1</N:0.1>)
     Dim A3, A4 As New Func(Of Integer, Integer)(<N:0.2>Function(a34) a34 + 1</N:0.2>)
     Dim A5(F(<N:0.3>Function(a51) a51 + 1</N:0.3>), F(<N:0.4>Function(a52) a52 + 1</N:0.4>)) As Integer
 End Class
@@ -4238,19 +4240,6 @@ End Class
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
         End Sub
 
-        <Fact(), WorkItem(2543, "https://github.com/dotnet/roslyn/issues/2543")>
-        Public Sub Field_InitializerUpdate2()
-            Dim src1 = "Class C : Dim a, b As Integer = 0 : End Class"
-            Dim src2 = "Class C : Dim a, b As Integer = 1 : End Class"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [a, b As Integer = 0]@14 -> [a, b As Integer = 1]@14")
-
-            edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
-        End Sub
-
         <Fact>
         Public Sub Property_Instance_InitializerUpdate()
             Dim src1 = "Class C : Property a As Integer = 0 : End Class"
@@ -4292,12 +4281,12 @@ End Class
 
         <Fact>
         Public Sub Field_InitializerUpdate_AsNew1()
-            Dim src1 = "Class C : Dim a As New D(1) : End Class"
-            Dim src2 = "Class C : Dim a As New D(2) : End Class"
+            Dim src1 = "Class C : Dim a As New Decimal(1) : End Class"
+            Dim src2 = "Class C : Dim a As New Decimal(2) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [a As New D(1)]@14 -> [a As New D(2)]@14")
+                "Update [a As New Decimal(1)]@14 -> [a As New Decimal(2)]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
@@ -4305,12 +4294,12 @@ End Class
 
         <Fact(), WorkItem(2543, "https://github.com/dotnet/roslyn/issues/2543")>
         Public Sub Field_InitializerUpdate_AsNew2()
-            Dim src1 = "Class C : Dim a, b As New C(1) : End Class"
-            Dim src2 = "Class C : Dim a, b As New C(2) : End Class"
+            Dim src1 = "Class C : Dim a, b As New Decimal(1) : End Class"
+            Dim src2 = "Class C : Dim a, b As New Decimal(2) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [a, b As New C(1)]@14 -> [a, b As New C(2)]@14")
+                "Update [a, b As New Decimal(1)]@14 -> [a, b As New Decimal(2)]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
@@ -4318,12 +4307,12 @@ End Class
 
         <Fact>
         Public Sub Property_InitializerUpdate_AsNew()
-            Dim src1 = "Class C : Property a As New D(1) : End Class"
-            Dim src2 = "Class C : Property a As New D(2) : End Class"
+            Dim src1 = "Class C : Property a As New Decimal(1) : End Class"
+            Dim src2 = "Class C : Property a As New Decimal(2) : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [Property a As New D(1)]@10 -> [Property a As New D(2)]@10")
+                "Update [Property a As New Decimal(1)]@10 -> [Property a As New Decimal(2)]@10")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
@@ -4376,19 +4365,6 @@ End Class
 
             edits.VerifyEdits(
                 "Update [Property a As Integer = 0]@10 -> [Property a As Integer]@10")
-
-            edits.VerifySemantics(ActiveStatementsDescription.Empty,
-                                  {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
-        End Sub
-
-        <Fact>
-        Public Sub Property_StructInitializerUpdate_Delete()
-            Dim src1 = "Structure C : Property a As Integer = 0 : End Structure"
-            Dim src2 = "Structure C : Property a As Integer : End Structure"
-            Dim edits = GetTopEdits(src1, src2)
-
-            edits.VerifyEdits(
-                "Update [Property a As Integer = 0]@14 -> [Property a As Integer]@14")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").InstanceConstructors.Single(), preserveLocalVariables:=True)})
@@ -4469,15 +4445,15 @@ End Class
 
         <Fact>
         Public Sub FieldUpdate_ModuleCtorUpdate1()
-            Dim src1 = "Module C : Dim a As Integer : " & vbLf & "Shared Sub New() : End Sub : End Module"
+            Dim src1 = "Module C : Dim a As Integer : " & vbLf & "Sub New() : End Sub : End Module"
             Dim src2 = "Module C : Dim a As Integer = 0 : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
                 "Update [a As Integer]@15 -> [a As Integer = 0]@15",
-                "Delete [Shared Sub New() : End Sub]@31",
-                "Delete [Shared Sub New()]@31",
-                "Delete [()]@45")
+                "Delete [Sub New() : End Sub]@31",
+                "Delete [Sub New()]@31",
+                "Delete [()]@38")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
                                   {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").SharedConstructors.Single())})
@@ -4593,8 +4569,8 @@ End Class
 
         <Fact>
         Public Sub PropertyUpdate_ModuleCtorUpdate2()
-            Dim src1 = "Module C : Property a As Integer : " & vbLf & "Shared Sub New() : End Sub : End Module"
-            Dim src2 = "Module C : Property a As Integer = 0 : " & vbLf & "Shared Sub New() : End Sub : End Module"
+            Dim src1 = "Module C : Property a As Integer : " & vbLf & "Sub New() : End Sub : End Module"
+            Dim src2 = "Module C : Property a As Integer = 0 : " & vbLf & "Sub New() : End Sub : End Module"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
@@ -4999,11 +4975,11 @@ End Class
         <Fact(), WorkItem(2543, "https://github.com/dotnet/roslyn/issues/2543")>
         Public Sub PrivateFieldInsert2()
             Dim src1 = "Class C : Private a As Integer = 1 : End Class"
-            Dim src2 = "Class C : Private a, b As Integer = 1 : End Class"
+            Dim src2 = "Class C : Private a, b As Integer : End Class"
             Dim edits = GetTopEdits(src1, src2)
 
             edits.VerifyEdits(
-                "Update [a As Integer = 1]@18 -> [a, b As Integer = 1]@18",
+                "Update [a As Integer = 1]@18 -> [a, b As Integer]@18",
                 "Insert [b]@21")
 
             edits.VerifySemantics(ActiveStatementsDescription.Empty,
@@ -6028,29 +6004,32 @@ End Class
 
         <Fact>
         Public Sub EventInsert_IntoLayoutClass_Sequential()
-            Dim src1 = <![CDATA[
+            Dim src1 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 <StructLayoutAttribute(LayoutKind.Sequential)>
 Class C
 End Class
-]]>.Value
-            Dim src2 = <![CDATA[
+"
+            Dim src2 = "
 Imports System
 Imports System.Runtime.InteropServices
 
 <StructLayoutAttribute(LayoutKind.Sequential)>
 Class C
     Private Custom Event c As Action
-        AddHandler
+        AddHandler(value As Action)
         End AddHandler
 
-        RemoveHandler
+        RemoveHandler(value As Action)
         End RemoveHandler
+
+        RaiseEvent()
+        End RaiseEvent
     End Event
 End Class
-]]>.Value
+"
             Dim edits = GetTopEdits(src1, src2)
             edits.VerifySemanticDiagnostics()
         End Sub

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/RudeEditTopLevelTests.vb
@@ -3181,6 +3181,39 @@ End Class
             '     {SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMember<NamedTypeSymbol>("C").Constructors.Single(), syntaxMap(0))})
 
         End Sub
+
+        <Fact>
+        Public Sub Constructor_SemanticError_Partial()
+            Dim src1 = "
+Partial Class C
+    Partial Sub New(x As Integer)
+    End Sub
+End Class
+
+Class C
+    Partial Sub New(x As Integer)
+        System.Console.WriteLine(1)
+    End Sub
+End Class
+
+"
+            Dim src2 = "
+Partial Class C
+    Partial Sub New(x As Integer)
+    End Sub
+End Class
+
+Class C
+    Partial Sub New(x As Integer)
+        System.Console.WriteLine(2)
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(ERRID.ERR_ConstructorCannotBeDeclaredPartial, "Partial").WithArguments("Partial").WithLocation(3, 5))
+        End Sub
+
 #End Region
 
 #Region "Declare"
@@ -5860,6 +5893,51 @@ End Class"
                 {SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(0), syntaxMap(0)),
                  SemanticEdit(SemanticEditKind.Update, Function(c) c.GetMember(Of NamedTypeSymbol)("C").Constructors(1), syntaxMap(0))})
         End Sub
+
+        <Fact>
+        Public Sub PropertyWithInitializer_SemanticError_Partial()
+            Dim src1 = "
+Partial Class C
+    Partial Public ReadOnly Property NewProperty() As String
+        Get
+            Return 1
+        End Get
+    End Property
+End Class
+
+Partial Class C
+    Partial Public ReadOnly Property NewProperty() As String
+        Get
+            Return 1
+        End Get
+    End Property
+End Class
+"
+            Dim src2 = "
+Partial Class C
+    Partial Public ReadOnly Property NewProperty() As String
+        Get
+            Return 1
+        End Get
+    End Property
+End Class
+
+Partial Class C
+    Partial Public ReadOnly Property NewProperty() As String
+        Get
+            Return 1
+        End Get
+    End Property
+
+    Sub New()
+    End Sub
+End Class
+"
+            Dim edits = GetTopEdits(src1, src2)
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(ERRID.ERR_BadPropertyFlags1, "Partial").WithArguments("Partial").WithLocation(3, 5))
+        End Sub
+
 #End Region
 
 #Region "Events"

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -543,8 +543,8 @@ End Class
             End Using
         End Function
 
-        <Fact>
-        Public Async Function AnalyzeDocumentAsync_SemanticError_Change() As Threading.Tasks.Task
+        <Fact, WorkItem(10683, "https://github.com/dotnet/roslyn/issues/10683")>
+        Public Async Function AnalyzeDocumentAsync_SemanticErrorInMethodBody_Change() As Task
             Dim source1 = "
 Class C
     Public Shared Sub Main()
@@ -558,6 +558,38 @@ Class C
     Public Shared Sub Main()
         System.Console.WriteLine(2)
         Bar()
+    End Sub
+End Class
+"
+
+            Dim analyzer = New VisualBasicEditAndContinueAnalyzer()
+            Using workspace = TestWorkspace.CreateVisualBasic(source1)
+                Dim documentId = workspace.CurrentSolution.Projects.First().Documents.First().Id
+                Dim oldSolution = workspace.CurrentSolution
+                Dim newSolution = workspace.CurrentSolution.WithDocumentText(documentId, SourceText.From(source2))
+
+                Dim baseActiveStatements = ImmutableArray.Create(Of ActiveStatementSpan)()
+                Dim result = Await analyzer.AnalyzeDocumentAsync(oldSolution, baseActiveStatements, newSolution.GetDocument(documentId), Nothing)
+
+                ' no declaration errors (error in method body is only reported when emitting)
+                Assert.False(result.HasChangesAndErrors)
+                Assert.False(result.HasChangesAndCompilationErrors)
+            End Using
+        End Function
+
+        <Fact, WorkItem(10683, "https://github.com/dotnet/roslyn/issues/10683")>
+        Public Async Function AnalyzeDocumentAsync_SemanticErrorInDeclaration_Change() As Task
+            Dim source1 = "
+Class C
+    Public Shared Sub Main(x As Bar)
+        System.Console.WriteLine(1)
+    End Sub
+End Class
+"
+            Dim source2 = "
+Class C
+    Public Shared Sub Main(x As Bar)
+        System.Console.WriteLine(2)
     End Sub
 End Class
 "

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -3271,7 +3271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             return true;
         }
 
-        internal override void ReportSemanticRudeEdits(SemanticModel oldModel, SyntaxNode oldNode, SemanticModel newModel, SyntaxNode newNode, List<RudeEditDiagnostic> diagnostics)
+        internal override void ReportMemberBodySemanticRudeEdits(SemanticModel oldModel, SyntaxNode oldNode, SemanticModel newModel, SyntaxNode newNode, List<RudeEditDiagnostic> diagnostics)
         {
             var foundNode = FindUnsupportedV7Switch(oldModel, oldNode, diagnostics);
             if (foundNode != null)

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -23,8 +23,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     {
         internal abstract bool ExperimentalFeaturesEnabled(SyntaxTree tree);
 
-        internal abstract void ReportSemanticRudeEdits(SemanticModel oldModel, SyntaxNode oldNode, SemanticModel newModel, SyntaxNode newNode, List<RudeEditDiagnostic> diagnostics);
-
         /// <summary>
         /// Finds a member declaration node containing given active statement node.
         /// </summary>
@@ -244,6 +242,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         internal abstract void ReportInsertedMemberSymbolRudeEdits(List<RudeEditDiagnostic> diagnostics, ISymbol newSymbol);
         internal abstract void ReportStateMachineSuspensionPointRudeEdits(List<RudeEditDiagnostic> diagnostics, SyntaxNode oldNode, SyntaxNode newNode);
 
+        internal abstract void ReportMemberBodySemanticRudeEdits(SemanticModel oldModel, SyntaxNode oldMemberBody, SemanticModel newModel, SyntaxNode newMemberBody, List<RudeEditDiagnostic> diagnostics);
+
         internal abstract bool IsMethod(SyntaxNode declaration);
         internal abstract bool IsLambda(SyntaxNode node);
         internal abstract bool IsLambdaExpression(SyntaxNode node);
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 var trackingService = baseSolution.Workspace.Services.GetService<IActiveStatementTrackingService>();
 
                 cancellationToken.ThrowIfCancellationRequested();
-
+                
                 // TODO: newTree.HasErrors?
                 var syntaxDiagnostics = newRoot.GetDiagnostics();
                 var syntaxErrorCount = syntaxDiagnostics.Count(d => d.Severity == DiagnosticSeverity.Error);
@@ -438,19 +438,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                // Bail if there were any semantic errors in the compilation.
-                var newCompilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                var firstError = newCompilation.GetDiagnostics(cancellationToken).FirstOrDefault(d => d.Severity == DiagnosticSeverity.Error);
-                if (firstError != null)
-                {
-                    var location = firstError.Location;
-                    DocumentAnalysisResults.Log.Write("Semantic errors, first: {0}", location.IsInSource ? location.SourceTree.FilePath : location.MetadataModule.Name);
-
-                    return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), ImmutableArray.Create<RudeEditDiagnostic>(), hasSemanticErrors: true);
-                }
-
-                cancellationToken.ThrowIfCancellationRequested();
-
                 var triviaEdits = new List<KeyValuePair<SyntaxNode, SyntaxNode>>();
                 var lineEdits = new List<LineChange>();
 
@@ -472,6 +459,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), diagnostics.AsImmutable());
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
+
                 List<SemanticEdit> semanticEdits = null;
                 if (syntacticEdits.Edits.Length > 0 || triviaEdits.Count > 0)
                 {
@@ -490,9 +479,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         newModel,
                         semanticEdits,
                         diagnostics,
+                        out var firstDeclaratingErrorOpt,
                         cancellationToken);
 
                     cancellationToken.ThrowIfCancellationRequested();
+
+                    if (firstDeclaratingErrorOpt != null)
+                    {
+                        var location = firstDeclaratingErrorOpt.Location;
+                        DocumentAnalysisResults.Log.Write("Declaration errors, first: {0}", location.IsInSource ? location.SourceTree.FilePath : location.MetadataModule.Name);
+
+                        return DocumentAnalysisResults.Errors(newActiveStatements.AsImmutable(), ImmutableArray.Create<RudeEditDiagnostic>(), hasSemanticErrors: true);
+                    }
 
                     if (diagnostics.Count > 0)
                     {
@@ -2095,6 +2093,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             SemanticModel newModel,
             [Out]List<SemanticEdit> semanticEdits,
             [Out]List<RudeEditDiagnostic> diagnostics,
+            out Diagnostic firstDeclarationErrorOpt,
             CancellationToken cancellationToken)
         {
             // { new type -> constructor update }
@@ -2104,6 +2103,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             INamedTypeSymbol layoutAttribute = null;
             var newSymbolsWithEdit = new HashSet<ISymbol>();
             int updatedMemberIndex = 0;
+            firstDeclarationErrorOpt = null;
             for (int i = 0; i < editScript.Edits.Length; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -2135,7 +2135,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 continue;
                             }
 
-                            // Deleting an parameterless constructor needs special handling:
+                            // The only member that is allowed to be deleted is a parameterless constructor. 
+                            // For any other member a rude edit is reported earlier during syntax edit classification.
+                            // Deleting a parameterless constructor needs special handling.
                             // If the new type has a parameterless ctor of the same accessibility then UPDATE.
                             // Error otherwise.
 
@@ -2208,12 +2210,24 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             Debug.Assert(oldType != null);
                             Debug.Assert(newType != null);
 
+                            // Validate that the type declarations are correct. If not we can't reason about their members.
+                            // Declaration diagnostics are cached on compilation, so we don't need to cache them here.
+                            firstDeclarationErrorOpt = 
+                                GetFirstDeclarationError(oldModel, oldType, cancellationToken) ??
+                                GetFirstDeclarationError(newModel, newType, cancellationToken);
+
+                            if (firstDeclarationErrorOpt != null)
+                            {
+                                continue;
+                            }
+
                             // Inserting a parameterless constructor needs special handling:
                             // 1) static ctor
                             //    a) old type has an implicit static ctor
                             //       UPDATE of the implicit static ctor
                             //    b) otherwise
                             //       INSERT of a static parameterless ctor
+                            // 
                             // 2) public instance ctor
                             //    a) old type has an implicit instance ctor
                             //       UPDATE of the implicit instance ctor
@@ -2305,16 +2319,31 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 continue;
                             }
 
-                            ReportSemanticRudeEdits(oldModel, edit.OldNode, newModel, edit.NewNode, diagnostics);
-
                             oldSymbol = GetSymbolForEdit(oldModel, edit.OldNode, edit.Kind, editMap, cancellationToken);
                             Debug.Assert((newSymbol == null) == (oldSymbol == null));
+
+                            var oldContainingType = oldSymbol.ContainingType;
+                            var newContainingType = newSymbol.ContainingType;
+
+                            // Validate that the type declarations are correct to avoid issues with invalid partial declarations, etc.
+                            // Declaration diagnostics are cached on compilation, so we don't need to cache them here.
+                            firstDeclarationErrorOpt =
+                                GetFirstDeclarationError(oldModel, oldContainingType, cancellationToken) ??
+                                GetFirstDeclarationError(newModel, newContainingType, cancellationToken);
+
+                            if (firstDeclarationErrorOpt != null)
+                            {
+                                continue;
+                            }
 
                             if (updatedMemberIndex < updatedMembers.Count && updatedMembers[updatedMemberIndex].EditOrdinal == i)
                             {
                                 var updatedMember = updatedMembers[updatedMemberIndex];
 
+                                ReportMemberBodySemanticRudeEdits(oldModel, updatedMember.OldBody, newModel, updatedMember.NewBody, diagnostics);
+
                                 ReportStateMachineRudeEdits(oldModel.Compilation, updatedMember, oldSymbol, diagnostics);
+
                                 ReportLambdaAndClosureRudeEdits(
                                     oldModel,
                                     updatedMember.OldBody,
@@ -2360,8 +2389,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                 IsDeclarationWithInitializer(edit.NewNode))
                             {
                                 if (DeferConstructorEdit(
-                                    oldSymbol.ContainingType,
-                                    newSymbol.ContainingType,
+                                    oldContainingType,
+                                    newContainingType,
                                     editKind,
                                     edit.NewNode,
                                     newSymbol,
@@ -2394,6 +2423,19 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 var oldSymbol = GetSymbolForEdit(oldModel, edit.Key, EditKind.Update, editMap, cancellationToken);
                 var newSymbol = GetSymbolForEdit(newModel, edit.Value, EditKind.Update, editMap, cancellationToken);
+                var oldContainingType = oldSymbol.ContainingType;
+                var newContainingType = newSymbol.ContainingType;
+
+                // Validate that the type declarations are correct to avoid issues with invalid partial declarations, etc.
+                // Declaration diagnostics are cached on compilation, so we don't need to cache them here.
+                firstDeclarationErrorOpt =
+                    GetFirstDeclarationError(oldModel, oldContainingType, cancellationToken) ??
+                    GetFirstDeclarationError(newModel, newContainingType, cancellationToken);
+
+                if (firstDeclarationErrorOpt != null)
+                {
+                    continue;
+                }
 
                 // We need to provide syntax map to the compiler if the member is active (see member update above):
                 bool isActiveMember =
@@ -2412,8 +2454,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     IsDeclarationWithInitializer(edit.Value))
                 {
                     if (DeferConstructorEdit(
-                        oldSymbol.ContainingType,
-                        newSymbol.ContainingType,
+                        oldContainingType,
+                        newContainingType,
                         SemanticEditKind.Update,
                         edit.Value,
                         newSymbol,
@@ -2464,6 +2506,31 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     diagnostics: diagnostics,
                     cancellationToken: cancellationToken);
             }
+        }
+
+        private Diagnostic GetFirstDeclarationError(SemanticModel primaryModel, ISymbol symbol, CancellationToken cancellationToken)
+        {
+            foreach (var syntaxReference in symbol.DeclaringSyntaxReferences)
+            {
+                SemanticModel model;
+                if (primaryModel.SyntaxTree == syntaxReference.SyntaxTree)
+                {
+                    model = primaryModel;
+                }
+                else
+                {
+                    model = primaryModel.Compilation.GetSemanticModel(syntaxReference.SyntaxTree, ignoreAccessibility: false);
+                }
+
+                var diagnostics = model.GetDeclarationDiagnostics(syntaxReference.Span, cancellationToken);
+                var firstError = diagnostics.FirstOrDefault(d => d.Severity == DiagnosticSeverity.Error);
+                if (firstError != null)
+                {
+                    return firstError;
+                }
+            }
+
+            return null;
         }
 
         #region Type Layout Update Validation 
@@ -3684,8 +3751,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return;
             }
 
-            // only methods and anonymous functions may be async/iterators machines:
-            var stateMachineAttributeQualifiedName = ((IMethodSymbol)oldMember).IsAsync ?
+            // Only methods and anonymous functions can be async/iterators machines, 
+            // but don't assume so to be resiliant against errors in code.
+            if (!(oldMember is IMethodSymbol oldMethod))
+            {
+                return;
+            }
+
+            var stateMachineAttributeQualifiedName = oldMethod.IsAsync ?
                 "System.Runtime.CompilerServices.AsyncStateMachineAttribute" :
                 "System.Runtime.CompilerServices.IteratorStateMachineAttribute";
 

--- a/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/EditAndContinue/VisualBasicEditAndContinueAnalyzer.vb
@@ -3173,7 +3173,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue
                                                                          DirectCast(n2.ForOrForEachStatement, ForEachStatementSyntax).ControlVariable))
         End Sub
 
-        Friend Overrides Sub ReportSemanticRudeEdits(oldModel As SemanticModel, oldNode As SyntaxNode, newModel As SemanticModel, newNode As SyntaxNode, diagnostics As List(Of RudeEditDiagnostic))
+        Friend Overrides Sub ReportMemberBodySemanticRudeEdits(oldModel As SemanticModel, oldNode As SyntaxNode, newModel As SemanticModel, newNode As SyntaxNode, diagnostics As List(Of RudeEditDiagnostic))
         End Sub
 
 #End Region


### PR DESCRIPTION
**Customer scenario**

Applying an EnC change in a project containing large method bodies might take a long time (minutes) during which the compiler calculates all semantic diagnostics and VS UI thread is blocked.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/10683

**Workarounds, if any**

None.

**Risk**

Medium. Although I went over the EnC analyzer code to find any code paths that might not be hardened against erroneous code it might happen I missed something. As a result an exception may occur, a non-fatal Watson reported and the debugging session terminated.

**Performance impact**

Improves performance.

**Is this a regression from a previous update?**

Roslyn regressed when compared to pre-Roslyn EnC.

**Root cause analysis:**

We used safer approach of not analyzing broken code when the analyzer was implemented.

**How was the bug found?**

Quite a few customer complains.