### PR TITLE
Various loose ends in preparation for merging refout feature

### DIFF
--- a/docs/features/refout.md
+++ b/docs/features/refout.md
@@ -37,11 +37,10 @@ The `/refout` parameter specifies a file path where the ref assembly should be o
 The `/refonly` parameter is a flag that indicates that a ref assembly should be output instead of an implementation assembly. 
 The `/refonly` parameter is not allowed together with the `/refout` parameter, as it doesn't make sense to have both the primary and secondary outputs be ref assemblies. Also, the `/refonly` parameter silently disables outputting PDBs, as ref assemblies cannot be executed. 
 The `/refonly` parameter translates to `EmitMetadataOnly` being `true`, and `IncludePrivateMembers` being `false` in the `Emit` API (see details below).
-Neither `/refonly` nor `/refout` are permitted with `/target:module` or `/addmodule` options.
-
-When the compiler produces documentation, the contents produced will match the APIs that go into the primary output. In other words, the documentation will be filtered down when using the `/refonly` parameter.
+Neither `/refonly` nor `/refout` are permitted with `/target:module`, `/addmodule`, or `/link:...` options.
 
 The compilation from the command-line will either produce both assemblies (implementation and ref) or neither. There is no "partial success" scenario.
+When the compiler produces documentation, it is un-affected by either the `/refonly` or `/refout` parameters.
 
 ### CscTask/CoreCompile
 The `CoreCompile` target will support a new output, called `IntermediateRefAssembly`, which parallels the existing `IntermediateAssembly`.
@@ -65,8 +64,10 @@ Going back to the 4 driving scenarios:
 
 ## Future
 As mentioned above, there may be further refinements after C# 7.1:
-- controlling internals (producing public ref assemblies)
-- produce ref assemblies even when there are errors outside method bodies (emitting error types when `EmitOptions.TolerateErrors` is set)
+- Controlling internals (producing public ref assemblies)
+- Produce ref assemblies even when there are errors outside method bodies (emitting error types when `EmitOptions.TolerateErrors` is set)
+- When the compiler produces documentation, the contents produced could be filtered down to match the APIs that go into the primary output. In other words, the documentation could be filtered down when using the `/refonly` parameter.
+
 
 ## Open questions
 - should explicit method implementations be included in ref assemblies?

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6731,6 +6731,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot embed types when using /refout or /refonly..
+        /// </summary>
+        internal static string ERR_NoEmbeddedTypeWhenRefOutOrRefOnly {
+            get {
+                return ResourceManager.GetString("ERR_NoEmbeddedTypeWhenRefOutOrRefOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Program does not contain a static &apos;Main&apos; method suitable for an entry point.
         /// </summary>
         internal static string ERR_NoEntryPoint {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2300,6 +2300,9 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_NoNetModuleOutputWhenRefOutOrRefOnly" xml:space="preserve">
     <value>Cannot compile net modules when using /refout or /refonly.</value>
   </data>
+  <data name="ERR_NoEmbeddedTypeWhenRefOutOrRefOnly" xml:space="preserve">
+    <value>Cannot embed types when using /refout or /refonly.</value>
+  </data>
   <data name="ERR_OvlOperatorExpected" xml:space="preserve">
     <value>Overloadable operator expected</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1178,7 +1178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AddDiagnostic(diagnostics, diagnosticOptions, ErrorCode.ERR_NoRefOutWhenRefOnly);
             }
 
-            if (metadataReferences.Any(r => r.Properties.EmbedInteropTypes) && (refOnly || outputRefFilePath != null))
+            if ((refOnly || outputRefFilePath != null) && metadataReferences.Any(r => r.Properties.EmbedInteropTypes))
             {
                 AddDiagnostic(diagnostics, diagnosticOptions, ErrorCode.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly);
             }

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1178,6 +1178,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AddDiagnostic(diagnostics, diagnosticOptions, ErrorCode.ERR_NoRefOutWhenRefOnly);
             }
 
+            if (metadataReferences.Any(r => r.Properties.EmbedInteropTypes) && (refOnly || outputRefFilePath != null))
+            {
+                AddDiagnostic(diagnostics, diagnosticOptions, ErrorCode.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly);
+            }
+
             if (outputKind == OutputKind.NetModule && (refOnly || outputRefFilePath != null))
             {
                 AddDiagnostic(diagnostics, diagnosticOptions, ErrorCode.ERR_NoNetModuleOutputWhenRefOutOrRefOnly);

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -325,7 +325,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             foreach (var member in this.GetMembers())
             {
-                // PROTOTYPE(refout) Do something here?
                 if (member.Kind == SymbolKind.Method)
                 {
                     var method = (MethodSymbol)member;

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1478,6 +1478,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_NoRefOutWhenRefOnly = 8355,
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 8356,
+        ERR_NoEmbeddedTypeWhenRefOutOrRefOnly = 8357,
 
         ERR_BadDynamicMethodArgDefaultLiteral = 9000,
         ERR_DefaultLiteralNotValid = 9001,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1476,12 +1476,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         WRN_Experimental = 8305,
         ERR_TupleInferredNamesNotAvailable = 8306,
 
-        ERR_NoRefOutWhenRefOnly = 8355,
-        ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 8356,
-        ERR_NoEmbeddedTypeWhenRefOutOrRefOnly = 8357,
+        ERR_NoRefOutWhenRefOnly = 8307,
+        ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 8308,
+        ERR_NoEmbeddedTypeWhenRefOutOrRefOnly = 8309,
 
-        ERR_BadDynamicMethodArgDefaultLiteral = 9000,
-        ERR_DefaultLiteralNotValid = 9001,
-        WRN_DefaultInSwitch = 9002,
+        ERR_BadDynamicMethodArgDefaultLiteral = 8310,
+        ERR_DefaultLiteralNotValid = 8311,
+        WRN_DefaultInSwitch = 8312,
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -261,11 +261,11 @@ public class C
                 emitResult.Diagnostics.Verify();
 
                 VerifyEntryPoint(output, expectZero: false);
-                VerifyMethods(output, new[] { "void C.Main()", "C..ctor()" });
+                VerifyMethods(output, "C", new[] { "void C.Main()", "C..ctor()" });
                 VerifyMvid(output, hasMvidSection: false);
 
                 VerifyEntryPoint(metadataOutput, expectZero: true);
-                VerifyMethods(metadataOutput, new[] { "C..ctor()" });
+                VerifyMethods(metadataOutput, "C", new[] { "C..ctor()" });
                 VerifyMvid(metadataOutput, hasMvidSection: true);
             }
 
@@ -399,9 +399,9 @@ public class C
                 Assert.True(emitResult.Success);
                 emitResult.Diagnostics.Verify();
 
-                VerifyMethods(output, new[] { "System.Int32 C.<PrivateSetter>k__BackingField", "System.Int32 C.PrivateSetter.get", "void C.PrivateSetter.set",
+                VerifyMethods(output, "C", new[] { "System.Int32 C.<PrivateSetter>k__BackingField", "System.Int32 C.PrivateSetter.get", "void C.PrivateSetter.set",
                     "C..ctor()", "System.Int32 C.PrivateSetter { get; private set; }" });
-                VerifyMethods(metadataOutput, new[] { "System.Int32 C.PrivateSetter.get", "C..ctor()", "System.Int32 C.PrivateSetter { get; }" });
+                VerifyMethods(metadataOutput, "C", new[] { "System.Int32 C.PrivateSetter.get", "C..ctor()", "System.Int32 C.PrivateSetter { get; }" });
                 VerifyMvid(output, hasMvidSection: false);
                 VerifyMvid(metadataOutput, hasMvidSection: true);
             }
@@ -425,9 +425,9 @@ public class C
                 Assert.True(emitResult.Success);
                 emitResult.Diagnostics.Verify();
 
-                VerifyMethods(output, new[] { "System.Int32 C.<PrivateGetter>k__BackingField", "System.Int32 C.PrivateGetter.get", "void C.PrivateGetter.set",
+                VerifyMethods(output, "C", new[] { "System.Int32 C.<PrivateGetter>k__BackingField", "System.Int32 C.PrivateGetter.get", "void C.PrivateGetter.set",
                     "C..ctor()", "System.Int32 C.PrivateGetter { private get; set; }" });
-                VerifyMethods(metadataOutput, new[] { "void C.PrivateGetter.set", "C..ctor()", "System.Int32 C.PrivateGetter { set; }" });
+                VerifyMethods(metadataOutput, "C", new[] { "void C.PrivateGetter.set", "C..ctor()", "System.Int32 C.PrivateGetter { set; }" });
             }
         }
 
@@ -449,9 +449,9 @@ public class C
                 Assert.True(emitResult.Success);
                 emitResult.Diagnostics.Verify();
 
-                VerifyMethods(output, new[] { "System.Int32 C.this[System.Int32 i].get", "void C.this[System.Int32 i].set",
+                VerifyMethods(output, "C", new[] { "System.Int32 C.this[System.Int32 i].get", "void C.this[System.Int32 i].set",
                     "C..ctor()", "System.Int32 C.this[System.Int32 i] { private get; set; }" });
-                VerifyMethods(metadataOutput, new[] { "void C.this[System.Int32 i].set", "C..ctor()",
+                VerifyMethods(metadataOutput, "C", new[] { "void C.this[System.Int32 i].set", "C..ctor()",
                     "System.Int32 C.this[System.Int32 i] { set; }" });
             }
         }
@@ -478,9 +478,9 @@ public class C : Base
                 emitResult.Diagnostics.Verify();
                 Assert.True(emitResult.Success);
 
-                VerifyMethods(output, new[] { "void C.Property.set", "C..ctor()", "System.Int32 C.Property.get", "System.Int32 C.Property { internal get; set; }" });
+                VerifyMethods(output, "C", new[] { "void C.Property.set", "C..ctor()", "System.Int32 C.Property.get", "System.Int32 C.Property { internal get; set; }" });
                 // A getter is synthesized on C.Property so that it can be marked as sealed. It is emitted despite being internal because it is virtual.
-                VerifyMethods(metadataOutput, new[] {  "void C.Property.set", "C..ctor()", "System.Int32 C.Property.get", "System.Int32 C.Property { internal get; set; }" });
+                VerifyMethods(metadataOutput, "C", new[] {  "void C.Property.set", "C..ctor()", "System.Int32 C.Property.get", "System.Int32 C.Property { internal get; set; }" });
             }
         }
 
@@ -504,7 +504,7 @@ public class C
                 );
         }
 
-        private static void VerifyMethods(MemoryStream stream, string[] expectedMethods)
+        private static void VerifyMethods(MemoryStream stream, string containingType, string[] expectedMethods)
         {
             stream.Position = 0;
             var metadataRef = AssemblyMetadata.CreateFromImage(stream.ToArray()).GetReference();
@@ -514,7 +514,7 @@ public class C
 
             AssertEx.Equal(
                 expectedMethods,
-                compWithMetadata.GetMember<NamedTypeSymbol>("C").GetMembers().Select(m => m.ToTestDisplayString()));
+                compWithMetadata.GetMember<NamedTypeSymbol>(containingType).GetMembers().Select(m => m.ToTestDisplayString()));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1057,7 +1057,7 @@ public class PublicClass
         }
 
         [Fact]
-        public void EmitMetadata_AllowEmbedding()
+        public void RefAssembly_AllowEmbeddingPdb()
         {
             CSharpCompilation comp = CreateCompilation("", references: new[] { MscorlibRef },
                 options: TestOptions.DebugDll);
@@ -1083,7 +1083,7 @@ public class PublicClass
         }
 
         [Fact]
-        public void EmitMetadataOnly_DisallowEmbedding()
+        public void EmitMetadataOnly_DisallowEmbeddingPdb()
         {
             CSharpCompilation comp = CreateCompilation("", references: new[] { MscorlibRef },
                 options: TestOptions.DebugDll);
@@ -1094,6 +1094,32 @@ public class PublicClass
                     options: EmitOptions.Default.WithEmitMetadataOnly(true)
                         .WithDebugInformationFormat(DebugInformationFormat.Embedded)));
             }
+        }
+
+        [Fact]
+        public void RefAssembly_DisallowEmbeddingTypes()
+        {
+            CSharpCompilation comp = CreateCompilation("", options: TestOptions.DebugDll,
+                references: new MetadataReference[]
+                {
+                    TestReferences.SymbolsTests.NoPia.GeneralPia.WithEmbedInteropTypes(true)
+                });
+
+            using (var output = new MemoryStream())
+            {
+                Assert.Throws<ArgumentException>(() => comp.Emit(output,
+                    options: EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false)));
+
+            }
+
+            using (var output = new MemoryStream())
+            using (var metadataOutput = new MemoryStream())
+            {
+                Assert.Throws<ArgumentException>(() => comp.Emit(output,
+                    metadataPEStream: metadataOutput,
+                    options: EmitOptions.Default.WithIncludePrivateMembers(false)));
+
+           }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -1434,7 +1434,7 @@ class C
 
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
-                // (7,14): error CS9000: Cannot use a default literal as an argument to a dynamically dispatched operation.
+                // (7,14): error CS8310: Cannot use a default literal as an argument to a dynamically dispatched operation.
                 //         d.M2(default);
                 Diagnostic(ErrorCode.ERR_BadDynamicMethodArgDefaultLiteral, "default").WithLocation(7, 14)
                 );
@@ -1524,7 +1524,7 @@ class C
 
             var comp = CreateStandardCompilation(text, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (6,27): error CS9001: Use of default literal is not valid in this context
+                // (6,27): error CS8311: Use of default literal is not valid in this context
                 //         foreach (int x in default) { }
                 Diagnostic(ErrorCode.ERR_DefaultLiteralNotValid, "default").WithLocation(6, 27),
                 // (7,27): error CS0186: Use of null is not valid in this context
@@ -1549,7 +1549,7 @@ static class C
 ";
             var compilation = CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.Regular7_1, references: new[] { SystemCoreRef });
             compilation.VerifyDiagnostics(
-                // (6,35): error CS9001: Use of default literal is not valid in this context
+                // (6,35): error CS8311: Use of default literal is not valid in this context
                 //         var q = from x in default select x;
                 Diagnostic(ErrorCode.ERR_DefaultLiteralNotValid, "select x").WithLocation(6, 35),
                 // (7,43): error CS1942: The type of the expression in the select clause is incorrect.  Type inference failed in the call to 'Select'.
@@ -1898,7 +1898,7 @@ class C
 
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (12,18): warning CS9002: Did you mean to use the default switch label (`default:`) rather than `case default:`? If you really mean to use the default literal, consider `case (default):` or another literal (`case 0:` or `case null:`) as appropriate.
+                // (12,18): warning CS8312: Did you mean to use the default switch label (`default:`) rather than `case default:`? If you really mean to use the default literal, consider `case (default):` or another literal (`case 0:` or `case null:`) as appropriate.
                 //             case default:
                 Diagnostic(ErrorCode.WRN_DefaultInSwitch, "default").WithLocation(12, 18)
                 );
@@ -1931,7 +1931,7 @@ class C
 
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (12,18): warning CS9002: Did you mean to use the default switch label (`default:`) rather than `case default:`? If you really mean to use the default literal, consider `case (default):` or another literal (`case 0:` or `case null:`) as appropriate.
+                // (12,18): warning CS8312: Did you mean to use the default switch label (`default:`) rather than `case default:`? If you really mean to use the default literal, consider `case (default):` or another literal (`case 0:` or `case null:`) as appropriate.
                 //             case default:
                 Diagnostic(ErrorCode.WRN_DefaultInSwitch, "default").WithLocation(12, 18)
                 );

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -183,9 +183,8 @@ class X
         [Fact]
         public void WarningLevel_1()
         {
-            for (int i = 0; i < 10000; i++)
+            foreach (ErrorCode errorCode in Enum.GetValues(typeof(ErrorCode)))
             {
-                ErrorCode errorCode = (ErrorCode)i;
                 string errorCodeName = errorCode.ToString();
                 if (errorCodeName.StartsWith("WRN", StringComparison.Ordinal))
                 {
@@ -215,12 +214,15 @@ class X
             Assert.Equal(3, ErrorFacts.GetWarningLevel(ErrorCode.WRN_IsDynamicIsConfusing));
             Assert.Equal(2, ErrorFacts.GetWarningLevel(ErrorCode.WRN_NoSources));
 
-            // There is space in the range of error codes from 7000-8999 that we might add for new errors in post-Dev10.
             // If a new warning is added, this test will fail and adding the new case with the expected error level will be required.
 
-            for (int i = 7000; i < 9000; i++)
+            foreach (ErrorCode errorCode in Enum.GetValues(typeof(ErrorCode)))
             {
-                ErrorCode errorCode = (ErrorCode)i;
+                if ((int)errorCode < 7000)
+                {
+                    continue;
+                }
+
                 string errorCodeName = errorCode.ToString();
                 if (errorCodeName.StartsWith("WRN", StringComparison.Ordinal))
                 {
@@ -244,6 +246,7 @@ class X
                         case ErrorCode.WRN_AlignmentMagnitude:
                         case ErrorCode.WRN_TupleLiteralNameMismatch:
                         case ErrorCode.WRN_Experimental:
+                        case ErrorCode.WRN_DefaultInSwitch:
                             Assert.Equal(1, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_MainIgnored:

--- a/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
+++ b/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
                 catch (Exception)
                 {
-                    Log.LogMessage(MessageImportance.High, "CopyRefAssembly_BadDestination1", DestinationPath);
+                    Log.LogMessageFromResources(MessageImportance.High, "CopyRefAssembly_BadDestination1", DestinationPath);
                 }
             }
 

--- a/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
+++ b/src/Compilers/Core/MSBuildTask/CopyRefAssembly.cs
@@ -20,6 +20,11 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         [Required]
         public string DestinationPath { get; set; }
 
+        static CopyRefAssembly()
+        {
+            AssemblyResolution.Install();
+        }
+
         public CopyRefAssembly()
         {
             TaskResources = ErrorString.ResourceManager;
@@ -45,19 +50,26 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     Log.LogMessageFromResources(MessageImportance.High, "CopyRefAssembly_BadSource3", SourcePath, e.Message, e.StackTrace);
                 }
 
-                try
+                if (source.Equals(Guid.Empty))
                 {
-                    Guid destination = ExtractMvid(DestinationPath);
-
-                    if (source.Equals(destination))
-                    {
-                        Log.LogMessageFromResources(MessageImportance.Low, "CopyRefAssembly_SkippingCopy1", DestinationPath);
-                        return true;
-                    }
+                    Log.LogMessageFromResources(MessageImportance.High, "CopyRefAssembly_SourceNotRef1", SourcePath);
                 }
-                catch (Exception)
+                else
                 {
-                    Log.LogMessageFromResources(MessageImportance.High, "CopyRefAssembly_BadDestination1", DestinationPath);
+                    try
+                    {
+                        Guid destination = ExtractMvid(DestinationPath);
+
+                        if (!source.Equals(Guid.Empty) && source.Equals(destination))
+                        {
+                            Log.LogMessageFromResources(MessageImportance.Low, "CopyRefAssembly_SkippingCopy1", DestinationPath);
+                            return true;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        Log.LogMessageFromResources(MessageImportance.High, "CopyRefAssembly_BadDestination1", DestinationPath);
+                    }
                 }
             }
 

--- a/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.Designer.cs
@@ -99,6 +99,15 @@ namespace Microsoft.CodeAnalysis.BuildTasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not extract the MVID from &quot;{0}&quot;. Are you sure it is a reference assembly?.
+        /// </summary>
+        internal static string CopyRefAssembly_SourceNotRef1 {
+            get {
+                return ResourceManager.GetString("CopyRefAssembly_SourceNotRef1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MSB3053: The assembly alias &quot;{1}&quot; on reference &quot;{0}&quot; contains illegal characters..
         /// </summary>
         internal static string Csc_AssemblyAliasContainsIllegalCharacters {

--- a/src/Compilers/Core/MSBuildTask/ErrorString.resx
+++ b/src/Compilers/Core/MSBuildTask/ErrorString.resx
@@ -154,6 +154,9 @@
   <data name="CopyRefAssembly_SkippingCopy1" xml:space="preserve">
     <value>Reference assembly "{0}" already has latest information. Leaving it untouched.</value>
   </data>
+  <data name="CopyRefAssembly_SourceNotRef1" xml:space="preserve">
+    <value>Could not extract the MVID from "{0}". Are you sure it is a reference assembly?</value>
+  </data>
   <data name="CopyRefAssembly_BadSource3" xml:space="preserve">
     <value>Failed to check the content hash of the source ref assembly '{0}': {1}
 {2}</value>

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -478,6 +478,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Embedded interop type references should not be given when emitting a ref assembly..
+        /// </summary>
+        internal static string EmbedInteropTypesUnexpectedWhenEmittingRefAssembly {
+            get {
+                return ResourceManager.GetString("EmbedInteropTypesUnexpectedWhenEmittingRefAssembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A key in the pathMap is empty..
         /// </summary>
         internal static string EmptyKeyInPathMap {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -333,6 +333,9 @@
   <data name="PdbStreamUnexpectedWhenEmittingMetadataOnly" xml:space="preserve">
     <value>PDB stream should not be given when emitting metadata only.</value>
   </data>
+  <data name="EmbedInteropTypesUnexpectedWhenEmittingRefAssembly" xml:space="preserve">
+    <value>Embedded interop type references should not be given when emitting a ref assembly.</value>
+  </data>
   <data name="MetadataPeStreamUnexpectedWhenEmittingMetadataOnly" xml:space="preserve">
     <value>Metadata PE stream should not be given when emitting metadata only.</value>
   </data>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2643,7 +2643,7 @@ namespace Microsoft.CodeAnalysis
             bool emitSecondaryAssembly = getMetadataPeStreamOpt != null;
 
             bool includePrivateMembersOnPrimaryOutput = metadataOnly ? includePrivateMembers : true;
-            bool deterministicPrimaryOutput = (metadataOnly && !includePrivateMembers) ? true : isDeterministic;
+            bool deterministicPrimaryOutput = (metadataOnly && !includePrivateMembers) || isDeterministic;
             if (!Cci.PeWriter.WritePeToStream(
                 new EmitContext(moduleBeingBuilt, null, metadataDiagnostics, metadataOnly, includePrivateMembersOnPrimaryOutput),
                 messageProvider,

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2087,6 +2087,13 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentException(CodeAnalysisResources.IncludingPrivateMembersUnexpectedWhenEmittingToMetadataPeStream, nameof(metadataPEStream));
             }
 
+            if ((metadataPEStream != null || options?.EmitMetadataOnly == true) &&
+                options?.IncludePrivateMembers == false &&
+                References.Any(r => r.Properties.EmbedInteropTypes))
+            {
+                throw new ArgumentException(CodeAnalysisResources.EmbedInteropTypesUnexpectedWhenEmittingRefAssembly, nameof(metadataPEStream));
+            }
+
             if (options?.DebugInformationFormat == DebugInformationFormat.Embedded &&
                 options?.EmitMetadataOnly == true)
             {

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2643,6 +2643,7 @@ namespace Microsoft.CodeAnalysis
             bool emitSecondaryAssembly = getMetadataPeStreamOpt != null;
 
             bool includePrivateMembersOnPrimaryOutput = metadataOnly ? includePrivateMembers : true;
+            bool deterministicPrimaryOutput = (metadataOnly && !includePrivateMembers) ? true : isDeterministic;
             if (!Cci.PeWriter.WritePeToStream(
                 new EmitContext(moduleBeingBuilt, null, metadataDiagnostics, metadataOnly, includePrivateMembersOnPrimaryOutput),
                 messageProvider,
@@ -2651,7 +2652,7 @@ namespace Microsoft.CodeAnalysis
                 nativePdbWriterOpt,
                 pdbPathOpt,
                 metadataOnly,
-                isDeterministic,
+                deterministicPrimaryOutput,
                 emitTestCoverageData,
                 cancellationToken))
             {
@@ -2672,7 +2673,7 @@ namespace Microsoft.CodeAnalysis
                     nativePdbWriterOpt: null,
                     pdbPathOpt: null,
                     metadataOnly: true,
-                    isDeterministic: isDeterministic,
+                    isDeterministic: true,
                     emitTestCoverageData: false,
                     cancellationToken: cancellationToken))
                 {

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.Emit
             uint token = _referencesInILMap.GetOrAddTokenFor(symbol, out added);
             if (added)
             {
-                ReferenceDependencyWalker.VisitReference(symbol, new EmitContext(this, syntaxNode, diagnostics, metadataOnly: false, includePrivateMembers: true)); // PROTOTYPE(refout) Not sure about this
+                ReferenceDependencyWalker.VisitReference(symbol, new EmitContext(this, syntaxNode, diagnostics, metadataOnly: false, includePrivateMembers: true));
             }
             return token;
         }

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1203,6 +1203,10 @@ lVbRuntimePlus:
                 AddDiagnostic(diagnostics, ERRID.ERR_NoRefOutWhenRefOnly)
             End If
 
+            If metadataReferences.Any(Function(r) r.Properties.EmbedInteropTypes) AndAlso (refOnly OrElse outputRefFileName IsNot Nothing) Then
+                AddDiagnostic(diagnostics, ERRID.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly)
+            End If
+
             If outputKind = OutputKind.NetModule AndAlso (refOnly OrElse outputRefFileName IsNot Nothing) Then
                 AddDiagnostic(diagnostics, ERRID.ERR_NoNetModuleOutputWhenRefOutOrRefOnly)
             End If

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1203,7 +1203,7 @@ lVbRuntimePlus:
                 AddDiagnostic(diagnostics, ERRID.ERR_NoRefOutWhenRefOnly)
             End If
 
-            If metadataReferences.Any(Function(r) r.Properties.EmbedInteropTypes) AndAlso (refOnly OrElse outputRefFileName IsNot Nothing) Then
+            If (refOnly OrElse outputRefFileName IsNot Nothing) AndAlso metadataReferences.Any(Function(r) r.Properties.EmbedInteropTypes) Then
                 AddDiagnostic(diagnostics, ERRID.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly)
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1733,6 +1733,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ERR_NoRefOutWhenRefOnly = 37300
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 37301
+        ERR_NoEmbeddedTypeWhenRefOutOrRefOnly = 37302
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -8071,6 +8071,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Cannot compile embed types when using /refout or /refonly..
+        '''</summary>
+        Friend ReadOnly Property ERR_NoEmbeddedTypeWhenRefOutOrRefOnly() As String
+            Get
+                Return ResourceManager.GetString("ERR_NoEmbeddedTypeWhenRefOutOrRefOnly", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Array bounds cannot appear in type specifiers..
         '''</summary>
         Friend ReadOnly Property ERR_NoExplicitArraySizes() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -8071,7 +8071,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Cannot compile embed types when using /refout or /refonly..
+        '''  Looks up a localized string similar to Cannot embed types when using /refout or /refonly..
         '''</summary>
         Friend ReadOnly Property ERR_NoEmbeddedTypeWhenRefOutOrRefOnly() As String
             Get

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5472,7 +5472,7 @@
     <value>Do not use refout when using refonly.</value>
   </data>
   <data name="ERR_NoEmbeddedTypeWhenRefOutOrRefOnly" xml:space="preserve">
-    <value>Cannot compile embed types when using /refout or /refonly.</value>
+    <value>Cannot embed types when using /refout or /refonly.</value>
   </data>
   <data name="ERR_NoNetModuleOutputWhenRefOutOrRefOnly" xml:space="preserve">
     <value>Cannot compile net modules when using /refout or /refonly.</value>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5471,6 +5471,9 @@
   <data name="ERR_NoRefOutWhenRefOnly" xml:space="preserve">
     <value>Do not use refout when using refonly.</value>
   </data>
+  <data name="ERR_NoEmbeddedTypeWhenRefOutOrRefOnly" xml:space="preserve">
+    <value>Cannot compile embed types when using /refout or /refonly.</value>
+  </data>
   <data name="ERR_NoNetModuleOutputWhenRefOutOrRefOnly" xml:space="preserve">
     <value>Cannot compile net modules when using /refout or /refonly.</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -2923,6 +2923,14 @@ print Goodbye, World"
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_NoNetModuleOutputWhenRefOutOrRefOnly).WithLocation(1, 1))
 
+            parsedArgs = DefaultParse({"/refout:ref.dll", "/link:b", "a.vb"}, baseDirectory)
+            parsedArgs.Errors.Verify(
+                Diagnostic(ERRID.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly).WithLocation(1, 1))
+
+            parsedArgs = DefaultParse({"/refonly", "/link:b", "a.vb"}, baseDirectory)
+            parsedArgs.Errors.Verify(
+                Diagnostic(ERRID.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly).WithLocation(1, 1))
+
             parsedArgs = DefaultParse({"/refonly", "/target:module", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_NoNetModuleOutputWhenRefOutOrRefOnly).WithLocation(1, 1))
@@ -8188,6 +8196,10 @@ Public Class C
     Public Shared Sub Main()
         System.Console.Write(""Hello"")
     End Sub
+    ''' <summary>Private method</summary>
+    Private Shared Sub PrivateMethod()
+        System.Console.Write(""Private"")
+    End Sub
 End Class")
 
             Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
@@ -8202,7 +8214,7 @@ End Class")
 
             MetadataReaderUtils.VerifyPEMetadata(exe,
                 {"TypeDefinition:<Module>", "TypeDefinition:C"},
-                {"MethodDefinition:Void Main()", "MethodDefinition:Void .ctor()"},
+                {"MethodDefinition:Void Main()", "MethodDefinition:Void .ctor()", "MethodDefinition:Void PrivateMethod()"},
                 {"CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute", "STAThreadAttribute"}
                 )
 
@@ -8221,6 +8233,9 @@ a
 <members>
 <member name=""M:C.Main"">
  <summary>Main method</summary>
+</member>
+<member name=""M:C.PrivateMethod"">
+ <summary>Private method</summary>
 </member>
 </members>
 </doc>"
@@ -8295,6 +8310,14 @@ outWriter.ToString().Trim())
     Public Shared Sub Main()
         Bad()
     End Sub
+    ''' <summary>Field</summary>
+    Private Dim field As Integer
+
+    ''' <summary>Field</summary>
+    Private Structure S
+        ''' <summary>Struct Field</summary>
+        Private Dim field As Integer
+    End Structure
 End Class")
 
             Dim outWriter = New StringWriter(CultureInfo.InvariantCulture)
@@ -8310,7 +8333,7 @@ End Class")
             ' The types and members that are included needs further refinement.
             ' See issue https://github.com/dotnet/roslyn/issues/17612
             MetadataReaderUtils.VerifyPEMetadata(refDll,
-                {"TypeDefinition:<Module>", "TypeDefinition:C"},
+                {"TypeDefinition:<Module>", "TypeDefinition:C", "TypeDefinition:S"},
                 {"MethodDefinition:Void Main()", "MethodDefinition:Void .ctor()"},
                 {"CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute", "DebuggableAttribute", "STAThreadAttribute", "ReferenceAssemblyAttribute"}
                 )
@@ -8333,6 +8356,15 @@ a
 <members>
 <member name=""M:C.Main"">
  <summary>Main method</summary>
+</member>
+<member name=""F:C.field"">
+ <summary>Field</summary>
+</member>
+<member name=""T:C.S"">
+ <summary>Field</summary>
+</member>
+<member name=""F:C.S.field"">
+ <summary>Struct Field</summary>
 </member>
 </members>
 </doc>"

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -887,6 +887,24 @@ End Class"
         End Sub
 
         <Fact>
+        Public Sub RefAssembly_DisallowEmbeddingTypes()
+            Dim comp = CreateCompilation("", references:={MscorlibRef.WithEmbedInteropTypes(True)},
+                            options:=TestOptions.DebugDll)
+
+            Using output As New MemoryStream()
+                Assert.Throws(Of ArgumentException)(Function() comp.Emit(output,
+                                    options:=EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)))
+            End Using
+
+            Using output As New MemoryStream()
+                Using metadataOutput = New MemoryStream()
+                    Assert.Throws(Of ArgumentException)(Function() comp.Emit(output, metadataPEStream:=metadataOutput,
+                                        options:=EmitOptions.Default.WithIncludePrivateMembers(False)))
+                End Using
+            End Using
+        End Sub
+
+        <Fact>
         Public Sub EmitMetadataOnly_DisallowMetadataPeStream()
             Dim comp = CreateCompilation("", references:={MscorlibRef},
                             options:=TestOptions.DebugDll.WithDeterministic(True))


### PR DESCRIPTION
A few things:
- xml docs are not filtered when using /refonly (updated doc and tests to reflect)
- NoPia is disallowed with either /refonly or /refout
- compacting error codes for C# 7.1 (and fixing a bug in test for warnings)
- emit ref assemblies with determinism, even if compilation isn't

@dotnet/roslyn-compiler for review. Thanks