### PR TITLE
LambdaRewriter should only assign proxies from locals in original frame in EE

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -649,75 +649,75 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var importChain = methodWithBody.ImportChainOpt;
                     compilationState.CurrentImportChain = importChain;
 
-                // We make sure that an asynchronous mutation to the diagnostic bag does not 
-                // confuse the method body generator by making a fresh bag and then loading
-                // any diagnostics emitted into it back into the main diagnostic bag.
-                var diagnosticsThisMethod = DiagnosticBag.GetInstance();
+                    // We make sure that an asynchronous mutation to the diagnostic bag does not 
+                    // confuse the method body generator by making a fresh bag and then loading
+                    // any diagnostics emitted into it back into the main diagnostic bag.
+                    var diagnosticsThisMethod = DiagnosticBag.GetInstance();
 
                     var method = methodWithBody.Method;
-                var lambda = method as SynthesizedLambdaMethod;
-                var variableSlotAllocatorOpt = ((object)lambda != null) ?
-                    _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(lambda, lambda.TopLevelMethod, diagnosticsThisMethod) :
-                    _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(method, method, diagnosticsThisMethod);
+                    var lambda = method as SynthesizedLambdaMethod;
+                    var variableSlotAllocatorOpt = ((object)lambda != null) ?
+                        _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(lambda, lambda.TopLevelMethod, diagnosticsThisMethod) :
+                        _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(method, method, diagnosticsThisMethod);
 
-                // Synthesized methods have no ordinal stored in custom debug information (only user-defined methods have ordinals).
-                // In case of async lambdas, which synthesize a state machine type during the following rewrite, the containing method has already been uniquely named, 
-                // so there is no need to produce a unique method ordinal for the corresponding state machine type, whose name includes the (unique) containing method name.
-                const int methodOrdinal = -1;
-                MethodBody emittedBody = null;
+                    // Synthesized methods have no ordinal stored in custom debug information (only user-defined methods have ordinals).
+                    // In case of async lambdas, which synthesize a state machine type during the following rewrite, the containing method has already been uniquely named, 
+                    // so there is no need to produce a unique method ordinal for the corresponding state machine type, whose name includes the (unique) containing method name.
+                    const int methodOrdinal = -1;
+                    MethodBody emittedBody = null;
 
-                try
-                {
-                    // Local functions can be iterators as well as be async (lambdas can only be async), so we need to lower both iterators and async
-                    IteratorStateMachine iteratorStateMachine;
-                    BoundStatement loweredBody = IteratorRewriter.Rewrite(methodWithBody.Body, method, methodOrdinal, variableSlotAllocatorOpt, compilationState, diagnosticsThisMethod, out iteratorStateMachine);
-                    StateMachineTypeSymbol stateMachine = iteratorStateMachine;
-
-                    if (!loweredBody.HasErrors)
+                    try
                     {
-                        AsyncStateMachine asyncStateMachine;
-                        loweredBody = AsyncRewriter.Rewrite(loweredBody, method, methodOrdinal, variableSlotAllocatorOpt, compilationState, diagnosticsThisMethod, out asyncStateMachine);
+                        // Local functions can be iterators as well as be async (lambdas can only be async), so we need to lower both iterators and async
+                        IteratorStateMachine iteratorStateMachine;
+                        BoundStatement loweredBody = IteratorRewriter.Rewrite(methodWithBody.Body, method, methodOrdinal, variableSlotAllocatorOpt, compilationState, diagnosticsThisMethod, out iteratorStateMachine);
+                        StateMachineTypeSymbol stateMachine = iteratorStateMachine;
 
-                        Debug.Assert(iteratorStateMachine == null || asyncStateMachine == null);
-                        stateMachine = stateMachine ?? asyncStateMachine;
+                        if (!loweredBody.HasErrors)
+                        {
+                            AsyncStateMachine asyncStateMachine;
+                            loweredBody = AsyncRewriter.Rewrite(loweredBody, method, methodOrdinal, variableSlotAllocatorOpt, compilationState, diagnosticsThisMethod, out asyncStateMachine);
+
+                            Debug.Assert(iteratorStateMachine == null || asyncStateMachine == null);
+                            stateMachine = stateMachine ?? asyncStateMachine;
+                        }
+
+                        if (!diagnosticsThisMethod.HasAnyErrors() && !_globalHasErrors)
+                        {
+                            emittedBody = GenerateMethodBody(
+                                _moduleBeingBuiltOpt,
+                                method,
+                                methodOrdinal,
+                                loweredBody,
+                                ImmutableArray<LambdaDebugInfo>.Empty,
+                                ImmutableArray<ClosureDebugInfo>.Empty,
+                                stateMachine,
+                                variableSlotAllocatorOpt,
+                                diagnosticsThisMethod,
+                                _debugDocumentProvider,
+                                method.GenerateDebugInfo ? importChain : null,
+                                emittingPdb: _emittingPdb,
+                                emitTestCoverageData: _emitTestCoverageData,
+                                dynamicAnalysisSpans: ImmutableArray<SourceSpan>.Empty);
+                        }
+                    }
+                    catch (BoundTreeVisitor.CancelledByStackGuardException ex)
+                    {
+                        ex.AddAnError(_diagnostics);
                     }
 
-                    if (!diagnosticsThisMethod.HasAnyErrors() && !_globalHasErrors)
+                    _diagnostics.AddRange(diagnosticsThisMethod);
+                    diagnosticsThisMethod.Free();
+
+                    // error while generating IL
+                    if (emittedBody == null)
                     {
-                        emittedBody = GenerateMethodBody(
-                            _moduleBeingBuiltOpt,
-                            method,
-                            methodOrdinal,
-                            loweredBody,
-                            ImmutableArray<LambdaDebugInfo>.Empty,
-                            ImmutableArray<ClosureDebugInfo>.Empty,
-                            stateMachine,
-                            variableSlotAllocatorOpt,
-                            diagnosticsThisMethod,
-                            _debugDocumentProvider,
-                            method.GenerateDebugInfo ? importChain : null,
-                            emittingPdb: _emittingPdb,
-                            emitTestCoverageData: _emitTestCoverageData,
-                            dynamicAnalysisSpans: ImmutableArray<SourceSpan>.Empty);
+                        break;
                     }
-                }
-                catch (BoundTreeVisitor.CancelledByStackGuardException ex)
-                {
-                    ex.AddAnError(_diagnostics);
-                }
 
-                _diagnostics.AddRange(diagnosticsThisMethod);
-                diagnosticsThisMethod.Free();
-
-                // error while generating IL
-                if (emittedBody == null)
-                {
-                    break;
+                    _moduleBeingBuiltOpt.SetMethodBody(method, emittedBody);
                 }
-
-                _moduleBeingBuiltOpt.SetMethodBody(method, emittedBody);
             }
-        }
             finally
             {
                 compilationState.CurrentImportChain = oldImportChain;
@@ -1143,7 +1143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 if (processedInitializers.LoweredInitializers.Kind == BoundKind.StatementList)
                                 {
-                                    BoundStatementList lowered = (BoundStatementList) processedInitializers.LoweredInitializers;
+                                    BoundStatementList lowered = (BoundStatementList)processedInitializers.LoweredInitializers;
                                     boundStatements = boundStatements.Concat(lowered.Statements);
                                 }
                                 else
@@ -1235,7 +1235,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     previousSubmissionFields: previousSubmissionFields,
                     allowOmissionOfConditionalCalls: true,
                     instrumentForDynamicAnalysis: instrumentForDynamicAnalysis,
-                    debugDocumentProvider:debugDocumentProvider,
+                    debugDocumentProvider: debugDocumentProvider,
                     dynamicAnalysisSpans: ref dynamicAnalysisSpans,
                     diagnostics: diagnostics,
                     sawLambdas: out sawLambdas,
@@ -1288,7 +1288,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         lazyVariableSlotAllocator,
                         compilationState,
                         diagnostics,
-                        assignLocals: false);
+                        assignLocals: null);
                 }
 
                 if (bodyWithoutLambdas.HasErrors)
@@ -1359,7 +1359,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool isAsyncStateMachine;
                 MethodSymbol kickoffMethod;
 
-                if (method is SynthesizedStateMachineMethod stateMachineMethod && 
+                if (method is SynthesizedStateMachineMethod stateMachineMethod &&
                     method.Name == WellKnownMemberNames.MoveNextMethodName)
                 {
                     kickoffMethod = stateMachineMethod.StateMachineType.KickoffMethod;
@@ -1387,9 +1387,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // So it is undesirable to consider these exceptions "user unhandled" since there may well be user code that is awaiting the task.
                     // This is a heuristic since it's possible that there is no user code awaiting the task.
                     moveNextBodyDebugInfoOpt = new AsyncMoveNextBodyDebugInfo(
-                        kickoffMethod, 
+                        kickoffMethod,
                         kickoffMethod.ReturnsVoid ? asyncCatchHandlerOffset : -1,
-                        asyncYieldPoints, 
+                        asyncYieldPoints,
                         asyncResumePoints);
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -98,10 +98,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         // or the "this" parameter when at the top level.  Keys in this map are never constructed types.
         private readonly Dictionary<NamedTypeSymbol, Symbol> _framePointers = new Dictionary<NamedTypeSymbol, Symbol>();
 
-        // True if the rewritten tree should include assignments of the
-        // original locals to the lifted proxies. This is only useful for the
-        // expression evaluator where the original locals are left as is.
-        private readonly bool _assignLocals;
+        // The set of original locals that should be assigned to proxies
+        // if lifted. This is useful for the expression evaluator where
+        // the original locals are left as is.
+        private readonly HashSet<LocalSymbol> _assignLocals;
 
         // The current method or lambda being processed.
         private MethodSymbol _currentMethod;
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VariableSlotAllocator slotAllocatorOpt,
             TypeCompilationState compilationState,
             DiagnosticBag diagnostics,
-            bool assignLocals)
+            HashSet<LocalSymbol> assignLocals)
             : base(slotAllocatorOpt, compilationState, diagnostics)
         {
             Debug.Assert(analysis != null);
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="slotAllocatorOpt">Slot allocator.</param>
         /// <param name="compilationState">The caller's buffer into which we produce additional methods to be emitted by the caller</param>
         /// <param name="diagnostics">Diagnostic bag for diagnostics</param>
-        /// <param name="assignLocals">The rewritten tree should include assignments of the original locals to the lifted proxies</param>
+        /// <param name="assignLocals">The set of original locals that should be assigned to proxies if lifted</param>
         public static BoundStatement Rewrite(
             BoundStatement loweredBody,
             NamedTypeSymbol thisType,
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             VariableSlotAllocator slotAllocatorOpt,
             TypeCompilationState compilationState,
             DiagnosticBag diagnostics,
-            bool assignLocals)
+            HashSet<LocalSymbol> assignLocals)
         {
             Debug.Assert((object)thisType != null);
             Debug.Assert(((object)thisParameter == null) || (thisParameter.Type == thisType));
@@ -748,12 +748,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         break;
 
                     case SymbolKind.Local:
-                        if (!_assignLocals)
+                        var local = (LocalSymbol)symbol;
+                        if (_assignLocals == null || !_assignLocals.Contains(local))
                         {
                             return;
                         }
 
-                        var local = (LocalSymbol)symbol;
                         LocalSymbol localToUse;
                         if (!localMap.TryGetValue(local, out localToUse))
                         {

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -6,12 +6,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -174,12 +171,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert((object)TopLevelMethod == null || TopLevelMethod.ContainingType == CurrentType);
 
-                // In EE scenarios, lambdas are considered to be contained by the user-defined methods,
-                // rather than the EE-defined methods for which we are generating bound nodes.  This is
-                // because the containing symbols are used to determine the type of the "this" parameter,
-                // which we need to the user-defined types.
+                // In EE scenarios, lambdas and local functions are considered to be contained by the
+                // user-defined methods, rather than the EE-defined methods for which we are generating
+                // bound nodes. This is because the containing symbols are used to determine the type
+                // of the "this" parameter, which we need to be the user-defined types.
                 Debug.Assert((object)CurrentMethod == null ||
                     CurrentMethod.MethodKind == MethodKind.AnonymousFunction ||
+                    CurrentMethod.MethodKind == MethodKind.LocalFunction ||
                     CurrentMethod.ContainingType == CurrentType);
             }
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -4038,7 +4038,7 @@ class Program
 }
 ");
         }
-        
+
         internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options)
         {
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, options: options);

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -497,126 +497,130 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     statementsBuilder.Add(new BoundReturnStatement(syntax, RefKind.None, expressionOpt: null));
                 }
 
-                var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
                 var localsSet = PooledHashSet<LocalSymbol>.GetInstance();
-                foreach (var local in this.LocalsForBinding)
+                try
                 {
-                    Debug.Assert(!localsSet.Contains(local));
-                    localsBuilder.Add(local);
-                    localsSet.Add(local);
-                }
-                foreach (var local in this.Locals)
-                {
-                    if (!localsSet.Contains(local))
+                    var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+                    foreach (var local in this.LocalsForBinding)
                     {
                         Debug.Assert(!localsSet.Contains(local));
                         localsBuilder.Add(local);
                         localsSet.Add(local);
                     }
-                }
-                localsSet.Free();
+                    foreach (var local in this.Locals)
+                    {
+                        if (localsSet.Add(local))
+                        {
+                            localsBuilder.Add(local);
+                        }
+                    }
 
-                body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
+                    body = new BoundBlock(syntax, localsBuilder.ToImmutableAndFree(), statementsBuilder.ToImmutableAndFree()) { WasCompilerGenerated = true };
 
-                Debug.Assert(!diagnostics.HasAnyErrors());
-                Debug.Assert(!body.HasErrors);
+                    Debug.Assert(!diagnostics.HasAnyErrors());
+                    Debug.Assert(!body.HasErrors);
 
-                bool sawLambdas;
-                bool sawLocalFunctions;
-                bool sawAwaitInExceptionHandler;
-                ImmutableArray<SourceSpan> dynamicAnalysisSpans = ImmutableArray<SourceSpan>.Empty;
-                body = LocalRewriter.Rewrite(
-                    compilation: this.DeclaringCompilation,
-                    method: this,
-                    methodOrdinal: _methodOrdinal,
-                    containingType: _container,
-                    statement: body,
-                    compilationState: compilationState,
-                    previousSubmissionFields: null,
-                    allowOmissionOfConditionalCalls: false,
-                    instrumentForDynamicAnalysis: false,
-                    debugDocumentProvider: null,
-                    dynamicAnalysisSpans: ref dynamicAnalysisSpans,
-                    diagnostics: diagnostics,
-                    sawLambdas: out sawLambdas,
-                    sawLocalFunctions: out sawLocalFunctions,
-                    sawAwaitInExceptionHandler: out sawAwaitInExceptionHandler);
-
-                Debug.Assert(!sawAwaitInExceptionHandler);
-                Debug.Assert(dynamicAnalysisSpans.Length == 0);
-
-                if (body.HasErrors)
-                {
-                    return;
-                }
-
-                // Variables may have been captured by lambdas in the original method
-                // or in the expression, and we need to preserve the existing values of
-                // those variables in the expression. This requires rewriting the variables
-                // in the expression based on the closure classes from both the original
-                // method and the expression, and generating a preamble that copies
-                // values into the expression closure classes.
-                //
-                // Consider the original method:
-                // static void M()
-                // {
-                //     int x, y, z;
-                //     ...
-                //     F(() => x + y);
-                // }
-                // and the expression in the EE: "F(() => x + z)".
-                //
-                // The expression is first rewritten using the closure class and local <1>
-                // from the original method: F(() => <1>.x + z)
-                // Then lambda rewriting introduces a new closure class that includes
-                // the locals <1> and z, and a corresponding local <2>: F(() => <2>.<1>.x + <2>.z)
-                // And a preamble is added to initialize the fields of <2>:
-                //     <2> = new <>c__DisplayClass0();
-                //     <2>.<1> = <1>;
-                //     <2>.z = z;
-
-                // Rewrite "this" and "base" references to parameter in this method.
-                // Rewrite variables within body to reference existing display classes.
-                body = (BoundStatement)CapturedVariableRewriter.Rewrite(
-                    this.GenerateThisReference,
-                    compilation.Conversions,
-                    _displayClassVariables,
-                    body,
-                    diagnostics);
-
-                if (body.HasErrors)
-                {
-                    Debug.Assert(false, "Please add a test case capturing whatever caused this assert.");
-                    return;
-                }
-
-                if (diagnostics.HasAnyErrors())
-                {
-                    return;
-                }
-
-                if (sawLambdas || sawLocalFunctions)
-                {
-                    var closureDebugInfoBuilder = ArrayBuilder<ClosureDebugInfo>.GetInstance();
-                    var lambdaDebugInfoBuilder = ArrayBuilder<LambdaDebugInfo>.GetInstance();
-
-                    body = LambdaRewriter.Rewrite(
-                        loweredBody: body,
-                        thisType: this.SubstitutedSourceMethod.ContainingType,
-                        thisParameter: _thisParameter,
+                    bool sawLambdas;
+                    bool sawLocalFunctions;
+                    bool sawAwaitInExceptionHandler;
+                    ImmutableArray<SourceSpan> dynamicAnalysisSpans = ImmutableArray<SourceSpan>.Empty;
+                    body = LocalRewriter.Rewrite(
+                        compilation: this.DeclaringCompilation,
                         method: this,
                         methodOrdinal: _methodOrdinal,
-                        substitutedSourceMethod: this.SubstitutedSourceMethod.OriginalDefinition,
-                        closureDebugInfoBuilder: closureDebugInfoBuilder,
-                        lambdaDebugInfoBuilder: lambdaDebugInfoBuilder,
-                        slotAllocatorOpt: null,
+                        containingType: _container,
+                        statement: body,
                         compilationState: compilationState,
+                        previousSubmissionFields: null,
+                        allowOmissionOfConditionalCalls: false,
+                        instrumentForDynamicAnalysis: false,
+                        debugDocumentProvider: null,
+                        dynamicAnalysisSpans: ref dynamicAnalysisSpans,
                         diagnostics: diagnostics,
-                        assignLocals: true);
+                        sawLambdas: out sawLambdas,
+                        sawLocalFunctions: out sawLocalFunctions,
+                        sawAwaitInExceptionHandler: out sawAwaitInExceptionHandler);
 
-                    // we don't need this information:
-                    closureDebugInfoBuilder.Free();
-                    lambdaDebugInfoBuilder.Free();
+                    Debug.Assert(!sawAwaitInExceptionHandler);
+                    Debug.Assert(dynamicAnalysisSpans.Length == 0);
+
+                    if (body.HasErrors)
+                    {
+                        return;
+                    }
+
+                    // Variables may have been captured by lambdas in the original method
+                    // or in the expression, and we need to preserve the existing values of
+                    // those variables in the expression. This requires rewriting the variables
+                    // in the expression based on the closure classes from both the original
+                    // method and the expression, and generating a preamble that copies
+                    // values into the expression closure classes.
+                    //
+                    // Consider the original method:
+                    // static void M()
+                    // {
+                    //     int x, y, z;
+                    //     ...
+                    //     F(() => x + y);
+                    // }
+                    // and the expression in the EE: "F(() => x + z)".
+                    //
+                    // The expression is first rewritten using the closure class and local <1>
+                    // from the original method: F(() => <1>.x + z)
+                    // Then lambda rewriting introduces a new closure class that includes
+                    // the locals <1> and z, and a corresponding local <2>: F(() => <2>.<1>.x + <2>.z)
+                    // And a preamble is added to initialize the fields of <2>:
+                    //     <2> = new <>c__DisplayClass0();
+                    //     <2>.<1> = <1>;
+                    //     <2>.z = z;
+
+                    // Rewrite "this" and "base" references to parameter in this method.
+                    // Rewrite variables within body to reference existing display classes.
+                    body = (BoundStatement)CapturedVariableRewriter.Rewrite(
+                        this.GenerateThisReference,
+                        compilation.Conversions,
+                        _displayClassVariables,
+                        body,
+                        diagnostics);
+
+                    if (body.HasErrors)
+                    {
+                        Debug.Assert(false, "Please add a test case capturing whatever caused this assert.");
+                        return;
+                    }
+
+                    if (diagnostics.HasAnyErrors())
+                    {
+                        return;
+                    }
+
+                    if (sawLambdas || sawLocalFunctions)
+                    {
+                        var closureDebugInfoBuilder = ArrayBuilder<ClosureDebugInfo>.GetInstance();
+                        var lambdaDebugInfoBuilder = ArrayBuilder<LambdaDebugInfo>.GetInstance();
+
+                        body = LambdaRewriter.Rewrite(
+                            loweredBody: body,
+                            thisType: this.SubstitutedSourceMethod.ContainingType,
+                            thisParameter: _thisParameter,
+                            method: this,
+                            methodOrdinal: _methodOrdinal,
+                            substitutedSourceMethod: this.SubstitutedSourceMethod.OriginalDefinition,
+                            closureDebugInfoBuilder: closureDebugInfoBuilder,
+                            lambdaDebugInfoBuilder: lambdaDebugInfoBuilder,
+                            slotAllocatorOpt: null,
+                            compilationState: compilationState,
+                            diagnostics: diagnostics,
+                            assignLocals: localsSet);
+
+                        // we don't need this information:
+                        closureDebugInfoBuilder.Free();
+                        lambdaDebugInfoBuilder.Free();
+                    }
+                }
+                finally
+                {
+                    localsSet.Free();
                 }
 
                 // Insert locals from the original method,

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -1426,12 +1426,11 @@ class P
             });
         }
 
-        [Fact(Skip = "18273"), WorkItem(18273, "https://github.com/dotnet/roslyn/issues/18273")]
+        [Fact, WorkItem(18273, "https://github.com/dotnet/roslyn/issues/18273")]
         public void CapturedLocalInNestedLambda()
         {
             var source = @"
 using System;
-
 class C
 {
     void M() { }
@@ -1440,11 +1439,69 @@ class C
             WithRuntimeInstance(compilation0, runtime =>
             {
                 var context = CreateMethodContext(runtime, "C.M");
-
                 var testData = new CompilationTestData();
                 context.CompileExpression("new Action(() => { int x; new Func<int>(() => x).Invoke(); }).Invoke()", out var error, testData);
                 Assert.Null(error);
-                testData.GetMethodData("<>x.<>m0").VerifyIL("");
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"{
+  // Code size       37 (0x25)
+  .maxstack  2
+  IL_0000:  ldsfld     ""System.Action <>x.<>c.<>9__0_0""
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_001f
+  IL_0008:  pop
+  IL_0009:  ldsfld     ""<>x.<>c <>x.<>c.<>9""
+  IL_000e:  ldftn      ""void <>x.<>c.<<>m0>b__0_0()""
+  IL_0014:  newobj     ""System.Action..ctor(object, System.IntPtr)""
+  IL_0019:  dup
+  IL_001a:  stsfld     ""System.Action <>x.<>c.<>9__0_0""
+  IL_001f:  callvirt   ""void System.Action.Invoke()""
+  IL_0024:  ret
+}");
+            });
+        }
+
+        [Fact, WorkItem(18273, "https://github.com/dotnet/roslyn/issues/18273")]
+        public void CapturedLocalInNestedLocalFunction()
+        {
+            var source = @"
+using System;
+class C
+{
+    void M() { }
+}";
+            var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
+            WithRuntimeInstance(compilation0, runtime =>
+            {
+                var context = CreateMethodContext(runtime, "C.M");
+                var testData = new CompilationTestData();
+                context.CompileExpression(
+@"new Action<int>(x =>
+{
+    int y;
+    int F() => x + y;
+    F();
+}).Invoke(1)",
+                    out var error,
+                    testData);
+                Assert.Null(error);
+                testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"{
+  // Code size       38 (0x26)
+  .maxstack  2
+  IL_0000:  ldsfld     ""System.Action<int> <>x.<>c.<>9__0_0""
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_001f
+  IL_0008:  pop
+  IL_0009:  ldsfld     ""<>x.<>c <>x.<>c.<>9""
+  IL_000e:  ldftn      ""void <>x.<>c.<<>m0>b__0_0(int)""
+  IL_0014:  newobj     ""System.Action<int>..ctor(object, System.IntPtr)""
+  IL_0019:  dup
+  IL_001a:  stsfld     ""System.Action<int> <>x.<>c.<>9__0_0""
+  IL_001f:  ldc.i4.1
+  IL_0020:  callvirt   ""void System.Action<int>.Invoke(int)""
+  IL_0025:  ret
+}");
             });
         }
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -471,7 +471,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 originalLocalsSet.Add(local)
             Next
             For Each local In Me.Locals
-                If Not originalLocalsSet.Contains(local) Then
+                If originalLocalsSet.Add(local) Then
                     originalLocalsBuilder.Add(local)
                 End If
             Next
@@ -555,10 +555,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 ' Rewrite references to "Me" to refer to this method's "Me" parameter.
                 ' Rewrite variables within body to reference existing display classes.
                 newBody = DirectCast(CapturedVariableRewriter.Rewrite(
-                If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
-                displayClassVariables,
-                newBody,
-                diagnostics), BoundBlock)
+                    If(Me.SubstitutedSourceMethod.IsShared, Nothing, Me.Parameters(0)),
+                    displayClassVariables,
+                    newBody,
+                    diagnostics), BoundBlock)
 
                 If diagnostics.HasAnyErrors() Then
                     Return newBody

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/LocalsTests.vb
@@ -830,6 +830,50 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub CapturedLocalInNestedLambda()
+            Const source =
+"Imports System
+Class C
+    Shared Sub M()
+    End Sub
+    Shared Sub F(a As Action)
+    End Sub
+End Class"
+            Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
+            WithRuntimeInstance(comp,
+                Sub(runtime)
+                    Dim context = CreateMethodContext(runtime, "C.M")
+                    Dim testData As New CompilationTestData()
+                    Dim errorMessage As String = Nothing
+                    context.CompileExpression(
+"F(Sub()
+        Dim x As Integer
+        Dim y As New Func(Of Integer)(Function() x)
+        y.Invoke()
+    End Sub)",
+                        errorMessage,
+                        testData)
+                    Assert.Null(errorMessage)
+                    testData.GetMethodData("<>x.<>m0").VerifyIL(
+"{
+  // Code size       42 (0x2a)
+  .maxstack  2
+  IL_0000:  ldsfld     ""<>x._Closure$__.$I0-0 As System.Action""
+  IL_0005:  brfalse.s  IL_000e
+  IL_0007:  ldsfld     ""<>x._Closure$__.$I0-0 As System.Action""
+  IL_000c:  br.s       IL_0024
+  IL_000e:  ldsfld     ""<>x._Closure$__.$I As <>x._Closure$__""
+  IL_0013:  ldftn      ""Sub <>x._Closure$__._Lambda$__0-0()""
+  IL_0019:  newobj     ""Sub System.Action..ctor(Object, System.IntPtr)""
+  IL_001e:  dup
+  IL_001f:  stsfld     ""<>x._Closure$__.$I0-0 As System.Action""
+  IL_0024:  call       ""Sub C.F(System.Action)""
+  IL_0029:  ret
+}")
+                End Sub)
+        End Sub
+
+        <Fact>
         Public Sub NestedLambdas()
             Const source = "
 Imports System


### PR DESCRIPTION
**Customer scenario**

Evaluate expression containing nested lambdas where the inner lambda closes over a local in outer lambda.

**Bugs this fixes:**

#18273

**Workarounds, if any**

Avoid evaluating such expressions

**Risk**

Low

**Performance impact**

Low

**Is this a regression from a previous update?**

Probably not a regression. Unit test included.


