### PR TITLE
Fix building on 15.3

### DIFF
--- a/src/CodeStyle/VisualBasic/Analyzers/BasicCodeStyle.vbproj
+++ b/src/CodeStyle/VisualBasic/Analyzers/BasicCodeStyle.vbproj
@@ -10,6 +10,7 @@
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.CodeStyle</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net45+win8;dotnet</PackageTargetFallback>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/CodeStyle/VisualBasic/CodeFixes/BasicCodeStyleFixes.vbproj
+++ b/src/CodeStyle/VisualBasic/CodeFixes/BasicCodeStyleFixes.vbproj
@@ -10,6 +10,7 @@
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.CodeStyle.Fixes</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net45+win8;dotnet</PackageTargetFallback>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/CodeStyle/VisualBasic/Tests/BasicCodeStyleTests.vbproj
+++ b/src/CodeStyle/VisualBasic/Tests/BasicCodeStyleTests.vbproj
@@ -12,6 +12,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net45+win8;dotnet</PackageTargetFallback>
     <RoslynProjectType>UnitTestPortable</RoslynProjectType>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -10,7 +10,7 @@
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
     <ServiceablePackage>true</ServiceablePackage>
-    <NoWarn>$(NoWarn);42014</NoWarn>
+    <NoWarn>$(NoWarn);42014;40057;42016;41999</NoWarn>
     <CodeAnalysisRuleSet>..\BasicCodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <!-- This is required to prevent downgrade references from CscCore/VbcCode since we must
          reference Microsoft.NETCore.App to target the shared framework (bug

--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -10,7 +10,7 @@
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
     <ServiceablePackage>true</ServiceablePackage>
-    <NoWarn>$(NoWarn);42014;40057;42016;41999</NoWarn>
+    <NoWarn>$(NoWarn);42014;40057</NoWarn>
     <CodeAnalysisRuleSet>..\BasicCodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
     <!-- This is required to prevent downgrade references from CscCore/VbcCode since we must
          reference Microsoft.NETCore.App to target the shared framework (bug

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -245,7 +245,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Debug.Assert(tree IsNot VisualBasicSyntaxTree.Dummy)
                             Debug.Assert(tree.IsMyTemplate)
 
-                            Interlocked.CompareExchange(_lazyMyTemplate, tree, VisualBasicSyntaxTree.Dummy)
+                            Interlocked.CompareExchange(Of SyntaxTree)(_lazyMyTemplate, tree, VisualBasicSyntaxTree.Dummy)
                         Else
                             ' we need to make one.
                             Dim text As String = EmbeddedResources.VbMyTemplateText
@@ -260,7 +260,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 Throw ExceptionUtilities.Unreachable
                             End If
 
-                            If Interlocked.CompareExchange(_lazyMyTemplate, tree, VisualBasicSyntaxTree.Dummy) Is VisualBasicSyntaxTree.Dummy Then
+                            If Interlocked.CompareExchange(Of SyntaxTree)(_lazyMyTemplate, tree, VisualBasicSyntaxTree.Dummy) Is VisualBasicSyntaxTree.Dummy Then
                                 ' set global cache
                                 s_myTemplateCache(parseOptions) = tree
                             End If

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -134,7 +134,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                             typesByName.Add(type.Name, type)
                         End If
                     Next
-                    Interlocked.CompareExchange(Me._lazyTopLevelTypes, typesByName, Nothing)
+                    Interlocked.CompareExchange(Of IReadOnlyDictionary(Of String, Cci.INamespaceTypeDefinition))(Me._lazyTopLevelTypes, typesByName, Nothing)
                 End If
                 Return Me._lazyTopLevelTypes
             End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceLambdaSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceLambdaSymbol.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 If Me._lazyAnonymousDelegateSymbol Is ErrorTypeSymbol.UnknownResultType Then
                     Dim newValue As NamedTypeSymbol = MakeAssociatedAnonymousDelegate()
-                    Dim oldValue As NamedTypeSymbol = Interlocked.CompareExchange(Me._lazyAnonymousDelegateSymbol, newValue, ErrorTypeSymbol.UnknownResultType)
+                    Dim oldValue As NamedTypeSymbol = Interlocked.CompareExchange(Of NamedTypeSymbol)(Me._lazyAnonymousDelegateSymbol, newValue, ErrorTypeSymbol.UnknownResultType)
                     Debug.Assert(oldValue Is ErrorTypeSymbol.UnknownResultType OrElse oldValue Is newValue)
                 End If
                 Return Me._lazyAnonymousDelegateSymbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -1296,7 +1296,7 @@ lReportErrorOnTwoTokens:
                 meParameter = Nothing
             Else
                 If _lazyMeParameter Is Nothing Then
-                    Interlocked.CompareExchange(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
+                    Interlocked.CompareExchange(Of ParameterSymbol)(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
                 End If
 
                 meParameter = _lazyMeParameter

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethodBase.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethodBase.vb
@@ -178,7 +178,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 meParameter = Nothing
             Else
                 If _lazyMeParameter Is Nothing Then
-                    Interlocked.CompareExchange(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
+                    Interlocked.CompareExchange(Of ParameterSymbol)(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
                 End If
 
                 meParameter = _lazyMeParameter

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/BasicExpressionCompiler.vbproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ExpressionCompiler</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
+    <NoWarn>$(NoWarn);40057</NoWarn>
     <PackageTargetFallback>portable-net46</PackageTargetFallback>
     <!-- Don't transitively copy output files, since everything builds to the same folder. -->
   </PropertyGroup>

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/BasicResultProvider.NetFX20.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/BasicResultProvider.NetFX20.vbproj
@@ -12,6 +12,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.ResultProvider</AssemblyName>
     <TargetFramework>net20</TargetFramework>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Portable/BasicResultProvider.Portable.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Portable/BasicResultProvider.Portable.vbproj
@@ -11,6 +11,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
     <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -10,6 +10,7 @@
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Features</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net45+win8;dotnet</PackageTargetFallback>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Interactive/VbiCore/VbiCore.vbproj
+++ b/src/Interactive/VbiCore/VbiCore.vbproj
@@ -16,6 +16,7 @@
     <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;osx.10.12-x64</RuntimeIdentifiers>
     <PackageTargetFallback>portable-net452</PackageTargetFallback>
     <NoStdLib>true</NoStdLib>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/BasicAnalyzers.vbproj
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/BasicAnalyzers.vbproj
@@ -14,7 +14,7 @@
     <PackageTargetFallback>portable-net45+win8;dotnet</PackageTargetFallback>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <OptionStrict>Off</OptionStrict>
-    <NoWarn>$(NoWarn);41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</NoWarn>
+    <NoWarn>$(NoWarn);41999,42016,42017,42018,42019,42020,42021,42022,42032,42036;40057</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Scripting/VisualBasic/BasicScripting.vbproj
+++ b/src/Scripting/VisualBasic/BasicScripting.vbproj
@@ -10,6 +10,7 @@
     <AssemblyName>Microsoft.CodeAnalysis.VisualBasic.Scripting</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net452</PackageTargetFallback>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">

--- a/src/Scripting/VisualBasicTest/BasicScriptingTest.vbproj
+++ b/src/Scripting/VisualBasicTest/BasicScriptingTest.vbproj
@@ -12,6 +12,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net452</PackageTargetFallback>
     <RoslynProjectType>UnitTestDesktop</RoslynProjectType>
+    <NoWarn>$(NoWarn);40057;42016</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Scripting/VisualBasicTest/BasicScriptingTest.vbproj
+++ b/src/Scripting/VisualBasicTest/BasicScriptingTest.vbproj
@@ -12,7 +12,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net452</PackageTargetFallback>
     <RoslynProjectType>UnitTestDesktop</RoslynProjectType>
-    <NoWarn>$(NoWarn);40057;42016</NoWarn>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
+++ b/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
                 ContinueWith("Dim y As Integer = 2").
                 ContinueWith("?x + y")
 
-            Assert.Equal(3, s.ReturnValue)
+            Assert.Equal(3, CType(s.ReturnValue, Integer))
         End Function
 
         <Fact>
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim source = "
 ?1 _
 "
-            Assert.Equal(1, VisualBasicScript.EvaluateAsync(source).Result)
+            Assert.Equal(1, CType(VisualBasicScript.EvaluateAsync(source).Result, Integer))
         End Sub
 
         <Fact>
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim source = "
 ?1
 "
-            Assert.Equal(1, VisualBasicScript.EvaluateAsync(source).Result)
+            Assert.Equal(1, CType(VisualBasicScript.EvaluateAsync(source).Result, Integer))
         End Sub
 
         <Fact>
@@ -61,7 +61,7 @@ End If
 ?x + 1
 "
 
-            Assert.Equal(6, VisualBasicScript.EvaluateAsync(source).Result)
+            Assert.Equal(6, CType(VisualBasicScript.EvaluateAsync(source).Result, Integer))
         End Sub
 
         <Fact>
@@ -81,7 +81,7 @@ Dim d = New With { Key .F = 777 }
     & "" "" & (a.GetType() Is b.GetType()).ToString() _
     & "" "" & (b.GetType() is d.GetType()).ToString()
 ")
-            Assert.Equal("True False True", script.EvaluateAsync().Result)
+            Assert.Equal("True False True", CType(script.EvaluateAsync().Result, String))
         End Sub
 
         <Fact>
@@ -107,7 +107,7 @@ Dim d = Function () As Integer
     & "" "" & (b.GetType() is d.GetType()).ToString()
 ")
 
-            Assert.Equal("True False True", script.EvaluateAsync().Result)
+            Assert.Equal("True False True", CType(script.EvaluateAsync().Result, String))
         End Sub
     End Class
 

--- a/src/Scripting/VisualBasicTest/ScriptTests.vb
+++ b/src/Scripting/VisualBasicTest/ScriptTests.vb
@@ -22,14 +22,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
 
         <Fact>
         Public Sub TestEvalScript()
-            Dim value = VisualBasicScript.EvaluateAsync("? 1 + 2", s_defaultOptions)
-            Assert.Equal(3, value.Result)
+            Dim value = CType(VisualBasicScript.EvaluateAsync("? 1 + 2", s_defaultOptions).Result, Integer)
+            Assert.Equal(3, value)
         End Sub
 
         <Fact>
         Public Async Function TestRunScript() As Task
             Dim state = Await VisualBasicScript.RunAsync("? 1 + 2", s_defaultOptions)
-            Assert.Equal(3, state.ReturnValue)
+            Assert.Equal(3, CType(state.ReturnValue, Integer))
         End Function
 
         <Fact>
@@ -37,13 +37,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim script = VisualBasicScript.Create("? 1 + 2", s_defaultOptions)
             Dim state = Await script.RunAsync()
             Assert.Same(script, state.Script)
-            Assert.Equal(3, state.ReturnValue)
+            Assert.Equal(3, CType(state.ReturnValue, Integer))
         End Function
 
         <Fact>
         Public Async Function TestRunScriptWithSpecifiedReturnType() As Task
             Dim state = Await VisualBasicScript.RunAsync("? 1 + 2", s_defaultOptions)
-            Assert.Equal(3, state.ReturnValue)
+            Assert.Equal(3, CType(state.ReturnValue, Integer))
         End Function
 
         <Fact>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/VisualBasicErrorFactsGenerator.vbproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/VisualBasicErrorFactsGenerator.vbproj
@@ -16,6 +16,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;osx.10.12-x64</RuntimeIdentifiers>
     <NonShipping>true</NonShipping>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VisualBasicSyntaxGenerator.vbproj
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/VisualBasicSyntaxGenerator.vbproj
@@ -17,6 +17,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;osx.10.12-x64</RuntimeIdentifiers>
     <NonShipping>true</NonShipping>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />

--- a/src/Workspaces/VisualBasic/Portable/BasicWorkspace.vbproj
+++ b/src/Workspaces/VisualBasic/Portable/BasicWorkspace.vbproj
@@ -11,6 +11,7 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTargetFallback>portable-net45+win8;dotnet</PackageTargetFallback>
     <ServiceablePackage>true</ServiceablePackage>
+    <NoWarn>$(NoWarn);40057</NoWarn>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">


### PR DESCRIPTION
dogfooding 15.3 I ran into a lot of instances of [BC40057](https://docs.microsoft.com/en-us/dotnet/articles/visual-basic/language-reference/error-messages/namespace-or-type-specified-in-the-project-level-imports-qualifiedelementname) being offered due to default namespace imports of assemblies that don't exist (introduced [here](this https://github.com/dotnet/sdk/pull/1127)).  These seem safe to ignore.

`BasicCodeAnalysis.vbproj` has a few new implicit conversion warning under 15.3 due to overload resolution on Interlocked.CompareExchange which I have fixed but I would like @dotnet/roslyn-compiler to review these changes.

`BasicScriptingTest.vbproj` also has implicit conversion errors that needed to be fixed up.  I am not too concerned about these fixes in the test project but would like @dotnet/roslyn-interactive to take a look all the same.