### PR TITLE
Fix a crash in the parser due to ParseStatementCore returning null

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8222,7 +8222,7 @@ tryAgain:
             var label = this.ParseIdentifierToken();
             var colon = this.EatToken(SyntaxKind.ColonToken);
             Debug.Assert(!colon.IsMissing);
-            var statement = this.ParseStatementCore();
+            var statement = this.ParseStatementCore() ?? SyntaxFactory.EmptyStatement(EatToken(SyntaxKind.SemicolonToken));
             return _syntaxFactory.LabeledStatement(label, colon, statement);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -2705,6 +2705,23 @@ System.Console.WriteLine(true)";
             Assert.Equal((int)ErrorCode.ERR_SemicolonExpected, statement.Errors()[0].Code);
         }
 
+        [WorkItem(266237, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=266237")]
+        [Fact]
+        public void NullExceptionInLabeledStatement()
+        {
+            UsingStatement(@"{ label: public",
+                // (1,1): error CS1073: Unexpected token 'public'
+                // { label: public
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "{ label: ").WithArguments("public").WithLocation(1, 1),
+                // (1,10): error CS1002: ; expected
+                // { label: public
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "public").WithLocation(1, 10),
+                // (1,10): error CS1513: } expected
+                // { label: public
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "public").WithLocation(1, 10)
+                );
+        }
+
         private sealed class TokenAndTriviaWalker : CSharpSyntaxWalker
         {
             public int Tokens;


### PR DESCRIPTION
**Customer scenario**

The following program text causes the parser to crash.

``` c#
class A { void M() { label: public
```

There are other ways to hit the failure. We've been seeing 1-2 Watson hits per day. The symptom is a VS crash.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=266237

**Workarounds, if any**

None. This is a fatal VS crash without giving the user a hint what happened.

**Risk**

Tiny. One-line change.

**Performance impact**

None.

**Is this a regression from a previous update?**

Regression from VS2015, and a side-effect of a parser overhaul when local functions were added.

**Root cause analysis:**

It is possible this would have been detected earlier if we developed some randomized parser fuzz tests.

**How was the bug found?**

Analysis of Watson dump.

**Description of change**

In ParseLabeledStatement, when `ParseStatementCore` returns null for the embedded statement, we build an empty statement node (and give an error). Other call sites appear to have been adapted already.

@jaredpar @dotnet/roslyn-compiler May I please have a couple of reviews for this teeny tiny crash fix?
