### PR TITLE
Allow the Simplify Type Names analyzer to run concurrently

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -88,6 +88,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
         public sealed override void Initialize(AnalysisContext context)
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
             context.RegisterSyntaxNodeAction(AnalyzeNode, _kindsOfInterest);
         }
 


### PR DESCRIPTION
This analyzer does not have state, so it can be enabled for concurrent execution.

## Ask Mode

**Customer scenario**

Run Fix All for one of the Simplify Type Names diagnostics.

**Bugs this fixes:**

N/A

**Workarounds, if any**

Wait longer.

**Risk**

Low, this analyzer was written as a state-free analyzer so it is safe for concurrent execution.

**Performance impact**

Performance is improved, in some cases by as much as 3x.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Found monitor contention while using PerfView to identify performance problems with Fix All in Project, and tracked a notable offender to this flag.

**How was the bug found?**

Manual testing with PerfView, and confirmed by heads-up comparison.