### PR TITLE
Check for missing hierarchies when mapping to Roslyn projects

### DIFF
--- a/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
@@ -62,6 +62,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                         // project files are in the same folder--they both use the full path to the _folder_ as the canonical
                         // name. To distinguish them we also examine the "regular" name, which will necessarily be different
                         // if the two projects are in the same folder.
+                        // Note that if a project has been loaded with Lightweight Solution Load it won't even have a
+                        // hierarchy, so we need to check for null first.
                         if (p.Hierarchy != null
                             && p.Hierarchy.TryGetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectCanonicalName)
                             && p.Hierarchy.TryGetItemName((uint)VSConstants.VSITEMID.Root, out string projectName)

--- a/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/HierarchyItemToProjectIdMap.cs
@@ -62,7 +62,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                         // project files are in the same folder--they both use the full path to the _folder_ as the canonical
                         // name. To distinguish them we also examine the "regular" name, which will necessarily be different
                         // if the two projects are in the same folder.
-                        if (p.Hierarchy.TryGetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectCanonicalName)
+                        if (p.Hierarchy != null
+                            && p.Hierarchy.TryGetCanonicalName((uint)VSConstants.VSITEMID.Root, out string projectCanonicalName)
                             && p.Hierarchy.TryGetItemName((uint)VSConstants.VSITEMID.Root, out string projectName)
                             && projectCanonicalName.Equals(nestedCanonicalName, System.StringComparison.OrdinalIgnoreCase)
                             && projectName.Equals(nestedName))


### PR DESCRIPTION
In order to shows the "Analyzers" node under the "References" node in
Solution Explorer and show the correct sets of analyzer assemblies and
diagnostics, we need to map the node for the project to the actual
Roslyn `AbstractProject` instance. This is done by matching up various
properties of the `IVsHierarchy` for the node to the same properties on
the `IVsHierarchy` returned by `AbstractProject.Hierarchy`.

This code path was initially written this `Hierarchy` property would
never return null; its value was supplied by the project system.
However, Delayed Project Load (DPL) bypasses the project system until
the user expands the project node in Solution Explorer, and as a result
we may now encounter `AbstractProjects` where `Hierarchy` returns null.
Currently if we run across one of these we'll throw a
`NullReferenceException` which has the end effect of preventing the
user from expanding the project node in Solution Explorer, and may even
result in a crash.

This commit adds in the null check. If the `Hierarchy` property is null
then it can't be the project we're looking for.

**Customer scenario**

Customer opens a solution with DPL enabled. When they expand a project node in Solution Explorer, nothing happens (the arrow indicates that the project is expanded, but nothing shows up under the project node).

Subsequently searching in Solution Explorer may lead to a crash.

**Bugs this fixes:**

Fixes #19517.

**Workarounds, if any**

Disable DPL for the solution.

**Risk**

Low; we're adding a null check that always should have been there.

**Performance impact**

Low; just the cost an additional null check when the user initially expands a project.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

This code path predates DPL, and until DPL the property in question couldn't be null. A subsequent refactoring to support the new project system made use of the property, but I didn't realize the null check was now necessary.

**How was the bug found?**

Internal customer report
