### PR TITLE
Consume ITextBuffer2.ChangedAsync from TextChanged tagging event source

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -63,7 +63,7 @@
     <MicrosoftServiceHubClientVersion>1.0.177-rc-g56d40a8a02</MicrosoftServiceHubClientVersion>
     <MicrosoftTplDataflowVersion>4.5.24</MicrosoftTplDataflowVersion>
     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
-    <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.0.26201-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
+    <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.0.26509-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.0.26201-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>
     <MicrosoftVisualStudioComponentModelHostVersion>15.0.26201-alpha</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>15.0.66-rc</MicrosoftVisualStudioCompositionVersion>
@@ -80,7 +80,7 @@
     <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>14.3.25407</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftVisualStudioInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioInteractiveWindowVersion>
     <MicrosoftVisualStudioLanguageCallHierarchyVersion>15.0.26201-alpha</MicrosoftVisualStudioLanguageCallHierarchyVersion>
-    <MicrosoftVisualStudioLanguageIntellisenseVersion>15.0.26201-alpha</MicrosoftVisualStudioLanguageIntellisenseVersion>
+    <MicrosoftVisualStudioLanguageIntellisenseVersion>15.0.26509-alpha</MicrosoftVisualStudioLanguageIntellisenseVersion>
     <MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>15.0.26201-alpha</MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>
     <MicrosoftVisualStudioLanguageStandardClassificationVersion>15.0.26201-alpha</MicrosoftVisualStudioLanguageStandardClassificationVersion>
     <MicrosoftVisualStudioOLEInteropVersion>7.10.6070</MicrosoftVisualStudioOLEInteropVersion>
@@ -110,7 +110,7 @@
     <MicrosoftVisualStudioShellInterop90Version>9.0.30729</MicrosoftVisualStudioShellInterop90Version>
     <MicrosoftVisualStudioTelemetryVersion>15.0.26201-alpha</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
-    <MicrosoftVisualStudioTextDataVersion>15.0.26201-alpha</MicrosoftVisualStudioTextDataVersion>
+    <MicrosoftVisualStudioTextDataVersion>15.0.26509-alpha</MicrosoftVisualStudioTextDataVersion>
     <MicrosoftVisualStudioTextInternalVersion>15.0.26201-alpha</MicrosoftVisualStudioTextInternalVersion>
     <MicrosoftVisualStudioTextLogicVersion>15.0.26201-alpha</MicrosoftVisualStudioTextLogicVersion>
     <MicrosoftVisualStudioTextUIVersion>15.0.26201-alpha</MicrosoftVisualStudioTextUIVersion>
@@ -119,9 +119,9 @@
     <MicrosoftVisualStudioTextManagerInterop100Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop100Version>
     <MicrosoftVisualStudioTextManagerInterop120Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop120Version>
     <MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>
-    <MicrosoftVisualStudioThreadingVersion>15.0.26201-alpha</MicrosoftVisualStudioThreadingVersion>
+    <MicrosoftVisualStudioThreadingVersion>15.0.26509-alpha</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioUtilitiesVersion>15.0.26201-alpha</MicrosoftVisualStudioUtilitiesVersion>
-    <MicrosoftVisualStudioValidationVersion>15.0.26201-alpha</MicrosoftVisualStudioValidationVersion>
+    <MicrosoftVisualStudioValidationVersion>15.0.26509-alpha</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioVsInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioVsInteractiveWindowVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <MDbgVersion>0.1.0</MDbgVersion>

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.TextChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.TextChangedEventSource.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
@@ -10,34 +11,34 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
     {
         private class TextChangedEventSource : AbstractTaggerEventSource
         {
-            private readonly ITextBuffer _subjectBuffer;
+            private readonly ITextBuffer2 _subjectBuffer;
 
             public TextChangedEventSource(ITextBuffer subjectBuffer, TaggerDelay delay)
                 : base(delay)
             {
                 Contract.ThrowIfNull(subjectBuffer);
 
-                _subjectBuffer = subjectBuffer;
+                _subjectBuffer = (ITextBuffer2)subjectBuffer;
             }
 
             public override void Connect()
             {
-                _subjectBuffer.Changed += OnTextBufferChanged;
+                _subjectBuffer.ChangedAsync += OnTextBufferChanged;
             }
 
             public override void Disconnect()
             {
-                _subjectBuffer.Changed -= OnTextBufferChanged;
+                _subjectBuffer.ChangedAsync -= OnTextBufferChanged;
             }
 
-            private void OnTextBufferChanged(object sender, TextContentChangedEventArgs e)
+            private Task OnTextBufferChanged(object sender, TextContentChangedEventArgs e)
             {
-                if (e.Changes.Count == 0)
+                if (e.Changes.Count != 0)
                 {
-                    return;
+                    this.RaiseChanged();
                 }
 
-                this.RaiseChanged();
+                return Task.CompletedTask;
             }
         }
     }


### PR DESCRIPTION
Just the tagger change from https://github.com/dotnet/roslyn/pull/19044/files#diff-0a92caf30de86ef523d80320c6dd1526.

Tag @dotnet/roslyn-ide for review.
Note that the Packages.props change will probably change.