### PR TITLE
Initial Implementation of ref structs.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             //PROTOTYPE(span): generalize to all restricted types or it would be a compat break?
             //cannot capture span-like types.
-            if (!method.IsStatic && methodGroup.Receiver.Type.IsSpanLikeType())
+            if (!method.IsStatic && methodGroup.Receiver.Type.IsByRefLikeType)
             {
                 return Conversion.NoConversion;
             }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -10323,6 +10323,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ref structs.
+        /// </summary>
+        internal static string IDS_FeatureRefStructs {
+            get {
+                return ResourceManager.GetString("IDS_FeatureRefStructs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to static classes.
         /// </summary>
         internal static string IDS_FeatureStaticClasses {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4215,6 +4215,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureReadonlyReferences" xml:space="preserve">
     <value>readonly references</value>
   </data>
+  <data name="IDS_FeatureRefStructs" xml:space="preserve">
+    <value>ref structs</value>
+  </data>
   <data name="CompilationC" xml:space="preserve">
     <value>Compilation (C#): </value>
   </data>

--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationModifiers.cs
@@ -31,9 +31,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         Indexer = 1 << 18, // not a real modifier, but used to record that indexer syntax was used. 
 
         Async = 1 << 19,
+        Ref = 1 << 20, // used only for structs
 
-        All = (1 << 20) - 1, // all modifiers
-        Unset = 1 << 20, // used when a modifiers value hasn't yet been computed
+        All = (1 << 21) - 1, // all modifiers
+        Unset = 1 << 21, // used when a modifiers value hasn't yet been computed
 
         AccessibilityMask = Private | Protected | Internal | ProtectedInternal | Public,
     }

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -132,6 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_ThrowExpression = MessageBase + 12717,
 
         IDS_FeatureReadonlyReferences = MessageBase + 12718,
+        IDS_FeatureRefStructs = MessageBase + 12719,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -190,6 +191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // C# 7.1 features.
                 case MessageID.IDS_FeatureReadonlyReferences:
+                case MessageID.IDS_FeatureRefStructs:
                     return LanguageVersion.CSharp7_1;
 
                 // C# 7 features.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1574,7 +1574,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             if (this.CurrentToken.Kind == SyntaxKind.RefKeyword)
             {
-                modifiers.Add(this.EatToken());
+                var refKeyword = this.EatToken();
+                refKeyword = CheckFeatureAvailability(refKeyword, MessageID.IDS_FeatureRefStructs);
+                modifiers.Add(refKeyword);
             }
 
             var classOrStructOrInterface = this.EatToken();

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2071,9 +2071,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        private static bool CanStartTypeDeclaration(SyntaxKind kind)
+        private bool IsTypeDeclarationStart()
         {
-            switch (kind)
+            switch (this.CurrentToken.Kind)
             {
                 case SyntaxKind.ClassKeyword:
                 case SyntaxKind.DelegateKeyword:
@@ -2081,6 +2081,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case SyntaxKind.InterfaceKeyword:
                 case SyntaxKind.StructKeyword:
                     return true;
+                case SyntaxKind.RefKeyword:
+                    return PeekToken(1).Kind == SyntaxKind.StructKeyword;
                 default:
                     return false;
             }
@@ -2320,8 +2322,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 }
 
                 // It's valid to have a type declaration here -- check for those
-                if (CanStartTypeDeclaration(this.CurrentToken.Kind) ||
-                    this.CurrentToken.Kind == SyntaxKind.RefKeyword && PeekToken(1).Kind == SyntaxKind.StructKeyword)
+                if (IsTypeDeclarationStart())
                 {
                     return this.ParseTypeDeclaration(attributes, modifiers);
                 }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1444,6 +1444,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
             switch (this.PeekToken(1).Kind)
             {
+                case SyntaxKind.RefKeyword:
+                    return this.PeekToken(2).Kind == SyntaxKind.StructKeyword;
                 case SyntaxKind.StructKeyword:
                 case SyntaxKind.ClassKeyword:
                 case SyntaxKind.InterfaceKeyword:

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -534,6 +534,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_TupleElementNamesAttribute__ctorTransformNames, args);
         }
 
+        internal SynthesizedAttributeData SynthesizeIsByRefLikeAttribute()
+        {
+            // PROTOTYPE(readonlyRefs) it is optional now as it will be generated in the next change
+            return TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor, isOptionalUse: true);
+        }
+
         internal static class TupleNamesEncoder
         {
             public static ImmutableArray<string> Encode(TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2075,7 +2075,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return false;
             }
 
-            return (object)ns.ContainingNamespace != null;
+            return ns.IsGlobalNamespace;
         }
 
         internal override bool HasDeclarativeSecurity

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -129,6 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             internal ObsoleteAttributeData lazyObsoleteAttributeData = ObsoleteAttributeData.Uninitialized;
             internal AttributeUsageInfo lazyAttributeUsageInfo = AttributeUsageInfo.Null;
             internal ThreeState lazyContainsExtensionMethods;
+            internal ThreeState lazyIsByRefLike;
             internal string lazyDefaultMemberName;
             internal NamedTypeSymbol lazyComImportCoClassType = ErrorTypeSymbol.UnknownResultType;
 
@@ -2019,6 +2020,62 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         internal override bool IsSerializable
         {
             get { return (_flags & TypeAttributes.Serializable) != 0; }
+        }
+
+        internal override bool IsByRefLikeType
+        {
+            get
+            {
+                var uncommon = GetUncommonProperties();
+                if (uncommon == s_noUncommonProperties)
+                {
+                    return false;
+                }
+
+                if (!uncommon.lazyIsByRefLike.HasValue())
+                {
+                    var isByRefLike = ThreeState.False;
+
+                    if (this.TypeKind == TypeKind.Struct)
+                    {
+                        if (IsWellknownSpans())
+                        {
+                            isByRefLike = ThreeState.True;
+                        }
+                        else
+                        {
+                            var moduleSymbol = this.ContainingPEModule;
+                            var module = moduleSymbol.Module;
+                            isByRefLike = module.HasIsByRefLikeAttribute(_handle).ToThreeState();
+                        }
+                    }
+
+                    uncommon.lazyIsByRefLike = isByRefLike;
+                }
+
+                return uncommon.lazyIsByRefLike.Value();
+            }
+        }
+
+        //PROTOTYPE(span): Span and ReadonlySpan should have spanLike marker.
+        //                 For now assume that any "System.Span" and "System.ReadOnlySpan" structs 
+        //                 are span-like
+        private bool IsWellknownSpans()
+        {
+            var originalDef = this.OriginalDefinition;
+
+            if (originalDef.Name != "Span" && originalDef.Name != "ReadonlySpan")
+            {
+                return false;
+            }
+
+            var ns = originalDef.ContainingSymbol as NamespaceSymbol;
+            if (ns?.Name != "System")
+            {
+                return false;
+            }
+
+            return (object)ns.ContainingNamespace != null;
         }
 
         internal override bool HasDeclarativeSecurity

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ModifierUtils.cs
@@ -104,6 +104,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return SyntaxFacts.GetText(SyntaxKind.OverrideKeyword);
                 case DeclarationModifiers.Async:
                     return SyntaxFacts.GetText(SyntaxKind.AsyncKeyword);
+                case DeclarationModifiers.Ref:
+                    return SyntaxFacts.GetText(SyntaxKind.RefKeyword);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(modifier);
             }
@@ -149,6 +151,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return DeclarationModifiers.Fixed;
                 case SyntaxKind.VolatileKeyword:
                     return DeclarationModifiers.Volatile;
+                case SyntaxKind.RefKeyword:
+                    return DeclarationModifiers.Ref;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(kind);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_DefaultValueBeforeRequiredValue, loc);
             }
             else if (parameter.RefKind != RefKind.None && 
-                parameter.Type.IsRestrictedType(ignoreSpanLikeTypes: parameter.RefKind == RefKind.RefReadOnly))
+                parameter.Type.IsRestrictedType(ignoreSpanLikeTypes: true))
             {
                 // CS1601: Cannot make reference to variable of type 'System.TypedReference'
                 diagnostics.Add(ErrorCode.ERR_MethodArgCantBeRefAny, parameterSyntax.Location, parameter.Type);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -670,6 +670,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal override bool IsByRefLikeType
+        {
+            get
+            {
+                return (_flags.DeclarationModifiers & DeclarationModifiers.Ref) != 0;
+            }
+        }
+
         public override bool IsSealed
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -35,13 +35,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // d = FieldDefinitionsNoted. 1 bit
             private const int SpecialTypeOffset = 0;
             private const int DeclarationModifiersOffset = 6;
-            private const int IsManagedTypeOffset = 26;
+            private const int IsManagedTypeOffset = 27;
 
             private const int SpecialTypeMask = 0x3F;
-            private const int DeclarationModifiersMask = 0x1FFFFF;
+            private const int DeclarationModifiersMask = 0x3FFFFF;
             private const int IsManagedTypeMask = 0x3;
 
-            private const int FieldDefinitionsNotedBit = 1 << 28;
+            private const int FieldDefinitionsNotedBit = 1 << 29;
 
             private int _flags;
 
@@ -249,6 +249,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     allowedModifiers |= DeclarationModifiers.Static | DeclarationModifiers.Sealed | DeclarationModifiers.Abstract | DeclarationModifiers.Unsafe;
                     break;
                 case TypeKind.Struct:
+                    allowedModifiers |= DeclarationModifiers.Ref | DeclarationModifiers.Unsafe;
+                    break;
                 case TypeKind.Interface:
                 case TypeKind.Delegate:
                     allowedModifiers |= DeclarationModifiers.Unsafe;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbol.cs
@@ -50,8 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 diagnostics.Add(ErrorCode.ERR_FieldCantHaveVoidType, TypeSyntax.Location);
             }
-            //PROTOTYPE(span): span-like instance fields are allowed in span-like types, for now allow inany  struct
-            else if (type.IsRestrictedType(ignoreSpanLikeTypes: !this.IsStatic && containingType.IsStructType()))
+            else if (type.IsRestrictedType(ignoreSpanLikeTypes: !this.IsStatic && containingType.IsByRefLikeType))
             {
                 diagnostics.Add(ErrorCode.ERR_FieldCantBeRefAny, TypeSyntax.Location, type);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -40,13 +40,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             private const int DeclarationModifiersOffset = 5;
 
             private const int MethodKindMask = 0x1F;
-            private const int DeclarationModifiersMask = 0x1FFFFF;
+            private const int DeclarationModifiersMask = 0x3FFFFF;
 
-            private const int ReturnsVoidBit = 1 << 26;
-            private const int IsExtensionMethodBit = 1 << 27;
-            private const int IsMetadataVirtualIgnoringInterfaceChangesBit = 1 << 28;
-            private const int IsMetadataVirtualBit = 1 << 29;
-            private const int IsMetadataVirtualLockedBit = 1 << 30;
+            private const int ReturnsVoidBit = 1 << 27;
+            private const int IsExtensionMethodBit = 1 << 28;
+            private const int IsMetadataVirtualIgnoringInterfaceChangesBit = 1 << 29;
+            private const int IsMetadataVirtualBit = 1 << 30;
+            private const int IsMetadataVirtualLockedBit = 1 << 31;
 
             private int _flags;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1097,6 +1097,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_ExtensionAttribute__ctor));
             }
 
+            if (this.IsByRefLikeType)
+            {
+                //PROTOTYPE(span): should also set [Obsolete] Attribute with a known marker
+                AddSynthesizedAttribute(ref attributes, compilation.SynthesizeIsByRefLikeAttribute());
+            }
+
             if (this.Indexers.Any())
             {
                 string defaultMemberName = this.Indexers.First().MetadataName; // UNDONE: IndexerNameAttribute

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -1308,8 +1308,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 var conversions = new TypeConversions(this.ContainingAssembly.CorLibrary);
                                 this.Type.CheckAllConstraints(conversions, _location, diagnostics);
 
-                                //PROTOTYPE(span): allow in span-like structs?
-                                if (this.Type.IsRestrictedType(ignoreSpanLikeTypes: !this.IsAutoProperty))
+                                // autoproperties can have span-like types only
+                                // inside a span-like type and when not static
+                                var canReturnSpan = !this.IsAutoProperty || 
+                                                    (!this.IsStatic && this.ContainingType.IsByRefLikeType);
+
+                                if (this.Type.IsRestrictedType(ignoreSpanLikeTypes: canReturnSpan))
                                 {
                                     diagnostics.Add(ErrorCode.ERR_FieldCantBeRefAny, this.CSharpSyntaxNode.Type.Location, this.Type);
                                 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -639,30 +639,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract bool IsManagedType { get; }
 
-        //PROTOTYPE(span): this will completely change depending on how span-like types are implemented.
-        //                 Span<T> and ReadOnlySpan<T> will be special types (currently they are not always)
-        //                 Users may be able to define their own Spanlike types, but that is completely NYI 
-        //                 For now we will be simply looking at "System.Span" and "System.ReadOnlySpan" names
         /// <summary>
-        /// Returns true if the type is a Span/ReadOnlySpan
+        /// Returns true if the type may contain embedded references
         /// </summary>
-        internal bool IsSpanLikeType()
-        {
-            var originalDef = this.OriginalDefinition;
-
-            if (originalDef.Name != "Span" && originalDef.Name != "ReadonlySpan")
-            {
-                return false;
-            }
-
-            var ns = originalDef.ContainingSymbol as NamespaceSymbol;
-            if (ns?.Name != "System")
-            {
-                return false;
-            }
-
-            return (object)ns.ContainingNamespace != null;
-        }
+        internal virtual bool IsByRefLikeType => false;
 
         #region ITypeSymbol Members
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -935,7 +935,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return ignoreSpanLikeTypes? 
                         false:
-                        type.IsSpanLikeType();
+                        type.IsByRefLikeType;
         }
 
         public static bool IsIntrinsicType(this TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -205,6 +205,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _underlyingType.IsSerializable; }
         }
 
+        internal override bool IsByRefLikeType
+        {
+            get { return _underlyingType.IsByRefLikeType; }
+        }
+
         internal override bool HasDeclarativeSecurity
         {
             get { return _underlyingType.HasDeclarativeSecurity; }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -55,15 +55,18 @@ namespace System.Runtime.CompilerServices
         //                 span lives.
         private static CSharpCompilation CreateCompilationWithMscorlibAndSpan(string text, CSharpCompilationOptions options = null)
         {
-            var reference = CreateCompilationWithMscorlib45(
+            var reference = CreateCompilation(
                 spanSource,
                 references: new List<MetadataReference>() { MscorlibRef_v4_0_30316_17626, SystemCoreRef, CSharpRef },
-                options: TestOptions.ReleaseDll).EmitToImageReference();
+                options: TestOptions.ReleaseDll);
 
-            var comp = CreateCompilationWithMscorlib45(
-                text, 
-                references: new List<MetadataReference>() { MscorlibRef_v4_0_30316_17626, SystemCoreRef, CSharpRef, reference}, 
+            reference.VerifyDiagnostics();
+
+            var comp = CreateCompilation(
+                text,
+                references: new List<MetadataReference>() { MscorlibRef_v4_0_30316_17626, SystemCoreRef, CSharpRef, reference.EmitToImageReference() },
                 options: options ?? TestOptions.ReleaseExe);
+
 
             return comp;
         }
@@ -71,7 +74,7 @@ namespace System.Runtime.CompilerServices
         private static CSharpCompilation CreateCompilationWithMscorlibAndSpanSrc(string text, CSharpCompilationOptions options = null)
         {
             var textWitSpan = new string[] { text, spanSource };
-            var comp = CreateCompilationWithMscorlib45(
+            var comp = CreateCompilation(
                 textWitSpan,
                 references: new List<MetadataReference>() { MscorlibRef_v4_0_30316_17626, SystemCoreRef, CSharpRef },
                 options: options ?? TestOptions.ReleaseExe);
@@ -312,40 +315,40 @@ public class Program
 
             comp.VerifyDiagnostics(
                 // (22,16): error CS0610: Field or property cannot be of type 'Span<int>'
-                //         public Span<int> fi1; 
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<int>").WithArguments("System.Span<int>"),
+                //         public Span<int> fi2; 
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<int>").WithArguments("System.Span<int>").WithLocation(22, 16),
                 // (21,23): error CS0610: Field or property cannot be of type 'Span<byte>'
-                //         public static Span<byte> fs1;
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>"),
+                //         public static Span<byte> fs2;
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>").WithLocation(21, 23),
                 // (10,19): error CS0610: Field or property cannot be of type 'Span<byte>'
                 //     public static Span<byte> fs;
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>"),
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>").WithLocation(10, 19),
                 // (11,12): error CS0610: Field or property cannot be of type 'Span<int>'
                 //     public Span<int> fi; 
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<int>").WithArguments("System.Span<int>"),
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<int>").WithArguments("System.Span<int>").WithLocation(11, 12),
                 // (15,23): error CS0610: Field or property cannot be of type 'Span<byte>'
                 //         public static Span<byte> fs1;
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>")
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>").WithLocation(15, 23)
             );
 
             comp = CreateCompilationWithMscorlibAndSpanSrc(text);
 
             comp.VerifyDiagnostics(
                 // (22,16): error CS0610: Field or property cannot be of type 'Span<int>'
-                //         public Span<int> fi1; 
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<int>").WithArguments("System.Span<int>"),
+                //         public Span<int> fi2; 
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<int>").WithArguments("System.Span<int>").WithLocation(22, 16),
                 // (21,23): error CS0610: Field or property cannot be of type 'Span<byte>'
-                //         public static Span<byte> fs1;
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>"),
+                //         public static Span<byte> fs2;
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>").WithLocation(21, 23),
                 // (10,19): error CS0610: Field or property cannot be of type 'Span<byte>'
                 //     public static Span<byte> fs;
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>"),
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>").WithLocation(10, 19),
                 // (11,12): error CS0610: Field or property cannot be of type 'Span<int>'
                 //     public Span<int> fi; 
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<int>").WithArguments("System.Span<int>"),
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<int>").WithArguments("System.Span<int>").WithLocation(11, 12),
                 // (15,23): error CS0610: Field or property cannot be of type 'Span<byte>'
                 //         public static Span<byte> fs1;
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>")
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "Span<byte>").WithArguments("System.Span<byte>").WithLocation(15, 23)
             );
         }
 
@@ -741,13 +744,13 @@ public class Program
             comp.VerifyEmitDiagnostics(
                 // (12,43): error CS0123: No overload for 'GetHashCode' matches delegate 'Func<int>'
                 //         Func<int> d1 = default(Span<int>).GetHashCode;
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "GetHashCode").WithArguments("GetHashCode", "System.Func<int>"),
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "GetHashCode").WithArguments("GetHashCode", "System.Func<int>").WithLocation(12, 43),
                 // (14,48): error CS0123: No overload for 'GetType' matches delegate 'Func<Type>'
                 //         Func<Type> d2 = default(SpanLike<int>).GetType;
                 Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "GetType").WithArguments("GetType", "System.Func<System.Type>").WithLocation(14, 48),
                 // (16,46): error CS0123: No overload for 'ToString' matches delegate 'Func<string>'
                 //         Func<string> d3 = default(Span<int>).ToString;
-                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "ToString").WithArguments("ToString", "System.Func<string>")
+                Diagnostic(ErrorCode.ERR_MethDelegateMismatch, "ToString").WithArguments("ToString", "System.Func<string>").WithLocation(16, 46)
             );
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -559,7 +559,8 @@ namespace System
                     case WellKnownType.System_FormattableString:
                     case WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory:
                     case WellKnownType.System_Runtime_CompilerServices_ReadOnlyAttribute:
-                        // Not yet in the platform.
+                    case WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute:
+                    // Not yet in the platform.
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
                         // Not always available.
                         continue;
@@ -861,6 +862,7 @@ namespace System
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload:
                     case WellKnownMember.System_Runtime_CompilerServices_ReadOnlyAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor:
                         // Not always available.
                         continue;
                 }

--- a/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
+++ b/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Parsing\ExpressionParsingTests.cs" />
     <Compile Include="Parsing\LocalFunctionParsingTests.cs" />
     <Compile Include="Parsing\ParserRegressionTests.cs" />
+    <Compile Include="Parsing\RefStructs.cs" />
     <Compile Include="Parsing\ScriptParsingTests.cs" />
     <Compile Include="Parsing\LambdaParameterParsingTests.cs" />
     <Compile Include="Parsing\NameAttributeValueParsingTests.cs" />

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
@@ -32,8 +32,7 @@ class Program
 ";
 
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), options: TestOptions.DebugDll);
-            comp.VerifyDiagnostics(
-            );
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -68,6 +67,10 @@ class Program
     ref class S1{}
 
     public ref unsafe struct S2{}
+
+    ref interface I1{};
+
+    public ref delegate ref int D1();
 }
 ";
 
@@ -75,13 +78,19 @@ class Program
             comp.VerifyDiagnostics(
                 // (4,9): error CS1031: Type expected
                 //     ref class S1{}
-                Diagnostic(ErrorCode.ERR_TypeExpected, "class").WithLocation(4, 9),
+                Diagnostic(ErrorCode.ERR_TypeExpected, "class"),
                 // (6,16): error CS1031: Type expected
                 //     public ref unsafe struct S2{}
-                Diagnostic(ErrorCode.ERR_TypeExpected, "unsafe").WithLocation(6, 16),
+                Diagnostic(ErrorCode.ERR_TypeExpected, "unsafe"),
+                // (8,9): error CS1031: Type expected
+                //     ref interface I1{};
+                Diagnostic(ErrorCode.ERR_TypeExpected, "interface").WithLocation(8, 9),
+                // (10,16): error CS1031: Type expected
+                //     public ref delegate ref int D1();
+                Diagnostic(ErrorCode.ERR_TypeExpected, "delegate").WithLocation(10, 16),
                 // (6,30): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 //     public ref unsafe struct S2{}
-                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "S2").WithLocation(6, 30)
+                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "S2")
             );
         }
 
@@ -98,9 +107,7 @@ class Program
 ";
 
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1), options: TestOptions.DebugDll);
-            comp.VerifyDiagnostics(
-            );
+            comp.VerifyDiagnostics();
         }
-
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
@@ -31,8 +31,31 @@ class Program
 }
 ";
 
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(
+            );
+        }
+
+        [Fact]
+        public void RefStructSimpleLangVer()
+        {
+            var text = @"
+class Program
+{
+    ref struct S1{}
+
+    public ref struct S2{}
+}
+";
+
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
+                // (4,5): error CS8107: Feature 'ref structs' is not available in C# 7. Please use language version 7.1 or greater.
+                //     ref struct S1{}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.1").WithLocation(4, 5),
+                // (6,12): error CS8107: Feature 'ref structs' is not available in C# 7. Please use language version 7.1 or greater.
+                //     public ref struct S2{}
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.1").WithLocation(6, 12)
             );
         }
 
@@ -48,7 +71,7 @@ class Program
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.DebugDll);
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
                 // (4,9): error CS1031: Type expected
                 //     ref class S1{}
@@ -74,7 +97,7 @@ class Program
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.DebugDll);
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1), options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
             );
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
         }
 
         [Fact]
-        public void RefStruct001()
+        public void RefStructSimple()
         {
             var text = @"
 class Program
@@ -28,6 +28,49 @@ class Program
     ref struct S1{}
 
     public ref struct S2{}
+}
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(
+            );
+        }
+
+        [Fact]
+        public void RefStructErr()
+        {
+            var text = @"
+class Program
+{
+    ref class S1{}
+
+    public ref unsafe struct S2{}
+}
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(
+                // (4,9): error CS1031: Type expected
+                //     ref class S1{}
+                Diagnostic(ErrorCode.ERR_TypeExpected, "class").WithLocation(4, 9),
+                // (6,16): error CS1031: Type expected
+                //     public ref unsafe struct S2{}
+                Diagnostic(ErrorCode.ERR_TypeExpected, "unsafe").WithLocation(6, 16),
+                // (6,30): error CS0227: Unsafe code may only appear if compiling with /unsafe
+                //     public ref unsafe struct S2{}
+                Diagnostic(ErrorCode.ERR_IllegalUnsafe, "S2").WithLocation(6, 30)
+            );
+        }
+
+        [Fact]
+        public void RefStructPartial()
+        {
+            var text = @"
+class Program
+{
+    partial ref struct S1{}
+
+    partial ref struct S1{}
 }
 ";
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
+{
+    [CompilerTrait(CompilerFeature.ReadonlyReferences)]
+    public class RefStructs : ParsingTests
+    {
+        public RefStructs(ITestOutputHelper output) : base(output) { }
+
+        protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
+        {
+            return SyntaxFactory.ParseSyntaxTree(text, options: options);
+        }
+
+        [Fact]
+        public void RefStruct001()
+        {
+            var text = @"
+class Program
+{
+    ref struct S1{}
+
+    public ref struct S2{}
+}
+";
+
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics(
+            );
+        }
+
+    }
+}

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1024,6 +1024,11 @@ namespace Microsoft.CodeAnalysis
             return TryExtractStringArrayValueFromAttribute(info.Handle, out tupleElementNames);
         }
 
+        internal bool HasIsByRefLikeAttribute(EntityHandle token)
+        {
+            return FindTargetAttribute(token, AttributeDescription.IsByRefLikeAttribute).HasValue;
+        }
+
         internal bool HasDeprecatedOrObsoleteAttribute(EntityHandle token, out ObsoleteAttributeData obsoleteData)
         {
             AttributeInfo info;

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -356,6 +356,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfObsoleteAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_String, s_signature_HasThis_Void_String_Boolean };
         private static readonly byte[][] s_signaturesOfDynamicAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
         private static readonly byte[][] s_signaturesOfTupleElementNamesAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_String };
+        private static readonly byte[][] s_signaturesOfIsByRefLikeAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfDebuggerHiddenAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfDebuggerNonUserCodeAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfDebuggerStepperBoundaryAttribute = { s_signature_HasThis_Void };
@@ -485,6 +486,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription TypeLibTypeAttribute = new AttributeDescription("System.Runtime.InteropServices", "TypeLibTypeAttribute", s_signaturesOfTypeLibTypeAttribute);
         internal static readonly AttributeDescription DynamicAttribute = new AttributeDescription("System.Runtime.CompilerServices", "DynamicAttribute", s_signaturesOfDynamicAttribute);
         internal static readonly AttributeDescription TupleElementNamesAttribute = new AttributeDescription("System.Runtime.CompilerServices", "TupleElementNamesAttribute", s_signaturesOfTupleElementNamesAttribute);
+        internal static readonly AttributeDescription IsByRefLikeAttribute = new AttributeDescription("System.Runtime.CompilerServices", "IsByRefLikeAttribute", s_signaturesOfIsByRefLikeAttribute);
         internal static readonly AttributeDescription DebuggerHiddenAttribute = new AttributeDescription("System.Diagnostics", "DebuggerHiddenAttribute", s_signaturesOfDebuggerHiddenAttribute);
         internal static readonly AttributeDescription DebuggerNonUserCodeAttribute = new AttributeDescription("System.Diagnostics", "DebuggerNonUserCodeAttribute", s_signaturesOfDebuggerNonUserCodeAttribute);
         internal static readonly AttributeDescription DebuggerStepperBoundaryAttribute = new AttributeDescription("System.Diagnostics", "DebuggerStepperBoundaryAttribute", s_signaturesOfDebuggerStepperBoundaryAttribute);

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -418,6 +418,8 @@ namespace Microsoft.CodeAnalysis
 
         System_Runtime_CompilerServices_ReadOnlyAttribute__ctor,
 
+        System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor,
+
         Count
     }
 }

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2885,6 +2885,13 @@ namespace Microsoft.CodeAnalysis
                  0,                                                                                                                                             // Arity
                      0,                                                                                                                                         // Method Signature
                      (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+
+                 // System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
+                 (byte)(MemberFlags.Constructor),                                                                                                               // Flags
+                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute - WellKnownType.ExtSentinel),                                   // DeclaringTypeId
+                 0,                                                                                                                                             // Arity
+                     0,                                                                                                                                         // Method Signature
+                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3244,6 +3251,7 @@ namespace Microsoft.CodeAnalysis
                 "Format",                                   // System_String__Format_IFormatProvider
                 "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload
                 ".ctor",                                    // System_Runtime_CompilerServices_ReadOnlyAttribute__ctor
+                ".ctor",                                    // System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);
@@ -3272,6 +3280,7 @@ namespace Microsoft.CodeAnalysis
                 case WellKnownMember.System_STAThreadAttribute__ctor:
                 case WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor:
                 case WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor:
+                case WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor:
                     return true;
 
                 default:

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -265,6 +265,7 @@ namespace Microsoft.CodeAnalysis
         Microsoft_CodeAnalysis_Runtime_Instrumentation,
 
         System_Runtime_CompilerServices_ReadOnlyAttribute,
+        System_Runtime_CompilerServices_IsByRefLikeAttribute,
 
         NextAvailable,
     }
@@ -524,6 +525,7 @@ namespace Microsoft.CodeAnalysis
             "Microsoft.CodeAnalysis.Runtime.Instrumentation",
 
             "System.Runtime.CompilerServices.ReadOnlyAttribute",
+            "System.Runtime.CompilerServices.IsByRefLikeAttribute",
         };
 
         private readonly static Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -508,7 +508,8 @@ End Namespace
                         ' Not a real type
                         Continue For
                     Case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation,
-                         WellKnownType.System_Runtime_CompilerServices_ReadOnlyAttribute
+                         WellKnownType.System_Runtime_CompilerServices_ReadOnlyAttribute,
+                        WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute
                         ' Not always available.
                         Continue For
                 End Select
@@ -544,7 +545,8 @@ End Namespace
                         ' Not a real type
                         Continue For
                     Case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation,
-                         WellKnownType.System_Runtime_CompilerServices_ReadOnlyAttribute
+                         WellKnownType.System_Runtime_CompilerServices_ReadOnlyAttribute,
+                        WellKnownType.System_Runtime_CompilerServices_IsByRefLikeAttribute
                         ' Not always available.
                         Continue For
                 End Select
@@ -583,7 +585,8 @@ End Namespace
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload,
-                         WellKnownMember.System_Runtime_CompilerServices_ReadOnlyAttribute__ctor
+                         WellKnownMember.System_Runtime_CompilerServices_ReadOnlyAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
                         ' Not always available.
                         Continue For
                 End Select
@@ -664,7 +667,8 @@ End Namespace
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload,
-                         WellKnownMember.System_Runtime_CompilerServices_ReadOnlyAttribute__ctor
+                         WellKnownMember.System_Runtime_CompilerServices_ReadOnlyAttribute__ctor,
+                        WellKnownMember.System_Runtime_CompilerServices_IsByRefLikeAttribute__ctor
                         ' Not always available.
                         Continue For
                 End Select


### PR DESCRIPTION
As described in https://github.com/VSadov/csharplang/blob/3ab16a77b9fefe3805fa81044ba72d6c254e00f9/proposals/span-safety.md

See the relevant parts copied below.

NOTE: `ref` is considered a modifier only when immediately preceding `struct` keyword. We need this to disambiguate with the case of parsing `ref` returning members where `ref` is considered an operator in the grammar and not a modifier.
This approach will need to be vetted by the LDM, but this is how it is done in this change.

NOT IN THIS CHANGE:
- We are not emitting [Obsolete], just yet. It is very breaking to the existing code with spans so we will do that in stages as separate changes. Possibly make it a warning  first, then, as another change, an error. (https://github.com/dotnet/roslyn/issues/19423)
- We are not generating embedded `IsByRefLikeAttribute` similarly to `IsReadOnly`, but that is the plan. It will be done as a separate change. (https://github.com/dotnet/roslyn/issues/19422)
- Not exposed via semantic info/symbol display, yet  (https://github.com/dotnet/roslyn/issues/19421)

---

## Generalized `ref-like` types in source code.

`ref-like` structs will have to be explicitly marked in the source code using `ref` modifier:

```c#
ref struct TwoSpans<T>
{
	// can have ref-like instance fields
	public Span<T> first;
	public Span<T> second;
} 

// error: arrays of ref-like types are not allowed. 
TwoSpans<T>[] arr = null;

``` 

Designating a struct as ref-like will allow the struct to have ref-like instance fields and will also make all the requirements of ref-like types applicable to the struct. 

An alternative proposal of "inferring" the ref-like property from the fact that a struct contains ref-like fields was also considered and rejected for the following reasons:

1) Implicit cascading of ref-like through containing structs appears to be dangerous. 
Since the implicit ref-like would work recursively, it would be too easy to turn multiple structs, possibly not in the current project, to become ref-like with one change.  

1) Span<T> and ReadOnlySpan<T> themselves do not contain ref-like fields. These types will have to be special-cased, which will be an issue if another trivial ref-like type needs to be added in the future.  

## Metadata representation or ref-like structs.

Ref-like structs will be marked with **System.Runtime.CompilerServices.IsRefLikeAttribute** attribute.

The attribute will be added to common base libraries such as `mscorlib`. In a case if the attribute is not available, compiler will generate an internal one similarly to other embedded-on-demand attributes such as `IsReadOnlyAttribute`.

An additional measure will be taken to prevent the use of ref-like structs in compilers not familiar with the safety rules (this includes C# compilers prior to the one in which this feature is implemented). 

Having no other good alternatives that work in old compilers without servicing, an `Obsolete` attribute with a known string will be added to all ref-like structs. Compilers that know how to use ref-like types will ignore this particular form of `Obsolete`.

A typical matadata representation: 

```C#
    [IsRefLike]
    [Obsolete("Types with embedded references are not supported in this version of your compiler.")]
    public struct TwoSpans<T>
    {
       . . . . 
    }
```