### PR TITLE
Fix crash in AddUsing when changing casing of a typename.

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4554,5 +4554,54 @@ class C
     }
 }");
         }
+
+        [WorkItem(19218, "https://github.com/dotnet/roslyn/issues/19218")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestChangeCaseWithUsingsInNestedNamespace()
+        {
+            await TestInRegularAndScriptAsync(
+@"namespace VS
+{
+    interface IVsStatusbar
+    {
+    }
+}
+
+namespace Outer
+{
+    using System;
+
+    class C
+    {
+        void M()
+        {
+            // Note: IVsStatusBar is cased incorrectly.
+            [|IVsStatusBar|] b;
+        }
+    }
+}
+",
+@"namespace VS
+{
+    interface IVsStatusbar
+    {
+    }
+}
+
+namespace Outer
+{
+    using System;
+    using VS;
+
+    class C
+    {
+        void M()
+        {
+            IVsStatusbar b;
+        }
+    }
+}
+");
+        }
     }
 }

--- a/src/Features/Core/Portable/AddImport/CodeActions/PackageReference.ParentCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/PackageReference.ParentCodeAction.cs
@@ -107,7 +107,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                     CancellationToken cancellationToken)
                 {
                     var oldDocument = document;
-                    reference.ReplaceNameNode(ref node, ref document, cancellationToken);
+                    (node, document) = await reference.ReplaceNameNodeAsync(
+                        node, document, cancellationToken).ConfigureAwait(false);
 
                     var newDocument = await reference.provider.AddImportAsync(
                         node, reference.SearchResult.NameParts, document, placeSystemNamespaceFirst, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
+++ b/src/Features/Core/Portable/AddImport/References/AssemblyReference.cs
@@ -105,9 +105,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                     var reference = service.GetReference(resolvedPath, MetadataReferenceProperties.Assembly);
 
                     // First add the "using/import" directive in the code.
-                    var node = _node;
-                    var document = _document;
-                    _reference.ReplaceNameNode(ref node, ref document, cancellationToken);
+                    (SyntaxNode node, Document document) = await _reference.ReplaceNameNodeAsync(
+                        _node, _document, cancellationToken).ConfigureAwait(false);
 
                     var newDocument = await _reference.provider.AddImportAsync(
                         node, _reference.SearchResult.NameParts, document, _placeSystemNamespaceFirst, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19218

Root cause was that we do 'add using' in two steps.  First, we update the name of the type in source (if there is a casing difference between what the user wrote and the type we found), then we go and add the 'using' to the right scope (or we add at the top of the file if we can't find a better scope).

In the case where we updated the type name, we weren't properly getting back to a node in the updated document we were creating.  That led to a crash later where we ended up using a 'containing scope node' that wasn't from the actual document we had.
