### PR TITLE
Remove DSRN VSIX prereq

### DIFF
--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -48,6 +48,5 @@
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.DiaSymReader.Native" Version="[15.0,16.0)" DisplayName="Windows PDB reader/writer" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
**Customer scenario**

With recent setup authoring changes Roslyn Insider VSIX requires Microsoft.DiaSymReader.Native Willow dependency, which prevents the insider package to be installed on VS builds other than those from lab/vsuml branch. 

Temporarily remove this setup prerequisite to unblock dogfooding. 

The prerequisite is correct though and will need to be added back for 15.3 RTM. Filed https://github.com/dotnet/roslyn/issues/19305 for tracking.

**Bugs this fixes:**

**Workarounds, if any**

Install VS build from lab/vsuml.

**Risk**

Low.

**Performance impact**

None.

**Is this a regression from a previous update?**

**Root cause analysis:**

**How was the bug found?**

Internal dogfooding.
