### PR TITLE
Disable scanning for designer attributes in CPS projects.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -78,7 +78,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 return;
             }
 
-#if false
             // CPS projects do not support designer attributes.  So we just skip these projects entirely.
             var isCPSProject = await Task.Factory.StartNew(
                 () => vsWorkspace.IsCPSProject(project),
@@ -90,7 +89,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             {
                 return;
             }
-#endif
 
             // Try to compute this data in the remote process.  If that fails, then compute
             // the results in the local process.


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19187
