### PR TITLE
Project.GetCompilationAsync cancels the task when failed

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -307,25 +307,14 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    var taskCompletionSource = new TaskCompletionSource<Compilation>();
-                    GetOrBuildCompilationInfoAsync(solution, lockGate: true, cancellationToken: cancellationToken)
-                        .ContinueWith(t =>
-                        {
-                            if (t.IsCanceled || cancellationToken.IsCancellationRequested)
-                            {
-                                taskCompletionSource.SetCanceled();
-                            }
-                            else if (t.IsFaulted)
-                            {
-                                taskCompletionSource.SetException(t.Exception.InnerExceptions);
-                            }
-                            else
-                            {
-                                taskCompletionSource.SetResult(t.Result.Compilation);
-                            }
-                        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
-                    return taskCompletionSource.Task;
+                    return GetCompilationSlowAsync(solution, cancellationToken);
                 }
+            }
+
+            private async Task<Compilation> GetCompilationSlowAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                var compilationInfo = await GetOrBuildCompilationInfoAsync(solution, lockGate: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return compilationInfo.Compilation;
             }
 
             private static string LogBuildCompilationAsync(ProjectState state)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -859,9 +859,14 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    return GetOrBuildCompilationInfoAsync(solution, lockGate: true, cancellationToken: cancellationToken)
-                        .ContinueWith(t => t.Result.HasSuccessfullyLoadedTransitively, cancellationToken, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
+                    return HasSuccessfullyLoadedSlowAsync(solution, cancellationToken);
                 }
+            }
+
+            private async Task<bool> HasSuccessfullyLoadedSlowAsync(SolutionState solution, CancellationToken cancellationToken)
+            {
+                var compilationInfo = await GetOrBuildCompilationInfoAsync(solution, lockGate: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return compilationInfo.HasSuccessfullyLoadedTransitively;
             }
 
             #region Versions

--- a/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
+++ b/src/Workspaces/CoreTest/FindAllDeclarationsTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public async Task FindDeclarationsAsync_Test_Cancellation()
         {
-            await Assert.ThrowsAnyAsync<TaskCanceledException>(async () =>
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
             {
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
@@ -278,7 +278,7 @@ Inner i;
         [Fact]
         public async Task FindSourceDeclarationsAsync_Project_Test_Cancellation()
         {
-            await Assert.ThrowsAnyAsync<TaskCanceledException>(async () =>
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
             {
                 var cts = new CancellationTokenSource();
                 var project = GetProject(WorkspaceKind.SingleClass);


### PR DESCRIPTION
# Summary of the bug
To create a `Compilation` instance from csproj file, I wrote like this:

```csharp
using (var workspace = MSBuildWorkspace.Create())
{
    var project = await workspace.OpenProjectAsync("foo.csproj");
    var compilation = await project.GetCompilationAsync();
}
```

At this time, if `GetCompilationAsync` fail, the task which was returned from `GetCompilationAsync` will be cancelled, and I will catch a `TaskCanceledException`.

I think the expected behavior is for the task to throw the inner exception.

# How to reproduce the bug
1. Make a csproj file for a .NET Framework application or library.
2. Add the same `<ProjectReference>` twice to the csproj, like this:

```xml
<ProjectReference Include="..\ClassLibrary2\ClassLibrary2.csproj">
  <Project>{45f7ea5e-8175-4df3-9828-250c11528c82}</Project>
  <Name>ClassLibrary2</Name>
</ProjectReference>
<ProjectReference Include="..\ClassLibrary2\ClassLibrary2.csproj">
  <Project>{45f7ea5e-8175-4df3-9828-250c11528c82}</Project>
  <Name>ClassLibrary2</Name>
</ProjectReference>
```

3. Load the csproj with the above code.

Then, you will catch a `TaskCanceledException`.

Applying this PR, you will catch an `ArgumentException` with the below message.

```
System.ArgumentException: 同一のキーを含む項目が既に追加されています。
   場所 System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   場所 System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   場所 System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   場所 Microsoft.CodeAnalysis.SolutionState.CompilationTracker.<FinalizeCompilationAsync>d__34.MoveNext() 場所 E:\\repo\\roslyn\\src\\Workspaces\\Core\\Portable\\Workspace\\Solution\\SolutionState.CompilationTracker.cs:行 642
--- 直前に例外がスローされた場所からのスタック トレースの終わり ---
   場所 System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   場所 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   場所 System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   場所 Microsoft.CodeAnalysis.SolutionState.CompilationTracker.<BuildCompilationInfoFromScratchAsync>d__28.MoveNext() 場所 E:\\repo\\roslyn\\src\\Workspaces\\Core\\Portable\\Workspace\\Solution\\SolutionState.CompilationTracker.cs:行 489
--- 直前に例外がスローされた場所からのスタック トレースの終わり ---
   場所 System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   場所 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   場所 System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   場所 Microsoft.CodeAnalysis.SolutionState.CompilationTracker.<GetOrBuildCompilationInfoAsync>d__26.MoveNext() 場所 E:\\repo\\roslyn\\src\\Workspaces\\Core\\Portable\\Workspace\\Solution\\SolutionState.CompilationTracker.cs:行 418
--- 直前に例外がスローされた場所からのスタック トレースの終わり ---
   場所 System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   場所 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   場所 System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   場所 RoslynGetCompilation.Program.<Run>d__1.MoveNext() 場所 C:\\Users\\azyob\\documents\\visual studio 2017\\Projects\\RoslynGetCompilation\\RoslynGetCompilation\\Program.cs:行 26"
```

# Performance impact
There are extra allocations for a `TaskCompletionSource` instance.

# How was the bug found?
I was writing the test runner for `DiagnosticAnalyzer`s.

# Roslyn version
* Microsoft.CodeAnalysis.CSharp.Workspaces 2.1.0 on NuGet
* 1e444cfd5d2a64adb4543e9f1661c594fe97905c (master)