### PR TITLE
add IVTs to Microsoft.VisualStudio.ProjectSystem.FSharp

### DIFF
--- a/build/Targets/GenerateInternalsVisibleTo.targets
+++ b/build/Targets/GenerateInternalsVisibleTo.targets
@@ -31,6 +31,9 @@
     <InternalsVisibleToMonodevelop>
       <Visible>false</Visible>
     </InternalsVisibleToMonodevelop>
+    <InternalsVisibleToProjectSystem>
+      <Visible>false</Visible>
+    </InternalsVisibleToProjectSystem>
     <InternalsVisibleToRazor>
       <Visible>false</Visible>
     </InternalsVisibleToRazor>
@@ -49,7 +52,7 @@
           Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFile)"
           Outputs="$(GeneratedInternalsVisibleToFile)"
           DependsOnTargets="PrepareForBuild"
-          Condition="'@(InternalsVisibleTo)' != '' OR '@(InternalsVisibleToTest)' != '' OR '@(InternalsVisibleToTypeScript)' != '' OR '@(InternalsVisibleToVisualStudio)' != '' OR '@(InternalsVisibleToFSharp)' != '' OR '@(InternalsVisibleToMoq)' != ''  OR '@(InternalsVisibleToRazor)' != '' OR '@(InternalsVisibleToMonodevelop)' != ''">
+          Condition="'@(InternalsVisibleTo)' != '' OR '@(InternalsVisibleToTest)' != '' OR '@(InternalsVisibleToTypeScript)' != '' OR '@(InternalsVisibleToVisualStudio)' != '' OR '@(InternalsVisibleToFSharp)' != '' OR '@(InternalsVisibleToMoq)' != ''  OR '@(InternalsVisibleToRazor)' != '' OR '@(InternalsVisibleToMonodevelop)' != '' OR '@(InternalsVisibleToProjectSystem)' != ''">
 
     <!--
          This is a slightly evil trick. What we have is a group of InternalsVisibleTo items which
@@ -100,6 +103,11 @@
     <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
                 AdditionalMetadata="_Parameter1=%(InternalsVisibleToMonodevelop.Identity)$(InternalsVisibleToMonodevelopSuffix)"
                 Condition="'@(InternalsVisibleToMonodevelop)' != ''">
+      <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
+    </CreateItem>
+    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+                AdditionalMetadata="_Parameter1=%(InternalsVisibleToProjectSystem.Identity), PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9"
+                Condition="'@(InternalsVisibleToProjectSystem)' != ''">
       <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
     </CreateItem>
     <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute"

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -864,6 +864,7 @@
     <InternalsVisibleTo Include="Microsoft.Build.Tasks.CodeAnalysis" />
     <InternalsVisibleTo Include="VBCSCompiler" />
     <InternalsVisibleTo Include="VBCSCompilerPortable" />
+    <InternalsVisibleToProjectSystem Include="Microsoft.VisualStudio.ProjectSystem.FSharp" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.CommandLine.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.Emit.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Compilers.CSharp.WinRT.UnitTests" />

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -257,6 +257,7 @@
     <InternalsVisibleToMonodevelop Include="MonoDevelop.Refactoring.Tests" />
     <InternalsVisibleToMonodevelop Include="MonoDevelop.CSharpBinding.Tests" />
     <InternalsVisibleToMonodevelop Include="MonoDevelop.VBNetBinding.Tests" />
+    <InternalsVisibleToProjectSystem Include="Microsoft.VisualStudio.ProjectSystem.FSharp" />
     <InternalsVisibleToTest Include="Microsoft.CodeAnalysis.Editor.UI.Wpf" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.CSharp.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests" />


### PR DESCRIPTION
To enable F# to play along nicely with the new project system work, new IVTs are necessary so that an [`ICommandLineParserService`](https://github.com/dotnet/roslyn/blob/89d6bba7d331af2e03b2de6c9db51443c9883703/src/Workspaces/Core/Portable/Workspace/Host/CommandLine/ICommandLineParserService.cs) can be `[Export]`ed like the [C#](https://github.com/dotnet/roslyn/blob/89d6bba7d331af2e03b2de6c9db51443c9883703/src/Workspaces/CSharp/Portable/LanguageServices/CSharpCommandLineParserService.cs#L14) and [VB](https://github.com/dotnet/roslyn/blob/89d6bba7d331af2e03b2de6c9db51443c9883703/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicCommandLineParserService.vb#L17) ones are.

The alternative is to expose `ICommandLineParserService` and everything in the [`CommandLineArguments`](https://github.com/dotnet/roslyn/blob/89d6bba7d331af2e03b2de6c9db51443c9883703/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs) class.

FYI @KevinRansom @jaredpar @Srivatsn @Pilchie