### PR TITLE
Filter projects based on language name

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplorer
 {
@@ -47,6 +46,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             var project = _workspace.DeferredState.ProjectTracker.ImmutableProjects
                     .Where(p =>
                     {
+                        // We're about to access various properties of the IVsHierarchy associated with the project.
+                        // The properties supported and the interpretation of their values varies from one project system
+                        // to another. This code is designed with C# and VB in mind, so we need to filter out everything
+                        // else.
+                        if (p.Language != LanguageNames.CSharp
+                            && p.Language != LanguageNames.VisualBasic)
+                        {
+                            return false;
+                        }
+
                         // Here we try to match the hierarchy from Solution Explorer to a hierarchy from the Roslyn project.
                         // The canonical name of a hierarchy item must be unique _within_ an hierarchy, but since we're
                         // examining multiple hierarchies the canonical name could be the same. Indeed this happens when two


### PR DESCRIPTION
When mapping an `IVsHierarchy` to the related Roslyn project we end up asking each project for its associated `IVsHierarchy` and checking if various properties match up with those on the "origin" hierarchy. The properties supported and the interpretation of their values varies from one project system to another. The `HierarchyItemToProjectIdMap` class was implemented when Roslyn only supported C# and VB projects, and was designed with those in mind. Now that TypeScript can also have Roslyn projects we need to filter out everything that isn't C# or VB or we risk asking for properties that aren't supported or possibly misinterpreting the values. In bug [bug 433873](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/433873), for example, it appears that TypeScript returns `null` for one of the properties, and we just aren't expecting that.

Note that _in theory_ this change shouldn't be necessary--the properties we check are common and normally I would say their interpretation is unambiguous. But rather than play whack-a-mole with bugs I'd rather just limit us to the scenarios we need to support.

**Customer scenario**

When working in a solution containing a TypeScript project Visual Studio just up and crashes. Based on the crashes I've seen this most likely happens when the user is traversing nodes in Solution Explorer, but there could be other scenarios as well.

**Bugs this fixes:**

Works around [VSO bug 433873](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/433873).

**Workarounds, if any**

None.

**Risk**

Low. This code path is part of our support for showing analyzer nodes in C# and VB projects in Solution Explorer; the change just makes it explicit that only C# and VB are supported.

**Performance impact**

Low.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

When this code path was first written C# and VB were the only languages we needed to consider, and so it basically assumes it will only encounter C# and VB projects. When TypeScript started to utilize Roslyn we basically got lucky that this didn't break. For Dev15 this code has been refactored to support both the old and new project systems, and in doing so several bugs were exposed.

**How was the bug found?**

Dogfooding
