### PR TITLE
setting default VB options

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -239,6 +239,7 @@
     <DefineConstants Condition="'$(InitialDefineConstants)' != ''">$(InitialDefineConstants)</DefineConstants>
 
     <!-- The NoWarn property is still being unconditionally set.  https://github.com/dotnet/sdk/issues/752 -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
+    <OptionStrict>Off</OptionStrict>
+    <NoWarn>$(NoWarn);1591;41999;42016</NoWarn>
   </PropertyGroup>
 </Project>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -239,7 +239,7 @@
     <DefineConstants Condition="'$(InitialDefineConstants)' != ''">$(InitialDefineConstants)</DefineConstants>
 
     <!-- The NoWarn property is still being unconditionally set.  https://github.com/dotnet/sdk/issues/752 -->
-    <OptionStrict>Off</OptionStrict>
+    <OptionStrict>On</OptionStrict>
     <NoWarn>$(NoWarn);1591;41999;42016</NoWarn>
   </PropertyGroup>
 </Project>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -240,6 +240,6 @@
 
     <!-- The NoWarn property is still being unconditionally set.  https://github.com/dotnet/sdk/issues/752 -->
     <OptionStrict>On</OptionStrict>
-    <NoWarn>$(NoWarn);1591;41999;42016</NoWarn>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -245,7 +245,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Debug.Assert(tree IsNot VisualBasicSyntaxTree.Dummy)
                             Debug.Assert(tree.IsMyTemplate)
 
-                            Interlocked.CompareExchange(Of SyntaxTree)(_lazyMyTemplate, tree, VisualBasicSyntaxTree.Dummy)
+                            Interlocked.CompareExchange(_lazyMyTemplate, tree, VisualBasicSyntaxTree.Dummy)
                         Else
                             ' we need to make one.
                             Dim text As String = EmbeddedResources.VbMyTemplateText
@@ -260,7 +260,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                 Throw ExceptionUtilities.Unreachable
                             End If
 
-                            If Interlocked.CompareExchange(Of SyntaxTree)(_lazyMyTemplate, tree, VisualBasicSyntaxTree.Dummy) Is VisualBasicSyntaxTree.Dummy Then
+                            If Interlocked.CompareExchange(_lazyMyTemplate, tree, VisualBasicSyntaxTree.Dummy) Is VisualBasicSyntaxTree.Dummy Then
                                 ' set global cache
                                 s_myTemplateCache(parseOptions) = tree
                             End If

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -134,7 +134,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                             typesByName.Add(type.Name, type)
                         End If
                     Next
-                    Interlocked.CompareExchange(Of IReadOnlyDictionary(Of String, Cci.INamespaceTypeDefinition))(Me._lazyTopLevelTypes, typesByName, Nothing)
+                    Interlocked.CompareExchange(Me._lazyTopLevelTypes, typesByName, Nothing)
                 End If
                 Return Me._lazyTopLevelTypes
             End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceLambdaSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceLambdaSymbol.vb
@@ -55,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Get
                 If Me._lazyAnonymousDelegateSymbol Is ErrorTypeSymbol.UnknownResultType Then
                     Dim newValue As NamedTypeSymbol = MakeAssociatedAnonymousDelegate()
-                    Dim oldValue As NamedTypeSymbol = Interlocked.CompareExchange(Of NamedTypeSymbol)(Me._lazyAnonymousDelegateSymbol, newValue, ErrorTypeSymbol.UnknownResultType)
+                    Dim oldValue As NamedTypeSymbol = Interlocked.CompareExchange(Me._lazyAnonymousDelegateSymbol, newValue, ErrorTypeSymbol.UnknownResultType)
                     Debug.Assert(oldValue Is ErrorTypeSymbol.UnknownResultType OrElse oldValue Is newValue)
                 End If
                 Return Me._lazyAnonymousDelegateSymbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -1296,7 +1296,7 @@ lReportErrorOnTwoTokens:
                 meParameter = Nothing
             Else
                 If _lazyMeParameter Is Nothing Then
-                    Interlocked.CompareExchange(Of ParameterSymbol)(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
+                    Interlocked.CompareExchange(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
                 End If
 
                 meParameter = _lazyMeParameter

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethodBase.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedMethodBase.vb
@@ -178,7 +178,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 meParameter = Nothing
             Else
                 If _lazyMeParameter Is Nothing Then
-                    Interlocked.CompareExchange(Of ParameterSymbol)(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
+                    Interlocked.CompareExchange(_lazyMeParameter, New MeParameterSymbol(Me), Nothing)
                 End If
 
                 meParameter = _lazyMeParameter

--- a/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
+++ b/src/Scripting/VisualBasicTest/InteractiveSessionTests.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
                 ContinueWith("Dim y As Integer = 2").
                 ContinueWith("?x + y")
 
-            Assert.Equal(3, CType(s.ReturnValue, Integer))
+            Assert.Equal(3, s.ReturnValue)
         End Function
 
         <Fact>
@@ -27,7 +27,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim source = "
 ?1 _
 "
-            Assert.Equal(1, CType(VisualBasicScript.EvaluateAsync(source).Result, Integer))
+            Assert.Equal(1, VisualBasicScript.EvaluateAsync(source).Result)
         End Sub
 
         <Fact>
@@ -35,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim source = "
 ?1
 "
-            Assert.Equal(1, CType(VisualBasicScript.EvaluateAsync(source).Result, Integer))
+            Assert.Equal(1, VisualBasicScript.EvaluateAsync(source).Result)
         End Sub
 
         <Fact>
@@ -61,7 +61,7 @@ End If
 ?x + 1
 "
 
-            Assert.Equal(6, CType(VisualBasicScript.EvaluateAsync(source).Result, Integer))
+            Assert.Equal(6, VisualBasicScript.EvaluateAsync(source).Result)
         End Sub
 
         <Fact>
@@ -81,7 +81,7 @@ Dim d = New With { Key .F = 777 }
     & "" "" & (a.GetType() Is b.GetType()).ToString() _
     & "" "" & (b.GetType() is d.GetType()).ToString()
 ")
-            Assert.Equal("True False True", CType(script.EvaluateAsync().Result, String))
+            Assert.Equal("True False True", script.EvaluateAsync().Result)
         End Sub
 
         <Fact>
@@ -107,7 +107,7 @@ Dim d = Function () As Integer
     & "" "" & (b.GetType() is d.GetType()).ToString()
 ")
 
-            Assert.Equal("True False True", CType(script.EvaluateAsync().Result, String))
+            Assert.Equal("True False True", script.EvaluateAsync().Result)
         End Sub
     End Class
 

--- a/src/Scripting/VisualBasicTest/ScriptTests.vb
+++ b/src/Scripting/VisualBasicTest/ScriptTests.vb
@@ -22,14 +22,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
 
         <Fact>
         Public Sub TestEvalScript()
-            Dim value = CType(VisualBasicScript.EvaluateAsync("? 1 + 2", s_defaultOptions).Result, Integer)
-            Assert.Equal(3, value)
+            Dim value = VisualBasicScript.EvaluateAsync("? 1 + 2", s_defaultOptions)
+            Assert.Equal(3, value.Result)
         End Sub
 
         <Fact>
         Public Async Function TestRunScript() As Task
             Dim state = Await VisualBasicScript.RunAsync("? 1 + 2", s_defaultOptions)
-            Assert.Equal(3, CType(state.ReturnValue, Integer))
+            Assert.Equal(3, state.ReturnValue)
         End Function
 
         <Fact>
@@ -37,13 +37,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
             Dim script = VisualBasicScript.Create("? 1 + 2", s_defaultOptions)
             Dim state = Await script.RunAsync()
             Assert.Same(script, state.Script)
-            Assert.Equal(3, CType(state.ReturnValue, Integer))
+            Assert.Equal(3, state.ReturnValue)
         End Function
 
         <Fact>
         Public Async Function TestRunScriptWithSpecifiedReturnType() As Task
             Dim state = Await VisualBasicScript.RunAsync("? 1 + 2", s_defaultOptions)
-            Assert.Equal(3, CType(state.ReturnValue, Integer))
+            Assert.Equal(3, state.ReturnValue)
         End Function
 
         <Fact>


### PR DESCRIPTION
**Customer scenario**

None, this is about fixing a build break in 15.3. In this PR: https://github.com/dotnet/roslyn/pull/19331 I chose to fixup the conversion warning instead of ignoring them.  As per @jaredpar, this PR correctly ignores conversion warnings in VB projects.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/19367

