### PR TITLE
fixed crash on TS due to missing designer attribute service on OOP

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -90,6 +90,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 return;
             }
 
+            var service = project.LanguageServices.GetService<IDesignerAttributeService>();
+            if (service == null)
+            {
+                // project doesn't support designer attribute service.
+                return;
+            }
+
             // Try to compute this data in the remote process.  If that fails, then compute
             // the results in the local process.
             var pathToResult = await TryAnalyzeProjectInRemoteProcessAsync(project, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
**Customer scenario**

customer opens up TS project and VS crash at some point later.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=433730&_a=edit 

**Workarounds, if any**

no workaround

**Risk**

Low.

**Performance impact**

Shouldn't affect perf

**Is this a regression from a previous update?**

Yes. introduced by https://github.com/dotnet/roslyn/commit/23dd5599

**Root cause analysis:**

forgot to filter out languages that doesnt support OOP

**How was the bug found?**

dogfood and testing.
