### PR TITLE
issue when trying to get a property access modifier of a expression-b…

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -1140,7 +1140,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
                 }
             }
 
-            if (node is AccessorDeclarationSyntax)
+            if (node is AccessorDeclarationSyntax || 
+                node is ArrowExpressionClauseSyntax)
             {
                 return GetAccess(node.FirstAncestorOrSelf<BasePropertyDeclarationSyntax>());
             }

--- a/src/VisualStudio/CSharp/Test/CodeModel/FileCodeClassTests.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/FileCodeClassTests.cs
@@ -31,6 +31,8 @@ public class Bar
             return a;
         }
     }
+
+    public string WindowsUserID => ""Domain""; 
 }")
         {
         }
@@ -227,7 +229,7 @@ public class Bar
 
             TextPoint endPoint = testObject.GetEndPoint(vsCMPart.vsCMPartBody);
 
-            Assert.Equal(19, endPoint.Line);
+            Assert.Equal(21, endPoint.Line);
             Assert.Equal(1, endPoint.LineCharOffset);
         }
 
@@ -292,7 +294,7 @@ public class Bar
 
             TextPoint endPoint = testObject.GetEndPoint(vsCMPart.vsCMPartWholeWithAttributes);
 
-            Assert.Equal(19, endPoint.Line);
+            Assert.Equal(21, endPoint.Line);
             Assert.Equal(2, endPoint.LineCharOffset);
         }
 
@@ -316,8 +318,20 @@ public class Bar
 
             TextPoint endPoint = testObject.EndPoint;
 
-            Assert.Equal(19, endPoint.Line);
+            Assert.Equal(21, endPoint.Line);
             Assert.Equal(2, endPoint.LineCharOffset);
         }
+
+        [ConditionalWpfFact(typeof(x86))]
+        [Trait(Traits.Feature, Traits.Features.CodeModel)]
+        public void Accessor()
+        {
+            CodeClass testObject = GetCodeClass("Bar");
+
+            var l =  from p in testObject.Members.OfType<CodeProperty>() where vsCMAccess.vsCMAccessPublic == p.Access && p.Getter != null && !p.Getter.IsShared && vsCMAccess.vsCMAccessPublic == p.Getter.Access select p ;
+            var z = l.ToList<CodeProperty>();
+            Assert.Equal(2, z.Count);
+        }
+
     }
 }


### PR DESCRIPTION
**Customer scenario**

Using EnvDTE to get the access modifier for an expression-body property accessor where the accessor has no access modifier

**Bugs this fixes:**

#19480

**Workarounds, if any**
NONE

**Risk**

Minimal

**Performance impact**

current code throws an exception as opposed to returning the correct value

**Is this a regression from a previous update?**

**Root cause analysis:**

New test added to CSharpVisualStudioTest under the FileCodeClassTest

**How was the bug found?**

Customer-reported. Note that the bug fix is community-contributed.

initial bug report stemmed from a bug found in 
TypeScript Definition Generator tool by Mad Kristensen

