### PR TITLE
Avoid toggle checkbox when clicked on an option's description.

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
@@ -20,8 +20,8 @@
                                         Width="Auto"
                                         Focusable="False"
                                         Margin="20, 0, 0, 0">
-                    <TextBlock Text="{Binding Description}" Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"/>
                 </CheckBox>
+                <TextBlock Text="{Binding Description}" Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"/>
             </StackPanel>
         </DataTemplate>
 

--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
@@ -15,13 +15,14 @@
     <options:AbstractOptionPageControl.Resources>
         <DataTemplate DataType="{x:Type options:CheckBoxOptionViewModel}">
             <StackPanel Orientation="Horizontal">
-                <CheckBox x:Uid="OptionCheckBox" 
+                <CheckBox x:Uid="OptionCheckBox"
+                                        AutomationProperties.LabeledBy="{Binding ElementName=OptionText}"
                                         IsChecked="{Binding IsChecked, Mode=TwoWay}" 
                                         Width="Auto"
                                         Focusable="False"
                                         Margin="20, 0, 0, 0">
                 </CheckBox>
-                <TextBlock Text="{Binding Description}" Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"/>
+                <TextBlock Name="OptionText" Text="{Binding Description}" Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}"/>
             </StackPanel>
         </DataTemplate>
 


### PR DESCRIPTION
**Customer scenario**

"Tools, Options, Text Editor, C#, Code Style, Formatting, New Lines.
It's currently impossible to just select one of the items in the list with mouse click - it registers as a toggle for the checkbox, no matter where on the line you click.

**Bugs this fixes:**

Fixes #18614

**Workarounds, if any**

Click on places without description text

**Risk**

Low

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
