### PR TITLE
Update to latest PDB reader/writer dependencies

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -19,6 +19,7 @@
     <add key="dotnet.myget.org symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />
     <add key="dotnet.myget.org symreader-portable" value="https://dotnet.myget.org/F/symreader-portable/api/v3/index.json" />
     <add key="dotnet.myget.org symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+    <add key="dotnet.myget.org symreader-native" value="https://dotnet.myget.org/F/symreader-native/api/v3/index.json" />
     <add key="dotnet.myget.org metadata-tools" value="https://dotnet.myget.org/F/metadata-tools/api/v3/index.json" />
     <add key="dotnet.myget.org interactive-window" value="https://dotnet.myget.org/F/interactive-window/api/v3/index.json" />
     <add key="dotnet.myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -36,9 +36,9 @@
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>
     <MicrosoftDiagnosticsTracingTraceEventVersion>1.0.35</MicrosoftDiagnosticsTracingTraceEventVersion>
     <MicrosoftDiaSymReaderVersion>1.1.0</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderConverterXmlVersion>1.0.0-beta1-61618-01</MicrosoftDiaSymReaderConverterXmlVersion>
-    <MicrosoftDiaSymReaderNativeVersion>1.5.0</MicrosoftDiaSymReaderNativeVersion>
-    <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0</MicrosoftDiaSymReaderPortablePdbVersion>
+    <MicrosoftDiaSymReaderConverterXmlVersion>1.0.0-beta1-61708-01</MicrosoftDiaSymReaderConverterXmlVersion>
+    <MicrosoftDiaSymReaderNativeVersion>1.6.0-beta2-25304</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderPortablePdbVersion>1.3.0-beta1-61619-01</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftDotNetIBCMerge>4.7.1-alpha-00001</MicrosoftDotNetIBCMerge>
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.13.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion>15.0.26201-alpha</MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion>

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -180,9 +180,11 @@ public class C
                     embeddedTexts: null,
                     testData: new CompilationTestData() { SymWriterFactory = () => new object() });
 
+                var libName = $"Microsoft.DiaSymReader.Native.{(IntPtr.Size == 4 ? "x86" : "amd64")}.dll";
+
                 result.Diagnostics.Verify(
-                    // error CS0041: Unexpected error writing debug information -- 'Windows PDB writer is not available -- could not find Microsoft.DiaSymReader.Native.{0}.dll'
-                    Diagnostic(ErrorCode.FTL_DebugEmitFailure).WithArguments(string.Format(CodeAnalysisResources.SymWriterNotAvailable, (IntPtr.Size == 4) ? "x86" : "amd64")));
+                    // error CS0041: Unexpected error writing debug information -- 'The version of Windows PDB writer is older than required: 'Microsoft.DiaSymReader.Native.x86.dll''
+                    Diagnostic(ErrorCode.FTL_DebugEmitFailure).WithArguments(string.Format(CodeAnalysisResources.SymWriterOlderVersionThanRequired, libName)));
 
                 Assert.False(result.Success);
             }
@@ -213,9 +215,11 @@ public class C
                     embeddedTexts: null,
                     testData: new CompilationTestData() { SymWriterFactory = () => new MockSymUnmanagedWriter() });
 
+                var libName = $"Microsoft.DiaSymReader.Native.{(IntPtr.Size == 4 ? "x86" : "amd64")}.dll";
+
                 result.Diagnostics.Verify(
-                    // error CS0041: Unexpected error writing debug information -- 'Windows PDB writer doesn't support deterministic compilation -- could not find Microsoft.DiaSymReader.Native.{0}.dll'
-                    Diagnostic(ErrorCode.FTL_DebugEmitFailure).WithArguments(string.Format(CodeAnalysisResources.SymWriterNotDeterministic, (IntPtr.Size == 4) ? "x86" : "amd64")));
+                    // error CS0041: Unexpected error writing debug information -- 'Windows PDB writer doesn't support deterministic compilation -- could not find {0}'
+                    Diagnostic(ErrorCode.FTL_DebugEmitFailure).WithArguments(string.Format(CodeAnalysisResources.SymWriterNotDeterministic, libName)));
 
                 Assert.False(result.Success);
             }

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -1289,20 +1289,20 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows PDB writer is not available -- could not find Microsoft.DiaSymReader.Native.{0}.dll.
-        /// </summary>
-        internal static string SymWriterNotAvailable {
-            get {
-                return ResourceManager.GetString("SymWriterNotAvailable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Windows PDB writer doesn&apos;t support deterministic compilation -- could not find Microsoft.DiaSymReader.Native.{0}.dll.
+        ///   Looks up a localized string similar to Windows PDB writer doesn&apos;t support deterministic compilation: &apos;{0}&apos;.
         /// </summary>
         internal static string SymWriterNotDeterministic {
             get {
                 return ResourceManager.GetString("SymWriterNotDeterministic", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The version of Windows PDB writer is older than required: &apos;{0}&apos;.
+        /// </summary>
+        internal static string SymWriterOlderVersionThanRequired {
+            get {
+                return ResourceManager.GetString("SymWriterOlderVersionThanRequired", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -465,10 +465,10 @@
     <value>Invalid data at offset {0}: {1}{2}*{3}{4}</value>
   </data>
   <data name="SymWriterNotDeterministic" xml:space="preserve">
-    <value>Windows PDB writer doesn't support deterministic compilation -- could not find Microsoft.DiaSymReader.Native.{0}.dll</value>
+    <value>Windows PDB writer doesn't support deterministic compilation: '{0}'</value>
   </data>
-  <data name="SymWriterNotAvailable" xml:space="preserve">
-    <value>Windows PDB writer is not available -- could not find Microsoft.DiaSymReader.Native.{0}.dll</value>
+  <data name="SymWriterOlderVersionThanRequired" xml:space="preserve">
+    <value>The version of Windows PDB writer is older than required: '{0}'</value>
   </data>
   <data name="RuleSetBadAttributeValue" xml:space="preserve">
     <value>The attribute {0} has an invalid value of {1}.</value>


### PR DESCRIPTION
**Customer scenario**

When using portable PDBs + EnC, if breakpoints are set in unedited methods, the line deltas aren't being applied. So the symbol reader seems to return the old line numbers causing breakpoints to be set on the wrong line (or not bind at all if the is no associated code with this bogus line number). This issue doesn't repo if using Windows PDBs.

The issue is fixed in Microsoft.DiaSymReader.PortablePdb and this change updates to the latest version.
It also slightly improves diagnostics when SymWriter fails to load.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/17539

**Workarounds, if any**

None.

**Risk**

Small.

**Performance impact**

None

**Is this a regression from a previous update?**

Regression vs Windows PDBs.

**Root cause analysis:**

Missing test case. Added test covering the code.

**How was the bug found?**

Reported by a partner team.
