### PR TITLE
Fix the build issues for EE components in IDE

### DIFF
--- a/src/Compilers/Extension/CompilerExtension.csproj
+++ b/src/Compilers/Extension/CompilerExtension.csproj
@@ -144,7 +144,7 @@
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\VisualBasic\vbc\vbc.csproj">
-      <Project>{2ac2755d-9437-4271-bbde-1a3795a0c320}</Project>
+      <Project>{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}</Project>
       <Name>vbc</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>

--- a/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
+++ b/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
@@ -62,7 +62,7 @@
       <NgenPriority>3</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\Core\Source\ResultProvider\Portable\ResultProvider.Portable.csproj">
-      <Project>{BEDC5A4A-809E-4017-9CFD-6C8D4E1847F0}</Project>
+      <Project>{fa0e905d-ec46-466d-b7b2-3b5557f9428c}</Project>
       <Name>ResultProvider.Portable</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
@@ -82,7 +82,7 @@
       <NgenPriority>3</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\CSharp\Source\ResultProvider\Portable\CSharpResultProvider.Portable.csproj">
-      <Project>{BF9DAC1E-3A5E-4DC3-BB44-9A64E0D4E9D3}</Project>
+      <Project>{bf9dac1e-3a5e-4dc3-bb44-9a64e0d4e9d4}</Project>
       <Name>CSharpResultProvider.Portable</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
@@ -102,7 +102,7 @@
       <NgenPriority>3</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\VisualBasic\Source\ResultProvider\Portable\BasicResultProvider.Portable.vbproj">
-      <Project>{76242A2D-2600-49DD-8C15-FEA07ECB1842}</Project>
+      <Project>{76242a2d-2600-49dd-8c15-fea07ecb1843}</Project>
       <Name>BasicResultProvider.Portable</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bVsdConfigOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>

--- a/src/Tools/BuildBoss/BuildBoss.csproj
+++ b/src/Tools/BuildBoss/BuildBoss.csproj
@@ -35,6 +35,7 @@
     <Compile Include="PackageReference.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ProjectData.cs" />
+    <Compile Include="ProjectReferenceEntry.cs" />
     <Compile Include="ProjectUtil.cs" />
     <Compile Include="ProjectKey.cs" />
     <Compile Include="ProjectType.cs" />

--- a/src/Tools/BuildBoss/ProjectReferenceEntry.cs
+++ b/src/Tools/BuildBoss/ProjectReferenceEntry.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuildBoss
+{
+    internal struct ProjectReferenceEntry
+    {
+        internal string FileName { get; }
+        internal Guid? Project { get; }
+
+        internal ProjectKey ProjectKey => new ProjectKey(FileName);
+
+        internal ProjectReferenceEntry(string fileName, Guid? project)
+        {
+            FileName = fileName;
+            Project = project;
+        }
+    }
+}

--- a/src/Tools/BuildBoss/ProjectUtil.cs
+++ b/src/Tools/BuildBoss/ProjectUtil.cs
@@ -137,10 +137,10 @@ namespace BuildBoss
             return _document.XPathSelectElements("//mb:ItemGroup", _manager);
         }
 
-        internal List<ProjectKey> GetDeclaredProjectReferences()
+        internal List<ProjectReferenceEntry> GetDeclaredProjectReferences()
         {
             var references = _document.XPathSelectElements("//mb:ProjectReference", _manager);
-            var list = new List<ProjectKey>();
+            var list = new List<ProjectReferenceEntry>();
             var directory = Path.GetDirectoryName(_key.FilePath);
             foreach (var r in references)
             {
@@ -156,9 +156,16 @@ namespace BuildBoss
                     }
                 }
 
+                Guid? project = null;
+                var projectElement = r.Element(_namespace.GetName("Project"));
+                if (projectElement != null)
+                {
+                    project = Guid.Parse(projectElement.Value.Trim());
+                }
+
                 var relativePath = r.Attribute("Include").Value;
                 var path = Path.Combine(directory, relativePath);
-                list.Add(new ProjectKey(path));
+                list.Add(new ProjectReferenceEntry(path, project));
             }
 
             return list;


### PR DESCRIPTION
Infrastructure change.  

This fixes the problem where EE components would occasional fail to build first time around in the IDE.  The source of the build failures is the GUID for the project and the GUID included in the reference were different.  Added validation to prevent this in the future and cleaned up the problems it found. 