### PR TITLE
Changed GetContextualKeywordKinds(), always return all contextual keywords

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -194,7 +194,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         AsyncKeyword = 8435,
         AwaitKeyword = 8436,
         WhenKeyword = 8437,
+        /// when adding a contextual keyword following functions must be adapted:
+        /// <see cref="SyntaxFacts.GetContextualKeywordKinds"/>
+        /// <see cref="SyntaxFacts.IsContextualKeyword(SyntaxKind)"/>
 
+        // keywords with an enum value less than ElifKeyword are considered i.a. contextual keywords
         // additional preprocessor keywords
         ElifKeyword = 8467,
         EndIfKeyword = 8468,


### PR DESCRIPTION
The iterator function `GetContextualKeywordKinds()` only returns keywords up to `WhenKeyword`, even if new contextual keywords are appended to the end of the section.

The change makes it unnecessary to adapt the function every time a new contextual keyword is added.