### PR TITLE
Enable multiline regex mode for "test <whatever> please"

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -38,7 +38,7 @@ static void addRoslynJob(def myJob, String jobName, String branchName, Boolean i
     if (triggerPhraseExtra) {
       triggerCore = "${triggerCore}|${triggerPhraseExtra}"
     }
-    def triggerPhrase = "(?i)^\\s*(@?dotnet-bot\\,?\\s+)?(re)?test\\s+(${triggerCore})(\\s+please\\.?)?\\s*\$";
+    def triggerPhrase = "(?im)^\\s*(@?dotnet-bot\\,?\\s+)?(re)?test\\s+(${triggerCore})(\\s+please\\.?)?\\s*\$";
     def contextName = jobName
     Utilities.addGithubPRTriggerForBranch(myJob, branchName, contextName, triggerPhrase, triggerPhraseOnly)
   } else {

--- a/perf.groovy
+++ b/perf.groovy
@@ -43,7 +43,7 @@ def generate(boolean isPr) {
         TriggerBuilder prTrigger = TriggerBuilder.triggerOnPullRequest()
         prTrigger.permitOrg('Microsoft')
         prTrigger.permitOrg('dotnet')
-        prTrigger.setCustomTriggerPhrase("(?i)^\\s*(@dotnet-bot\\s+)?(re)?test\\s+perf(\\s+please)?\\s*\$" )
+        prTrigger.setCustomTriggerPhrase("(?im)^\\s*(@dotnet-bot\\s+)?(re)?test\\s+perf(\\s+please)?\\s*\$" )
         prTrigger.triggerForBranch(branchName);
         prTrigger.setGithubContext('Performance Test Run')
         prTrigger.emitTrigger(myJob)


### PR DESCRIPTION
This means you can write a comment and then do the line by itself in
one GitHub comment. Otherwise it's requiring you have exactly one
per comment which is annoying.

*Review:* @dotnet/roslyn-infrastructure