### PR TITLE
Refout: Re-enable NoPia, add tests from feature review

### DIFF
--- a/docs/features/refout.md
+++ b/docs/features/refout.md
@@ -39,6 +39,7 @@ Neither `/refonly` nor `/refout` are permitted with net modules (`/target:module
 
 The compilation from the command-line will either produce both assemblies (implementation and ref) or neither. There is no "partial success" scenario.
 When the compiler produces documentation, it is un-affected by either the `/refonly` or `/refout` parameters. This may change in the future.
+The main purpose of the `/refout` option is to speed up incremental build scenarios. The current implementation for this flag can produce a ref assembly with more metadata than `/refonly` (for instance, anonymous types). This is a candidate for post-C#-7.1 refinement.
 
 ### CscTask/CoreCompile
 The `CoreCompile` target will support a new output, called `IntermediateRefAssembly`, which parallels the existing `IntermediateAssembly`.
@@ -64,6 +65,7 @@ Going back to the 4 driving scenarios:
 
 ## Future
 As mentioned above, there may be further refinements after C# 7.1:
+- Further reduce the metadata in ref assemblies produced by `/refout`, to match those produced by `/refonly`.
 - Controlling internals (producing public ref assemblies)
 - Produce ref assemblies even when there are errors outside method bodies (emitting error types when `EmitOptions.TolerateErrors` is set)
 - When the compiler produces documentation, the contents produced could be filtered down to match the APIs that go into the primary output. In other words, the documentation could be filtered down when using the `/refonly` parameter.

--- a/docs/features/refout.md
+++ b/docs/features/refout.md
@@ -1,6 +1,7 @@
 # Reference assemblies
 
 Reference assemblies are metadata-only assemblies with the minimum amount of metadata to preserve the compile-time behavior of consumers (diagnostics may be affected, though).
+The compiler may choose to remove more metadata in later versions, if it is determined to be safe (ie. respects the principle above).
 
 ## Scenarios
 There are 4 scenarios:
@@ -13,17 +14,14 @@ There are 4 scenarios:
 
 ## Definition of ref assemblies
 Metadata-only assembly have their method bodies replaced with a single `throw null` body, but include all members except anonymous types. The reason for using `throw null` bodies (as opposed to no bodies) is so that PEVerify could run and pass (thus validating the completeness of the metadata).
-Ref assemblies further remove metadata (private members) from metadata-only assemblies.
+Ref assemblies will include an assembly-level `ReferenceAssembly` attribute. This attribute may be specified in should (then we won't need to synthesize it). Because of this attribute, runtimes will refuse to load ref assemblies for execution (but they can still be loaded Reflection-only mode).
+Ref assemblies further remove metadata (private members) from metadata-only assemblies:
 
-A reference assembly will only have references for what it needs in the API surface. The real assembly may have additional references related to specific implementations. For instance, the reference assembly for `class C { private void M() { dynamic .... } }` will not have any references for `dynamic` types.
-
-Private function-members (methods, properties and events) will be removed. If there are no `InternalsVisibleTo` attributes, do the same for internal function-members
-
-All types (including private or nested types) must be kept in reference assemblies.
-
-All fields of a struct will be kept (in C# 7.1 timeframe), but this can later be refined. There are three cases to consider (ref case, struct case, generic case), where we could possibly substitute the fields with adequate placeholders that would minimize the rate of change of the ref assembly.
-
-Reference assemblies will include an assembly-level `ReferenceAssembly` attribute. If such an attribute is found in source, we won't need to synthesize it. Because of this attribute, runtimes will refuse to load reference assemblies.
+- A ref assembly will only have references for what it needs in the API surface. The real assembly may have additional references related to specific implementations. For instance, the ref assembly for `class C { private void M() { dynamic d = 1; ... } }` will not reference any types required for `dynamic`.
+- Private function-members (methods, properties and events) will be removed. If there are no `InternalsVisibleTo` attributes, do the same for internal function-members
+- But all types (including private or nested types) must be kept in ref assemblies. All attributes must be kept (even internal ones).
+- All virtual methods will be kept. Explicit interface implementations will be kept.
+- All fields of a struct will be kept. (This is a candidate for post-C#-7.1 refinement)
 
 ## API changes
 
@@ -32,15 +30,15 @@ Two mutually exclusive command-line parameters will be added to `csc.exe` and `v
 - `/refout`
 - `/refonly`
 
-The `/refout` parameter specifies a file path where the ref assembly should be output. This translates to `metadataPeStream` in the `Emit` API (see details below). The filename for the ref assembly should generally match that of the primary assembly, but it can be in a different folder.
+The `/refout` parameter specifies a file path where the ref assembly should be output. This translates to `metadataPeStream` in the `Emit` API (see details below). The filename for the ref assembly should generally match that of the primary assembly (we will warn when they don't match). The recommended convention (used by MSBuild) is to place the ref assembly in a "ref/" sub-folder relative to the primary assembly.
 
-The `/refonly` parameter is a flag that indicates that a ref assembly should be output instead of an implementation assembly. 
+The `/refonly` parameter is a flag that indicates that a ref assembly should be output instead of an implementation assembly, as the primary output.
 The `/refonly` parameter is not allowed together with the `/refout` parameter, as it doesn't make sense to have both the primary and secondary outputs be ref assemblies. Also, the `/refonly` parameter silently disables outputting PDBs, as ref assemblies cannot be executed. 
 The `/refonly` parameter translates to `EmitMetadataOnly` being `true`, and `IncludePrivateMembers` being `false` in the `Emit` API (see details below).
-Neither `/refonly` nor `/refout` are permitted with `/target:module`, `/addmodule`, or `/link:...` options.
+Neither `/refonly` nor `/refout` are permitted with net modules (`/target:module`, `/addmodule` options).
 
 The compilation from the command-line will either produce both assemblies (implementation and ref) or neither. There is no "partial success" scenario.
-When the compiler produces documentation, it is un-affected by either the `/refonly` or `/refout` parameters.
+When the compiler produces documentation, it is un-affected by either the `/refonly` or `/refout` parameters. This may change in the future.
 
 ### CscTask/CoreCompile
 The `CoreCompile` target will support a new output, called `IntermediateRefAssembly`, which parallels the existing `IntermediateAssembly`.
@@ -48,6 +46,8 @@ The `Csc` task will support a new output, called `OutputRefAssembly`, which para
 Both of those basically map to the `/refout` command-line parameter.
 
 An additional task, called `CopyRefAssembly`, will be provided along with the existing `Csc` task. It takes a `SourcePath` and a `DestinationPath` and generally copies the file from the source over to the destination. But if it can determine that the contents of those two files match (by comparing their MVIDs, see details below), then the destination file is left untouched.
+
+As a side-note, `CopyRefAssembly` uses the same assembly resolution/redirection trick as `Csc` and `Vbc`, to avoid type loading problems with `System.IO.FileSystem`.
 
 ### CodeAnalysis APIs
 It is already possible to produce metadata-only assemblies by using `EmitOptions.EmitMetadataOnly`, which is used in IDE scenarios with cross-language dependencies.
@@ -68,11 +68,7 @@ As mentioned above, there may be further refinements after C# 7.1:
 - Produce ref assemblies even when there are errors outside method bodies (emitting error types when `EmitOptions.TolerateErrors` is set)
 - When the compiler produces documentation, the contents produced could be filtered down to match the APIs that go into the primary output. In other words, the documentation could be filtered down when using the `/refonly` parameter.
 
-
 ## Open questions
-- should explicit method implementations be included in ref assemblies?
-- Non-public attributes on public APIs (emit attribute based on accessibility rule)
-- ref assemblies and NoPia
 
 ## Related issues
 - Produce ref assemblies from command-line and msbuild (https://github.com/dotnet/roslyn/issues/2184)

--- a/docs/features/refout.md
+++ b/docs/features/refout.md
@@ -14,7 +14,7 @@ There are 4 scenarios:
 
 ## Definition of ref assemblies
 Metadata-only assembly have their method bodies replaced with a single `throw null` body, but include all members except anonymous types. The reason for using `throw null` bodies (as opposed to no bodies) is so that PEVerify could run and pass (thus validating the completeness of the metadata).
-Ref assemblies will include an assembly-level `ReferenceAssembly` attribute. This attribute may be specified in should (then we won't need to synthesize it). Because of this attribute, runtimes will refuse to load ref assemblies for execution (but they can still be loaded Reflection-only mode).
+Ref assemblies will include an assembly-level `ReferenceAssembly` attribute. This attribute may be specified in source (then we won't need to synthesize it). Because of this attribute, runtimes will refuse to load ref assemblies for execution (but they can still be loaded Reflection-only mode).
 Ref assemblies further remove metadata (private members) from metadata-only assemblies:
 
 - A ref assembly will only have references for what it needs in the API surface. The real assembly may have additional references related to specific implementations. For instance, the ref assembly for `class C { private void M() { dynamic d = 1; ... } }` will not reference any types required for `dynamic`.

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6731,15 +6731,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot embed types when using /refout or /refonly..
-        /// </summary>
-        internal static string ERR_NoEmbeddedTypeWhenRefOutOrRefOnly {
-            get {
-                return ResourceManager.GetString("ERR_NoEmbeddedTypeWhenRefOutOrRefOnly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Program does not contain a static &apos;Main&apos; method suitable for an entry point.
         /// </summary>
         internal static string ERR_NoEntryPoint {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2303,9 +2303,6 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_NoNetModuleOutputWhenRefOutOrRefOnly" xml:space="preserve">
     <value>Cannot compile net modules when using /refout or /refonly.</value>
   </data>
-  <data name="ERR_NoEmbeddedTypeWhenRefOutOrRefOnly" xml:space="preserve">
-    <value>Cannot embed types when using /refout or /refonly.</value>
-  </data>
   <data name="ERR_OvlOperatorExpected" xml:space="preserve">
     <value>Overloadable operator expected</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1178,11 +1178,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AddDiagnostic(diagnostics, diagnosticOptions, ErrorCode.ERR_NoRefOutWhenRefOnly);
             }
 
-            if ((refOnly || outputRefFilePath != null) && metadataReferences.Any(r => r.Properties.EmbedInteropTypes))
-            {
-                AddDiagnostic(diagnostics, diagnosticOptions, ErrorCode.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly);
-            }
-
             if (outputKind == OutputKind.NetModule && (refOnly || outputRefFilePath != null))
             {
                 AddDiagnostic(diagnostics, diagnosticOptions, ErrorCode.ERR_NoNetModuleOutputWhenRefOutOrRefOnly);

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1481,7 +1481,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_NoRefOutWhenRefOnly = 8308,
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 8309,
-        ERR_NoEmbeddedTypeWhenRefOutOrRefOnly = 8310,
+        // Available = 8310,
         ERR_BadDynamicMethodArgDefaultLiteral = 8311,
         ERR_DefaultLiteralNotValid = 8312,
         WRN_DefaultInSwitch = 8313,

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -2886,6 +2886,12 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
                 // error CS8301: Do not use refout when using refonly.
                 Diagnostic(ErrorCode.ERR_NoRefOutWhenRefOnly).WithLocation(1, 1));
 
+            parsedArgs = DefaultParse(new[] { @"/refout:ref.dll", "/link:b", "a.cs" }, baseDirectory);
+            parsedArgs.Errors.Verify();
+
+            parsedArgs = DefaultParse(new[] { "/refonly", "/link:b", "a.cs" }, baseDirectory);
+            parsedArgs.Errors.Verify();
+
             parsedArgs = DefaultParse(new[] { "/refonly:incorrect", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2007: Unrecognized option: '/refonly:incorrect'

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -2886,18 +2886,6 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
                 // error CS8301: Do not use refout when using refonly.
                 Diagnostic(ErrorCode.ERR_NoRefOutWhenRefOnly).WithLocation(1, 1));
 
-            parsedArgs = DefaultParse(new[] { @"/refout:ref.dll", "/link:b", "a.cs" }, baseDirectory);
-            parsedArgs.Errors.Verify(
-                // error CS8357: Cannot embed types when using /refout or /refonly.
-                Diagnostic(ErrorCode.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly).WithLocation(1, 1)
-                );
-
-            parsedArgs = DefaultParse(new[] { "/refonly", "/link:b", "a.cs" }, baseDirectory);
-            parsedArgs.Errors.Verify(
-                // error CS8357: Cannot embed types when using /refout or /refonly.
-                Diagnostic(ErrorCode.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly).WithLocation(1, 1)
-                );
-
             parsedArgs = DefaultParse(new[] { "/refonly:incorrect", "a.cs" }, baseDirectory);
             parsedArgs.Errors.Verify(
                 // error CS2007: Unrecognized option: '/refonly:incorrect'

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1160,6 +1160,8 @@ public class PublicClass
     private void PrivateMethod() { System.Console.Write(""Hello""); }
     protected void ProtectedMethod() { System.Console.Write(""Hello""); }
     internal void InternalMethod() { System.Console.Write(""Hello""); }
+    public event System.Action PublicEvent;
+    internal event System.Action InternalEvent;
 }
 ";
             CSharpCompilation comp = CreateCompilation(source, references: new[] { MscorlibRef },
@@ -1178,7 +1180,10 @@ public class PublicClass
             AssertEx.Equal(
                 new[] { "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
                     "void PublicClass.ProtectedMethod()", "void PublicClass.InternalMethod()",
-                    "PublicClass..ctor()" },
+                    "void PublicClass.PublicEvent.add", "void PublicClass.PublicEvent.remove",
+                    "void PublicClass.InternalEvent.add", "void PublicClass.InternalEvent.remove",
+                    "PublicClass..ctor()",
+                    "event System.Action PublicClass.PublicEvent", "event System.Action PublicClass.InternalEvent" },
                 compWithReal.GetMember<NamedTypeSymbol>("PublicClass").GetMembers()
                     .Select(m => m.ToTestDisplayString()));
 
@@ -1202,7 +1207,10 @@ public class PublicClass
             AssertEx.Equal(
                 new[] { "void PublicClass.PublicMethod()", "void PublicClass.PrivateMethod()",
                     "void PublicClass.ProtectedMethod()", "void PublicClass.InternalMethod()",
-                    "PublicClass..ctor()" },
+                    "void PublicClass.PublicEvent.add", "void PublicClass.PublicEvent.remove",
+                    "void PublicClass.InternalEvent.add", "void PublicClass.InternalEvent.remove",
+                    "PublicClass..ctor()",
+                    "event System.Action PublicClass.PublicEvent", "event System.Action PublicClass.InternalEvent" },
                 compWithMetadata.GetMember<NamedTypeSymbol>("PublicClass").GetMembers().Select(m => m.ToTestDisplayString()));
 
             AssertEx.Equal(
@@ -1225,7 +1233,9 @@ public class PublicClass
                 compWithRef.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
 
             AssertEx.Equal(
-                new[] { "void PublicClass.PublicMethod()", "void PublicClass.ProtectedMethod()", "PublicClass..ctor()" },
+                new[] { "void PublicClass.PublicMethod()", "void PublicClass.ProtectedMethod()",
+                    "void PublicClass.PublicEvent.add", "void PublicClass.PublicEvent.remove",
+                    "PublicClass..ctor()", "event System.Action PublicClass.PublicEvent"},
                 compWithRef.GetMember<NamedTypeSymbol>("PublicClass").GetMembers().Select(m => m.ToTestDisplayString()));
 
             AssertEx.Equal(

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -478,15 +478,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Embedded interop type references should not be given when emitting a ref assembly..
-        /// </summary>
-        internal static string EmbedInteropTypesUnexpectedWhenEmittingRefAssembly {
-            get {
-                return ResourceManager.GetString("EmbedInteropTypesUnexpectedWhenEmittingRefAssembly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A key in the pathMap is empty..
         /// </summary>
         internal static string EmptyKeyInPathMap {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -333,9 +333,6 @@
   <data name="PdbStreamUnexpectedWhenEmittingMetadataOnly" xml:space="preserve">
     <value>PDB stream should not be given when emitting metadata only.</value>
   </data>
-  <data name="EmbedInteropTypesUnexpectedWhenEmittingRefAssembly" xml:space="preserve">
-    <value>Embedded interop type references should not be given when emitting a ref assembly.</value>
-  </data>
   <data name="MetadataPeStreamUnexpectedWhenEmittingMetadataOnly" xml:space="preserve">
     <value>Metadata PE stream should not be given when emitting metadata only.</value>
   </data>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2087,13 +2087,6 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentException(CodeAnalysisResources.IncludingPrivateMembersUnexpectedWhenEmittingToMetadataPeStream, nameof(metadataPEStream));
             }
 
-            if ((metadataPEStream != null || options?.EmitMetadataOnly == true) &&
-                options?.IncludePrivateMembers == false &&
-                References.Any(r => r.Properties.EmbedInteropTypes))
-            {
-                throw new ArgumentException(CodeAnalysisResources.EmbedInteropTypesUnexpectedWhenEmittingRefAssembly, nameof(metadataPEStream));
-            }
-
             if (options?.DebugInformationFormat == DebugInformationFormat.Embedded &&
                 options?.EmitMetadataOnly == true)
             {

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1203,10 +1203,6 @@ lVbRuntimePlus:
                 AddDiagnostic(diagnostics, ERRID.ERR_NoRefOutWhenRefOnly)
             End If
 
-            If (refOnly OrElse outputRefFileName IsNot Nothing) AndAlso metadataReferences.Any(Function(r) r.Properties.EmbedInteropTypes) Then
-                AddDiagnostic(diagnostics, ERRID.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly)
-            End If
-
             If outputKind = OutputKind.NetModule AndAlso (refOnly OrElse outputRefFileName IsNot Nothing) Then
                 AddDiagnostic(diagnostics, ERRID.ERR_NoNetModuleOutputWhenRefOutOrRefOnly)
             End If

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1733,7 +1733,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ERR_NoRefOutWhenRefOnly = 37300
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 37301
-        ERR_NoEmbeddedTypeWhenRefOutOrRefOnly = 37302
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -8071,15 +8071,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Cannot embed types when using /refout or /refonly..
-        '''</summary>
-        Friend ReadOnly Property ERR_NoEmbeddedTypeWhenRefOutOrRefOnly() As String
-            Get
-                Return ResourceManager.GetString("ERR_NoEmbeddedTypeWhenRefOutOrRefOnly", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Array bounds cannot appear in type specifiers..
         '''</summary>
         Friend ReadOnly Property ERR_NoExplicitArraySizes() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5471,9 +5471,6 @@
   <data name="ERR_NoRefOutWhenRefOnly" xml:space="preserve">
     <value>Do not use refout when using refonly.</value>
   </data>
-  <data name="ERR_NoEmbeddedTypeWhenRefOutOrRefOnly" xml:space="preserve">
-    <value>Cannot embed types when using /refout or /refonly.</value>
-  </data>
   <data name="ERR_NoNetModuleOutputWhenRefOutOrRefOnly" xml:space="preserve">
     <value>Cannot compile net modules when using /refout or /refonly.</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -2923,6 +2923,12 @@ print Goodbye, World"
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_NoNetModuleOutputWhenRefOutOrRefOnly).WithLocation(1, 1))
 
+            parsedArgs = DefaultParse({"/refout:ref.dll", "/link:b", "a.vb"}, baseDirectory)
+            parsedArgs.Errors.Verify()
+
+            parsedArgs = DefaultParse({"/refonly", "/link:b", "a.vb"}, baseDirectory)
+            parsedArgs.Errors.Verify()
+
             parsedArgs = DefaultParse({"/refonly", "/target:module", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_NoNetModuleOutputWhenRefOutOrRefOnly).WithLocation(1, 1))

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -2923,14 +2923,6 @@ print Goodbye, World"
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_NoNetModuleOutputWhenRefOutOrRefOnly).WithLocation(1, 1))
 
-            parsedArgs = DefaultParse({"/refout:ref.dll", "/link:b", "a.vb"}, baseDirectory)
-            parsedArgs.Errors.Verify(
-                Diagnostic(ERRID.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly).WithLocation(1, 1))
-
-            parsedArgs = DefaultParse({"/refonly", "/link:b", "a.vb"}, baseDirectory)
-            parsedArgs.Errors.Verify(
-                Diagnostic(ERRID.ERR_NoEmbeddedTypeWhenRefOutOrRefOnly).WithLocation(1, 1))
-
             parsedArgs = DefaultParse({"/refonly", "/target:module", "a.vb"}, baseDirectory)
             parsedArgs.Errors.Verify(
                 Diagnostic(ERRID.ERR_NoNetModuleOutputWhenRefOutOrRefOnly).WithLocation(1, 1))

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -790,6 +790,8 @@ Public MustInherit Class PublicClass
         System.Console.Write(""Hello"")
     End Sub
     Public MustOverride Sub AbstractMethod()
+    Public Event PublicEvent As System.Action
+    Friend Event InternalEvent As System.Action
 End Class"
             Dim comp As Compilation = CreateCompilation(source, references:={MscorlibRef},
                             options:=TestOptions.DebugDll.WithDeterministic(True))
@@ -805,10 +807,14 @@ End Class"
                 {"<Module>", "PublicClass"},
                 realAssembly.GlobalNamespace.GetMembers().Select(Function(m) m.ToDisplayString()))
 
-            AssertEx.SetEqual(
-                {"Sub PublicClass.PublicMethod()", "Sub PublicClass.PrivateMethod()",
-                    "Sub PublicClass.InternalMethod()", "Sub PublicClass.ProtectedMethod()",
-                    "Sub PublicClass.AbstractMethod()", "Sub PublicClass..ctor()"},
+            AssertEx.Equal(
+                {"PublicClass.PublicEventEvent As System.Action", "PublicClass.InternalEventEvent As System.Action",
+                    "Sub PublicClass..ctor()", "Sub PublicClass.PublicMethod()",
+                    "Sub PublicClass.PrivateMethod()", "Sub PublicClass.ProtectedMethod()",
+                    "Sub PublicClass.InternalMethod()", "Sub PublicClass.AbstractMethod()",
+                    "Sub PublicClass.add_PublicEvent(obj As System.Action)", "Sub PublicClass.remove_PublicEvent(obj As System.Action)",
+                    "Sub PublicClass.add_InternalEvent(obj As System.Action)", "Sub PublicClass.remove_InternalEvent(obj As System.Action)",
+                    "Event PublicClass.PublicEvent As System.Action", "Event PublicClass.InternalEvent As System.Action"},
                 compWithReal.GetMember(Of NamedTypeSymbol)("PublicClass").GetMembers().
                     Select(Function(m) m.ToTestDisplayString()))
 
@@ -830,10 +836,14 @@ End Class"
                 {"<Module>", "PublicClass"},
                 metadataAssembly.GlobalNamespace.GetMembers().Select(Function(m) m.ToDisplayString()))
 
-            AssertEx.SetEqual(
-                {"Sub PublicClass.PublicMethod()", "Sub PublicClass.PrivateMethod()",
-                    "Sub PublicClass.InternalMethod()", "Sub PublicClass.ProtectedMethod()",
-                    "Sub PublicClass.AbstractMethod()", "Sub PublicClass..ctor()"},
+            AssertEx.Equal(
+                {"PublicClass.PublicEventEvent As System.Action", "PublicClass.InternalEventEvent As System.Action",
+                    "Sub PublicClass..ctor()", "Sub PublicClass.PublicMethod()",
+                    "Sub PublicClass.PrivateMethod()", "Sub PublicClass.ProtectedMethod()",
+                    "Sub PublicClass.InternalMethod()", "Sub PublicClass.AbstractMethod()",
+                    "Sub PublicClass.add_PublicEvent(obj As System.Action)", "Sub PublicClass.remove_PublicEvent(obj As System.Action)",
+                    "Sub PublicClass.add_InternalEvent(obj As System.Action)", "Sub PublicClass.remove_InternalEvent(obj As System.Action)",
+                    "Event PublicClass.PublicEvent As System.Action", "Event PublicClass.InternalEvent As System.Action"},
                 compWithMetadata.GetMember(Of NamedTypeSymbol)("PublicClass").GetMembers().
                     Select(Function(m) m.ToTestDisplayString()))
 
@@ -845,7 +855,7 @@ End Class"
 
             MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitMetadataOnly))
 
-            ' verify metadata (types, members, attributes) of the metadata-only assembly
+            ' verify metadata (types, members, attributes) of the ref assembly
             Dim emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)
             CompileAndVerify(comp, emitOptions:=emitRefOnly, verify:=True)
 
@@ -859,7 +869,9 @@ End Class"
 
             AssertEx.SetEqual(
                 {"Sub PublicClass..ctor()", "Sub PublicClass.PublicMethod()",
-                    "Sub PublicClass.ProtectedMethod()", "Sub PublicClass.AbstractMethod()"},
+                    "Sub PublicClass.ProtectedMethod()", "Sub PublicClass.AbstractMethod()",
+                    "Sub PublicClass.add_PublicEvent(obj As System.Action)", "Sub PublicClass.remove_PublicEvent(obj As System.Action)",
+                    "Event PublicClass.PublicEvent As System.Action"},
                 compWithRef.GetMember(Of NamedTypeSymbol)("PublicClass").GetMembers().
                     Select(Function(m) m.ToTestDisplayString()))
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -887,24 +887,6 @@ End Class"
         End Sub
 
         <Fact>
-        Public Sub RefAssembly_DisallowEmbeddingTypes()
-            Dim comp = CreateCompilation("", references:={MscorlibRef.WithEmbedInteropTypes(True)},
-                            options:=TestOptions.DebugDll)
-
-            Using output As New MemoryStream()
-                Assert.Throws(Of ArgumentException)(Function() comp.Emit(output,
-                                    options:=EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)))
-            End Using
-
-            Using output As New MemoryStream()
-                Using metadataOutput = New MemoryStream()
-                    Assert.Throws(Of ArgumentException)(Function() comp.Emit(output, metadataPEStream:=metadataOutput,
-                                        options:=EmitOptions.Default.WithIncludePrivateMembers(False)))
-                End Using
-            End Using
-        End Sub
-
-        <Fact>
         Public Sub EmitMetadataOnly_DisallowMetadataPeStream()
             Dim comp = CreateCompilation("", references:={MscorlibRef},
                             options:=TestOptions.DebugDll.WithDeterministic(True))

--- a/src/Test/Utilities/Portable/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/Portable/CommonTestBase.CompilationVerifier.cs
@@ -311,7 +311,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 return assemblies.Last();
             }
 
-            private static MetadataReference LoadTestEmittedExecutableForSymbolValidation(
+            internal static MetadataReference LoadTestEmittedExecutableForSymbolValidation(
                 ImmutableArray<byte> image,
                 OutputKind outputKind,
                 string display = null)


### PR DESCRIPTION
This addresses the blocking concerns for merging the ref assemblies feature to master.
Aside from re-enabling NoPia, this is mostly test changes.

@AlekseyTs @gafter @dotnet/roslyn-compiler for review. If I can get a review today, I will merge to master later tonight.