### PR TITLE
Restore developer build desktop deployment

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -440,22 +440,18 @@
   </Target>
 
   <!-- This is part of our developer convenience work to allow easy testing of our portable
-       unit test projects.  It's a similar mechanism to CopyNuGetImplementations but is
-       both unsupported and somewhat special cased to our build setup.
+       unit test projects.  It is special cased to our build setup.
 
        This bug tracks getting an official solution out of MSBuild.
 
        https://github.com/Microsoft/msbuild/issues/1499 -->
   <Target Name="DeployPortableOnDeveloperBuild"
-          Condition="'$(_IsAnyPortableUnitTest)' == 'true' AND '$(DeveloperBuild)' == 'true' AND '$(OS)' == 'Windows_NT' AND '$(RoslynSdkProject)' != 'true'">
-    <ResolveNuGetPackageAssets IncludeFrameworkReferences="true"
-                               NuGetPackagesDirectory="$(NuGetPackageRoot)"
-                               RuntimeIdentifier="win7"
-                               ProjectLanguage="$(ProjectLanguage)"
-                               ProjectLockFile="$(MSBuildThisFileDirectory)..\..\src\Test\DeployDesktopTestRuntime\project.lock.json"
-                               TargetMonikers=".NETFramework,Version=v4.6">
-      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="ReferenceCopyLocalPaths" />
-    </ResolveNuGetPackageAssets>
+          Condition="'$(_IsAnyPortableUnitTest)' == 'true' AND '$(DeveloperBuild)' == 'true' AND '$(OS)' == 'Windows_NT'">
+    <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\src\Test\DeployDesktopTestRuntime\DeployDesktopTestRuntime.csproj"
+             Properties="ExcludeProjectReferences=true"
+             Targets="GetReferenceCopyLocalPaths">
+      <Output TaskParameter="TargetOutputs" ItemName="ReferenceCopyLocalPaths" />
+    </MSBuild>
 
     <!-- Desktop tests need to load the Desktop version of the TestUtilities via reflection at runtime without
          referencing the assembly at compile time. However, it looks like adding a project-to-project reference 
@@ -470,6 +466,21 @@
       <Output TaskParameter="TargetOutputs" ItemName="ReferenceCopyLocalPaths" />
     </MSBuild>
   </Target>
+
+  <!-- When getting the dependencies to copy local for developer builds to portable project outputs,
+       (see above), we need to filter out the project references as they create cycles back to the
+       calling test projects and we are only interested in getting the nuget copy local items raised
+       from the deployment project's project.assets.json. -->
+  <Target Name="RemoveExcludedProjectReferences"
+          Condition="'$(ExcludeProjectReferences)' == 'true'">
+    <ItemGroup>
+      <ProjectReference Remove="@(ProjectReference)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetReferenceCopyLocalPaths" 
+          DependsOnTargets="RemoveExcludedProjectReferences;ResolveAssemblyReferences"
+          Returns="@(ReferenceCopyLocalPaths)" />
 
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->
   <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -483,7 +483,7 @@
           Returns="@(ReferenceCopyLocalPaths)" />
 
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->
-  <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />
+  <Target Name="GetBuildVersion" Returns="$(VsixVersion)" />
 
   <!-- 
     In order to leverage LUT testing we need to have both of the follownig packages in 


### PR DESCRIPTION
Infrastructure-only change to reinstate desktop asset deployment for portable unit test projects that had been lost in the move to SDK-based projects. Unblocks running these unit tests in the IDE.

@jaredpar @agocke @AlekseyTs @dotnet/roslyn-infrastructure 