### PR TITLE
remove _showPosition from DiagnosticDescription

### DIFF
--- a/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DiagnosticDescription.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         private readonly string _squiggledText;
         private readonly object[] _arguments;
         private readonly LinePosition? _startPosition; // May not have a value only in the case that we're constructed via factories
-        private bool _showPosition; // show start position in ToString if comparison fails
         private readonly bool _argumentOrderDoesNotMatter;
         private readonly Type _errorCodeType;
         private readonly bool _ignoreArgumentsWhenComparing;
@@ -96,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             _errorCodeType = errorCodeType ?? code.GetType();
         }
 
-        public DiagnosticDescription(Diagnostic d, bool errorCodeOnly, bool showPosition = false)
+        public DiagnosticDescription(Diagnostic d, bool errorCodeOnly)
         {
             _code = d.Code;
             _isWarningAsError = d.IsWarningAsError;
@@ -124,7 +123,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
 
             _ignoreArgumentsWhenComparing = errorCodeOnly;
-            _showPosition = showPosition;
 
             if (!_ignoreArgumentsWhenComparing)
             {
@@ -219,13 +217,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 {
                     if (_startPosition.Value != d._startPosition.Value)
                     {
-                        _showPosition = true;
-                        d._showPosition = true;
                         return false;
                     }
-
-                    _showPosition = false;
-                    d._showPosition = false;
                 }
             }
 
@@ -354,7 +347,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 sb.Append(")");
             }
 
-            if (_startPosition != null && _showPosition)
+            if (_startPosition != null)
             {
                 sb.Append(".WithLocation(");
                 sb.Append(_startPosition.Value.Line + 1);
@@ -438,7 +431,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     }
                 }
 
-                var description = new DiagnosticDescription(d, errorCodeOnly: false, showPosition: true);
+                var description = new DiagnosticDescription(d, errorCodeOnly: false);
                 var diffDescription = description;
                 var idx = Array.IndexOf(expected, description);
                 if (idx != -1)


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/17155 

_showPosition was *really* weird.  

* Nowhere was _showPosition ever set to false from the constructor.  
* The Equals method set showPosition to false on `both` DiagnosticDescriptions if both have locations and both are the same, but only if the method didn't bail out earlier.

CC @jcouv @AlekseyTs 