### PR TITLE
Use static methods in CSharpSyntaxGenerator where possible

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -7,7 +7,6 @@ using System.Composition;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -39,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxList<UsingDirectiveSyntax> AsUsingDirectives(IEnumerable<SyntaxNode> declarations)
         {
-            return (declarations != null)
+            return declarations != null
                 ? SyntaxFactory.List(declarations.Select(AsUsingDirective).OfType<UsingDirectiveSyntax>())
                 : default(SyntaxList<UsingDirectiveSyntax>);
         }
@@ -49,20 +48,20 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             var name = node as NameSyntax;
             if (name != null)
             {
-                return this.NamespaceImportDeclaration(name);
+                return NamespaceImportDeclaration(name);
             }
 
             return node as UsingDirectiveSyntax;
         }
 
-        private SyntaxList<MemberDeclarationSyntax> AsNamespaceMembers(IEnumerable<SyntaxNode> declarations)
+        private static SyntaxList<MemberDeclarationSyntax> AsNamespaceMembers(IEnumerable<SyntaxNode> declarations)
         {
-            return (declarations != null)
+            return declarations != null
                 ? SyntaxFactory.List(declarations.Select(AsNamespaceMember).OfType<MemberDeclarationSyntax>())
                 : default(SyntaxList<MemberDeclarationSyntax>);
         }
 
-        private SyntaxNode AsNamespaceMember(SyntaxNode declaration)
+        private static SyntaxNode AsNamespaceMember(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -121,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 initializer != null ? SyntaxFactory.EqualsValueClause((ExpressionSyntax)initializer) : null);
         }
 
-        private SyntaxTokenList GetParameterModifiers(RefKind refKind)
+        private static SyntaxTokenList GetParameterModifiers(RefKind refKind)
         {
             switch (refKind)
             {
@@ -187,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxKind GetTokenKind(OperatorKind kind)
+        private static SyntaxKind GetTokenKind(OperatorKind kind)
         {
             switch (kind)
             {
@@ -222,7 +221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private ParameterListSyntax AsParameterList(IEnumerable<SyntaxNode> parameters)
+        private static ParameterListSyntax AsParameterList(IEnumerable<SyntaxNode> parameters)
         {
             return parameters != null
                 ? SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(parameters.Cast<ParameterSyntax>()))
@@ -348,14 +347,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)));
         }
 
-        private BracketedParameterListSyntax AsBracketedParameterList(IEnumerable<SyntaxNode> parameters)
+        private static BracketedParameterListSyntax AsBracketedParameterList(IEnumerable<SyntaxNode> parameters)
         {
             return parameters != null
                 ? SyntaxFactory.BracketedParameterList(SyntaxFactory.SeparatedList(parameters.Cast<ParameterSyntax>()))
                 : SyntaxFactory.BracketedParameterList();
         }
 
-        private AccessorDeclarationSyntax AccessorDeclaration(SyntaxKind kind, IEnumerable<SyntaxNode> statements)
+        private static AccessorDeclarationSyntax AccessorDeclaration(SyntaxKind kind, IEnumerable<SyntaxNode> statements)
         {
             var ad = SyntaxFactory.AccessorDeclaration(
                 kind,
@@ -463,31 +462,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 var method = (MethodDeclarationSyntax)declaration;
                 if (method.ConstraintClauses.Count > 0)
                 {
-                    return this.RemoveNodes(method, method.ConstraintClauses);
+                    return RemoveNodes(method, method.ConstraintClauses);
                 }
             }
 
             return declaration;
         }
 
-        private ExplicitInterfaceSpecifierSyntax GetInterfaceSpecifier(SyntaxNode declaration)
-        {
-            switch (declaration.Kind())
-            {
-                case SyntaxKind.MethodDeclaration:
-                    return ((MethodDeclarationSyntax)declaration).ExplicitInterfaceSpecifier;
-                case SyntaxKind.PropertyDeclaration:
-                    return ((PropertyDeclarationSyntax)declaration).ExplicitInterfaceSpecifier;
-                case SyntaxKind.IndexerDeclaration:
-                    return ((IndexerDeclarationSyntax)declaration).ExplicitInterfaceSpecifier;
-                case SyntaxKind.EventDeclaration:
-                    return ((EventDeclarationSyntax)declaration).ExplicitInterfaceSpecifier;
-                default:
-                    return null;
-            }
-        }
-
-        private SyntaxNode WithInterfaceSpecifier(SyntaxNode declaration, ExplicitInterfaceSpecifierSyntax specifier)
+        private static SyntaxNode WithInterfaceSpecifier(SyntaxNode declaration, ExplicitInterfaceSpecifierSyntax specifier)
         {
             switch (declaration.Kind())
             {
@@ -506,20 +488,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode AsImplementation(SyntaxNode declaration, Accessibility requiredAccess)
         {
-            var mods = this.GetModifiers(declaration);
-            declaration = this.WithAccessibility(declaration, requiredAccess);
-            declaration = this.WithModifiers(declaration, this.GetModifiers(declaration) - DeclarationModifiers.Abstract);
-            declaration = this.WithBodies(declaration);
+            declaration = WithAccessibility(declaration, requiredAccess);
+            declaration = WithModifiers(declaration, GetModifiers(declaration) - DeclarationModifiers.Abstract);
+            declaration = WithBodies(declaration);
             return declaration;
         }
 
-        private SyntaxNode WithBodies(SyntaxNode declaration)
+        private static SyntaxNode WithBodies(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
                 case SyntaxKind.MethodDeclaration:
                     var method = (MethodDeclarationSyntax)declaration;
-                    return (method.Body == null) ? method.WithSemicolonToken(default(SyntaxToken)).WithBody(CreateBlock(null)) : method;
+                    return method.Body == null ? method.WithSemicolonToken(default(SyntaxToken)).WithBody(CreateBlock(null)) : method;
                 case SyntaxKind.OperatorDeclaration:
                     var op = (OperatorDeclarationSyntax)declaration;
                     return op.Body == null ? op.WithSemicolonToken(default(SyntaxToken)).WithBody(CreateBlock(null)) : op;
@@ -540,12 +521,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return declaration;
         }
 
-        private AccessorListSyntax WithBodies(AccessorListSyntax accessorList)
+        private static AccessorListSyntax WithBodies(AccessorListSyntax accessorList)
         {
-            return accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(a => WithBody(a))));
+            return accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(WithBody)));
         }
 
-        private AccessorDeclarationSyntax WithBody(AccessorDeclarationSyntax accessor)
+        private static AccessorDeclarationSyntax WithBody(AccessorDeclarationSyntax accessor)
         {
             if (accessor.Body == null)
             {
@@ -557,41 +538,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxNode WithoutBodies(SyntaxNode declaration)
-        {
-            switch (declaration.Kind())
-            {
-                case SyntaxKind.MethodDeclaration:
-                    var method = (MethodDeclarationSyntax)declaration;
-                    return (method.Body != null) ? method.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)).WithBody(null) : method;
-                case SyntaxKind.OperatorDeclaration:
-                    var op = (OperatorDeclarationSyntax)declaration;
-                    return op.Body != null ? op.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)).WithBody(null) : op;
-                case SyntaxKind.ConversionOperatorDeclaration:
-                    var cop = (ConversionOperatorDeclarationSyntax)declaration;
-                    return cop.Body == null ? cop.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)).WithBody(null) : cop;
-                case SyntaxKind.PropertyDeclaration:
-                    var prop = (PropertyDeclarationSyntax)declaration;
-                    return prop.WithAccessorList(WithoutBodies(prop.AccessorList));
-                case SyntaxKind.IndexerDeclaration:
-                    var ind = (IndexerDeclarationSyntax)declaration;
-                    return ind.WithAccessorList(WithoutBodies(ind.AccessorList));
-                case SyntaxKind.EventDeclaration:
-                    var ev = (EventDeclarationSyntax)declaration;
-                    return ev.WithAccessorList(WithoutBodies(ev.AccessorList));
-            }
-
-            return declaration;
-        }
-
-        private AccessorListSyntax WithoutBodies(AccessorListSyntax accessorList)
+        private static AccessorListSyntax WithoutBodies(AccessorListSyntax accessorList)
         {
             return accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(WithoutBody)));
         }
 
-        private AccessorDeclarationSyntax WithoutBody(AccessorDeclarationSyntax accessor)
+        private static AccessorDeclarationSyntax WithoutBody(AccessorDeclarationSyntax accessor)
         {
-            return (accessor.Body != null) ? accessor.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)).WithBody(null) : accessor;
+            return accessor.Body != null ? accessor.WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)).WithBody(null) : accessor;
         }
 
         public override SyntaxNode ClassDeclaration(
@@ -651,7 +605,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
                 case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.VariableDeclarator:
-                    node = this.AsIsolatedDeclaration(node);
+                    node = AsIsolatedDeclaration(node);
                     break;
             }
 
@@ -666,8 +620,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> interfaceTypes,
             IEnumerable<SyntaxNode> members)
         {
-            var itypes = interfaceTypes != null ? interfaceTypes.Select(i => (BaseTypeSyntax)SyntaxFactory.SimpleBaseType((TypeSyntax)i)).ToList() : null;
-            if (itypes != null && itypes.Count == 0)
+            var itypes = interfaceTypes?.Select(i => (BaseTypeSyntax)SyntaxFactory.SimpleBaseType((TypeSyntax)i)).ToList();
+            if (itypes?.Count == 0)
             {
                 itypes = null;
             }
@@ -689,8 +643,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode> interfaceTypes = null,
             IEnumerable<SyntaxNode> members = null)
         {
-            var itypes = interfaceTypes != null ? interfaceTypes.Select(i => (BaseTypeSyntax)SyntaxFactory.SimpleBaseType((TypeSyntax)i)).ToList() : null;
-            if (itypes != null && itypes.Count == 0)
+            var itypes = interfaceTypes?.Select(i => (BaseTypeSyntax)SyntaxFactory.SimpleBaseType((TypeSyntax)i)).ToList();
+            if (itypes?.Count == 0)
             {
                 itypes = null;
             }
@@ -742,7 +696,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // convert event into field event
                     case SyntaxKind.EventDeclaration:
                         var ev = (EventDeclarationSyntax)member;
-                        return this.EventDeclaration(
+                        return EventDeclaration(
                             ev.Identifier.ValueText,
                             ev.Type,
                             Accessibility.NotApplicable,
@@ -755,9 +709,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // convert field into property
                     case SyntaxKind.FieldDeclaration:
                         var f = (FieldDeclarationSyntax)member;
-                        this.GetAccessibilityAndModifiers(f.Modifiers, out acc, out modifiers);
-                        return this.AsInterfaceMember(
-                            this.PropertyDeclaration(this.GetName(f), this.ClearTrivia(this.GetType(f)), acc, modifiers, getAccessorStatements: null, setAccessorStatements: null));
+                        GetAccessibilityAndModifiers(f.Modifiers, out acc, out modifiers);
+                        return AsInterfaceMember(
+                            PropertyDeclaration(GetName(f), ClearTrivia(GetType(f)), acc, modifiers, getAccessorStatements: null, setAccessorStatements: null));
 
                     default:
                         return null;
@@ -843,7 +797,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 : SyntaxFactory.AttributeArgument((ExpressionSyntax)expression);
         }
 
-        private AttributeArgumentListSyntax AsAttributeArgumentList(IEnumerable<SyntaxNode> arguments)
+        private static AttributeArgumentListSyntax AsAttributeArgumentList(IEnumerable<SyntaxNode> arguments)
         {
             if (arguments != null)
             {
@@ -855,7 +809,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private AttributeArgumentSyntax AsAttributeArgument(SyntaxNode node)
+        private static AttributeArgumentSyntax AsAttributeArgument(SyntaxNode node)
         {
             var expr = node as ExpressionSyntax;
             if (expr != null)
@@ -885,7 +839,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxList<AttributeListSyntax> AsAttributeLists(IEnumerable<SyntaxNode> attributes)
+        private static SyntaxList<AttributeListSyntax> AsAttributeLists(IEnumerable<SyntaxNode> attributes)
         {
             if (attributes != null)
             {
@@ -897,7 +851,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private AttributeListSyntax AsAttributeList(SyntaxNode node)
+        private static AttributeListSyntax AsAttributeList(SyntaxNode node)
         {
             var attr = node as AttributeSyntax;
             if (attr != null)
@@ -917,7 +871,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             if (!s_declAttributes.TryGetValue(declaration, out var attrs))
             {
-                var tmp = this.Flatten(GetAttributeLists(declaration).Where(al => !IsReturnAttribute(al)).ToImmutableReadOnlyListOrEmpty());
+                var tmp = Flatten(GetAttributeLists(declaration).Where(al => !IsReturnAttribute(al)).ToImmutableReadOnlyListOrEmpty());
                 attrs = s_declAttributes.GetValue(declaration, _d => tmp);
             }
 
@@ -931,7 +885,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             if (!s_declReturnAttributes.TryGetValue(declaration, out var attrs))
             {
-                var tmp = this.Flatten(GetAttributeLists(declaration).Where(al => IsReturnAttribute(al)).ToImmutableReadOnlyListOrEmpty());
+                var tmp = Flatten(GetAttributeLists(declaration).Where(al => IsReturnAttribute(al)).ToImmutableReadOnlyListOrEmpty());
                 attrs = s_declReturnAttributes.GetValue(declaration, _d => tmp);
             }
 
@@ -940,7 +894,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private static bool IsReturnAttribute(AttributeListSyntax list)
         {
-            return list.Target != null ? list.Target.Identifier.IsKind(SyntaxKind.ReturnKeyword) : false;
+            return list.Target?.Identifier.IsKind(SyntaxKind.ReturnKeyword) ?? false;
         }
 
         public override SyntaxNode InsertAttributes(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributes)
@@ -952,14 +906,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             var newAttributes = AsAttributeLists(attributes);
 
-            var existingAttributes = this.GetAttributes(declaration);
+            var existingAttributes = GetAttributes(declaration);
             if (index >= 0 && index < existingAttributes.Count)
             {
-                return this.InsertNodesBefore(declaration, existingAttributes[index], newAttributes);
+                return InsertNodesBefore(declaration, existingAttributes[index], newAttributes);
             }
             else if (existingAttributes.Count > 0)
             {
-                return this.InsertNodesAfter(declaration, existingAttributes[existingAttributes.Count - 1], newAttributes);
+                return InsertNodesAfter(declaration, existingAttributes[existingAttributes.Count - 1], newAttributes);
             }
             else
             {
@@ -987,14 +941,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             var newAttributes = AsReturnAttributes(attributes);
 
-            var existingAttributes = this.GetReturnAttributes(d);
+            var existingAttributes = GetReturnAttributes(d);
             if (index >= 0 && index < existingAttributes.Count)
             {
-                return this.InsertNodesBefore(d, existingAttributes[index], newAttributes);
+                return InsertNodesBefore(d, existingAttributes[index], newAttributes);
             }
             else if (existingAttributes.Count > 0)
             {
-                return this.InsertNodesAfter(d, existingAttributes[existingAttributes.Count - 1], newAttributes);
+                return InsertNodesAfter(d, existingAttributes[existingAttributes.Count - 1], newAttributes);
             }
             else
             {
@@ -1004,13 +958,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private IEnumerable<AttributeListSyntax> AsReturnAttributes(IEnumerable<SyntaxNode> attributes)
+        private static IEnumerable<AttributeListSyntax> AsReturnAttributes(IEnumerable<SyntaxNode> attributes)
         {
             return AsAttributeLists(attributes)
                 .Select(list => list.WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.ReturnKeyword))));
         }
 
-        private SyntaxList<AttributeListSyntax> AsAssemblyAttributes(IEnumerable<AttributeListSyntax> attributes)
+        private static SyntaxList<AttributeListSyntax> AsAssemblyAttributes(IEnumerable<AttributeListSyntax> attributes)
         {
             return SyntaxFactory.List(
                     attributes.Select(list => list.WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)))));
@@ -1044,19 +998,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return Isolate(declaration, d => InsertAttributeArgumentsInternal(d, index, attributeArguments));
         }
 
-        private SyntaxNode InsertAttributeArgumentsInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributeArguments)
+        private static SyntaxNode InsertAttributeArgumentsInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributeArguments)
         {
-            var newArgumentList = this.AsAttributeArgumentList(attributeArguments);
+            var newArgumentList = AsAttributeArgumentList(attributeArguments);
 
-            var existingArgumentList = this.GetAttributeArgumentList(declaration);
+            var existingArgumentList = GetAttributeArgumentList(declaration);
 
             if (existingArgumentList == null)
             {
-                return this.WithAttributeArgumentList(declaration, newArgumentList);
+                return WithAttributeArgumentList(declaration, newArgumentList);
             }
             else if (newArgumentList != null)
             {
-                return this.WithAttributeArgumentList(declaration, existingArgumentList.WithArguments(existingArgumentList.Arguments.InsertRange(index, newArgumentList.Arguments)));
+                return WithAttributeArgumentList(declaration, existingArgumentList.WithArguments(existingArgumentList.Arguments.InsertRange(index, newArgumentList.Arguments)));
             }
             else
             {
@@ -1064,7 +1018,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private AttributeArgumentListSyntax GetAttributeArgumentList(SyntaxNode declaration)
+        private static AttributeArgumentListSyntax GetAttributeArgumentList(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -1083,7 +1037,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return null;
         }
 
-        private SyntaxNode WithAttributeArgumentList(SyntaxNode declaration, AttributeArgumentListSyntax argList)
+        private static SyntaxNode WithAttributeArgumentList(SyntaxNode declaration, AttributeArgumentListSyntax argList)
         {
             switch (declaration.Kind())
             {
@@ -1102,7 +1056,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return declaration;
         }
 
-        private SyntaxList<AttributeListSyntax> GetAttributeLists(SyntaxNode declaration)
+        private static SyntaxList<AttributeListSyntax> GetAttributeLists(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -1148,7 +1102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxNode WithAttributeLists(SyntaxNode declaration, SyntaxList<AttributeListSyntax> attributeLists)
+        private static SyntaxNode WithAttributeLists(SyntaxNode declaration, SyntaxList<AttributeListSyntax> attributeLists)
         {
             switch (declaration.Kind())
             {
@@ -1241,7 +1195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return Flatten(GetUnflattenedMembers(declaration));
         }
 
-        private IReadOnlyList<SyntaxNode> GetUnflattenedMembers(SyntaxNode declaration)
+        private static IReadOnlyList<SyntaxNode> GetUnflattenedMembers(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -1262,7 +1216,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private IReadOnlyList<SyntaxNode> Flatten(IReadOnlyList<SyntaxNode> members)
+        private static IReadOnlyList<SyntaxNode> Flatten(IReadOnlyList<SyntaxNode> members)
         {
             if (members.Count == 0 || !members.Any(m => GetDeclarationCount(m) > 1))
             {
@@ -1326,7 +1280,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private void Flatten(SyntaxNode declaration, VariableDeclarationSyntax vd, List<SyntaxNode> flat)
+        private static void Flatten(SyntaxNode declaration, VariableDeclarationSyntax vd, List<SyntaxNode> flat)
         {
             if (vd.Variables.Count > 1)
             {
@@ -1340,38 +1294,38 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertMembers(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> members)
         {
-            var newMembers = this.AsMembersOf(declaration, members);
+            var newMembers = AsMembersOf(declaration, members);
 
-            var existingMembers = this.GetMembers(declaration);
+            var existingMembers = GetMembers(declaration);
             if (index >= 0 && index < existingMembers.Count)
             {
-                return this.InsertNodesBefore(declaration, existingMembers[index], newMembers);
+                return InsertNodesBefore(declaration, existingMembers[index], newMembers);
             }
             else if (existingMembers.Count > 0)
             {
-                return this.InsertNodesAfter(declaration, existingMembers[existingMembers.Count - 1], newMembers);
+                return InsertNodesAfter(declaration, existingMembers[existingMembers.Count - 1], newMembers);
             }
             else
             {
                 switch (declaration.Kind())
                 {
                     case SyntaxKind.ClassDeclaration:
-                        var cd = ((ClassDeclarationSyntax)declaration);
+                        var cd = (ClassDeclarationSyntax)declaration;
                         return cd.WithMembers(cd.Members.AddRange(newMembers));
                     case SyntaxKind.StructDeclaration:
-                        var sd = ((StructDeclarationSyntax)declaration);
+                        var sd = (StructDeclarationSyntax)declaration;
                         return sd.WithMembers(sd.Members.AddRange(newMembers));
                     case SyntaxKind.InterfaceDeclaration:
-                        var id = ((InterfaceDeclarationSyntax)declaration);
+                        var id = (InterfaceDeclarationSyntax)declaration;
                         return id.WithMembers(id.Members.AddRange(newMembers));
                     case SyntaxKind.EnumDeclaration:
-                        var ed = ((EnumDeclarationSyntax)declaration);
+                        var ed = (EnumDeclarationSyntax)declaration;
                         return ed.WithMembers(ed.Members.AddRange(newMembers.OfType<EnumMemberDeclarationSyntax>()));
                     case SyntaxKind.NamespaceDeclaration:
-                        var nd = ((NamespaceDeclarationSyntax)declaration);
+                        var nd = (NamespaceDeclarationSyntax)declaration;
                         return nd.WithMembers(nd.Members.AddRange(newMembers));
                     case SyntaxKind.CompilationUnit:
-                        var cu = ((CompilationUnitSyntax)declaration);
+                        var cu = (CompilationUnitSyntax)declaration;
                         return cu.WithMembers(cu.Members.AddRange(newMembers));
                     default:
                         return declaration;
@@ -1381,7 +1335,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private IEnumerable<MemberDeclarationSyntax> AsMembersOf(SyntaxNode declaration, IEnumerable<SyntaxNode> members)
         {
-            return members != null ? members.Select(m => AsMemberOf(declaration, m)).OfType<MemberDeclarationSyntax>() : null;
+            return members?.Select(m => AsMemberOf(declaration, m)).OfType<MemberDeclarationSyntax>();
         }
 
         private SyntaxNode AsMemberOf(SyntaxNode declaration, SyntaxNode member)
@@ -1389,23 +1343,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             switch (declaration.Kind())
             {
                 case SyntaxKind.ClassDeclaration:
-                    var cd = ((ClassDeclarationSyntax)declaration);
-                    return this.AsClassMember(member, cd.Identifier.Text);
+                    var cd = (ClassDeclarationSyntax)declaration;
+                    return AsClassMember(member, cd.Identifier.Text);
                 case SyntaxKind.StructDeclaration:
-                    var sd = ((StructDeclarationSyntax)declaration);
-                    return this.AsClassMember(member, sd.Identifier.Text);
+                    var sd = (StructDeclarationSyntax)declaration;
+                    return AsClassMember(member, sd.Identifier.Text);
                 case SyntaxKind.InterfaceDeclaration:
-                    var id = ((InterfaceDeclarationSyntax)declaration);
-                    return this.AsInterfaceMember(member);
+                    return AsInterfaceMember(member);
                 case SyntaxKind.EnumDeclaration:
-                    var ed = ((EnumDeclarationSyntax)declaration);
-                    return this.AsEnumMember(member);
+                    return AsEnumMember(member);
                 case SyntaxKind.NamespaceDeclaration:
-                    var nd = ((NamespaceDeclarationSyntax)declaration);
-                    return this.AsNamespaceMember(member);
+                    return AsNamespaceMember(member);
                 case SyntaxKind.CompilationUnit:
-                    var cu = ((CompilationUnitSyntax)declaration);
-                    return this.AsNamespaceMember(member);
+                    return AsNamespaceMember(member);
                 default:
                     return null;
             }
@@ -1468,25 +1418,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return Isolate(declaration, d =>
             {
                 var tokens = GetModifierTokens(d);
-                this.GetAccessibilityAndModifiers(tokens, out var tmp, out var modifiers);
-                var newTokens = this.Merge(tokens, AsModifierList(accessibility, modifiers));
+                GetAccessibilityAndModifiers(tokens, out var tmp, out var modifiers);
+                var newTokens = Merge(tokens, AsModifierList(accessibility, modifiers));
                 return SetModifierTokens(d, newTokens);
             });
         }
 
-        private static DeclarationModifiers s_fieldModifiers = DeclarationModifiers.Const | DeclarationModifiers.New | DeclarationModifiers.ReadOnly | DeclarationModifiers.Static;
-        private static DeclarationModifiers s_methodModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.Async | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Partial | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual;
-        private static DeclarationModifiers s_constructorModifiers = DeclarationModifiers.Static;
-        private static DeclarationModifiers s_propertyModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.ReadOnly | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual;
-        private static DeclarationModifiers s_eventModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual;
-        private static DeclarationModifiers s_eventFieldModifiers = DeclarationModifiers.New | DeclarationModifiers.Static;
-        private static DeclarationModifiers s_indexerModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.ReadOnly | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual;
-        private static DeclarationModifiers s_classModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Partial | DeclarationModifiers.Sealed | DeclarationModifiers.Static;
-        private static DeclarationModifiers s_structModifiers = DeclarationModifiers.New | DeclarationModifiers.Partial;
-        private static DeclarationModifiers s_interfaceModifiers = DeclarationModifiers.New | DeclarationModifiers.Partial;
-        private static DeclarationModifiers s_accessorModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Virtual;
+        private static readonly DeclarationModifiers s_fieldModifiers = DeclarationModifiers.Const | DeclarationModifiers.New | DeclarationModifiers.ReadOnly | DeclarationModifiers.Static;
+        private static readonly DeclarationModifiers s_methodModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.Async | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Partial | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual;
+        private static readonly DeclarationModifiers s_constructorModifiers = DeclarationModifiers.Static;
+        private static readonly DeclarationModifiers s_propertyModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.ReadOnly | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual;
+        private static readonly DeclarationModifiers s_eventModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual;
+        private static readonly DeclarationModifiers s_eventFieldModifiers = DeclarationModifiers.New | DeclarationModifiers.Static;
+        private static readonly DeclarationModifiers s_indexerModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.ReadOnly | DeclarationModifiers.Sealed | DeclarationModifiers.Static | DeclarationModifiers.Virtual;
+        private static readonly DeclarationModifiers s_classModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Partial | DeclarationModifiers.Sealed | DeclarationModifiers.Static;
+        private static readonly DeclarationModifiers s_structModifiers = DeclarationModifiers.New | DeclarationModifiers.Partial;
+        private static readonly DeclarationModifiers s_interfaceModifiers = DeclarationModifiers.New | DeclarationModifiers.Partial;
+        private static readonly DeclarationModifiers s_accessorModifiers = DeclarationModifiers.Abstract | DeclarationModifiers.New | DeclarationModifiers.Override | DeclarationModifiers.Virtual;
 
-        private DeclarationModifiers GetAllowedModifiers(SyntaxKind kind)
+        private static DeclarationModifiers GetAllowedModifiers(SyntaxKind kind)
         {
             switch (kind)
             {
@@ -1565,8 +1515,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 return Isolate(declaration, d =>
                 {
                     var tokens = GetModifierTokens(d);
-                    this.GetAccessibilityAndModifiers(tokens, out var accessibility, out var tmp);
-                    var newTokens = this.Merge(tokens, AsModifierList(accessibility, modifiers));
+                    GetAccessibilityAndModifiers(tokens, out var accessibility, out var tmp);
+                    var newTokens = Merge(tokens, AsModifierList(accessibility, modifiers));
                     return SetModifierTokens(d, newTokens);
                 });
             }
@@ -1577,7 +1527,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxTokenList GetModifierTokens(SyntaxNode declaration)
+        private static SyntaxTokenList GetModifierTokens(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -1632,7 +1582,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return default(SyntaxTokenList);
         }
 
-        private SyntaxNode SetModifierTokens(SyntaxNode declaration, SyntaxTokenList modifiers)
+        private static SyntaxNode SetModifierTokens(SyntaxNode declaration, SyntaxTokenList modifiers)
         {
             switch (declaration.Kind())
             {
@@ -1680,12 +1630,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxTokenList AsModifierList(Accessibility accessibility, DeclarationModifiers modifiers, SyntaxKind kind)
+        private static SyntaxTokenList AsModifierList(Accessibility accessibility, DeclarationModifiers modifiers, SyntaxKind kind)
         {
             return AsModifierList(accessibility, GetAllowedModifiers(kind) & modifiers);
         }
 
-        private SyntaxTokenList AsModifierList(Accessibility accessibility, DeclarationModifiers modifiers)
+        private static SyntaxTokenList AsModifierList(Accessibility accessibility, DeclarationModifiers modifiers)
         {
             SyntaxTokenList list = SyntaxFactory.TokenList();
 
@@ -1770,13 +1720,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return list;
         }
 
-        private SyntaxTokenList Merge(SyntaxTokenList original, SyntaxTokenList newList)
+        private static SyntaxTokenList Merge(SyntaxTokenList original, SyntaxTokenList newList)
         {
             // return tokens from newList, but use original tokens of kind matches
             return SyntaxFactory.TokenList(newList.Select(token => original.Any(token.Kind()) ? original.First(tk => tk.IsKind(token.Kind())) : token));
         }
 
-        private void GetAccessibilityAndModifiers(SyntaxTokenList modifierList, out Accessibility accessibility, out DeclarationModifiers modifiers)
+        private static void GetAccessibilityAndModifiers(SyntaxTokenList modifierList, out Accessibility accessibility, out DeclarationModifiers modifiers)
         {
             accessibility = Accessibility.NotApplicable;
             modifiers = DeclarationModifiers.None;
@@ -1864,7 +1814,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private TypeParameterListSyntax AsTypeParameterList(IEnumerable<string> typeParameterNames)
+        private static TypeParameterListSyntax AsTypeParameterList(IEnumerable<string> typeParameterNames)
         {
             var typeParameters = typeParameterNames != null
                 ? SyntaxFactory.TypeParameterList(SyntaxFactory.SeparatedList(typeParameterNames.Select(name => SyntaxFactory.TypeParameter(name))))
@@ -1880,7 +1830,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode WithTypeParameters(SyntaxNode declaration, IEnumerable<string> typeParameterNames)
         {
-            var typeParameters = this.AsTypeParameterList(typeParameterNames);
+            var typeParameters = AsTypeParameterList(typeParameterNames);
 
             switch (declaration.Kind())
             {
@@ -1931,7 +1881,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxList<TypeParameterConstraintClauseSyntax> WithTypeConstraints(
+        private static SyntaxList<TypeParameterConstraintClauseSyntax> WithTypeConstraints(
             SyntaxList<TypeParameterConstraintClauseSyntax> clauses, string typeParameterName, SpecialTypeConstraintKind kinds, IEnumerable<SyntaxNode> types)
         {
             var constraints = types != null
@@ -2123,19 +2073,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return DeclarationKind.None;
         }
 
-        private bool ParentIsFieldDeclaration(SyntaxNode node)
+        private static bool ParentIsFieldDeclaration(SyntaxNode node)
         {
-            return node != null && node.Parent != null && node.Parent.IsKind(SyntaxKind.FieldDeclaration);
+            return node?.Parent.IsKind(SyntaxKind.FieldDeclaration) ?? false;
         }
 
-        private bool ParentIsEventFieldDeclaration(SyntaxNode node)
+        private static bool ParentIsEventFieldDeclaration(SyntaxNode node)
         {
-            return node != null && node.Parent != null && node.Parent.IsKind(SyntaxKind.EventFieldDeclaration);
+            return node?.Parent.IsKind(SyntaxKind.EventFieldDeclaration) ?? false;
         }
 
-        private bool ParentIsLocalDeclarationStatement(SyntaxNode node)
+        private static bool ParentIsLocalDeclarationStatement(SyntaxNode node)
         {
-            return node != null && node.Parent != null && node.Parent.IsKind(SyntaxKind.LocalDeclarationStatement);
+            return node?.Parent.IsKind(SyntaxKind.LocalDeclarationStatement) ?? false;
         }
 
         public override string GetName(SyntaxNode declaration)
@@ -2173,7 +2123,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case SyntaxKind.LocalDeclarationStatement:
                     return GetName(((LocalDeclarationStatementSyntax)declaration).Declaration);
                 case SyntaxKind.VariableDeclaration:
-                    var vd = ((VariableDeclarationSyntax)declaration);
+                    var vd = (VariableDeclarationSyntax)declaration;
                     if (vd.Variables.Count == 1)
                     {
                         return vd.Variables[0].Identifier.ValueText;
@@ -2241,9 +2191,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case SyntaxKind.EventDeclaration:
                     return ReplaceWithTrivia(declaration, ((EventDeclarationSyntax)declaration).Identifier, id);
                 case SyntaxKind.NamespaceDeclaration:
-                    return ReplaceWithTrivia(declaration, ((NamespaceDeclarationSyntax)declaration).Name, this.DottedName(name));
+                    return ReplaceWithTrivia(declaration, ((NamespaceDeclarationSyntax)declaration).Name, DottedName(name));
                 case SyntaxKind.UsingDirective:
-                    return ReplaceWithTrivia(declaration, ((UsingDirectiveSyntax)declaration).Name, this.DottedName(name));
+                    return ReplaceWithTrivia(declaration, ((UsingDirectiveSyntax)declaration).Name, DottedName(name));
                 case SyntaxKind.Parameter:
                     return ReplaceWithTrivia(declaration, ((ParameterSyntax)declaration).Identifier, id);
                 case SyntaxKind.LocalDeclarationStatement:
@@ -2259,11 +2209,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     var al = (AttributeListSyntax)declaration;
                     if (al.Attributes.Count == 1)
                     {
-                        return ReplaceWithTrivia(declaration, al.Attributes[0].Name, this.DottedName(name));
+                        return ReplaceWithTrivia(declaration, al.Attributes[0].Name, DottedName(name));
                     }
                     break;
                 case SyntaxKind.Attribute:
-                    return ReplaceWithTrivia(declaration, ((AttributeSyntax)declaration).Name, this.DottedName(name));
+                    return ReplaceWithTrivia(declaration, ((AttributeSyntax)declaration).Name, DottedName(name));
                 case SyntaxKind.VariableDeclaration:
                     var vd = (VariableDeclarationSyntax)declaration;
                     if (vd.Variables.Count == 1)
@@ -2313,7 +2263,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return null;
         }
 
-        private TypeSyntax NotVoid(TypeSyntax type)
+        private static TypeSyntax NotVoid(TypeSyntax type)
         {
             var pd = type as PredefinedTypeSyntax;
             return pd != null && pd.Keyword.IsKind(SyntaxKind.VoidKeyword) ? null : type;
@@ -2324,7 +2274,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return Isolate(declaration, d => WithTypeInternal(d, type));
         }
 
-        private SyntaxNode WithTypeInternal(SyntaxNode declaration, SyntaxNode type)
+        private static SyntaxNode WithTypeInternal(SyntaxNode declaration, SyntaxNode type)
         {
             switch (declaration.Kind())
             {
@@ -2378,7 +2328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                         var v = (VariableDeclaratorSyntax)declaration;
                         if (v.Parent != null && v.Parent.Parent != null)
                         {
-                            return this.ClearTrivia(this.WithVariable(v.Parent.Parent, v));
+                            return ClearTrivia(WithVariable(v.Parent.Parent, v));
                         }
                         break;
 
@@ -2396,18 +2346,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return declaration;
         }
 
-        private SyntaxNode WithVariable(SyntaxNode declaration, VariableDeclaratorSyntax variable)
+        private static SyntaxNode WithVariable(SyntaxNode declaration, VariableDeclaratorSyntax variable)
         {
-            var vd = this.GetVariableDeclaration(declaration);
+            var vd = GetVariableDeclaration(declaration);
             if (vd != null)
             {
-                return this.WithVariableDeclaration(declaration, vd.WithVariables(SyntaxFactory.SingletonSeparatedList(variable)));
+                return WithVariableDeclaration(declaration, vd.WithVariables(SyntaxFactory.SingletonSeparatedList(variable)));
             }
 
             return declaration;
         }
 
-        private VariableDeclarationSyntax GetVariableDeclaration(SyntaxNode declaration)
+        private static VariableDeclarationSyntax GetVariableDeclaration(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -2422,7 +2372,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxNode WithVariableDeclaration(SyntaxNode declaration, VariableDeclarationSyntax variables)
+        private static SyntaxNode WithVariableDeclaration(SyntaxNode declaration, VariableDeclarationSyntax variables)
         {
             switch (declaration.Kind())
             {
@@ -2437,7 +2387,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxNode GetFullDeclaration(SyntaxNode declaration)
+        private static SyntaxNode GetFullDeclaration(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -2466,11 +2416,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return declaration;
         }
 
-        private IEnumerable<SyntaxNode> AsNodesLike(SyntaxNode existingNode, IEnumerable<SyntaxNode> newNodes)
-        {
-            return newNodes != null ? newNodes.Select(n => AsNodeLike(existingNode, n)).Where(n => n != null) : null;
-        }
-
         private SyntaxNode AsNodeLike(SyntaxNode existingNode, SyntaxNode newNode)
         {
             switch (GetDeclarationKind(existingNode))
@@ -2481,15 +2426,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case DeclarationKind.Enum:
                 case DeclarationKind.Namespace:
                 case DeclarationKind.CompilationUnit:
-                    var container = this.GetDeclaration(existingNode.Parent);
+                    var container = GetDeclaration(existingNode.Parent);
                     if (container != null)
                     {
-                        return this.AsMemberOf(container, newNode);
+                        return AsMemberOf(container, newNode);
                     }
                     break;
 
                 case DeclarationKind.Attribute:
-                    return this.AsAttributeList(newNode);
+                    return AsAttributeList(newNode);
             }
 
             return newNode;
@@ -2512,24 +2457,22 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             var newParameters = AsParameterList(parameters);
 
-            var currentList = this.GetParameterList(declaration);
+            var currentList = GetParameterList(declaration);
             if (currentList == null)
             {
-                currentList = (declaration.IsKind(SyntaxKind.IndexerDeclaration))
+                currentList = declaration.IsKind(SyntaxKind.IndexerDeclaration)
                     ? SyntaxFactory.BracketedParameterList()
                     : (BaseParameterListSyntax)SyntaxFactory.ParameterList();
             }
 
             var newList = currentList.WithParameters(currentList.Parameters.InsertRange(index, newParameters.Parameters));
-            return this.WithParameterList(declaration, newList);
+            return WithParameterList(declaration, newList);
         }
 
         public override IReadOnlyList<SyntaxNode> GetSwitchSections(SyntaxNode switchStatement)
         {
             var statement = switchStatement as SwitchStatementSyntax;
-            return statement == null
-                ? SpecializedCollections.EmptyReadOnlyList<SyntaxNode>()
-                : statement.Sections;
+            return statement?.Sections ?? SpecializedCollections.EmptyReadOnlyList<SyntaxNode>();
         }
 
         public override SyntaxNode InsertSwitchSections(SyntaxNode switchStatement, int index, IEnumerable<SyntaxNode> switchSections)
@@ -2584,7 +2527,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private BaseParameterListSyntax GetParameterList(SyntaxNode declaration)
+        private static BaseParameterListSyntax GetParameterList(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -2611,7 +2554,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxNode WithParameterList(SyntaxNode declaration, BaseParameterListSyntax list)
+        private static SyntaxNode WithParameterList(SyntaxNode declaration, BaseParameterListSyntax list)
         {
             switch (declaration.Kind())
             {
@@ -2659,7 +2602,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return ((SimpleLambdaExpressionSyntax)declaration).Body as ExpressionSyntax;
 
                 case SyntaxKind.PropertyDeclaration:
-                    var pd = ((PropertyDeclarationSyntax)declaration);
+                    var pd = (PropertyDeclarationSyntax)declaration;
                     if (pd.ExpressionBody != null)
                     {
                         return pd.ExpressionBody.Expression;
@@ -2667,7 +2610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     goto default;
 
                 case SyntaxKind.IndexerDeclaration:
-                    var id = ((IndexerDeclarationSyntax)declaration);
+                    var id = (IndexerDeclarationSyntax)declaration;
                     if (id.ExpressionBody != null)
                     {
                         return id.ExpressionBody.Expression;
@@ -2684,7 +2627,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return Isolate(declaration, d => WithExpressionInternal(d, expression));
         }
 
-        private SyntaxNode WithExpressionInternal(SyntaxNode declaration, SyntaxNode expression)
+        private static SyntaxNode WithExpressionInternal(SyntaxNode declaration, SyntaxNode expression)
         {
             var expr = (ExpressionSyntax)expression;
 
@@ -2718,7 +2661,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     {
                         if (expression == null)
                         {
-                            return this.WithEqualsValue(declaration, null);
+                            return WithEqualsValue(declaration, null);
                         }
                         else
                         {
@@ -2728,7 +2671,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     }
                     else if (expression != null)
                     {
-                        return this.WithEqualsValue(declaration, SyntaxFactory.EqualsValueClause(expr));
+                        return WithEqualsValue(declaration, SyntaxFactory.EqualsValueClause(expr));
                     }
                     else
                     {
@@ -2737,29 +2680,29 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private EqualsValueClauseSyntax GetEqualsValue(SyntaxNode declaration)
+        private static EqualsValueClauseSyntax GetEqualsValue(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
                 case SyntaxKind.FieldDeclaration:
-                    var fd = ((FieldDeclarationSyntax)declaration);
+                    var fd = (FieldDeclarationSyntax)declaration;
                     if (fd.Declaration.Variables.Count == 1)
                     {
                         return fd.Declaration.Variables[0].Initializer;
                     }
                     break;
                 case SyntaxKind.PropertyDeclaration:
-                    var pd = ((PropertyDeclarationSyntax)declaration);
+                    var pd = (PropertyDeclarationSyntax)declaration;
                     return pd.Initializer;
                 case SyntaxKind.LocalDeclarationStatement:
-                    var ld = ((LocalDeclarationStatementSyntax)declaration);
+                    var ld = (LocalDeclarationStatementSyntax)declaration;
                     if (ld.Declaration.Variables.Count == 1)
                     {
                         return ld.Declaration.Variables[0].Initializer;
                     }
                     break;
                 case SyntaxKind.VariableDeclaration:
-                    var vd = ((VariableDeclarationSyntax)declaration);
+                    var vd = (VariableDeclarationSyntax)declaration;
                     if (vd.Variables.Count == 1)
                     {
                         return vd.Variables[0].Initializer;
@@ -2774,29 +2717,29 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return null;
         }
 
-        private SyntaxNode WithEqualsValue(SyntaxNode declaration, EqualsValueClauseSyntax eq)
+        private static SyntaxNode WithEqualsValue(SyntaxNode declaration, EqualsValueClauseSyntax eq)
         {
             switch (declaration.Kind())
             {
                 case SyntaxKind.FieldDeclaration:
-                    var fd = ((FieldDeclarationSyntax)declaration);
+                    var fd = (FieldDeclarationSyntax)declaration;
                     if (fd.Declaration.Variables.Count == 1)
                     {
                         return ReplaceWithTrivia(declaration, fd.Declaration.Variables[0], fd.Declaration.Variables[0].WithInitializer(eq));
                     }
                     break;
                 case SyntaxKind.PropertyDeclaration:
-                    var pd = ((PropertyDeclarationSyntax)declaration);
+                    var pd = (PropertyDeclarationSyntax)declaration;
                     return pd.WithInitializer(eq);
                 case SyntaxKind.LocalDeclarationStatement:
-                    var ld = ((LocalDeclarationStatementSyntax)declaration);
+                    var ld = (LocalDeclarationStatementSyntax)declaration;
                     if (ld.Declaration.Variables.Count == 1)
                     {
                         return ReplaceWithTrivia(declaration, ld.Declaration.Variables[0], ld.Declaration.Variables[0].WithInitializer(eq));
                     }
                     break;
                 case SyntaxKind.VariableDeclaration:
-                    var vd = ((VariableDeclarationSyntax)declaration);
+                    var vd = (VariableDeclarationSyntax)declaration;
                     if (vd.Variables.Count == 1)
                     {
                         return ReplaceWithTrivia(declaration, vd.Variables[0], vd.Variables[0].WithInitializer(eq));
@@ -2883,7 +2826,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             var newAccessors = AsAccessorList(accessors, declaration.Kind());
 
-            var currentList = this.GetAccessorList(declaration);
+            var currentList = GetAccessorList(declaration);
             if (currentList == null)
             {
                 if (CanHaveAccessors(declaration))
@@ -2897,10 +2840,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
 
             var newList = currentList.WithAccessors(currentList.Accessors.InsertRange(index, newAccessors.Accessors));
-            return this.WithAccessorList(declaration, newList);
+            return WithAccessorList(declaration, newList);
         }
 
-        private AccessorListSyntax GetAccessorList(SyntaxNode declaration)
+        private static AccessorListSyntax GetAccessorList(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -2915,7 +2858,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private bool CanHaveAccessors(SyntaxNode declaration)
+        private static bool CanHaveAccessors(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -2930,7 +2873,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxNode WithAccessorList(SyntaxNode declaration, AccessorListSyntax accessorList)
+        private static SyntaxNode WithAccessorList(SyntaxNode declaration, AccessorListSyntax accessorList)
         {
             switch (declaration.Kind())
             {
@@ -2945,13 +2888,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private AccessorListSyntax AsAccessorList(IEnumerable<SyntaxNode> nodes, SyntaxKind parentKind)
+        private static AccessorListSyntax AsAccessorList(IEnumerable<SyntaxNode> nodes, SyntaxKind parentKind)
         {
             return SyntaxFactory.AccessorList(
-                SyntaxFactory.List(nodes.Select(n => this.AsAccessor(n, parentKind)).Where(n => n != null)));
+                SyntaxFactory.List(nodes.Select(n => AsAccessor(n, parentKind)).Where(n => n != null)));
         }
 
-        private AccessorDeclarationSyntax AsAccessor(SyntaxNode node, SyntaxKind parentKind)
+        private static AccessorDeclarationSyntax AsAccessor(SyntaxNode node, SyntaxKind parentKind)
         {
             switch (parentKind)
             {
@@ -2977,7 +2920,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return null;
         }
 
-        private AccessorDeclarationSyntax GetAccessor(SyntaxNode declaration, SyntaxKind kind)
+        private static AccessorDeclarationSyntax GetAccessor(SyntaxNode declaration, SyntaxKind kind)
         {
             var accessorList = GetAccessorList(declaration);
             return accessorList?.Accessors.FirstOrDefault(a => a.IsKind(kind));
@@ -2995,11 +2938,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 var acc = accessorList.Accessors.FirstOrDefault(a => a.IsKind(kind));
                 if (acc != null)
                 {
-                    return this.ReplaceNode(declaration, acc, accessor);
+                    return ReplaceNode(declaration, acc, accessor);
                 }
                 else if (accessor != null)
                 {
-                    return this.ReplaceNode(declaration, accessorList, accessorList.AddAccessors(accessor));
+                    return ReplaceNode(declaration, accessorList, accessorList.AddAccessors(accessor));
                 }
             }
 
@@ -3020,31 +2963,31 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode WithGetAccessorStatements(SyntaxNode declaration, IEnumerable<SyntaxNode> statements)
         {
-            return this.WithAccessorStatements(declaration, SyntaxKind.GetAccessorDeclaration, statements);
+            return WithAccessorStatements(declaration, SyntaxKind.GetAccessorDeclaration, statements);
         }
 
         public override SyntaxNode WithSetAccessorStatements(SyntaxNode declaration, IEnumerable<SyntaxNode> statements)
         {
-            return this.WithAccessorStatements(declaration, SyntaxKind.SetAccessorDeclaration, statements);
+            return WithAccessorStatements(declaration, SyntaxKind.SetAccessorDeclaration, statements);
         }
 
         private SyntaxNode WithAccessorStatements(SyntaxNode declaration, SyntaxKind kind, IEnumerable<SyntaxNode> statements)
         {
-            var accessor = this.GetAccessor(declaration, kind);
+            var accessor = GetAccessor(declaration, kind);
             if (accessor == null)
             {
                 accessor = AccessorDeclaration(kind, statements);
-                return this.WithAccessor(declaration, kind, accessor);
+                return WithAccessor(declaration, kind, accessor);
             }
             else
             {
-                return this.WithAccessor(declaration, kind, (AccessorDeclarationSyntax)this.WithStatements(accessor, statements));
+                return WithAccessor(declaration, kind, (AccessorDeclarationSyntax)WithStatements(accessor, statements));
             }
         }
 
         public override IReadOnlyList<SyntaxNode> GetBaseAndInterfaceTypes(SyntaxNode declaration)
         {
-            var baseList = this.GetBaseList(declaration);
+            var baseList = GetBaseList(declaration);
             if (baseList != null)
             {
                 return baseList.Types.OfType<SimpleBaseTypeSyntax>().Select(bt => bt.Type).ToReadOnlyCollection();
@@ -3057,41 +3000,41 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode AddBaseType(SyntaxNode declaration, SyntaxNode baseType)
         {
-            var baseList = this.GetBaseList(declaration);
+            var baseList = GetBaseList(declaration);
 
             if (baseList != null)
             {
-                return this.WithBaseList(declaration, baseList.WithTypes(baseList.Types.Insert(0, SyntaxFactory.SimpleBaseType((TypeSyntax)baseType))));
+                return WithBaseList(declaration, baseList.WithTypes(baseList.Types.Insert(0, SyntaxFactory.SimpleBaseType((TypeSyntax)baseType))));
             }
             else
             {
-                return this.AddBaseList(declaration, SyntaxFactory.BaseList(SyntaxFactory.SingletonSeparatedList<BaseTypeSyntax>(SyntaxFactory.SimpleBaseType((TypeSyntax)baseType))));
+                return AddBaseList(declaration, SyntaxFactory.BaseList(SyntaxFactory.SingletonSeparatedList<BaseTypeSyntax>(SyntaxFactory.SimpleBaseType((TypeSyntax)baseType))));
             }
         }
 
         public override SyntaxNode AddInterfaceType(SyntaxNode declaration, SyntaxNode interfaceType)
         {
-            var baseList = this.GetBaseList(declaration);
+            var baseList = GetBaseList(declaration);
 
             if (baseList != null)
             {
-                return this.WithBaseList(declaration, baseList.WithTypes(baseList.Types.Insert(baseList.Types.Count, SyntaxFactory.SimpleBaseType((TypeSyntax)interfaceType))));
+                return WithBaseList(declaration, baseList.WithTypes(baseList.Types.Insert(baseList.Types.Count, SyntaxFactory.SimpleBaseType((TypeSyntax)interfaceType))));
             }
             else
             {
-                return this.AddBaseList(declaration, SyntaxFactory.BaseList(SyntaxFactory.SingletonSeparatedList<BaseTypeSyntax>(SyntaxFactory.SimpleBaseType((TypeSyntax)interfaceType))));
+                return AddBaseList(declaration, SyntaxFactory.BaseList(SyntaxFactory.SingletonSeparatedList<BaseTypeSyntax>(SyntaxFactory.SimpleBaseType((TypeSyntax)interfaceType))));
             }
         }
 
-        private SyntaxNode AddBaseList(SyntaxNode declaration, BaseListSyntax baseList)
+        private static SyntaxNode AddBaseList(SyntaxNode declaration, BaseListSyntax baseList)
         {
-            var newDecl = this.WithBaseList(declaration, baseList);
+            var newDecl = WithBaseList(declaration, baseList);
 
             // move trivia from type identifier to after base list
-            return this.ShiftTrivia(newDecl, this.GetBaseList(newDecl));
+            return ShiftTrivia(newDecl, GetBaseList(newDecl));
         }
 
-        private BaseListSyntax GetBaseList(SyntaxNode declaration)
+        private static BaseListSyntax GetBaseList(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -3106,7 +3049,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private SyntaxNode WithBaseList(SyntaxNode declaration, BaseListSyntax baseList)
+        private static SyntaxNode WithBaseList(SyntaxNode declaration, BaseListSyntax baseList)
         {
             switch (declaration.Kind())
             {
@@ -3127,17 +3070,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode ReplaceNode(SyntaxNode root, SyntaxNode declaration, SyntaxNode newDeclaration)
         {
-            newDeclaration = this.AsNodeLike(declaration, newDeclaration);
+            newDeclaration = AsNodeLike(declaration, newDeclaration);
 
             if (newDeclaration == null)
             {
-                return this.RemoveNode(root, declaration);
+                return RemoveNode(root, declaration);
             }
 
             if (root.Span.Contains(declaration.Span))
             {
-                var newFullDecl = this.AsIsolatedDeclaration(newDeclaration);
-                var fullDecl = this.GetFullDeclaration(declaration);
+                var newFullDecl = AsIsolatedDeclaration(newDeclaration);
+                var fullDecl = GetFullDeclaration(declaration);
 
                 // special handling for replacing at location of sub-declaration
                 if (fullDecl != declaration)
@@ -3145,7 +3088,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // try to replace inline if possible
                     if (fullDecl.IsKind(newFullDecl.Kind()) && GetDeclarationCount(newFullDecl) == 1)
                     {
-                        var newSubDecl = this.GetSubDeclarations(newFullDecl)[0];
+                        var newSubDecl = GetSubDeclarations(newFullDecl)[0];
                         if (AreInlineReplaceableSubDeclarations(declaration, newSubDecl))
                         {
                             return base.ReplaceNode(root, declaration, newSubDecl);
@@ -3153,10 +3096,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     }
 
                     // replace sub declaration by splitting full declaration and inserting between
-                    var index = IndexOf(this.GetSubDeclarations(fullDecl), declaration);
+                    var index = IndexOf(GetSubDeclarations(fullDecl), declaration);
 
                     // replace declaration with multiple declarations
-                    return ReplaceRange(root, fullDecl, this.SplitAndReplace(fullDecl, index, new[] { newDeclaration }));
+                    return ReplaceRange(root, fullDecl, SplitAndReplace(fullDecl, index, new[] { newDeclaration }));
                 }
 
                 // attempt normal replace
@@ -3169,7 +3112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         }
 
         // returns true if one sub-declaration can be replaced inline with another sub-declaration
-        private bool AreInlineReplaceableSubDeclarations(SyntaxNode decl1, SyntaxNode decl2)
+        private static bool AreInlineReplaceableSubDeclarations(SyntaxNode decl1, SyntaxNode decl2)
         {
             var kind = decl1.Kind();
             if (decl2.IsKind(kind))
@@ -3185,7 +3128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return false;
         }
 
-        private bool AreSimilarExceptForSubDeclarations(SyntaxNode decl1, SyntaxNode decl2)
+        private static bool AreSimilarExceptForSubDeclarations(SyntaxNode decl1, SyntaxNode decl2)
         {
             if (decl1 == decl2)
             {
@@ -3245,7 +3188,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 if (index > 0)
                 {
                     // make a single declaration with only sub-declarations before the sub-declaration being replaced
-                    newNodes.Add(this.WithSubDeclarationsRemoved(multiPartDeclaration, index, count - index).WithTrailingTrivia(SyntaxFactory.ElasticSpace));
+                    newNodes.Add(WithSubDeclarationsRemoved(multiPartDeclaration, index, count - index).WithTrailingTrivia(SyntaxFactory.ElasticSpace));
                 }
 
                 newNodes.AddRange(newDeclarations);
@@ -3253,7 +3196,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 if (index < count - 1)
                 {
                     // make a single declaration with only the sub-declarations after the sub-declaration being replaced
-                    newNodes.Add(this.WithSubDeclarationsRemoved(multiPartDeclaration, 0, index + 1).WithLeadingTrivia(SyntaxFactory.ElasticSpace));
+                    newNodes.Add(WithSubDeclarationsRemoved(multiPartDeclaration, 0, index + 1).WithLeadingTrivia(SyntaxFactory.ElasticSpace));
                 }
 
                 return newNodes;
@@ -3278,20 +3221,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode InsertNodesBeforeInternal(SyntaxNode root, SyntaxNode declaration, IEnumerable<SyntaxNode> newDeclarations)
         {
-            var fullDecl = this.GetFullDeclaration(declaration);
+            var fullDecl = GetFullDeclaration(declaration);
             if (fullDecl == declaration || GetDeclarationCount(fullDecl) == 1)
             {
                 return base.InsertNodesBefore(root, fullDecl, newDeclarations);
             }
 
-            var subDecls = this.GetSubDeclarations(fullDecl);
-            var count = subDecls.Count;
+            var subDecls = GetSubDeclarations(fullDecl);
             var index = IndexOf(subDecls, declaration);
 
             // insert new declaration between full declaration split into two
             if (index > 0)
             {
-                return ReplaceRange(root, fullDecl, this.SplitAndInsert(fullDecl, index, newDeclarations));
+                return ReplaceRange(root, fullDecl, SplitAndInsert(fullDecl, index, newDeclarations));
             }
 
             return base.InsertNodesBefore(root, fullDecl, newDeclarations);
@@ -3311,20 +3253,20 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode InsertNodesAfterInternal(SyntaxNode root, SyntaxNode declaration, IEnumerable<SyntaxNode> newDeclarations)
         {
-            var fullDecl = this.GetFullDeclaration(declaration);
+            var fullDecl = GetFullDeclaration(declaration);
             if (fullDecl == declaration || GetDeclarationCount(fullDecl) == 1)
             {
                 return base.InsertNodesAfter(root, fullDecl, newDeclarations);
             }
 
-            var subDecls = this.GetSubDeclarations(fullDecl);
+            var subDecls = GetSubDeclarations(fullDecl);
             var count = subDecls.Count;
             var index = IndexOf(subDecls, declaration);
 
             // insert new declaration between full declaration split into two
             if (index >= 0 && index < count - 1)
             {
-                return ReplaceRange(root, fullDecl, this.SplitAndInsert(fullDecl, index + 1, newDeclarations));
+                return ReplaceRange(root, fullDecl, SplitAndInsert(fullDecl, index + 1, newDeclarations));
             }
 
             return base.InsertNodesAfter(root, fullDecl, newDeclarations);
@@ -3334,18 +3276,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             int count = GetDeclarationCount(multiPartDeclaration);
             var newNodes = new List<SyntaxNode>();
-            newNodes.Add(this.WithSubDeclarationsRemoved(multiPartDeclaration, index, count - index).WithTrailingTrivia(SyntaxFactory.ElasticSpace));
+            newNodes.Add(WithSubDeclarationsRemoved(multiPartDeclaration, index, count - index).WithTrailingTrivia(SyntaxFactory.ElasticSpace));
             newNodes.AddRange(newDeclarations);
-            newNodes.Add(this.WithSubDeclarationsRemoved(multiPartDeclaration, 0, index).WithLeadingTrivia(SyntaxFactory.ElasticSpace));
+            newNodes.Add(WithSubDeclarationsRemoved(multiPartDeclaration, 0, index).WithLeadingTrivia(SyntaxFactory.ElasticSpace));
             return newNodes;
         }
 
         private SyntaxNode WithSubDeclarationsRemoved(SyntaxNode declaration, int index, int count)
         {
-            return this.RemoveNodes(declaration, this.GetSubDeclarations(declaration).Skip(index).Take(count));
+            return RemoveNodes(declaration, GetSubDeclarations(declaration).Skip(index).Take(count));
         }
 
-        private IReadOnlyList<SyntaxNode> GetSubDeclarations(SyntaxNode declaration)
+        private static IReadOnlyList<SyntaxNode> GetSubDeclarations(SyntaxNode declaration)
         {
             switch (declaration.Kind())
             {
@@ -3374,7 +3316,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             if (root.Span.Contains(node.Span))
             {
                 // node exists within normal span of the root (not in trivia)
-                return this.Isolate(root.TrackNodes(node), r => RemoveNodeInternal(r, r.GetCurrentNode(node), options));
+                return Isolate(root.TrackNodes(node), r => RemoveNodeInternal(r, r.GetCurrentNode(node), options));
             }
             else
             {
@@ -3392,7 +3334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     if (attrList != null && attrList.Attributes.Count == 1)
                     {
                         // remove entire list if only one attribute
-                        return this.RemoveNodeInternal(root, attrList, options);
+                        return RemoveNodeInternal(root, attrList, options);
                     }
                     break;
 
@@ -3400,16 +3342,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     if (declaration.Parent != null && ((AttributeArgumentListSyntax)declaration.Parent).Arguments.Count == 1)
                     {
                         // remove entire argument list if only one argument
-                        return this.RemoveNodeInternal(root, declaration.Parent, options);
+                        return RemoveNodeInternal(root, declaration.Parent, options);
                     }
                     break;
 
                 case SyntaxKind.VariableDeclarator:
-                    var full = this.GetFullDeclaration(declaration);
+                    var full = GetFullDeclaration(declaration);
                     if (full != declaration && GetDeclarationCount(full) == 1)
                     {
                         // remove full declaration if only one declarator
-                        return this.RemoveNodeInternal(root, full, options);
+                        return RemoveNodeInternal(root, full, options);
                     }
                     break;
 
@@ -3418,7 +3360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     if (baseList != null && baseList.Types.Count == 1)
                     {
                         // remove entire base list if this is the only base type.
-                        return this.RemoveNodeInternal(root, baseList, options);
+                        return RemoveNodeInternal(root, baseList, options);
                     }
                     break;
 
@@ -3441,7 +3383,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         /// <summary>
         /// Moves the trailing trivia from the node's previous token to the end of the node
         /// </summary>
-        private SyntaxNode ShiftTrivia(SyntaxNode root, SyntaxNode node)
+        private static SyntaxNode ShiftTrivia(SyntaxNode root, SyntaxNode node)
         {
             var firstToken = node.GetFirstToken();
             var previousToken = firstToken.GetPreviousToken();
@@ -3523,22 +3465,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private BlockSyntax CreateBlock(IEnumerable<SyntaxNode> statements)
+        private static BlockSyntax CreateBlock(IEnumerable<SyntaxNode> statements)
             => SyntaxFactory.Block(AsStatementList(statements)).WithAdditionalAnnotations(Simplifier.Annotation);
 
-        private SyntaxList<StatementSyntax> AsStatementList(IEnumerable<SyntaxNode> nodes)
+        private static SyntaxList<StatementSyntax> AsStatementList(IEnumerable<SyntaxNode> nodes)
         {
-            if (nodes == null)
-            {
-                return default(SyntaxList<StatementSyntax>);
-            }
-            else
-            {
-                return SyntaxFactory.List(nodes.Select(AsStatement));
-            }
+            return nodes == null ? default(SyntaxList<StatementSyntax>) : SyntaxFactory.List(nodes.Select(AsStatement));
         }
 
-        private StatementSyntax AsStatement(SyntaxNode node)
+        private static StatementSyntax AsStatement(SyntaxNode node)
         {
             var expression = node as ExpressionSyntax;
             if (expression != null)
@@ -3572,7 +3507,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         /// <summary>
         /// Parenthesize the left hand size of a member access, invocation or element access expression
         /// </summary>
-        private ExpressionSyntax ParenthesizeLeft(ExpressionSyntax expression)
+        private static ExpressionSyntax ParenthesizeLeft(ExpressionSyntax expression)
         {
             if (expression is TypeSyntax ||
                 expression.IsKind(SyntaxKind.ThisExpression) ||
@@ -3586,10 +3521,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 return expression;
             }
 
-            return this.Parenthesize(expression);
+            return Parenthesize(expression);
         }
 
-        private SeparatedSyntaxList<ExpressionSyntax> AsExpressionList(IEnumerable<SyntaxNode> expressions)
+        private static SeparatedSyntaxList<ExpressionSyntax> AsExpressionList(IEnumerable<SyntaxNode> expressions)
         {
             return SyntaxFactory.SeparatedList(expressions.OfType<ExpressionSyntax>());
         }
@@ -3612,27 +3547,20 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return SyntaxFactory.ObjectCreationExpression((TypeSyntax)type, CreateArgumentList(arguments), null);
         }
 
-        private ArgumentListSyntax CreateArgumentList(IEnumerable<SyntaxNode> arguments)
+        private static ArgumentListSyntax CreateArgumentList(IEnumerable<SyntaxNode> arguments)
         {
             return SyntaxFactory.ArgumentList(CreateArguments(arguments));
         }
 
-        private SeparatedSyntaxList<ArgumentSyntax> CreateArguments(IEnumerable<SyntaxNode> arguments)
+        private static SeparatedSyntaxList<ArgumentSyntax> CreateArguments(IEnumerable<SyntaxNode> arguments)
         {
-            return SyntaxFactory.SeparatedList(arguments.Select(AsArgument).Cast<ArgumentSyntax>());
+            return SyntaxFactory.SeparatedList(arguments.Select(AsArgument));
         }
 
-        private ArgumentSyntax AsArgument(SyntaxNode argOrExpression)
+        private static ArgumentSyntax AsArgument(SyntaxNode argOrExpression)
         {
             var arg = argOrExpression as ArgumentSyntax;
-            if (arg != null)
-            {
-                return arg;
-            }
-            else
-            {
-                return SyntaxFactory.Argument((ExpressionSyntax)argOrExpression);
-            }
+            return arg ?? SyntaxFactory.Argument((ExpressionSyntax)argOrExpression);
         }
 
         public override SyntaxNode InvocationExpression(SyntaxNode expression, IEnumerable<SyntaxNode> arguments)
@@ -3704,7 +3632,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return SyntaxFactory.DefaultExpression(type.GenerateTypeSyntax());
         }
 
-        private ExpressionSyntax Parenthesize(SyntaxNode expression)
+        private static ExpressionSyntax Parenthesize(SyntaxNode expression)
         {
             return ((ExpressionSyntax)expression).Parenthesize();
         }
@@ -3737,7 +3665,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         public override SyntaxNode AssignmentStatement(SyntaxNode left, SyntaxNode right)
             => SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, (ExpressionSyntax)left, Parenthesize(right));
 
-        private SyntaxNode CreateBinaryExpression(SyntaxKind syntaxKind, SyntaxNode left, SyntaxNode right)
+        private static SyntaxNode CreateBinaryExpression(SyntaxKind syntaxKind, SyntaxNode left, SyntaxNode right)
         {
             return SyntaxFactory.BinaryExpression(syntaxKind, Parenthesize(left), Parenthesize(right));
         }
@@ -3992,10 +3920,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             return SyntaxFactory.LocalDeclarationStatement(
                 isConst ? SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.ConstKeyword)) : default(SyntaxTokenList),
-                this.VariableDeclaration(type, name, initializer));
+                VariableDeclaration(type, name, initializer));
         }
 
-        private VariableDeclarationSyntax VariableDeclaration(SyntaxNode type, string name, SyntaxNode expression = null)
+        private static VariableDeclarationSyntax VariableDeclaration(SyntaxNode type, string name, SyntaxNode expression = null)
         {
             return SyntaxFactory.VariableDeclaration(
                 type == null ? SyntaxFactory.IdentifierName("var") : (TypeSyntax)type,
@@ -4074,7 +4002,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return SyntaxFactory.SwitchSection(SyntaxFactory.SingletonList(SyntaxFactory.DefaultSwitchLabel() as SwitchLabelSyntax), AsStatementList(statements));
         }
 
-        private SyntaxList<SwitchLabelSyntax> AsSwitchLabels(IEnumerable<SyntaxNode> expressions)
+        private static SyntaxList<SwitchLabelSyntax> AsSwitchLabels(IEnumerable<SyntaxNode> expressions)
         {
             var labels = default(SyntaxList<SwitchLabelSyntax>);
 
@@ -4105,7 +4033,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
         }
 
-        private bool IsSimpleLambdaParameter(SyntaxNode node)
+        private static bool IsSimpleLambdaParameter(SyntaxNode node)
         {
             var p = node as ParameterSyntax;
             return p != null && p.Type == null && p.Default == null && p.Modifiers.Count == 0;
@@ -4131,16 +4059,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return ParameterDeclaration(identifier, type, null, RefKind.None);
         }
 
-        private IReadOnlyList<T> AsReadOnlyList<T>(IEnumerable<T> sequence)
+        private static IReadOnlyList<T> AsReadOnlyList<T>(IEnumerable<T> sequence)
         {
-            var list = sequence as IReadOnlyList<T>;
-
-            if (list == null)
-            {
-                list = sequence.ToImmutableReadOnlyListOrEmpty();
-            }
-
-            return list;
+            return sequence as IReadOnlyList<T> ?? sequence.ToImmutableReadOnlyListOrEmpty();
         }
 
         internal override SyntaxNode IdentifierName(SyntaxToken identifier)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -32,14 +32,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         public override SyntaxNode CompilationUnit(IEnumerable<SyntaxNode> declarations)
         {
             return SyntaxFactory.CompilationUnit()
-                .WithUsings(AsUsingDirectives(declarations))
+                .WithUsings(this.AsUsingDirectives(declarations))
                 .WithMembers(AsNamespaceMembers(declarations));
         }
 
         private SyntaxList<UsingDirectiveSyntax> AsUsingDirectives(IEnumerable<SyntaxNode> declarations)
         {
             return declarations != null
-                ? SyntaxFactory.List(declarations.Select(AsUsingDirective).OfType<UsingDirectiveSyntax>())
+                ? SyntaxFactory.List(declarations.Select(this.AsUsingDirective).OfType<UsingDirectiveSyntax>())
                 : default(SyntaxList<UsingDirectiveSyntax>);
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             var name = node as NameSyntax;
             if (name != null)
             {
-                return NamespaceImportDeclaration(name);
+                return this.NamespaceImportDeclaration(name);
             }
 
             return node as UsingDirectiveSyntax;
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return SyntaxFactory.NamespaceDeclaration(
                 (NameSyntax)name,
                 default(SyntaxList<ExternAliasDirectiveSyntax>),
-                AsUsingDirectives(declarations),
+                this.AsUsingDirectives(declarations),
                 AsNamespaceMembers(declarations));
         }
 
@@ -428,11 +428,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             // C# interface implementations are implicit/not-specified -- so they are just named the name as the interface member
             return PreserveTrivia(declaration, d =>
             {
-                d = AsImplementation(d, Accessibility.Public);
+                d = this.AsImplementation(d, Accessibility.Public);
 
                 if (interfaceMemberName != null)
                 {
-                    d = WithName(d, interfaceMemberName);
+                    d = this.WithName(d, interfaceMemberName);
                 }
 
                 return WithInterfaceSpecifier(d, null);
@@ -443,12 +443,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             return PreserveTrivia(declaration, d =>
             {
-                d = AsImplementation(d, Accessibility.NotApplicable);
-                d = WithoutConstraints(d);
+                d = this.AsImplementation(d, Accessibility.NotApplicable);
+                d = this.WithoutConstraints(d);
 
                 if (interfaceMemberName != null)
                 {
-                    d = WithName(d, interfaceMemberName);
+                    d = this.WithName(d, interfaceMemberName);
                 }
 
                 return WithInterfaceSpecifier(d, SyntaxFactory.ExplicitInterfaceSpecifier((NameSyntax)interfaceTypeName));
@@ -462,7 +462,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 var method = (MethodDeclarationSyntax)declaration;
                 if (method.ConstraintClauses.Count > 0)
                 {
-                    return RemoveNodes(method, method.ConstraintClauses);
+                    return this.RemoveNodes(method, method.ConstraintClauses);
                 }
             }
 
@@ -488,8 +488,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode AsImplementation(SyntaxNode declaration, Accessibility requiredAccess)
         {
-            declaration = WithAccessibility(declaration, requiredAccess);
-            declaration = WithModifiers(declaration, GetModifiers(declaration) - DeclarationModifiers.Abstract);
+            declaration = this.WithAccessibility(declaration, requiredAccess);
+            declaration = this.WithModifiers(declaration, this.GetModifiers(declaration) - DeclarationModifiers.Abstract);
             declaration = WithBodies(declaration);
             return declaration;
         }
@@ -523,7 +523,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private static AccessorListSyntax WithBodies(AccessorListSyntax accessorList)
         {
-            return accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(WithBody)));
+            return accessorList.WithAccessors(SyntaxFactory.List(accessorList.Accessors.Select(x => WithBody(x))));
         }
 
         private static AccessorDeclarationSyntax WithBody(AccessorDeclarationSyntax accessor)
@@ -585,13 +585,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 AsTypeParameterList(typeParameters),
                 baseTypes != null ? SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(baseTypes)) : null,
                 default(SyntaxList<TypeParameterConstraintClauseSyntax>),
-                AsClassMembers(name, members));
+                this.AsClassMembers(name, members));
         }
 
         private SyntaxList<MemberDeclarationSyntax> AsClassMembers(string className, IEnumerable<SyntaxNode> members)
         {
             return members != null
-                ? SyntaxFactory.List(members.Select(m => AsClassMember(m, className)).Where(m => m != null))
+                ? SyntaxFactory.List(members.Select(m => this.AsClassMember(m, className)).Where(m => m != null))
                 : default(SyntaxList<MemberDeclarationSyntax>);
         }
 
@@ -605,7 +605,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
                 case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.VariableDeclarator:
-                    node = AsIsolatedDeclaration(node);
+                    node = this.AsIsolatedDeclaration(node);
                     break;
             }
 
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 AsTypeParameterList(typeParameters),
                 itypes != null ? SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(itypes)) : null,
                 default(SyntaxList<TypeParameterConstraintClauseSyntax>),
-                AsClassMembers(name, members));
+                this.AsClassMembers(name, members));
         }
 
         public override SyntaxNode InterfaceDeclaration(
@@ -656,19 +656,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 AsTypeParameterList(typeParameters),
                 itypes != null ? SyntaxFactory.BaseList(SyntaxFactory.SeparatedList(itypes)) : null,
                 default(SyntaxList<TypeParameterConstraintClauseSyntax>),
-                AsInterfaceMembers(members));
+                this.AsInterfaceMembers(members));
         }
 
         private SyntaxList<MemberDeclarationSyntax> AsInterfaceMembers(IEnumerable<SyntaxNode> members)
         {
             return members != null
-                ? SyntaxFactory.List(members.Select(AsInterfaceMember).OfType<MemberDeclarationSyntax>())
+                ? SyntaxFactory.List(members.Select(this.AsInterfaceMember).OfType<MemberDeclarationSyntax>())
                 : default(SyntaxList<MemberDeclarationSyntax>);
         }
 
         internal override SyntaxNode AsInterfaceMember(SyntaxNode m)
         {
-            return Isolate(m, member =>
+            return this.Isolate(m, member =>
             {
                 Accessibility acc;
                 DeclarationModifiers modifiers;
@@ -696,7 +696,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     // convert event into field event
                     case SyntaxKind.EventDeclaration:
                         var ev = (EventDeclarationSyntax)member;
-                        return EventDeclaration(
+                        return this.EventDeclaration(
                             ev.Identifier.ValueText,
                             ev.Type,
                             Accessibility.NotApplicable,
@@ -710,8 +710,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     case SyntaxKind.FieldDeclaration:
                         var f = (FieldDeclarationSyntax)member;
                         GetAccessibilityAndModifiers(f.Modifiers, out acc, out modifiers);
-                        return AsInterfaceMember(
-                            PropertyDeclaration(GetName(f), ClearTrivia(GetType(f)), acc, modifiers, getAccessorStatements: null, setAccessorStatements: null));
+                        return this.AsInterfaceMember(
+                            this.PropertyDeclaration(this.GetName(f), this.ClearTrivia(this.GetType(f)), acc, modifiers, getAccessorStatements: null, setAccessorStatements: null));
 
                     default:
                         return null;
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 AsModifierList(accessibility, modifiers, SyntaxKind.EnumDeclaration),
                 name.ToIdentifierToken(),
                 default(BaseListSyntax),
-                AsEnumMembers(members));
+                this.AsEnumMembers(members));
         }
 
         public override SyntaxNode EnumMember(string name, SyntaxNode expression)
@@ -747,14 +747,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             {
                 case SyntaxKind.IdentifierName:
                     var id = (IdentifierNameSyntax)node;
-                    return (EnumMemberDeclarationSyntax)EnumMember(id.Identifier.ToString(), null);
+                    return (EnumMemberDeclarationSyntax) this.EnumMember(id.Identifier.ToString(), null);
 
                 case SyntaxKind.FieldDeclaration:
                     var fd = (FieldDeclarationSyntax)node;
                     if (fd.Declaration.Variables.Count == 1)
                     {
                         var vd = fd.Declaration.Variables[0];
-                        return (EnumMemberDeclarationSyntax)EnumMember(vd.Identifier.ToString(), vd.Initializer);
+                        return (EnumMemberDeclarationSyntax) this.EnumMember(vd.Identifier.ToString(), vd.Initializer);
                     }
                     break;
             }
@@ -764,7 +764,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SeparatedSyntaxList<EnumMemberDeclarationSyntax> AsEnumMembers(IEnumerable<SyntaxNode> members)
         {
-            return members != null ? SyntaxFactory.SeparatedList(members.Select(AsEnumMember)) : default(SeparatedSyntaxList<EnumMemberDeclarationSyntax>);
+            return members != null ? SyntaxFactory.SeparatedList(members.Select(this.AsEnumMember)) : default(SeparatedSyntaxList<EnumMemberDeclarationSyntax>);
         }
 
         public override SyntaxNode DelegateDeclaration(
@@ -899,21 +899,21 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertAttributes(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributes)
         {
-            return Isolate(declaration, d => InsertAttributesInternal(d, index, attributes));
+            return this.Isolate(declaration, d => this.InsertAttributesInternal(d, index, attributes));
         }
 
         private SyntaxNode InsertAttributesInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributes)
         {
             var newAttributes = AsAttributeLists(attributes);
 
-            var existingAttributes = GetAttributes(declaration);
+            var existingAttributes = this.GetAttributes(declaration);
             if (index >= 0 && index < existingAttributes.Count)
             {
-                return InsertNodesBefore(declaration, existingAttributes[index], newAttributes);
+                return this.InsertNodesBefore(declaration, existingAttributes[index], newAttributes);
             }
             else if (existingAttributes.Count > 0)
             {
-                return InsertNodesAfter(declaration, existingAttributes[existingAttributes.Count - 1], newAttributes);
+                return this.InsertNodesAfter(declaration, existingAttributes[existingAttributes.Count - 1], newAttributes);
             }
             else
             {
@@ -931,7 +931,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case SyntaxKind.OperatorDeclaration:
                 case SyntaxKind.ConversionOperatorDeclaration:
                 case SyntaxKind.DelegateDeclaration:
-                    return Isolate(declaration, d => InsertReturnAttributesInternal(d, index, attributes));
+                    return this.Isolate(declaration, d => this.InsertReturnAttributesInternal(d, index, attributes));
                 default:
                     return declaration;
             }
@@ -941,14 +941,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             var newAttributes = AsReturnAttributes(attributes);
 
-            var existingAttributes = GetReturnAttributes(d);
+            var existingAttributes = this.GetReturnAttributes(d);
             if (index >= 0 && index < existingAttributes.Count)
             {
-                return InsertNodesBefore(d, existingAttributes[index], newAttributes);
+                return this.InsertNodesBefore(d, existingAttributes[index], newAttributes);
             }
             else if (existingAttributes.Count > 0)
             {
-                return InsertNodesAfter(d, existingAttributes[existingAttributes.Count - 1], newAttributes);
+                return this.InsertNodesAfter(d, existingAttributes[existingAttributes.Count - 1], newAttributes);
             }
             else
             {
@@ -978,7 +978,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     var list = (AttributeListSyntax)attributeDeclaration;
                     if (list.Attributes.Count == 1)
                     {
-                        return GetAttributeArguments(list.Attributes[0]);
+                        return this.GetAttributeArguments(list.Attributes[0]);
                     }
                     break;
                 case SyntaxKind.Attribute:
@@ -995,7 +995,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertAttributeArguments(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributeArguments)
         {
-            return Isolate(declaration, d => InsertAttributeArgumentsInternal(d, index, attributeArguments));
+            return this.Isolate(declaration, d => InsertAttributeArgumentsInternal(d, index, attributeArguments));
         }
 
         private static SyntaxNode InsertAttributeArgumentsInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> attributeArguments)
@@ -1170,12 +1170,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertNamespaceImports(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> imports)
         {
-            return PreserveTrivia(declaration, d => InsertNamespaceImportsInternal(d, index, imports));
+            return PreserveTrivia(declaration, d => this.InsertNamespaceImportsInternal(d, index, imports));
         }
 
         private SyntaxNode InsertNamespaceImportsInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> imports)
         {
-            SyntaxList<UsingDirectiveSyntax> usingsToInsert = AsUsingDirectives(imports);
+            SyntaxList<UsingDirectiveSyntax> usingsToInsert = this.AsUsingDirectives(imports);
 
             switch (declaration.Kind())
             {
@@ -1294,16 +1294,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertMembers(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> members)
         {
-            var newMembers = AsMembersOf(declaration, members);
+            var newMembers = this.AsMembersOf(declaration, members);
 
-            var existingMembers = GetMembers(declaration);
+            var existingMembers = this.GetMembers(declaration);
             if (index >= 0 && index < existingMembers.Count)
             {
-                return InsertNodesBefore(declaration, existingMembers[index], newMembers);
+                return this.InsertNodesBefore(declaration, existingMembers[index], newMembers);
             }
             else if (existingMembers.Count > 0)
             {
-                return InsertNodesAfter(declaration, existingMembers[existingMembers.Count - 1], newMembers);
+                return this.InsertNodesAfter(declaration, existingMembers[existingMembers.Count - 1], newMembers);
             }
             else
             {
@@ -1335,7 +1335,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private IEnumerable<MemberDeclarationSyntax> AsMembersOf(SyntaxNode declaration, IEnumerable<SyntaxNode> members)
         {
-            return members?.Select(m => AsMemberOf(declaration, m)).OfType<MemberDeclarationSyntax>();
+            return members?.Select(m => this.AsMemberOf(declaration, m)).OfType<MemberDeclarationSyntax>();
         }
 
         private SyntaxNode AsMemberOf(SyntaxNode declaration, SyntaxNode member)
@@ -1344,14 +1344,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             {
                 case SyntaxKind.ClassDeclaration:
                     var cd = (ClassDeclarationSyntax)declaration;
-                    return AsClassMember(member, cd.Identifier.Text);
+                    return this.AsClassMember(member, cd.Identifier.Text);
                 case SyntaxKind.StructDeclaration:
                     var sd = (StructDeclarationSyntax)declaration;
-                    return AsClassMember(member, sd.Identifier.Text);
+                    return this.AsClassMember(member, sd.Identifier.Text);
                 case SyntaxKind.InterfaceDeclaration:
-                    return AsInterfaceMember(member);
+                    return this.AsInterfaceMember(member);
                 case SyntaxKind.EnumDeclaration:
-                    return AsEnumMember(member);
+                    return this.AsEnumMember(member);
                 case SyntaxKind.NamespaceDeclaration:
                     return AsNamespaceMember(member);
                 case SyntaxKind.CompilationUnit:
@@ -1386,7 +1386,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     return true;
                 case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.VariableDeclarator:
-                    return GetDeclarationKind(declaration) == DeclarationKind.Field;
+                    return this.GetDeclarationKind(declaration) == DeclarationKind.Field;
                 case SyntaxKind.EnumMemberDeclaration:
                 case SyntaxKind.Parameter:
                 case SyntaxKind.LocalDeclarationStatement:
@@ -1398,7 +1398,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override Accessibility GetAccessibility(SyntaxNode declaration)
         {
-            if (!CanHaveAccessibility(declaration))
+            if (!this.CanHaveAccessibility(declaration))
             {
                 return Accessibility.NotApplicable;
             }
@@ -1410,12 +1410,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode WithAccessibility(SyntaxNode declaration, Accessibility accessibility)
         {
-            if (!CanHaveAccessibility(declaration))
+            if (!this.CanHaveAccessibility(declaration))
             {
                 return declaration;
             }
 
-            return Isolate(declaration, d =>
+            return this.Isolate(declaration, d =>
             {
                 var tokens = GetModifierTokens(d);
                 GetAccessibilityAndModifiers(tokens, out var tmp, out var modifiers);
@@ -1502,17 +1502,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode WithModifiers(SyntaxNode declaration, DeclarationModifiers modifiers)
         {
-            return Isolate(declaration, d => WithModifiersInternal(d, modifiers));
+            return this.Isolate(declaration, d => this.WithModifiersInternal(d, modifiers));
         }
 
         private SyntaxNode WithModifiersInternal(SyntaxNode declaration, DeclarationModifiers modifiers)
         {
             modifiers = modifiers & GetAllowedModifiers(declaration.Kind());
-            var existingModifiers = GetModifiers(declaration);
+            var existingModifiers = this.GetModifiers(declaration);
 
             if (modifiers != existingModifiers)
             {
-                return Isolate(declaration, d =>
+                return this.Isolate(declaration, d =>
                 {
                     var tokens = GetModifierTokens(d);
                     GetAccessibilityAndModifiers(tokens, out var accessibility, out var tmp);
@@ -2105,13 +2105,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case SyntaxKind.MethodDeclaration:
                     return ((MethodDeclarationSyntax)declaration).Identifier.ValueText;
                 case SyntaxKind.FieldDeclaration:
-                    return GetName(((FieldDeclarationSyntax)declaration).Declaration);
+                    return this.GetName(((FieldDeclarationSyntax)declaration).Declaration);
                 case SyntaxKind.PropertyDeclaration:
                     return ((PropertyDeclarationSyntax)declaration).Identifier.ValueText;
                 case SyntaxKind.EnumMemberDeclaration:
                     return ((EnumMemberDeclarationSyntax)declaration).Identifier.ValueText;
                 case SyntaxKind.EventFieldDeclaration:
-                    return GetName(((EventFieldDeclarationSyntax)declaration).Declaration);
+                    return this.GetName(((EventFieldDeclarationSyntax)declaration).Declaration);
                 case SyntaxKind.EventDeclaration:
                     return ((EventDeclarationSyntax)declaration).Identifier.ValueText;
                 case SyntaxKind.NamespaceDeclaration:
@@ -2121,7 +2121,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case SyntaxKind.Parameter:
                     return ((ParameterSyntax)declaration).Identifier.ValueText;
                 case SyntaxKind.LocalDeclarationStatement:
-                    return GetName(((LocalDeclarationStatementSyntax)declaration).Declaration);
+                    return this.GetName(((LocalDeclarationStatementSyntax)declaration).Declaration);
                 case SyntaxKind.VariableDeclaration:
                     var vd = (VariableDeclarationSyntax)declaration;
                     if (vd.Variables.Count == 1)
@@ -2149,7 +2149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode WithName(SyntaxNode declaration, string name)
         {
-            return Isolate(declaration, d => WithNameInternal(d, name));
+            return this.Isolate(declaration, d => this.WithNameInternal(d, name));
         }
 
         private SyntaxNode WithNameInternal(SyntaxNode declaration, string name)
@@ -2191,9 +2191,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case SyntaxKind.EventDeclaration:
                     return ReplaceWithTrivia(declaration, ((EventDeclarationSyntax)declaration).Identifier, id);
                 case SyntaxKind.NamespaceDeclaration:
-                    return ReplaceWithTrivia(declaration, ((NamespaceDeclarationSyntax)declaration).Name, DottedName(name));
+                    return ReplaceWithTrivia(declaration, ((NamespaceDeclarationSyntax)declaration).Name, this.DottedName(name));
                 case SyntaxKind.UsingDirective:
-                    return ReplaceWithTrivia(declaration, ((UsingDirectiveSyntax)declaration).Name, DottedName(name));
+                    return ReplaceWithTrivia(declaration, ((UsingDirectiveSyntax)declaration).Name, this.DottedName(name));
                 case SyntaxKind.Parameter:
                     return ReplaceWithTrivia(declaration, ((ParameterSyntax)declaration).Identifier, id);
                 case SyntaxKind.LocalDeclarationStatement:
@@ -2209,11 +2209,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     var al = (AttributeListSyntax)declaration;
                     if (al.Attributes.Count == 1)
                     {
-                        return ReplaceWithTrivia(declaration, al.Attributes[0].Name, DottedName(name));
+                        return ReplaceWithTrivia(declaration, al.Attributes[0].Name, this.DottedName(name));
                     }
                     break;
                 case SyntaxKind.Attribute:
-                    return ReplaceWithTrivia(declaration, ((AttributeSyntax)declaration).Name, DottedName(name));
+                    return ReplaceWithTrivia(declaration, ((AttributeSyntax)declaration).Name, this.DottedName(name));
                 case SyntaxKind.VariableDeclaration:
                     var vd = (VariableDeclarationSyntax)declaration;
                     if (vd.Variables.Count == 1)
@@ -2255,7 +2255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case SyntaxKind.VariableDeclarator:
                     if (declaration.Parent != null)
                     {
-                        return GetType(declaration.Parent);
+                        return this.GetType(declaration.Parent);
                     }
                     break;
             }
@@ -2271,7 +2271,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode WithType(SyntaxNode declaration, SyntaxNode type)
         {
-            return Isolate(declaration, d => WithTypeInternal(d, type));
+            return this.Isolate(declaration, d => WithTypeInternal(d, type));
         }
 
         private static SyntaxNode WithTypeInternal(SyntaxNode declaration, SyntaxNode type)
@@ -2305,7 +2305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode Isolate(SyntaxNode declaration, Func<SyntaxNode, SyntaxNode> editor)
         {
-            var isolated = AsIsolatedDeclaration(declaration);
+            var isolated = this.AsIsolatedDeclaration(declaration);
 
             return PreserveTrivia(isolated, editor);
         }
@@ -2320,7 +2320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                         var vd = (VariableDeclarationSyntax)declaration;
                         if (vd.Parent != null && vd.Variables.Count == 1)
                         {
-                            return AsIsolatedDeclaration(vd.Parent);
+                            return this.AsIsolatedDeclaration(vd.Parent);
                         }
                         break;
 
@@ -2328,7 +2328,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                         var v = (VariableDeclaratorSyntax)declaration;
                         if (v.Parent != null && v.Parent.Parent != null)
                         {
-                            return ClearTrivia(WithVariable(v.Parent.Parent, v));
+                            return this.ClearTrivia(WithVariable(v.Parent.Parent, v));
                         }
                         break;
 
@@ -2418,7 +2418,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode AsNodeLike(SyntaxNode existingNode, SyntaxNode newNode)
         {
-            switch (GetDeclarationKind(existingNode))
+            switch (this.GetDeclarationKind(existingNode))
             {
                 case DeclarationKind.Class:
                 case DeclarationKind.Interface:
@@ -2426,10 +2426,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 case DeclarationKind.Enum:
                 case DeclarationKind.Namespace:
                 case DeclarationKind.CompilationUnit:
-                    var container = GetDeclaration(existingNode.Parent);
+                    var container = this.GetDeclaration(existingNode.Parent);
                     if (container != null)
                     {
-                        return AsMemberOf(container, newNode);
+                        return this.AsMemberOf(container, newNode);
                     }
                     break;
 
@@ -2501,17 +2501,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             public AddMissingTokensRewriter(bool recurse)
             {
-                _recurse = recurse;
+                this._recurse = recurse;
             }
 
             public override SyntaxNode Visit(SyntaxNode node)
             {
-                if (!_recurse && !_firstVisit)
+                if (!this._recurse && !this._firstVisit)
                 {
                     return node;
                 }
 
-                _firstVisit = false;
+                this._firstVisit = false;
                 return base.Visit(node);
             }
 
@@ -2624,7 +2624,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode WithExpression(SyntaxNode declaration, SyntaxNode expression)
         {
-            return Isolate(declaration, d => WithExpressionInternal(d, expression));
+            return this.Isolate(declaration, d => WithExpressionInternal(d, expression));
         }
 
         private static SyntaxNode WithExpressionInternal(SyntaxNode declaration, SyntaxNode expression)
@@ -2928,7 +2928,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private SyntaxNode WithAccessor(SyntaxNode declaration, SyntaxKind kind, AccessorDeclarationSyntax accessor)
         {
-            return WithAccessor(declaration, GetAccessorList(declaration), kind, accessor);
+            return this.WithAccessor(declaration, GetAccessorList(declaration), kind, accessor);
         }
 
         private SyntaxNode WithAccessor(SyntaxNode declaration, AccessorListSyntax accessorList, SyntaxKind kind, AccessorDeclarationSyntax accessor)
@@ -2938,11 +2938,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 var acc = accessorList.Accessors.FirstOrDefault(a => a.IsKind(kind));
                 if (acc != null)
                 {
-                    return ReplaceNode(declaration, acc, accessor);
+                    return this.ReplaceNode(declaration, acc, accessor);
                 }
                 else if (accessor != null)
                 {
-                    return ReplaceNode(declaration, accessorList, accessorList.AddAccessors(accessor));
+                    return this.ReplaceNode(declaration, accessorList, accessorList.AddAccessors(accessor));
                 }
             }
 
@@ -2963,12 +2963,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode WithGetAccessorStatements(SyntaxNode declaration, IEnumerable<SyntaxNode> statements)
         {
-            return WithAccessorStatements(declaration, SyntaxKind.GetAccessorDeclaration, statements);
+            return this.WithAccessorStatements(declaration, SyntaxKind.GetAccessorDeclaration, statements);
         }
 
         public override SyntaxNode WithSetAccessorStatements(SyntaxNode declaration, IEnumerable<SyntaxNode> statements)
         {
-            return WithAccessorStatements(declaration, SyntaxKind.SetAccessorDeclaration, statements);
+            return this.WithAccessorStatements(declaration, SyntaxKind.SetAccessorDeclaration, statements);
         }
 
         private SyntaxNode WithAccessorStatements(SyntaxNode declaration, SyntaxKind kind, IEnumerable<SyntaxNode> statements)
@@ -2977,11 +2977,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             if (accessor == null)
             {
                 accessor = AccessorDeclaration(kind, statements);
-                return WithAccessor(declaration, kind, accessor);
+                return this.WithAccessor(declaration, kind, accessor);
             }
             else
             {
-                return WithAccessor(declaration, kind, (AccessorDeclarationSyntax)WithStatements(accessor, statements));
+                return this.WithAccessor(declaration, kind, (AccessorDeclarationSyntax) this.WithStatements(accessor, statements));
             }
         }
 
@@ -3070,16 +3070,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode ReplaceNode(SyntaxNode root, SyntaxNode declaration, SyntaxNode newDeclaration)
         {
-            newDeclaration = AsNodeLike(declaration, newDeclaration);
+            newDeclaration = this.AsNodeLike(declaration, newDeclaration);
 
             if (newDeclaration == null)
             {
-                return RemoveNode(root, declaration);
+                return this.RemoveNode(root, declaration);
             }
 
             if (root.Span.Contains(declaration.Span))
             {
-                var newFullDecl = AsIsolatedDeclaration(newDeclaration);
+                var newFullDecl = this.AsIsolatedDeclaration(newDeclaration);
                 var fullDecl = GetFullDeclaration(declaration);
 
                 // special handling for replacing at location of sub-declaration
@@ -3096,10 +3096,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     }
 
                     // replace sub declaration by splitting full declaration and inserting between
-                    var index = IndexOf(GetSubDeclarations(fullDecl), declaration);
+                    var index = this.IndexOf(GetSubDeclarations(fullDecl), declaration);
 
                     // replace declaration with multiple declarations
-                    return ReplaceRange(root, fullDecl, SplitAndReplace(fullDecl, index, new[] { newDeclaration }));
+                    return ReplaceRange(root, fullDecl, this.SplitAndReplace(fullDecl, index, new[] { newDeclaration }));
                 }
 
                 // attempt normal replace
@@ -3188,7 +3188,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 if (index > 0)
                 {
                     // make a single declaration with only sub-declarations before the sub-declaration being replaced
-                    newNodes.Add(WithSubDeclarationsRemoved(multiPartDeclaration, index, count - index).WithTrailingTrivia(SyntaxFactory.ElasticSpace));
+                    newNodes.Add(this.WithSubDeclarationsRemoved(multiPartDeclaration, index, count - index).WithTrailingTrivia(SyntaxFactory.ElasticSpace));
                 }
 
                 newNodes.AddRange(newDeclarations);
@@ -3196,7 +3196,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 if (index < count - 1)
                 {
                     // make a single declaration with only the sub-declarations after the sub-declaration being replaced
-                    newNodes.Add(WithSubDeclarationsRemoved(multiPartDeclaration, 0, index + 1).WithLeadingTrivia(SyntaxFactory.ElasticSpace));
+                    newNodes.Add(this.WithSubDeclarationsRemoved(multiPartDeclaration, 0, index + 1).WithLeadingTrivia(SyntaxFactory.ElasticSpace));
                 }
 
                 return newNodes;
@@ -3211,7 +3211,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             if (root.Span.Contains(declaration.Span))
             {
-                return Isolate(root.TrackNodes(declaration), r => InsertNodesBeforeInternal(r, r.GetCurrentNode(declaration), newDeclarations));
+                return this.Isolate(root.TrackNodes(declaration), r => this.InsertNodesBeforeInternal(r, r.GetCurrentNode(declaration), newDeclarations));
             }
             else
             {
@@ -3228,12 +3228,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
 
             var subDecls = GetSubDeclarations(fullDecl);
-            var index = IndexOf(subDecls, declaration);
+            var index = this.IndexOf(subDecls, declaration);
 
             // insert new declaration between full declaration split into two
             if (index > 0)
             {
-                return ReplaceRange(root, fullDecl, SplitAndInsert(fullDecl, index, newDeclarations));
+                return ReplaceRange(root, fullDecl, this.SplitAndInsert(fullDecl, index, newDeclarations));
             }
 
             return base.InsertNodesBefore(root, fullDecl, newDeclarations);
@@ -3243,7 +3243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             if (root.Span.Contains(declaration.Span))
             {
-                return Isolate(root.TrackNodes(declaration), r => InsertNodesAfterInternal(r, r.GetCurrentNode(declaration), newDeclarations));
+                return this.Isolate(root.TrackNodes(declaration), r => this.InsertNodesAfterInternal(r, r.GetCurrentNode(declaration), newDeclarations));
             }
             else
             {
@@ -3261,12 +3261,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             var subDecls = GetSubDeclarations(fullDecl);
             var count = subDecls.Count;
-            var index = IndexOf(subDecls, declaration);
+            var index = this.IndexOf(subDecls, declaration);
 
             // insert new declaration between full declaration split into two
             if (index >= 0 && index < count - 1)
             {
-                return ReplaceRange(root, fullDecl, SplitAndInsert(fullDecl, index + 1, newDeclarations));
+                return ReplaceRange(root, fullDecl, this.SplitAndInsert(fullDecl, index + 1, newDeclarations));
             }
 
             return base.InsertNodesAfter(root, fullDecl, newDeclarations);
@@ -3276,15 +3276,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             int count = GetDeclarationCount(multiPartDeclaration);
             var newNodes = new List<SyntaxNode>();
-            newNodes.Add(WithSubDeclarationsRemoved(multiPartDeclaration, index, count - index).WithTrailingTrivia(SyntaxFactory.ElasticSpace));
+            newNodes.Add(this.WithSubDeclarationsRemoved(multiPartDeclaration, index, count - index).WithTrailingTrivia(SyntaxFactory.ElasticSpace));
             newNodes.AddRange(newDeclarations);
-            newNodes.Add(WithSubDeclarationsRemoved(multiPartDeclaration, 0, index).WithLeadingTrivia(SyntaxFactory.ElasticSpace));
+            newNodes.Add(this.WithSubDeclarationsRemoved(multiPartDeclaration, 0, index).WithLeadingTrivia(SyntaxFactory.ElasticSpace));
             return newNodes;
         }
 
         private SyntaxNode WithSubDeclarationsRemoved(SyntaxNode declaration, int index, int count)
         {
-            return RemoveNodes(declaration, GetSubDeclarations(declaration).Skip(index).Take(count));
+            return this.RemoveNodes(declaration, GetSubDeclarations(declaration).Skip(index).Take(count));
         }
 
         private static IReadOnlyList<SyntaxNode> GetSubDeclarations(SyntaxNode declaration)
@@ -3308,7 +3308,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode RemoveNode(SyntaxNode root, SyntaxNode node)
         {
-            return RemoveNode(root, node, DefaultRemoveOptions);
+            return this.RemoveNode(root, node, DefaultRemoveOptions);
         }
 
         public override SyntaxNode RemoveNode(SyntaxNode root, SyntaxNode node, SyntaxRemoveOptions options)
@@ -3316,11 +3316,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             if (root.Span.Contains(node.Span))
             {
                 // node exists within normal span of the root (not in trivia)
-                return Isolate(root.TrackNodes(node), r => RemoveNodeInternal(r, r.GetCurrentNode(node), options));
+                return this.Isolate(root.TrackNodes(node), r => this.RemoveNodeInternal(r, r.GetCurrentNode(node), options));
             }
             else
             {
-                return RemoveNodeInternal(root, node, options);
+                return this.RemoveNodeInternal(root, node, options);
             }
         }
 
@@ -3334,7 +3334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     if (attrList != null && attrList.Attributes.Count == 1)
                     {
                         // remove entire list if only one attribute
-                        return RemoveNodeInternal(root, attrList, options);
+                        return this.RemoveNodeInternal(root, attrList, options);
                     }
                     break;
 
@@ -3342,7 +3342,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     if (declaration.Parent != null && ((AttributeArgumentListSyntax)declaration.Parent).Arguments.Count == 1)
                     {
                         // remove entire argument list if only one argument
-                        return RemoveNodeInternal(root, declaration.Parent, options);
+                        return this.RemoveNodeInternal(root, declaration.Parent, options);
                     }
                     break;
 
@@ -3351,7 +3351,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     if (full != declaration && GetDeclarationCount(full) == 1)
                     {
                         // remove full declaration if only one declarator
-                        return RemoveNodeInternal(root, full, options);
+                        return this.RemoveNodeInternal(root, full, options);
                     }
                     break;
 
@@ -3360,7 +3360,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                     if (baseList != null && baseList.Types.Count == 1)
                     {
                         // remove entire base list if this is the only base type.
-                        return RemoveNodeInternal(root, baseList, options);
+                        return this.RemoveNodeInternal(root, baseList, options);
                     }
                     break;
 
@@ -3371,7 +3371,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                         switch (parent.Kind())
                         {
                             case SyntaxKind.SimpleBaseType:
-                                return RemoveNodeInternal(root, parent, options);
+                                return this.RemoveNodeInternal(root, parent, options);
                         }
                     }
                     break;
@@ -3424,8 +3424,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode NameOfExpression(SyntaxNode expression)
         {
-            return InvocationExpression(
-                IdentifierName(SyntaxFacts.GetText(SyntaxKind.NameOfKeyword)),
+            return this.InvocationExpression(
+                this.IdentifierName(SyntaxFacts.GetText(SyntaxKind.NameOfKeyword)),
                 expression);
         }
 
@@ -3825,16 +3825,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
                 case SyntaxKind.QualifiedName:
                     var qname = (QualifiedNameSyntax)expression;
-                    return qname.WithRight((SimpleNameSyntax)WithTypeArguments(qname.Right, typeArguments));
+                    return qname.WithRight((SimpleNameSyntax) this.WithTypeArguments(qname.Right, typeArguments));
 
                 case SyntaxKind.AliasQualifiedName:
                     var aname = (AliasQualifiedNameSyntax)expression;
-                    return aname.WithName((SimpleNameSyntax)WithTypeArguments(aname.Name, typeArguments));
+                    return aname.WithName((SimpleNameSyntax) this.WithTypeArguments(aname.Name, typeArguments));
 
                 case SyntaxKind.SimpleMemberAccessExpression:
                 case SyntaxKind.PointerMemberAccessExpression:
                     var sma = (MemberAccessExpressionSyntax)expression;
-                    return sma.WithName((SimpleNameSyntax)WithTypeArguments(sma.Name, typeArguments));
+                    return sma.WithName((SimpleNameSyntax) this.WithTypeArguments(sma.Name, typeArguments));
 
                 default:
                     return expression;
@@ -3993,7 +3993,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal override SyntaxNode SwitchSectionFromLabels(IEnumerable<SyntaxNode> labels, IEnumerable<SyntaxNode> statements)
         {
             return SyntaxFactory.SwitchSection(
-                labels.Cast<SwitchLabelSyntax>().ToSyntaxList(), 
+                labels.Cast<SwitchLabelSyntax>().ToSyntaxList(),
                 AsStatementList(statements));
         }
 
@@ -4041,22 +4041,22 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode VoidReturningLambdaExpression(IEnumerable<SyntaxNode> lambdaParameters, SyntaxNode expression)
         {
-            return ValueReturningLambdaExpression(lambdaParameters, expression);
+            return this.ValueReturningLambdaExpression(lambdaParameters, expression);
         }
 
         public override SyntaxNode ValueReturningLambdaExpression(IEnumerable<SyntaxNode> parameterDeclarations, IEnumerable<SyntaxNode> statements)
         {
-            return ValueReturningLambdaExpression(parameterDeclarations, CreateBlock(statements));
+            return this.ValueReturningLambdaExpression(parameterDeclarations, CreateBlock(statements));
         }
 
         public override SyntaxNode VoidReturningLambdaExpression(IEnumerable<SyntaxNode> lambdaParameters, IEnumerable<SyntaxNode> statements)
         {
-            return ValueReturningLambdaExpression(lambdaParameters, statements);
+            return this.ValueReturningLambdaExpression(lambdaParameters, statements);
         }
 
         public override SyntaxNode LambdaParameter(string identifier, SyntaxNode type = null)
         {
-            return ParameterDeclaration(identifier, type, null, RefKind.None);
+            return this.ParameterDeclaration(identifier, type, null, RefKind.None);
         }
 
         private static IReadOnlyList<T> AsReadOnlyList<T>(IEnumerable<T> sequence)


### PR DESCRIPTION
and remove some unused methods. 