### PR TITLE
Do a better job preserving blank lines when we convert code to using an object initializer.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseCollectionInitializer/UseCollectionInitializerTests.cs
@@ -981,5 +981,40 @@ public class Foo
     }
 }");
         }
+
+        [WorkItem(19253, "https://github.com/dotnet/roslyn/issues/19253")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCollectionInitializer)]
+        public async Task TestKeepBlankLinesAfter()
+        {
+            await TestInRegularAndScript1Async(
+@"
+using System.Collections.Generic;
+
+class MyClass
+{
+    public void Main()
+    {
+        var list = [||]new List<int>();
+        list.Add(1);
+
+        int horse = 1;
+    }
+}",
+@"
+using System.Collections.Generic;
+
+class MyClass
+{
+    public void Main()
+    {
+        var list = new List<int>
+        {
+            1
+        };
+
+        int horse = 1;
+    }
+}", ignoreTrivia: false);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -536,5 +536,46 @@ public class Foo
     public string Value { get; set; }
 }", ignoreTrivia: false);
         }
+
+        [WorkItem(19253, "https://github.com/dotnet/roslyn/issues/19253")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestKeepBlankLinesAfter()
+        {
+            await TestInRegularAndScript1Async(
+@"
+class Foo
+{
+    public int Bar { get; set; }
+}
+
+class MyClass
+{
+    public void Main()
+    {
+        var foo = [||]new Foo();
+        foo.Bar = 1;
+
+        int horse = 1;
+    }
+}",
+@"
+class Foo
+{
+    public int Bar { get; set; }
+}
+
+class MyClass
+{
+    public void Main()
+    {
+        var foo = new Foo
+        {
+            Bar = 1
+        };
+
+        int horse = 1;
+    }
+}", ignoreTrivia: false);
+        }
     }
 }

--- a/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerCodeFixProvider.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 subEditor.ReplaceNode(statement, newStatement);
                 foreach (var match in matches)
                 {
-                    subEditor.RemoveNode(match);
+                    subEditor.RemoveNode(match, SyntaxRemoveOptions.KeepUnbalancedDirectives);
                 }
 
                 document = document.WithSyntaxRoot(subEditor.GetChangedRoot());

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerCodeFixProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 subEditor.ReplaceNode(statement, newStatement);
                 foreach (var match in matches)
                 {
-                    subEditor.RemoveNode(match.Statement);
+                    subEditor.RemoveNode(match.Statement, SyntaxRemoveOptions.KeepUnbalancedDirectives);
                 }
 
                 document = document.WithSyntaxRoot(subEditor.GetChangedRoot());


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19253
