### PR TITLE
Fix partial method instrumentation

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2719,7 +2719,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Debug.Assert(node.Method.IsDefinition);
             Debug.Assert(node.Type.SpecialType == SpecialType.System_Int32);
             _builder.EmitOpCode(ILOpCode.Ldtoken);
-            EmitSymbolToken(node.Method, node.Syntax, null, encodeAsRawDefinitionToken: true);
+
+            // For partial methods, we emit pseudo token based on the symbol for the partial
+            // definition part as opposed to the symbol for the partial implementation part.
+            // We will need to resolve the symbol associated with each pseudo token in order
+            // to compute the real method definition tokens later. For partial methods, this
+            // resolution can only succeed if the associated symbol is the symbol for the
+            // partial definition and not the symbol for the partial implementation (see
+            // MethodSymbol.ResolvedMethodImpl()).
+            var symbol = node.Method.PartialDefinitionPart ?? node.Method;
+
+            EmitSymbolToken(symbol, node.Syntax, null, encodeAsRawDefinitionToken: true);
         }
 
         private void EmitMaximumMethodDefIndexExpression(BoundMaximumMethodDefIndex node)

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Cci
             this.Context = context;
             this.messageProvider = messageProvider;
             _cancellationToken = cancellationToken;
-            
+
             this.metadata = metadata;
             _debugMetadataOpt = debugMetadataOpt;
             _dynamicAnalysisDataWriterOpt = dynamicAnalysisDataWriterOpt;
@@ -322,7 +322,7 @@ namespace Microsoft.Cci
         /// The greatest index given to any method definition.
         /// </summary>
         protected abstract int GreatestMethodDefIndex { get; }
-        
+
         /// <summary>
         /// Return true and full metadata handle of the type reference
         /// if the reference is available in the current generation.
@@ -423,9 +423,9 @@ namespace Microsoft.Cci
         // Shared builder (reference equals heaps) if we are embedding Portable PDB into the metadata stream.
         // Null otherwise.
         protected readonly MetadataBuilder _debugMetadataOpt;
-        
+
         internal bool EmitStandaloneDebugMetadata => _debugMetadataOpt != null && metadata != _debugMetadataOpt;
-        
+
         private readonly DynamicAnalysisDataWriter _dynamicAnalysisDataWriterOpt;
 
         private readonly Dictionary<ICustomAttribute, BlobHandle> _customAttributeSignatureIndex = new Dictionary<ICustomAttribute, BlobHandle>();
@@ -611,8 +611,8 @@ namespace Microsoft.Cci
 
                 // No explicit param row is needed if param has no flags (other than optionally IN),
                 // no name and no references to the param row, such as CustomAttribute, Constant, or FieldMarshal
-                if (parDef.Name != String.Empty || 
-                    parDef.HasDefaultValue || parDef.IsOptional || parDef.IsOut || parDef.IsMarshalledExplicitly ||                   
+                if (parDef.Name != String.Empty ||
+                    parDef.HasDefaultValue || parDef.IsOptional || parDef.IsOut || parDef.IsMarshalledExplicitly ||
                     IteratorHelper.EnumerableIsNotEmpty(parDef.GetAttributes(Context)))
                 {
                     if (builder != null)
@@ -675,7 +675,7 @@ namespace Microsoft.Cci
         private void CreateInitialFileRefIndex()
         {
             Debug.Assert(!_tableIndicesAreComplete);
-            
+
             foreach (IFileReference fileRef in module.GetFiles(Context))
             {
                 string key = fileRef.FileName;
@@ -1153,7 +1153,7 @@ namespace Microsoft.Cci
             var builder = PooledBlobBuilder.GetInstance();
 
             var encoder = new BlobEncoder(builder).MethodSignature(
-                new SignatureHeader((byte)methodReference.CallingConvention).CallingConvention, 
+                new SignatureHeader((byte)methodReference.CallingConvention).CallingConvention,
                 methodReference.GenericParameterCount,
                 isInstanceMethod: (methodReference.CallingConvention & CallingConvention.HasThis) != 0);
 
@@ -1724,10 +1724,10 @@ namespace Microsoft.Cci
 
             BuildMetadataAndIL(
                 nativePdbWriterOpt,
-                ilBuilder, 
+                ilBuilder,
                 mappedFieldDataBuilder,
                 managedResourceDataBuilder,
-                out Blob mvidFixup, 
+                out Blob mvidFixup,
                 out Blob mvidStringFixup);
 
             var typeSystemRowCounts = metadata.GetRowCounts();
@@ -1791,14 +1791,14 @@ namespace Microsoft.Cci
             _tableIndicesAreComplete = true;
 
             ReportReferencesToAddedSymbols();
-            
+
             BlobBuilder dynamicAnalysisDataOpt = null;
             if (_dynamicAnalysisDataWriterOpt != null)
             {
                 dynamicAnalysisDataOpt = new BlobBuilder();
                 _dynamicAnalysisDataWriterOpt.SerializeMetadataTables(dynamicAnalysisDataOpt);
             }
-            
+
             PopulateTypeSystemTables(methodBodyOffsets, mappedFieldDataBuilder, managedResourceDataBuilder, dynamicAnalysisDataOpt, out mvidFixup);
         }
 
@@ -1948,7 +1948,7 @@ namespace Microsoft.Cci
                 name: GetStringHandleForPathAndCheckLength(module.Name, module),
                 culture: metadata.GetOrAddString(sourceAssembly.Identity.CultureName));
         }
-        
+
         private void PopulateCustomAttributeTableRows(ImmutableArray<IGenericParameter> sortedGenericParameters)
         {
             if (this.IsFullMetadata)
@@ -2278,9 +2278,9 @@ namespace Microsoft.Cci
 
                 var marshallingInformation = parDef.MarshallingInformation;
 
-               BlobHandle descriptor = (marshallingInformation != null)
-                    ? GetMarshallingDescriptorHandle(marshallingInformation)
-                    : GetMarshallingDescriptorHandle(parDef.MarshallingDescriptor);
+                BlobHandle descriptor = (marshallingInformation != null)
+                     ? GetMarshallingDescriptorHandle(marshallingInformation)
+                     : GetMarshallingDescriptorHandle(parDef.MarshallingDescriptor);
 
                 metadata.AddMarshallingDescriptor(
                     parent: GetParameterHandle(parDef),
@@ -2450,7 +2450,7 @@ namespace Microsoft.Cci
                 }
             }
         }
-        
+
         private void PopulateManifestResourceTableRows(BlobBuilder resourceDataWriter, BlobBuilder dynamicAnalysisDataOpt)
         {
             if (dynamicAnalysisDataOpt != null)
@@ -2462,7 +2462,7 @@ namespace Microsoft.Cci
                     offset: GetManagedResourceOffset(dynamicAnalysisDataOpt, resourceDataWriter)
                 );
             }
-            
+
             foreach (var resource in this.module.GetResources(Context))
             {
                 EntityHandle implementation;
@@ -2497,11 +2497,11 @@ namespace Microsoft.Cci
             {
                 metadata.AddMemberReference(
                     parent: GetMemberReferenceParent(memberRef),
-                    name: GetStringHandleForNameAndCheckLength(memberRef.Name, memberRef), 
+                    name: GetStringHandleForNameAndCheckLength(memberRef.Name, memberRef),
                     signature: GetMemberReferenceSignatureHandle(memberRef));
             }
         }
-        
+
         private void PopulateMethodImplTableRows()
         {
             metadata.SetCapacity(TableIndex.MethodImpl, methodImplList.Count);
@@ -2514,7 +2514,7 @@ namespace Microsoft.Cci
                     methodDeclaration: GetMethodDefinitionOrReferenceHandle(methodImplementation.ImplementedMethod));
             }
         }
-        
+
         private void PopulateMethodSpecTableRows()
         {
             var methodSpecs = this.GetMethodSpecs();
@@ -2652,7 +2652,7 @@ namespace Microsoft.Cci
                 encId: metadata.GetOrAddGuid(EncId),
                 encBaseId: metadata.GetOrAddGuid(EncBaseId));
         }
-        
+
         private void PopulateParamTableRows()
         {
             var parameterDefs = this.GetParameterDefs();
@@ -2680,7 +2680,7 @@ namespace Microsoft.Cci
                     signature: GetPropertySignatureHandle(propertyDef));
             }
         }
-        
+
         private void PopulateTypeDefTableRows()
         {
             var typeDefs = this.GetTypeDefs();
@@ -2863,7 +2863,7 @@ namespace Microsoft.Cci
                 }
 
                 _dynamicAnalysisDataWriterOpt?.SerializeMethodDynamicAnalysisData(body);
-                
+
                 bodyOffsets[methodRid - 1] = bodyOffset;
 
                 methodRid++;
@@ -2891,11 +2891,11 @@ namespace Microsoft.Cci
             }
 
             var encodedBody = encoder.AddMethodBody(
-                codeSize: methodBody.IL.Length, 
-                maxStack: methodBody.MaxStack, 
-                exceptionRegionCount: exceptionRegions.Length, 
+                codeSize: methodBody.IL.Length,
+                maxStack: methodBody.MaxStack,
+                exceptionRegionCount: exceptionRegions.Length,
                 hasSmallExceptionRegions: MayUseSmallExceptionHeaders(exceptionRegions),
-                localVariablesSignature: localSignatureHandleOpt, 
+                localVariablesSignature: localSignatureHandleOpt,
                 attributes: (methodBody.LocalsAreZeroed ? MethodBodyAttributes.InitLocals : 0));
 
             // Don't do small body method caching during deterministic builds until this issue is fixed
@@ -3083,7 +3083,7 @@ namespace Microsoft.Cci
         internal const uint LiteralGreatestMethodDefinitionToken = 0x40000000;
         internal const uint SourceDocumentIndex = 0x20000000;
         internal const uint ModuleVersionIdStringToken = 0x80000000;
-        
+
         private void WriteInstructions(Blob finalIL, ImmutableArray<byte> generatedIL, ref UserStringHandle mvidStringHandle, ref Blob mvidStringFixup)
         {
             // write the raw body first and then patch tokens:
@@ -3119,7 +3119,9 @@ namespace Microsoft.Cci
                                     switch ((uint)tokenMask)
                                     {
                                         case LiteralMethodDefinitionToken:
-                                            token = MetadataTokens.GetToken(ResolveEntityHandleFromPseudoToken(pseudoToken & 0x00ffffff)) & 0x00ffffff;
+                                            // Crash the compiler if pseudo token fails to resolve to a MethodDefinitionHandle.
+                                            var handle = (MethodDefinitionHandle)ResolveEntityHandleFromPseudoToken(pseudoToken & 0x00ffffff);
+                                            token = MetadataTokens.GetToken(handle) & 0x00ffffff;
                                             break;
                                         case LiteralGreatestMethodDefinitionToken:
                                             token = GreatestMethodDefIndex;
@@ -3137,7 +3139,7 @@ namespace Microsoft.Cci
                             offset += 4;
                             break;
                         }
-                        
+
                     case OperandType.InlineString:
                         {
                             writer.Offset = offset;
@@ -3221,7 +3223,7 @@ namespace Microsoft.Cci
                     region.TryLength,
                     region.HandlerStartOffset,
                     region.HandlerLength,
-                    (exceptionType != null) ? GetTypeHandle(exceptionType) : default(EntityHandle), 
+                    (exceptionType != null) ? GetTypeHandle(exceptionType) : default(EntityHandle),
                     region.FilterDecisionStartOffset);
             }
         }
@@ -3380,7 +3382,7 @@ namespace Microsoft.Cci
                 {
                     CustomAttributeElementTypeEncoder typeEncoder;
                     encoder.TaggedScalar(out typeEncoder, out scalarEncoder);
-                    
+
                     // special case null argument assigned to Object parameter - treat as null string
                     if (c != null &&
                         c.Value == null &&
@@ -3405,7 +3407,7 @@ namespace Microsoft.Cci
                         scalarEncoder.NullArray();
                         return;
                     }
-                 
+
                     Debug.Assert(!module.IsPlatformType(c.Type, PlatformType.SystemType) || c.Value == null);
                     scalarEncoder.Constant(c.Value);
                 }
@@ -3599,7 +3601,7 @@ namespace Microsoft.Cci
         private void SerializeReturnValueAndParameters(MethodSignatureEncoder encoder, ISignature signature, ImmutableArray<IParameterTypeInformation> varargParameters)
         {
             var declaredParameters = signature.GetParameters(Context);
-			var returnType = signature.GetType(Context);
+            var returnType = signature.GetType(Context);
 
             ReturnTypeEncoder returnTypeEncoder;
             ParametersEncoder parametersEncoder;

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1,18 +1,13 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
-Imports System.Diagnostics
-Imports System.Linq
 Imports System.Reflection.Metadata
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports TypeKind = Microsoft.CodeAnalysis.TypeKind
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
 
-    Friend Partial Class CodeGenerator
+    Partial Friend Class CodeGenerator
         Private _recursionDepth As Integer
 
         Private Class EmitCancelledException
@@ -2205,7 +2200,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             Debug.Assert(node.Method.IsDefinition)
             Debug.Assert(node.Type.SpecialType = SpecialType.System_Int32)
             _builder.EmitOpCode(ILOpCode.Ldtoken)
-            EmitSymbolToken(node.Method, node.Syntax, encodeAsRawDefinitionToken:=True)
+
+            ' For partial methods, we emit pseudo token based on the symbol for the partial
+            ' definition part as opposed to the symbol for the partial implementation part.
+            ' We will need to resolve the symbol associated with each pseudo token in order
+            ' to compute the real method definition tokens later. For partial methods, this
+            ' resolution can only succeed if the associated symbol is the symbol for the
+            ' partial definition and not the symbol for the partial implementation (see
+            ' MethodSymbol.ResolvedMethodImpl()).
+            Dim symbol = If(node.Method.PartialDefinitionPart, node.Method)
+
+            EmitSymbolToken(symbol, node.Syntax, encodeAsRawDefinitionToken:=True)
         End Sub
 
         Private Sub EmitMaximumMethodDefIndexExpression(node As BoundMaximumMethodDefIndex)


### PR DESCRIPTION
In the case of instrumented partial methods, the method index that the compiler emits (as part of the generated call to `Microsoft.CodeAnalysis.Runtime.CreatePayload()`) currently ends up being a random integer that can either clash with the index for some other existing method or end up falling outside the range of valid method indices in the assembly.

The bug is that we were using symbol for the partial implementation part (as opposed to symbol for the partial definition part) when creating pseudo tokens for partial methods. When this symbol was [resolved](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Emitter/Model/MethodSymbolAdapter.cs#L156) later (as part of substituting the real method definition token) [this assert](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Emitter/Model/MethodSymbolAdapter.cs#L164) would pop up and we would [fail to get a `MethodDefinitionHandle`](https://github.com/dotnet/roslyn/blob/master/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs#L1194) for the method and end up [returning a `MemberReferenceHandle`](https://github.com/dotnet/roslyn/blob/master/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs#L1202) instead. This in turn meant that we would [end up emitting the wrong token](https://github.com/dotnet/roslyn/blob/master/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs#L3122) for the partial method.

The fix is to always use (remember) the symbol for the partial definition part when creating pseudo tokens - this ensures that the subsequent resolution will succeed and we will end up emitting the correct token.

---
**Customer scenario**
This issue causes significant problems for the Live Unit Testing (LUT) feature in VS if the user's solution contains partial methods. In the most benign cases, LUT will end up associating the wrong methods with tests (which means LUT won't run the correct set of tests when user makes edits). In other cases, this bug can cause LUT to incorrectly display glyphs that belong to a partial method next to some other random method in the same assembly. In the worst case, this can result in runtime crashes (e.g. IndexOutOfRangeException when the instrumented binary containing partial methods is run) or crashes in the LUT.

**Bugs this fixes:**

**Workarounds, if any**
None. The only workaround is to stop instrumenting the impacted code (i.e. exclude the project containing the partial methods from LUT instrumentation) or change the code to stop using partial methods. However, because the symptoms of this bug are somewhat random (as described above), it would be hard for users to figure out that the problem is being caused because of partial methods and apply these workarounds...

**Risk**
Low.

**Performance impact**
None.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
We probably missed this because we didn't test partial methods enough. It is also possible that we missed this because, as mentioned above, sometimes the symptoms of this bug can be benign and rather subtle (not easily noticeable). I have added tests for partial methods as part of this change.

**How was the bug found?**
Dogfooding Live Unit Testing against roslyn's Compilers.sln