### PR TITLE
Consider name when matching hierarchy items to projects

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
@@ -32,7 +32,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             var nestedHierarchy = hierarchyItem.HierarchyIdentity.NestedHierarchy;
             var nestedHierarchyId = hierarchyItem.HierarchyIdentity.NestedItemID;
 
-            if (!nestedHierarchy.TryGetCanonicalName(nestedHierarchyId, out string nestedCanonicalName))
+            if (!nestedHierarchy.TryGetCanonicalName(nestedHierarchyId, out string nestedCanonicalName)
+                || !nestedHierarchy.TryGetItemName(nestedHierarchyId, out string nestedName))
             {
                 projectId = default(ProjectId);
                 return false;
@@ -42,7 +43,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                     .Where(p =>
                     {
                         if (p.Hierarchy.TryGetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectCanonicalName)
-                            && projectCanonicalName.Equals(nestedCanonicalName, System.StringComparison.OrdinalIgnoreCase))
+                            && p.Hierarchy.TryGetItemName((uint)VSConstants.VSITEMID.Root, out string projectName)
+                            && projectCanonicalName.Equals(nestedCanonicalName, System.StringComparison.OrdinalIgnoreCase)
+                            && projectName.Equals(nestedName))
                         {
                             if (targetFrameworkMoniker == null)
                             {

--- a/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
@@ -29,6 +29,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 return false;
             }
 
+            // A project node is represented in two different hierarchies: the solution's IVsHierarchy (where it is a leaf node)
+            // and the project's own IVsHierarchy (where it is the root node). The IVsHierarchyItem joins them together for the
+            // purpose of creating the tree displayed in Solution Explorer. The project's hierarchy is what is passed from the
+            // project system to the language service, so that's the one the one to query here. To do that we need to get
+            // the "nested" hierarchy from the IVsHierarchyItem.
             var nestedHierarchy = hierarchyItem.HierarchyIdentity.NestedHierarchy;
             var nestedHierarchyId = hierarchyItem.HierarchyIdentity.NestedItemID;
 
@@ -42,6 +47,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             var project = _workspace.DeferredState.ProjectTracker.ImmutableProjects
                     .Where(p =>
                     {
+                        // Here we try to match the hierarchy from Solution Explorer to a hierarchy from the Roslyn project.
+                        // The canonical name of a hierarchy item must be unique _within_ an hierarchy, but since we're
+                        // examining multiple hierarchies the canonical name could be the same. Indeed this happens when two
+                        // project files are in the same folder--they both use the full path to the _folder_ as the canonical
+                        // name. To distinguish them we also examine the "regular" name, which will necessarily be different
+                        // if the two projects are in the same folder.
                         if (p.Hierarchy.TryGetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectCanonicalName)
                             && p.Hierarchy.TryGetItemName((uint)VSConstants.VSITEMID.Root, out string projectName)
                             && projectCanonicalName.Equals(nestedCanonicalName, System.StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Our support for showing nodes for analyzers and diagnostics in the Solution Explorer depends on us being able to map from an `IVsHierarchy` and item ID representing a project node to the corresponding Roslyn project in the workspace. In Dev14 this was relatively easy, as we could simply check each `IVsHierarchy` held by a Roslyn project for reference equality with the `IVsHierarchy` for the project in Solution Explorer.

This approach doesn't work in Dev15 for CPS-based projects. Because of multi-targeting there is a one-to-many mapping from a project in Solution Explorer to projects in the Roslyn workspace; each project in the Roslyn workspace holds on to a different, target-framework-specific `IVsHierarchy` that comes from the project system and is never seen by Solution Explorer. To handle this I switched to using the "canonical name" and target framework to match things up.

It turns out this breaks the legacy project system when two projects are in the same folder--they both report the _directory path_ as their canonical name, rather than their full path. The code to map from Solution Explorer nodes to Roslyn projects thus ends up finding two matching projects where it expected only one. The end result is that the project loads, but when you try to expand it in Solution Explorer you get no children.

To fix this we need to check both the canonical name (e.g. "C:\my\project\folder"), and the regular name (e.g. "MyProject"). Even if two projects share the same directory, their names will necessarily be different.

**Customer scenario**

This will occur any time the customer opens a solution where two or more projects reside in the same directory. The projects will load but the customer will be unable to expand their nodes in the Solution Explorer.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/429299

**Workarounds, if any**

Unloading all affected projects, and then loading only one of them at a time will work around this issue.

**Risk**

Low

**Performance impact**

Minimal. This particular code path is generally only hit when the user is drilling down in Solution Explorer to see the list of analyzers and diagnostics.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

There are no tests that check how we handle multiple projects within the same directory.

**How was the bug found?**

Dogfooding
