### PR TITLE
log info for ab testing

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Experimentation;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
 using Roslyn.Utilities;
@@ -223,6 +224,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 await SerializeAsync(serializer, project, result.ProjectId, _owner.NonLocalStateName, result.Others).ConfigureAwait(false);
+
+                AnalyzerABTestLogger.LogProjectDiagnostics(project, result);
             }
 
             public void ResetVersion()
@@ -240,6 +243,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 var syntax = state.GetAnalysisData(AnalysisKind.Syntax);
                 var semantic = state.GetAnalysisData(AnalysisKind.Semantic);
+
+                AnalyzerABTestLogger.LogDocumentDiagnostics(document, syntax.Items, semantic.Items);
 
                 var project = document.Project;
 

--- a/src/Features/Core/Portable/Experimentation/AnalyzerABTestLogger.cs
+++ b/src/Features/Core/Portable/Experimentation/AnalyzerABTestLogger.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Experimentation
         private static bool s_reportErrors = false;
         private static readonly ConcurrentDictionary<object, object> s_reported = new ConcurrentDictionary<object, object>(concurrencyLevel: 2, capacity: 10);
 
-        private const string Name = "AnalyzerVsix";
+        private const string Name = "LiveCodeAnalysisVsix";
 
         public static void Log(string action)
         {
@@ -67,6 +67,8 @@ namespace Microsoft.CodeAnalysis.Experimentation
                 return;
             }
 
+            // logs count of errors for this project. this won't log anything if FSA off since
+            // we don't collect any diagnostics for a project if FSA is off.
             var map = new Dictionary<string, int>();
             foreach (var documentId in result.DocumentIdsOrEmpty)
             {
@@ -88,6 +90,10 @@ namespace Microsoft.CodeAnalysis.Experimentation
                 return;
             }
 
+            // logs count of errors for this document. this only logs errors for 
+            // this particular document. we do this since when FSA is off, this is
+            // only errors we get. otherwise, we don't get any info when FSA is off and
+            // that is default for C#.
             var map = new Dictionary<string, int>();
             CountErrors(map, syntax);
             CountErrors(map, semantic);

--- a/src/Features/Core/Portable/Experimentation/AnalyzerABTestLogger.cs
+++ b/src/Features/Core/Portable/Experimentation/AnalyzerABTestLogger.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Shared.Options;
+using Microsoft.CodeAnalysis.Workspaces.Diagnostics;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Experimentation
+{
+    internal static class AnalyzerABTestLogger
+    {
+        private static bool s_reportErrors = false;
+        private static readonly ConcurrentDictionary<object, object> s_reported = new ConcurrentDictionary<object, object>(concurrencyLevel: 2, capacity: 10);
+
+        private const string Name = "AnalyzerVsix";
+
+        public static void Log(string action)
+        {
+            Logger.Log(FunctionId.Experiment_ABTesting, KeyValueLogMessage.Create(LogType.UserAction, m =>
+            {
+                m[nameof(Name)] = Name;
+                m[nameof(action)] = action;
+            }));
+        }
+
+        public static void LogInstallationStatus(Workspace workspace, LiveCodeAnalysisInstallStatus installStatus)
+        {
+            var vsixInstalled = workspace.Options.GetOption(AnalyzerABTestOptions.VsixInstalled);
+            if (!vsixInstalled && installStatus == LiveCodeAnalysisInstallStatus.Installed)
+            {
+                // first time after vsix installed
+                workspace.Options = workspace.Options.WithChangedOption(AnalyzerABTestOptions.VsixInstalled, true);
+                workspace.Options = workspace.Options.WithChangedOption(AnalyzerABTestOptions.ParticipatedInExperiment, true);
+                Log("Installed");
+
+                // set the system to report the errors.
+                s_reportErrors = true;
+            }
+
+            if (vsixInstalled && installStatus == LiveCodeAnalysisInstallStatus.NotInstalled)
+            {
+                // first time after vsix is uninstalled
+                workspace.Options = workspace.Options.WithChangedOption(AnalyzerABTestOptions.VsixInstalled, false);
+                Log("Uninstalled");
+            }
+        }
+
+        public static void LogCandidacyRequirementsTracking(long lastTriggeredTimeBinary)
+        {
+            if (lastTriggeredTimeBinary == AnalyzerABTestOptions.LastDateTimeUsedSuggestionAction.DefaultValue)
+            {
+                Log("StartCandidacyRequirementsTracking");
+            }
+        }
+
+        public static void LogProjectDiagnostics(Project project, DiagnosticAnalysisResult result)
+        {
+            if (!s_reportErrors || !s_reported.TryAdd(project.Id, null))
+            {
+                // doesn't meet the bar to report the issue.
+                return;
+            }
+
+            var map = new Dictionary<string, int>();
+            foreach (var documentId in result.DocumentIdsOrEmpty)
+            {
+                CountErrors(map, result.GetResultOrEmpty(result.SyntaxLocals, documentId));
+                CountErrors(map, result.GetResultOrEmpty(result.SemanticLocals, documentId));
+                CountErrors(map, result.GetResultOrEmpty(result.NonLocals, documentId));
+            }
+
+            CountErrors(map, result.Others);
+
+            LogErrors(project, "ProjectDignostics", project.Id.Id, map);
+        }
+
+        public static void LogDocumentDiagnostics(Document document, ImmutableArray<DiagnosticData> syntax, ImmutableArray<DiagnosticData> semantic)
+        {
+            if (!s_reportErrors || !s_reported.TryAdd(document.Id, null))
+            {
+                // doesn't meet the bar to report the issue.
+                return;
+            }
+
+            var map = new Dictionary<string, int>();
+            CountErrors(map, syntax);
+            CountErrors(map, semantic);
+
+            LogErrors(document.Project, "DocumentDignostics", document.Id.Id, map);
+        }
+
+        private static void LogErrors(Project project, string action, Guid target, Dictionary<string, int> map)
+        {
+            if (map.Count == 0)
+            {
+                // nothing to report
+                return;
+            }
+
+            var fsa = ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project);
+            Logger.Log(FunctionId.Experiment_ABTesting, KeyValueLogMessage.Create(LogType.UserAction, m =>
+            {
+                m[nameof(Name)] = Name;
+                m[nameof(action)] = action;
+                m[nameof(target)] = target.ToString();
+                m["FSA"] = fsa;
+                m["errors"] = string.Join("|", map.Select(kv => $"{kv.Key}={kv.Value}"));
+            }));
+        }
+
+        private static void CountErrors(Dictionary<string, int> map, ImmutableArray<DiagnosticData> diagnostics)
+        {
+            if (diagnostics.IsDefaultOrEmpty)
+            {
+                return;
+            }
+
+            foreach (var group in diagnostics.GroupBy(d => d.Id))
+            {
+                map[group.Key] = IDictionaryExtensions.GetValueOrDefault(map, group.Key) + group.Count();
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/Experimentation/AnalyzerABTestOptions.cs
+++ b/src/Features/Core/Portable/Experimentation/AnalyzerABTestOptions.cs
@@ -3,7 +3,7 @@
 using System;
 using Microsoft.CodeAnalysis.Options;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
+namespace Microsoft.CodeAnalysis.Experimentation
 {
     internal static class AnalyzerABTestOptions
     {
@@ -25,5 +25,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
         public static readonly Option<long> LastDateTimeInfoBarShown = new Option<long>(nameof(AnalyzerABTestOptions), nameof(LastDateTimeInfoBarShown),
             defaultValue: DateTime.MinValue.ToBinary(),
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(LastDateTimeInfoBarShown)));
+
+        public static readonly Option<bool> VsixInstalled = new Option<bool>(nameof(AnalyzerABTestOptions),
+            nameof(VsixInstalled), defaultValue: false,
+            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(VsixInstalled)));
+
+        public static readonly Option<bool> ParticipatedInExperiment = new Option<bool>(nameof(AnalyzerABTestOptions),
+            nameof(ParticipatedInExperiment), defaultValue: false,
+            storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(ParticipatedInExperiment)));
     }
 }

--- a/src/Features/Core/Portable/Experimentation/LiveCodeAnalysisInstallStatus.cs
+++ b/src/Features/Core/Portable/Experimentation/LiveCodeAnalysisInstallStatus.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
+namespace Microsoft.CodeAnalysis.Experimentation
 {
     internal enum LiveCodeAnalysisInstallStatus
     {

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -133,6 +133,9 @@
     <Compile Include="Diagnostics\DiagnosticResultSerializer.cs" />
     <Compile Include="Diagnostics\SymbolAnalysisContextExtensions.cs" />
     <Compile Include="EncapsulateField\EncapsulateFieldRefactoringProvider.cs" />
+    <Compile Include="Experimentation\AnalyzerABTestLogger.cs" />
+    <Compile Include="Experimentation\AnalyzerABTestOptions.cs" />
+    <Compile Include="Experimentation\LiveCodeAnalysisInstallStatus.cs" />
     <Compile Include="ExtractInterface\ExtractInterfaceCodeRefactoringProvider.cs" />
     <Compile Include="CodeFixes\FixAllOccurrences\FixSomeCodeAction.cs" />
     <Compile Include="AddPackage\InstallPackageDirectlyCodeAction.cs" />

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/AnalyzerVsixSuggestedActionCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/AnalyzerVsixSuggestedActionCallback.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Editor.Implementation.Suggestions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Experimentation;
 using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.VisualStudio.Shell;
@@ -95,6 +96,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                 else
                 {
                     _installStatus = installed != 0 ? LiveCodeAnalysisInstallStatus.Installed : LiveCodeAnalysisInstallStatus.NotInstalled;
+                    AnalyzerABTestLogger.LogInstallationStatus(_workspace, _installStatus);
                 }
             }
 
@@ -103,6 +105,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
 
         private bool IsCandidate()
         {
+            // if this user ever participated in the experiement and then uninstall the vsix, then
+            // this user will never be candidate again.
+            if (_workspace.Options.GetOption(AnalyzerABTestOptions.ParticipatedInExperiment))
+            {
+                return false;
+            }
+
             // Filter for valid A/B test candidates. Candidates fill the following critera:
             //     1: Are a Dotnet user (as evidenced by the fact that this code is being run)
             //     2: Have triggered a lightbulb on 3 separate days
@@ -114,21 +123,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             if (!isCandidate)
             {
                 // We store in UTC to avoid any timezone offset weirdness
-                var lastTriggeredTime = DateTime.FromBinary(options.GetOption(AnalyzerABTestOptions.LastDateTimeUsedSuggestionAction));
+                var lastTriggeredTimeBinary = options.GetOption(AnalyzerABTestOptions.LastDateTimeUsedSuggestionAction);
+                AnalyzerABTestLogger.LogCandidacyRequirementsTracking(lastTriggeredTimeBinary);
+
+                var lastTriggeredTime = DateTime.FromBinary(lastTriggeredTimeBinary);
                 var currentTime = DateTime.UtcNow;
                 var span = currentTime - lastTriggeredTime;
                 if (span.TotalDays >= 1)
                 {
                     options = options.WithChangedOption(AnalyzerABTestOptions.LastDateTimeUsedSuggestionAction, currentTime.ToBinary());
+
                     var usageCount = options.GetOption(AnalyzerABTestOptions.UsedSuggestedActionCount);
-                    usageCount++;
-                    options = options.WithChangedOption(AnalyzerABTestOptions.UsedSuggestedActionCount, usageCount);
+                    options = options.WithChangedOption(AnalyzerABTestOptions.UsedSuggestedActionCount, ++usageCount);
 
                     if (usageCount >= 3)
                     {
                         isCandidate = true;
                         options = options.WithChangedOption(AnalyzerABTestOptions.HasMetCandidacyRequirements, true);
+                        AnalyzerABTestLogger.Log(nameof(AnalyzerABTestOptions.HasMetCandidacyRequirements));
                     }
+
                     _workspace.Options = options;
                 }
             }
@@ -142,6 +156,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             _infoBarChecked = true;
             if (_experimentationService.IsExperimentEnabled(AnalyzerEnabledFlight))
             {
+                AnalyzerABTestLogger.Log(nameof(AnalyzerEnabledFlight));
+
                 // If we got true from the experimentation service, then we're in the treatment
                 // group, and the experiment is enabled. We determine if the infobar has been
                 // displayed in the past 24 hours. If it hasn't been displayed, then we do so now.
@@ -152,6 +168,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
                 if (timeSinceLastShown.TotalDays >= 1)
                 {
                     _workspace.Options = _workspace.Options.WithChangedOption(AnalyzerABTestOptions.LastDateTimeInfoBarShown, utcNow.ToBinary());
+                    AnalyzerABTestLogger.Log("InfoBarShown");
 
                     var infoBarService = _workspace.Services.GetRequiredService<IInfoBarService>();
                     infoBarService.ShowInfoBarInGlobalView(
@@ -171,11 +188,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
         private void OpenInstallHyperlink()
         {
             System.Diagnostics.Process.Start(AnalyzerVsixHyperlink);
+            AnalyzerABTestLogger.Log(nameof(AnalyzerVsixHyperlink));
         }
 
         private void DoNotShowAgain()
         {
             _workspace.Options = _workspace.Options.WithChangedOption(AnalyzerABTestOptions.NeverShowAgain, true);
+            AnalyzerABTestLogger.Log(nameof(AnalyzerABTestOptions.NeverShowAgain));
         }
     }
 }

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -63,8 +63,6 @@
     <Compile Include="Implementation\AnalyzerDependency\IIgnorableAssemblyList.cs" />
     <Compile Include="Implementation\AnalyzerDependency\IBindingRedirectionService.cs" />
     <Compile Include="Implementation\Experimentation\AnalyzerVsixSuggestedActionCallback.cs" />
-    <Compile Include="Implementation\Experimentation\AnalyzerABTestOptions.cs" />
-    <Compile Include="Implementation\Experimentation\LiveCodeAnalysisInstallStatus.cs" />
     <Compile Include="Implementation\Extensions\ServiceProviderExtensions.cs" />
     <Compile Include="ID.InteractiveCommands.cs" />
     <Compile Include="Implementation\FindReferences\VisualStudioDefinitionsAndReferencesFactory.cs" />

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -392,5 +392,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         CompilationService_GetCompilationAsync,
         SolutionCreator_AssetDifferences,
         Extension_InfoBar,
+        Experiment_ABTesting,
     }
 }


### PR DESCRIPTION
state progress as below

1. StartCandidacyRequirementsTracking <- first time user use LB (only once per user)
2. HasMetCandidacyRequirements <- when requirement is met (only once per user)
3. AnalyzerEnabledFlight <- when the user accepted as flight group (multiple times until user take action)
4. InfoBarShown <- when info bar is shown (multiple times until user takes an action)

actions user can take. (this can only happen once)
1. AnalyzerVsixHyperLine <- user choose to go to the link
2. NeverShowAgain <- user decide not to participate in the experiment

if user choose to install vsix (this can only happen once - unless user manually reinstall the vsix...)
1. Installed
2. Uninstalled

the first time user installed the vsix, we will report these extra info
1. DocumentDiagnostics - report only once per a document
2. ProjectDiagnostics - report only once per project

these 2 report include count per errors and FSA status. these only report once and never report again. these are not about either local/nonlocal/document level or project level errors. this is about scope of error counting. when FSA is off, we never run analyzers for whole project so we can't count errors for whole project. so that's why we report count for document (opened document) so that we can at least get some data for FSA off case.

...

**Customer scenario**

this is not user facing change but telemetry related change. this code will track info on our new analyzers impact on users - the a/b testing we are planning to do on new analyzers.

**Bugs this fixes:**

N/A

**Workarounds, if any**

N/A

**Risk**

Shouldn't affect anything. 

**Performance impact**

Shouldn't affect anything. this doesn't add or remove analyzers to the product.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

N/A

**How was the bug found?**

N/A