### PR TITLE
Attempt to diagnose devdiv #384109

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -264,12 +264,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
         private Document GetDocument()
         {
-            return this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+            // Crash if we don't find a document, we're already in a bad state.
+            var document = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+            Contract.ThrowIfNull(document, nameof(document));
+            return document;
         }
 
         private CompletionHelper GetCompletionHelper()
         {
-            // Crash if we don't find a document, we're already in a bad state.
             var document = GetDocument();
             return CompletionHelper.GetHelper(document);
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -269,13 +269,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
         private CompletionHelper GetCompletionHelper()
         {
+            // Crash if we don't find a document, we're already in a bad state.
             var document = GetDocument();
-            if (document != null)
-            {
-                return CompletionHelper.GetHelper(document);
-            }
-
-            return null;
+            return CompletionHelper.GetHelper(document);
         }
 
         private bool IsTextualTriggerCharacter(CompletionService completionService, char ch, OptionSet options)


### PR DESCRIPTION
Sometimes completion filtering crashes in MatchesFilterText. From
inspecting the code, it appears that the only possible cause is that a
null completionHelper is passed in. The method that retrieves a
CompletionHelper sometimes returns null. This change will cause a crash
instead, allowing us to investigate why the Document was null, or try to
further determine why MatchesFilterText might crash.

Tag @dotnet/roslyn-ide 
Addresses https://devdiv.visualstudio.com/DevDiv/_workitems?id=384019&_a=edit
