### PR TITLE
Clarify the diagnostic message when a local function is left unused

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -14212,6 +14212,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The local function &apos;{0}&apos; is declared but never used.
+        /// </summary>
+        internal static string WRN_UnreferencedLocalFunction {
+            get {
+                return ResourceManager.GetString("WRN_UnreferencedLocalFunction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local function is declared but never used.
+        /// </summary>
+        internal static string WRN_UnreferencedLocalFunction_Title {
+            get {
+                return ResourceManager.GetString("WRN_UnreferencedLocalFunction_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The variable &apos;{0}&apos; is declared but never used.
         /// </summary>
         internal static string WRN_UnreferencedVar {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5099,4 +5099,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_PatternWrongGenericTypeInVersion" xml:space="preserve">
     <value>An expression of type '{0}' cannot be handled by a pattern of type '{1}' in C# {2}. Please use language version {3} or greater.</value>
   </data>
+  <data name="WRN_UnreferencedLocalFunction" xml:space="preserve">
+    <value>The local function '{0}' is declared but never used</value>
+  </data>
+  <data name="WRN_UnreferencedLocalFunction_Title" xml:space="preserve">
+    <value>Local function is declared but never used</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1492,6 +1492,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region diagnostics introduced for C# 7.2
         ERR_FeatureNotAvailableInVersion7_2 = 8320,
+        WRN_UnreferencedLocalFunction = 8321,
         #endregion diagnostics introduced for C# 7.2
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -163,6 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_UnreferencedVar:
                 case ErrorCode.WRN_UnreferencedField:
                 case ErrorCode.WRN_UnreferencedVarAssg:
+                case ErrorCode.WRN_UnreferencedLocalFunction:
                 case ErrorCode.WRN_SequentialOnPartialClass:
                 case ErrorCode.WRN_UnreferencedFieldAssg:
                 case ErrorCode.WRN_AmbiguousXMLReference:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1702,7 +1702,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (!string.IsNullOrEmpty(symbol.Name)) // avoid diagnostics for parser-inserted names
                 {
-                    Diagnostics.Add(ErrorCode.WRN_UnreferencedVar, symbol.Locations[0], symbol.Name);
+                    Diagnostics.Add(ErrorCode.WRN_UnreferencedLocalFunction, symbol.Locations[0], symbol.Name);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/ErrorFacts.Generated.cs
@@ -175,6 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.WRN_TupleLiteralNameMismatch:
                 case ErrorCode.WRN_Experimental:
                 case ErrorCode.WRN_DefaultInSwitch:
+                case ErrorCode.WRN_UnreferencedLocalFunction:
                     return true;
                 default:
                     return false;

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -580,9 +580,9 @@ class C
     }
 }");
             comp.VerifyDiagnostics(
-                // (7,14): warning CS0168: The variable 'Local' is declared but never used
+                // (7,14): warning CS8321: The local function 'Local' is declared but never used
                 //         bool Local() => x == 0;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local").WithArguments("Local").WithLocation(7, 14));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local").WithArguments("Local").WithLocation(7, 14));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2851,9 +2851,9 @@ class Program
                 // (6,36): warning CS0219: The variable 'i' is assigned but its value is never used
                 //         void f() { if () const int i = 0; }
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 36),
-                // (6,14): warning CS0168: The variable 'f' is declared but never used
+                // (6,14): warning CS8321: The local function 'f' is declared but never used
                 //         void f() { if () const int i = 0; }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(6, 14)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "f").WithArguments("f").WithLocation(6, 14)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ExpressionBodiedMemberTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ExpressionBodiedMemberTests.cs
@@ -934,9 +934,9 @@ public class C
                 // (6,9): error CS8057: Block bodies and expression bodies cannot both be provided.
                 //         int Bar() { return 0; } => 0;
                 Diagnostic(ErrorCode.ERR_BlockBodyAndExpressionBody, "int Bar() { return 0; } => 0;").WithLocation(6, 9),
-                // (6,13): warning CS0168: The variable 'Bar' is declared but never used
+                // (6,13): warning CS8321: The local function 'Bar' is declared but never used
                 //         int Bar() { return 0; } => 0;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Bar").WithArguments("Bar").WithLocation(6, 13));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Bar").WithArguments("Bar").WithLocation(6, 13));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -50,12 +50,12 @@ class C
                 // (7,16): error CS0246: The type or namespace name 'L' could not be found (are you missing a using directive or an assembly reference?)
                 //         int L2(L l1) => 0;
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "L").WithArguments("L").WithLocation(7, 16),
-                // (6,13): warning CS0168: The variable 'L' is declared but never used
+                // (6,13): warning CS8321: The local function 'L' is declared but never used
                 //         int L(L2 l2) => 0;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "L").WithArguments("L").WithLocation(6, 13),
-                // (7,13): warning CS0168: The variable 'L2' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "L").WithArguments("L").WithLocation(6, 13),
+                // (7,13): warning CS8321: The local function 'L2' is declared but never used
                 //         int L2(L l1) => 0;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "L2").WithArguments("L2").WithLocation(7, 13));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "L2").WithArguments("L2").WithLocation(7, 13));
         }
 
         [Fact]
@@ -230,9 +230,9 @@ class C
                 // (7,26): error CS8204: Attributes are not allowed on local function parameters or type parameters
                 //         void Local<[A]T, [CLSCompliant]U>() { }
                 Diagnostic(ErrorCode.ERR_AttributesInLocalFuncDecl, "[CLSCompliant]").WithLocation(7, 26),
-                // (7,14): warning CS0168: The variable 'Local' is declared but never used
+                // (7,14): warning CS8321: The local function 'Local' is declared but never used
                 //         void Local<[A]T, [CLSCompliant]U>() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local").WithArguments("Local").WithLocation(7, 14));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local").WithArguments("Local").WithLocation(7, 14));
 
             var tree = comp.SyntaxTrees[0];
             var root = tree.GetRoot();
@@ -311,9 +311,9 @@ class C
                 // (7,31): error CS7036: There is no argument given that corresponds to the required formal parameter 'isCompliant' of 'CLSCompliantAttribute.CLSCompliantAttribute(bool)'
                 //         void Local([A]int x, [CLSCompliant]int y) { }
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "CLSCompliant").WithArguments("isCompliant", "System.CLSCompliantAttribute.CLSCompliantAttribute(bool)").WithLocation(7, 31),
-                // (7,14): warning CS0168: The variable 'Local' is declared but never used
+                // (7,14): warning CS8321: The local function 'Local' is declared but never used
                 //         void Local([A]int x, [CLSCompliant]int y) { }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local").WithArguments("Local").WithLocation(7, 14));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local").WithArguments("Local").WithLocation(7, 14));
 
             var tree = comp.SyntaxTrees[0];
             var root = tree.GetRoot();
@@ -857,12 +857,12 @@ class C
                 // (10,14): error CS1061: 'C' does not contain a definition for 'BadLocal2' and no extension method 'BadLocal2' accepting a first argument of type 'C' could be found (are you missing a using directive or an assembly reference?)
                 //         this.BadLocal2();
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "BadLocal2").WithArguments("C", "BadLocal2").WithLocation(10, 14),
-                // (8,17): warning CS0168: The variable 'BadLocal1' is declared but never used
+                // (8,17): warning CS8321: The local function 'BadLocal1' is declared but never used
                 //     public void BadLocal1()
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "BadLocal1").WithArguments("BadLocal1").WithLocation(8, 17),
-                // (13,17): warning CS0168: The variable 'BadLocal2' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "BadLocal1").WithArguments("BadLocal1").WithLocation(8, 17),
+                // (13,17): warning CS8321: The local function 'BadLocal2' is declared but never used
                 //     public void BadLocal2()
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "BadLocal2").WithArguments("BadLocal2").WithLocation(13, 17));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "BadLocal2").WithArguments("BadLocal2").WithLocation(13, 17));
 
         }
 
@@ -1087,9 +1087,9 @@ class C
                 // (8,14): error CS0128: A local variable named 'Overload' is already defined in this scope
                 //         void Overload(string s) => Console.Write(s);
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "Overload").WithArguments("Overload").WithLocation(8, 14),
-                // (8,14): warning CS0168: The variable 'Overload' is declared but never used
+                // (8,14): warning CS8321: The local function 'Overload' is declared but never used
                 //         void Overload(string s) => Console.Write(s);
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Overload").WithArguments("Overload").WithLocation(8, 14));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Overload").WithArguments("Overload").WithLocation(8, 14));
         }
 
         [Fact]
@@ -1238,9 +1238,9 @@ class Program
     // (7,14): error CS0128: A local variable named 'Duplicate' is already defined in this scope
     //         void Duplicate() { }
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "Duplicate").WithArguments("Duplicate").WithLocation(7, 14),
-    // (7,14): warning CS0168: The variable 'Duplicate' is declared but never used
+    // (7,14): warning CS8321: The local function 'Duplicate' is declared but never used
     //         void Duplicate() { }
-    Diagnostic(ErrorCode.WRN_UnreferencedVar, "Duplicate").WithArguments("Duplicate").WithLocation(7, 14)
+    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Duplicate").WithArguments("Duplicate").WithLocation(7, 14)
     );
         }
 
@@ -1336,9 +1336,9 @@ class Program
     // (6,13): warning CS0168: The variable 'Conflict' is declared but never used
     //         int Conflict;
     Diagnostic(ErrorCode.WRN_UnreferencedVar, "Conflict").WithArguments("Conflict").WithLocation(6, 13),
-    // (7,14): warning CS0168: The variable 'Conflict' is declared but never used
+    // (7,14): warning CS8321: The local function 'Conflict' is declared but never used
     //         void Conflict() { }
-    Diagnostic(ErrorCode.WRN_UnreferencedVar, "Conflict").WithArguments("Conflict").WithLocation(7, 14)
+    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Conflict").WithArguments("Conflict").WithLocation(7, 14)
     );
         }
 
@@ -1363,9 +1363,9 @@ class Program
     // (7,13): warning CS0168: The variable 'Conflict' is declared but never used
     //         int Conflict;
     Diagnostic(ErrorCode.WRN_UnreferencedVar, "Conflict").WithArguments("Conflict").WithLocation(7, 13),
-    // (6,14): warning CS0168: The variable 'Conflict' is declared but never used
+    // (6,14): warning CS8321: The local function 'Conflict' is declared but never used
     //         void Conflict() { }
-    Diagnostic(ErrorCode.WRN_UnreferencedVar, "Conflict").WithArguments("Conflict").WithLocation(6, 14)
+    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Conflict").WithArguments("Conflict").WithLocation(6, 14)
     );
         }
 
@@ -1617,9 +1617,9 @@ class Program
     }
 }";
             VerifyDiagnostics(source,
-    // (6,14): warning CS0168: The variable 'Local' is declared but never used
+    // (6,14): warning CS8321: The local function 'Local' is declared but never used
     //         void Local()
-    Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local").WithArguments("Local").WithLocation(6, 14)
+    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local").WithArguments("Local").WithLocation(6, 14)
     );
         }
 
@@ -1646,9 +1646,9 @@ class Program
     }
 }";
             VerifyDiagnostics(source,
-    // (9,18): warning CS0168: The variable 'Local' is declared but never used
+    // (9,18): warning CS8321: The local function 'Local' is declared but never used
     //             void Local()
-    Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local").WithArguments("Local").WithLocation(9, 18)
+    Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local").WithArguments("Local").WithLocation(9, 18)
     );
         }
 
@@ -2194,9 +2194,9 @@ class Program
                 // (7,9): error CS1023: Embedded statement cannot be a declaration or labeled statement
                 //         int Add(int x, int y) => x + y;
                 Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "int Add(int x, int y) => x + y;").WithLocation(7, 9),
-                // (7,13): warning CS0168: The variable 'Add' is declared but never used
+                // (7,13): warning CS8321: The local function 'Add' is declared but never used
                 //         int Add(int x, int y) => x + y;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Add").WithArguments("Add").WithLocation(7, 13)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Add").WithArguments("Add").WithLocation(7, 13)
                 );
         }
 
@@ -2223,9 +2223,9 @@ a:      int Add(int x, int y) => x + y;
                 // (7,1): warning CS0164: This label has not been referenced
                 // a:      int Add(int x, int y) => x + y;
                 Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(7, 1),
-                // (7,13): warning CS0168: The variable 'Add' is declared but never used
+                // (7,13): warning CS8321: The local function 'Add' is declared but never used
                 // a:      int Add(int x, int y) => x + y;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Add").WithArguments("Add").WithLocation(7, 13)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Add").WithArguments("Add").WithLocation(7, 13)
                 );
         }
 
@@ -2754,24 +2754,24 @@ namespace System
                 // (14,42): error CS0103: The name 'z6' does not exist in the current context
                 //         int t = z1 + z2 + z3 + z4 + z5 + z6;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z6").WithArguments("z6").WithLocation(14, 42),
-                // (6,14): warning CS0168: The variable 'Local1' is declared but never used
+                // (6,14): warning CS8321: The local function 'Local1' is declared but never used
                 //         void Local1(bool b = M(arg is int z1, z1), int s1 = z1) {}
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local1").WithArguments("Local1").WithLocation(6, 14),
-                // (7,14): warning CS0168: The variable 'Local2' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local1").WithArguments("Local1").WithLocation(6, 14),
+                // (7,14): warning CS8321: The local function 'Local2' is declared but never used
                 //         void Local2(bool b = M(M(out int z2), z2), int s2 = z2) {}
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local2").WithArguments("Local2").WithLocation(7, 14),
-                // (8,14): warning CS0168: The variable 'Local3' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local2").WithArguments("Local2").WithLocation(7, 14),
+                // (8,14): warning CS8321: The local function 'Local3' is declared but never used
                 //         void Local3(bool b = M(M((int z3, int a2) = (1, 2)), z3), int a3 = z3) {}
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local3").WithArguments("Local3").WithLocation(8, 14),
-                // (10,14): warning CS0168: The variable 'Local4' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local3").WithArguments("Local3").WithLocation(8, 14),
+                // (10,14): warning CS8321: The local function 'Local4' is declared but never used
                 //         void Local4(bool b = M(arg is var z4, z4), int s1 = z4) {}
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local4").WithArguments("Local4").WithLocation(10, 14),
-                // (11,14): warning CS0168: The variable 'Local5' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local4").WithArguments("Local4").WithLocation(10, 14),
+                // (11,14): warning CS8321: The local function 'Local5' is declared but never used
                 //         void Local5(bool b = M(M(out var z5), z5), int s2 = z5) {}
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local5").WithArguments("Local5").WithLocation(11, 14),
-                // (12,14): warning CS0168: The variable 'Local6' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local5").WithArguments("Local5").WithLocation(11, 14),
+                // (12,14): warning CS8321: The local function 'Local6' is declared but never used
                 //         void Local6(bool b = M(M((var z6, int a2) = (1, 2)), z6), int a3 = z6) {}
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local6").WithArguments("Local6").WithLocation(12, 14)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local6").WithArguments("Local6").WithLocation(12, 14)
                 );
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -19303,9 +19303,9 @@ public class Cls
                 // (10,16): warning CS0168: The variable 'e' is declared but never used
                 //         int d, e(out var x4); // parsed as a broken bracketed argument list on the declarator
                 Diagnostic(ErrorCode.WRN_UnreferencedVar, "e").WithArguments("e").WithLocation(10, 16),
-                // (7,13): warning CS0168: The variable 'b' is declared but never used
+                // (7,13): warning CS8321: The local function 'b' is declared but never used
                 //         int b(out var x2) = null; // parsed as a local function with syntax error
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "b").WithArguments("b").WithLocation(7, 13)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "b").WithArguments("b").WithLocation(7, 13)
                 );
         }
 
@@ -31371,12 +31371,12 @@ class C
                 // (9,22): error CS0103: The name 'z2' does not exist in the current context
                 //         int x = z1 + z2;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(9, 22),
-                // (6,14): warning CS0168: The variable 'Local2' is declared but never used
+                // (6,14): warning CS8321: The local function 'Local2' is declared but never used
                 //         void Local2(bool b = M(M(out int z1), z1), int s2 = z1) { var t = z1; }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local2").WithArguments("Local2").WithLocation(6, 14),
-                // (7,14): warning CS0168: The variable 'Local5' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local2").WithArguments("Local2").WithLocation(6, 14),
+                // (7,14): warning CS8321: The local function  'Local5' is declared but never used
                 //         void Local5(bool b = M(M(out var z2), z2), int s2 = z2) { var t = z2; }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local5").WithArguments("Local5").WithLocation(7, 14)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local5").WithArguments("Local5").WithLocation(7, 14)
                 );
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);
@@ -32054,12 +32054,12 @@ class C
                 // (9,22): error CS0103: The name 'z2' does not exist in the current context
                 //         int x = z1 + z2;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(9, 22),
-                // (6,14): warning CS0168: The variable 'Local2' is declared but never used
+                // (6,14): warning CS8321: The local function 'Local2' is declared but never used
                 //         void Local2(bool b = M(nameof(M(out int z1)), z1), int s2 = z1) { var t = z1; }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local2").WithArguments("Local2").WithLocation(6, 14),
-                // (7,14): warning CS0168: The variable 'Local5' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local2").WithArguments("Local2").WithLocation(6, 14),
+                // (7,14): warning CS8321: The local function 'Local5' is declared but never used
                 //         void Local5(bool b = M(nameof(M(out var z2)), z2), int s2 = z2) { var t = z2; }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local5").WithArguments("Local5").WithLocation(7, 14)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local5").WithArguments("Local5").WithLocation(7, 14)
                 );
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -62,9 +62,9 @@ public class Vec
                 // (14,20): error CS8059: Feature 'pattern matching' is not available in C# 6. Please use language version 7.0 or greater.
                 //         string s = o is string k ? k : null; // pattern matching
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "o is string k").WithArguments("pattern matching", "7.0").WithLocation(14, 20),
-                // (12,13): warning CS0168: The variable 'f' is declared but never used
+                // (12,13): warning CS8321: The local function 'f' is declared but never used
                 //         int f() => 2;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(12, 13)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "f").WithArguments("f").WithLocation(12, 13)
                 );
 
             // enables binary literals, digit separators, local functions, ref locals, pattern matching
@@ -72,9 +72,9 @@ public class Vec
                 // (8,13): warning CS0219: The variable 'i2' is assigned but its value is never used
                 //         int i2 = 23_554; // digit separators
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i2").WithArguments("i2").WithLocation(8, 13),
-                // (12,13): warning CS0168: The variable 'f' is declared but never used
+                // (12,13): warning CS8321: The local function 'f' is declared but never used
                 //         int f() => 2;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(12, 13)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "f").WithArguments("f").WithLocation(12, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -859,15 +859,15 @@ public class Test
                 // (19,13): error CS8150: By-value returns may only be used in methods that return by value
                 //             return c;
                 Diagnostic(ErrorCode.ERR_MustHaveRefReturn, "return").WithLocation(19, 13),
-                // (6,18): warning CS0168: The variable 'Foo' is declared but never used
+                // (6,18): warning CS8321: The local function 'Foo' is declared but never used
                 //         ref char Foo(ref char a, ref char b)
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Foo").WithArguments("Foo").WithLocation(6, 18),
-                // (12,14): warning CS0168: The variable 'Foo1' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Foo").WithArguments("Foo").WithLocation(6, 18),
+                // (12,14): warning CS8321: The local function 'Foo1' is declared but never used
                 //         char Foo1(ref char a, ref char b)
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Foo1").WithArguments("Foo1").WithLocation(12, 14),
-                // (17,18): warning CS0168: The variable 'Foo2' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Foo1").WithArguments("Foo1").WithLocation(12, 14),
+                // (17,18): warning CS8321: The local function 'Foo2' is declared but never used
                 //         ref char Foo2(ref char c, ref char b)
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Foo2").WithArguments("Foo2").WithLocation(17, 18));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Foo2").WithArguments("Foo2").WithLocation(17, 18));
         }
 
         [Fact]
@@ -913,21 +913,21 @@ public class Test
                 // (17,46): error CS0266: Cannot implicitly convert type 'int' to 'char'. An explicit conversion exists (are you missing a cast?)
                 //         char Moo3(ref char a, ref char b) => r;
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "r").WithArguments("int", "char").WithLocation(17, 46),
-                // (7,18): warning CS0168: The variable 'Foo' is declared but never used
+                // (7,18): warning CS8321: The local function 'Foo' is declared but never used
                 //         ref char Foo(ref char a, ref char b) => ref a;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Foo").WithArguments("Foo").WithLocation(7, 18),
-                // (9,14): warning CS0168: The variable 'Foo1' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Foo").WithArguments("Foo").WithLocation(7, 18),
+                // (9,14): warning CS8321: The local function 'Foo1' is declared but never used
                 //         char Foo1(ref char a, ref char b) => ref b;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Foo1").WithArguments("Foo1").WithLocation(9, 14),
-                // (11,18): warning CS0168: The variable 'Foo2' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Foo1").WithArguments("Foo1").WithLocation(9, 14),
+                // (11,18): warning CS8321: The local function 'Foo2' is declared but never used
                 //         ref char Foo2(ref char c, ref char b) => c;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Foo2").WithArguments("Foo2").WithLocation(11, 18),
-                // (16,18): warning CS0168: The variable 'Moo1' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Foo2").WithArguments("Foo2").WithLocation(11, 18),
+                // (16,18): warning CS8321: The local function 'Moo1' is declared but never used
                 //         ref char Moo1(ref char a, ref char b) => ref r;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Moo1").WithArguments("Moo1").WithLocation(16, 18),
-                // (17,14): warning CS0168: The variable 'Moo3' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Moo1").WithArguments("Moo1").WithLocation(16, 18),
+                // (17,14): warning CS8321: The local function 'Moo3' is declared but never used
                 //         char Moo3(ref char a, ref char b) => r;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Moo3").WithArguments("Moo3").WithLocation(17, 14));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Moo3").WithArguments("Moo3").WithLocation(17, 14));
         }
 
         [Fact, WorkItem(13062, "https://github.com/dotnet/roslyn/issues/13062")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
@@ -2191,9 +2191,9 @@ static class C
                 // (6,13): error CS1547: Keyword 'void' cannot be used in this context
                 //         ref void M() { }
                 Diagnostic(ErrorCode.ERR_NoVoidHere, "void").WithLocation(6, 13),
-                // (6,18): warning CS0168: The variable 'M' is declared but never used
+                // (6,18): warning CS8321: The local function 'M' is declared but never used
                 //         ref void M() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "M").WithArguments("M").WithLocation(6, 18)
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "M").WithArguments("M").WithLocation(6, 18)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Diagnostics/DiagnosticTest.cs
@@ -256,6 +256,7 @@ class X
                             Assert.Equal(2, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_PdbLocalNameTooLong:
+                        case ErrorCode.WRN_UnreferencedLocalFunction:
                             Assert.Equal(3, ErrorFacts.GetWarningLevel(errorCode));
                             break;
                         case ErrorCode.WRN_InvalidVersionFormat:

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -367,15 +367,15 @@ class C
                 // (11,13): error CS0161: 'foo<T>()': not all code paths return a value
                 //             foo<T>) { }
                 Diagnostic(ErrorCode.ERR_ReturnExpected, "foo").WithArguments("foo<T>()").WithLocation(11, 13),
-                // (7,13): warning CS0168: The variable 'foo' is declared but never used
+                // (7,13): warning CS8321: The local function 'foo' is declared but never used
                 //             foo() where T : IFace => 5;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "foo").WithArguments("foo").WithLocation(7, 13),
-                // (9,13): warning CS0168: The variable 'foo' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "foo").WithArguments("foo").WithLocation(7, 13),
+                // (9,13): warning CS8321: The local function 'foo' is declared but never used
                 //             foo() where T : IFace { return 5; }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "foo").WithArguments("foo").WithLocation(9, 13),
-                // (11,13): warning CS0168: The variable 'foo' is declared but never used
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "foo").WithArguments("foo").WithLocation(9, 13),
+                // (11,13): warning CS8321: The local function 'foo' is declared but never used
                 //             foo<T>) { }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "foo").WithArguments("foo").WithLocation(11, 13));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "foo").WithArguments("foo").WithLocation(11, 13));
 
             var m = Assert.IsType<MethodDeclarationSyntax>(file.DescendantNodes()
                 .Where(n => n.Kind() == SyntaxKind.MethodDeclaration)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2007,9 +2007,9 @@ public class a {
                 // (6,35): error CS1023: Embedded statement cannot be a declaration or labeled statement
                 //         for (int i=0; i < 3; i++) void j() { }
                 Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "void j() { }").WithLocation(6, 35),
-                // (6,40): warning CS0168: The variable 'j' is declared but never used
+                // (6,40): warning CS8321: The local function 'j' is declared but never used
                 //         for (int i=0; i < 3; i++) void j() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "j").WithArguments("j").WithLocation(6, 40));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "j").WithArguments("j").WithLocation(6, 40));
         }
 
         // Preprocessor:

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -4688,9 +4688,9 @@ class A<out T>
                 // (5,20): error CS1960: Invalid variance modifier. Only interface and delegate type parameters can be specified as variant.
                 //         void Local<in T>() { }
                 Diagnostic(ErrorCode.ERR_IllegalVarianceSyntax, "in").WithLocation(5, 20),
-                // (5,14): warning CS0168: The variable 'Local' is declared but never used
+                // (5,14): warning CS8321: The local function 'Local' is declared but never used
                 //         void Local<in T>() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "Local").WithArguments("Local").WithLocation(5, 14));
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "Local").WithArguments("Local").WithLocation(5, 14));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #9661