### PR TITLE
Verify member is in scope before trying to replace it

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
+++ b/src/EditorFeatures/Test2/Simplification/TypeNameSimplifierTest.vb
@@ -764,7 +764,8 @@ namespace N1
             Await TestAsync(input, expected)
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/19368")>
+        <Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Async Function TestSimplifyNot_Delegate1() As Task
             Dim input =
         <Workspace>

--- a/src/Workspaces/Core/Portable/Utilities/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ImmutableArrayExtensions.cs
@@ -8,6 +8,9 @@ namespace Roslyn.Utilities
 {
     internal static class ImmutableArrayExtensions
     {
+        internal static bool Contains<T>(this ImmutableArray<T> items, T item, IEqualityComparer<T> equalityComparer)
+            => items.IndexOf(item, 0, equalityComparer) >= 0;
+
         internal static ImmutableArray<T> ToImmutableArrayOrEmpty<T>(this T[] items)
         {
             if (items == null)


### PR DESCRIPTION
This corrects the largest low-hanging fruit for Fix All operations involving Simplify Type Name. Prior to creating a temporary workspace with an expression replaced (used to provide the validity of a replacement), we do a quick check using the C# speculative semantic model to ensure that the unqualified name at least has a possibility of resolving to the same member.

The time to execute a Fix All in Project on the CodeAnalysis project was previously dominated by examination of **WellKnownMembers.cs**. Each of the enum members referenced in the static constructor cannot be simplified, and this check will fail for each of those cases. This change is good for a 100+ second _wall clock_ time reduction in the Fix All in Project performance for this project.

## Ask Mode

**Customer scenario**

Attempt to use Fix All in a large project/solution for one of the name simplification diagnostics.

**Bugs this fixes:**

None that I could find, which surprised me.

**Workarounds, if any**

Simplify names one at a time, and/or by hand.

**Risk**

I would consider this a medium risk, with high reward. The @dotnet/roslyn-compiler team should verify that this code is either not used for compilation correctness, or is truly correct in all cases. Unit tests revealed several edge cases which have been accommodated to ensure behavior is unchanged, except for a small edge case described in #19368 which is knowingly deferred.

**Performance impact**

This change dramatically improves performance of the Simplify Type Name analyzer operating on C# code. It may also improve the simplification process in the formatter.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

The previous behavior was correct, but inefficient. PerfView was used to identify the majority offending code.

**How was the bug found?**

It became a clear problem during my attempts to scale analyzer features to Roslyn.sln.
