### PR TITLE
Add back 'beta2' nuget moniker for official builds.

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -15,6 +15,7 @@
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta2</RoslynNuGetMoniker>
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>
 


### PR DESCRIPTION
Add back the 'beta2' nuget package moniker for official builds. 

The moniker was accidentally removed in a2e2bf45c31a7f91626017296d5e247631e92886 (PR #19469).
