### PR TITLE
Tuple name completion should not include colon

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TupleNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TupleNameCompletionProviderTests.cs
@@ -32,7 +32,7 @@ class Program
     {
         (int word, int zword) t = ($$
     }
-}", "word:");
+}", "word");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -45,7 +45,7 @@ class Program
     {
         (int word, int zword) t = ($$)
     }
-}", "word:");
+}", "word");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -58,7 +58,7 @@ class Program
     {
         (int word, int zword) t = ($$, zword: 2
     }
-}", "word:");
+}", "word");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -71,7 +71,7 @@ class Program
     {
         (int word, int zword) t = ($$, zword: 2
     }
-}", "word:");
+}", "word");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -84,7 +84,7 @@ class Program
     {
         (int word, int zword) t = (1, $$
     }
-}", "zword:");
+}", "zword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -97,7 +97,7 @@ class Program
     {
         (int word, int zword) t = (1, $$)
     }
-}", "zword:");
+}", "zword");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -110,7 +110,7 @@ class Program
     {
          Main(($$))
     }
-}", "word:");
+}", "word");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -124,8 +124,8 @@ class Program
         Main(($$
     }
 }";
-            await VerifyItemExistsAsync(markup, "word:");
-            await VerifyItemExistsAsync(markup, "number:");
+            await VerifyItemExistsAsync(markup, "word");
+            await VerifyItemExistsAsync(markup, "number");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -139,8 +139,8 @@ class Program
         Main((1, $$
     }
 }";
-            await VerifyItemExistsAsync(markup, "zword:");
-            await VerifyItemExistsAsync(markup, "znumber:");
+            await VerifyItemExistsAsync(markup, "zword");
+            await VerifyItemExistsAsync(markup, "znumber");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -168,7 +168,7 @@ class C
         (int goat, int moat) x = (g$$)1;
     }
 }";
-            await VerifyItemExistsAsync(markup, "goat:");
+            await VerifyItemExistsAsync(markup, "goat");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TupleNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TupleNameCompletionProviderTests.cs
@@ -32,7 +32,7 @@ class Program
     {
         (int word, int zword) t = ($$
     }
-}", "word");
+}", "word:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -45,7 +45,7 @@ class Program
     {
         (int word, int zword) t = ($$)
     }
-}", "word");
+}", "word:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -58,7 +58,7 @@ class Program
     {
         (int word, int zword) t = ($$, zword: 2
     }
-}", "word");
+}", "word:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -71,7 +71,7 @@ class Program
     {
         (int word, int zword) t = ($$, zword: 2
     }
-}", "word");
+}", "word:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -84,7 +84,7 @@ class Program
     {
         (int word, int zword) t = (1, $$
     }
-}", "zword");
+}", "zword:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -97,7 +97,7 @@ class Program
     {
         (int word, int zword) t = (1, $$)
     }
-}", "zword");
+}", "zword:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -110,7 +110,7 @@ class Program
     {
          Main(($$))
     }
-}", "word");
+}", "word:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -124,8 +124,8 @@ class Program
         Main(($$
     }
 }";
-            await VerifyItemExistsAsync(markup, "word");
-            await VerifyItemExistsAsync(markup, "number");
+            await VerifyItemExistsAsync(markup, "word:");
+            await VerifyItemExistsAsync(markup, "number:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -139,8 +139,8 @@ class Program
         Main((1, $$
     }
 }";
-            await VerifyItemExistsAsync(markup, "zword");
-            await VerifyItemExistsAsync(markup, "znumber");
+            await VerifyItemExistsAsync(markup, "zword:");
+            await VerifyItemExistsAsync(markup, "znumber:");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -168,7 +168,7 @@ class C
         (int goat, int moat) x = (g$$)1;
     }
 }";
-            await VerifyItemExistsAsync(markup, "goat");
+            await VerifyItemExistsAsync(markup, "goat:");
         }
     }
 }

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -593,7 +593,7 @@ class C
                 Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
                 Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
                 state.SendTypeChars(":")
-                Assert.Contains("(fi:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("(first:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 
@@ -635,7 +635,7 @@ class C
                 Await state.AssertSelectedCompletionItem(displayText:="second:", isHardSelected:=True)
                 Assert.Equal("second", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
                 state.SendTypeChars(":")
-                Assert.Contains("(0, se:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("(0, second:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -590,7 +590,7 @@ class C
 }]]></Document>)
 
                 state.SendTypeChars("fi")
-                Await state.AssertSelectedCompletionItem(displayText:="first", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
                 state.SendTypeChars(":")
                 Assert.Contains("(fi:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -610,7 +610,7 @@ class C
 }]]></Document>)
 
                 state.SendTypeChars("se")
-                Await state.AssertSelectedCompletionItem(displayText:="second", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="second:", isHardSelected:=True)
                 state.SendTypeChars(":")
                 Assert.Contains("(0, se:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -630,10 +630,11 @@ class C
 }]]></Document>)
 
                 state.SendTypeChars("fi")
-                Await state.AssertSelectedCompletionItem(displayText:="first", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
                 state.SendTab()
                 state.SendTypeChars(":")
-                Assert.Contains("(first:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("0")
+                Assert.Contains("(first:0", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 
@@ -651,10 +652,11 @@ class C
 }]]></Document>)
 
                 state.SendTypeChars("se")
-                Await state.AssertSelectedCompletionItem(displayText:="second", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="second:", isHardSelected:=True)
                 state.SendTab()
                 state.SendTypeChars(":")
-                Assert.Contains("(0, second:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                state.SendTypeChars("1")
+                Assert.Contains("(0, second:1", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -591,6 +591,7 @@ class C
 
                 state.SendTypeChars("fi")
                 Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
                 state.SendTypeChars(":")
                 Assert.Contains("(fi:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -611,6 +612,7 @@ class C
 
                 state.SendTypeChars("first")
                 Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
                 state.SendTypeChars(":")
                 Assert.Contains("(first:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -631,6 +633,7 @@ class C
 
                 state.SendTypeChars("se")
                 Await state.AssertSelectedCompletionItem(displayText:="second:", isHardSelected:=True)
+                Assert.Equal("second", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
                 state.SendTypeChars(":")
                 Assert.Contains("(0, se:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
@@ -651,6 +654,7 @@ class C
 
                 state.SendTypeChars("fi")
                 Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
                 state.SendTab()
                 state.SendTypeChars(":")
                 state.SendTypeChars("0")
@@ -673,6 +677,7 @@ class C
 
                 state.SendTypeChars("first")
                 Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                Assert.Equal("first", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
                 state.SendTab()
                 state.SendTypeChars(":")
                 state.SendTypeChars("0")
@@ -695,6 +700,7 @@ class C
 
                 state.SendTypeChars("se")
                 Await state.AssertSelectedCompletionItem(displayText:="second:", isHardSelected:=True)
+                Assert.Equal("second", state.CurrentCompletionPresenterSession.SelectedItem.FilterText)
                 state.SendTab()
                 state.SendTypeChars(":")
                 state.SendTypeChars("1")

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -577,7 +577,7 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
         Public Async Function ColonInTupleNameInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(
                   <Document><![CDATA[
@@ -597,7 +597,27 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
+        Public Async Function ColonInExactTupleNameInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("first")
+                Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(first:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
         Public Async Function ColonInTupleNameInTupleLiteralAfterComma() As Task
             Using state = TestState.CreateCSharpTestState(
                   <Document><![CDATA[
@@ -617,7 +637,7 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
         Public Async Function TabInTupleNameInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(
                   <Document><![CDATA[
@@ -639,7 +659,29 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
+        Public Async Function TabInExactTupleNameInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("first")
+                Await state.AssertSelectedCompletionItem(displayText:="first:", isHardSelected:=True)
+                state.SendTab()
+                state.SendTypeChars(":")
+                state.SendTypeChars("0")
+                Assert.Contains("(first:0", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(19335, "https://github.com/dotnet/roslyn/issues/19335")>
         Public Async Function TabInTupleNameInTupleLiteralAfterComma() As Task
             Using state = TestState.CreateCSharpTestState(
                   <Document><![CDATA[

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -578,6 +578,88 @@ class C
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function ColonInTupleNameInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("fi")
+                Await state.AssertSelectedCompletionItem(displayText:="first", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(fi:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function ColonInTupleNameInTupleLiteralAfterComma() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = (0, $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("se")
+                Await state.AssertSelectedCompletionItem(displayText:="second", isHardSelected:=True)
+                state.SendTypeChars(":")
+                Assert.Contains("(0, se:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TabInTupleNameInTupleLiteral() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("fi")
+                Await state.AssertSelectedCompletionItem(displayText:="first", isHardSelected:=True)
+                state.SendTab()
+                state.SendTypeChars(":")
+                Assert.Contains("(first:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
+        Public Async Function TabInTupleNameInTupleLiteralAfterComma() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M()
+    {
+        (int first, int second) t = (0, $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("se")
+                Await state.AssertSelectedCompletionItem(displayText:="second", isHardSelected:=True)
+                state.SendTab()
+                state.SendTypeChars(":")
+                Assert.Contains("(0, second:", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestKeywordInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(
                   <Document><![CDATA[

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/TupleNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/TupleNameCompletionProvider.cs
@@ -78,8 +78,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     return;
                 }
 
+                // Note: the filter text does not include the ':'.  We want to ensure that if
+                // the user types the name exactly (up to the colon) that it is selected as an
+                // exact match.
+
                 var field = type.TupleElements[index];
-                var item = CommonCompletionItem.Create(field.Name + ColonString, _cachedRules, Glyph.FieldPublic);
+                var item = CommonCompletionItem.Create(field.Name + ColonString, _cachedRules, Glyph.FieldPublic, filterText: field.Name);
                 context.AddItem(item);
             }
         }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/TupleNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/TupleNameCompletionProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 var field = type.TupleElements[index];
                 var item = CommonCompletionItem.Create(
-                    field.Name + ":", _cachedRules, Glyph.FieldPublic);
+                    field.Name, _cachedRules, Glyph.FieldPublic);
                 context.AddItem(item);
             }
         }


### PR DESCRIPTION
**Customer scenario**
Use Intellisense to complete a tuple element name, by pressing tab. For instance, in `(int first, int second) t = ($$`, press `fi` then tab.
In other similar situations (named parameters in methods), the `:` (colon) will not be completed and you have to type it yourself. But for tuples, the colon was inserted.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/18994

**Workarounds, if any**
Adjust your muscle memory.

**Risk**
**Performance impact**
Low. This is only affecting the tuple name completion logic.

**Is this a regression from a previous update?**

**Root cause analysis:**
When the change to add the tuple name completion should probably have included some completion command handler test (which simulates the experience of typing characters), not just the narrow scenario (what Intellisense completion shows up).

**How was the bug found?**
Reported by Cyrus

@CyrusNajmabadi @rchande for review.