### PR TITLE
Revert "Merge pull request #10993 from rchande/quickinfosession"

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Controller.cs
@@ -77,26 +77,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
             else
             {
+                var quickInfoItem = modelOpt.Item;
+
                 // We want the span to actually only go up to the caret.  So get the expected span
                 // and then update its end point accordingly.
-                ITrackingSpan trackingSpan;
-                QuickInfoItem item = null;
+                var triggerSpan = modelOpt.GetCurrentSpanInSnapshot(quickInfoItem.TextSpan, this.SubjectBuffer.CurrentSnapshot);
+                var trackingSpan = triggerSpan.CreateTrackingSpan(SpanTrackingMode.EdgeInclusive);
 
-                // Whether or not we have an item to show, we need to start the session.
-                // If the user Edit.QuickInfo's on a squiggle, they want to see the 
-                // error text even if there's no symbol quickinfo.
-                if (modelOpt.Item != null)
-                {
-                    item = modelOpt.Item;
-                    var triggerSpan = modelOpt.GetCurrentSpanInSnapshot(item.TextSpan, this.SubjectBuffer.CurrentSnapshot);
-                    trackingSpan = triggerSpan.CreateTrackingSpan(SpanTrackingMode.EdgeInclusive);
-                }
-                else
-                {
-                    var caret = this.TextView.GetCaretPoint(this.SubjectBuffer).Value;
-                    trackingSpan = caret.Snapshot.CreateTrackingSpan(caret.Position, 0, SpanTrackingMode.EdgeInclusive, TrackingFidelityMode.Forward);
-                }
-                sessionOpt.PresenterSession.PresentItem(trackingSpan, item, modelOpt.TrackMouse);
+                sessionOpt.PresenterSession.PresentItem(trackingSpan, quickInfoItem, modelOpt.TrackMouse);
             }
         }
 
@@ -170,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                         }
                     }
 
-                    return new Model(snapshot.Version, null, null, trackMouse);
+                    return null;
                 }
             }
             catch (Exception e) when (FatalError.ReportUnlessCanceled(e))

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Model.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             IQuickInfoProvider provider,
             bool trackMouse)
         {
+            Contract.ThrowIfNull(item);
+
             this.TextVersion = textVersion;
             this.Item = item;
             this.Provider = provider;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoPresenterSession.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Presentation/QuickInfoPresenter.QuickInfoPresenterSession.cs
@@ -100,12 +100,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo.Pr
 
             internal void AugmentQuickInfoSession(IList<object> quickInfoContent, out ITrackingSpan applicableToSpan)
             {
-                if (_item == null)
-                {
-                    applicableToSpan = null;
-                    return;
-                }
-
                 applicableToSpan = _triggerSpan;
                 quickInfoContent.Add(_item.Content.Create());
             }


### PR DESCRIPTION
This reverts commit 3ef5891043f89145b1e1c1a7de8c0e02acd15c6e, reversing
changes made to 923fcbf40f87c7c50ea09c8375556c293795874a and fixes https://github.com/dotnet/roslyn/issues/18596. The flickering regression described in #18596 is incredibly irritating. We'll have to find another way to make ctrl-k-i work. I think this is an acceptable takeback ecause we only ever received internal feedback about ctrk-k-i.

Tag @dotnet/roslyn-ide for review.

**Customer scenario**

The customer hovers the mouse over an error squiggle that contains a light bulb fix to see the error message. The error popup rapidly flickers, making it difficult to read. 

**Bugs this fixes:**

#18596


**Workarounds, if any**

None

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

Low--this change simply reverts the change the introduced this bug. This reversion introduces a different, far less annoying bug that we only ever received internal feedback about.

**Performance impact**

Low. By fixing the flickering we will do fewer quickinfo computations.

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

We failed to test the case of mouse-hover quickinfo with a lightbulb quick fix available.

**How was the bug found?**

Internal feedback
