### PR TITLE
Consume IBCMerge from internal NuGet feed

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -133,6 +133,8 @@
     <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''" >true</DisableImplicitFrameworkReferences>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+
+    <IbcMergePath>$(NuGetPackageRoot)\Microsoft.DotNet.IBCMerge\$(MicrosoftDotNetIBCMerge)\lib\net45\ibcmerge.exe</IbcMergePath>
   </PropertyGroup>
 
   <!-- If the project hasn't configured a ruleset, set a default ruleset. -->
@@ -423,16 +425,24 @@
     </PropertyGroup>
   </Target>
 
-  <!-- The path to IBCMerge.exe must be specified at build time via $(IbcMergePath).  Typically this is passed as a
-       build definition variable -->
+  <!-- The IBCMerge tool is internal only and hence only available during official Microbuild runs.  This target is 
+       specifically not gated on the existance of this file.  During an official build it shoudl always be present and 
+       if it's not then an error needs to be raised.
+
+       A local build emulating an official build can pass /p:SkipApplyOptimizations=true to avoid this error.
+       -->
   <Target Name="ApplyOptimizations"
-          Condition="'$(OfficialBuild)' == 'true' AND '$(NonShipping)' != 'true' AND '$(SkipApplyOptimizations)' != 'true' AND Exists('$(OptimizationDataFile)') AND '$(IbcMergePath)' != ''"
+          Condition="'$(OfficialBuild)' == 'true' AND '$(NonShipping)' != 'true' AND '$(SkipApplyOptimizations)' != 'true' AND Exists('$(OptimizationDataFile)')"
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
       <Message Text="Adding optimization data to @(IntermediateAssembly)" />
 
+      <Error Text="IBCMerge not found at $(IbcMergePath). Local developer builds should pass /p:SkipApplyOptimizations=true to avoid this"
+             Condition="!Exists('$(IbcMergePath)')" />
+
       <Exec Command="&quot;$(IbcMergePath)&quot; -q -f -partialNGEN -minify -mo &quot;@(IntermediateAssembly)&quot; -incremental &quot;$(OptimizationDataFile)&quot;"
-            ConsoleToMSBuild="true">
+            ConsoleToMSBuild="true"
+            Condition="Exists('$(IbcMergePath)')">
         <Output TaskParameter="ConsoleOutput" PropertyName="IbcMergeOutput" />
       </Exec>
 

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -39,6 +39,7 @@
     <MicrosoftDiaSymReaderConverterXmlVersion>1.0.0-beta1-61618-01</MicrosoftDiaSymReaderConverterXmlVersion>
     <MicrosoftDiaSymReaderNativeVersion>1.5.0</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0</MicrosoftDiaSymReaderPortablePdbVersion>
+    <MicrosoftDotNetIBCMerge>4.7.1-alpha-00001</MicrosoftDotNetIBCMerge>
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.13.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion>15.0.26201-alpha</MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion>
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>

--- a/build/ToolsetPackages/InternalToolset.csproj
+++ b/build/ToolsetPackages/InternalToolset.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(MSBuildThisFileDirectory)..\Targets\Packages.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\Targets\FixedPackages.props" />
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMerge)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This both removes our flaky dependency on a file share and sets us up to
get updates for the package.  This is a necessary pre-req for us resolving one of our RPS bugs around MS.CA.Workspaces.

Once this is merged we also need to update our internal build definition as well to run the restore on InternalToolset.csproj.  I have a draft build which does this and a green build against that draft.

https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=726146&_a=summary


