### PR TITLE
Implemented automatic regeneration of syntax, error facts and bound nodes

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -20,6 +20,10 @@
          contains a reference to C# + VB CodeAnalysis. This ensures that the project
          reference is a higher version than the NuGet reference. -->
     <Version>$(NuGetPerBuildPreReleaseVersion)</Version>
+    <PreBuildEvent>dotnet "$(SolutionDir)Binaries\Debug\Exes\CSharpSyntaxGenerator\CSharpSyntaxGenerator.dll" "$(SolutionDir)src\Compilers\CSharp\Portable\Syntax\Syntax.xml" "$(SolutionDir)src\Compilers\CSharp\Portable\Generated\"
+dotnet "$(SolutionDir)Binaries\Debug\Exes\CSharpErrorFactsGenerator\CSharpErrorFactsGenerator.dll" "$(SolutionDir)src\Compilers\CSharp\Portable\Errors\ErrorCode.cs" "$(SolutionDir)src\Compilers\CSharp\Portable\Generated\ErrorFacts.Generated.cs"
+dotnet "$(SolutionDir)Binaries\Debug\Exes\CompilersBoundTreeGenerator\BoundTreeGenerator.dll" CSharp "$(SolutionDir)src\Compilers\CSharp\Portable\BoundTree\BoundNodes.xml" "$(SolutionDir)src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs"
+</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -916,6 +916,7 @@
     <None Include="RuleSet\RuleSetSchema.xsd">
       <SubType>Designer</SubType>
     </None>
+    <ProjectReference Include="..\..\..\Tools\Source\CompilerGeneratorTools\DeployCompilerGeneratorToolsRuntime\DeployCompilerGeneratorToolsRuntime.csproj" />
     <PublicAPI Include="PublicAPI.Shipped.txt" />
     <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -18,6 +18,10 @@
          contains a reference to C# + VB CodeAnalysis. This ensures that the project
          reference is a higher version than the NuGet reference. -->
     <Version>$(NuGetPerBuildPreReleaseVersion)</Version>
+    <PreBuildEvent>dotnet "$(SolutionDir)Binaries\Debug\Exes\VisualBasicSyntaxGenerator\VisualBasicSyntaxGenerator.dll" "$(SolutionDir)src\Compilers\VisualBasic\Portable\Syntax\Syntax.xml" "$(SolutionDir)src\Compilers\VisualBasic\Portable\Generated\"
+dotnet "$(SolutionDir)Binaries\Debug\Exes\VisualBasicErrorFactsGenerator\VisualBasicErrorFactsGenerator.dll" "$(SolutionDir)src\Compilers\VisualBasic\Portable\Errors\ErrorCode.vb" "$(SolutionDir)src\Compilers\VisualBasic\Portable\Generated\ErrorFacts.Generated.vb"
+dotnet "$(SolutionDir)Binaries\Debug\Exes\CompilersBoundTreeGenerator\BoundTreeGenerator.dll" VB "$(SolutionDir)src\Compilers\VisualBasic\Portable\BoundTree\BoundNodes.xml" "$(SolutionDir)src\Compilers\VisualBasic\Portable\Generated\BoundNodes.xml.Generated.vb"
+</PreBuildEvent>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyVersionAttribute Include="Microsoft.CodeAnalysis.CommitHashAttribute">


### PR DESCRIPTION
**Customer scenario**

When you edit any of the xml files that are used to generate sources, they are not picked up automatically like they used to.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/19399

**Workarounds, if any**

You could use a batch file, but it's a pain when you have to build twice because you forgot to run it.

**Risk**

The commands are flakier than I wanted because of https://github.com/dotnet/project-system/issues/1569

**Performance impact**

No impact on the compiler, the build time of CSharpCodeAnalysis and its VB cousin is extended by two-three seconds.

**Is this a regression from a previous update?**

**Root cause analysis:**

I don't know. Someone changed the generators.

**How was the bug found?**

Contributor pain
