### PR TITLE
Use a wait-free fast path in AsyncLazy<T>.GetValueAsync

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
@@ -179,6 +179,12 @@ namespace Roslyn.Utilities
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // If the value is already available, return it immediately
+            if (TryGetValue(out T value))
+            {
+                return value;
+            }
+
             Request request = null;
             AsynchronousComputationToStart? newAsynchronousComputation = null;
 
@@ -297,7 +303,14 @@ namespace Roslyn.Utilities
             // Optimization: if we're already cancelled, do not pass go
             if (cancellationToken.IsCancellationRequested)
             {
-                return new Task<T>(() => default(T), cancellationToken);
+                return Task.FromCanceled<T>(cancellationToken);
+            }
+
+            // Avoid taking the lock if a cached value is available
+            var cachedResult = _cachedResult;
+            if (cachedResult != null)
+            {
+                return cachedResult;
             }
 
             Request request;


### PR DESCRIPTION
This is the third lowest-hanging fruit when running a Fix All operation, and accounted for more than 15 seconds of the CPU time during a Fix All for removing a `this.` prefix in the CodeAnalysis project. I addressed it first because it's the least risky specific improvement and most likely to have a positive impact throughout other features.

## Ask Mode

**Customer scenario**

Attempt to run a Fix All operation on a machine with a large number of cores.

**Bugs this fixes:**

N/A

**Workarounds, if any**

Get some coffee while you wait?

**Risk**

Low, the cached value returned outside the lock is only written once, so the only impact of reading a stale value is the code is forced through the original slow path.

**Performance impact**

This change results in a substantial performance improvement on machines with many cores.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

A subtle detail missed during code review, and is only obvious on relatively rare test machines (e.g. it was found on a 28 core machine).

**How was the bug found?**

PerfView. The following image shows the impact after the primary low-hanging fruit was already addressed (it's a wholly separate issue that accounts for around than 80% of the overall CPU time during this feature).

![image](https://cloud.githubusercontent.com/assets/1408396/25704549/7ffe15b8-309f-11e7-9fb2-3608d8850967.png)
