### PR TITLE
Disabling some flaky tests

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs
@@ -93,7 +93,7 @@ w.Content = g;");
             VisualStudio.InteractiveWindow.SubmitText("b = null; w.Close(); w = null;");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19232")]
         public void TypingHelpDirectiveWorks()
         {
             VisualStudio.Workspace.SetUseSuggestionMode(true);


### PR DESCRIPTION
TypingHelpDirectiveWorks()   - https://github.com/dotnet/roslyn/issues/19232
WorkspacesNetCore.ProjectReference() -  https://github.com/dotnet/roslyn/issues/19231

Example of a failure: https://ci.dot.net/job/dotnet_roslyn/job/master/job/windows_debug_vs-integration_prtest/3661/console
