### PR TITLE
Delete the PR branch if nothing to merge

### DIFF
--- a/src/Tools/Github/GithubMergeTool/GithubMergeTool.cs
+++ b/src/Tools/Github/GithubMergeTool/GithubMergeTool.cs
@@ -121,6 +121,8 @@ Once all conflicts are resolved and all the tests pass, you are free to merge th
             // 422 (Unprocessable Entity) indicates there were no commits to merge
             if (response.StatusCode == (HttpStatusCode)422)
             {
+                // Delete the pr branch if the PR was not created.
+                await _client.DeleteAsync($"repos/{repoOwner}/{repoName}/git/refs/heads/{prBranchName}");
                 return response;
             }
 


### PR DESCRIPTION
**Customer scenario**

When a merge bot attempts to create a PR for a branch that has no commits to merge it leaves an empty branch around.

**Bugs this fixes:**

#18493

**How was the bug found?**

Infrastructure backlog
