### PR TITLE
Don't offer to add a null check for an unknown type when one already exists.

### DIFF
--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -704,5 +704,22 @@ class C
     }
 }", index: 2);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestMissingOnUnboundTypeWithExistingNullCheck()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    public C(String [||]s)
+    {
+        if (s == null)
+        {
+            throw new System.Exception();
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -117,7 +117,10 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
         {
             if (statement is IIfStatement ifStatement)
             {
-                if (ifStatement.Condition is IBinaryOperatorExpression binaryOperator)
+                var condition = ifStatement.Condition;
+                condition = UnwrapImplicitConversion(condition);
+
+                if (condition is IBinaryOperatorExpression binaryOperator)
                 {
                     // Look for code of the form "if (p == null)" or "if (null == p)"
                     if (IsNullCheck(binaryOperator.LeftOperand, binaryOperator.RightOperand, parameter) ||
@@ -127,7 +130,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                     }
                 }
                 else if (parameter.Type.SpecialType == SpecialType.System_String &&
-                         IsStringCheck(ifStatement.Condition, parameter))
+                         IsStringCheck(condition, parameter))
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19173

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
