### PR TITLE
Support serializing longs to/from the local registry

### DIFF
--- a/src/Features/Core/Portable/Experimentation/AnalyzerABTestOptions.cs
+++ b/src/Features/Core/Portable/Experimentation/AnalyzerABTestOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Experimentation
             nameof(LastDateTimeUsedSuggestionAction), defaultValue: DateTime.MinValue.ToBinary(),
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(LastDateTimeUsedSuggestionAction)));
 
-        public static readonly Option<uint> UsedSuggestedActionCount = new Option<uint>(nameof(AnalyzerABTestOptions), nameof(UsedSuggestedActionCount),
+        public static readonly Option<int> UsedSuggestedActionCount = new Option<int>(nameof(AnalyzerABTestOptions), nameof(UsedSuggestedActionCount),
             defaultValue: 0, storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(UsedSuggestedActionCount)));
 
         public static readonly Option<bool> NeverShowAgain = new Option<bool>(nameof(AnalyzerABTestOptions), nameof(NeverShowAgain),

--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/AnalyzerVsixSuggestedActionCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/AnalyzerVsixSuggestedActionCallback.cs
@@ -14,8 +14,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
 {
-    // Disabling until https://github.com/dotnet/roslyn/issues/19629 is fixed.
-    // [Export(typeof(ISuggestedActionCallback))]
+    [Export(typeof(ISuggestedActionCallback))]
     internal class AnalyzerVsixSuggestedActionCallback : ForegroundThreadAffinitizedObject, ISuggestedActionCallback
     {
         private const string AnalyzerEnabledFlight = @"LiveCA/LiveCAcf";
@@ -52,7 +51,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
             // thread to get it
             AssertIsForeground();
 
-            
             // If the user has previously clicked don't show again, then we bail out immediately
             if (_workspace.Options.GetOption(AnalyzerABTestOptions.NeverShowAgain))
             {


### PR DESCRIPTION
Fixes dotnet/roslyn#19629.