### PR TITLE
Remove unnecessary delegate allocations when calling back to analyzers

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -201,9 +201,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </remarks>
         public void ExecuteInitializeMethod(DiagnosticAnalyzer analyzer, HostSessionStartAnalysisScope sessionScope)
         {
+            var context = new AnalyzerAnalysisContext(analyzer, sessionScope, _compilation.IsIOperationFeatureEnabled());
+
             // The Initialize method should be run asynchronously in case it is not well behaved, e.g. does not terminate.
-            ExecuteAndCatchIfThrows(analyzer,
-                () => analyzer.Initialize(new AnalyzerAnalysisContext(analyzer, sessionScope, _compilation.IsIOperationFeatureEnabled())));
+            ExecuteAndCatchIfThrows(
+                analyzer,
+                data => data.analyzer.Initialize(data.context),
+                (analyzer: analyzer, context: context));
         }
 
         /// <summary>
@@ -217,9 +221,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 _cancellationToken.ThrowIfCancellationRequested();
 
-                ExecuteAndCatchIfThrows(startAction.Analyzer,
-                    () => startAction.Action(new AnalyzerCompilationStartAnalysisContext(startAction.Analyzer, compilationScope,
-                        _compilation, _analyzerOptions, _compilationAnalysisValueProviderFactory, _cancellationToken)),
+                var context = new AnalyzerCompilationStartAnalysisContext(startAction.Analyzer, compilationScope,
+                    _compilation, _analyzerOptions, _compilationAnalysisValueProviderFactory, _cancellationToken);
+
+                ExecuteAndCatchIfThrows(
+                    startAction.Analyzer,
+                    data => data.action(data.context),
+                    (action: startAction.Action, context: context),
                     new AnalysisContextInfo(_compilation));
             }
         }
@@ -267,6 +275,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private void ExecuteCompilationActionsCore(ImmutableArray<CompilationAnalyzerAction> compilationActions, DiagnosticAnalyzer analyzer, AnalyzerStateData analyzerStateOpt)
         {
             var addDiagnostic = GetAddCompilationDiagnostic(analyzer);
+            Func<Diagnostic, bool> isSupportedDiagnostic = d => IsSupportedDiagnostic(analyzer, d);
 
             foreach (var endAction in compilationActions)
             {
@@ -274,10 +283,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 if (ShouldExecuteAction(analyzerStateOpt, endAction))
                 {
-                    ExecuteAndCatchIfThrows(endAction.Analyzer,
-                        () => endAction.Action(new CompilationAnalysisContext(
-                            _compilation, _analyzerOptions, addDiagnostic,
-                            d => IsSupportedDiagnostic(endAction.Analyzer, d), _compilationAnalysisValueProviderFactory, _cancellationToken)),
+                    var context = new CompilationAnalysisContext(
+                        _compilation, _analyzerOptions, addDiagnostic,
+                        isSupportedDiagnostic, _compilationAnalysisValueProviderFactory, _cancellationToken);
+
+                    ExecuteAndCatchIfThrows(
+                        endAction.Analyzer,
+                        data => data.action(data.context),
+                        (action: endAction.Action, context: context),
                         new AnalysisContextInfo(_compilation));
 
                     analyzerStateOpt?.ProcessedActions.Add(endAction);
@@ -345,6 +358,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             var symbol = symbolDeclaredEvent.Symbol;
             var addDiagnostic = GetAddDiagnostic(symbol, symbolDeclaredEvent.DeclaringSyntaxReferences, analyzer, getTopMostNodeForAnalysis);
+            Func<Diagnostic, bool> isSupportedDiagnostic = d => IsSupportedDiagnostic(analyzer, d);
 
             foreach (var symbolAction in symbolActions)
             {
@@ -357,9 +371,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         _cancellationToken.ThrowIfCancellationRequested();
 
-                        ExecuteAndCatchIfThrows(symbolAction.Analyzer,
-                            () => action(new SymbolAnalysisContext(symbol, _compilation, _analyzerOptions, addDiagnostic,
-                                d => IsSupportedDiagnostic(symbolAction.Analyzer, d), _cancellationToken)),
+                        var context = new SymbolAnalysisContext(symbol, _compilation, _analyzerOptions, addDiagnostic,
+                            isSupportedDiagnostic, _cancellationToken);
+
+                        ExecuteAndCatchIfThrows(
+                            symbolAction.Analyzer,
+                            data => data.action(data.context),
+                            (action: action, context: context),
                             new AnalysisContextInfo(_compilation, symbol));
 
                         analyzerStateOpt?.ProcessedActions.Add(symbolAction);
@@ -423,6 +441,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             var addDiagnostic = GetAddDiagnostic(semanticModel.SyntaxTree, analyzer, isSyntaxDiagnostic: false);
+            Func<Diagnostic, bool> isSupportedDiagnostic = d => IsSupportedDiagnostic(analyzer, d);
 
             foreach (var semanticModelAction in semanticModelActions)
             {
@@ -430,10 +449,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     _cancellationToken.ThrowIfCancellationRequested();
 
+                    var context = new SemanticModelAnalysisContext(semanticModel, _analyzerOptions, addDiagnostic,
+                        isSupportedDiagnostic, _cancellationToken);
+
                     // Catch Exception from action.
-                    ExecuteAndCatchIfThrows(semanticModelAction.Analyzer,
-                        () => semanticModelAction.Action(new SemanticModelAnalysisContext(semanticModel, _analyzerOptions, addDiagnostic,
-                            d => IsSupportedDiagnostic(semanticModelAction.Analyzer, d), _cancellationToken)),
+                    ExecuteAndCatchIfThrows(
+                        semanticModelAction.Analyzer,
+                        data => data.action(data.context),
+                        (action: semanticModelAction.Action, context: context),
                         new AnalysisContextInfo(semanticModel));
 
                     analyzerStateOpt?.ProcessedActions.Add(semanticModelAction);
@@ -494,6 +517,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             var addDiagnostic = GetAddDiagnostic(tree, analyzer, isSyntaxDiagnostic: true);
+            Func<Diagnostic, bool> isSupportedDiagnostic = d => IsSupportedDiagnostic(analyzer, d);
 
             foreach (var syntaxTreeAction in syntaxTreeActions)
             {
@@ -501,10 +525,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     _cancellationToken.ThrowIfCancellationRequested();
 
+                    var context = new SyntaxTreeAnalysisContext(tree, _analyzerOptions, addDiagnostic, isSupportedDiagnostic, _compilation, _cancellationToken);
+
                     // Catch Exception from action.
-                    ExecuteAndCatchIfThrows(syntaxTreeAction.Analyzer,
-                        () => syntaxTreeAction.Action(new SyntaxTreeAnalysisContext(tree, _analyzerOptions, addDiagnostic,
-                            d => IsSupportedDiagnostic(syntaxTreeAction.Analyzer, d), _compilation, _cancellationToken)),
+                    ExecuteAndCatchIfThrows(
+                        syntaxTreeAction.Analyzer,
+                        data => data.action(data.context),
+                        (action: syntaxTreeAction.Action, context: context),
                         new AnalysisContextInfo(_compilation, tree));
 
                     analyzerStateOpt?.ProcessedActions.Add(syntaxTreeAction);
@@ -518,6 +545,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ISymbol containingSymbol,
             SemanticModel semanticModel,
             Action<Diagnostic> addDiagnostic,
+            Func<Diagnostic, bool> isSupportedDiagnostic,
             SyntaxNodeAnalyzerStateData analyzerStateOpt)
             where TLanguageKindEnum : struct
         {
@@ -526,9 +554,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             if (ShouldExecuteAction(analyzerStateOpt, syntaxNodeAction))
             {
                 var syntaxNodeContext = new SyntaxNodeAnalysisContext(node, containingSymbol, semanticModel, _analyzerOptions, addDiagnostic,
-                    d => IsSupportedDiagnostic(syntaxNodeAction.Analyzer, d), _cancellationToken);
-                ExecuteAndCatchIfThrows(syntaxNodeAction.Analyzer,
-                    () => syntaxNodeAction.Action(syntaxNodeContext),
+                    isSupportedDiagnostic, _cancellationToken);
+
+                ExecuteAndCatchIfThrows(
+                    syntaxNodeAction.Analyzer,
+                    data => data.action(data.context),
+                    (action: syntaxNodeAction.Action, context: syntaxNodeContext),
                     new AnalysisContextInfo(_compilation, node));
 
                 analyzerStateOpt?.ProcessedActions.Add(syntaxNodeAction);
@@ -541,15 +572,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ISymbol containingSymbol,
             SemanticModel semanticModel,
             Action<Diagnostic> addDiagnostic,
+            Func<Diagnostic, bool> isSupportedDiagnostic,
             OperationAnalyzerStateData analyzerStateOpt)
         {
             Debug.Assert(analyzerStateOpt == null || analyzerStateOpt.CurrentOperation == operation);
 
             if (ShouldExecuteAction(analyzerStateOpt, operationAction))
             {
-                var operationContext = new OperationAnalysisContext(operation, containingSymbol, semanticModel.Compilation, _analyzerOptions, addDiagnostic, d => IsSupportedDiagnostic(operationAction.Analyzer, d), _cancellationToken);
-                ExecuteAndCatchIfThrows(operationAction.Analyzer,
-                    () => operationAction.Action(operationContext),
+                var operationContext = new OperationAnalysisContext(operation, containingSymbol, semanticModel.Compilation, _analyzerOptions, addDiagnostic, isSupportedDiagnostic, _cancellationToken);
+                ExecuteAndCatchIfThrows(
+                    operationAction.Analyzer,
+                    data => data.action(data.context),
+                    (action: operationAction.Action, context: operationContext),
                     new AnalysisContextInfo(_compilation, operation));
 
                 analyzerStateOpt?.ProcessedActions.Add(operationAction);
@@ -701,6 +735,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             var addDiagnostic = GetAddDiagnostic(semanticModel.SyntaxTree, declaredNode.FullSpan, analyzer, isSyntaxDiagnostic: false);
+            Func<Diagnostic, bool> isSupportedDiagnostic = d => IsSupportedDiagnostic(analyzer, d);
 
             try
             {
@@ -713,17 +748,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         if (codeBlockStartAction != null)
                         {
                             var codeBlockEndActions = blockEndActions as PooledHashSet<CodeBlockAnalyzerAction>;
+                            var codeBlockScope = new HostCodeBlockStartAnalysisScope<TLanguageKindEnum>();
+                            var blockStartContext = new AnalyzerCodeBlockStartAnalysisContext<TLanguageKindEnum>(startAction.Analyzer,
+                                codeBlockScope, declaredNode, declaredSymbol, semanticModel, _analyzerOptions, _cancellationToken);
+
                             // Catch Exception from the start action.
-                            ExecuteAndCatchIfThrows(startAction.Analyzer, () =>
-                            {
-                                var codeBlockScope = new HostCodeBlockStartAnalysisScope<TLanguageKindEnum>();
-                                var blockStartContext = new AnalyzerCodeBlockStartAnalysisContext<TLanguageKindEnum>(startAction.Analyzer,
-                                    codeBlockScope, declaredNode, declaredSymbol, semanticModel, _analyzerOptions, _cancellationToken);
-                                codeBlockStartAction.Action(blockStartContext);
-                                codeBlockEndActions.AddAll(codeBlockScope.CodeBlockEndActions);
-                                syntaxNodeActions.AddRange(codeBlockScope.SyntaxNodeActions);
-                            },
-                            new AnalysisContextInfo(_compilation, declaredSymbol, declaredNode));
+                            ExecuteAndCatchIfThrows(
+                                startAction.Analyzer,
+                                data =>
+                                {
+                                    data.action(data.context);
+                                    data.blockEndActions.AddAll(data.scope.CodeBlockEndActions);
+                                    data.syntaxNodeActions.AddRange(data.scope.SyntaxNodeActions);
+                                },
+                                (action: codeBlockStartAction.Action, context: blockStartContext, scope: codeBlockScope, blockEndActions: codeBlockEndActions, syntaxNodeActions: syntaxNodeActions),
+                                new AnalysisContextInfo(_compilation, declaredSymbol, declaredNode));
                         }
                         else
                         {
@@ -731,17 +770,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                             if (operationBlockStartAction != null)
                             {
                                 var operationBlockEndActions = blockEndActions as PooledHashSet<OperationBlockAnalyzerAction>;
+                                var operationBlockScope = new HostOperationBlockStartAnalysisScope();
+                                var operationStartContext = new AnalyzerOperationBlockStartAnalysisContext(startAction.Analyzer,
+                                    operationBlockScope, operationBlocks, declaredSymbol, semanticModel.Compilation, _analyzerOptions, _cancellationToken);
+
                                 // Catch Exception from the start action.
-                                ExecuteAndCatchIfThrows(startAction.Analyzer, () =>
-                                {
-                                    var operationBlockScope = new HostOperationBlockStartAnalysisScope();
-                                    var operationStartContext = new AnalyzerOperationBlockStartAnalysisContext(startAction.Analyzer,
-                                        operationBlockScope, operationBlocks, declaredSymbol, semanticModel.Compilation, _analyzerOptions, _cancellationToken);
-                                    operationBlockStartAction.Action(operationStartContext);
-                                    operationBlockEndActions.AddAll(operationBlockScope.OperationBlockEndActions);
-                                    operationActions.AddRange(operationBlockScope.OperationActions);
-                                },
-                                new AnalysisContextInfo(_compilation, declaredSymbol));
+                                ExecuteAndCatchIfThrows(
+                                    startAction.Analyzer,
+                                    data =>
+                                    {
+                                        data.action(data.context);
+                                        data.blockEndActions.AddAll(data.scope.OperationBlockEndActions);
+                                        data.operationActions.AddRange(data.scope.OperationActions);
+                                    },
+                                    (action: operationBlockStartAction.Action, context: operationStartContext, scope: operationBlockScope, blockEndActions: operationBlockEndActions, operationActions: operationActions),
+                                    new AnalysisContextInfo(_compilation, declaredSymbol));
                             }
                         }
 
@@ -765,20 +808,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     var executableNodeActionsByKind = GetNodeActionsByKind(syntaxNodeActions);
                     var syntaxNodesToAnalyze = (IEnumerable<SyntaxNode>)getNodesToAnalyze(executableBlocks);
-                    ExecuteSyntaxNodeActions(syntaxNodesToAnalyze, executableNodeActionsByKind, analyzer, declaredSymbol, semanticModel, getKind, addDiagnostic, analyzerStateOpt?.ExecutableNodesAnalysisState as SyntaxNodeAnalyzerStateData);
+                    ExecuteSyntaxNodeActions(syntaxNodesToAnalyze, executableNodeActionsByKind, analyzer, declaredSymbol, semanticModel, getKind, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt?.ExecutableNodesAnalysisState as SyntaxNodeAnalyzerStateData);
                 }
                 else if (operationActions != null)
                 {
                     var operationActionsByKind = GetOperationActionsByKind(operationActions);
                     var operationsToAnalyze = (IEnumerable<IOperation>)getNodesToAnalyze(executableBlocks);
-                    ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, semanticModel, addDiagnostic, analyzerStateOpt?.ExecutableNodesAnalysisState as OperationAnalyzerStateData);
+                    ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, semanticModel, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt?.ExecutableNodesAnalysisState as OperationAnalyzerStateData);
                 }
             }
 
             executableNodeActions.Free();
 
-            ExecuteBlockActions(blockActions, declaredNode, declaredSymbol, semanticModel, operationBlocks, addDiagnostic, analyzerStateOpt);
-            ExecuteBlockActions(blockEndActions, declaredNode, declaredSymbol, semanticModel, operationBlocks, addDiagnostic, analyzerStateOpt);
+            ExecuteBlockActions(blockActions, declaredNode, declaredSymbol, semanticModel, operationBlocks, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
+            ExecuteBlockActions(blockEndActions, declaredNode, declaredSymbol, semanticModel, operationBlocks, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
         }
 
         private void ExecuteBlockActions<TBlockAction, TNodeStateData>(
@@ -788,6 +831,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel semanticModel,
             ImmutableArray<IOperation> operationBlocks,
             Action<Diagnostic> addDiagnostic,
+            Func<Diagnostic, bool> isSupportedDiagnostic,
             AnalysisState.BlockAnalyzerStateData<TBlockAction, TNodeStateData> analyzerStateOpt)
             where TBlockAction : AnalyzerAction
             where TNodeStateData : AnalyzerStateData, new()
@@ -797,12 +841,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 if (ShouldExecuteAction(analyzerStateOpt, blockAction))
                 {
                     var codeBlockAction = blockAction as CodeBlockAnalyzerAction;
-                    Func<Diagnostic, bool> isSupportedDiagnostic = d => IsSupportedDiagnostic(blockAction.Analyzer, d);
                     if (codeBlockAction != null)
                     {
+                        var context = new CodeBlockAnalysisContext(declaredNode, declaredSymbol, semanticModel, _analyzerOptions, addDiagnostic, isSupportedDiagnostic, _cancellationToken);
+
                         ExecuteAndCatchIfThrows(
                             codeBlockAction.Analyzer,
-                            () => codeBlockAction.Action(new CodeBlockAnalysisContext(declaredNode, declaredSymbol, semanticModel, _analyzerOptions, addDiagnostic, isSupportedDiagnostic, _cancellationToken)),
+                            data => data.action(data.context),
+                            (action: codeBlockAction.Action, context: context),
                             new AnalysisContextInfo(_compilation, declaredSymbol, declaredNode));
                     }
                     else
@@ -810,9 +856,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         var operationBlockAction = blockAction as OperationBlockAnalyzerAction;
                         if (operationBlockAction != null)
                         {
+                            var context = new OperationBlockAnalysisContext(operationBlocks, declaredSymbol, semanticModel.Compilation, _analyzerOptions, addDiagnostic, isSupportedDiagnostic, _cancellationToken);
+
                             ExecuteAndCatchIfThrows(
                                 operationBlockAction.Analyzer,
-                                () => operationBlockAction.Action(new OperationBlockAnalysisContext(operationBlocks, declaredSymbol, semanticModel.Compilation, _analyzerOptions, addDiagnostic, isSupportedDiagnostic, _cancellationToken)),
+                                data => data.action(data.context),
+                                (action: operationBlockAction.Action, context: context),
                                 new AnalysisContextInfo(_compilation, declaredSymbol));
                         }
                     }
@@ -909,7 +958,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             var addDiagnostic = GetAddDiagnostic(model.SyntaxTree, filterSpan, analyzer, isSyntaxDiagnostic: false);
-            ExecuteSyntaxNodeActions(nodesToAnalyze, nodeActionsByKind, analyzer, containingSymbol, model, getKind, addDiagnostic, analyzerStateOpt);
+            Func<Diagnostic, bool> isSupportedDiagnostic = d => IsSupportedDiagnostic(analyzer, d);
+            ExecuteSyntaxNodeActions(nodesToAnalyze, nodeActionsByKind, analyzer, containingSymbol, model, getKind, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
         }
 
         private void ExecuteSyntaxNodeActions<TLanguageKindEnum>(
@@ -920,6 +970,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel model,
             Func<SyntaxNode, TLanguageKindEnum> getKind,
             Action<Diagnostic> addDiagnostic,
+            Func<Diagnostic, bool> isSupportedDiagnostic,
             SyntaxNodeAnalyzerStateData analyzerStateOpt)
             where TLanguageKindEnum : struct
         {
@@ -929,7 +980,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SyntaxNode partiallyProcessedNode = analyzerStateOpt?.CurrentNode;
             if (partiallyProcessedNode != null)
             {
-                ExecuteSyntaxNodeActions(partiallyProcessedNode, nodeActionsByKind, containingSymbol, model, getKind, addDiagnostic, analyzerStateOpt);
+                ExecuteSyntaxNodeActions(partiallyProcessedNode, nodeActionsByKind, containingSymbol, model, getKind, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
             }
 
             foreach (var child in nodesToAnalyze)
@@ -938,7 +989,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     SetCurrentNode(analyzerStateOpt, child);
 
-                    ExecuteSyntaxNodeActions(child, nodeActionsByKind, containingSymbol, model, getKind, addDiagnostic, analyzerStateOpt);
+                    ExecuteSyntaxNodeActions(child, nodeActionsByKind, containingSymbol, model, getKind, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
                 }
             }
         }
@@ -950,6 +1001,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SemanticModel model,
             Func<SyntaxNode, TLanguageKindEnum> getKind,
             Action<Diagnostic> addDiagnostic,
+            Func<Diagnostic, bool> isSupportedDiagnostic,
             SyntaxNodeAnalyzerStateData analyzerStateOpt)
             where TLanguageKindEnum : struct
         {
@@ -958,7 +1010,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 foreach (var action in actionsForKind)
                 {
-                    ExecuteSyntaxNodeAction(action, node, containingSymbol, model, addDiagnostic, analyzerStateOpt);
+                    ExecuteSyntaxNodeAction(action, node, containingSymbol, model, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
                 }
             }
 
@@ -1044,7 +1096,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             var addDiagnostic = GetAddDiagnostic(model.SyntaxTree, filterSpan, analyzer, isSyntaxDiagnostic: false);
-            ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, containingSymbol, model, addDiagnostic, analyzerStateOpt);
+            Func<Diagnostic, bool> isSupportedDiagnostic = d => IsSupportedDiagnostic(analyzer, d);
+            ExecuteOperationActions(operationsToAnalyze, operationActionsByKind, analyzer, containingSymbol, model, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
         }
 
         private void ExecuteOperationActions(
@@ -1054,6 +1107,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ISymbol containingSymbol,
             SemanticModel model,
             Action<Diagnostic> addDiagnostic,
+            Func<Diagnostic, bool> isSupportedDiagnostic,
             OperationAnalyzerStateData analyzerStateOpt)
         {
             Debug.Assert(operationActionsByKind != null);
@@ -1062,7 +1116,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             IOperation partiallyProcessedNode = analyzerStateOpt?.CurrentOperation;
             if (partiallyProcessedNode != null)
             {
-                ExecuteOperationActions(partiallyProcessedNode, operationActionsByKind, containingSymbol, model, addDiagnostic, analyzerStateOpt);
+                ExecuteOperationActions(partiallyProcessedNode, operationActionsByKind, containingSymbol, model, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
             }
 
             foreach (var child in operationsToAnalyze)
@@ -1071,7 +1125,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     SetCurrentOperation(analyzerStateOpt, child);
 
-                    ExecuteOperationActions(child, operationActionsByKind, containingSymbol, model, addDiagnostic, analyzerStateOpt);
+                    ExecuteOperationActions(child, operationActionsByKind, containingSymbol, model, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
                 }
             }
         }
@@ -1082,6 +1136,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ISymbol containingSymbol,
             SemanticModel model,
             Action<Diagnostic> addDiagnostic,
+            Func<Diagnostic, bool> isSupportedDiagnostic,
             OperationAnalyzerStateData analyzerStateOpt)
         {
             ImmutableArray<OperationAnalyzerAction> actionsForKind;
@@ -1089,7 +1144,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 foreach (var action in actionsForKind)
                 {
-                    ExecuteOperationAction(action, operation, containingSymbol, model, addDiagnostic, analyzerStateOpt);
+                    ExecuteOperationAction(action, operation, containingSymbol, model, addDiagnostic, isSupportedDiagnostic, analyzerStateOpt);
                 }
             }
 
@@ -1115,23 +1170,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        internal void ExecuteAndCatchIfThrows(DiagnosticAnalyzer analyzer, Action analyze, AnalysisContextInfo? info = null)
+        internal void ExecuteAndCatchIfThrows<TArg>(DiagnosticAnalyzer analyzer, Action<TArg> analyze, TArg argument, AnalysisContextInfo? info = null)
         {
             object gate = _getAnalyzerGateOpt?.Invoke(analyzer);
             if (gate != null)
             {
                 lock (gate)
                 {
-                    ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, info);
+                    ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, argument, info);
                 }
             }
             else
             {
-                ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, info);
+                ExecuteAndCatchIfThrows_NoLock(analyzer, analyze, argument, info);
             }
         }
 
-        private void ExecuteAndCatchIfThrows_NoLock(DiagnosticAnalyzer analyzer, Action analyze, AnalysisContextInfo? info)
+        private void ExecuteAndCatchIfThrows_NoLock<TArg>(DiagnosticAnalyzer analyzer, Action<TArg> analyze, TArg argument, AnalysisContextInfo? info)
         {
             try
             {
@@ -1143,7 +1198,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     timer = Stopwatch.StartNew();
                 }
 
-                analyze();
+                analyze(argument);
 
                 if (timer != null)
                 {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.AnalyzerExecutionContext.cs
@@ -151,14 +151,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var supportedDiagnostics = ImmutableArray<DiagnosticDescriptor>.Empty;
 
                 // Catch Exception from analyzer.SupportedDiagnostics
-                analyzerExecutor.ExecuteAndCatchIfThrows(analyzer, () =>
-                {
-                    var supportedDiagnosticsLocal = analyzer.SupportedDiagnostics;
-                    if (!supportedDiagnosticsLocal.IsDefaultOrEmpty)
+                analyzerExecutor.ExecuteAndCatchIfThrows(
+                    analyzer,
+                    _ =>
                     {
-                        supportedDiagnostics = supportedDiagnosticsLocal;
-                    }
-                });
+                        var supportedDiagnosticsLocal = analyzer.SupportedDiagnostics;
+                        if (!supportedDiagnosticsLocal.IsDefaultOrEmpty)
+                        {
+                            supportedDiagnostics = supportedDiagnosticsLocal;
+                        }
+                    },
+                    argument: default(object));
 
                 // Force evaluate and report exception diagnostics from LocalizableString.ToString().
                 Action<Exception, DiagnosticAnalyzer, Diagnostic> onAnalyzerException = analyzerExecutor.OnAnalyzerException;


### PR DESCRIPTION
**Customer scenario**

This change reduces the number of allocations required to execute analyzers. The improvement applies to all analyzers at each point where a callback is made from the analyzer driver into the analyzer code. As such, analyzers which use large numbers of callbacks (`SyntaxNode`, `ISymbol`, and `IOperation` analyzers) are the most heavily impacted.

**Bugs this fixes:**

N/A

**Workarounds, if any**

None (the behavior is correct, but the overhead is unavoidable).

**Risk**

Low. Passing state as an argument is common practice for avoiding delegate allocation overhead.

**Performance impact**

This change improves performance by avoiding unnecessary delegate allocations. For the case of syntax node, symbol, and IOperation analyzers, the number of avoided allocations is substantial. The amortized improvement is the following:

* Symbol analyzer: 2 delegate instances and 2 captures per symbol per analyzer
* Syntax node analyzer: 2 delegate instances and 2 captures per syntax node per analyzer
* IOperation analyzer: 2 delegate instances and 2 captures per operation per analyzer

Other analysis modes are impacted to a lesser extent.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Should have been caught during review.

**How was the bug found?**

Manual code review.