### PR TITLE
Fix a small memory leak related to batching project loads

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -41,6 +41,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private readonly HostWorkspaceServices _workspaceServices;
 
         /// <summary>
+        /// Set to true while we're batching project loads. That is, between
+        /// <see cref="IVsSolutionLoadEvents.OnBeforeLoadProjectBatch" /> and
+        /// <see cref="IVsSolutionLoadEvents.OnAfterLoadProjectBatch"/>.
+        /// </summary>
+        private bool _batchingProjectLoads = false;
+
+        /// <summary>
         /// The list of projects loaded in this batch between <see cref="IVsSolutionLoadEvents.OnBeforeLoadProjectBatch" /> and
         /// <see cref="IVsSolutionLoadEvents.OnAfterLoadProjectBatch(bool)"/>.
         /// </summary>
@@ -282,7 +289,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 StartPushingToWorkspaceAndNotifyOfOpenDocuments(SpecializedCollections.SingletonEnumerable(project));
             }
-            else
+            else if (_batchingProjectLoads)
             {
                 _projectsLoadedThisBatch.Add(project);
             }
@@ -916,6 +923,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             AssertIsForeground();
 
+            _batchingProjectLoads = true;
             _projectsLoadedThisBatch.Clear();
         }
 
@@ -930,6 +938,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 StartPushingToWorkspaceAndNotifyOfOpenDocuments(_projectsLoadedThisBatch);
             }
 
+            _batchingProjectLoads = false;
             _projectsLoadedThisBatch.Clear();
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/1918.

The language service implements `IVsSolutionLoadEvents.OnBeforeLoadProjectBatch` and `IVsSolutionLoadEvents.OnAfterLoadProjectBatch` to support asynchronous solution loads. While a batch is in progress we try to avoid pushing added projects to the workspace and instead store them in a list. When the batch is complete we may push all of those projects to the workspace at once.

The current implementation has a memory leak. Project may be added outside of a pair of `OnBeforeLoadProjectBatch`/`OnAfterLoadProjectBatch` calls, and it is possible for projects to be added without those methods ever being called. However, during a solution load adding a project always causes us to put it in the list of batched projects. Since we only clear the list on calls to `OnBeforeLoadProjectBatch` or `OnAfterLoadProjectBatch` the user could close the project or even the whole solution and we could still be holding on to one or more projects and all of their associated memory.

The fix here is to add a `bool` to track whether or not we're batching projects, and only put an added project in the list if we are.

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
