### PR TITLE
Use file path to hook up analyzers nodes in Solution Explorer

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/CpsDiagnosticItemProvider.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/CpsDiagnosticItemProvider.cs
@@ -121,7 +121,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             {
                 var workspace = TryGetWorkspace();
                 var analyzerService = GetAnalyzerService();
-                return new CpsDiagnosticItemSource(workspace, projectId, item, _commandHandler, analyzerService);
+
+                var hierarchy = projectRootItem.HierarchyIdentity.NestedHierarchy;
+                var itemId = projectRootItem.HierarchyIdentity.NestedItemID;
+                if (hierarchy.GetCanonicalName(itemId, out string projectCanonicalName) == VSConstants.S_OK)
+                {
+                    return new CpsDiagnosticItemSource(workspace, projectCanonicalName, projectId, item, _commandHandler, analyzerService);
+                }
             }
 
             return null;

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/CpsDiagnosticItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/CpsDiagnosticItemSource.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Internal.VisualStudio.PlatformUI;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
@@ -13,15 +14,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
     internal partial class CpsDiagnosticItemSource : BaseDiagnosticItemSource, INotifyPropertyChanged
     {
         private readonly IVsHierarchyItem _item;
+        private readonly string _projectDirectoryPath;
 
         private AnalyzerReference _analyzerReference;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public CpsDiagnosticItemSource(Workspace workspace, ProjectId projectId, IVsHierarchyItem item, IAnalyzersCommandHandler commandHandler, IDiagnosticAnalyzerService analyzerService)
+        public CpsDiagnosticItemSource(Workspace workspace, string projectPath, ProjectId projectId, IVsHierarchyItem item, IAnalyzersCommandHandler commandHandler, IDiagnosticAnalyzerService analyzerService)
             : base(workspace, projectId, commandHandler, analyzerService)
         {
             _item = item;
+            _projectDirectoryPath = Path.GetDirectoryName(projectPath);
 
             _analyzerReference = TryGetAnalyzerReference(_workspace.CurrentSolution);
             if (_analyzerReference == null)
@@ -91,12 +94,50 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 return null;
             }
 
-            if (!_item.HierarchyIdentity.NestedHierarchy.TryGetItemName(_item.HierarchyIdentity.NestedItemID, out string name))
+            var canonicalName = _item.CanonicalName;
+            var analyzerFilePath = ExtractAnalyzerFilePath(canonicalName);
+
+            return project.AnalyzerReferences.FirstOrDefault(r => r.FullPath.Equals(analyzerFilePath, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Given the canonical name of a node representing an analyzer assembly in the
+        /// CPS-based project system extracts out the full path to the assembly.
+        /// </summary>
+        /// <remarks>
+        /// The canonical name takes the following form:
+        /// 
+        ///   [{path to project directory}\]{target framework}\analyzerdependency\{path to assembly}
+        ///   
+        /// e.g.:
+        /// 
+        ///   C:\projects\solutions\MyProj\netstandard2.0\analyzerdependency\C:\users\me\.packages\somePackage\lib\someAnalyzer.dll
+        ///   
+        /// This method exists solely to extract out the "path to assembly" part, i.e.
+        /// "C:\users\me\.packages\somePackage\lib\someAnalyzer.dll". We don't need the
+        /// other parts.
+        /// 
+        /// Note that the path to the project directory is optional. It's not clear if
+        /// this is intentional or a bug in the project system, but either way it
+        /// doesn't really matter.
+        /// </remarks>
+        private string ExtractAnalyzerFilePath(string canonicalName)
+        {
+            // The canonical name may or may not start with the path to the project's directory.
+            if (canonicalName.StartsWith(_projectDirectoryPath, StringComparison.OrdinalIgnoreCase))
             {
-                return null;
+                // Extract the rest of the string, taking into account the "\" separating the directory
+                // path from the rest of the canonical name
+                canonicalName = canonicalName.Substring(_projectDirectoryPath.Length + 1);
             }
 
-            return project.AnalyzerReferences.FirstOrDefault(r => r.Display.Equals(name));
+            // Find the slash after the target framework
+            var backslashIndex = canonicalName.IndexOf('\\');
+            // Find the slash after "analyzerdependency"
+            backslashIndex = canonicalName.IndexOf('\\', backslashIndex + 1);
+
+            // The rest of the string is the path.
+            return canonicalName.Substring(backslashIndex + 1);
         }
     }
 }


### PR DESCRIPTION
Currently we match a hierarchy node representing an analyzer in Solution Explorer up to the proper Roslyn `AnalyzerReference` based on the "display name"--basically, the name of the assembly without the extension. This mostly works, but you can run into problems if a project uses two different versions of the same analyzer, each with a different set of diagnostics. In this case expanding one of the analyzer nodes in Solution Explorer will show you the wrong set of diagnostics for one or the other, since they both have the same display name.

To uniquely identify an analyzer assembly we should use its full path rather than the display name. However, the project system initially didn't expose the full path through the hierarchy node. This has been fixed, and now the full path is one of the components of the node's "canonical name", along with other bits of information such as the project directory and target framework.

This commit updates our code to extract and use the full path instead of the display name.

**Customer scenario**

Customer adds multiple versions of the same analyzer to their .NET Core or .NET Standard project. Nodes for both show up in Solution Explorer, but the set of diagnostics will be wrong for one or the other.

**Bugs this fixes:**

Fixes https://github.com/dotnet/project-system/issues/2062.

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

Little to no impact. This code path is only executed on-demand when the users expands analyzer nodes in Solution Explorer.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

N/A

**How was the bug found?**

In the course of implementing analyzer support in Solution Explorer for .NET Core/Standard projects.
