### PR TITLE
tweak how we merge build and live errors for language such as F#

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -122,6 +122,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// </summary>
             public ImmutableArray<StateSet> CreateBuildOnlyProjectStateSet(Project project)
             {
+                if (!project.SupportsCompilation)
+                {
+                    // languages which don't use our compilation model but diagnostic framework,
+                    // all their analyzer should be host analyzers. return all host analyzers
+                    // for the language
+                    return _hostStates.GetOrCreateStateSets(project.Language).ToImmutableArray();
+                }
+
                 // create project analyzer reference identity map
                 var referenceIdentities = project.AnalyzerReferences.Select(r => _analyzerManager.GetAnalyzerReferenceIdentity(r)).ToSet();
 


### PR DESCRIPTION
**Customer scenario**

F# user builds and errors from command line and errors from IDE are both shown in error list.

**Bugs this fixes:**

#19547

**Workarounds, if any**

There is no workaround.

**Risk**

I don't see any risk.

**Performance impact**

now VS does build/live errors de-duplication when build ran. compared to build, de-duplication cost is neglect-able. but still it is new cost.

**Is this a regression from a previous update?**

Experience wise, it is a regression from old F# to Roslyn based F#. but this fix is not to fix the experience itself but to make it possible for F# to fix the issue on top of Roslyn.

**Root cause analysis:**

Roslyn's de-duplication assumed it only supports C# and VB. now that assumption is removed and let the framework flexible on ones like F#.

**How was the bug found?**

from F# people.