### PR TITLE
Serialization kinds

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcSession.cs
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 writer.WriteInt32(1);
 
                 checksum.WriteTo(writer);
-                writer.WriteString(remotableData.Kind);
+                writer.WriteInt32((int)remotableData.Kind);
 
                 await remotableData.WriteObjectToAsync(writer, _source.Token).ConfigureAwait(false);
             }
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     var remotableData = kv.Value;
 
                     checksum.WriteTo(writer);
-                    writer.WriteString(remotableData.Kind);
+                    writer.WriteInt32((int)remotableData.Kind);
 
                     await remotableData.WriteObjectToAsync(writer, _source.Token).ConfigureAwait(false);
                 }

--- a/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal abstract class CustomAsset : RemotableData
     {
-        public CustomAsset(Checksum checksum, WellKnownSynchronizationKinds kind) : base(checksum, kind)
+        public CustomAsset(Checksum checksum, WellKnownSynchronizationKind kind) : base(checksum, kind)
         {
         }
     }
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Execution
     {
         private readonly Action<ObjectWriter, CancellationToken> _writer;
 
-        public SimpleCustomAsset(WellKnownSynchronizationKinds kind, Action<ObjectWriter, CancellationToken> writer) :
+        public SimpleCustomAsset(WellKnownSynchronizationKind kind, Action<ObjectWriter, CancellationToken> writer) :
             base(CreateChecksumFromStreamWriter(kind, writer), kind)
         {
             // unlike SolutionAsset which gets checksum from solution states, this one build one by itself.
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Execution
             return SpecializedTasks.EmptyTask;
         }
 
-        private static Checksum CreateChecksumFromStreamWriter(WellKnownSynchronizationKinds kind, Action<ObjectWriter, CancellationToken> writer)
+        private static Checksum CreateChecksumFromStreamWriter(WellKnownSynchronizationKind kind, Action<ObjectWriter, CancellationToken> writer)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var objectWriter = new ObjectWriter(stream))
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Execution
         public WorkspaceAnalyzerReferenceAsset(AnalyzerReference reference, Serializer serializer) :
             base(
                 serializer.CreateChecksum(reference, CancellationToken.None),
-                WellKnownSynchronizationKinds.AnalyzerReference)
+                WellKnownSynchronizationKind.AnalyzerReference)
         {
             _reference = reference;
             _serializer = serializer;

--- a/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal abstract class CustomAsset : RemotableData
     {
-        public CustomAsset(Checksum checksum, string kind) : base(checksum, kind)
+        public CustomAsset(Checksum checksum, WellKnownSynchronizationKinds kind) : base(checksum, kind)
         {
         }
     }
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Execution
     {
         private readonly Action<ObjectWriter, CancellationToken> _writer;
 
-        public SimpleCustomAsset(string kind, Action<ObjectWriter, CancellationToken> writer) :
+        public SimpleCustomAsset(WellKnownSynchronizationKinds kind, Action<ObjectWriter, CancellationToken> writer) :
             base(CreateChecksumFromStreamWriter(kind, writer), kind)
         {
             // unlike SolutionAsset which gets checksum from solution states, this one build one by itself.
@@ -39,12 +39,12 @@ namespace Microsoft.CodeAnalysis.Execution
             return SpecializedTasks.EmptyTask;
         }
 
-        private static Checksum CreateChecksumFromStreamWriter(string kind, Action<ObjectWriter, CancellationToken> writer)
+        private static Checksum CreateChecksumFromStreamWriter(WellKnownSynchronizationKinds kind, Action<ObjectWriter, CancellationToken> writer)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var objectWriter = new ObjectWriter(stream))
             {
-                objectWriter.WriteString(kind);
+                objectWriter.WriteInt32((int)kind);
                 writer(objectWriter, CancellationToken.None);
                 return Checksum.Create(stream);
             }

--- a/src/Workspaces/Core/Portable/Execution/CustomAssetBuilder.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAssetBuilder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Execution
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return new SimpleCustomAsset(WellKnownSynchronizationKinds.OptionSet,
+            return new SimpleCustomAsset(WellKnownSynchronizationKind.OptionSet,
                 (writer, cancellationTokenOnStreamWriting) =>
                     _serializer.SerializeOptionSet(options, language, writer, cancellationTokenOnStreamWriting));
         }

--- a/src/Workspaces/Core/Portable/Execution/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Execution/Extensions.cs
@@ -15,30 +15,30 @@ namespace Microsoft.CodeAnalysis.Execution
             return (T[])reader.ReadValue();
         }
 
-        public static WellKnownSynchronizationKinds GetWellKnownSynchronizationKind(this object value)
+        public static WellKnownSynchronizationKind GetWellKnownSynchronizationKind(this object value)
         {
             switch (value)
             {
-                case SolutionStateChecksums _: return WellKnownSynchronizationKinds.SolutionState;
-                case ProjectStateChecksums _: return WellKnownSynchronizationKinds.ProjectState;
-                case DocumentStateChecksums _: return WellKnownSynchronizationKinds.DocumentState;
-                case ProjectChecksumCollection _: return WellKnownSynchronizationKinds.Projects;
-                case DocumentChecksumCollection _: return WellKnownSynchronizationKinds.Documents;
-                case TextDocumentChecksumCollection _: return WellKnownSynchronizationKinds.TextDocuments;
-                case ProjectReferenceChecksumCollection _: return WellKnownSynchronizationKinds.ProjectReferences;
-                case MetadataReferenceChecksumCollection _: return WellKnownSynchronizationKinds.MetadataReferences;
-                case AnalyzerReferenceChecksumCollection _: return WellKnownSynchronizationKinds.AnalyzerReferences;
-                case SolutionInfo.SolutionAttributes _: return WellKnownSynchronizationKinds.SolutionAttributes;
-                case ProjectInfo.ProjectAttributes _: return WellKnownSynchronizationKinds.ProjectAttributes;
-                case DocumentInfo.DocumentAttributes _: return WellKnownSynchronizationKinds.DocumentAttributes;
-                case CompilationOptions _: return WellKnownSynchronizationKinds.CompilationOptions;
-                case ParseOptions _: return WellKnownSynchronizationKinds.ParseOptions;
-                case ProjectReference _: return WellKnownSynchronizationKinds.ProjectReference;
-                case MetadataReference _: return WellKnownSynchronizationKinds.MetadataReference;
-                case AnalyzerReference _: return WellKnownSynchronizationKinds.AnalyzerReference;
-                case TextDocumentState _: return WellKnownSynchronizationKinds.RecoverableSourceText;
-                case SourceText _: return WellKnownSynchronizationKinds.SourceText;
-                case OptionSet _: return WellKnownSynchronizationKinds.OptionSet;
+                case SolutionStateChecksums _: return WellKnownSynchronizationKind.SolutionState;
+                case ProjectStateChecksums _: return WellKnownSynchronizationKind.ProjectState;
+                case DocumentStateChecksums _: return WellKnownSynchronizationKind.DocumentState;
+                case ProjectChecksumCollection _: return WellKnownSynchronizationKind.Projects;
+                case DocumentChecksumCollection _: return WellKnownSynchronizationKind.Documents;
+                case TextDocumentChecksumCollection _: return WellKnownSynchronizationKind.TextDocuments;
+                case ProjectReferenceChecksumCollection _: return WellKnownSynchronizationKind.ProjectReferences;
+                case MetadataReferenceChecksumCollection _: return WellKnownSynchronizationKind.MetadataReferences;
+                case AnalyzerReferenceChecksumCollection _: return WellKnownSynchronizationKind.AnalyzerReferences;
+                case SolutionInfo.SolutionAttributes _: return WellKnownSynchronizationKind.SolutionAttributes;
+                case ProjectInfo.ProjectAttributes _: return WellKnownSynchronizationKind.ProjectAttributes;
+                case DocumentInfo.DocumentAttributes _: return WellKnownSynchronizationKind.DocumentAttributes;
+                case CompilationOptions _: return WellKnownSynchronizationKind.CompilationOptions;
+                case ParseOptions _: return WellKnownSynchronizationKind.ParseOptions;
+                case ProjectReference _: return WellKnownSynchronizationKind.ProjectReference;
+                case MetadataReference _: return WellKnownSynchronizationKind.MetadataReference;
+                case AnalyzerReference _: return WellKnownSynchronizationKind.AnalyzerReference;
+                case TextDocumentState _: return WellKnownSynchronizationKind.RecoverableSourceText;
+                case SourceText _: return WellKnownSynchronizationKind.SourceText;
+                case OptionSet _: return WellKnownSynchronizationKind.OptionSet;
             }
 
             throw ExceptionUtilities.UnexpectedValue(value);

--- a/src/Workspaces/Core/Portable/Execution/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Execution/Extensions.cs
@@ -15,106 +15,30 @@ namespace Microsoft.CodeAnalysis.Execution
             return (T[])reader.ReadValue();
         }
 
-        public static string GetWellKnownSynchronizationKind(this object value)
+        public static WellKnownSynchronizationKinds GetWellKnownSynchronizationKind(this object value)
         {
-            if (value is SolutionStateChecksums)
+            switch (value)
             {
-                return WellKnownSynchronizationKinds.SolutionState;
-            }
-
-            if (value is ProjectStateChecksums)
-            {
-                return WellKnownSynchronizationKinds.ProjectState;
-            }
-
-            if (value is DocumentStateChecksums)
-            {
-                return WellKnownSynchronizationKinds.DocumentState;
-            }
-
-            if (value is ProjectChecksumCollection)
-            {
-                return WellKnownSynchronizationKinds.Projects;
-            }
-
-            if (value is DocumentChecksumCollection)
-            {
-                return WellKnownSynchronizationKinds.Documents;
-            }
-
-            if (value is TextDocumentChecksumCollection)
-            {
-                return WellKnownSynchronizationKinds.TextDocuments;
-            }
-
-            if (value is ProjectReferenceChecksumCollection)
-            {
-                return WellKnownSynchronizationKinds.ProjectReferences;
-            }
-
-            if (value is MetadataReferenceChecksumCollection)
-            {
-                return WellKnownSynchronizationKinds.MetadataReferences;
-            }
-
-            if (value is AnalyzerReferenceChecksumCollection)
-            {
-                return WellKnownSynchronizationKinds.AnalyzerReferences;
-            }
-
-            if (value is SolutionInfo.SolutionAttributes)
-            {
-                return WellKnownSynchronizationKinds.SolutionAttributes;
-            }
-
-            if (value is ProjectInfo.ProjectAttributes)
-            {
-                return WellKnownSynchronizationKinds.ProjectAttributes;
-            }
-
-            if (value is DocumentInfo.DocumentAttributes)
-            {
-                return WellKnownSynchronizationKinds.DocumentAttributes;
-            }
-
-            if (value is CompilationOptions)
-            {
-                return WellKnownSynchronizationKinds.CompilationOptions;
-            }
-
-            if (value is ParseOptions)
-            {
-                return WellKnownSynchronizationKinds.ParseOptions;
-            }
-
-            if (value is ProjectReference)
-            {
-                return WellKnownSynchronizationKinds.ProjectReference;
-            }
-
-            if (value is MetadataReference)
-            {
-                return WellKnownSynchronizationKinds.MetadataReference;
-            }
-
-            if (value is AnalyzerReference)
-            {
-                return WellKnownSynchronizationKinds.AnalyzerReference;
-            }
-
-            if (value is TextDocumentState)
-            {
-                return WellKnownSynchronizationKinds.RecoverableSourceText;
-            }
-
-            if (value is SourceText)
-            {
-                return WellKnownSynchronizationKinds.SourceText;
-            }
-
-            if (value is OptionSet)
-            {
-                return WellKnownSynchronizationKinds.OptionSet;
+                case SolutionStateChecksums _: return WellKnownSynchronizationKinds.SolutionState;
+                case ProjectStateChecksums _: return WellKnownSynchronizationKinds.ProjectState;
+                case DocumentStateChecksums _: return WellKnownSynchronizationKinds.DocumentState;
+                case ProjectChecksumCollection _: return WellKnownSynchronizationKinds.Projects;
+                case DocumentChecksumCollection _: return WellKnownSynchronizationKinds.Documents;
+                case TextDocumentChecksumCollection _: return WellKnownSynchronizationKinds.TextDocuments;
+                case ProjectReferenceChecksumCollection _: return WellKnownSynchronizationKinds.ProjectReferences;
+                case MetadataReferenceChecksumCollection _: return WellKnownSynchronizationKinds.MetadataReferences;
+                case AnalyzerReferenceChecksumCollection _: return WellKnownSynchronizationKinds.AnalyzerReferences;
+                case SolutionInfo.SolutionAttributes _: return WellKnownSynchronizationKinds.SolutionAttributes;
+                case ProjectInfo.ProjectAttributes _: return WellKnownSynchronizationKinds.ProjectAttributes;
+                case DocumentInfo.DocumentAttributes _: return WellKnownSynchronizationKinds.DocumentAttributes;
+                case CompilationOptions _: return WellKnownSynchronizationKinds.CompilationOptions;
+                case ParseOptions _: return WellKnownSynchronizationKinds.ParseOptions;
+                case ProjectReference _: return WellKnownSynchronizationKinds.ProjectReference;
+                case MetadataReference _: return WellKnownSynchronizationKinds.MetadataReference;
+                case AnalyzerReference _: return WellKnownSynchronizationKinds.AnalyzerReference;
+                case TextDocumentState _: return WellKnownSynchronizationKinds.RecoverableSourceText;
+                case SourceText _: return WellKnownSynchronizationKinds.SourceText;
+                case OptionSet _: return WellKnownSynchronizationKinds.OptionSet;
             }
 
             throw ExceptionUtilities.UnexpectedValue(value);

--- a/src/Workspaces/Core/Portable/Execution/RemotableData.cs
+++ b/src/Workspaces/Core/Portable/Execution/RemotableData.cs
@@ -21,14 +21,14 @@ namespace Microsoft.CodeAnalysis.Execution
         /// this will be used in tranportation framework and deserialization service
         /// to hand shake how to send over data and deserialize serialized data
         /// </summary>
-        public readonly string Kind;
+        public readonly WellKnownSynchronizationKinds Kind;
 
         /// <summary>
         /// Checksum of this object
         /// </summary>
         public readonly Checksum Checksum;
 
-        public RemotableData(Checksum checksum, string kind)
+        public RemotableData(Checksum checksum, WellKnownSynchronizationKinds kind)
         {
             Checksum = checksum;
             Kind = kind;

--- a/src/Workspaces/Core/Portable/Execution/RemotableData.cs
+++ b/src/Workspaces/Core/Portable/Execution/RemotableData.cs
@@ -16,19 +16,19 @@ namespace Microsoft.CodeAnalysis.Execution
 
         /// <summary>
         /// Indicates what kind of object it is
-        /// <see cref="WellKnownSynchronizationKinds"/> for examples.
+        /// <see cref="WellKnownSynchronizationKind"/> for examples.
         /// 
         /// this will be used in tranportation framework and deserialization service
         /// to hand shake how to send over data and deserialize serialized data
         /// </summary>
-        public readonly WellKnownSynchronizationKinds Kind;
+        public readonly WellKnownSynchronizationKind Kind;
 
         /// <summary>
         /// Checksum of this object
         /// </summary>
         public readonly Checksum Checksum;
 
-        public RemotableData(Checksum checksum, WellKnownSynchronizationKinds kind)
+        public RemotableData(Checksum checksum, WellKnownSynchronizationKind kind)
         {
             Checksum = checksum;
             Kind = kind;
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Execution
         private sealed class NullRemotableData : RemotableData
         {
             public NullRemotableData() :
-                base(Checksum.Null, WellKnownSynchronizationKinds.Null)
+                base(Checksum.Null, WellKnownSynchronizationKind.Null)
             {
                 // null object has null kind and null checksum. 
                 // this null object is known to checksum framework and transportation framework to handle null case

--- a/src/Workspaces/Core/Portable/Execution/Serializer.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer.cs
@@ -63,21 +63,21 @@ namespace Microsoft.CodeAnalysis.Serialization
 
                 switch (kind)
                 {
-                    case WellKnownSynchronizationKinds.Null:
+                    case WellKnownSynchronizationKind.Null:
                         return Checksum.Null;
 
-                    case WellKnownSynchronizationKinds.CompilationOptions:
-                    case WellKnownSynchronizationKinds.ParseOptions:
-                    case WellKnownSynchronizationKinds.ProjectReference:
+                    case WellKnownSynchronizationKind.CompilationOptions:
+                    case WellKnownSynchronizationKind.ParseOptions:
+                    case WellKnownSynchronizationKind.ProjectReference:
                         return Checksum.Create(kind, value, this);
 
-                    case WellKnownSynchronizationKinds.MetadataReference:
+                    case WellKnownSynchronizationKind.MetadataReference:
                         return Checksum.Create(kind, _hostSerializationService.CreateChecksum((MetadataReference)value, cancellationToken));
 
-                    case WellKnownSynchronizationKinds.AnalyzerReference:
+                    case WellKnownSynchronizationKind.AnalyzerReference:
                         return Checksum.Create(kind, _hostSerializationService.CreateChecksum((AnalyzerReference)value, cancellationToken));
 
-                    case WellKnownSynchronizationKinds.SourceText:
+                    case WellKnownSynchronizationKind.SourceText:
                         return Checksum.Create(kind, ((SourceText)value).GetChecksum());
 
                     default:
@@ -104,37 +104,37 @@ namespace Microsoft.CodeAnalysis.Serialization
 
                 switch (kind)
                 {
-                    case WellKnownSynchronizationKinds.Null:
+                    case WellKnownSynchronizationKind.Null:
                         // do nothing
                         return;
 
-                    case WellKnownSynchronizationKinds.SolutionAttributes:
-                    case WellKnownSynchronizationKinds.ProjectAttributes:
-                    case WellKnownSynchronizationKinds.DocumentAttributes:
+                    case WellKnownSynchronizationKind.SolutionAttributes:
+                    case WellKnownSynchronizationKind.ProjectAttributes:
+                    case WellKnownSynchronizationKind.DocumentAttributes:
                         ((IObjectWritable)value).WriteTo(writer);
                         return;
 
-                    case WellKnownSynchronizationKinds.CompilationOptions:
+                    case WellKnownSynchronizationKind.CompilationOptions:
                         SerializeCompilationOptions((CompilationOptions)value, writer, cancellationToken);
                         return;
 
-                    case WellKnownSynchronizationKinds.ParseOptions:
+                    case WellKnownSynchronizationKind.ParseOptions:
                         SerializeParseOptions((ParseOptions)value, writer, cancellationToken);
                         return;
 
-                    case WellKnownSynchronizationKinds.ProjectReference:
+                    case WellKnownSynchronizationKind.ProjectReference:
                         SerializeProjectReference((ProjectReference)value, writer, cancellationToken);
                         return;
 
-                    case WellKnownSynchronizationKinds.MetadataReference:
+                    case WellKnownSynchronizationKind.MetadataReference:
                         SerializeMetadataReference((MetadataReference)value, writer, cancellationToken);
                         return;
 
-                    case WellKnownSynchronizationKinds.AnalyzerReference:
+                    case WellKnownSynchronizationKind.AnalyzerReference:
                         SerializeAnalyzerReference((AnalyzerReference)value, writer, usePathFromAssembly: true, cancellationToken: cancellationToken);
                         return;
 
-                    case WellKnownSynchronizationKinds.SourceText:
+                    case WellKnownSynchronizationKind.SourceText:
                         SerializeSourceText(storage: null, text: (SourceText)value, writer: writer, cancellationToken: cancellationToken);
                         return;
 
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             }
         }
 
-        public T Deserialize<T>(WellKnownSynchronizationKinds kind, ObjectReader reader, CancellationToken cancellationToken)
+        public T Deserialize<T>(WellKnownSynchronizationKind kind, ObjectReader reader, CancellationToken cancellationToken)
         {
             using (Logger.LogBlock(FunctionId.Serializer_Deserialize, kind.ToString(), cancellationToken))
             {
@@ -154,39 +154,39 @@ namespace Microsoft.CodeAnalysis.Serialization
 
                 switch (kind)
                 {
-                    case WellKnownSynchronizationKinds.Null:
+                    case WellKnownSynchronizationKind.Null:
                         return default(T);
 
-                    case WellKnownSynchronizationKinds.SolutionState:
-                    case WellKnownSynchronizationKinds.ProjectState:
-                    case WellKnownSynchronizationKinds.DocumentState:
-                    case WellKnownSynchronizationKinds.Projects:
-                    case WellKnownSynchronizationKinds.Documents:
-                    case WellKnownSynchronizationKinds.TextDocuments:
-                    case WellKnownSynchronizationKinds.ProjectReferences:
-                    case WellKnownSynchronizationKinds.MetadataReferences:
-                    case WellKnownSynchronizationKinds.AnalyzerReferences:
+                    case WellKnownSynchronizationKind.SolutionState:
+                    case WellKnownSynchronizationKind.ProjectState:
+                    case WellKnownSynchronizationKind.DocumentState:
+                    case WellKnownSynchronizationKind.Projects:
+                    case WellKnownSynchronizationKind.Documents:
+                    case WellKnownSynchronizationKind.TextDocuments:
+                    case WellKnownSynchronizationKind.ProjectReferences:
+                    case WellKnownSynchronizationKind.MetadataReferences:
+                    case WellKnownSynchronizationKind.AnalyzerReferences:
                         return (T)(object)DeserializeChecksumWithChildren(reader, cancellationToken);
 
-                    case WellKnownSynchronizationKinds.SolutionAttributes:
+                    case WellKnownSynchronizationKind.SolutionAttributes:
                         return (T)(object)SolutionInfo.SolutionAttributes.ReadFrom(reader);
-                    case WellKnownSynchronizationKinds.ProjectAttributes:
+                    case WellKnownSynchronizationKind.ProjectAttributes:
                         return (T)(object)ProjectInfo.ProjectAttributes.ReadFrom(reader);
-                    case WellKnownSynchronizationKinds.DocumentAttributes:
+                    case WellKnownSynchronizationKind.DocumentAttributes:
                         return (T)(object)DocumentInfo.DocumentAttributes.ReadFrom(reader);
-                    case WellKnownSynchronizationKinds.CompilationOptions:
+                    case WellKnownSynchronizationKind.CompilationOptions:
                         return (T)(object)DeserializeCompilationOptions(reader, cancellationToken);
-                    case WellKnownSynchronizationKinds.ParseOptions:
+                    case WellKnownSynchronizationKind.ParseOptions:
                         return (T)(object)DeserializeParseOptions(reader, cancellationToken);
-                    case WellKnownSynchronizationKinds.ProjectReference:
+                    case WellKnownSynchronizationKind.ProjectReference:
                         return (T)(object)DeserializeProjectReference(reader, cancellationToken);
-                    case WellKnownSynchronizationKinds.MetadataReference:
+                    case WellKnownSynchronizationKind.MetadataReference:
                         return (T)(object)DeserializeMetadataReference(reader, cancellationToken);
-                    case WellKnownSynchronizationKinds.AnalyzerReference:
+                    case WellKnownSynchronizationKind.AnalyzerReference:
                         return (T)(object)DeserializeAnalyzerReference(reader, cancellationToken);
-                    case WellKnownSynchronizationKinds.SourceText:
+                    case WellKnownSynchronizationKind.SourceText:
                         return (T)(object)DeserializeSourceText(reader, cancellationToken);
-                    case WellKnownSynchronizationKinds.OptionSet:
+                    case WellKnownSynchronizationKind.OptionSet:
                         return (T)(object)DeserializeOptionSet(reader, cancellationToken);
 
                     default:

--- a/src/Workspaces/Core/Portable/Execution/Serializer.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
             var kind = value.GetWellKnownSynchronizationKind();
 
-            using (Logger.LogBlock(FunctionId.Serializer_CreateChecksum, kind, cancellationToken))
+            using (Logger.LogBlock(FunctionId.Serializer_CreateChecksum, kind.ToString(), cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
             var kind = value.GetWellKnownSynchronizationKind();
 
-            using (Logger.LogBlock(FunctionId.Serializer_Serialize, kind, cancellationToken))
+            using (Logger.LogBlock(FunctionId.Serializer_Serialize, kind.ToString(), cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -146,9 +146,9 @@ namespace Microsoft.CodeAnalysis.Serialization
             }
         }
 
-        public T Deserialize<T>(string kind, ObjectReader reader, CancellationToken cancellationToken)
+        public T Deserialize<T>(WellKnownSynchronizationKinds kind, ObjectReader reader, CancellationToken cancellationToken)
         {
-            using (Logger.LogBlock(FunctionId.Serializer_Deserialize, kind, cancellationToken))
+            using (Logger.LogBlock(FunctionId.Serializer_Deserialize, kind.ToString(), cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Workspaces/Core/Portable/Execution/Serializer.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
             var kind = value.GetWellKnownSynchronizationKind();
 
-            using (Logger.LogBlock(FunctionId.Serializer_CreateChecksum, kind.ToString(), cancellationToken))
+            using (Logger.LogBlock(FunctionId.Serializer_CreateChecksum, kind.ToStringFast(), cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Workspaces/Core/Portable/Execution/Serializer_ChecksumWithChildren.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer_ChecksumWithChildren.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         private const byte ChecksumKind = 0;
         private const byte ChecksumWithChildrenKind = 1;
 
-        private static readonly ImmutableDictionary<WellKnownSynchronizationKinds, Func<object[], ChecksumWithChildren>> s_creatorMap = CreateCreatorMap();
+        private static readonly ImmutableDictionary<WellKnownSynchronizationKind, Func<object[], ChecksumWithChildren>> s_creatorMap = CreateCreatorMap();
 
         public void SerializeChecksumWithChildren(ChecksumWithChildren checksums, ObjectWriter writer, CancellationToken cancellationToken)
         {
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var kind = (WellKnownSynchronizationKinds)reader.ReadInt32();
+            var kind = (WellKnownSynchronizationKind)reader.ReadInt32();
             var checksum = Checksum.ReadFrom(reader);
 
             var childrenCount = reader.ReadInt32();
@@ -84,18 +84,18 @@ namespace Microsoft.CodeAnalysis.Serialization
             return checksums;
         }
 
-        private static ImmutableDictionary<WellKnownSynchronizationKinds, Func<object[], ChecksumWithChildren>> CreateCreatorMap()
+        private static ImmutableDictionary<WellKnownSynchronizationKind, Func<object[], ChecksumWithChildren>> CreateCreatorMap()
         {
-            return ImmutableDictionary<WellKnownSynchronizationKinds, Func<object[], ChecksumWithChildren>>.Empty
-                .Add(WellKnownSynchronizationKinds.SolutionState, children => new SolutionStateChecksums(children))
-                .Add(WellKnownSynchronizationKinds.ProjectState, children => new ProjectStateChecksums(children))
-                .Add(WellKnownSynchronizationKinds.DocumentState, children => new DocumentStateChecksums(children))
-                .Add(WellKnownSynchronizationKinds.Projects, children => new ProjectChecksumCollection(children))
-                .Add(WellKnownSynchronizationKinds.Documents, children => new DocumentChecksumCollection(children))
-                .Add(WellKnownSynchronizationKinds.TextDocuments, children => new TextDocumentChecksumCollection(children))
-                .Add(WellKnownSynchronizationKinds.ProjectReferences, children => new ProjectReferenceChecksumCollection(children))
-                .Add(WellKnownSynchronizationKinds.MetadataReferences, children => new MetadataReferenceChecksumCollection(children))
-                .Add(WellKnownSynchronizationKinds.AnalyzerReferences, children => new AnalyzerReferenceChecksumCollection(children));
+            return ImmutableDictionary<WellKnownSynchronizationKind, Func<object[], ChecksumWithChildren>>.Empty
+                .Add(WellKnownSynchronizationKind.SolutionState, children => new SolutionStateChecksums(children))
+                .Add(WellKnownSynchronizationKind.ProjectState, children => new ProjectStateChecksums(children))
+                .Add(WellKnownSynchronizationKind.DocumentState, children => new DocumentStateChecksums(children))
+                .Add(WellKnownSynchronizationKind.Projects, children => new ProjectChecksumCollection(children))
+                .Add(WellKnownSynchronizationKind.Documents, children => new DocumentChecksumCollection(children))
+                .Add(WellKnownSynchronizationKind.TextDocuments, children => new TextDocumentChecksumCollection(children))
+                .Add(WellKnownSynchronizationKind.ProjectReferences, children => new ProjectReferenceChecksumCollection(children))
+                .Add(WellKnownSynchronizationKind.MetadataReferences, children => new MetadataReferenceChecksumCollection(children))
+                .Add(WellKnownSynchronizationKind.AnalyzerReferences, children => new AnalyzerReferenceChecksumCollection(children));
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/Serializer_ChecksumWithChildren.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer_ChecksumWithChildren.cs
@@ -17,14 +17,14 @@ namespace Microsoft.CodeAnalysis.Serialization
         private const byte ChecksumKind = 0;
         private const byte ChecksumWithChildrenKind = 1;
 
-        private static readonly ImmutableDictionary<string, Func<object[], ChecksumWithChildren>> s_creatorMap = CreateCreatorMap();
+        private static readonly ImmutableDictionary<WellKnownSynchronizationKinds, Func<object[], ChecksumWithChildren>> s_creatorMap = CreateCreatorMap();
 
         public void SerializeChecksumWithChildren(ChecksumWithChildren checksums, ObjectWriter writer, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var kind = checksums.GetWellKnownSynchronizationKind();
-            writer.WriteString(kind);
+            writer.WriteInt32((int)kind);
             checksums.Checksum.WriteTo(writer);
 
             writer.WriteInt32(checksums.Children.Count);
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var kind = reader.ReadString();
+            var kind = (WellKnownSynchronizationKinds)reader.ReadInt32();
             var checksum = Checksum.ReadFrom(reader);
 
             var childrenCount = reader.ReadInt32();
@@ -84,9 +84,9 @@ namespace Microsoft.CodeAnalysis.Serialization
             return checksums;
         }
 
-        private static ImmutableDictionary<string, Func<object[], ChecksumWithChildren>> CreateCreatorMap()
+        private static ImmutableDictionary<WellKnownSynchronizationKinds, Func<object[], ChecksumWithChildren>> CreateCreatorMap()
         {
-            return ImmutableDictionary<string, Func<object[], ChecksumWithChildren>>.Empty
+            return ImmutableDictionary<WellKnownSynchronizationKinds, Func<object[], ChecksumWithChildren>>.Empty
                 .Add(WellKnownSynchronizationKinds.SolutionState, children => new SolutionStateChecksums(children))
                 .Add(WellKnownSynchronizationKinds.ProjectState, children => new ProjectStateChecksums(children))
                 .Add(WellKnownSynchronizationKinds.DocumentState, children => new DocumentStateChecksums(children))

--- a/src/Workspaces/Core/Portable/Execution/SolutionAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/SolutionAsset.cs
@@ -13,7 +13,8 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal abstract class SolutionAsset : RemotableData
     {
-        protected SolutionAsset(Checksum checksum, string kind) : base(checksum, kind)
+        protected SolutionAsset(Checksum checksum, WellKnownSynchronizationKinds kind) 
+            : base(checksum, kind)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Execution/SolutionAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/SolutionAsset.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal abstract class SolutionAsset : RemotableData
     {
-        protected SolutionAsset(Checksum checksum, WellKnownSynchronizationKinds kind) 
+        protected SolutionAsset(Checksum checksum, WellKnownSynchronizationKind kind) 
             : base(checksum, kind)
         {
         }
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Execution
             private readonly Serializer _serializer;
 
             public SourceTextAsset(Checksum checksum, TextDocumentState state, Serializer serializer) :
-                base(checksum, WellKnownSynchronizationKinds.SourceText)
+                base(checksum, WellKnownSynchronizationKind.SourceText)
             {
                 _state = state;
                 _serializer = serializer;

--- a/src/Workspaces/Core/Portable/Execution/WellKnownSynchronizationKind.cs
+++ b/src/Workspaces/Core/Portable/Execution/WellKnownSynchronizationKind.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
+using System.Reflection;
+
 namespace Microsoft.CodeAnalysis.Serialization
 {
     // TODO: Kind might not actually needed. see whether we can get rid of this
@@ -46,5 +49,36 @@ namespace Microsoft.CodeAnalysis.Serialization
         SolutionStateChecksums,
         ProjectStateChecksums,
         DocumentStateChecksums,
+    }
+
+    internal static class WellKnownSynchronizationKindExtensions
+    {
+        private static readonly string[] s_strings;
+
+        static WellKnownSynchronizationKindExtensions()
+        {
+            var fields = typeof(WellKnownSynchronizationKind).GetTypeInfo().DeclaredFields.Where(f => f.IsStatic);
+
+            var maxValue = 0;
+            foreach (var field in fields)
+            {
+                var value = (int)field.GetValue(null);
+                if (value > maxValue)
+                {
+                    maxValue = value;
+                }
+            }
+
+            s_strings = new string[maxValue + 1];
+
+            foreach (var field in fields)
+            {
+                var value = (int)field.GetValue(null);
+                s_strings[value] = field.Name;
+            }
+        }
+
+        public static string ToStringFast(this WellKnownSynchronizationKind kind)
+            => s_strings[(int)kind];
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/WellKnownSynchronizationKind.cs
+++ b/src/Workspaces/Core/Portable/Execution/WellKnownSynchronizationKind.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.CodeAnalysis.Serialization
 {
     // TODO: Kind might not actually needed. see whether we can get rid of this
-    internal enum WellKnownSynchronizationKinds
+    internal enum WellKnownSynchronizationKind
     {
         Null,
 

--- a/src/Workspaces/Core/Portable/Execution/WellKnownSynchronizationKind.cs
+++ b/src/Workspaces/Core/Portable/Execution/WellKnownSynchronizationKind.cs
@@ -59,16 +59,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
             var fields = typeof(WellKnownSynchronizationKind).GetTypeInfo().DeclaredFields.Where(f => f.IsStatic);
 
-            var maxValue = 0;
-            foreach (var field in fields)
-            {
-                var value = (int)field.GetValue(null);
-                if (value > maxValue)
-                {
-                    maxValue = value;
-                }
-            }
-
+            var maxValue = fields.Max(f => (int)f.GetValue(null));
             s_strings = new string[maxValue + 1];
 
             foreach (var field in fields)

--- a/src/Workspaces/Core/Portable/Execution/WellKnownSynchronizationKinds.cs
+++ b/src/Workspaces/Core/Portable/Execution/WellKnownSynchronizationKinds.cs
@@ -3,33 +3,48 @@
 namespace Microsoft.CodeAnalysis.Serialization
 {
     // TODO: Kind might not actually needed. see whether we can get rid of this
-    internal static class WellKnownSynchronizationKinds
+    internal enum WellKnownSynchronizationKinds
     {
-        public const string Null = nameof(Null);
+        Null,
 
-        public const string SolutionState = nameof(SolutionStateChecksums);
-        public const string ProjectState = nameof(ProjectStateChecksums);
-        public const string DocumentState = nameof(DocumentStateChecksums);
+        SolutionState,
+        ProjectState,
+        DocumentState,
 
-        public const string Projects = nameof(ProjectChecksumCollection);
-        public const string Documents = nameof(DocumentChecksumCollection);
-        public const string TextDocuments = nameof(TextDocumentChecksumCollection);
-        public const string ProjectReferences = nameof(ProjectReferenceChecksumCollection);
-        public const string MetadataReferences = nameof(MetadataReferenceChecksumCollection);
-        public const string AnalyzerReferences = nameof(AnalyzerReferenceChecksumCollection);
+        Projects,
+        Documents,
+        TextDocuments,
+        ProjectReferences,
+        MetadataReferences,
+        AnalyzerReferences,
 
-        public const string SolutionAttributes = nameof(SolutionInfo.SolutionAttributes);
-        public const string ProjectAttributes = nameof(ProjectInfo.ProjectAttributes);
-        public const string DocumentAttributes = nameof(DocumentInfo.DocumentAttributes);
+        SolutionAttributes,
+        ProjectAttributes,
+        DocumentAttributes,
 
-        public const string CompilationOptions = nameof(CompilationOptions);
-        public const string ParseOptions = nameof(ParseOptions);
-        public const string ProjectReference = nameof(ProjectReference);
-        public const string MetadataReference = nameof(MetadataReference);
-        public const string AnalyzerReference = nameof(AnalyzerReference);
-        public const string SourceText = nameof(SourceText);
-        public const string OptionSet = nameof(OptionSet);
+        CompilationOptions,
+        ParseOptions,
+        ProjectReference,
+        MetadataReference,
+        AnalyzerReference,
+        SourceText,
+        OptionSet,
 
-        public const string RecoverableSourceText = nameof(RecoverableSourceText);
+        RecoverableSourceText,
+
+        //
+
+        SyntaxTreeIndex,
+        SymbolTreeInfo,
+
+        ProjectReferenceChecksumCollection,
+        MetadataReferenceChecksumCollection,
+        AnalyzerReferenceChecksumCollection,
+        TextDocumentChecksumCollection,
+        DocumentChecksumCollection,
+        ProjectChecksumCollection,
+        SolutionStateChecksums,
+        ProjectStateChecksums,
+        DocumentStateChecksums,
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 allChecksums.Add(compilationOptionsChecksum);
                 allChecksums.Add(parseOptionsChecksum);
 
-                var checksum = Checksum.Create(nameof(SymbolTreeInfo), allChecksums);
+                var checksum = Checksum.Create(WellKnownSynchronizationKinds.SymbolTreeInfo, allChecksums);
                 return checksum;
             }
             finally

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 allChecksums.Add(compilationOptionsChecksum);
                 allChecksums.Add(parseOptionsChecksum);
 
-                var checksum = Checksum.Create(WellKnownSynchronizationKinds.SymbolTreeInfo, allChecksums);
+                var checksum = Checksum.Create(WellKnownSynchronizationKind.SymbolTreeInfo, allChecksums);
                 return checksum;
             }
             finally

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var parseOptionsChecksum = ChecksumCache.GetOrCreate(
                 parseOptions, _ => serializer.CreateChecksum(parseOptions, cancellationToken));
 
-            return Checksum.Create(nameof(SyntaxTreeIndex), new[] { textChecksum, parseOptionsChecksum });
+            return Checksum.Create(WellKnownSynchronizationKinds.SyntaxTreeIndex, new[] { textChecksum, parseOptionsChecksum });
         }
 
         private async Task<bool> SaveAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var parseOptionsChecksum = ChecksumCache.GetOrCreate(
                 parseOptions, _ => serializer.CreateChecksum(parseOptions, cancellationToken));
 
-            return Checksum.Create(WellKnownSynchronizationKinds.SyntaxTreeIndex, new[] { textChecksum, parseOptionsChecksum });
+            return Checksum.Create(WellKnownSynchronizationKind.SyntaxTreeIndex, new[] { textChecksum, parseOptionsChecksum });
         }
 
         private async Task<bool> SaveAsync(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
@@ -12,11 +12,11 @@ namespace Microsoft.CodeAnalysis.Serialization
     /// </summary>
     internal abstract class ChecksumCollection : ChecksumWithChildren, IEnumerable<Checksum>
     {
-        protected ChecksumCollection(WellKnownSynchronizationKinds kind, Checksum[] checksums) : this(kind, (object[])checksums)
+        protected ChecksumCollection(WellKnownSynchronizationKind kind, Checksum[] checksums) : this(kind, (object[])checksums)
         {
         }
 
-        protected ChecksumCollection(WellKnownSynchronizationKinds kind, object[] checksums) : base(kind, checksums)
+        protected ChecksumCollection(WellKnownSynchronizationKind kind, object[] checksums) : base(kind, checksums)
         {
         }
 
@@ -38,36 +38,36 @@ namespace Microsoft.CodeAnalysis.Serialization
     internal class ProjectChecksumCollection : ChecksumCollection
     {
         public ProjectChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public ProjectChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.ProjectChecksumCollection, checksums) { }
+        public ProjectChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKind.ProjectChecksumCollection, checksums) { }
     }
 
     internal class DocumentChecksumCollection : ChecksumCollection
     {
         public DocumentChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public DocumentChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.DocumentChecksumCollection, checksums) { }
+        public DocumentChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKind.DocumentChecksumCollection, checksums) { }
     }
 
     internal class TextDocumentChecksumCollection : ChecksumCollection
     {
         public TextDocumentChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public TextDocumentChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.TextDocumentChecksumCollection, checksums) { }
+        public TextDocumentChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKind.TextDocumentChecksumCollection, checksums) { }
     }
 
     internal class ProjectReferenceChecksumCollection : ChecksumCollection
     {
         public ProjectReferenceChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public ProjectReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.ProjectReferenceChecksumCollection, checksums) { }
+        public ProjectReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKind.ProjectReferenceChecksumCollection, checksums) { }
     }
 
     internal class MetadataReferenceChecksumCollection : ChecksumCollection
     {
         public MetadataReferenceChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public MetadataReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.MetadataReferenceChecksumCollection, checksums) { }
+        public MetadataReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKind.MetadataReferenceChecksumCollection, checksums) { }
     }
 
     internal class AnalyzerReferenceChecksumCollection : ChecksumCollection
     {
         public AnalyzerReferenceChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public AnalyzerReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.AnalyzerReferenceChecksumCollection, checksums) { }
+        public AnalyzerReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKind.AnalyzerReferenceChecksumCollection, checksums) { }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumCollection.cs
@@ -12,11 +12,11 @@ namespace Microsoft.CodeAnalysis.Serialization
     /// </summary>
     internal abstract class ChecksumCollection : ChecksumWithChildren, IEnumerable<Checksum>
     {
-        protected ChecksumCollection(string kind, Checksum[] checksums) : this(kind, (object[])checksums)
+        protected ChecksumCollection(WellKnownSynchronizationKinds kind, Checksum[] checksums) : this(kind, (object[])checksums)
         {
         }
 
-        protected ChecksumCollection(string kind, object[] checksums) : base(kind, checksums)
+        protected ChecksumCollection(WellKnownSynchronizationKinds kind, object[] checksums) : base(kind, checksums)
         {
         }
 
@@ -38,36 +38,36 @@ namespace Microsoft.CodeAnalysis.Serialization
     internal class ProjectChecksumCollection : ChecksumCollection
     {
         public ProjectChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public ProjectChecksumCollection(object[] checksums) : base(nameof(ProjectChecksumCollection), checksums) { }
+        public ProjectChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.ProjectChecksumCollection, checksums) { }
     }
 
     internal class DocumentChecksumCollection : ChecksumCollection
     {
         public DocumentChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public DocumentChecksumCollection(object[] checksums) : base(nameof(DocumentChecksumCollection), checksums) { }
+        public DocumentChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.DocumentChecksumCollection, checksums) { }
     }
 
     internal class TextDocumentChecksumCollection : ChecksumCollection
     {
         public TextDocumentChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public TextDocumentChecksumCollection(object[] checksums) : base(nameof(TextDocumentChecksumCollection), checksums) { }
+        public TextDocumentChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.TextDocumentChecksumCollection, checksums) { }
     }
 
     internal class ProjectReferenceChecksumCollection : ChecksumCollection
     {
         public ProjectReferenceChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public ProjectReferenceChecksumCollection(object[] checksums) : base(nameof(ProjectReferenceChecksumCollection), checksums) { }
+        public ProjectReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.ProjectReferenceChecksumCollection, checksums) { }
     }
 
     internal class MetadataReferenceChecksumCollection : ChecksumCollection
     {
         public MetadataReferenceChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public MetadataReferenceChecksumCollection(object[] checksums) : base(nameof(MetadataReferenceChecksumCollection), checksums) { }
+        public MetadataReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.MetadataReferenceChecksumCollection, checksums) { }
     }
 
     internal class AnalyzerReferenceChecksumCollection : ChecksumCollection
     {
         public AnalyzerReferenceChecksumCollection(Checksum[] checksums) : this((object[])checksums) { }
-        public AnalyzerReferenceChecksumCollection(object[] checksums) : base(nameof(AnalyzerReferenceChecksumCollection), checksums) { }
+        public AnalyzerReferenceChecksumCollection(object[] checksums) : base(WellKnownSynchronizationKinds.AnalyzerReferenceChecksumCollection, checksums) { }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumWithChildren.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumWithChildren.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Serialization
     /// </summary>
     internal abstract class ChecksumWithChildren : IChecksummedObject
     {
-        public ChecksumWithChildren(string kind, params object[] children)
+        public ChecksumWithChildren(WellKnownSynchronizationKinds kind, params object[] children)
         {
             Checksum = CreateChecksum(kind, children);
             Children = children;
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Serialization
 
         public IReadOnlyList<object> Children { get; }
 
-        private static Checksum CreateChecksum(string kind, object[] children)
+        private static Checksum CreateChecksum(WellKnownSynchronizationKinds kind, object[] children)
         {
             // given children must be either Checksum or Checksums (collection of a checksum)
             return Checksum.Create(kind, children.Select(c => c as Checksum ?? ((ChecksumCollection)c).Checksum));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumWithChildren.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ChecksumWithChildren.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Serialization
     /// </summary>
     internal abstract class ChecksumWithChildren : IChecksummedObject
     {
-        public ChecksumWithChildren(WellKnownSynchronizationKinds kind, params object[] children)
+        public ChecksumWithChildren(WellKnownSynchronizationKind kind, params object[] children)
         {
             Checksum = CreateChecksum(kind, children);
             Children = children;
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Serialization
 
         public IReadOnlyList<object> Children { get; }
 
-        private static Checksum CreateChecksum(WellKnownSynchronizationKinds kind, object[] children)
+        private static Checksum CreateChecksum(WellKnownSynchronizationKind kind, object[] children)
         {
             // given children must be either Checksum or Checksums (collection of a checksum)
             return Checksum.Create(kind, children.Select(c => c as Checksum ?? ((ChecksumCollection)c).Checksum));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static Checksum Create(WellKnownSynchronizationKinds kind, IObjectWritable @object)
+        public static Checksum Create(WellKnownSynchronizationKind kind, IObjectWritable @object)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var objectWriter = new ObjectWriter(stream))
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static Checksum Create(WellKnownSynchronizationKinds kind, IEnumerable<Checksum> checksums)
+        public static Checksum Create(WellKnownSynchronizationKind kind, IEnumerable<Checksum> checksums)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var writer = new ObjectWriter(stream))
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static Checksum Create(WellKnownSynchronizationKinds kind, ImmutableArray<byte> bytes)
+        public static Checksum Create(WellKnownSynchronizationKind kind, ImmutableArray<byte> bytes)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var writer = new ObjectWriter(stream))
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static Checksum Create<T>(WellKnownSynchronizationKinds kind, T value, Serializer serializer)
+        public static Checksum Create<T>(WellKnownSynchronizationKind kind, T value, Serializer serializer)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var objectWriter = new ObjectWriter(stream))

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum_Factory.cs
@@ -24,24 +24,24 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static Checksum Create(string kind, IObjectWritable @object)
+        public static Checksum Create(WellKnownSynchronizationKinds kind, IObjectWritable @object)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var objectWriter = new ObjectWriter(stream))
             {
-                objectWriter.WriteString(kind);
+                objectWriter.WriteInt32((int)kind);
                 @object.WriteTo(objectWriter);
 
                 return Create(stream);
             }
         }
 
-        public static Checksum Create(string kind, IEnumerable<Checksum> checksums)
+        public static Checksum Create(WellKnownSynchronizationKinds kind, IEnumerable<Checksum> checksums)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var writer = new ObjectWriter(stream))
             {
-                writer.WriteString(kind);
+                writer.WriteInt32((int)kind);
 
                 foreach (var checksum in checksums)
                 {
@@ -52,12 +52,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static Checksum Create(string kind, ImmutableArray<byte> bytes)
+        public static Checksum Create(WellKnownSynchronizationKinds kind, ImmutableArray<byte> bytes)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var writer = new ObjectWriter(stream))
             {
-                writer.WriteString(kind);
+                writer.WriteInt32((int)kind);
 
                 for (var i = 0; i < bytes.Length; i++)
                 {
@@ -68,12 +68,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public static Checksum Create<T>(string kind, T value, Serializer serializer)
+        public static Checksum Create<T>(WellKnownSynchronizationKinds kind, T value, Serializer serializer)
         {
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var objectWriter = new ObjectWriter(stream))
             {
-                objectWriter.WriteString(kind);
+                objectWriter.WriteInt32((int)kind);
                 serializer.Serialize(value, objectWriter, CancellationToken.None);
                 return Create(stream);
             }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -234,7 +235,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (_lazyChecksum == null)
                     {
-                        _lazyChecksum = Checksum.Create(nameof(DocumentAttributes), this);
+                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKinds.DocumentAttributes, this);
                     }
 
                     return _lazyChecksum;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentInfo.cs
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (_lazyChecksum == null)
                     {
-                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKinds.DocumentAttributes, this);
+                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKind.DocumentAttributes, this);
                     }
 
                     return _lazyChecksum;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -474,7 +475,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (_lazyChecksum == null)
                     {
-                        _lazyChecksum = Checksum.Create(nameof(ProjectAttributes), this);
+                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKinds.ProjectAttributes, this);
                     }
 
                     return _lazyChecksum;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectInfo.cs
@@ -475,7 +475,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (_lazyChecksum == null)
                     {
-                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKinds.ProjectAttributes, this);
+                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKind.ProjectAttributes, this);
                     }
 
                     return _lazyChecksum;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (_lazyChecksum == null)
                     {
-                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKinds.SolutionAttributes, this);
+                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKind.SolutionAttributes, this);
                     }
 
                     return _lazyChecksum;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionInfo.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -138,7 +139,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (_lazyChecksum == null)
                     {
-                        _lazyChecksum = Checksum.Create(nameof(SolutionAttributes), this);
+                        _lazyChecksum = Checksum.Create(WellKnownSynchronizationKinds.SolutionAttributes, this);
                     }
 
                     return _lazyChecksum;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
         }
 
-        public SolutionStateChecksums(params object[] children) : base(nameof(SolutionStateChecksums), children)
+        public SolutionStateChecksums(params object[] children) : base(WellKnownSynchronizationKinds.SolutionStateChecksums, children)
         {
         }
 
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
         }
 
-        public ProjectStateChecksums(params object[] children) : base(nameof(ProjectStateChecksums), children)
+        public ProjectStateChecksums(params object[] children) : base(WellKnownSynchronizationKinds.ProjectStateChecksums, children)
         {
         }
 
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
         }
 
-        public DocumentStateChecksums(params object[] children) : base(nameof(DocumentStateChecksums), children)
+        public DocumentStateChecksums(params object[] children) : base(WellKnownSynchronizationKinds.DocumentStateChecksums, children)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/StateChecksums.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
         }
 
-        public SolutionStateChecksums(params object[] children) : base(WellKnownSynchronizationKinds.SolutionStateChecksums, children)
+        public SolutionStateChecksums(params object[] children) : base(WellKnownSynchronizationKind.SolutionStateChecksums, children)
         {
         }
 
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
         }
 
-        public ProjectStateChecksums(params object[] children) : base(WellKnownSynchronizationKinds.ProjectStateChecksums, children)
+        public ProjectStateChecksums(params object[] children) : base(WellKnownSynchronizationKind.ProjectStateChecksums, children)
         {
         }
 
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
         }
 
-        public DocumentStateChecksums(params object[] children) : base(WellKnownSynchronizationKinds.DocumentStateChecksums, children)
+        public DocumentStateChecksums(params object[] children) : base(WellKnownSynchronizationKind.DocumentStateChecksums, children)
         {
         }
 

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -368,7 +368,7 @@
     <Compile Include="Execution\CustomAsset.cs" />
     <Compile Include="Execution\CustomAssetBuilder.cs" />
     <Compile Include="Execution\SolutionAsset.cs" />
-    <Compile Include="Execution\WellKnownSynchronizationKinds.cs" />
+    <Compile Include="Execution\WellKnownSynchronizationKind.cs" />
     <Compile Include="Experiments\IExperimentationService.cs" />
     <Compile Include="FindSymbols\Declarations\DeclarationFinder.cs" />
     <Compile Include="FindSymbols\Declarations\DeclarationFinder_AllDeclarations.cs" />

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTestBase.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTestBase.cs
@@ -111,8 +111,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         internal static async Task<T> VerifyAssetSerializationAsync<T>(
             ISolutionSynchronizationService service,
             Checksum checksum,
-            string kind,
-            Func<T, string, Serializer, RemotableData> assetGetter)
+            WellKnownSynchronizationKinds kind,
+            Func<T, WellKnownSynchronizationKinds, Serializer, RemotableData> assetGetter)
         {
             // re-create asset from object
             var syncService = (SolutionSynchronizationServiceFactory.Service)service;
@@ -219,7 +219,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             VerifyCollectionInService(snapshotService, projectObject.AdditionalDocuments.ToDocumentObjects(snapshotService), expectedAdditionalDocumentCount);
         }
 
-        internal static void VerifyCollectionInService(ISolutionSynchronizationService snapshotService, ChecksumCollection checksums, int expectedCount, string expectedItemKind)
+        internal static void VerifyCollectionInService(ISolutionSynchronizationService snapshotService, ChecksumCollection checksums, int expectedCount, WellKnownSynchronizationKinds expectedItemKind)
         {
             VerifyChecksumInService(snapshotService, checksums.Checksum, checksums.GetWellKnownSynchronizationKind());
             Assert.Equal(checksums.Count, expectedCount);
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             VerifyChecksumInService(snapshotService, syncObject.Checksum, syncObject.Kind);
         }
 
-        internal static void VerifyChecksumInService(ISolutionSynchronizationService snapshotService, Checksum checksum, string kind)
+        internal static void VerifyChecksumInService(ISolutionSynchronizationService snapshotService, Checksum checksum, WellKnownSynchronizationKinds kind)
         {
             Assert.NotNull(checksum);
             var otherObject = snapshotService.GetRemotableData(checksum, CancellationToken.None);
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             ChecksumEqual(checksumObject1.Checksum, checksumObject1.Kind, checksumObject2.Checksum, checksumObject2.Kind);
         }
 
-        internal static void ChecksumEqual(Checksum checksum1, string kind1, Checksum checksum2, string kind2)
+        internal static void ChecksumEqual(Checksum checksum1, WellKnownSynchronizationKinds kind1, Checksum checksum2, WellKnownSynchronizationKinds kind2)
         {
             Assert.Equal(checksum1, checksum2);
             Assert.Equal(kind1, kind2);

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTestBase.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTestBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         internal static async Task VerifyAssetAsync(ISolutionSynchronizationService service, SolutionStateChecksums solutionObject)
         {
             await VerifyAssetSerializationAsync<SolutionInfo.SolutionAttributes>(
-                service, solutionObject.Info, WellKnownSynchronizationKinds.SolutionAttributes,
+                service, solutionObject.Info, WellKnownSynchronizationKind.SolutionAttributes,
                 (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s)).ConfigureAwait(false);
 
             foreach (var projectChecksum in solutionObject.Projects)
@@ -52,15 +52,15 @@ namespace Microsoft.CodeAnalysis.UnitTests
         internal static async Task VerifyAssetAsync(ISolutionSynchronizationService service, ProjectStateChecksums projectObject)
         {
             var info = await VerifyAssetSerializationAsync<ProjectInfo.ProjectAttributes>(
-                service, projectObject.Info, WellKnownSynchronizationKinds.ProjectAttributes,
+                service, projectObject.Info, WellKnownSynchronizationKind.ProjectAttributes,
                 (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s)).ConfigureAwait(false);
 
             await VerifyAssetSerializationAsync<CompilationOptions>(
-                service, projectObject.CompilationOptions, WellKnownSynchronizationKinds.CompilationOptions,
+                service, projectObject.CompilationOptions, WellKnownSynchronizationKind.CompilationOptions,
                 (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s));
 
             await VerifyAssetSerializationAsync<ParseOptions>(
-                service, projectObject.ParseOptions, WellKnownSynchronizationKinds.ParseOptions,
+                service, projectObject.ParseOptions, WellKnownSynchronizationKind.ParseOptions,
                 (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s));
 
             foreach (var checksum in projectObject.Documents)
@@ -72,21 +72,21 @@ namespace Microsoft.CodeAnalysis.UnitTests
             foreach (var checksum in projectObject.ProjectReferences)
             {
                 await VerifyAssetSerializationAsync<ProjectReference>(
-                    service, checksum, WellKnownSynchronizationKinds.ProjectReference,
+                    service, checksum, WellKnownSynchronizationKind.ProjectReference,
                     (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s));
             }
 
             foreach (var checksum in projectObject.MetadataReferences)
             {
                 await VerifyAssetSerializationAsync<MetadataReference>(
-                    service, checksum, WellKnownSynchronizationKinds.MetadataReference,
+                    service, checksum, WellKnownSynchronizationKind.MetadataReference,
                     (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s));
             }
 
             foreach (var checksum in projectObject.AnalyzerReferences)
             {
                 await VerifyAssetSerializationAsync<AnalyzerReference>(
-                    service, checksum, WellKnownSynchronizationKinds.AnalyzerReference,
+                    service, checksum, WellKnownSynchronizationKind.AnalyzerReference,
                     (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s));
             }
 
@@ -100,19 +100,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
         internal static async Task VerifyAssetAsync(ISolutionSynchronizationService service, DocumentStateChecksums documentObject)
         {
             var info = await VerifyAssetSerializationAsync<DocumentInfo.DocumentAttributes>(
-                service, documentObject.Info, WellKnownSynchronizationKinds.DocumentAttributes,
+                service, documentObject.Info, WellKnownSynchronizationKind.DocumentAttributes,
                 (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s)).ConfigureAwait(false);
 
             await VerifyAssetSerializationAsync<SourceText>(
-                service, documentObject.Text, WellKnownSynchronizationKinds.SourceText,
+                service, documentObject.Text, WellKnownSynchronizationKind.SourceText,
                 (v, k, s) => SolutionAsset.Create(s.CreateChecksum(v, CancellationToken.None), v, s));
         }
 
         internal static async Task<T> VerifyAssetSerializationAsync<T>(
             ISolutionSynchronizationService service,
             Checksum checksum,
-            WellKnownSynchronizationKinds kind,
-            Func<T, WellKnownSynchronizationKinds, Serializer, RemotableData> assetGetter)
+            WellKnownSynchronizationKind kind,
+            Func<T, WellKnownSynchronizationKind, Serializer, RemotableData> assetGetter)
         {
             // re-create asset from object
             var syncService = (SolutionSynchronizationServiceFactory.Service)service;
@@ -206,20 +206,20 @@ namespace Microsoft.CodeAnalysis.UnitTests
             int expectedAdditionalDocumentCount)
         {
             VerifyChecksumInService(snapshotService, projectObject.Checksum, projectObject.GetWellKnownSynchronizationKind());
-            VerifyChecksumInService(snapshotService, projectObject.Info, WellKnownSynchronizationKinds.ProjectAttributes);
-            VerifyChecksumInService(snapshotService, projectObject.CompilationOptions, WellKnownSynchronizationKinds.CompilationOptions);
-            VerifyChecksumInService(snapshotService, projectObject.ParseOptions, WellKnownSynchronizationKinds.ParseOptions);
+            VerifyChecksumInService(snapshotService, projectObject.Info, WellKnownSynchronizationKind.ProjectAttributes);
+            VerifyChecksumInService(snapshotService, projectObject.CompilationOptions, WellKnownSynchronizationKind.CompilationOptions);
+            VerifyChecksumInService(snapshotService, projectObject.ParseOptions, WellKnownSynchronizationKind.ParseOptions);
 
             VerifyCollectionInService(snapshotService, projectObject.Documents.ToDocumentObjects(snapshotService), expectedDocumentCount);
 
-            VerifyCollectionInService(snapshotService, projectObject.ProjectReferences, expectedProjectReferenceCount, WellKnownSynchronizationKinds.ProjectReference);
-            VerifyCollectionInService(snapshotService, projectObject.MetadataReferences, expectedMetadataReferenceCount, WellKnownSynchronizationKinds.MetadataReference);
-            VerifyCollectionInService(snapshotService, projectObject.AnalyzerReferences, expectedAnalyzerReferenceCount, WellKnownSynchronizationKinds.AnalyzerReference);
+            VerifyCollectionInService(snapshotService, projectObject.ProjectReferences, expectedProjectReferenceCount, WellKnownSynchronizationKind.ProjectReference);
+            VerifyCollectionInService(snapshotService, projectObject.MetadataReferences, expectedMetadataReferenceCount, WellKnownSynchronizationKind.MetadataReference);
+            VerifyCollectionInService(snapshotService, projectObject.AnalyzerReferences, expectedAnalyzerReferenceCount, WellKnownSynchronizationKind.AnalyzerReference);
 
             VerifyCollectionInService(snapshotService, projectObject.AdditionalDocuments.ToDocumentObjects(snapshotService), expectedAdditionalDocumentCount);
         }
 
-        internal static void VerifyCollectionInService(ISolutionSynchronizationService snapshotService, ChecksumCollection checksums, int expectedCount, WellKnownSynchronizationKinds expectedItemKind)
+        internal static void VerifyCollectionInService(ISolutionSynchronizationService snapshotService, ChecksumCollection checksums, int expectedCount, WellKnownSynchronizationKind expectedItemKind)
         {
             VerifyChecksumInService(snapshotService, checksums.Checksum, checksums.GetWellKnownSynchronizationKind());
             Assert.Equal(checksums.Count, expectedCount);
@@ -244,8 +244,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         internal static void VerifySnapshotInService(ISolutionSynchronizationService snapshotService, DocumentStateChecksums documentObject)
         {
             VerifyChecksumInService(snapshotService, documentObject.Checksum, documentObject.GetWellKnownSynchronizationKind());
-            VerifyChecksumInService(snapshotService, documentObject.Info, WellKnownSynchronizationKinds.DocumentAttributes);
-            VerifyChecksumInService(snapshotService, documentObject.Text, WellKnownSynchronizationKinds.SourceText);
+            VerifyChecksumInService(snapshotService, documentObject.Info, WellKnownSynchronizationKind.DocumentAttributes);
+            VerifyChecksumInService(snapshotService, documentObject.Text, WellKnownSynchronizationKind.SourceText);
         }
 
         internal static void VerifySynchronizationObjectInService<T>(ISolutionSynchronizationService snapshotService, T syncObject) where T : RemotableData
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             VerifyChecksumInService(snapshotService, syncObject.Checksum, syncObject.Kind);
         }
 
-        internal static void VerifyChecksumInService(ISolutionSynchronizationService snapshotService, Checksum checksum, WellKnownSynchronizationKinds kind)
+        internal static void VerifyChecksumInService(ISolutionSynchronizationService snapshotService, Checksum checksum, WellKnownSynchronizationKind kind)
         {
             Assert.NotNull(checksum);
             var otherObject = snapshotService.GetRemotableData(checksum, CancellationToken.None);
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             ChecksumEqual(checksumObject1.Checksum, checksumObject1.Kind, checksumObject2.Checksum, checksumObject2.Kind);
         }
 
-        internal static void ChecksumEqual(Checksum checksum1, WellKnownSynchronizationKinds kind1, Checksum checksum2, WellKnownSynchronizationKinds kind2)
+        internal static void ChecksumEqual(Checksum checksum1, WellKnownSynchronizationKind kind1, Checksum checksum2, WellKnownSynchronizationKind kind2)
         {
             Assert.Equal(checksum1, checksum2);
             Assert.Equal(kind1, kind2);

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 VerifySynchronizationObjectInService(snapshotService, solutionSyncObject);
 
                 var solutionObject = await snapshotService.GetValueAsync<SolutionStateChecksums>(checksum).ConfigureAwait(false);
-                VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKinds.SolutionAttributes);
+                VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKind.SolutionAttributes);
 
                 var projectsSyncObject = snapshotService.GetRemotableData(solutionObject.Projects.Checksum, CancellationToken.None);
                 VerifySynchronizationObjectInService(snapshotService, projectsSyncObject);
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
                 var solutionObject = await snapshotService.GetValueAsync<SolutionStateChecksums>(checksum).ConfigureAwait(false);
 
-                VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKinds.SolutionAttributes);
+                VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKind.SolutionAttributes);
 
                 var projectSyncObject = snapshotService.GetRemotableData(solutionObject.Projects.Checksum, CancellationToken.None);
                 VerifySynchronizationObjectInService(snapshotService, projectSyncObject);
@@ -114,8 +114,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 var solutionObject = await snapshotService.GetValueAsync<SolutionStateChecksums>(syncObject.Checksum).ConfigureAwait(false);
 
                 VerifySynchronizationObjectInService(snapshotService, syncObject);
-                VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKinds.SolutionAttributes);
-                VerifyChecksumInService(snapshotService, solutionObject.Projects.Checksum, WellKnownSynchronizationKinds.Projects);
+                VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKind.SolutionAttributes);
+                VerifyChecksumInService(snapshotService, solutionObject.Projects.Checksum, WellKnownSynchronizationKind.Projects);
 
                 Assert.Equal(solutionObject.Projects.Count, 1);
                 VerifySnapshotInService(snapshotService, solutionObject.Projects.ToProjectObjects(snapshotService)[0], 1, 0, 0, 0, 0);
@@ -151,8 +151,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 var solutionObject = await snapshotService.GetValueAsync<SolutionStateChecksums>(syncObject.Checksum).ConfigureAwait(false);
 
                 VerifySynchronizationObjectInService(snapshotService, syncObject);
-                VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKinds.SolutionAttributes);
-                VerifyChecksumInService(snapshotService, solutionObject.Projects.Checksum, WellKnownSynchronizationKinds.Projects);
+                VerifyChecksumInService(snapshotService, solutionObject.Info, WellKnownSynchronizationKind.SolutionAttributes);
+                VerifyChecksumInService(snapshotService, solutionObject.Projects.Checksum, WellKnownSynchronizationKind.Projects);
 
                 Assert.Equal(solutionObject.Projects.Count, 2);
 

--- a/src/Workspaces/Remote/Core/Services/AssetService.cs
+++ b/src/Workspaces/Remote/Core/Services/AssetService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Remote
             _assetStorage = assetStorage;
         }
 
-        public T Deserialize<T>(string kind, ObjectReader reader, CancellationToken cancellationToken)
+        public T Deserialize<T>(WellKnownSynchronizationKinds kind, ObjectReader reader, CancellationToken cancellationToken)
         {
             return s_serializer.Deserialize<T>(kind, reader, cancellationToken);
         }

--- a/src/Workspaces/Remote/Core/Services/AssetService.cs
+++ b/src/Workspaces/Remote/Core/Services/AssetService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Remote
             _assetStorage = assetStorage;
         }
 
-        public T Deserialize<T>(WellKnownSynchronizationKinds kind, ObjectReader reader, CancellationToken cancellationToken)
+        public T Deserialize<T>(WellKnownSynchronizationKind kind, ObjectReader reader, CancellationToken cancellationToken)
         {
             return s_serializer.Deserialize<T>(kind, reader, cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
@@ -73,7 +73,7 @@ This data should always be correct as we're never persisting the data between se
                         var responseChecksum = Checksum.ReadFrom(reader);
                         Contract.ThrowIfFalse(checksums.Contains(responseChecksum));
 
-                        var kind = (WellKnownSynchronizationKinds)reader.ReadInt32();
+                        var kind = (WellKnownSynchronizationKind)reader.ReadInt32();
 
                         // in service hub, cancellation means simply closed stream
                         var @object = _owner.RoslynServices.AssetService.Deserialize<object>(kind, reader, cancellationToken);

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 using RoslynLogger = Microsoft.CodeAnalysis.Internal.Log.Logger;
 
@@ -72,7 +73,7 @@ This data should always be correct as we're never persisting the data between se
                         var responseChecksum = Checksum.ReadFrom(reader);
                         Contract.ThrowIfFalse(checksums.Contains(responseChecksum));
 
-                        var kind = reader.ReadString();
+                        var kind = (WellKnownSynchronizationKinds)reader.ReadInt32();
 
                         // in service hub, cancellation means simply closed stream
                         var @object = _owner.RoslynServices.AssetService.Deserialize<object>(kind, reader, cancellationToken);


### PR DESCRIPTION
Switch to using an enum to represent serialization kinds instead of a string.  Strings add more cost to transmitting data, computing hashes, and doing dispatch in our code.  I found that several percent of the time in OOP asset sync was just doing work on these strings.
