### PR TITLE
Hack around PublicAPI item group support in the new project system

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -534,4 +534,12 @@
       <BuildProjectReferences>false</BuildProjectReferences>
     </PropertyGroup>
   </Target>
+
+  <!-- Count PublicAPIs as AdditionalFiles to get them to analyzers. This is working around
+       https://github.com/dotnet/project-system/issues/2160 where AdditionalFileItemNames
+       isn't fully supported yet in the new project system. Removal of this hack is tracked
+       by https://github.com/dotnet/roslyn/issues/19545. -->
+  <ItemGroup>
+    <AdditionalFiles Include="@(PublicAPI)" />
+  </ItemGroup>
 </Project>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -18,7 +18,6 @@
     <RoslynDiagnosticsPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.RoslynDiagnostics\$(RoslynDiagnosticsNugetPackageVersion)\build\Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
     <RoslynBuildUtilFilePath>$(NuGetPackageRoot)\Roslyn.Build.Util\0.9.4-portable\lib\dotnet\Roslyn.MSBuild.Util.dll</RoslynBuildUtilFilePath>
     <RoslynRuntimeIdentifier Condition="'$(RoslynRuntimeIdentifier)' == '' AND '$(OS)' == 'Windows_NT'">win7-x64</RoslynRuntimeIdentifier>
-    <AdditionalFileItemNames>$(AdditionalFileItemNames);PublicAPI</AdditionalFileItemNames>
     <Features>strict,IOperation</Features>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
This is a workaround for dotnet/project-system#2160 where
AdditionalFileItemNames isn't quite behaving correctly with the IDE.
This can be reverted once that bug is fixed.

@dotnet/roslyn-infrastructure or @dotnet/roslyn-analysis or @dotnet/project-system for review.

@MattGertz this is just a tooling improvement for our repo to work around a project system/IDE bug that impacts dogfooding with the new project system. There should otherwise be no change to the product we build.