### PR TITLE
Fix case that was causing us to not offer completion after a case-pattern-label in a switch.

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -3311,6 +3311,31 @@ class C
                     New TextChange(New TextSpan(0, _caretPosition), newText))
                 Return Task.FromResult(change)
             End Function
+
+            <WorkItem(15348, "https://github.com/dotnet/roslyn/issues/15348")>
+            <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+            Public Async Function TestAfterCasePatternSwitchLabel() As Task
+                Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void M()
+    {
+        object o = 1;
+        switch(o)
+        {
+            case int i:
+                $$
+                break;
+        }
+    }
+}
+                              </Document>)
+
+                    state.SendTypeChars("this")
+                    Await state.AssertSelectedCompletionItem(displayText:="this", isHardSelected:=True)
+                End Using
+            End Function
         End Class
     End Class
 End Namespace

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -153,7 +153,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             if (token.Kind() == SyntaxKind.ColonToken)
             {
-                if (token.Parent.IsKind(SyntaxKind.CaseSwitchLabel, SyntaxKind.DefaultSwitchLabel, SyntaxKind.LabeledStatement))
+                if (token.Parent.IsKind(SyntaxKind.CaseSwitchLabel,
+                                        SyntaxKind.DefaultSwitchLabel,
+                                        SyntaxKind.CasePatternSwitchLabel,
+                                        SyntaxKind.LabeledStatement))
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes #15348