### PR TITLE
Fix analysis of IOperation descendants for BoundDelegateCreationExpre…

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -414,44 +414,20 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundDelegateCreationExpression : IMethodBindingExpression
+    internal partial class BoundDelegateCreationExpression
     {
-        IOperation IMemberReferenceExpression.Instance
-        {
-            get
-            {
-                BoundMethodGroup methodGroup = this.Argument as BoundMethodGroup;
-                if (methodGroup != null)
-                {
-                    return methodGroup.InstanceOpt;
-                }
+        protected override OperationKind ExpressionKind => OperationKind.None;
 
-                return null;
-            }
-        }
-
-        bool IMethodBindingExpression.IsVirtual =>
-            (object)this.MethodOpt != null &&
-            (this.MethodOpt.IsVirtual || this.MethodOpt.IsAbstract || this.MethodOpt.IsOverride) &&
-            !this.SuppressVirtualCalls;
-
-        ISymbol IMemberReferenceExpression.Member => this.MethodOpt;
-
-        IMethodSymbol IMethodBindingExpression.Method => this.MethodOpt;
-
-        protected override OperationKind ExpressionKind => OperationKind.MethodBindingExpression;
-
-        // SyntaxNode for MethodBindingExpression is the argument of DelegateCreationExpression 
-        SyntaxNode IOperation.Syntax => this.Argument.Syntax;
+        protected override ImmutableArray<IOperation> Children => ImmutableArray.Create<IOperation>(this.Argument); 
 
         public override void Accept(OperationVisitor visitor)
         {
-            visitor.VisitMethodBindingExpression(this);
+            visitor.VisitNoneOperation(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
-            return visitor.VisitMethodBindingExpression(this, argument);
+            return visitor.VisitNoneOperation(this, argument);
         }
     }
 

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
@@ -1121,7 +1121,7 @@ class D : C
                 );
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18839")]
         public void EventAndMethodReferencesCSharp()
         {
             const string source = @"
@@ -1440,8 +1440,7 @@ class C
                 Diagnostic(LambdaTestAnalyzer.LambdaExpressionDescriptor.Id, "input => input++").WithLocation(9, 31),
                 Diagnostic(LambdaTestAnalyzer.LambdaExpressionDescriptor.Id, "input => { input++; input++; if (input > 0) return true; return false; }").WithLocation(10, 32),
                 Diagnostic(LambdaTestAnalyzer.TooManyStatementsInLambdaExpressionDescriptor.Id, "input => { input++; input++; if (input > 0) return true; return false; }").WithLocation(10, 32),
-                // Bug: missing a Lambda expression in delegate creation https://github.com/dotnet/roslyn/issues/8347
-                //Diagnostic(LambdaTestAnalyzer.LambdaExpressionDescriptor.Id, "(s, e) => { }").WithLocation(22, 42),
+                Diagnostic(LambdaTestAnalyzer.LambdaExpressionDescriptor.Id, "(s, e) => { }").WithLocation(22, 42),
                 Diagnostic(LambdaTestAnalyzer.LambdaExpressionDescriptor.Id, "(s, e) => { int i = 0; i++; i++; i++; }").WithLocation(23, 19),
                 Diagnostic(LambdaTestAnalyzer.TooManyStatementsInLambdaExpressionDescriptor.Id, "(s, e) => { int i = 0; i++; i++; i++; }").WithLocation(23, 19));
         }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.cs
@@ -192,6 +192,96 @@ IObjectCreationExpression (Constructor: Class..ctor()) (OperationKind.ObjectCrea
         }
 
         [Fact, WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
+        public void ParameterReference_DelegateCreationExpressionWithLambdaArgument()
+        {
+            string source = @"
+using System;
+
+class Class
+{
+    // Used parameter methods
+    public void UsedParameterMethod1(Action a)
+    {
+        Action a2 = /*<bind>*/new Action(() =>
+        {
+            a();
+        })/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IOperation:  (OperationKind.None) (Syntax: 'new Action( ... })')
+  Children(1): ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: System.Action) (Syntax: '() => ... }')
+      IBlockStatement (2 statements) (OperationKind.BlockStatement) (Syntax: '{ ... }')
+        IExpressionStatement (OperationKind.ExpressionStatement) (Syntax: 'a();')
+          IInvocationExpression (virtual void System.Action.Invoke()) (OperationKind.InvocationExpression, Type: System.Void) (Syntax: 'a()')
+            Instance Receiver: IParameterReferenceExpression: a (OperationKind.ParameterReferenceExpression, Type: System.Action) (Syntax: 'a')
+        IReturnStatement (OperationKind.ReturnStatement) (Syntax: '{ ... }')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
+        public void ParameterReference_DelegateCreationExpressionWithMethodArgument()
+        {
+            string source = @"
+using System;
+
+class Class
+{
+    public delegate void Delegate(int x, int y);
+
+    public void Method(Delegate d)
+    {
+        var a = /*<bind>*/new Delegate(Method2)/*</bind>*/;
+    }
+
+    public void Method2(int x, int y)
+    {
+    }
+}
+";
+            string expectedOperationTree = @"
+IOperation:  (OperationKind.None) (Syntax: 'new Delegate(Method2)')
+  Children(1): IOperation:  (OperationKind.None) (Syntax: 'Method2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
+        public void ParameterReference_DelegateCreationExpressionWithInvalidArgument()
+        {
+            string source = @"
+using System;
+
+class Class
+{
+    public delegate void Delegate(int x, int y);
+
+    public void Method(int x)
+    {
+        var a = /*<bind>*/new Delegate(x)/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IInvalidExpression (OperationKind.InvalidExpression, Type: Class.Delegate, IsInvalid) (Syntax: 'new Delegate(x)')
+  Children(1): IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'x')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0149: Method name expected
+                //         var a = /*<bind>*/new Delegate(x)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_MethodNameExpected, "x").WithLocation(10, 40)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(8884, "https://github.com/dotnet/roslyn/issues/8884")]
         public void ParameterReference_DynamicCollectionInitializer()
         {
             string source = @"

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -1500,46 +1500,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     End Class
 
     Friend Partial Class BoundDelegateCreationExpression
-        Implements IMethodBindingExpression
-
-        Private ReadOnly Property IMemberReferenceExpression_Instance As IOperation Implements IMemberReferenceExpression.Instance
-            Get
-                If Me.Method.IsShared Then
-                    Return Nothing
-                Else
-                    Return Me.ReceiverOpt
-                End If
-            End Get
-        End Property
-
-        Private ReadOnly Property IMethodBindingExpression_IsVirtual As Boolean Implements IMethodBindingExpression.IsVirtual
-            Get
-                Return Me.Method IsNot Nothing AndAlso (Me.Method.IsOverridable OrElse Me.Method.IsOverrides OrElse Me.Method.IsMustOverride) AndAlso Not Me.SuppressVirtualCalls
-            End Get
-        End Property
-
-        Private ReadOnly Property IMemberReferenceExpression_Member As ISymbol Implements IMemberReferenceExpression.Member
-            Get
-                Return Me.Method
-            End Get
-        End Property
-
-        Private ReadOnly Property IMethodBindingExpression_Method As IMethodSymbol Implements IMethodBindingExpression.Method
-            Get
-                Return Me.Method
-            End Get
-        End Property
 
         Protected Overrides Function ExpressionKind() As OperationKind
-            Return OperationKind.MethodBindingExpression
+            Return OperationKind.None
         End Function
 
+        Protected Overrides ReadOnly Property Children As ImmutableArray(Of IOperation)
+            Get
+                Return ImmutableArray.Create(Of IOperation)(Me.ReceiverOpt)
+            End Get
+        End Property
+
         Public Overrides Sub Accept(visitor As OperationVisitor)
-            visitor.VisitMethodBindingExpression(Me)
+            visitor.VisitNoneOperation(Me)
         End Sub
 
         Public Overrides Function Accept(Of TArgument, TResult)(visitor As OperationVisitor(Of TArgument, TResult), argument As TArgument) As TResult
-            Return visitor.VisitMethodBindingExpression(Me, argument)
+            Return visitor.VisitNoneOperation(Me, argument)
         End Function
     End Class
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
@@ -1138,7 +1138,7 @@ End Class
                Diagnostic(ExplicitVsImplicitInstanceAnalyzer.ImplicitInstanceDescriptor.Id, "M2").WithLocation(15, 9))
         End Sub
 
-        <Fact>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/18839")>
         Public Sub EventAndMethodReferencesVisualBasic()
             Dim source = <compilation>
                              <file name="c.vb">
@@ -1411,7 +1411,7 @@ End Class
         End Sub
 
         <WorkItem(8385, "https://github.com/dotnet/roslyn/issues/8385")>
-        <Fact>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/18839")>
         Public Sub StaticMemberReferenceVisualBasic()
             Dim source = <compilation>
                              <file name="c.vb">

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -978,7 +978,7 @@ CodeStyleOptions.QualifyPropertyAccess, NotificationOption.Error);
         }
 
         [WorkItem(15325, "https://github.com/dotnet/roslyn/issues/15325")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/18839"), Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task QualifyInstanceMethodInDelegateCreation()
         {
             await TestAsyncWithOption(


### PR DESCRIPTION
…ssion

**Customer scenario**

Customer uses IOperation analyzers in their code base and see large number of false positives in code with delegate creation expressions taking lambda arguments. For example see https://github.com/dotnet/roslyn/issues/8884#issue-134680222

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn/issues/8884#issue-134680222

**Workarounds, if any**

Customer has to suppress all IOperation analyzers in code containing delegate creation expressions OR disable these analyzers completely.

**Risk**

Low. We have taken same approach for bunch of other bound nodes that still require IOperation design.

**Performance impact**

Low.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**

The current IOperation API implementation of BoundDelegateCreationExpression has a bunch of issues and needs to be redesigned. This is tracked by #8897 and will be addressed post 15.3. Meanwhile, to unblock analyzers on code containing delegate creation expressions with lambda arguments, this bound node has been switched to OperationKind.None with override for Children property.

**How was the bug found?**

Dogfooding/customer reports.