### PR TITLE
Update toolset compilers to 2.3.0-beta2-61716-09. Use LangVersion=latest

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -45,8 +45,8 @@
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-61531-03</MicrosoftMetadataVisualizerVersion>
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
-    <MicrosoftNetCompilersVersion>2.0.1</MicrosoftNetCompilersVersion>
-    <MicrosoftNetCompilersnetcoreVersion>2.0.0-rc2-61102-09</MicrosoftNetCompilersnetcoreVersion>
+    <MicrosoftNetCompilersVersion>2.3.0-beta2-61716-09</MicrosoftNetCompilersVersion>
+    <MicrosoftNetCompilersnetcoreVersion>2.3.0-beta2-61716-09</MicrosoftNetCompilersnetcoreVersion>
     <MicrosoftNetRoslynDiagnosticsVersion>2.0.0-beta1-61628-06</MicrosoftNetRoslynDiagnosticsVersion>
     <MicrosoftNetCoreILAsmVersion>1.1.0</MicrosoftNetCoreILAsmVersion>
     <MicrosoftNETCoreCompilersVersion>2.3.0-dev-56735-00</MicrosoftNETCoreCompilersVersion>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -124,7 +124,6 @@
     <When Condition="'$(MSBuildProjectExtension)' == '.vbproj' OR '$(Language)' == 'VB' OR '$(ProjectLanguage)' == 'VB'">
       <PropertyGroup>
         <ProjectLanguage>VB</ProjectLanguage>
-        <LangVersion>15.3</LangVersion>
         <MyType>Empty</MyType>
         <OptionCompare>Binary</OptionCompare>
         <OptionExplicit>On</OptionExplicit>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -124,7 +124,7 @@
     <When Condition="'$(MSBuildProjectExtension)' == '.vbproj' OR '$(Language)' == 'VB' OR '$(ProjectLanguage)' == 'VB'">
       <PropertyGroup>
         <ProjectLanguage>VB</ProjectLanguage>
-        <LangVersion>Latest</LangVersion>
+        <LangVersion>15.3</LangVersion>
         <MyType>Empty</MyType>
         <OptionCompare>Binary</OptionCompare>
         <OptionExplicit>On</OptionExplicit>
@@ -163,7 +163,7 @@
     <When Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#' OR '$(ProjectLanguage)' == 'CSharp'">
       <PropertyGroup>
         <ProjectLanguage>CSharp</ProjectLanguage>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>7.1</LangVersion>
         <WarningLevel>4</WarningLevel>
         <ErrorReport>prompt</ErrorReport>
 

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -124,6 +124,7 @@
     <When Condition="'$(MSBuildProjectExtension)' == '.vbproj' OR '$(Language)' == 'VB' OR '$(ProjectLanguage)' == 'VB'">
       <PropertyGroup>
         <ProjectLanguage>VB</ProjectLanguage>
+        <LangVersion>Latest</LangVersion>
         <MyType>Empty</MyType>
         <OptionCompare>Binary</OptionCompare>
         <OptionExplicit>On</OptionExplicit>
@@ -162,6 +163,7 @@
     <When Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#' OR '$(ProjectLanguage)' == 'CSharp'">
       <PropertyGroup>
         <ProjectLanguage>CSharp</ProjectLanguage>
+        <LangVersion>latest</LangVersion>
         <WarningLevel>4</WarningLevel>
         <ErrorReport>prompt</ErrorReport>
 

--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -13,7 +13,7 @@ Using the command line Roslyn can be developed using the following pattern:
 
 1. [Visual Studio 2017](https://www.visualstudio.com/downloads/)
     - Ensure C#, VB, MSBuild and Visual Studio Extensibility are included in the selected work loads
-    - Ensure Visual Studio is on at least update 1 
+    - Ensure Visual Studio is on at least version 15.1
 1. Run Restore.cmd
 1. Open Roslyn.sln
 
@@ -24,6 +24,8 @@ do the following:
 - The Visual Studio installation will be listed under the Installed section
 - Click on the hamburger menu, click Modify 
 - Choose the workloads listed above and click Modify
+
+During the last few weeks of a development cycle for a quarterly release (versions 15.3, 15.6, etc.), it is possible for the Roslyn codebase to make use of new language features, which will not be suppored by the last released version. During that period, it is recommended to use the [preview version of Visual Studio](https://www.visualstudio.com/vs/preview/) or [Roslyn nightlies](https://github.com/dotnet/roslyn/issues/18783#issuecomment-299064434). Alternatively, you can just ignore some red squiggles produced by the IDE that do not correspond to build errors (on portions of the code using the latest language features).
 
 ## Running Tests
 

--- a/src/Compilers/Core/Portable/AdditionalTextFile.cs
+++ b/src/Compilers/Core/Portable/AdditionalTextFile.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis
         /// Returns a <see cref="SourceText"/> with the contents of this file, or <c>null</c> if
         /// there were errors reading the file.
         /// </summary>
-        public override SourceText GetText(CancellationToken cancellationToken = default(CancellationToken))
+        public override SourceText GetText(CancellationToken cancellationToken = default)
         {
             lock (_lockObject)
             {

--- a/src/Compilers/Core/Portable/FileSystemExtensions.cs
+++ b/src/Compilers/Core/Portable/FileSystemExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis
             string xmlDocPath = null,
             string win32ResourcesPath = null,
             IEnumerable<ResourceDescription> manifestResources = null,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             if (compilation == null)
             {


### PR DESCRIPTION
For the version, I picked the latest beta2 version from myget.
@jaredpar @jasonmalinowski @agocke @dotnet/roslyn-infrastructure for review.
Fixes https://github.com/dotnet/roslyn/issues/19443

@dotnet/roslyn-compiler @sharwell @CyrusNajmabadi  FYI