### PR TITLE
Handle out of range span in GetSemanticModelForSpanAsync

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -52,6 +52,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 }
 
                 var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                if (!root.FullSpan.Contains(span.Start))
+                {
+                    return await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                }
+
                 var token = root.FindToken(span.Start);
                 if (token.Parent == null)
                 {

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -113,6 +113,7 @@
     <Compile Include="FindReferencesTests.cs" />
     <Compile Include="FormattingTests.cs" />
     <Compile Include="GeneratedCodeRecognitionTests.cs" />
+    <Compile Include="WorkspaceTests\DocumentExtensionsTests.cs" />
     <Compile Include="WorkspaceTests\MSBuildWorkspaceTests.cs" />
     <Compile Include="WorkspaceTests\MSBuildWorkspaceTestBase.cs" />
     <Compile Include="WorkspaceTests\WorkspaceReferenceTests.cs" />

--- a/src/Workspaces/CoreTest/WorkspaceTests/DocumentExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/DocumentExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceTests
+{
+    [Trait(Traits.Feature, Traits.Features.Workspace)]
+    public class DocumentExtensionsTests
+    {
+        [Fact]
+        public async Task GetSemanticModelForSpanAsync1()
+        {
+            using (var ws = new AdhocWorkspace())
+            {
+                var project = ws.AddProject("TestProject", LanguageNames.CSharp);
+                var src = "class C {}";
+                var doc = ws.AddDocument(project.Id, "test.cs", SourceText.From(src));
+
+                Assert.NotNull(await doc.GetSemanticModelForSpanAsync(new TextSpan(src.Length, 0), default(CancellationToken)).ConfigureAwait(false));
+                Assert.NotNull(await doc.GetSemanticModelForSpanAsync(new TextSpan(src.Length + 1, 0), default(CancellationToken)).ConfigureAwait(false));
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**

VS crashes while deleting text in interactive window when completion list is displayed.

Repro:

1) submit ```int a;```
2) type```a``` , wait for completion list to appear, hover over ```a``` in the list, type Backspace, crash.

**Bugs this fixes:**

VSO Bug [434828](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=434828)
VSO bug [395081](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=395081)

**Workarounds, if any**

Do not hover over completion list items while deleting text in submission.

**Risk**

Small.

**Performance impact**

None.

**Is this a regression from a previous update?**

**Root cause analysis:**

Edge case not handled.

**How was the bug found?**

Customer reported.