### PR TITLE
Include overflow checks in tuple conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Roslyn.Utilities;
-using System.Collections.Immutable;
-using System;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -114,38 +113,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 syntax,
                 source,
                 conversion,
-                IsCheckedConversion(source.Type, destination),
+                @checked: CheckOverflowAtRuntime,
                 explicitCastInCode: isCast && !wasCompilerGenerated,
                 constantValueOpt: constantValue,
                 type: destination)
             { WasCompilerGenerated = wasCompilerGenerated };
-        }
-
-        private bool IsCheckedConversion(TypeSymbol source, TypeSymbol target)
-        {
-            Debug.Assert((object)target != null);
-
-            if ((object)source == null || !CheckOverflowAtRuntime)
-            {
-                return false;
-            }
-
-            if (source.IsDynamic())
-            {
-                return true;
-            }
-
-            SpecialType sourceST = source.StrippedType().EnumUnderlyingType().SpecialType;
-            SpecialType targetST = target.StrippedType().EnumUnderlyingType().SpecialType;
-
-            // integral to double or float is never checked, but float/double to integral 
-            // may be checked.
-            bool sourceIsNumeric = SpecialType.System_Char <= sourceST && sourceST <= SpecialType.System_Double;
-            bool targetIsNumeric = SpecialType.System_Char <= targetST && targetST <= SpecialType.System_UInt64;
-
-            return
-                sourceIsNumeric && (targetIsNumeric || target.IsPointerType()) ||
-                targetIsNumeric && source.IsPointerType();
         }
 
         protected BoundExpression CreateUserDefinedConversion(SyntaxNode syntax, BoundExpression source, Conversion conversion, bool isCast, TypeSymbol destination, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_inExpressionLambda)
             {
-                @checked = @checked && NeedsCheckedInExpressionTree(rewrittenOperand.Type, rewrittenType);
+                @checked = @checked && NeedsCheckedConversionInExpressionTree(rewrittenOperand.Type, rewrittenType);
             }
 
             switch (conversion.Kind)
@@ -376,19 +376,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // Determine if the conversion can actually overflow at runtime.  If not, no need to generate a checked instruction.
-        private static bool NeedsCheckedInExpressionTree(TypeSymbol source, TypeSymbol target)
+        private static bool NeedsCheckedConversionInExpressionTree(TypeSymbol source, TypeSymbol target)
         {
             Debug.Assert((object)target != null);
 
             if ((object)source == null)
             {
                 return false;
-            }
-
-            if (source.IsTupleType)
-            {
-                // Assume the conversion can overflow.
-                return true;
             }
 
             // integral to double or float is never checked, but float/double to integral 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCheckedTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenCheckedTests.cs
@@ -2367,5 +2367,391 @@ class Derived2 : Base1
 }
 ");
         }
+
+        [Fact]
+        public void CheckedConversionsInExpressionTrees_Implicit()
+        {
+            // char
+            CheckedConversionInExpressionTree_Implicit("char", "char", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("char", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("char", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("char", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("char", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("char", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("char", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("char", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("char", "double", ConvertMethod.Convert);
+
+            // sbyte
+            CheckedConversionInExpressionTree_Implicit("sbyte", "sbyte", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("sbyte", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("sbyte", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("sbyte", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("sbyte", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("sbyte", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("sbyte", "double", ConvertMethod.Convert);
+
+            // byte
+            CheckedConversionInExpressionTree_Implicit("byte", "byte", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("byte", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("byte", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("byte", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("byte", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("byte", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("byte", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("byte", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("byte", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("byte", "double", ConvertMethod.Convert);
+
+            // short
+            CheckedConversionInExpressionTree_Implicit("short", "short", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("short", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("short", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("short", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("short", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("short", "double", ConvertMethod.Convert);
+
+            // ushort
+            CheckedConversionInExpressionTree_Implicit("ushort", "ushort", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("ushort", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("ushort", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("ushort", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("ushort", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("ushort", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("ushort", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("ushort", "double", ConvertMethod.Convert);
+
+            // int
+            CheckedConversionInExpressionTree_Implicit("int", "int", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("int", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("int", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("int", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("int", "double", ConvertMethod.Convert);
+
+            // uint
+            CheckedConversionInExpressionTree_Implicit("uint", "uint", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("uint", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("uint", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Implicit("uint", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("uint", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("uint", "double", ConvertMethod.Convert);
+
+            // long
+            CheckedConversionInExpressionTree_Implicit("long", "long", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("long", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("long", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("long", "double", ConvertMethod.Convert);
+
+            // ulong
+            CheckedConversionInExpressionTree_Implicit("ulong", "ulong", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("ulong", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("ulong", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("ulong", "double", ConvertMethod.Convert);
+
+            // decimal
+            CheckedConversionInExpressionTree_Implicit("decimal", "decimal", ConvertMethod.None);
+
+            // float
+            CheckedConversionInExpressionTree_Implicit("float", "float", ConvertMethod.None);
+            CheckedConversionInExpressionTree_Implicit("float", "double", ConvertMethod.Convert);
+
+            // double
+            CheckedConversionInExpressionTree_Implicit("double", "double", ConvertMethod.None);
+
+            // object
+            CheckedConversionInExpressionTree_Implicit("int", "object", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Implicit("string", "object", ConvertMethod.None);
+        }
+
+        [Fact]
+        [WorkItem(18459, "https://github.com/dotnet/roslyn/issues/18459")]
+        public void CheckedConversionsInExpressionTrees_ImplicitTuple()
+        {
+            var source =
+@"using System;
+using System.Linq.Expressions;
+class C
+{
+    static (int, int)? F((int, int)? arg) => arg;
+    static void Main()
+    {
+        Expression<Func<(int, int), (int, int)?>> e = arg => checked(F(arg));
+        Console.WriteLine(e);
+    }
+}";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.ReleaseExe, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            var verifier = CompileAndVerify(compilation, expectedOutput: "arg => F(ConvertChecked(arg))");
+            VerifyConversionInExpressionTreeIL(verifier.TestData.GetMethodData("C.Main").GetMethodIL(), ConvertMethod.ConvertChecked);
+        }
+
+        [Fact]
+        public void CheckedConversionsInExpressionTrees_Explicit()
+        {
+            // char
+            CheckedConversionInExpressionTree_Explicit("char", "char", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("char", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("char", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("char", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("char", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("char", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("char", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("char", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("char", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("char", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("char", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("char", "double", ConvertMethod.Convert);
+
+            // sbyte
+            CheckedConversionInExpressionTree_Explicit("sbyte", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "sbyte", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("sbyte", "double", ConvertMethod.Convert);
+
+            // byte
+            CheckedConversionInExpressionTree_Explicit("byte", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("byte", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("byte", "byte", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("byte", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("byte", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("byte", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("byte", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("byte", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("byte", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("byte", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("byte", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("byte", "double", ConvertMethod.Convert);
+
+            // short
+            CheckedConversionInExpressionTree_Explicit("short", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("short", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("short", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("short", "short", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("short", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("short", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("short", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("short", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("short", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("short", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("short", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("short", "double", ConvertMethod.Convert);
+
+            // ushort
+            CheckedConversionInExpressionTree_Explicit("ushort", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ushort", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ushort", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ushort", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ushort", "ushort", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("ushort", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ushort", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ushort", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ushort", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ushort", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("ushort", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("ushort", "double", ConvertMethod.Convert);
+
+            // int
+            CheckedConversionInExpressionTree_Explicit("int", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("int", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("int", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("int", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("int", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("int", "int", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("int", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("int", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("int", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("int", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("int", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("int", "double", ConvertMethod.Convert);
+
+            // uint
+            CheckedConversionInExpressionTree_Explicit("uint", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("uint", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("uint", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("uint", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("uint", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("uint", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("uint", "uint", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("uint", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("uint", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("uint", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("uint", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("uint", "double", ConvertMethod.Convert);
+
+            // long
+            CheckedConversionInExpressionTree_Explicit("long", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("long", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("long", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("long", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("long", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("long", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("long", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("long", "long", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("long", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("long", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("long", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("long", "double", ConvertMethod.Convert);
+
+            // ulong
+            CheckedConversionInExpressionTree_Explicit("ulong", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ulong", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ulong", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ulong", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ulong", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ulong", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ulong", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ulong", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("ulong", "ulong", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("ulong", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("ulong", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("ulong", "double", ConvertMethod.Convert);
+
+            // decimal
+            CheckedConversionInExpressionTree_Explicit("decimal", "char", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "sbyte", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "byte", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "short", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "ushort", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "int", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "uint", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "long", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "ulong", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("decimal", "double", ConvertMethod.Convert);
+
+            // float
+            CheckedConversionInExpressionTree_Explicit("float", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("float", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("float", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("float", "double", ConvertMethod.Convert);
+
+            // double
+            CheckedConversionInExpressionTree_Explicit("double", "char", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "sbyte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "byte", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "short", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "ushort", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "int", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "uint", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "long", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "ulong", ConvertMethod.ConvertChecked);
+            CheckedConversionInExpressionTree_Explicit("double", "decimal", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("double", "float", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("double", "double", ConvertMethod.Convert);
+
+            // enum
+            CheckedConversionInExpressionTree_Explicit("E", "int", ConvertMethod.ConvertChecked, "enum E { }");
+            CheckedConversionInExpressionTree_Explicit("int", "E", ConvertMethod.ConvertChecked, "enum E { }");
+            CheckedConversionInExpressionTree_Explicit("E", "int", ConvertMethod.ConvertChecked, "enum E : short { }");
+            CheckedConversionInExpressionTree_Explicit("int", "E", ConvertMethod.ConvertChecked, "enum E : short { }");
+
+            // object
+            CheckedConversionInExpressionTree_Explicit("int", "object", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("object", "int", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("string", "object", ConvertMethod.Convert);
+            CheckedConversionInExpressionTree_Explicit("object", "string", ConvertMethod.Convert);
+        }
+
+        private enum ConvertMethod
+        {
+            None,
+            Convert,
+            ConvertChecked,
+        }
+
+        private void CheckedConversionInExpressionTree_Implicit(string fromType, string toType, ConvertMethod expectedMethod, string additionalTypes = "")
+        {
+            var source =
+$@"using System;
+using System.Linq.Expressions;
+{additionalTypes}
+class C
+{{
+    static {toType} F({toType} arg) => arg;
+    static void Main()
+    {{
+        Expression<Func<{fromType}, {toType}>> e = arg => checked(F(arg));
+        Console.WriteLine(e);
+    }}
+}}";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.ReleaseExe);
+            string expectedOutput;
+            switch (expectedMethod)
+            {
+                default:
+                    expectedOutput = "arg => F(arg)";
+                    break;
+                case ConvertMethod.Convert:
+                    expectedOutput = "arg => F(Convert(arg))";
+                    break;
+                case ConvertMethod.ConvertChecked:
+                    expectedOutput = "arg => F(ConvertChecked(arg))";
+                    break;
+            }
+            var verifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            // Since Expression.ConvertChecked can generate a Checked result
+            // (rather than ConvertChecked), verify the correct method was called.
+            VerifyConversionInExpressionTreeIL(verifier.TestData.GetMethodData("C.Main").GetMethodIL(), expectedMethod);
+        }
+
+        private void CheckedConversionInExpressionTree_Explicit(string fromType, string toType, ConvertMethod expectedMethod, string additionalTypes = "")
+        {
+            var source =
+$@"using System;
+using System.Linq.Expressions;
+{additionalTypes}
+class C
+{{
+    static void Main()
+    {{
+        Expression<Func<{fromType}, {toType}>> e = arg => checked(({toType})arg);
+        Console.WriteLine(e);
+    }}
+}}";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.ReleaseExe);
+            string expectedOutput;
+            switch (expectedMethod)
+            {
+                default:
+                    expectedOutput = "arg => arg";
+                    break;
+                case ConvertMethod.Convert:
+                    expectedOutput = "arg => Convert(arg)";
+                    break;
+                case ConvertMethod.ConvertChecked:
+                    expectedOutput = "arg => ConvertChecked(arg)";
+                    break;
+            }
+            var verifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            // Since Expression.ConvertChecked can generate a Checked result
+            // (rather than ConvertChecked), verify the correct method was called.
+            VerifyConversionInExpressionTreeIL(verifier.TestData.GetMethodData("C.Main").GetMethodIL(), expectedMethod);
+        }
+
+        private static void VerifyConversionInExpressionTreeIL(string actualIL, ConvertMethod expectedMethod)
+        {
+            Assert.Equal(
+                actualIL.Contains($"System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression, "),
+                expectedMethod == ConvertMethod.Convert);
+            Assert.Equal(
+                actualIL.Contains($"System.Linq.Expressions.Expression.ConvertChecked(System.Linq.Expressions.Expression, "),
+                expectedMethod == ConvertMethod.ConvertChecked);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -22751,7 +22751,6 @@ static class C
                 //         System.Console.WriteLine(notAliteral.M());
                 Diagnostic(ErrorCode.ERR_BadExtensionArgTypes, "M").WithArguments("(int A, int B)", "M", "C.M((int x, long y))").WithLocation(23, 46)
                 );
-
         }
 
         [Fact]
@@ -22871,6 +22870,176 @@ class C
                 //         var x = (0, null) as (int, T)?;
                 Diagnostic(ErrorCode.ERR_TypelessTupleInAs, "(0, null) as (int, T)?").WithLocation(6, 17)
                 );
+        }
+
+
+        [Fact]
+        public void CheckedConstantConversions()
+        {
+            var source =
+@"#pragma warning disable 219
+class C
+{
+    static void Main()
+    {
+        unchecked
+        {
+            var u = ((byte, byte))(0, -1);
+            var (a, b) = ((byte, byte))(0, -2);
+        }
+        checked
+        {
+            var c = ((byte, byte))(0, -1);
+            var (a, b) = ((byte, byte))(0, -2);
+        }
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics(
+                // (13,39): error CS0221: Constant value '-1' cannot be converted to a 'byte' (use 'unchecked' syntax to override)
+                //             var c = ((byte, byte))(0, -1);
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "-1").WithArguments("-1", "byte").WithLocation(13, 39),
+                // (14,44): error CS0221: Constant value '-2' cannot be converted to a 'byte' (use 'unchecked' syntax to override)
+                //             var (a, b) = ((byte, byte))(0, -2);
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "-2").WithArguments("-2", "byte").WithLocation(14, 44));
+        }
+
+        [Fact]
+        [WorkItem(18459, "https://github.com/dotnet/roslyn/issues/18459")]
+        public void CheckedConversions()
+        {
+            var source =
+@"using System;
+class C
+{
+    static (long, byte) Unchecked((int, int) t)
+    {
+        unchecked
+        {
+            return ((long, byte))t;
+        }
+    }
+    static (long, byte) Checked((int, int) t)
+    {
+        checked
+        {
+            return ((long, byte))t;
+        }
+    }
+    static void Main()
+    {
+        try
+        {
+            var u = Unchecked((-1, -1));
+            Console.WriteLine(u);
+            var c = Checked((-1, -1));
+            Console.WriteLine(c);
+        }
+        catch (OverflowException)
+        {
+            Console.WriteLine(""overflow"");
+        }
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput:
+@"(-1, 255)
+overflow");
+            verifier.VerifyIL("C.Unchecked",
+@"{
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (System.ValueTuple<int, int> V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0008:  conv.i8
+  IL_0009:  ldloc.0
+  IL_000a:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_000f:  conv.u1
+  IL_0010:  newobj     ""System.ValueTuple<long, byte>..ctor(long, byte)""
+  IL_0015:  ret
+}");
+            verifier.VerifyIL("C.Checked",
+@"{
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (System.ValueTuple<int, int> V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+  IL_0008:  conv.i8
+  IL_0009:  ldloc.0
+  IL_000a:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_000f:  conv.ovf.u1
+  IL_0010:  newobj     ""System.ValueTuple<long, byte>..ctor(long, byte)""
+  IL_0015:  ret
+}");
+        }
+
+        [Fact(Skip = "19398")]
+        [WorkItem(18459, "https://github.com/dotnet/roslyn/issues/18459")]
+        [WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]
+        public void CheckedDeconstructionConversions()
+        {
+            var source =
+@"using System;
+class C
+{
+    static void Unchecked((int, int) t, out long a, out byte b)
+    {
+        unchecked
+        {
+            (a, b) = ((long, byte))t;
+        }
+    }
+    static void Checked((int, int) t, out long a, out byte b)
+    {
+        checked
+        {
+            (a, b) = ((long, byte))t;
+        }
+    }
+    static void Main()
+    {
+        try
+        {
+            long a;
+            byte b;
+            Unchecked((-1, -1), out a, out b);
+            Console.WriteLine((a, b));
+            Checked((-1, -1), out a, out b);
+            Console.WriteLine((a, b));
+        }
+        catch (OverflowException)
+        {
+            Console.WriteLine(""overflow"");
+        }
+    }
+}";
+            var comp = CreateStandardCompilation(
+                source,
+                references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
+                options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(comp, expectedOutput:
+@"(-1, 255)
+overflow");
+            verifier.VerifyIL("C.Unchecked",
+@"{
+ ...
+}");
+            verifier.VerifyIL("C.Checked",
+@"{
+ ...
+}");
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -20200,6 +20200,51 @@ End Namespace
 
         End Sub
 
+        <Fact>
+        Public Sub CheckedConversions()
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file>
+Imports System
+Class C
+    Shared Function F(t As (Integer, Integer)) As (Long, Byte)
+        Return CType(t, (Long, Byte))
+    End Function
+    Shared Sub Main()
+        Try
+            Dim t = F((1, 1))
+            Console.WriteLine(t)
+            t = F((-1, -1))
+            Console.WriteLine(t)
+        Catch e As OverflowException
+            Console.WriteLine("overflow")
+        End Try
+    End Sub
+End Class
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+(1, 1)
+overflow
+            ]]>)
+            verifier.VerifyIL("C.F", <![CDATA[
+{
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Integer, Integer) V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldfld      "System.ValueTuple(Of Integer, Integer).Item1 As Integer"
+  IL_0008:  conv.i8
+  IL_0009:  ldloc.0
+  IL_000a:  ldfld      "System.ValueTuple(Of Integer, Integer).Item2 As Integer"
+  IL_000f:  conv.ovf.u1
+  IL_0010:  newobj     "Sub System.ValueTuple(Of Long, Byte)..ctor(Long, Byte)"
+  IL_0015:  ret
+}
+]]>)
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -20202,7 +20202,7 @@ End Namespace
 
         <Fact>
         Public Sub CheckedConversions()
-            Dim verifier = CompileAndVerify(
+            Dim source =
 <compilation>
     <file>
 Imports System
@@ -20212,9 +20212,7 @@ Class C
     End Function
     Shared Sub Main()
         Try
-            Dim t = F((1, 1))
-            Console.WriteLine(t)
-            t = F((-1, -1))
+            Dim t = F((-1, -1))
             Console.WriteLine(t)
         Catch e As OverflowException
             Console.WriteLine("overflow")
@@ -20222,10 +20220,32 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
-(1, 1)
-overflow
-            ]]>)
+</compilation>
+            Dim verifier = CompileAndVerify(
+                source,
+                options:=TestOptions.ReleaseExe.WithOverflowChecks(False),
+                additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[(-1, 255)]]>)
+            verifier.VerifyIL("C.F", <![CDATA[
+{
+  // Code size       22 (0x16)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Integer, Integer) V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldfld      "System.ValueTuple(Of Integer, Integer).Item1 As Integer"
+  IL_0008:  conv.i8
+  IL_0009:  ldloc.0
+  IL_000a:  ldfld      "System.ValueTuple(Of Integer, Integer).Item2 As Integer"
+  IL_000f:  conv.u1
+  IL_0010:  newobj     "Sub System.ValueTuple(Of Long, Byte)..ctor(Long, Byte)"
+  IL_0015:  ret
+}
+]]>)
+            verifier = CompileAndVerify(
+                source,
+                options:=TestOptions.ReleaseExe.WithOverflowChecks(True),
+                additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[overflow]]>)
             verifier.VerifyIL("C.F", <![CDATA[
 {
   // Code size       22 (0x16)


### PR DESCRIPTION
**Customer scenario**

Tuple conversions in `checked` contexts should include overflow checks.

**Bugs this fixes:**

#18459

**Workarounds, if any**

Deconstruct and reconstruct tuples, applying conversions on each element individually.

**Risk**

Low. Note however that the conditions in which `BoundConversion.Checked` is set have been simplified significantly. For non-Expression trees, binding and lowering set the state based only on whether the expression is in a `checked` context. For Expression trees, the conditions are now implemented in lowering only rather than split between binding and lowering. The code generator, which is responsible for emitting overflow checks, has not changed however and the code generator implements a set of checks based on the actual types if `BoundConversion.Checked` is set.

Note, this is a breaking change since overflow checks were not included within tuple conversions in 15.0.

**Performance impact**

Low

**How was the bug found?**

Customer reported