### PR TITLE
Remove refout package moniker from build

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -15,8 +15,6 @@
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
-    <!-- PROTOTYPE(refout) This needs to be reverted before merging to master -->
-    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">refout</RoslynNuGetMoniker>
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>
 

--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -43,7 +43,6 @@ try
         "dev15.3-preview1" { } 
         "master" { } 
         "post-dev15" { } 
-        "features/refout" { }
         default
         {
             if (-not $test)


### PR DESCRIPTION
I forgot to remove a build setting that is specific to the features/refout branch when merging to master. This causes packages to be built and published with the wrong name.

@tmeschter @jaredpar for review.
@dotnet/roslyn-compiler FYI