### PR TITLE
Force load project were we don't have command line args in DPL

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -636,9 +636,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var start = DateTimeOffset.UtcNow;
             var solution4 = (IVsSolution4)_vsSolution;
             var solution7 = (IVsSolution7)_vsSolution;
-            var guidsOfProjectsThatFailed = projectInfos.Where(pi => DesignTimeBuildFailed(pi.Value) && !solution7.IsDeferredProjectLoadAllowed(pi.Key)).Select(pi => GetProjectGuid(pi.Key)).ToArray();
+            var projectInfosOfProjectsThatFailed = projectInfos.Where(pi => DesignTimeBuildFailed(pi.Value) && !solution7.IsDeferredProjectLoadAllowed(pi.Key));
+            var guidsOfProjectsThatFailed = projectInfosOfProjectsThatFailed.Select(pi => GetProjectGuid(pi.Key)).ToArray();
             OutputToOutputWindow($"\tForcing load of {guidsOfProjectsThatFailed.Length} projects.");
-            OutputListToOutputWindow("\tIncluding ", projectInfos.Where(pi => DesignTimeBuildFailed(pi.Value) && !solution7.IsDeferredProjectLoadAllowed(pi.Key)).Select(pi => pi.Key));
+            OutputListToOutputWindow("\tIncluding ", projectInfosOfProjectsThatFailed.Select(pi => pi.Key));
             solution4.EnsureProjectsAreLoaded((uint)guidsOfProjectsThatFailed.Length, guidsOfProjectsThatFailed, (uint)__VSBSLFLAGS.VSBSLFLAGS_None);
             OutputToOutputWindow($"Loading projects whose design time builds failed - done (took {DateTimeOffset.UtcNow - start})");
         }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -769,6 +769,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return project;
             }
 
+            // If the project system has opted this project out of deferred loading, or AnyCode
+            // was unable to get command line info for it, we can't create a project for it.
+            // NOTE: We need to check this even though it happened in CreateDeferredProjects
+            // because we could be in a recursive call from a project reference below.
+            var solution7 = (IVsSolution7)_vsSolution;
+            if (DesignTimeBuildFailed(projectInfo) ||
+                !solution7.IsDeferredProjectLoadAllowed(projectFilename))
+            {
+                return null;
+            }
+
             var commandLineParser = _workspaceServices.GetLanguageServices(languageName).GetService<ICommandLineParserService>();
             var projectDirectory = PathUtilities.GetDirectoryName(projectFilename);
             var commandLineArguments = commandLineParser.Parse(

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl_IVsSolutionEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl_IVsSolutionEvents.cs
@@ -18,13 +18,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public void AdviseSolutionEvents(IVsSolution solution)
         {
             _vsSolution = solution;
-            _vsSolution.AdviseSolutionEvents(this, out var solutionEventsCookie);
-            _solutionEventsCookie = solutionEventsCookie;
+            if (_solutionEventsCookie == null)
+            {
+                _vsSolution.AdviseSolutionEvents(this, out var solutionEventsCookie);
+                _solutionEventsCookie = solutionEventsCookie;
+            }
         }
 
         public void UnadviseSolutionEvents()
         {
-            if (_solutionEventsCookie.HasValue)
+            if (_solutionEventsCookie != null)
             {
                 _vsSolution.UnadviseSolutionEvents(_solutionEventsCookie.Value);
                 _solutionEventsCookie = null;

--- a/src/VisualStudio/Core/Next/ProjectSystem/DeferredProjectWorkspaceService.cs
+++ b/src/VisualStudio/Core/Next/ProjectSystem/DeferredProjectWorkspaceService.cs
@@ -43,7 +43,9 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
                     new DeferredProjectInformation(
                         kvp.Value.TargetPath,
                         kvp.Value.CommandLineArgs,
-                        kvp.Value.ProjectReferences.Select(p => p.Substring("/ProjectReference:".Length)).ToImmutableArray()))));
+                        kvp.Value.ProjectReferences.IsDefaultOrEmpty
+                            ? ImmutableArray<string>.Empty
+                            : kvp.Value.ProjectReferences.Select(p => p.Substring("/ProjectReference:".Length)).ToImmutableArray()))));
             return result;
         }
     }


### PR DESCRIPTION
## Ask Mode
**Customer scenario**

In the case where we AnyCode is unable to determine the command line
arguments for a project (likely because something is different about the
way design time builds are set up), fall back to forcing the project to
load normally so that users still get a good experience from IDE
features.

**Bugs this fixes:**

Fixes #19407, and internal bug 432432.

**Workarounds, if any**

The customer can disable LSL, but we want people to be able to use it and continue to provide feedback.

**Risk**

This code should only be executed if LSL is enabled.

**Performance impact**

Low, because we still operate on the same set of projects, but we might skip some of them.

**Is this a regression from a previous update?**

Currently there is a crash, because AnyCode is now passing the failed projects to us.  

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

We didn't, it's planned work.

**How was the bug found?**

Planned work for 15.3 to address "broken" features with LSL enabled.