### PR TITLE
Additional tests for refout. Additional argument check on IncludePrivateMembers

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5948,15 +5948,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: an entry point cannot be marked with the &apos;async&apos; modifier.
-        /// </summary>
-        internal static string ERR_MainCantBeAsync {
-            get {
-                return ResourceManager.GetString("ERR_MainCantBeAsync", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot use &apos;{0}&apos; for Main method because it is imported.
         /// </summary>
         internal static string ERR_MainClassIsImport {
@@ -6191,7 +6182,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No Deconstruct instance or extension method was found for type &apos;{0}&apos;, with {1} out parameters and a void return type..
+        ///   Looks up a localized string similar to No suitable Deconstruct instance or extension method was found for type &apos;{0}&apos;, with {1} out parameters and a void return type..
         /// </summary>
         internal static string ERR_MissingDeconstruct {
             get {
@@ -6891,18 +6882,16 @@ namespace Microsoft.CodeAnalysis.CSharp {
                 return ResourceManager.GetString("ERR_NonInvocableMemberCalled", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Async Main methods must return Task or Task&lt;int&gt;.
+        ///   Looks up a localized string similar to A void or int returning entry point cannot be async.
         /// </summary>
-        internal static string ERR_NonTaskMainCantBeAsync
-        {
-            get
-            {
+        internal static string ERR_NonTaskMainCantBeAsync {
+            get {
                 return ResourceManager.GetString("ERR_NonTaskMainCantBeAsync", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot embed interop types from assembly &apos;{0}&apos; because it is missing the &apos;{1}&apos; attribute..
         /// </summary>
@@ -9899,7 +9888,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
                 return ResourceManager.GetString("IDS_Covariantly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to 
         ///                              Visual C# Compiler Options
@@ -9913,10 +9902,8 @@ namespace Microsoft.CodeAnalysis.CSharp {
         ///                               /t:winexe)
         /// /target:library        [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string IDS_CSCHelp
-        {
-            get
-            {
+        internal static string IDS_CSCHelp {
+            get {
                 return ResourceManager.GetString("IDS_CSCHelp", resourceCulture);
             }
         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4887,7 +4887,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>tuples</value>
   </data>
   <data name="ERR_MissingDeconstruct" xml:space="preserve">
-    <value>No Deconstruct instance or extension method was found for type '{0}', with {1} out parameters and a void return type.</value>
+    <value>No suitable Deconstruct instance or extension method was found for type '{0}', with {1} out parameters and a void return type.</value>
   </data>
   <data name="ERR_DeconstructRequiresExpression" xml:space="preserve">
     <value>Deconstruct assignment requires an expression with a type on the right-hand-side.</value>

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1613,6 +1613,19 @@ internal struct InternalStruct
         }
 
         [Fact]
+        public void MustIncludePrivateMembersUnlessRefAssembly()
+        {
+            CSharpCompilation comp = CreateCompilation("", references: new[] { MscorlibRef },
+                options: TestOptions.DebugDll.WithDeterministic(true));
+
+            using (var output = new MemoryStream())
+            {
+                Assert.Throws<ArgumentException>(() => comp.Emit(output,
+                    options: EmitOptions.Default.WithIncludePrivateMembers(false)));
+            }
+        }
+
+        [Fact]
         public void EmitMetadata_DisallowOutputtingNetModule()
         {
             CSharpCompilation comp = CreateCompilation("", references: new[] { MscorlibRef },

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -956,6 +956,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Must include private members unless emitting a ref assembly..
+        /// </summary>
+        internal static string MustIncludePrivateMembersUnlessRefAssembly {
+            get {
+                return ResourceManager.GetString("MustIncludePrivateMembersUnlessRefAssembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name cannot be empty..
         /// </summary>
         internal static string NameCannotBeEmpty {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -339,6 +339,9 @@
   <data name="IncludingPrivateMembersUnexpectedWhenEmittingToMetadataPeStream" xml:space="preserve">
     <value>Including private members should not be used when emitting to the secondary assembly output.</value>
   </data>
+  <data name="MustIncludePrivateMembersUnlessRefAssembly" xml:space="preserve">
+    <value>Must include private members unless emitting a ref assembly.</value>
+  </data>
   <data name="EmbeddingPdbUnexpectedWhenEmittingMetadata" xml:space="preserve">
     <value>Embedding PDB is not allowed when emitting metadata.</value>
   </data>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2086,6 +2086,11 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentException(CodeAnalysisResources.IncludingPrivateMembersUnexpectedWhenEmittingToMetadataPeStream, nameof(metadataPEStream));
             }
 
+            if (metadataPEStream == null && options?.EmitMetadataOnly == false && options?.IncludePrivateMembers == false)
+            {
+                throw new ArgumentException(CodeAnalysisResources.MustIncludePrivateMembersUnlessRefAssembly, nameof(options.IncludePrivateMembers));
+            }
+
             if (options?.DebugInformationFormat == DebugInformationFormat.Embedded &&
                 options?.EmitMetadataOnly == true)
             {

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -33,7 +33,7 @@ End Module
     </file>
 </compilation>)
 
-            Dim emitResult As emitResult
+            Dim emitResult As EmitResult
 
             Using output = New MemoryStream()
                 emitResult = compilation.Emit(output, Nothing, Nothing, Nothing)
@@ -536,6 +536,179 @@ End Function",
 End Function", Match.BothMetadataAndRefOut)
 
         End Sub
+
+        <Fact()>
+        Public Sub RefAssemblyNoPia()
+            Dim piaSource = <compilation name="Pia"><file name="a.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
+
+<Assembly: Guid("f9c2d51d-4f44-45f0-9eda-c9d599b58257")>
+<Assembly: ImportedFromTypeLib("Pia1.dll")>
+
+Public Structure S
+    Public Dim field As Integer
+End Structure
+<ComImport()>
+<Guid("f9c2d51d-4f44-45f0-9eda-c9d599b58280")>
+Public Interface ITest1
+    Function M() As S
+End Interface
+]]></file></compilation>
+            Dim pia = CreateCompilationWithMscorlib(piaSource)
+            CompileAndVerify(pia)
+            Dim source = <compilation name="LocalTypes2"><file name="a.vb"><![CDATA[
+Public Class D
+    Implements ITest1
+
+    Function M() As S Implements ITest1.M
+        Throw New System.Exception()
+    End Function
+End Class
+]]></file></compilation>
+
+            Dim piaImageReference = pia.EmitToImageReference(embedInteropTypes:=True)
+            RefAssemblyNoPia_VerifyRefOnly(source, piaImageReference)
+            RefAssemblyNoPia_VerifyRefOut(source, piaImageReference)
+
+            Dim piaMetadataReference = pia.ToMetadataReference(embedInteropTypes:=True)
+            RefAssemblyNoPia_VerifyRefOnly(source, piaMetadataReference)
+            RefAssemblyNoPia_VerifyRefOut(source, piaMetadataReference)
+        End Sub
+
+        Private Sub RefAssemblyNoPia_VerifyRefOnly(source As Xml.Linq.XElement, reference As MetadataReference)
+            Dim comp = CreateCompilationWithMscorlib(source, options:=TestOptions.ReleaseDll, references:={reference})
+            Dim refOnlyImage = EmitRefOnly(comp)
+            RefAssemblyNoPia_VerifyNoPia(refOnlyImage)
+        End Sub
+
+        Private Sub RefAssemblyNoPia_VerifyRefOut(source As Xml.Linq.XElement, reference As MetadataReference)
+            Dim comp = CreateCompilationWithMscorlib(source, options:=TestOptions.DebugDll, references:={reference})
+            Dim pair = EmitRefOut(comp)
+            RefAssemblyNoPia_VerifyNoPia(pair.image)
+            RefAssemblyNoPia_VerifyNoPia(pair.refImage)
+        End Sub
+
+        Private Sub RefAssemblyNoPia_VerifyNoPia(image As ImmutableArray(Of Byte))
+            Dim reference = CompilationVerifier.LoadTestEmittedExecutableForSymbolValidation(image, OutputKind.DynamicallyLinkedLibrary)
+            Dim comp = CreateCompilationWithMscorlib("", references:={reference})
+            Dim referencedAssembly = comp.GetReferencedAssemblySymbol(reference)
+            Dim [module] = DirectCast(referencedAssembly.Modules(0), PEModuleSymbol)
+
+            Dim itest1 = [module].GlobalNamespace.GetMember(Of NamedTypeSymbol)("ITest1")
+            Assert.NotNull(itest1.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).First())
+
+            Dim method = DirectCast(itest1.GetMember("M"), PEMethodSymbol)
+            Assert.Equal("Function ITest1.M() As S", method.ToTestDisplayString())
+
+            Dim s = DirectCast(method.ReturnType, NamedTypeSymbol)
+            Assert.Equal("S", s.ToTestDisplayString())
+            Assert.NotNull(s.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).First())
+
+            Dim field = s.GetMember("field")
+            Assert.Equal("S.field As System.Int32", field.ToTestDisplayString())
+        End Sub
+
+        Private Sub RefAssemblyNoPiaReferenceFromMethodBody()
+
+            Dim piaSource = <compilation name="Pia"><file name="a.vb"><![CDATA[
+Imports System.Runtime.CompilerServices
+Imports System.Runtime.InteropServices
+
+<Assembly: Guid("f9c2d51d-4f44-45f0-9eda-c9d599b58257")>
+<Assembly: ImportedFromTypeLib("Pia1.dll")>
+
+Public Structure S
+    Public Dim field As Integer
+End Structure
+<ComImport()>
+<Guid("f9c2d51d-4f44-45f0-9eda-c9d599b58280")>
+Public Interface ITest1
+    Function M() As S
+End Interface
+]]></file></compilation>
+            Dim pia = CreateCompilationWithMscorlib(piaSource)
+            CompileAndVerify(pia)
+            Dim source = <compilation name="LocalTypes2"><file name="a.vb"><![CDATA[
+Public Class D
+    Sub M2()
+        Dim x As ITest1 = Nothing
+        Dim s As S = x.M()
+    End Sub
+End Class
+]]></file></compilation>
+
+            Dim piaImageReference = pia.EmitToImageReference(embedInteropTypes:=True)
+            RefAssemblyNoPiaReferenceFromMethodBody_VerifyRefOnly(source, piaImageReference)
+            RefAssemblyNoPiaReferenceFromMethodBody_VerifyRefOut(source, piaImageReference)
+
+            Dim piaMetadataReference = pia.ToMetadataReference(embedInteropTypes:=True)
+            RefAssemblyNoPiaReferenceFromMethodBody_VerifyRefOnly(source, piaMetadataReference)
+            RefAssemblyNoPiaReferenceFromMethodBody_VerifyRefOut(source, piaMetadataReference)
+        End Sub
+
+        Private Sub RefAssemblyNoPiaReferenceFromMethodBody_VerifyRefOnly(source As Xml.Linq.XElement, reference As MetadataReference)
+            Dim comp = CreateCompilationWithMscorlib(source, options:=TestOptions.ReleaseDll, references:={reference})
+            Dim refOnlyImage = EmitRefOnly(comp)
+            RefAssemblyNoPiaReferenceFromMethodBody_verifyNoPia(refOnlyImage, expectMissing:=True)
+        End Sub
+
+        Private Sub RefAssemblyNoPiaReferenceFromMethodBody_VerifyRefOut(source As Xml.Linq.XElement, reference As MetadataReference)
+            Dim comp = CreateCompilationWithMscorlib(source, options:=TestOptions.ReleaseDll, references:={reference})
+            Dim pair = EmitRefOut(comp)
+            RefAssemblyNoPiaReferenceFromMethodBody_verifyNoPia(pair.image, expectMissing:=False)
+            RefAssemblyNoPiaReferenceFromMethodBody_verifyNoPia(pair.refImage, expectMissing:=False)
+        End Sub
+
+        ' The ref assembly produced by refout has more types than that produced by refonly,
+        ' because refout will bind the method bodies (and therefore populate more referenced types).
+        ' This will be refined in the future. Follow-up issue: https://github.com/dotnet/roslyn/issues/19403
+        Private Sub RefAssemblyNoPiaReferenceFromMethodBody_verifyNoPia(image As ImmutableArray(Of Byte), expectMissing As Boolean)
+            Dim reference = CompilationVerifier.LoadTestEmittedExecutableForSymbolValidation(image, OutputKind.DynamicallyLinkedLibrary)
+            Dim comp = CreateCompilationWithMscorlib("", references:={reference})
+            Dim referencedAssembly = comp.GetReferencedAssemblySymbol(reference)
+            Dim [module] = DirectCast(referencedAssembly.Modules(0), PEModuleSymbol)
+
+            Dim itest1Array = [module].GlobalNamespace.GetMembers("ITest1")
+            If expectMissing Then
+                Assert.Empty(itest1Array)
+                Assert.Empty([module].GlobalNamespace.GetMembers("S"))
+                Return
+            End If
+
+            Dim itest1 = DirectCast(itest1Array.Single(), PENamedTypeSymbol)
+            Assert.NotNull(itest1.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).First())
+
+            Dim method = DirectCast(itest1.GetMembers("M").Single(), PEMethodSymbol)
+            Assert.Equal("Function ITest1.M() As S", method.ToTestDisplayString())
+
+            Dim s = DirectCast(method.ReturnType, NamedTypeSymbol)
+            Assert.Equal("S", s.ToTestDisplayString())
+            Assert.NotNull(s.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).First())
+
+            Dim field = s.GetMember("field")
+            Assert.Equal("S.field As System.Int32", field.ToTestDisplayString())
+        End Sub
+
+        Private Shared Function EmitRefOut(comp As VisualBasicCompilation) As (image As ImmutableArray(Of Byte), refImage As ImmutableArray(Of Byte))
+            Using output = New MemoryStream()
+                Using metadataOutput = New MemoryStream()
+                    Dim options = EmitOptions.Default.WithIncludePrivateMembers(False)
+                    comp.VerifyEmitDiagnostics()
+                    Dim result = comp.Emit(output, metadataPEStream:=metadataOutput, options:=options)
+                    Return (output.ToImmutable(), metadataOutput.ToImmutable())
+                End Using
+            End Using
+        End Function
+
+        Private Shared Function EmitRefOnly(comp As VisualBasicCompilation) As ImmutableArray(Of Byte)
+            Using output = New MemoryStream()
+                Dim options = EmitOptions.Default.WithEmitMetadataOnly(True).WithIncludePrivateMembers(False)
+                comp.VerifyEmitDiagnostics()
+                Dim result = comp.Emit(output, options:=options)
+                Return output.ToImmutable()
+            End Using
+        End Function
 
         <Fact>
         Public Sub RefAssembly_InvariantToSomeChangesWithInternalsVisibleTo()

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -596,20 +596,21 @@ End Class
             Dim [module] = DirectCast(referencedAssembly.Modules(0), PEModuleSymbol)
 
             Dim itest1 = [module].GlobalNamespace.GetMember(Of NamedTypeSymbol)("ITest1")
-            Assert.NotNull(itest1.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).First())
+            Assert.NotNull(itest1.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).Single())
 
             Dim method = DirectCast(itest1.GetMember("M"), PEMethodSymbol)
             Assert.Equal("Function ITest1.M() As S", method.ToTestDisplayString())
 
             Dim s = DirectCast(method.ReturnType, NamedTypeSymbol)
             Assert.Equal("S", s.ToTestDisplayString())
-            Assert.NotNull(s.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).First())
+            Assert.NotNull(s.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).Single())
 
             Dim field = s.GetMember("field")
             Assert.Equal("S.field As System.Int32", field.ToTestDisplayString())
         End Sub
 
-        Private Sub RefAssemblyNoPiaReferenceFromMethodBody()
+        <Fact()>
+        Public Sub RefAssemblyNoPiaReferenceFromMethodBody()
 
             Dim piaSource = <compilation name="Pia"><file name="a.vb"><![CDATA[
 Imports System.Runtime.CompilerServices
@@ -650,20 +651,20 @@ End Class
         Private Sub RefAssemblyNoPiaReferenceFromMethodBody_VerifyRefOnly(source As Xml.Linq.XElement, reference As MetadataReference)
             Dim comp = CreateCompilationWithMscorlib(source, options:=TestOptions.ReleaseDll, references:={reference})
             Dim refOnlyImage = EmitRefOnly(comp)
-            RefAssemblyNoPiaReferenceFromMethodBody_verifyNoPia(refOnlyImage, expectMissing:=True)
+            RefAssemblyNoPiaReferenceFromMethodBody_VerifyNoPia(refOnlyImage, expectMissing:=True)
         End Sub
 
         Private Sub RefAssemblyNoPiaReferenceFromMethodBody_VerifyRefOut(source As Xml.Linq.XElement, reference As MetadataReference)
             Dim comp = CreateCompilationWithMscorlib(source, options:=TestOptions.ReleaseDll, references:={reference})
             Dim pair = EmitRefOut(comp)
-            RefAssemblyNoPiaReferenceFromMethodBody_verifyNoPia(pair.image, expectMissing:=False)
-            RefAssemblyNoPiaReferenceFromMethodBody_verifyNoPia(pair.refImage, expectMissing:=False)
+            RefAssemblyNoPiaReferenceFromMethodBody_VerifyNoPia(pair.image, expectMissing:=False)
+            RefAssemblyNoPiaReferenceFromMethodBody_VerifyNoPia(pair.refImage, expectMissing:=False)
         End Sub
 
         ' The ref assembly produced by refout has more types than that produced by refonly,
         ' because refout will bind the method bodies (and therefore populate more referenced types).
         ' This will be refined in the future. Follow-up issue: https://github.com/dotnet/roslyn/issues/19403
-        Private Sub RefAssemblyNoPiaReferenceFromMethodBody_verifyNoPia(image As ImmutableArray(Of Byte), expectMissing As Boolean)
+        Private Sub RefAssemblyNoPiaReferenceFromMethodBody_VerifyNoPia(image As ImmutableArray(Of Byte), expectMissing As Boolean)
             Dim reference = CompilationVerifier.LoadTestEmittedExecutableForSymbolValidation(image, OutputKind.DynamicallyLinkedLibrary)
             Dim comp = CreateCompilationWithMscorlib("", references:={reference})
             Dim referencedAssembly = comp.GetReferencedAssemblySymbol(reference)
@@ -677,14 +678,14 @@ End Class
             End If
 
             Dim itest1 = DirectCast(itest1Array.Single(), PENamedTypeSymbol)
-            Assert.NotNull(itest1.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).First())
+            Assert.NotNull(itest1.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).Single())
 
             Dim method = DirectCast(itest1.GetMembers("M").Single(), PEMethodSymbol)
             Assert.Equal("Function ITest1.M() As S", method.ToTestDisplayString())
 
             Dim s = DirectCast(method.ReturnType, NamedTypeSymbol)
             Assert.Equal("S", s.ToTestDisplayString())
-            Assert.NotNull(s.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).First())
+            Assert.NotNull(s.GetAttributes().Where(Function(a) a.IsTargetAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute")).Single())
 
             Dim field = s.GetMember("field")
             Assert.Equal("S.field As System.Int32", field.ToTestDisplayString())


### PR DESCRIPTION
This is a follow-up on the ref assemblies feature, adding more tests that were not blockers (from the test plan, https://github.com/dotnet/roslyn/issues/18612).
Also, I realized there is one more combination of parameters that should be disallowed when emitting (IncludePrivateMembers=false, but neither EmitMetadataOnly or metadataPeStream are set).

Also tweaking an error message for deconstruction (to fix https://github.com/dotnet/roslyn/issues/16543). Notice that the designer file seemed out of date, so more changes got pulled in.

**Risk**
**Performance impact**
Low. This is mostly test changes and a very minor change to check arguments.

@dotnet/roslyn-compiler for review.