### PR TITLE
Fix instrumentation for methods that have spans in multiple files

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Roslyn.Utilities;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System;
+using System.Linq;
+using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -18,7 +19,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly MethodSymbol _method;
         private readonly BoundStatement _methodBody;
-        private readonly MethodSymbol _createPayload;
+        private readonly MethodSymbol _createPayloadForMethodsSpanningSingleFile;
+        private readonly MethodSymbol _createPayloadForMethodsSpanningMultipleFiles;
         private readonly ArrayBuilder<SourceSpan> _spansBuilder;
         private ImmutableArray<SourceSpan> _dynamicAnalysisSpans = ImmutableArray<SourceSpan>.Empty;
         private readonly BoundStatement _methodEntryInstrumentation;
@@ -28,7 +30,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly DebugDocumentProvider _debugDocumentProvider;
         private readonly SyntheticBoundNodeFactory _methodBodyFactory;
 
-        public static DynamicAnalysisInjector TryCreate(MethodSymbol method, BoundStatement methodBody, SyntheticBoundNodeFactory methodBodyFactory, DiagnosticBag diagnostics, DebugDocumentProvider debugDocumentProvider, Instrumenter previous)
+        public static DynamicAnalysisInjector TryCreate(
+            MethodSymbol method,
+            BoundStatement methodBody,
+            SyntheticBoundNodeFactory methodBodyFactory,
+            DiagnosticBag diagnostics,
+            DebugDocumentProvider debugDocumentProvider,
+            Instrumenter previous)
         {
             // Do not instrument implicitly-declared methods, except for constructors.
             // Instrument implicit constructors in order to instrument member initializers.
@@ -43,28 +51,54 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            MethodSymbol createPayload = GetCreatePayload(methodBodyFactory.Compilation, methodBody.Syntax, diagnostics);
+            MethodSymbol createPayloadForMethodsSpanningSingleFile = GetCreatePayloadOverload(
+                methodBodyFactory.Compilation,
+                WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
+                methodBody.Syntax,
+                diagnostics);
+
+            MethodSymbol createPayloadForMethodsSpanningMultipleFiles = GetCreatePayloadOverload(
+                methodBodyFactory.Compilation,
+                WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles,
+                methodBody.Syntax,
+                diagnostics);
 
             // Do not instrument any methods if CreatePayload is not present.
-            if ((object)createPayload == null)
+            if ((object)createPayloadForMethodsSpanningSingleFile == null || (object)createPayloadForMethodsSpanningMultipleFiles == null)
             {
                 return null;
             }
 
             // Do not instrument CreatePayload if it is part of the current compilation (which occurs only during testing).
             // CreatePayload will fail at run time with an infinite recursion if it is instrumented.
-            if (method.Equals(createPayload))
+            if (method.Equals(createPayloadForMethodsSpanningSingleFile) || method.Equals(createPayloadForMethodsSpanningMultipleFiles))
             {
                 return null;
             }
 
-            return new DynamicAnalysisInjector(method, methodBody, methodBodyFactory, createPayload, diagnostics, debugDocumentProvider, previous);
+            return new DynamicAnalysisInjector(
+                method,
+                methodBody,
+                methodBodyFactory,
+                createPayloadForMethodsSpanningSingleFile,
+                createPayloadForMethodsSpanningMultipleFiles,
+                diagnostics,
+                debugDocumentProvider,
+                previous);
         }
 
-        private DynamicAnalysisInjector(MethodSymbol method, BoundStatement methodBody, SyntheticBoundNodeFactory methodBodyFactory, MethodSymbol createPayload, DiagnosticBag diagnostics, DebugDocumentProvider debugDocumentProvider, Instrumenter previous)
-            : base(previous)
+        private DynamicAnalysisInjector(
+            MethodSymbol method,
+            BoundStatement methodBody,
+            SyntheticBoundNodeFactory methodBodyFactory,
+            MethodSymbol createPayloadForMethodsSpanningSingleFile,
+            MethodSymbol createPayloadForMethodsSpanningMultipleFiles,
+            DiagnosticBag diagnostics,
+            DebugDocumentProvider debugDocumentProvider,
+            Instrumenter previous) : base(previous)
         {
-            _createPayload = createPayload;
+            _createPayloadForMethodsSpanningSingleFile = createPayloadForMethodsSpanningSingleFile;
+            _createPayloadForMethodsSpanningMultipleFiles = createPayloadForMethodsSpanningMultipleFiles;
             _method = method;
             _methodBody = methodBody;
             _spansBuilder = ArrayBuilder<SourceSpan>.GetInstance();
@@ -129,6 +163,78 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
+        private static BoundExpressionStatement GetCreatePayloadStatement(
+            ImmutableArray<SourceSpan> dynamicAnalysisSpans,
+            SyntaxNode methodBodySyntax,
+            LocalSymbol methodPayload,
+            MethodSymbol createPayloadForMethodsSpanningSingleFile,
+            MethodSymbol createPayloadForMethodsSpanningMultipleFiles,
+            BoundExpression mvid,
+            BoundExpression methodToken,
+            BoundExpression payloadSlot,
+            SyntheticBoundNodeFactory methodBodyFactory,
+            DebugDocumentProvider debugDocumentProvider)
+        {
+            MethodSymbol createPayloadOverload;
+            BoundExpression fileIndexOrIndicesArgument;
+
+            if (dynamicAnalysisSpans.IsEmpty)
+            {
+                createPayloadOverload = createPayloadForMethodsSpanningSingleFile;
+
+                // For a compiler generated method that has no 'real' spans, we emit the index for
+                // the document corresponding to the syntax node that is associated with its bound node.
+                var document = GetSourceDocument(debugDocumentProvider, methodBodySyntax);
+                fileIndexOrIndicesArgument = methodBodyFactory.SourceDocumentIndex(document);
+            }
+            else
+            {
+                var documents = PooledHashSet<DebugSourceDocument>.GetInstance();
+                var fileIndices = ArrayBuilder<BoundExpression>.GetInstance();
+
+                foreach (var span in dynamicAnalysisSpans)
+                {
+                    var document = span.Document;
+                    if (documents.Add(document))
+                    {
+                        fileIndices.Add(methodBodyFactory.SourceDocumentIndex(document));
+                    }
+                }
+
+                documents.Free();
+
+                // At this point, we should have at least one document since we have already
+                // handled the case where method has no 'real' spans (and therefore no documents) above.
+                if (fileIndices.Count == 1)
+                {
+                    createPayloadOverload = createPayloadForMethodsSpanningSingleFile;
+                    fileIndexOrIndicesArgument = fileIndices.Single();
+                }
+                else
+                {
+                    createPayloadOverload = createPayloadForMethodsSpanningMultipleFiles;
+
+                    // Order of elements in fileIndices should be deterministic because these
+                    // elements were added based on order of spans in dynamicAnalysisSpans above.
+                    fileIndexOrIndicesArgument = methodBodyFactory.Array(
+                        methodBodyFactory.SpecialType(SpecialType.System_Int32), fileIndices.ToImmutable());
+                }
+
+                fileIndices.Free();
+            }
+
+            return methodBodyFactory.Assignment(
+                methodBodyFactory.Local(methodPayload),
+                methodBodyFactory.Call(
+                    null,
+                    createPayloadOverload,
+                    mvid,
+                    methodToken,
+                    fileIndexOrIndicesArgument,
+                    payloadSlot,
+                    methodBodyFactory.Literal(dynamicAnalysisSpans.Length)));
+        }
+
         public override BoundStatement CreateBlockPrologue(BoundBlock original, out LocalSymbol synthesizedLocal)
         {
             BoundStatement previousPrologue = base.CreateBlockPrologue(original, out synthesizedLocal);
@@ -138,22 +244,50 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // In the future there will be multiple analysis kinds.
                 const int analysisKind = 0;
 
-                ArrayTypeSymbol modulePayloadType = ArrayTypeSymbol.CreateCSharpArray(_methodBodyFactory.Compilation.Assembly, _payloadType);
+                ArrayTypeSymbol modulePayloadType =
+                    ArrayTypeSymbol.CreateCSharpArray(_methodBodyFactory.Compilation.Assembly, _payloadType);
 
                 // Synthesize the initialization of the instrumentation payload array, using concurrency-safe code:
                 //
                 // var payload = PID.PayloadRootField[methodIndex];
                 // if (payload == null)
-                //     payload = Instrumentation.CreatePayload(mvid, methodIndex, fileIndex, ref PID.PayloadRootField[methodIndex], payloadLength);
+                //     payload = Instrumentation.CreatePayload(mvid, methodIndex, fileIndexOrIndices, ref PID.PayloadRootField[methodIndex], payloadLength);
 
-                BoundStatement payloadInitialization = _methodBodyFactory.Assignment(_methodBodyFactory.Local(_methodPayload), _methodBodyFactory.ArrayAccess(_methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType), ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method))));
+                BoundStatement payloadInitialization =
+                    _methodBodyFactory.Assignment(
+                        _methodBodyFactory.Local(_methodPayload),
+                        _methodBodyFactory.ArrayAccess(
+                            _methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType),
+                            ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method))));
+
                 BoundExpression mvid = _methodBodyFactory.ModuleVersionId();
                 BoundExpression methodToken = _methodBodyFactory.MethodDefIndex(_method);
-                BoundExpression fileIndex = _methodBodyFactory.SourceDocumentIndex(GetSourceDocument(_methodBody.Syntax));
-                BoundExpression payloadSlot = _methodBodyFactory.ArrayAccess(_methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType), ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method)));
-                BoundStatement createPayloadCall = _methodBodyFactory.Assignment(_methodBodyFactory.Local(_methodPayload), _methodBodyFactory.Call(null, _createPayload, mvid, methodToken, fileIndex, payloadSlot, _methodBodyFactory.Literal(_dynamicAnalysisSpans.Length)));
 
-                BoundExpression payloadNullTest = _methodBodyFactory.Binary(BinaryOperatorKind.ObjectEqual, _methodBodyFactory.SpecialType(SpecialType.System_Boolean), _methodBodyFactory.Local(_methodPayload), _methodBodyFactory.Null(_payloadType));
+                BoundExpression payloadSlot =
+                    _methodBodyFactory.ArrayAccess(
+                        _methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType),
+                        ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method)));
+
+                BoundStatement createPayloadCall =
+                    GetCreatePayloadStatement(
+                        _dynamicAnalysisSpans,
+                        _methodBody.Syntax,
+                        _methodPayload,
+                        _createPayloadForMethodsSpanningSingleFile,
+                        _createPayloadForMethodsSpanningMultipleFiles,
+                        mvid,
+                        methodToken,
+                        payloadSlot,
+                        _methodBodyFactory,
+                        _debugDocumentProvider);
+
+                BoundExpression payloadNullTest =
+                    _methodBodyFactory.Binary(
+                        BinaryOperatorKind.ObjectEqual,
+                        _methodBodyFactory.SpecialType(SpecialType.System_Boolean),
+                        _methodBodyFactory.Local(_methodPayload),
+                        _methodBodyFactory.Null(_payloadType));
+
                 BoundStatement payloadIf = _methodBodyFactory.If(payloadNullTest, createPayloadCall);
 
                 Debug.Assert(synthesizedLocal == null);
@@ -271,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return AddDynamicAnalysis(original, rewritten);
         }
-        
+
         private static bool ReturnsValueWithinExpressionBodiedConstruct(BoundReturnStatement returnStatement)
         {
             if (returnStatement.WasCompilerGenerated &&
@@ -340,12 +474,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return statementFactory.StatementList(AddAnalysisPoint(SyntaxForSpan(original), statementFactory), rewritten);
         }
 
-        private Cci.DebugSourceDocument GetSourceDocument(SyntaxNode syntax)
+        private static Cci.DebugSourceDocument GetSourceDocument(DebugDocumentProvider debugDocumentProvider, SyntaxNode syntax)
         {
-            return GetSourceDocument(syntax, syntax.GetLocation().GetMappedLineSpan());
+            return GetSourceDocument(debugDocumentProvider, syntax, syntax.GetLocation().GetMappedLineSpan());
         }
 
-        private Cci.DebugSourceDocument GetSourceDocument(SyntaxNode syntax, FileLinePositionSpan span)
+        private static Cci.DebugSourceDocument GetSourceDocument(DebugDocumentProvider debugDocumentProvider, SyntaxNode syntax, FileLinePositionSpan span)
         {
             string path = span.Path;
             // If the path for the syntax node is empty, try the path for the entire syntax tree.
@@ -354,7 +488,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 path = syntax.SyntaxTree.FilePath;
             }
 
-            return _debugDocumentProvider.Invoke(path, basePath: "");
+            return debugDocumentProvider.Invoke(path, basePath: "");
         }
 
         private BoundStatement AddAnalysisPoint(SyntaxNode syntaxForSpan, Text.TextSpan alternateSpan, SyntheticBoundNodeFactory statementFactory)
@@ -371,10 +505,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // Add an entry in the spans array.
             int spansIndex = _spansBuilder.Count;
-            _spansBuilder.Add(new SourceSpan(GetSourceDocument(syntaxForSpan, span), span.StartLinePosition.Line, span.StartLinePosition.Character, span.EndLinePosition.Line, span.EndLinePosition.Character));
+            _spansBuilder.Add(new SourceSpan(
+                GetSourceDocument(_debugDocumentProvider, syntaxForSpan, span),
+                span.StartLinePosition.Line,
+                span.StartLinePosition.Character,
+                span.EndLinePosition.Line,
+                span.EndLinePosition.Character));
 
             // Generate "_payload[pointIndex] = true".
-            BoundArrayAccess payloadCell = statementFactory.ArrayAccess(statementFactory.Local(_methodPayload), statementFactory.Literal(spansIndex));
+            BoundArrayAccess payloadCell =
+                statementFactory.ArrayAccess(
+                    statementFactory.Local(_methodPayload),
+                    statementFactory.Literal(spansIndex));
+
             return statementFactory.Assignment(payloadCell, statementFactory.Literal(true));
         }
 
@@ -421,10 +564,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return syntaxForSpan;
         }
-        
-        private static MethodSymbol GetCreatePayload(CSharpCompilation compilation, SyntaxNode syntax, DiagnosticBag diagnostics)
+
+        private static MethodSymbol GetCreatePayloadOverload(CSharpCompilation compilation, WellKnownMember overload, SyntaxNode syntax, DiagnosticBag diagnostics)
         {
-            return (MethodSymbol)Binder.GetWellKnownTypeMember(compilation, WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload, diagnostics, syntax: syntax);
+            return (MethodSymbol)Binder.GetWellKnownTypeMember(compilation, overload, diagnostics, syntax: syntax);
         }
 
         private static SyntaxNode MethodDeclarationIfAvailable(SyntaxNode body)
@@ -478,7 +621,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return syntax.Span;
         }
-        
+
         private static Text.TextSpan SkipAttributes(SyntaxNode syntax, SyntaxList<AttributeListSyntax> attributes, SyntaxTokenList modifiers, SyntaxToken keyword, TypeSyntax type)
         {
             Text.TextSpan originalSpan = syntax.Span;

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
@@ -24,6 +24,11 @@ namespace Microsoft.CodeAnalysis.Runtime
             return payload;
         }
 
+        public static bool[] CreatePayload(System.Guid mvid, int methodToken, int[] fileIndices, ref bool[] payload, int payloadLength)
+        {
+            return payload;
+        }
+
         public static void FlushPayload()
         {
         }
@@ -63,14 +68,14 @@ public class C
         {
             var c = CreateStandardCompilation(Parse(ExampleSource + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
-       
+
             var peReader = new PEReader(peImage);
             var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader, "<DynamicAnalysisData>");
 
             VerifyDocuments(reader, reader.Documents,
-                @"'C:\myproject\doc1.cs' FF-9A-1F-F4-03-A5-A1-F7-8D-CD-00-15-67-0E-BA-F7-23-9D-3F-0F (SHA1)");
+                @"'C:\myproject\doc1.cs' 44-3F-7C-A1-EF-CA-A8-16-40-D2-09-4F-3E-52-7C-44-8D-22-C8-02 (SHA1)");
 
-            Assert.Equal(12, reader.Methods.Length);
+            Assert.Equal(13, reader.Methods.Length);
 
             string[] sourceLines = ExampleSource.Split('\n');
 
@@ -212,9 +217,9 @@ public class C
             var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader, "<DynamicAnalysisData>");
 
             VerifyDocuments(reader, reader.Documents,
-                @"'C:\myproject\doc1.cs' 89-73-A7-64-40-88-BA-0A-21-33-05-5D-E7-22-9B-74-1C-6A-2C-DC (SHA1)");
+                @"'C:\myproject\doc1.cs' 6A-DC-C0-8A-16-CB-7C-A5-99-8B-2E-0C-3C-81-69-2C-B2-10-EE-F1 (SHA1)");
 
-            Assert.Equal(5, reader.Methods.Length);
+            Assert.Equal(6, reader.Methods.Length);
 
             string[] sourceLines = source.Split('\n');
 
@@ -332,9 +337,9 @@ public class C
             var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader, "<DynamicAnalysisData>");
 
             VerifyDocuments(reader, reader.Documents,
-                @"'C:\myproject\doc1.cs' 45-00-3A-4C-F3-AC-01-6A-D2-57-35-E5-43-5E-BD-DB-98-AF-FD-41 (SHA1)");
+                @"'C:\myproject\doc1.cs' A3-08-94-55-7C-64-8D-C7-61-7A-11-0B-4B-68-2C-3B-51-C3-C4-58 (SHA1)");
 
-            Assert.Equal(14, reader.Methods.Length);
+            Assert.Equal(15, reader.Methods.Length);
 
             string[] sourceLines = source.Split('\n');
 
@@ -343,7 +348,7 @@ public class C
                 new SpanResult(10, 8, 10, 15, "Fred()"));
 
             VerifySpans(reader, reader.Methods[1], sourceLines,
-                new SpanResult(14,4,16,5, "static void Fred()"));
+                new SpanResult(14, 4, 16, 5, "static void Fred()"));
 
             VerifySpans(reader, reader.Methods[2], sourceLines,
                 new SpanResult(18, 4, 21, 5, "static C()"),
@@ -537,7 +542,7 @@ public class C
     }
 }
 ";
-            var c = CreateStandardCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { ValueTupleRef, SystemRuntimeFacadeRef});
+            var c = CreateStandardCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -705,7 +710,7 @@ public class C
             VerifySpans(reader, reader.Methods[2], sourceLines,
                new SpanResult(15, 4, 15, 28, "static int Init() => 33"),
                new SpanResult(15, 25, 15, 27, "33"));
-            
+
             VerifySpans(reader, reader.Methods[5], sourceLines,                     // Synthesized instance constructor
                 new SpanResult(17, 13, 17, 19, "Init()"),
                 new SpanResult(18, 13, 18, 24, "Init() + 12"),

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -26,6 +26,7 @@ public class Program
     }
 }
 ";
+
             string expectedOutput = @"Flushing
 Method 1
 File 1
@@ -47,8 +48,28 @@ True
 True
 True
 True
+True
+True
 ";
-            string expectedCreatePayloadIL = @"{
+
+            string expectedCreatePayloadForMethodsSpanningSingleFileIL = @"{
+  // Code size       21 (0x15)
+  .maxstack  6
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  ldc.i4.1
+  IL_0003:  newarr     ""int""
+  IL_0008:  dup
+  IL_0009:  ldc.i4.0
+  IL_000a:  ldarg.2
+  IL_000b:  stelem.i4
+  IL_000c:  ldarg.3
+  IL_000d:  ldarg.s    V_4
+  IL_000f:  call       ""bool[] Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, int[], ref bool[], int)""
+  IL_0014:  ret
+}";
+
+            string expectedCreatePayloadForMethodsSpanningMultipleFilesIL = @"{
   // Code size       87 (0x57)
   .maxstack  3
   IL_0000:  ldsfld     ""System.Guid Microsoft.CodeAnalysis.Runtime.Instrumentation._mvid""
@@ -59,8 +80,8 @@ True
   IL_000f:  newarr     ""bool[]""
   IL_0014:  stsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
   IL_0019:  ldc.i4.s   100
-  IL_001b:  newarr     ""int""
-  IL_0020:  stsfld     ""int[] Microsoft.CodeAnalysis.Runtime.Instrumentation._fileIndices""
+  IL_001b:  newarr     ""int[]""
+  IL_0020:  stsfld     ""int[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._fileIndices""
   IL_0025:  ldarg.0
   IL_0026:  stsfld     ""System.Guid Microsoft.CodeAnalysis.Runtime.Instrumentation._mvid""
   IL_002b:  ldarg.3
@@ -74,10 +95,10 @@ True
   IL_0041:  ldarg.3
   IL_0042:  ldind.ref
   IL_0043:  stelem.ref
-  IL_0044:  ldsfld     ""int[] Microsoft.CodeAnalysis.Runtime.Instrumentation._fileIndices""
+  IL_0044:  ldsfld     ""int[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._fileIndices""
   IL_0049:  ldarg.1
   IL_004a:  ldarg.2
-  IL_004b:  stelem.i4
+  IL_004b:  stelem.ref
   IL_004c:  ldarg.3
   IL_004d:  ldind.ref
   IL_004e:  ret
@@ -88,12 +109,13 @@ True
 }";
 
             string expectedFlushPayloadIL = @"{
-  // Code size      247 (0xf7)
+  // Code size      288 (0x120)
   .maxstack  5
   .locals init (bool[] V_0,
                 int V_1, //i
                 bool[] V_2, //payload
-                int V_3) //j
+                int V_3, //j
+                int V_4) //j
   IL_0000:  ldsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
   IL_0005:  ldtoken    ""void Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload()""
   IL_000a:  ldelem.ref
@@ -106,7 +128,7 @@ True
   IL_001e:  ldsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
   IL_0023:  ldtoken    ""void Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload()""
   IL_0028:  ldelema    ""bool[]""
-  IL_002d:  ldc.i4.s   14
+  IL_002d:  ldc.i4.s   16
   IL_002f:  call       ""bool[] Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, int, ref bool[], int)""
   IL_0034:  stloc.0
   IL_0035:  ldloc.0
@@ -136,7 +158,7 @@ True
   IL_005a:  stelem.i1
   IL_005b:  ldc.i4.0
   IL_005c:  stloc.1
-  IL_005d:  br         IL_00e9
+  IL_005d:  br         IL_0112
   IL_0062:  ldloc.0
   IL_0063:  ldc.i4.6
   IL_0064:  ldc.i4.1
@@ -146,84 +168,110 @@ True
   IL_006c:  ldelem.ref
   IL_006d:  stloc.2
   IL_006e:  ldloc.0
-  IL_006f:  ldc.i4.s   13
+  IL_006f:  ldc.i4.s   15
   IL_0071:  ldc.i4.1
   IL_0072:  stelem.i1
   IL_0073:  ldloc.2
-  IL_0074:  brfalse.s  IL_00e1
-  IL_0076:  ldloc.0
-  IL_0077:  ldc.i4.7
-  IL_0078:  ldc.i4.1
-  IL_0079:  stelem.i1
-  IL_007a:  ldstr      ""Method ""
-  IL_007f:  ldloca.s   V_1
-  IL_0081:  call       ""string int.ToString()""
-  IL_0086:  call       ""string string.Concat(string, string)""
-  IL_008b:  call       ""void System.Console.WriteLine(string)""
-  IL_0090:  ldloc.0
-  IL_0091:  ldc.i4.8
-  IL_0092:  ldc.i4.1
-  IL_0093:  stelem.i1
-  IL_0094:  ldstr      ""File ""
-  IL_0099:  ldsfld     ""int[] Microsoft.CodeAnalysis.Runtime.Instrumentation._fileIndices""
-  IL_009e:  ldloc.1
-  IL_009f:  ldelema    ""int""
-  IL_00a4:  call       ""string int.ToString()""
-  IL_00a9:  call       ""string string.Concat(string, string)""
-  IL_00ae:  call       ""void System.Console.WriteLine(string)""
-  IL_00b3:  ldloc.0
-  IL_00b4:  ldc.i4.s   9
-  IL_00b6:  ldc.i4.1
-  IL_00b7:  stelem.i1
-  IL_00b8:  ldc.i4.0
-  IL_00b9:  stloc.3
-  IL_00ba:  br.s       IL_00db
-  IL_00bc:  ldloc.0
-  IL_00bd:  ldc.i4.s   11
-  IL_00bf:  ldc.i4.1
-  IL_00c0:  stelem.i1
-  IL_00c1:  ldloc.2
-  IL_00c2:  ldloc.3
-  IL_00c3:  ldelem.u1
-  IL_00c4:  call       ""void System.Console.WriteLine(bool)""
-  IL_00c9:  ldloc.0
-  IL_00ca:  ldc.i4.s   12
-  IL_00cc:  ldc.i4.1
-  IL_00cd:  stelem.i1
-  IL_00ce:  ldloc.2
-  IL_00cf:  ldloc.3
-  IL_00d0:  ldc.i4.0
-  IL_00d1:  stelem.i1
-  IL_00d2:  ldloc.0
-  IL_00d3:  ldc.i4.s   10
-  IL_00d5:  ldc.i4.1
-  IL_00d6:  stelem.i1
-  IL_00d7:  ldloc.3
-  IL_00d8:  ldc.i4.1
-  IL_00d9:  add
-  IL_00da:  stloc.3
-  IL_00db:  ldloc.3
-  IL_00dc:  ldloc.2
-  IL_00dd:  ldlen
-  IL_00de:  conv.i4
-  IL_00df:  blt.s      IL_00bc
-  IL_00e1:  ldloc.0
-  IL_00e2:  ldc.i4.5
+  IL_0074:  brfalse    IL_010a
+  IL_0079:  ldloc.0
+  IL_007a:  ldc.i4.7
+  IL_007b:  ldc.i4.1
+  IL_007c:  stelem.i1
+  IL_007d:  ldstr      ""Method ""
+  IL_0082:  ldloca.s   V_1
+  IL_0084:  call       ""string int.ToString()""
+  IL_0089:  call       ""string string.Concat(string, string)""
+  IL_008e:  call       ""void System.Console.WriteLine(string)""
+  IL_0093:  ldloc.0
+  IL_0094:  ldc.i4.8
+  IL_0095:  ldc.i4.1
+  IL_0096:  stelem.i1
+  IL_0097:  ldc.i4.0
+  IL_0098:  stloc.3
+  IL_0099:  br.s       IL_00ca
+  IL_009b:  ldloc.0
+  IL_009c:  ldc.i4.s   10
+  IL_009e:  ldc.i4.1
+  IL_009f:  stelem.i1
+  IL_00a0:  ldstr      ""File ""
+  IL_00a5:  ldsfld     ""int[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._fileIndices""
+  IL_00aa:  ldloc.1
+  IL_00ab:  ldelem.ref
+  IL_00ac:  ldloc.3
+  IL_00ad:  ldelema    ""int""
+  IL_00b2:  call       ""string int.ToString()""
+  IL_00b7:  call       ""string string.Concat(string, string)""
+  IL_00bc:  call       ""void System.Console.WriteLine(string)""
+  IL_00c1:  ldloc.0
+  IL_00c2:  ldc.i4.s   9
+  IL_00c4:  ldc.i4.1
+  IL_00c5:  stelem.i1
+  IL_00c6:  ldloc.3
+  IL_00c7:  ldc.i4.1
+  IL_00c8:  add
+  IL_00c9:  stloc.3
+  IL_00ca:  ldloc.3
+  IL_00cb:  ldsfld     ""int[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._fileIndices""
+  IL_00d0:  ldloc.1
+  IL_00d1:  ldelem.ref
+  IL_00d2:  ldlen
+  IL_00d3:  conv.i4
+  IL_00d4:  blt.s      IL_009b
+  IL_00d6:  ldloc.0
+  IL_00d7:  ldc.i4.s   11
+  IL_00d9:  ldc.i4.1
+  IL_00da:  stelem.i1
+  IL_00db:  ldc.i4.0
+  IL_00dc:  stloc.s    V_4
+  IL_00de:  br.s       IL_0103
+  IL_00e0:  ldloc.0
+  IL_00e1:  ldc.i4.s   13
   IL_00e3:  ldc.i4.1
   IL_00e4:  stelem.i1
-  IL_00e5:  ldloc.1
-  IL_00e6:  ldc.i4.1
-  IL_00e7:  add
-  IL_00e8:  stloc.1
-  IL_00e9:  ldloc.1
-  IL_00ea:  ldsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
-  IL_00ef:  ldlen
-  IL_00f0:  conv.i4
-  IL_00f1:  blt        IL_0062
-  IL_00f6:  ret
+  IL_00e5:  ldloc.2
+  IL_00e6:  ldloc.s    V_4
+  IL_00e8:  ldelem.u1
+  IL_00e9:  call       ""void System.Console.WriteLine(bool)""
+  IL_00ee:  ldloc.0
+  IL_00ef:  ldc.i4.s   14
+  IL_00f1:  ldc.i4.1
+  IL_00f2:  stelem.i1
+  IL_00f3:  ldloc.2
+  IL_00f4:  ldloc.s    V_4
+  IL_00f6:  ldc.i4.0
+  IL_00f7:  stelem.i1
+  IL_00f8:  ldloc.0
+  IL_00f9:  ldc.i4.s   12
+  IL_00fb:  ldc.i4.1
+  IL_00fc:  stelem.i1
+  IL_00fd:  ldloc.s    V_4
+  IL_00ff:  ldc.i4.1
+  IL_0100:  add
+  IL_0101:  stloc.s    V_4
+  IL_0103:  ldloc.s    V_4
+  IL_0105:  ldloc.2
+  IL_0106:  ldlen
+  IL_0107:  conv.i4
+  IL_0108:  blt.s      IL_00e0
+  IL_010a:  ldloc.0
+  IL_010b:  ldc.i4.5
+  IL_010c:  ldc.i4.1
+  IL_010d:  stelem.i1
+  IL_010e:  ldloc.1
+  IL_010f:  ldc.i4.1
+  IL_0110:  add
+  IL_0111:  stloc.1
+  IL_0112:  ldloc.1
+  IL_0113:  ldsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
+  IL_0118:  ldlen
+  IL_0119:  conv.i4
+  IL_011a:  blt        IL_0062
+  IL_011f:  ret
 }";
+
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
-            verifier.VerifyIL("Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload", expectedCreatePayloadIL);
+            verifier.VerifyIL("Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, int, ref bool[], int)", expectedCreatePayloadForMethodsSpanningSingleFileIL);
+            verifier.VerifyIL("Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, int[], ref bool[], int)", expectedCreatePayloadForMethodsSpanningMultipleFilesIL);
             verifier.VerifyIL("Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload", expectedFlushPayloadIL);
             verifier.VerifyDiagnostics();
         }
@@ -333,6 +381,8 @@ File 1
 True
 True
 False
+True
+True
 True
 True
 True
@@ -498,6 +548,8 @@ File 1
 True
 True
 False
+True
+True
 True
 True
 True
@@ -684,6 +736,8 @@ public class Program
                 .True()
                 .True()
                 .True()
+                .True()
+                .True()
                 .True();
 
             CompilationVerifier verifier = CompileAndVerify(source, expectedOutput: checker.ExpectedOutput, options: TestOptions.ReleaseExe);
@@ -793,6 +847,8 @@ True
 True
 True
 True
+True
+True
 ";
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.ReleaseExe);
             verifier.VerifyDiagnostics();
@@ -884,6 +940,8 @@ public class D
                 .True()
                 .True()
                 .True()
+                .True()
+                .True()
                 .True();
 
             CompilationVerifier verifier = CompileAndVerify(source, expectedOutput: checker.ExpectedOutput, options: TestOptions.ReleaseExe);
@@ -954,6 +1012,8 @@ File 5
 True
 True
 False
+True
+True
 True
 True
 True
@@ -1062,6 +1122,8 @@ True
 True
 True
 True
+True
+True
 ";
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
@@ -1147,6 +1209,8 @@ File 1
 True
 True
 False
+True
+True
 True
 True
 True
@@ -1345,6 +1409,8 @@ True
 True
 True
 True
+True
+True
 ";
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
@@ -1437,6 +1503,8 @@ True
 True
 True
 True
+True
+True
 ";
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
@@ -1501,6 +1569,8 @@ File 1
 True
 True
 False
+True
+True
 True
 True
 True
@@ -1599,6 +1669,8 @@ True
 True
 True
 True
+True
+True
 ";
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
         }
@@ -1662,6 +1734,8 @@ File 1
 True
 True
 False
+True
+True
 True
 True
 True
@@ -1776,6 +1850,8 @@ True
 True
 True
 True
+True
+True
 ";
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
@@ -1851,6 +1927,8 @@ File 1
 True
 True
 False
+True
+True
 True
 True
 True
@@ -1973,6 +2051,8 @@ True
 True
 True
 True
+True
+True
 ";
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
@@ -2046,6 +2126,8 @@ File 1
 True
 True
 False
+True
+True
 True
 True
 True
@@ -2169,6 +2251,8 @@ File 1
 True
 True
 False
+True
+True
 True
 True
 True
@@ -2694,6 +2778,8 @@ public class Program
                 .True()
                 .True()
                 .True()
+                .True()
+                .True()
                 .True();
 
             var expectedOutput = @"Test
@@ -2759,6 +2845,8 @@ public class Program
             checker.Method(7, 1)
                 .True()
                 .False()
+                .True()
+                .True()
                 .True()
                 .True()
                 .True()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -858,7 +858,8 @@ namespace System
                     case WellKnownMember.System_Array__Empty:
                         // Not yet in the platform.
                         continue;
-                    case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload:
+                    case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:
+                    case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles:
                         // Not always available.
                         continue;
                 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -414,7 +414,9 @@ namespace Microsoft.CodeAnalysis
 
         System_String__Format_IFormatProvider,
 
-        Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload,
+        Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
+        Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles,
+
         System_Runtime_CompilerServices_ReferenceAssemblyAttribute__ctor,
 
         Count

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2867,7 +2867,7 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
                     (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Object,
 
-                // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload
+                // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                                                    // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation - WellKnownType.ExtSentinel),  // DeclaringTypeId
                 0,                                                                                                                                  // Arity
@@ -2876,6 +2876,18 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Guid,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
+                // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                                                    // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                                                  // Arity
+                    5,                                                                                                                              // Method Signature
+                    (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Guid,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
                     (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
 
@@ -3242,7 +3254,8 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Runtime_CompilerServices_TupleElementNamesAttribute__ctorTransformNames
 
                 "Format",                                   // System_String__Format_IFormatProvider
-                "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload
+                "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile
+                "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles
 
                 ".ctor",                                    // System_Runtime_CompilerServices_ReferenceAssemblyAttribute__ctor
             };

--- a/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
@@ -1,11 +1,11 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
+Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis.CodeGen
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Roslyn.Utilities
-Imports System.Collections.Immutable
-Imports System.Diagnostics
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
 
@@ -18,7 +18,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private ReadOnly _method As MethodSymbol
         Private ReadOnly _methodBody As BoundStatement
-        Private ReadOnly _createPayload As MethodSymbol
+        Private ReadOnly _createPayloadForMethodsSpanningSingleFile As MethodSymbol
+        Private ReadOnly _createPayloadForMethodsSpanningMultipleFiles As MethodSymbol
         Private ReadOnly _spansBuilder As ArrayBuilder(Of SourceSpan)
         Private _dynamicAnalysisSpans As ImmutableArray(Of SourceSpan) = ImmutableArray(Of SourceSpan).Empty
         Private ReadOnly _methodEntryInstrumentation As BoundStatement
@@ -28,7 +29,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _debugDocumentProvider As DebugDocumentProvider
         Private ReadOnly _methodBodyFactory As SyntheticBoundNodeFactory
 
-        Public Shared Function TryCreate(method As MethodSymbol, methodBody As BoundStatement, methodBodyFactory As SyntheticBoundNodeFactory, diagnostics As DiagnosticBag, debugDocumentProvider As DebugDocumentProvider, previous As Instrumenter) As DynamicAnalysisInjector
+        Public Shared Function TryCreate(
+            method As MethodSymbol,
+            methodBody As BoundStatement,
+            methodBodyFactory As SyntheticBoundNodeFactory,
+            diagnostics As DiagnosticBag,
+            debugDocumentProvider As DebugDocumentProvider,
+            previous As Instrumenter) As DynamicAnalysisInjector
+
             ' Do not instrument implicitly-declared methods, except for constructors.
             ' Instrument implicit constructors in order to instrument member initializers.
             If method.IsImplicitlyDeclared AndAlso Not method.IsAnyConstructor Then
@@ -45,20 +53,38 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Nothing
             End If
 
-            Dim createPayload As MethodSymbol = GetCreatePayload(methodBodyFactory.Compilation, methodBody.Syntax, diagnostics)
+            Dim createPayloadForMethodsSpanningSingleFile As MethodSymbol = GetCreatePayloadOverload(
+                methodBodyFactory.Compilation,
+                WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
+                methodBody.Syntax,
+                diagnostics)
+
+            Dim createPayloadForMethodsSpanningMultipleFiles As MethodSymbol = GetCreatePayloadOverload(
+                methodBodyFactory.Compilation,
+                WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles,
+                methodBody.Syntax,
+                diagnostics)
 
             ' Do not instrument any methods if CreatePayload is not present.
-            If createPayload Is Nothing Then
+            If createPayloadForMethodsSpanningSingleFile Is Nothing OrElse createPayloadForMethodsSpanningMultipleFiles Is Nothing Then
                 Return Nothing
             End If
 
             ' Do not instrument CreatePayload if it is part of the current compilation (which occurs only during testing).
             ' CreatePayload will fail at run time with an infinite recursion if it is instrumented.
-            If method.Equals(createPayload) Then
+            If method.Equals(createPayloadForMethodsSpanningSingleFile) OrElse method.Equals(createPayloadForMethodsSpanningMultipleFiles) Then
                 Return Nothing
             End If
 
-            Return New DynamicAnalysisInjector(method, methodBody, methodBodyFactory, createPayload, diagnostics, debugDocumentProvider, previous)
+            Return New DynamicAnalysisInjector(
+                method,
+                methodBody,
+                methodBodyFactory,
+                createPayloadForMethodsSpanningSingleFile,
+                createPayloadForMethodsSpanningMultipleFiles,
+                diagnostics,
+                debugDocumentProvider,
+                previous)
         End Function
 
         Private Shared Function HasValidMappedLineSpan(syntax As SyntaxNode) As Boolean
@@ -71,9 +97,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private Sub New(method As MethodSymbol, methodBody As BoundStatement, methodBodyFactory As SyntheticBoundNodeFactory, createPayload As MethodSymbol, diagnostics As DiagnosticBag, debugDocumentProvider As DebugDocumentProvider, previous As Instrumenter)
+        Private Sub New(
+            method As MethodSymbol,
+            methodBody As BoundStatement,
+            methodBodyFactory As SyntheticBoundNodeFactory,
+            createPayloadForMethodsSpanningSingleFile As MethodSymbol,
+            createPayloadForMethodsSpanningMultipleFiles As MethodSymbol,
+            diagnostics As DiagnosticBag,
+            debugDocumentProvider As DebugDocumentProvider,
+            previous As Instrumenter)
+
             MyBase.New(previous)
-            _createPayload = createPayload
+            _createPayloadForMethodsSpanningSingleFile = createPayloadForMethodsSpanningSingleFile
+            _createPayloadForMethodsSpanningMultipleFiles = createPayloadForMethodsSpanningMultipleFiles
             _method = method
             _methodBody = methodBody
             _spansBuilder = ArrayBuilder(Of SourceSpan).GetInstance()
@@ -128,6 +164,69 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return False
         End Function
 
+        Private Shared Function GetCreatePayloadStatement(
+            dynamicAnalysisSpans As ImmutableArray(Of SourceSpan),
+            methodBodySyntax As SyntaxNode,
+            methodPayload As LocalSymbol,
+            createPayloadForMethodsSpanningSingleFile As MethodSymbol,
+            createPayloadForMethodsSpanningMultipleFiles As MethodSymbol,
+            mvid As BoundExpression,
+            methodToken As BoundExpression,
+            payloadSlot As BoundExpression,
+            methodBodyFactory As SyntheticBoundNodeFactory,
+            debugDocumentProvider As DebugDocumentProvider) As BoundExpressionStatement
+
+            Dim createPayloadOverload As MethodSymbol
+            Dim fileIndexOrIndicesArgument As BoundExpression
+
+            If dynamicAnalysisSpans.IsEmpty Then
+                createPayloadOverload = createPayloadForMethodsSpanningSingleFile
+
+                ' For a compiler generated method that has no 'real' spans, we emit the index for
+                ' the document corresponding to the syntax node that is associated with its bound node.
+                Dim document = GetSourceDocument(debugDocumentProvider, methodBodySyntax)
+                fileIndexOrIndicesArgument = methodBodyFactory.SourceDocumentIndex(document)
+            Else
+                Dim documents = PooledHashSet(Of DebugSourceDocument).GetInstance()
+                Dim fileIndices = ArrayBuilder(Of BoundExpression).GetInstance()
+
+                For Each span In dynamicAnalysisSpans
+                    Dim document = span.Document
+                    If documents.Add(document) Then
+                        fileIndices.Add(methodBodyFactory.SourceDocumentIndex(document))
+                    End If
+                Next
+
+                documents.Free()
+
+                ' At this point, we should have at least one document since we have already
+                ' handled the case where method has no 'real' spans (and therefore no documents) above.
+                If fileIndices.Count = 1 Then
+                    createPayloadOverload = createPayloadForMethodsSpanningSingleFile
+                    fileIndexOrIndicesArgument = fileIndices.Single()
+                Else
+                    createPayloadOverload = createPayloadForMethodsSpanningMultipleFiles
+
+                    ' Order of elements in fileIndices should be deterministic because these
+                    ' elements were added based on order of spans in dynamicAnalysisSpans above.
+                    fileIndexOrIndicesArgument = methodBodyFactory.Array(
+                        methodBodyFactory.SpecialType(SpecialType.System_Int32), fileIndices.ToImmutable())
+                End If
+
+                fileIndices.Free()
+            End If
+
+            Return methodBodyFactory.Assignment(
+                methodBodyFactory.Local(methodPayload, isLValue:=True),
+                methodBodyFactory.Call(
+                    Nothing,
+                    createPayloadOverload,
+                    mvid,
+                    methodToken,
+                    fileIndexOrIndicesArgument,
+                    payloadSlot,
+                    methodBodyFactory.Literal(dynamicAnalysisSpans.Length)))
+        End Function
 
         Public Overrides Function CreateBlockPrologue(trueOriginal As BoundBlock, original As BoundBlock, ByRef synthesizedLocal As LocalSymbol) As BoundStatement
             Dim previousPrologue As BoundStatement = MyBase.CreateBlockPrologue(trueOriginal, original, synthesizedLocal)
@@ -137,23 +236,53 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 ' In the future there will be multiple analysis kinds.
                 Const analysisKind As Integer = 0
 
-                Dim modulePayloadType As ArrayTypeSymbol = ArrayTypeSymbol.CreateVBArray(_payloadType, ImmutableArray(Of CustomModifier).Empty, 1, _methodBodyFactory.Compilation.Assembly)
+                Dim modulePayloadType As ArrayTypeSymbol =
+                    ArrayTypeSymbol.CreateVBArray(_payloadType, ImmutableArray(Of CustomModifier).Empty, 1, _methodBodyFactory.Compilation.Assembly)
 
                 ' Synthesize the initialization of the instrumentation payload array, using concurrency-safe code
                 '
                 ' Dim payload = PID.PayloadRootField(methodIndex)
                 ' If payload Is Nothing Then
-                '     payload = Instrumentation.CreatePayload(mvid, methodIndex, fileIndex, PID.PayloadRootField(methodIndex), payloadLength)
+                '     payload = Instrumentation.CreatePayload(mvid, methodIndex, fileIndexOrIndices, PID.PayloadRootField(methodIndex), payloadLength)
                 ' End If
 
-                Dim payloadInitialization As BoundStatement = _methodBodyFactory.Assignment(_methodBodyFactory.Local(_methodPayload, isLValue:=True), _methodBodyFactory.ArrayAccess(_methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType, isLValue:=False), isLValue:=False, indices:=ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method))))
+                Dim payloadInitialization As BoundStatement =
+                    _methodBodyFactory.Assignment(
+                        _methodBodyFactory.Local(_methodPayload, isLValue:=True),
+                        _methodBodyFactory.ArrayAccess(
+                            _methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType, isLValue:=False),
+                            isLValue:=False,
+                            indices:=ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method))))
+
                 Dim mvid As BoundExpression = _methodBodyFactory.ModuleVersionId(isLValue:=False)
                 Dim methodToken As BoundExpression = _methodBodyFactory.MethodDefIndex(_method)
-                Dim fileIndex As BoundExpression = _methodBodyFactory.SourceDocumentIndex(GetSourceDocument(_methodBody.Syntax))
-                Dim payloadSlot As BoundExpression = _methodBodyFactory.ArrayAccess(_methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType, isLValue:=False), isLValue:=True, indices:=ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method)))
-                Dim createPayloadCall As BoundStatement = _methodBodyFactory.Assignment(_methodBodyFactory.Local(_methodPayload, isLValue:=True), _methodBodyFactory.Call(Nothing, _createPayload, mvid, methodToken, fileIndex, payloadSlot, _methodBodyFactory.Literal(_dynamicAnalysisSpans.Length)))
 
-                Dim payloadNullTest As BoundExpression = _methodBodyFactory.Binary(BinaryOperatorKind.Equals, _methodBodyFactory.SpecialType(SpecialType.System_Boolean), _methodBodyFactory.Local(_methodPayload, False), _methodBodyFactory.Null(_payloadType))
+                Dim payloadSlot As BoundExpression =
+                    _methodBodyFactory.ArrayAccess(
+                        _methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType, isLValue:=False),
+                        isLValue:=True,
+                        indices:=ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method)))
+
+                Dim createPayloadCall As BoundStatement =
+                    GetCreatePayloadStatement(
+                        _dynamicAnalysisSpans,
+                        _methodBody.Syntax,
+                        _methodPayload,
+                        _createPayloadForMethodsSpanningSingleFile,
+                        _createPayloadForMethodsSpanningMultipleFiles,
+                        mvid,
+                        methodToken,
+                        payloadSlot,
+                        _methodBodyFactory,
+                        _debugDocumentProvider)
+
+                Dim payloadNullTest As BoundExpression =
+                    _methodBodyFactory.Binary(
+                        BinaryOperatorKind.Equals,
+                        _methodBodyFactory.SpecialType(SpecialType.System_Boolean),
+                        _methodBodyFactory.Local(_methodPayload, False),
+                        _methodBodyFactory.Null(_payloadType))
+
                 Dim payloadIf As BoundStatement = _methodBodyFactory.If(payloadNullTest, createPayloadCall)
 
                 Debug.Assert(synthesizedLocal Is Nothing)
@@ -300,18 +429,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return If(rewritten IsNot Nothing, statementFactory.StatementList(analysisPoint, rewritten), analysisPoint)
         End Function
 
-        Private Function GetSourceDocument(syntax As SyntaxNode) As Cci.DebugSourceDocument
-            Return GetSourceDocument(syntax, syntax.GetLocation().GetMappedLineSpan())
+        Private Shared Function GetSourceDocument(debugDocumentProvider As DebugDocumentProvider, syntax As SyntaxNode) As Cci.DebugSourceDocument
+            Return GetSourceDocument(debugDocumentProvider, syntax, syntax.GetLocation().GetMappedLineSpan())
         End Function
 
-        Private Function GetSourceDocument(syntax As SyntaxNode, span As FileLinePositionSpan) As Cci.DebugSourceDocument
+        Private Shared Function GetSourceDocument(debugDocumentProvider As DebugDocumentProvider, syntax As SyntaxNode, span As FileLinePositionSpan) As Cci.DebugSourceDocument
             Dim path As String = span.Path
             ' If the path for the syntax node is empty, try the path for the entire syntax tree.
             If path.Length = 0 Then
                 path = syntax.SyntaxTree.FilePath
             End If
 
-            Return _debugDocumentProvider.Invoke(path, basePath:="")
+            Return debugDocumentProvider.Invoke(path, basePath:="")
         End Function
 
         Private Function AddAnalysisPoint(syntaxForSpan As SyntaxNode, alternateSpan As Text.TextSpan, statementFactory As SyntheticBoundNodeFactory) As BoundStatement
@@ -323,13 +452,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Private Function AddAnalysisPoint(syntaxForSpan As SyntaxNode, span As FileLinePositionSpan, statementFactory As SyntheticBoundNodeFactory) As BoundStatement
-
             ' Add an entry in the spans array.
             Dim spansIndex As Integer = _spansBuilder.Count
-            _spansBuilder.Add(New SourceSpan(GetSourceDocument(syntaxForSpan, span), span.StartLinePosition.Line, span.StartLinePosition.Character, span.EndLinePosition.Line, span.EndLinePosition.Character))
+            _spansBuilder.Add(New SourceSpan(
+                GetSourceDocument(_debugDocumentProvider, syntaxForSpan, span),
+                span.StartLinePosition.Line,
+                span.StartLinePosition.Character,
+                span.EndLinePosition.Line,
+                span.EndLinePosition.Character))
 
             ' Generate "_payload(pointIndex) = True".
-            Dim payloadCell As BoundArrayAccess = statementFactory.ArrayAccess(statementFactory.Local(_methodPayload, isLValue:=False), isLValue:=True, indices:=ImmutableArray.Create(Of BoundExpression)(statementFactory.Literal(spansIndex)))
+            Dim payloadCell As BoundArrayAccess =
+                statementFactory.ArrayAccess(
+                    statementFactory.Local(_methodPayload, isLValue:=False),
+                    isLValue:=True,
+                    indices:=ImmutableArray.Create(Of BoundExpression)(statementFactory.Literal(spansIndex)))
+
             Return statementFactory.Assignment(payloadCell, statementFactory.Literal(True))
         End Function
 
@@ -371,8 +509,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return statement.Syntax
         End Function
 
-        Private Shared Function GetCreatePayload(compilation As VisualBasicCompilation, syntax As SyntaxNode, diagnostics As DiagnosticBag) As MethodSymbol
-            Return DirectCast(Binder.GetWellKnownTypeMember(compilation, WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload, syntax, diagnostics), MethodSymbol)
+        Private Shared Function GetCreatePayloadOverload(compilation As VisualBasicCompilation, overload As WellKnownMember, syntax As SyntaxNode, diagnostics As DiagnosticBag) As MethodSymbol
+            Return DirectCast(Binder.GetWellKnownTypeMember(compilation, overload, syntax, diagnostics), MethodSymbol)
         End Function
 
         ' If the method, property, etc. has attributes, the attributes are excluded from the span of the method definition.

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.vb
@@ -1,15 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System
 Imports System.Collections.Immutable
-Imports System.Linq
 Imports System.Reflection.PortableExecutable
 Imports System.Xml.Linq
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
 Imports Roslyn.Test.Utilities
-Imports Xunit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.DynamicAnalysis.UnitTests
 
@@ -21,6 +18,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.DynamicAnalysis.UnitTests
 Namespace Microsoft.CodeAnalysis.Runtime
     Public Class Instrumentation
         Public Shared Function CreatePayload(mvid As System.Guid, methodToken As Integer, fileIndex As Integer, ByRef payload As Boolean(), payloadLength As Integer) As Boolean()
+            Return payload
+        End Function
+
+        Public Shared Function CreatePayload(mvid As System.Guid, methodToken As Integer, fileIndices As Integer(), ByRef payload As Boolean(), payloadLength As Integer) As Boolean()
             Return payload
         End Function
 
@@ -76,9 +77,9 @@ End Class
 
             VerifyDocuments(reader, reader.Documents,
                             "'c.vb' 1A-10-00-3A-D1-71-8C-BD-53-CC-9D-9C-5D-53-5D-7F-8C-70-89-0F (SHA1)",
-                            "'a.vb' 04-2B-9F-E0-61-0E-58-A3-32-F2-82-C4-EB-B6-2F-CD-CA-42-5D-D5 (SHA1)")
+                            "'a.vb' C2-D0-74-6D-08-69-59-85-2E-64-93-75-AE-DD-55-73-C3-C1-48-3A (SHA1)")
 
-            Assert.Equal(11, reader.Methods.Length)
+            Assert.Equal(12, reader.Methods.Length)
 
             Dim sourceLines As String() = ExampleSource.ToString().Split(vbLf(0))
 
@@ -193,7 +194,7 @@ End Module
 
             VerifyDocuments(reader, reader.Documents,
                             "'c.vb' 55-FA-D1-46-BA-6F-EC-77-0E-02-1A-A6-BC-62-21-F7-E3-31-4F-2C (SHA1)",
-                            "'a.vb' 04-2B-9F-E0-61-0E-58-A3-32-F2-82-C4-EB-B6-2F-CD-CA-42-5D-D5 (SHA1)")
+                            "'a.vb' C2-D0-74-6D-08-69-59-85-2E-64-93-75-AE-DD-55-73-C3-C1-48-3A (SHA1)")
 
             Dim sourceLines As String() = testSource.ToString().Split(vbLf(0))
 
@@ -293,7 +294,7 @@ End Module
 
             VerifyDocuments(reader, reader.Documents,
                             "'c.vb' 36-B0-C2-29-F1-DC-B1-63-93-45-31-11-58-6C-5A-46-89-A1-42-34 (SHA1)",
-                            "'a.vb' 04-2B-9F-E0-61-0E-58-A3-32-F2-82-C4-EB-B6-2F-CD-CA-42-5D-D5 (SHA1)")
+                            "'a.vb' C2-D0-74-6D-08-69-59-85-2E-64-93-75-AE-DD-55-73-C3-C1-48-3A (SHA1)")
 
             Dim sourceLines As String() = testSource.ToString().Split(vbLf(0))
 
@@ -361,7 +362,7 @@ End Module
 
             VerifyDocuments(reader, reader.Documents,
                             "'c.vb' 1B-06-B9-C5-D5-D3-AD-EE-8A-D3-31-8F-48-EC-20-BE-AF-7D-2C-27 (SHA1)",
-                            "'a.vb' 04-2B-9F-E0-61-0E-58-A3-32-F2-82-C4-EB-B6-2F-CD-CA-42-5D-D5 (SHA1)")
+                            "'a.vb' C2-D0-74-6D-08-69-59-85-2E-64-93-75-AE-DD-55-73-C3-C1-48-3A (SHA1)")
 
             Dim sourceLines As String() = testSource.ToString().Split(vbLf(0))
 
@@ -455,7 +456,7 @@ End Class
 
             VerifyDocuments(reader, reader.Documents,
                             "'c.vb' 49-14-6E-73-25-48-FF-97-B3-56-26-54-65-D2-2B-00-B2-1A-FA-F5 (SHA1)",
-                            "'a.vb' 04-2B-9F-E0-61-0E-58-A3-32-F2-82-C4-EB-B6-2F-CD-CA-42-5D-D5 (SHA1)")
+                            "'a.vb' C2-D0-74-6D-08-69-59-85-2E-64-93-75-AE-DD-55-73-C3-C1-48-3A (SHA1)")
 
             Dim sourceLines As String() = testSource.ToString().Split(vbLf(0))
 
@@ -560,7 +561,7 @@ End Class
 
             VerifyDocuments(reader, reader.Documents,
                             "'c.vb' 13-52-6F-4D-3B-A7-8B-F7-A3-50-EE-1C-3B-0A-57-AB-B7-E5-33-0C (SHA1)",
-                            "'a.vb' 04-2B-9F-E0-61-0E-58-A3-32-F2-82-C4-EB-B6-2F-CD-CA-42-5D-D5 (SHA1)")
+                            "'a.vb' C2-D0-74-6D-08-69-59-85-2E-64-93-75-AE-DD-55-73-C3-C1-48-3A (SHA1)")
 
             Dim sourceLines As String() = testSource.ToString().Split(vbLf(0))
 
@@ -650,7 +651,7 @@ End Class
 
             VerifyDocuments(reader, reader.Documents,
                             "'c.vb' 7D-27-1F-B0-ED-E6-00-8D-6C-FF-13-69-26-40-2D-4B-AB-06-0D-2E (SHA1)",
-                            "'a.vb' 04-2B-9F-E0-61-0E-58-A3-32-F2-82-C4-EB-B6-2F-CD-CA-42-5D-D5 (SHA1)")
+                            "'a.vb' C2-D0-74-6D-08-69-59-85-2E-64-93-75-AE-DD-55-73-C3-C1-48-3A (SHA1)")
 
             Dim sourceLines As String() = testSource.ToString().Split(vbLf(0))
 
@@ -748,7 +749,7 @@ End Module
 
             VerifyDocuments(reader, reader.Documents,
                             "'c.vb' 71-DD-56-A9-0E-56-57-E0-2B-53-EC-DA-0E-60-47-5E-CD-D1-D9-16 (SHA1)",
-                            "'a.vb' 04-2B-9F-E0-61-0E-58-A3-32-F2-82-C4-EB-B6-2F-CD-CA-42-5D-D5 (SHA1)")
+                            "'a.vb' C2-D0-74-6D-08-69-59-85-2E-64-93-75-AE-DD-55-73-C3-C1-48-3A (SHA1)")
 
             Dim sourceLines As String() = testSource.ToString().Split(vbLf(0))
 
@@ -833,23 +834,23 @@ End Module
             Next
 
             VerifySpans(reader, methodData, expectedSpanSpellings.ToArrayAndFree())
-        End sub
+        End Sub
 
         Private Shared Sub VerifySpans(reader As DynamicAnalysisDataReader, methodData As DynamicAnalysisMethod, ParamArray expected As String())
-                AssertEx.Equal(expected, reader.GetSpans(methodData.Blob).Select(Function(s) $"({s.StartLine},{s.StartColumn})-({s.EndLine},{s.EndColumn})"))
-            End Sub
+            AssertEx.Equal(expected, reader.GetSpans(methodData.Blob).Select(Function(s) $"({s.StartLine},{s.StartColumn})-({s.EndLine},{s.EndColumn})"))
+        End Sub
 
-            Private Sub VerifyDocuments(reader As DynamicAnalysisDataReader, documents As ImmutableArray(Of DynamicAnalysisDocument), ParamArray expected As String())
-                Dim sha1 = New Guid("ff1816ec-aa5e-4d10-87F7-6F4963833460")
+        Private Sub VerifyDocuments(reader As DynamicAnalysisDataReader, documents As ImmutableArray(Of DynamicAnalysisDocument), ParamArray expected As String())
+            Dim sha1 = New Guid("ff1816ec-aa5e-4d10-87F7-6F4963833460")
 
-                Dim actual = From d In documents
-                             Let name = reader.GetDocumentName(d.Name)
-                             Let hash = If(d.Hash.IsNil, "", " " + BitConverter.ToString(reader.GetBytes(d.Hash)))
-                             Let hashAlgGuid = reader.GetGuid(d.HashAlgorithm)
-                             Let hashAlg = If(hashAlgGuid = sha1, " (SHA1)", If(hashAlgGuid = New Guid, "", " " + hashAlgGuid.ToString()))
-                             Select $"'{name}'{hash}{hashAlg}"
+            Dim actual = From d In documents
+                         Let name = reader.GetDocumentName(d.Name)
+                         Let hash = If(d.Hash.IsNil, "", " " + BitConverter.ToString(reader.GetBytes(d.Hash)))
+                         Let hashAlgGuid = reader.GetGuid(d.HashAlgorithm)
+                         Let hashAlg = If(hashAlgGuid = sha1, " (SHA1)", If(hashAlgGuid = New Guid, "", " " + hashAlgGuid.ToString()))
+                         Select $"'{name}'{hash}{hashAlg}"
 
-                AssertEx.Equal(expected, actual)
-            End Sub
-        End Class
+            AssertEx.Equal(expected, actual)
+        End Sub
+    End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
@@ -2552,6 +2552,244 @@ Method2: x = 1
             verifier.VerifyDiagnostics()
         End Sub
 
+        <Fact>
+        Public Sub TestSynthesizedConstructorWithSpansInMultipleFilesCoverage()
+            Dim source1 = <file name="aa.vb">
+                              <![CDATA[
+Imports System
+
+Partial Class Class1
+    Dim a As Action(Of Integer) =
+            Sub(i As Integer)
+                Console.WriteLine(i)
+            End Sub
+End Class
+
+Module Program
+    Public Sub Main()
+        Test()
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload()
+    End Sub
+
+    Sub Test()
+        Console.WriteLine("Test")
+        Dim c = new Class1()
+        c.Method1(1)
+    End Sub
+End Module
+]]>
+                          </file>
+
+            Dim source2 = <file name="bb.vb">
+                              <![CDATA[
+Imports System
+
+Partial Class Class1
+    Dim x As Integer = 1
+
+    Sub Method1(i As Integer)
+        a(i)
+        Console.WriteLine(x)
+        Console.WriteLine(y)
+        Console.WriteLine(z)
+    End Sub
+End Class
+]]>
+                          </file>
+
+            Dim source3 = <file name="cc.vb">
+                              <![CDATA[
+Partial Class Class1
+    Dim y As Integer = 2
+    Dim z As Integer = 3
+End Class
+]]>
+                          </file>
+
+            Dim source = <compilation>
+                             <%= source1 %>
+                             <%= source2 %>
+                             <%= source3 %>
+                             <%= InstrumentationHelperSource %>
+                         </compilation>
+
+            Dim expectedOutput = <![CDATA[Test
+1
+1
+2
+3
+Flushing
+Method 1
+File 1
+File 2
+File 3
+True
+True
+True
+True
+True
+Method 2
+File 2
+True
+True
+True
+True
+True
+Method 3
+File 1
+True
+True
+True
+Method 4
+File 1
+True
+True
+True
+True
+Method 7
+File 4
+True
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+]]>
+
+            Dim verifier = CompileAndVerify(source, expectedOutput, options:=TestOptions.ReleaseExe)
+            verifier.VerifyDiagnostics()
+
+            verifier = CompileAndVerify(source, expectedOutput, options:=TestOptions.DebugExe)
+            verifier.VerifyDiagnostics()
+        End Sub
+
+        <Fact>
+        Public Sub TestSynthesizedStaticConstructorWithSpansInMultipleFilesCoverage()
+            Dim source1 = <file name="aa.vb">
+                              <![CDATA[
+Imports System
+
+Partial Class Class1
+    Shared Dim a As Action(Of Integer) =
+            Sub(i As Integer)
+                Console.WriteLine(i)
+            End Sub
+End Class
+
+Module Program
+    Public Sub Main()
+        Test()
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload()
+    End Sub
+
+    Sub Test()
+        Console.WriteLine("Test")
+        Dim c = new Class1()
+        Class1.Method1(1)
+    End Sub
+End Module
+]]>
+                          </file>
+
+            Dim source2 = <file name="bb.vb">
+                              <![CDATA[
+Imports System
+
+Partial Class Class1
+    Shared Dim x As Integer = 1
+
+    Shared Sub Method1(i As Integer)
+        a(i)
+        Console.WriteLine(x)
+        Console.WriteLine(y)
+        Console.WriteLine(z)
+    End Sub
+End Class
+]]>
+                          </file>
+
+            Dim source3 = <file name="cc.vb">
+                              <![CDATA[
+Partial Class Class1
+    Shared Dim y As Integer = 2
+    Shared Dim z As Integer = 3
+End Class
+]]>
+                          </file>
+
+            Dim source = <compilation>
+                             <%= source1 %>
+                             <%= source2 %>
+                             <%= source3 %>
+                             <%= InstrumentationHelperSource %>
+                         </compilation>
+
+            Dim expectedOutput = <![CDATA[Test
+1
+1
+2
+3
+Flushing
+Method 1
+File 1
+File 2
+File 3
+True
+True
+True
+True
+True
+Method 2
+File 1
+Method 3
+File 2
+True
+True
+True
+True
+True
+Method 4
+File 1
+True
+True
+True
+Method 5
+File 1
+True
+True
+True
+True
+Method 8
+File 4
+True
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+]]>
+
+            Dim verifier = CompileAndVerify(source, expectedOutput, options:=TestOptions.ReleaseExe)
+            verifier.VerifyDiagnostics()
+
+            verifier = CompileAndVerify(source, expectedOutput, options:=TestOptions.DebugExe)
+            verifier.VerifyDiagnostics()
+        End Sub
+
         Private Shared Sub AssertNotInstrumented(verifier As CompilationVerifier, qualifiedMethodName As String)
             AssertInstrumented(verifier, qualifiedMethodName, expected:=False)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
@@ -49,6 +49,7 @@ End Module
                 True().
                 True().
                 True().
+                True().
                 True()
 
             Dim verifier As CompilationVerifier = CompileAndVerify(source, checker.ExpectedOutput)
@@ -56,8 +57,7 @@ End Module
 
             verifier.VerifyIL(
                 "Program.TestMain",
-            <![CDATA[
-{
+            <![CDATA[{
   // Code size       57 (0x39)
   .maxstack  5
   .locals init (Boolean() V_0)
@@ -83,6 +83,7 @@ End Module
   IL_0038:  ret
 }
                 ]]>.Value)
+
             verifier.VerifyIL(
                 ".cctor",
             <![CDATA[
@@ -136,6 +137,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -233,6 +235,7 @@ True
 True
 True
 True
+True
 ]]>
 
             Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
@@ -309,6 +312,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -448,6 +452,7 @@ True
 True
 True
 True
+True
 ]]>
 
             Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
@@ -518,6 +523,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -701,6 +707,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -1022,6 +1029,7 @@ True
 True
 True
 True
+True
 ]]>
 
             Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
@@ -1092,6 +1100,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -1188,6 +1197,7 @@ True
 True
 True
 True
+True
 ]]>
 
             Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
@@ -1244,6 +1254,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -1330,22 +1341,23 @@ True
 True
 True
 True
-Method 9
+True
+Method 10
 File 1
 True
-True
-Method 14
-File 1
 True
 Method 15
 File 1
 True
-True
-True
-True
-True
-True
 Method 16
+File 1
+True
+True
+True
+True
+True
+True
+Method 17
 File 1
 True
 True
@@ -1411,6 +1423,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -1503,6 +1516,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -1623,6 +1637,7 @@ True
 True
 True
 True
+True
 ]]>
 
             Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
@@ -1703,6 +1718,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -1835,6 +1851,7 @@ File 1
 True
 True
 False
+True
 True
 True
 True
@@ -2443,6 +2460,7 @@ End Module
                 True().
                 True().
                 True().
+                True().
                 True()
 
             Dim expectedOutput = "Test
@@ -2510,6 +2528,7 @@ End Module
             checker.Method(7, 1).
                 True().
                 False().
+                True().
                 True().
                 True().
                 True().

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -580,7 +580,8 @@ End Namespace
                     Case WellKnownMember.System_Array__Empty
                         ' Not available yet, but will be in upcoming release.
                         Continue For
-                    Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload
+                    Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
+                         WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles
                         ' Not always available.
                         Continue For
                 End Select
@@ -660,7 +661,8 @@ End Namespace
                     Case WellKnownMember.System_Array__Empty
                         ' Not available yet, but will be in upcoming release.
                         Continue For
-                    Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload
+                    Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
+                         WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningMultipleFiles
                         ' Not always available.
                         Continue For
                 End Select

--- a/src/Test/Utilities/Desktop/InstrumentationChecker.cs
+++ b/src/Test/Utilities/Desktop/InstrumentationChecker.cs
@@ -82,22 +82,22 @@ namespace Microsoft.CodeAnalysis.Runtime
     public static class Instrumentation
     {
         private static bool[][] _payloads;
-        private static int[] _fileIndices;
+        private static int[][] _fileIndices;
         private static System.Guid _mvid;
 
-        public static bool[] CreatePayload(System.Guid mvid, int methodIndex, int fileIndex, ref bool[] payload, int payloadLength)
+        public static bool[] CreatePayload(System.Guid mvid, int methodIndex, int[] fileIndices, ref bool[] payload, int payloadLength)
         {
             if (_mvid != mvid)
             {
                 _payloads = new bool[100][];
-                _fileIndices = new int[100];
+                _fileIndices = new int[100][];
                 _mvid = mvid;
             }
 
             if (System.Threading.Interlocked.CompareExchange(ref payload, new bool[payloadLength], null) == null)
             {
                 _payloads[methodIndex] = payload;
-                _fileIndices[methodIndex] = fileIndex;
+                _fileIndices[methodIndex] = fileIndices;
                 return payload;
             }
 
@@ -117,7 +117,10 @@ namespace Microsoft.CodeAnalysis.Runtime
                 if (payload != null)
                 {
                     Console.WriteLine(""Method "" + i.ToString());
-                    Console.WriteLine(""File "" + _fileIndices[i].ToString());
+                    for (int j = 0; j < _fileIndices[i].Length; j++)
+                    {
+                        Console.WriteLine(""File "" + _fileIndices[i][j].ToString());
+                    }
                     for (int j = 0; j < payload.Length; j++)
                     {
                         Console.WriteLine(payload[j]);
@@ -125,6 +128,11 @@ namespace Microsoft.CodeAnalysis.Runtime
                     }
                 }
             }
+        }
+
+        public static bool[] CreatePayload(System.Guid mvid, int methodIndex, int fileIndex, ref bool[] payload, int payloadLength)
+        {
+            return CreatePayload(mvid, methodIndex, new[] { fileIndex }, ref payload, payloadLength);
         }
     }
 }
@@ -210,13 +218,13 @@ Namespace Microsoft.CodeAnalysis.Runtime
     Public Class Instrumentation
 
         Private Shared _payloads As Boolean()()
-        Private Shared _fileIndices As Integer()
+        Private Shared _fileIndices As Integer()()
         Private Shared _mvid As System.Guid
 
-        Public Shared Function CreatePayload(mvid As System.Guid, methodIndex As Integer, fileIndex As Integer, ByRef payload As Boolean(), payloadLength As Integer) As Boolean()
+        Public Shared Function CreatePayload(mvid As System.Guid, methodIndex As Integer, fileIndices As Integer(), ByRef payload As Boolean(), payloadLength As Integer) As Boolean()
             If _mvid <> mvid Then
                 _payloads = New Boolean(100)() {}
-                _fileIndices = New Integer(100) {}
+                _fileIndices = New Integer(100)() {}
                 _mvid = mvid
             End If
 
@@ -225,7 +233,7 @@ Namespace Microsoft.CodeAnalysis.Runtime
                     Throw New System.ArgumentException(""Overwriting existing payload array."")
                 End If
                 _payloads(methodIndex) = payload
-                _fileIndices(methodIndex) = fileIndex
+                _fileIndices(methodIndex) = fileIndices
                 Return payload
             End If
 
@@ -241,7 +249,9 @@ Namespace Microsoft.CodeAnalysis.Runtime
                 Dim payload As Boolean() = _payloads(i)
                 if payload IsNot Nothing
                     System.Console.WriteLine(""Method "" & i.ToString())
-                    System.Console.WriteLine(""File "" & _fileIndices(i).ToString())
+                    For j As Integer = 0 To _fileIndices(i).Length - 1
+                        System.Console.WriteLine(""File "" & _fileIndices(i)(j).ToString())
+                    Next
                     For j As Integer = 0 To payload.Length - 1
                         System.Console.WriteLine(payload(j))
                         payload(j) = False
@@ -249,6 +259,10 @@ Namespace Microsoft.CodeAnalysis.Runtime
                 End If
             Next
         End Sub
+
+        Public Shared Function CreatePayload(mvid As System.Guid, methodIndex As Integer, fileIndex As Integer, ByRef payload As Boolean(), payloadLength As Integer) As Boolean()
+            Return CreatePayload(mvid, methodIndex, { fileIndex }, payload, payloadLength)
+        End Function
     End Class
 End Namespace
 ";


### PR DESCRIPTION
A single method could have spans in multiple source files. For example, synthesized constructors of partial types can have spans in multiple files if this type has field initializers in multiple files. Another example is methods with #line directives.

This change changes instrumentation for such methods - the instrumented IL for such methods will now include a call to a new overload of Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload() that accepts an array of file indices as opposed to single file index.

**Note:** The introduction of the new overload means that it will be a breaking change if someone tries to use old version of Live Unit Testing (LUT) with new version of compiler. We have discussed this on the LUT team and are making this change intentionally *because LUT always uses the compiler that is loaded in VS (as opposed to any toolset compiler that the command line build for the solution may be using)* and it is therefore highly unlikely for the LUT and compiler bits to go out of sync.

---
**Customer scenario**

This change fixes an instrumentation bug that impacts the Live Unit Testing (LUT) feature in VS. The bug causes LUT to associate tests that cover field initializers with the wrong source file. For example, a test may actually cover field initializers in files 1, 2 and 3, but because of this bug,  LUT will think that the test only covers file 1. If the user later makes a change in file 2 that breaks this test, user will not find out about the test failure because LUT will not know to run this test in response to the change. 

**Bugs this fixes:**

**Workarounds, if any**
None.

**Risk**
Low.

**Performance impact**
Low.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
We didn't have enough testing for the partial types case. The bug is also quite subtle and it is probably hard to notice this issue and figure out that LUT is not running a test that it should be running in this case...

**How was the bug found?**
Dogfooding LUT against Roslyn Compilers.sln
