### PR TITLE
Respect member access options around string/String when generating parameter checks.

### DIFF
--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -705,6 +705,7 @@ class C
 }", index: 2);
         }
 
+        [WorkItem(19173, "https://github.com/dotnet/roslyn/issues/19173")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
         public async Task TestMissingOnUnboundTypeWithExistingNullCheck()
         {
@@ -720,6 +721,39 @@ class C
         }
     }
 }");
+        }
+
+        [WorkItem(19174, "https://github.com/dotnet/roslyn/issues/19174")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestRespectPredefinedTypePreferences()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System;
+
+class Program
+{
+    static void Main([||]String bar)
+    {
+    }
+}",
+@"
+using System;
+
+class Program
+{
+    static void Main(String bar)
+    {
+        if (String.IsNullOrEmpty(bar))
+        {
+            throw new ArgumentException(""message"", nameof(bar));
+        }
+    }
+}", index: 1,
+    parameters: new TestParameters(
+        options: Option(
+            CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess,
+            CodeStyleOptions.FalseWithSuggestionEnforcement)));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/InitializeParameter/AddParameterCheckTests.cs
@@ -704,5 +704,22 @@ class C
     }
 }", index: 2);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInitializeParameter)]
+        public async Task TestMissingOnUnboundTypeWithExistingNullCheck()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    public C(String [||]s)
+    {
+        if (s == null)
+        {
+            throw new System.Exception();
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/InitializeParameter/CSharpAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/InitializeParameter/CSharpAddParameterCheckCodeRefactoringProvider.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.InitializeParameter;
-using Microsoft.CodeAnalysis.Semantics;
 
 namespace Microsoft.CodeAnalysis.CSharp.InitializeParameter
 {

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -241,11 +241,13 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
             Compilation compilation, SyntaxGenerator generator,
             IParameterSymbol parameter, string methodName)
         {
+            var stringType = compilation.GetSpecialType(SpecialType.System_String);
+
             // generates: if (string.IsXXX(s)) throw new ArgumentException("message", nameof(s))
             return (TStatementSyntax)generator.IfStatement(
                 generator.InvocationExpression(
                     generator.MemberAccessExpression(
-                        generator.TypeExpression(SpecialType.System_String),
+                        generator.TypeExpression(stringType),
                         generator.IdentifierName(methodName)),
                     generator.Argument(generator.IdentifierName(parameter.Name))),
                 SpecializedCollections.SingletonEnumerable(

--- a/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/InitializeParameter/AbstractAddParameterCheckCodeRefactoringProvider.cs
@@ -117,7 +117,10 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
         {
             if (statement is IIfStatement ifStatement)
             {
-                if (ifStatement.Condition is IBinaryOperatorExpression binaryOperator)
+                var condition = ifStatement.Condition;
+                condition = UnwrapImplicitConversion(condition);
+
+                if (condition is IBinaryOperatorExpression binaryOperator)
                 {
                     // Look for code of the form "if (p == null)" or "if (null == p)"
                     if (IsNullCheck(binaryOperator.LeftOperand, binaryOperator.RightOperand, parameter) ||
@@ -127,7 +130,7 @@ namespace Microsoft.CodeAnalysis.InitializeParameter
                     }
                 }
                 else if (parameter.Type.SpecialType == SpecialType.System_String &&
-                         IsStringCheck(ifStatement.Condition, parameter))
+                         IsStringCheck(condition, parameter))
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19174

