### PR TITLE
removed direct Workspace access from WorkspaceAnalyzerOptions and made OOP analyzers to use snapshot of OptionSet

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -120,28 +120,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return typeInfo.Assembly.GetName().Name;
         }
 
-        public static async Task<OptionSet> GetDocumentOptionSetAsync(this AnalyzerOptions analyzerOptions, SyntaxTree syntaxTree, CancellationToken cancellationToken)
+        public static Task<OptionSet> GetDocumentOptionSetAsync(this AnalyzerOptions analyzerOptions, SyntaxTree syntaxTree, CancellationToken cancellationToken)
         {
-            var workspace = (analyzerOptions as WorkspaceAnalyzerOptions)?.Workspace;
-            if (workspace == null)
+            var workspaceAnalyzerOptions = analyzerOptions as WorkspaceAnalyzerOptions;
+            if (workspaceAnalyzerOptions == null)
             {
-                return null;
+                return SpecializedTasks.Default<OptionSet>();
             }
 
-            var documentId = workspace.CurrentSolution.GetDocumentId(syntaxTree);
-            if (documentId == null)
-            {
-                return workspace.Options;
-            }
-
-            var document = workspace.CurrentSolution.GetDocument(documentId);
-            if (document == null)
-            {
-                return workspace.Options;
-            }
-
-            var documentOptionSet = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-            return documentOptionSet ?? workspace.Options;
+            return workspaceAnalyzerOptions.GetDocumentOptionSetAsync(syntaxTree, cancellationToken);
         }
 
         internal static void OnAnalyzerException_NoTelemetryLogging(

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // in IDE, we always set concurrentAnalysis == false otherwise, we can get into thread starvation due to
                 // async being used with syncronous blocking concurrency.
                 return new CompilationWithAnalyzersOptions(
-                    options: new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Workspace, project.Solution.Options),
+                    options: new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Options, project.Solution.Workspace),
                     onAnalyzerException: GetOnAnalyzerException(project.Id),
                     analyzerExceptionFilter: GetAnalyzerExceptionFilter(project),
                     concurrentAnalysis: false,

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // in IDE, we always set concurrentAnalysis == false otherwise, we can get into thread starvation due to
                 // async being used with syncronous blocking concurrency.
                 return new CompilationWithAnalyzersOptions(
-                    options: new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Workspace),
+                    options: new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Workspace, project.Solution.Options),
                     onAnalyzerException: GetOnAnalyzerException(project.Id),
                     analyzerExceptionFilter: GetAnalyzerExceptionFilter(project),
                     concurrentAnalysis: false,

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // in IDE, we always set concurrentAnalysis == false otherwise, we can get into thread starvation due to
                 // async being used with syncronous blocking concurrency.
                 return new CompilationWithAnalyzersOptions(
-                    options: new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Options, project.Solution.Workspace),
+                    options: new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Options, project.Solution),
                     onAnalyzerException: GetOnAnalyzerException(project.Id),
                     analyzerExceptionFilter: GetAnalyzerExceptionFilter(project),
                     concurrentAnalysis: false,

--- a/src/Features/Core/Portable/Diagnostics/WorkspaceAnalyzerOptions.cs
+++ b/src/Features/Core/Portable/Diagnostics/WorkspaceAnalyzerOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private readonly Workspace _workspace;
         private readonly OptionSet _optionSet;
 
-        public WorkspaceAnalyzerOptions(AnalyzerOptions options, Workspace workspace, OptionSet optionSet)
+        public WorkspaceAnalyzerOptions(AnalyzerOptions options, OptionSet optionSet, Workspace workspace)
             : base(options.AdditionalFiles)
         {
             _workspace = workspace;

--- a/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/RemoveUnnecessaryImports/AbstractRemoveUnnecessaryImportsDiagnosticAnalyzer.cs
@@ -69,9 +69,8 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryImports
                 return;
             }
 
-            var workspace = workspaceOptions.Workspace;
-            var service = workspace.Services.GetLanguageServices(context.SemanticModel.Compilation.Language)
-                                            .GetService<IUnnecessaryImportsService>();
+            var service = workspaceOptions.Services.GetLanguageServices(context.SemanticModel.Compilation.Language)
+                                                   .GetService<IUnnecessaryImportsService>();
 
             var unnecessaryImports = service.GetUnnecessaryImports(context.SemanticModel, cancellationToken);
             if (unnecessaryImports.Any())

--- a/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/SolutionServiceTests.cs
@@ -94,53 +94,6 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
-        public async Task TestCreationWithOption()
-        {
-            var code = @"class Test { void Method() { } }";
-
-            using (var workspace = TestWorkspace.CreateCSharp(code))
-            {
-                var options = new TestOptionSet().WithChangedOption(RemoteHostOptions.RemoteHostTest, true);
-
-                var solution = workspace.CurrentSolution;
-                var service = await GetSolutionServiceAsync(solution);
-
-                var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
-                var synched = await service.GetSolutionAsync(solutionChecksum, options, CancellationToken.None);
-
-                Assert.Equal(solutionChecksum, await synched.State.GetChecksumAsync(CancellationToken.None));
-                Assert.Empty(options.GetChangedOptions(synched.Workspace.Options));
-
-                Assert.True(options.GetOption(RemoteHostOptions.RemoteHostTest));
-                Assert.True(synched.Workspace.Options.GetOption(RemoteHostOptions.RemoteHostTest));
-            }
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
-        public async Task TestOptionIsolation()
-        {
-            var code = @"class Test { void Method() { } }";
-
-            using (var workspace = TestWorkspace.CreateCSharp(code))
-            {
-                var solution = workspace.CurrentSolution;
-                var service = await GetSolutionServiceAsync(solution);
-
-                var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
-
-                var options = new TestOptionSet().WithChangedOption(RemoteHostOptions.RemoteHostTest, true);
-                var first = await service.GetSolutionAsync(solutionChecksum, options, CancellationToken.None);
-                var second = await service.GetSolutionAsync(solutionChecksum, options.WithChangedOption(RemoteHostOptions.RemoteHostTest, false), CancellationToken.None);
-
-                Assert.Equal(await first.State.GetChecksumAsync(CancellationToken.None), await second.State.GetChecksumAsync(CancellationToken.None));
-
-                // option change shouldn't affect other workspace
-                Assert.True(first.Workspace.Options.GetOption(RemoteHostOptions.RemoteHostTest));
-                Assert.False(second.Workspace.Options.GetOption(RemoteHostOptions.RemoteHostTest));
-            }
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public async Task TestCache()
         {
             var code = @"class Test { void Method() { } }";
@@ -157,36 +110,6 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
                 // same instance from cache
                 Assert.True(object.ReferenceEquals(first, second));
-                Assert.True(first.Workspace is TemporaryWorkspace);
-            }
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
-        public async Task TestCacheWithOption()
-        {
-            var code = @"class Test { void Method() { } }";
-
-            using (var workspace = TestWorkspace.CreateCSharp(code))
-            {
-                var options = new TestOptionSet().WithChangedOption(RemoteHostOptions.RemoteHostTest, true);
-
-                var solution = workspace.CurrentSolution;
-                var service = await GetSolutionServiceAsync(solution);
-
-                var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
-
-                var first = await service.GetSolutionAsync(solutionChecksum, options, CancellationToken.None);
-                var second = await service.GetSolutionAsync(solutionChecksum, options, CancellationToken.None);
-
-                // new solutions if option is involved for isolation
-                Assert.False(object.ReferenceEquals(first, second));
-
-                // but semantic of both solution should be same
-                Assert.Equal(await first.State.GetChecksumAsync(CancellationToken.None), await second.State.GetChecksumAsync(CancellationToken.None));
-
-                // also any sub nodes such as projects should be same
-                Assert.True(object.ReferenceEquals(first.Projects.First().State, second.Projects.First().State));
-
                 Assert.True(first.Workspace is TemporaryWorkspace);
             }
         }

--- a/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace Microsoft.CodeAnalysis.Options
 {
     /// <summary>
-    /// An <see cref="OptionSet"/> that comes from <see cref="Document.GetOptionsAsync"/>. It behaves just like a normal
+    /// An <see cref="OptionSet"/> that comes from <see cref="Document.GetOptionsAsync(System.Threading.CancellationToken)"/>. It behaves just like a normal
     /// <see cref="OptionSet"/> but remembers which language the <see cref="Document"/> is, so you don't have to
     /// pass that information redundantly when calling <see cref="GetOption{T}(PerLanguageOption{T})"/>.
     /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -464,13 +464,22 @@ namespace Microsoft.CodeAnalysis
         /// </remarks>
         public Task<DocumentOptionSet> GetOptionsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
+            return GetOptionsAsync(Project.Solution.Options, cancellationToken);
+        }
+
+        internal Task<DocumentOptionSet> GetOptionsAsync(OptionSet globalOptionSet, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // TODO: we have this workaround since Solution.Options is not actually snapshot but just return Workspace.Options which violate snapshot model.
+            //       this doesn't validate whether same optionset is given to invalidate the cache or not. this is not new since existing implementation
+            //       also didn't check whether Workspace.Option is same as before or not. all wierd-ness come from the root cause of Solution.Options violating
+            //       snapshot model. once that is fixed, we can remove this workaround
             if (_cachedOptions == null)
             {
                 var newAsyncLazy = new AsyncLazy<DocumentOptionSet>(async c =>
                 {
                     var optionsService = Project.Solution.Workspace.Services.GetRequiredService<IOptionService>();
-                    var optionSet = await optionsService.GetUpdatedOptionSetForDocumentAsync(this, Project.Solution.Options, c).ConfigureAwait(false);
-                    return new DocumentOptionSet(optionSet, Project.Language);
+                    var documentOptionSet = await optionsService.GetUpdatedOptionSetForDocumentAsync(this, globalOptionSet, c).ConfigureAwait(false);
+                    return new DocumentOptionSet(documentOptionSet, Project.Language);
                 }, cacheResult: true);
 
                 Interlocked.CompareExchange(ref _cachedOptions, newAsyncLazy, comparand: null);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis
             // TODO: we have this workaround since Solution.Options is not actually snapshot but just return Workspace.Options which violate snapshot model.
             //       this doesn't validate whether same optionset is given to invalidate the cache or not. this is not new since existing implementation
             //       also didn't check whether Workspace.Option is same as before or not. all wierd-ness come from the root cause of Solution.Options violating
-            //       snapshot model. once that is fixed, we can remove this workaround
+            //       snapshot model. once that is fixed, we can remove this workaround - https://github.com/dotnet/roslyn/issues/19284
             if (_cachedOptions == null)
             {
                 var newAsyncLazy = new AsyncLazy<DocumentOptionSet>(async c =>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -467,7 +467,7 @@ namespace Microsoft.CodeAnalysis
             return GetOptionsAsync(Project.Solution.Options, cancellationToken);
         }
 
-        internal Task<DocumentOptionSet> GetOptionsAsync(OptionSet globalOptionSet, CancellationToken cancellationToken = default(CancellationToken))
+        internal Task<DocumentOptionSet> GetOptionsAsync(OptionSet globalOptionSet, CancellationToken cancellationToken)
         {
             // TODO: we have this workaround since Solution.Options is not actually snapshot but just return Workspace.Options which violate snapshot model.
             //       this doesn't validate whether same optionset is given to invalidate the cache or not. this is not new since existing implementation

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -467,7 +467,7 @@ namespace Microsoft.CodeAnalysis
             return GetOptionsAsync(Project.Solution.Options, cancellationToken);
         }
 
-        internal Task<DocumentOptionSet> GetOptionsAsync(OptionSet globalOptionSet, CancellationToken cancellationToken)
+        internal Task<DocumentOptionSet> GetOptionsAsync(OptionSet solutionOptions, CancellationToken cancellationToken)
         {
             // TODO: we have this workaround since Solution.Options is not actually snapshot but just return Workspace.Options which violate snapshot model.
             //       this doesn't validate whether same optionset is given to invalidate the cache or not. this is not new since existing implementation
@@ -478,7 +478,7 @@ namespace Microsoft.CodeAnalysis
                 var newAsyncLazy = new AsyncLazy<DocumentOptionSet>(async c =>
                 {
                     var optionsService = Project.Solution.Workspace.Services.GetRequiredService<IOptionService>();
-                    var documentOptionSet = await optionsService.GetUpdatedOptionSetForDocumentAsync(this, globalOptionSet, c).ConfigureAwait(false);
+                    var documentOptionSet = await optionsService.GetUpdatedOptionSetForDocumentAsync(this, solutionOptions, c).ConfigureAwait(false);
                     return new DocumentOptionSet(documentOptionSet, Project.Language);
                 }, cacheResult: true);
 

--- a/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             // TODO: can we support analyzerExceptionFilter in remote host? 
             //       right now, host doesn't support watson, we might try to use new NonFatal watson API?
             var analyzerOptions = new CompilationWithAnalyzersOptions(
-                    options: new WorkspaceAnalyzerOptions(_project.AnalyzerOptions, MergeOptions(_project.Solution.Options, options), temporaryWorksapce),
+                    options: new WorkspaceAnalyzerOptions(_project.AnalyzerOptions, MergeOptions(_project.Solution.Options, options), temporaryWorksapce.CurrentSolution),
                     onAnalyzerException: OnAnalyzerException,
                     analyzerExceptionFilter: null,
                     concurrentAnalysis: useConcurrent,

--- a/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
@@ -68,10 +68,14 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             // faster
             compilation = compilation.WithOptions(compilation.Options.WithConcurrentBuild(useConcurrent));
 
+            // We need this to fork soluton, otherwise, option is cached at document.
+            // all this can go away once we do this - https://github.com/dotnet/roslyn/issues/19284
+            var temporaryWorksapce = new TemporaryWorkspace(_project.Solution);
+
             // TODO: can we support analyzerExceptionFilter in remote host? 
             //       right now, host doesn't support watson, we might try to use new NonFatal watson API?
             var analyzerOptions = new CompilationWithAnalyzersOptions(
-                    options: new WorkspaceAnalyzerOptions(_project.AnalyzerOptions, MergeOptions(_project.Solution.Options, options), _project.Solution.Workspace),
+                    options: new WorkspaceAnalyzerOptions(_project.AnalyzerOptions, MergeOptions(_project.Solution.Options, options), temporaryWorksapce),
                     onAnalyzerException: OnAnalyzerException,
                     analyzerExceptionFilter: null,
                     concurrentAnalysis: useConcurrent,

--- a/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             // TODO: can we support analyzerExceptionFilter in remote host? 
             //       right now, host doesn't support watson, we might try to use new NonFatal watson API?
             var analyzerOptions = new CompilationWithAnalyzersOptions(
-                    options: new WorkspaceAnalyzerOptions(_project.AnalyzerOptions, _project.Solution.Workspace, MergeOptions(_project.Solution.Options, options)),
+                    options: new WorkspaceAnalyzerOptions(_project.AnalyzerOptions, MergeOptions(_project.Solution.Options, options), _project.Solution.Workspace),
                     onAnalyzerException: OnAnalyzerException,
                     analyzerExceptionFilter: null,
                     concurrentAnalysis: useConcurrent,

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -27,16 +27,15 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 try
                 {
-                    var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.OptionSetChecksum, CancellationToken).ConfigureAwait(false);
-
                     // entry point for diagnostic service
-                    var solution = await GetSolutionWithSpecificOptionsAsync(optionSet).ConfigureAwait(false);
+                    var solution = await GetSolutionAsync().ConfigureAwait(false);
 
+                    var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.OptionSetChecksum, CancellationToken).ConfigureAwait(false);
                     var projectId = arguments.ProjectId;
                     var analyzers = RoslynServices.AssetService.GetGlobalAssetsOfType<AnalyzerReference>(CancellationToken);
 
                     var result = await (new DiagnosticComputer(solution.GetProject(projectId))).GetDiagnosticsAsync(
-                        analyzers, arguments.AnalyzerIds, arguments.ReportSuppressedDiagnostics, arguments.LogAnalyzerExecutionTime, CancellationToken).ConfigureAwait(false);
+                        analyzers, optionSet, arguments.AnalyzerIds, arguments.ReportSuppressedDiagnostics, arguments.LogAnalyzerExecutionTime, CancellationToken).ConfigureAwait(false);
 
                     await SerializeDiagnosticResultAsync(streamName, result).ConfigureAwait(false);
                 }

--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -93,12 +93,6 @@ namespace Microsoft.CodeAnalysis.Remote
             return RoslynServices.SolutionService.GetSolutionAsync(_solutionChecksumOpt, CancellationToken);
         }
 
-        protected Task<Solution> GetSolutionWithSpecificOptionsAsync(OptionSet options)
-        {
-            Contract.ThrowIfNull(_solutionChecksumOpt);
-            return RoslynServices.SolutionService.GetSolutionAsync(_solutionChecksumOpt, options, CancellationToken);
-        }
-
         protected virtual void Dispose(bool disposing)
         {
             // do nothing here


### PR DESCRIPTION
**Customer scenario**

Customer has either code lens/FSA on, and just opened new solution. and in some cases, VS sync some data twice.

**Bugs this fixes:**

This doesn't have an associate bug, but one of PRs to improve OOP perf on the initial solution synchronization.

**Workarounds, if any**

There is no workaround. before the very first primary solution synchronization, all solution treated as temporary solution and not reused to incrementally update the solution.

**Risk**

Low. There should be no functional behavior change.

**Performance impact**

Should make initial solution perf better in OOP (not this PR alone but with next PR combined - https://github.com/dotnet/roslyn/pull/19311)

**Is this a regression from a previous update?**

No

**Root cause analysis:**

This is not regression. it was just the way it is designed. now I am trying to make this particular case to have better perf by not making all solution a temporary solution before the very first primary workspace synchronization.

**How was the bug found?**

While doing FAR/GoTo OOP work.