### PR TITLE
Set proxy credentials in download-nuget.ps1

### DIFF
--- a/build/scripts/download-nuget.ps1
+++ b/build/scripts/download-nuget.ps1
@@ -27,6 +27,7 @@ try {
 
     Write-Host "Downloading NuGet.exe"
     $webClient = New-Object -TypeName "System.Net.WebClient"
+    $webClient.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
     $webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v$nugetVersion/NuGet.exe", $scratchFile)
     $nugetVersion | Out-File $versionFile
     Copy-Item $scratchFile $destFile


### PR DESCRIPTION
Following the [build instructions](https://github.com/dotnet/roslyn/blob/master/docs/contributing/Building,%20Debugging,%20and%20Testing%20on%20Windows.md) I ran `Restore.cmd` but the download of NuGet.exe failed with error "401 Proxy Authentication Required".

My Windows proxy settings are 'automatically detect settings'. Most applications work without any special setup.

The patch attached fixed the problem for me.