### PR TITLE
Add more exception handling for portable PDB writing in PeWriter

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -4584,6 +4584,35 @@ public class X
         }
 
         [Fact]
+        public void BadPdbStreamWithPortablePdbEmit()
+        {
+            var comp = CreateStandardCompilation("class C {}");
+            var broken = new BrokenStream();
+            broken.BreakHow = BrokenStream.BreakHowType.ThrowOnWrite;
+            using (var peStream = new MemoryStream())
+            {
+                var portablePdbOptions = EmitOptions.Default
+                    .WithDebugInformationFormat(DebugInformationFormat.PortablePdb);
+
+                var result = comp.Emit(peStream,
+                    pdbStream: broken,
+                    options: portablePdbOptions);
+
+                Assert.False(result.Success);
+                result.Diagnostics.Verify(
+                    // error CS0041: Unexpected error writing debug information -- 'I/O error occurred.'
+                    Diagnostic(ErrorCode.FTL_DebugEmitFailure).WithArguments("I/O error occurred.").WithLocation(1, 1));
+
+                // Allow for cancellation
+                broken = new BrokenStream();
+                broken.BreakHow = BrokenStream.BreakHowType.CancelOnWrite;
+                Assert.Throws<OperationCanceledException>(() => comp.Emit(peStream,
+                    pdbStream: broken,
+                    options: portablePdbOptions));
+            }
+        }
+
+        [Fact]
         [WorkItem(9308, "https://github.com/dotnet/roslyn/issues/9308")]
         public void FailingEmitterAllowsCancelationExceptionsThrough()
         {

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -160,7 +160,14 @@ namespace Microsoft.Cci
                     Stream portablePdbStream = getPortablePdbStreamOpt();
                     if (portablePdbStream != null)
                     {
-                        portablePdbBlob.WriteContentTo(portablePdbStream);
+                        try
+                        {
+                            portablePdbBlob.WriteContentTo(portablePdbStream);
+                        }
+                        catch (Exception e) when (!(e is OperationCanceledException))
+                        {
+                            throw new PdbWritingException(e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Customer scenario**

Exception is causing crashes on customer machines.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=403647

**Workarounds, if any**

This is an IOException, so it's usually caused by the output path being non-writable for some reason. The user could choose a different output path which may be writable.

**Risk**

Very low risk -- simply catches exception and propagates the failure upward.

**Performance impact**

None -- additional try/catch.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This code path was only used by portable PDBs, so it's likely that users weren't using portable PDBs as often and thus wouldn't hit the crash as often if an I/O failure occurred.

**How was the bug found?**

Watson.