### PR TITLE
bypass command line argument passing if no command line parser is available

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Options.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Options.cs
@@ -11,6 +11,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     {
         #region Options
         private string _lastParsedCompilerOptions;
+
+        /// Can be null if there is no <see cref="CommandLineParserService" /> available.
         private CommandLineArguments _lastParsedCommandLineArguments;
         private CompilationOptions _currentCompilationOptions;
         private ParseOptions _currentParseOptions;
@@ -47,23 +49,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         #endregion
 
         /// <summary>
-        /// Creates and sets new options using the last parsed command line arguments.
+        /// Creates and sets new options using the last parsed command line arguments.  In the case that the last
+        /// parsed options are <see langword="null"/> then this call is a NOP.
         /// </summary>
         protected void UpdateOptions()
         {
             AssertIsForeground();
 
             CommandLineArguments lastParsedCommandLineArguments = _lastParsedCommandLineArguments;
-            Contract.ThrowIfNull(lastParsedCommandLineArguments);
-
-            var newParseOptions = CreateParseOptions(lastParsedCommandLineArguments);
-            var newCompilationOptions = CreateCompilationOptions(lastParsedCommandLineArguments, newParseOptions);
-            if (newCompilationOptions == CurrentCompilationOptions && newParseOptions == CurrentParseOptions)
+            if (lastParsedCommandLineArguments != null)
             {
-                return;
-            }
+                // do nothing if the last parsed arguments aren't present, which is the case for languages that don't
+                // export an ICommandLineParserService like F#
+                var newParseOptions = CreateParseOptions(lastParsedCommandLineArguments);
+                var newCompilationOptions = CreateCompilationOptions(lastParsedCommandLineArguments, newParseOptions);
+                if (newCompilationOptions == CurrentCompilationOptions && newParseOptions == CurrentParseOptions)
+                {
+                    return;
+                }
 
-            SetOptions(newCompilationOptions, newParseOptions);
+                SetOptions(newCompilationOptions, newParseOptions);
+            }
         }
 
         /// <summary>

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -120,10 +120,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             ExecuteForegroundAction(() =>
             {
                 var commandLineArguments = SetArgumentsAndUpdateOptions(commandLineForOptions);
-
-                SetRuleSetFile(commandLineArguments.RuleSetPath);
-
-                PostSetOptions(commandLineArguments);
+                if (commandLineArguments != null)
+                {
+                    // some languages (e.g., F#) don't expose a command line parser and this might be `null`
+                    SetRuleSetFile(commandLineArguments.RuleSetPath);
+                    PostSetOptions(commandLineArguments);
+                }
             });
         }
 


### PR DESCRIPTION
This is to enable F# to participate in CPS projects, even though it doesn't export an [`ICommandLineParserService`](https://github.com/dotnet/roslyn/blob/0a5202322a8aa23eb2454ff5f05ecdb258d64956/src/Workspaces/Core/Portable/Workspace/Host/CommandLine/ICommandLineParserService.cs).

The entry point into this code is the `SetOptions()` method in the second file.  This simple allows for a graceful exit if no command line parser service is available, instead of the current behavior of crashing [here](https://github.com/dotnet/roslyn/blob/0a5202322a8aa23eb2454ff5f05ecdb258d64956/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Options.cs#L57).

@srivatsn @jasonmalinowski @CyrusNajmabadi @Pilchie @KevinRansom

Edit: I've verified these changes locally along with dotnet/project-system#2206.