### PR TITLE
Add IOperation support for tuple expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -1,19 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.Semantics;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal partial class BoundTupleExpression
-    {
-        protected override ImmutableArray<BoundNode> Children => StaticCast<BoundNode>.From(this.Arguments);
-    }
-
     internal partial class BoundDelegateCreationExpression
     {
         protected override ImmutableArray<BoundNode> Children => ImmutableArray.Create<BoundNode>(this.Argument);

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -165,6 +165,9 @@ namespace Microsoft.CodeAnalysis.Semantics
                     return CreateBoundLabeledStatementOperation((BoundLabeledStatement)boundNode);
                 case BoundKind.ExpressionStatement:
                     return CreateBoundExpressionStatementOperation((BoundExpressionStatement)boundNode);
+                case BoundKind.TupleLiteral:
+                case BoundKind.ConvertedTupleLiteral:
+                    return CreateBoundTupleExpressionOperation((BoundTupleExpression)boundNode);
                 default:
                     var constantValue = ConvertToOptional((boundNode as BoundExpression)?.ConstantValue);
                     return Operation.CreateOperationNone(boundNode.HasErrors, boundNode.Syntax, constantValue, getChildren: () => GetIOperationChildren(boundNode));
@@ -984,6 +987,16 @@ namespace Microsoft.CodeAnalysis.Semantics
             ITypeSymbol type = null;
             Optional<object> constantValue = default(Optional<object>);
             return new LazyExpressionStatement(expression, isInvalid, syntax, type, constantValue);
+        }
+
+        private static ITupleExpression CreateBoundTupleExpressionOperation(BoundTupleExpression boundTupleExpression)
+        {
+            Lazy<ImmutableArray<IOperation>> elements = new Lazy<ImmutableArray<IOperation>>(() => GetTupleElements(boundTupleExpression));
+            bool isInvalid = boundTupleExpression.HasErrors;
+            SyntaxNode syntax = boundTupleExpression.Syntax;
+            ITypeSymbol type = boundTupleExpression.Type;
+            Optional<object> constantValue = ConvertToOptional(boundTupleExpression.ConstantValue);
+            return new LazyTupleExpression(elements, isInvalid, syntax, type, constantValue);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -340,6 +340,15 @@ namespace Microsoft.CodeAnalysis.Semantics
                         OperationFactory.CreateVariableDeclaration(declaration.LocalSymbol, Create(declaration.InitializerOpt), declaration.Syntax)));
         }
 
+        private static readonly ConditionalWeakTable<BoundTupleExpression, object> s_tupleElementsMappings =
+            new ConditionalWeakTable<BoundTupleExpression, object>();
+
+        private static ImmutableArray<IOperation> GetTupleElements(BoundTupleExpression boundTupleExpression)
+        {
+            return (ImmutableArray<IOperation>)s_tupleElementsMappings.GetValue(boundTupleExpression,
+                tupleExpr => tupleExpr.Arguments.SelectAsArray(element => Create(element)));
+        }
+
         // TODO: We need to reuse the logic in `LocalRewriter.MakeArguments` instead of using private implementation. 
         //       Also. this implementation here was for the (now removed) API `ArgumentsInParameter`, which doesn't fulfill
         //       the contract of `ArgumentsInEvaluationOrder` plus it doesn't handle various scenarios correctly even for parameter order, 

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Diagnostics\DiagnosticAnalyzerTests.cs" />
     <Compile Include="Diagnostics\GetDiagnosticsTests.cs" />
     <Compile Include="IOperation\IOperationTests_IArgument.cs" />
+    <Compile Include="IOperation\IOperationTests_ITupleExpression.cs" />
     <Compile Include="IOperation\IOperationTests_IIfStatement.cs" />
     <Compile Include="IOperation\IOperationTests_IFieldReferenceExpression.cs" />
     <Compile Include="IOperation\IOperationTests_IObjectCreationExpression.cs" />

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.cs
@@ -23,8 +23,8 @@ class Class1
 }
 ";
             string expectedOperationTree = @"
-IOperation:  (OperationKind.None) (Syntax: '(x, x + y)')
-  Children(2): IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'x')
+ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32 x, System.Int32)) (Syntax: '(x, x + y)')
+  Elements(2): IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'x')
     IBinaryOperatorExpression (BinaryOperationKind.IntegerAdd) (OperationKind.BinaryOperatorExpression, Type: System.Int32) (Syntax: 'x + y')
       Left: IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'x')
       Right: IParameterReferenceExpression: y (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'y')
@@ -66,8 +66,8 @@ class Class1
 ";
             string expectedOperationTree = @"
 IOperation:  (OperationKind.None) (Syntax: 'var (x, y) = point')
-  Children(2): IOperation:  (OperationKind.None) (Syntax: 'var (x, y)')
-      Children(2): ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: System.Int32) (Syntax: 'x')
+  Children(2): ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32 x, System.Int32 y)) (Syntax: 'var (x, y)')
+      Elements(2): ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: System.Int32) (Syntax: 'x')
         ILocalReferenceExpression: y (OperationKind.LocalReferenceExpression, Type: System.Int32) (Syntax: 'y')
     IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: (System.Int32 x, System.Int32 y)) (Syntax: 'point')
       IParameterReferenceExpression: point (OperationKind.ParameterReferenceExpression, Type: Point) (Syntax: 'point')

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ITupleExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_ITupleExpression.cs
@@ -1,0 +1,473 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public partial class IOperationTests : SemanticModelTestBase
+    {
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_NoConversions()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        (int, int) t = /*<bind>*/(1, 2)/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32, System.Int32)) (Syntax: '(1, 2)')
+  Elements(2): ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<TupleExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_ImplicitConversions()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        (uint, uint) t = /*<bind>*/(1, 2)/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+ITupleExpression (OperationKind.TupleExpression, Type: (System.UInt32, System.UInt32)) (Syntax: '(1, 2)')
+  Elements(2): IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.UInt32, Constant: 1) (Syntax: '1')
+      ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.UInt32, Constant: 2) (Syntax: '2')
+      ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<TupleExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_ImplicitConversionFromNull()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        (uint, string) t = /*<bind>*/(1, null)/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+ITupleExpression (OperationKind.TupleExpression, Type: (System.UInt32, System.String)) (Syntax: '(1, null)')
+  Elements(2): IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.UInt32, Constant: 1) (Syntax: '1')
+      ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: System.String, Constant: null) (Syntax: 'null')
+      ILiteralExpression (Text: null) (OperationKind.LiteralExpression, Type: null, Constant: null) (Syntax: 'null')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<TupleExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_NamedArguments()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        var t = /*<bind>*/(A: 1, B: 2)/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32 A, System.Int32 B)) (Syntax: '(A: 1, B: 2)')
+  Elements(2): ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<TupleExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_NamedElementsInTupleType()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        (int A, int B) t = /*<bind>*/(1, 2)/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32, System.Int32)) (Syntax: '(1, 2)')
+  Elements(2): ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<TupleExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_NamedElementsAndImplicitConversions()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        (short, string) t = /*<bind>*/(A: 1, B: null)/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+ITupleExpression (OperationKind.TupleExpression, Type: (System.Int16 A, System.String B)) (Syntax: '(A: 1, B: null)')
+  Elements(2): IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.Int16, Constant: 1) (Syntax: '1')
+      ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: System.String, Constant: null) (Syntax: 'null')
+      ILiteralExpression (Text: null) (OperationKind.LiteralExpression, Type: null, Constant: null) (Syntax: 'null')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS8123: The tuple element name 'A' is ignored because a different name or no name is specified by the target type '(short, string)'.
+                //         (short, string) t = /*<bind>*/(A: 1, B: null)/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "A: 1").WithArguments("A", "(short, string)").WithLocation(8, 40),
+                // CS8123: The tuple element name 'B' is ignored because a different name or no name is specified by the target type '(short, string)'.
+                //         (short, string) t = /*<bind>*/(A: 1, B: null)/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "B: null").WithArguments("B", "(short, string)").WithLocation(8, 46)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<TupleExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_UserDefinedConversionsForArguments()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    private readonly int _x;
+    public C(int x)
+    {
+        _x = x;
+    }
+
+    public static implicit operator C(int value)
+    {
+        return new C(value);
+    }
+
+    public static implicit operator short(C c)
+    {
+        return (short)c._x;
+    }
+
+    public static implicit operator string(C c)
+    {
+        return c._x.ToString();
+    }
+
+    public void M(C c1)
+    {
+        (short, string) t = /*<bind>*/(new C(0), c1)/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+ITupleExpression (OperationKind.TupleExpression, Type: (System.Int16, System.String c1)) (Syntax: '(new C(0), c1)')
+  Elements(2): IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: System.Int16 C.op_Implicit(C c)) (OperationKind.ConversionExpression, Type: System.Int16) (Syntax: 'new C(0)')
+      IObjectCreationExpression (Constructor: C..ctor(System.Int32 x)) (OperationKind.ObjectCreationExpression, Type: C) (Syntax: 'new C(0)')
+        Arguments(1): IArgument (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument) (Syntax: '0')
+            ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+    IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: System.String C.op_Implicit(C c)) (OperationKind.ConversionExpression, Type: System.String) (Syntax: 'c1')
+      IParameterReferenceExpression: c1 (OperationKind.ParameterReferenceExpression, Type: C) (Syntax: 'c1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<TupleExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_UserDefinedConversionFromTupleExpression()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    private readonly int _x;
+    public C(int x)
+    {
+        _x = x;
+    }
+
+    public static implicit operator C((int, string) x)
+    {
+        return new C(x.Item1);
+    }
+
+    public static implicit operator (int, string)(C c)
+    {
+        return (c._x, c._x.ToString());
+    }
+
+    public void M(C c1)
+    {
+        C t /*<bind>*/= (0, null)/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C t /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C t /*<bind ... *</bind>*/;')
+    Variables: Local_1: C t
+    Initializer: IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: C C.op_Implicit((System.Int32, System.String) x)) (OperationKind.ConversionExpression, Type: C) (Syntax: '(0, null)')
+        IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: (System.Int32, System.String)) (Syntax: '(0, null)')
+          ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32, System.String)) (Syntax: '(0, null)')
+            Elements(2): ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+              IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: System.String, Constant: null) (Syntax: 'null')
+                ILiteralExpression (Text: null) (OperationKind.LiteralExpression, Type: null, Constant: null) (Syntax: 'null')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<EqualsValueClauseSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_UserDefinedConversionToTupleType()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    private readonly int _x;
+    public C(int x)
+    {
+        _x = x;
+    }
+
+    public static implicit operator C((int, string) x)
+    {
+        return new C(x.Item1);
+    }
+
+    public static implicit operator (int, string)(C c)
+    {
+        return (c._x, c._x.ToString());
+    }
+
+    public void M(C c1)
+    {
+        (int, string) t /*<bind>*/= c1/*</bind>*/;
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: '(int, strin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: '(int, strin ... *</bind>*/;')
+    Variables: Local_1: (System.Int32, System.String) t
+    Initializer: IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: (System.Int32, System.String) C.op_Implicit(C c)) (OperationKind.ConversionExpression, Type: (System.Int32, System.String)) (Syntax: 'c1')
+        IParameterReferenceExpression: c1 (OperationKind.ParameterReferenceExpression, Type: C) (Syntax: 'c1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<EqualsValueClauseSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_InvalidConversion()
+        {
+            string source = @"
+using System;
+
+class C
+{
+    private readonly int _x;
+    public C(int x)
+    {
+        _x = x;
+    }
+
+    public static implicit operator C(int value)
+    {
+        return new C(value);
+    }
+
+    public static implicit operator int(C c)
+    {
+        return (short)c._x;
+    }
+
+    public static implicit operator string(C c)
+    {
+        return c._x.ToString();
+    }
+
+    public void M(C c1)
+    {
+        /*<bind>*/(short, string) t = (new C(0), c1);/*</bind>*/
+        Console.WriteLine(t);
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: '(short, str ...  C(0), c1);')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: '(short, str ...  C(0), c1);')
+    Variables: Local_1: (System.Int16, System.String) t
+    Initializer: IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: (System.Int16, System.String), IsInvalid) (Syntax: '(new C(0), c1)')
+        ITupleExpression (OperationKind.TupleExpression, Type: (C, C c1)) (Syntax: '(new C(0), c1)')
+          Elements(2): IObjectCreationExpression (Constructor: C..ctor(System.Int32 x)) (OperationKind.ObjectCreationExpression, Type: C) (Syntax: 'new C(0)')
+              Arguments(1): IArgument (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument) (Syntax: '0')
+                  ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+            IParameterReferenceExpression: c1 (OperationKind.ParameterReferenceExpression, Type: C) (Syntax: 'c1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0029: Cannot implicitly convert type 'C' to 'short'
+                //         /*<bind>*/(short, string) t = (new C(0), c1);/*</bind>*/
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "new C(0)").WithArguments("C", "short").WithLocation(29, 40)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<LocalDeclarationStatementSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_Deconstruction()
+        {
+            string source = @"
+class Point
+{
+    public int X { get; }
+    public int Y { get; }
+
+    public Point(int x, int y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public void Deconstruct(out int x, out int y)
+    {
+        x = X;
+        y = Y;
+    }
+}
+
+class Class1
+{
+    public void M()
+    {
+        /*<bind>*/var (x, y) = new Point(0, 1)/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IOperation:  (OperationKind.None) (Syntax: 'var (x, y)  ... Point(0, 1)')
+  Children(2): ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32 x, System.Int32 y)) (Syntax: 'var (x, y)')
+      Elements(2): ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: System.Int32) (Syntax: 'x')
+        ILocalReferenceExpression: y (OperationKind.LocalReferenceExpression, Type: System.Int32) (Syntax: 'y')
+    IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: (System.Int32 x, System.Int32 y)) (Syntax: 'new Point(0, 1)')
+      IObjectCreationExpression (Constructor: Point..ctor(System.Int32 x, System.Int32 y)) (OperationKind.ObjectCreationExpression, Type: Point) (Syntax: 'new Point(0, 1)')
+        Arguments(2): IArgument (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument) (Syntax: '0')
+            ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+          IArgument (ArgumentKind.Explicit, Matching Parameter: y) (OperationKind.Argument) (Syntax: '1')
+            ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")]
+        public void TupleExpression_DeconstructionWithConversion()
+        {
+            string source = @"
+class Point
+{
+    public int X { get; }
+    public int Y { get; }
+
+    public Point(int x, int y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public void Deconstruct(out uint x, out uint y)
+    {
+        x = X;
+        y = Y;
+    }
+}
+
+class Class1
+{
+    public void M()
+    {
+        /*<bind>*/(uint x, uint y) = new Point(0, 1)/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IOperation:  (OperationKind.None) (Syntax: '(uint x, ui ... Point(0, 1)')
+  Children(2): ITupleExpression (OperationKind.TupleExpression, Type: (System.UInt32 x, System.UInt32 y)) (Syntax: '(uint x, uint y)')
+      Elements(2): ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: System.UInt32) (Syntax: 'uint x')
+        ILocalReferenceExpression: y (OperationKind.LocalReferenceExpression, Type: System.UInt32) (Syntax: 'uint y')
+    IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: (System.UInt32 x, System.UInt32 y)) (Syntax: 'new Point(0, 1)')
+      IObjectCreationExpression (Constructor: Point..ctor(System.Int32 x, System.Int32 y)) (OperationKind.ObjectCreationExpression, Type: Point) (Syntax: 'new Point(0, 1)')
+        Arguments(2): IArgument (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument) (Syntax: '0')
+            ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+          IArgument (ArgumentKind.Explicit, Matching Parameter: y) (OperationKind.Argument) (Syntax: '1')
+            ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0266: Cannot implicitly convert type 'int' to 'uint'. An explicit conversion exists (are you missing a cast?)
+                //         x = X;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "X").WithArguments("int", "uint").WithLocation(15, 13),
+                // CS0266: Cannot implicitly convert type 'int' to 'uint'. An explicit conversion exists (are you missing a cast?)
+                //         y = Y;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "Y").WithArguments("int", "uint").WithLocation(16, 13)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<AssignmentExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Operations\ISyntheticLocalReferenceExpression.cs" />
     <Compile Include="Operations\IThrowStatement.cs" />
     <Compile Include="Operations\ITryStatement.cs" />
+    <Compile Include="Operations\ITupleExpression.cs" />
     <Compile Include="Operations\ITypeOfExpression.cs" />
     <Compile Include="Operations\ITypeOperationExpression.cs" />
     <Compile Include="Operations\ITypeParameterObjectCreationExpression.cs" />

--- a/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.xml.Generated.cs
@@ -3837,6 +3837,63 @@ namespace Microsoft.CodeAnalysis.Semantics
     }
 
     /// <summary>
+    /// Represents a tuple expression.
+    /// </summary>
+    internal abstract partial class BaseTupleExpression : Operation, ITupleExpression
+    {
+        protected BaseTupleExpression(bool isInvalid, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue) :
+                    base(OperationKind.TupleExpression, isInvalid, syntax, type, constantValue)
+        {
+        }
+        /// <summary>
+        /// Elements for tuple expression.
+        /// </summary>
+        public abstract ImmutableArray<IOperation> Elements { get; }
+        public override void Accept(OperationVisitor visitor)
+        {
+            visitor.VisitTupleExpression(this);
+        }
+        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
+        {
+            return visitor.VisitTupleExpression(this, argument);
+        }
+    }
+
+    /// <summary>
+    /// Represents a tuple expression.
+    /// </summary>
+    internal sealed partial class TupleExpression : BaseTupleExpression, ITupleExpression
+    {
+        public TupleExpression(ImmutableArray<IOperation> elements, bool isInvalid, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue) :
+            base(isInvalid, syntax, type, constantValue)
+        {
+            Elements = elements;
+        }
+        /// <summary>
+        /// Elements for tuple expression.
+        /// </summary>
+        public override ImmutableArray<IOperation> Elements { get; }
+    }
+
+    /// <summary>
+    /// Represents a C# try or a VB Try statement.
+    /// </summary>
+    internal sealed partial class LazyTupleExpression : BaseTupleExpression, ITupleExpression
+    {
+        private readonly Lazy<ImmutableArray<IOperation>> _lazyElements;
+
+        public LazyTupleExpression(Lazy<ImmutableArray<IOperation>> elements, bool isInvalid, SyntaxNode syntax, ITypeSymbol type, Optional<object> constantValue) :
+            base(isInvalid, syntax, type, constantValue)
+        {
+            _lazyElements = elements;
+        }
+        /// <summary>
+        /// Elements for tuple expression.
+        /// </summary>
+        public override ImmutableArray<IOperation> Elements => _lazyElements.Value;
+    }
+
+    /// <summary>
     /// Represents a TypeOf expression.
     /// </summary>
     internal sealed partial class TypeOfExpression : TypeOperationExpression, ITypeOfExpression

--- a/src/Compilers/Core/Portable/Operations/IOperationKind.cs
+++ b/src/Compilers/Core/Portable/Operations/IOperationKind.cs
@@ -126,6 +126,8 @@ namespace Microsoft.CodeAnalysis
         ConditionalAccessExpression = 0x11c,
         /// <summary>Indicates an <see cref="IConditionalAccessInstanceExpression"/>.</summary>
         ConditionalAccessInstanceExpression = 0x11d,
+        /// <summary>Indicates an <see cref="ITupleExpression"/>.</summary>
+        TupleExpression = 0x11f,
 
         // Expressions that occur only in C#.
 

--- a/src/Compilers/Core/Portable/Operations/ITupleExpression.cs
+++ b/src/Compilers/Core/Portable/Operations/ITupleExpression.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Semantics
+{
+    /// <summary>
+    /// Represents a tuple expression.
+    /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    public interface ITupleExpression : IOperation
+    {
+        /// <summary>
+        /// Elements for tuple expression.
+        /// </summary>
+        ImmutableArray<IOperation> Elements { get; }
+    }
+}
+

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -394,6 +394,11 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             DefaultVisit(operation);
         }
+
+        public virtual void VisitTupleExpression(ITupleExpression operation)
+        {
+            DefaultVisit(operation);
+        }
     }
 
     /// <summary>
@@ -791,6 +796,11 @@ namespace Microsoft.CodeAnalysis.Semantics
         }
 
         public virtual TResult VisitLocalFunctionStatement(IOperation operation, TArgument argument)
+        {
+            return DefaultVisit(operation, argument);
+        }
+
+        public virtual TResult VisitTupleExpression(ITupleExpression operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Core/Portable/Operations/OperationWalker.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationWalker.cs
@@ -420,5 +420,10 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             VisitArray(operation.Children);
         }
+
+        public override void VisitTupleExpression(ITupleExpression operation)
+        {
+            VisitArray(operation.Elements);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -116,6 +116,7 @@ Microsoft.CodeAnalysis.OperationKind.SwitchStatement = 4 -> Microsoft.CodeAnalys
 Microsoft.CodeAnalysis.OperationKind.SyntheticLocalReferenceExpression = 263 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.ThrowStatement = 10 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.TryStatement = 14 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.OperationKind.TupleExpression = 287 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.TypeOfExpression = 513 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.TypeParameterObjectCreationExpression = 275 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.UnaryOperatorExpression = 269 -> Microsoft.CodeAnalysis.OperationKind
@@ -503,6 +504,8 @@ Microsoft.CodeAnalysis.Semantics.ITryStatement
 Microsoft.CodeAnalysis.Semantics.ITryStatement.Body.get -> Microsoft.CodeAnalysis.Semantics.IBlockStatement
 Microsoft.CodeAnalysis.Semantics.ITryStatement.Catches.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Semantics.ICatchClause>
 Microsoft.CodeAnalysis.Semantics.ITryStatement.FinallyHandler.get -> Microsoft.CodeAnalysis.Semantics.IBlockStatement
+Microsoft.CodeAnalysis.Semantics.ITupleExpression
+Microsoft.CodeAnalysis.Semantics.ITupleExpression.Elements.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation>
 Microsoft.CodeAnalysis.Semantics.ITypeOfExpression
 Microsoft.CodeAnalysis.Semantics.ITypeOperationExpression
 Microsoft.CodeAnalysis.Semantics.ITypeOperationExpression.TypeOperand.get -> Microsoft.CodeAnalysis.ITypeSymbol
@@ -729,6 +732,7 @@ override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitSwitchStatement(M
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitSyntheticLocalReferenceExpression(Microsoft.CodeAnalysis.Semantics.ISyntheticLocalReferenceExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitThrowStatement(Microsoft.CodeAnalysis.Semantics.IThrowStatement operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitTryStatement(Microsoft.CodeAnalysis.Semantics.ITryStatement operation) -> void
+override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitTupleExpression(Microsoft.CodeAnalysis.Semantics.ITupleExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitTypeOfExpression(Microsoft.CodeAnalysis.Semantics.ITypeOfExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitTypeParameterObjectCreationExpression(Microsoft.CodeAnalysis.Semantics.ITypeParameterObjectCreationExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitUnaryOperatorExpression(Microsoft.CodeAnalysis.Semantics.IUnaryOperatorExpression operation) -> void
@@ -828,6 +832,7 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitSwitchStatement(M
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitSyntheticLocalReferenceExpression(Microsoft.CodeAnalysis.Semantics.ISyntheticLocalReferenceExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitThrowStatement(Microsoft.CodeAnalysis.Semantics.IThrowStatement operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitTryStatement(Microsoft.CodeAnalysis.Semantics.ITryStatement operation) -> void
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitTupleExpression(Microsoft.CodeAnalysis.Semantics.ITupleExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitTypeOfExpression(Microsoft.CodeAnalysis.Semantics.ITypeOfExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitTypeParameterObjectCreationExpression(Microsoft.CodeAnalysis.Semantics.ITypeParameterObjectCreationExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitUnaryOperatorExpression(Microsoft.CodeAnalysis.Semantics.IUnaryOperatorExpression operation) -> void
@@ -904,6 +909,7 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.Vi
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitSyntheticLocalReferenceExpression(Microsoft.CodeAnalysis.Semantics.ISyntheticLocalReferenceExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitThrowStatement(Microsoft.CodeAnalysis.Semantics.IThrowStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitTryStatement(Microsoft.CodeAnalysis.Semantics.ITryStatement operation, TArgument argument) -> TResult
+virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitTupleExpression(Microsoft.CodeAnalysis.Semantics.ITupleExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitTypeOfExpression(Microsoft.CodeAnalysis.Semantics.ITypeOfExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitTypeParameterObjectCreationExpression(Microsoft.CodeAnalysis.Semantics.ITypeParameterObjectCreationExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitUnaryOperatorExpression(Microsoft.CodeAnalysis.Semantics.IUnaryOperatorExpression operation, TArgument argument) -> TResult

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -27,18 +27,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
     End Class
 
-    Friend Partial Class BoundAttribute
+    Partial Friend Class BoundAttribute
         Protected Overrides ReadOnly Property Children As ImmutableArray(Of BoundNode)
             Get
                 Return StaticCast(Of BoundNode).From(Me.ConstructorArguments.AddRange(Me.NamedArguments))
-            End Get
-        End Property
-    End Class
-
-    Friend Partial MustInherit Class BoundTupleExpression
-        Protected Overrides ReadOnly Property Children As ImmutableArray(Of BoundNode)
-            Get
-                Return StaticCast(Of BoundNode).From(Me.Arguments)
             End Get
         End Property
     End Class

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -161,6 +161,8 @@ Namespace Microsoft.CodeAnalysis.Semantics
                     Return CreateBoundAddHandlerStatementOperation(DirectCast(boundNode, BoundAddHandlerStatement))
                 Case BoundKind.RemoveHandlerStatement
                     Return CreateBoundRemoveHandlerStatementOperation(DirectCast(boundNode, BoundRemoveHandlerStatement))
+                Case BoundKind.TupleLiteral, BoundKind.ConvertedTupleLiteral
+                    Return CreateBoundTupleExpressionOperation(DirectCast(boundNode, BoundTupleExpression))
                 Case Else
                     Dim constantValue = ConvertToOptional(TryCast(boundNode, BoundExpression)?.ConstantValueOpt)
                     Return Operation.CreateOperationNone(boundNode.HasErrors, boundNode.Syntax, constantValue, Function() GetIOperationChildren(boundNode))
@@ -1015,6 +1017,15 @@ Namespace Microsoft.CodeAnalysis.Semantics
             Dim type As ITypeSymbol = Nothing
             Dim constantValue As [Optional](Of Object) = New [Optional](Of Object)()
             Return New LazyExpressionStatement(expression, isInvalid, syntax, type, constantValue)
+        End Function
+
+        Private Shared Function CreateBoundTupleExpressionOperation(boundTupleExpression As BoundTupleExpression) As ITupleExpression
+            Dim elements As New Lazy(Of ImmutableArray(Of IOperation))(Function() GetTupleElements(boundTupleExpression))
+            Dim isInvalid As Boolean = boundTupleExpression.HasErrors
+            Dim syntax As SyntaxNode = boundTupleExpression.Syntax
+            Dim type As ITypeSymbol = boundTupleExpression.Type
+            Dim constantValue As [Optional](Of Object) = ConvertToOptional(boundTupleExpression.ConstantValueOpt)
+            Return New LazyTupleExpression(elements, isInvalid, syntax, type, constantValue)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -489,6 +489,14 @@ Namespace Microsoft.CodeAnalysis.Semantics
                 End Function)
         End Function
 
+        Private Shared ReadOnly s_tupleElementsMappings As New ConditionalWeakTable(Of BoundTupleExpression, Object)()
+
+        Private Shared Function GetTupleElements(boundTupleExpression As BoundTupleExpression) As ImmutableArray(Of IOperation)
+            Return DirectCast(s_tupleElementsMappings.GetValue(
+                boundTupleExpression,
+                Function(tupleExpr) tupleExpr.Arguments.SelectAsArray(Function(element) Create(element))), ImmutableArray(Of IOperation))
+        End Function
+
         Friend Class Helper
             Friend Shared Function DeriveUnaryOperationKind(operatorKind As UnaryOperatorKind) As UnaryOperationKind
                 Select Case operatorKind And UnaryOperatorKind.OpMask

--- a/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
@@ -109,6 +109,7 @@
     <Compile Include="Diagnostics\GetDiagnosticsTests.vb" />
     <Compile Include="IOperation\IOperationTests_IArgument.vb" />
     <Compile Include="IOperation\IOperationTests_IFieldReferenceExpression.vb" />
+    <Compile Include="IOperation\IOperationTests_ITupleExpression.vb" />
     <Compile Include="IOperation\IOperationTests_IObjectCreationExpression.vb" />
     <Compile Include="IOperation\IOperationTests_IParameterReferenceExpression.vb" />
     <Compile Include="IOperation\IOperationTests_InvalidStatement.vb" />

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.vb
@@ -20,8 +20,8 @@ Class Class1
 End Class]]>.Value
 
             Dim expectedOperationTree = <![CDATA[
-IOperation:  (OperationKind.None) (Syntax: '(x, x + y)')
-  Children(2): IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'x')
+ITupleExpression (OperationKind.TupleExpression, Type: (x As System.Int32, System.Int32)) (Syntax: '(x, x + y)')
+  Elements(2): IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'x')
     IBinaryOperatorExpression (BinaryOperationKind.IntegerAdd) (OperationKind.BinaryOperatorExpression, Type: System.Int32) (Syntax: 'x + y')
       Left: IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'x')
       Right: IParameterReferenceExpression: y (OperationKind.ParameterReferenceExpression, Type: System.Int32) (Syntax: 'y')

--- a/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_ITupleExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/IOperation/IOperationTests_ITupleExpression.vb
@@ -1,0 +1,330 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
+
+    Partial Public Class IOperationTests
+        Inherits SemanticModelTestBase
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_NoConversions()
+            Dim source = <![CDATA[
+Imports System
+
+Class C
+    Shared Sub Main()
+        Dim t As (Integer, Integer) = (1, 2)'BIND:"(1, 2)"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32, System.Int32)) (Syntax: '(1, 2)')
+  Elements(2): ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of TupleExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_ImplicitConversions()
+            Dim source = <![CDATA[
+Imports System
+
+Class C
+    Shared Sub Main()
+        Dim t As (UInteger, UInteger) = (1, 2)'BIND:"(1, 2)"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: (System.UInt32, System.UInt32)) (Syntax: '(1, 2)')
+  ITupleExpression (OperationKind.TupleExpression, Type: (System.UInt32, System.UInt32)) (Syntax: '(1, 2)')
+    Elements(2): IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.UInt32, Constant: 1) (Syntax: '1')
+        ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+      IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.UInt32, Constant: 2) (Syntax: '2')
+        ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of TupleExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_ImplicitConversionFromNull()
+            Dim source = <![CDATA[
+Imports System
+
+Class C
+    Shared Sub Main()
+        Dim t As (UInteger, String) = (1, Nothing)'BIND:"(1, Nothing)"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: (System.UInt32, System.String)) (Syntax: '(1, Nothing)')
+  ITupleExpression (OperationKind.TupleExpression, Type: (System.UInt32, System.String)) (Syntax: '(1, Nothing)')
+    Elements(2): IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.UInt32, Constant: 1) (Syntax: '1')
+        ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+      IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.String, Constant: null) (Syntax: 'Nothing')
+        ILiteralExpression (OperationKind.LiteralExpression, Type: null, Constant: null) (Syntax: 'Nothing')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of TupleExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_NamedArguments()
+            Dim source = <![CDATA[
+Option Strict Off
+Imports System
+
+Class C
+    Shared Sub Main()
+        Dim t = (A:=1, B:=2)'BIND:"(A:=1, B:=2)"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+ITupleExpression (OperationKind.TupleExpression, Type: (A As System.Int32, B As System.Int32)) (Syntax: '(A:=1, B:=2)')
+  Elements(2): ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of TupleExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_NamedElementsInTupleType()
+            Dim source = <![CDATA[
+Option Strict Off
+Imports System
+
+Class C
+    Shared Sub Main()
+        Dim t As (A As Integer, B As Integer) = (1, 2)'BIND:"(1, 2)"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: (A As System.Int32, B As System.Int32)) (Syntax: '(1, 2)')
+  ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32, System.Int32)) (Syntax: '(1, 2)')
+    Elements(2): ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+      ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of TupleExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_NamedElementsAndImplicitConversions()
+            Dim source = <![CDATA[
+Option Strict Off
+Imports System
+
+Class C
+    Shared Sub Main()
+        Dim t As (A As Int16, B As String) = (A:=1, B:=Nothing)'BIND:"(A:=1, B:=Nothing)"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: (A As System.Int16, B As System.String)) (Syntax: '(A:=1, B:=Nothing)')
+  ITupleExpression (OperationKind.TupleExpression, Type: (A As System.Int16, B As System.String)) (Syntax: '(A:=1, B:=Nothing)')
+    Elements(2): IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Int16, Constant: 1) (Syntax: '1')
+        ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+      IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.String, Constant: null) (Syntax: 'Nothing')
+        ILiteralExpression (OperationKind.LiteralExpression, Type: null, Constant: null) (Syntax: 'Nothing')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of TupleExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_UserDefinedConversionsForArguments()
+            Dim source = <![CDATA[
+Imports System
+
+Class C
+    Private ReadOnly _x As Integer
+    Public Sub New(x As Integer)
+        _x = x
+    End Sub
+
+    Public Shared Widening Operator CType(value As Integer) As C
+        Return New C(value)
+    End Operator
+
+    Public Shared Widening Operator CType(c As C) As Short
+        Return CShort(c._x)
+    End Operator
+
+    Public Shared Widening Operator CType(c As C) As String
+        Return c._x.ToString()
+    End Operator
+
+    Public Sub M(c1 As C)
+        Dim t As (A As Int16, B As String) = (New C(0), c1)'BIND:"(New C(0), c1)"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: (A As System.Int16, B As System.String)) (Syntax: '(New C(0), c1)')
+  ITupleExpression (OperationKind.TupleExpression, Type: (System.Int16, c1 As System.String)) (Syntax: '(New C(0), c1)')
+    Elements(2): IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Int16) (Syntax: 'New C(0)')
+        IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: Function C.op_Implicit(c As C) As System.Int16) (OperationKind.ConversionExpression, Type: C) (Syntax: 'New C(0)')
+          IObjectCreationExpression (Constructor: Sub C..ctor(x As System.Int32)) (OperationKind.ObjectCreationExpression, Type: C) (Syntax: 'New C(0)')
+            Arguments(1): IArgument (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument) (Syntax: '0')
+                ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+      IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.String) (Syntax: 'c1')
+        IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: Function C.op_Implicit(c As C) As System.String) (OperationKind.ConversionExpression, Type: C) (Syntax: 'c1')
+          IParameterReferenceExpression: c1 (OperationKind.ParameterReferenceExpression, Type: C) (Syntax: 'c1')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of TupleExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_UserDefinedConversionFromTupleExpression()
+            Dim source = <![CDATA[
+Imports System
+
+Class C
+    Private ReadOnly _x As Integer
+    Public Sub New(x As Integer)
+        _x = x
+    End Sub
+
+    Public Shared Widening Operator CType(x As (Integer, String)) As C
+        Return New C(x.Item1)
+    End Operator
+
+    Public Shared Widening Operator CType(c As C) As (Integer, String)
+        Return (c._x, c._x.ToString)
+    End Operator
+
+    Public Sub M(c1 As C)
+        Dim t As C = (0, Nothing)'BIND:"(0, Nothing)"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: C) (Syntax: '(0, Nothing)')
+  IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: Function C.op_Implicit(x As (System.Int32, System.String)) As C) (OperationKind.ConversionExpression, Type: (System.Int32, System.Object)) (Syntax: '(0, Nothing)')
+    IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: (System.Int32, System.Object)) (Syntax: '(0, Nothing)')
+      ITupleExpression (OperationKind.TupleExpression, Type: (System.Int32, System.Object)) (Syntax: '(0, Nothing)')
+        Elements(2): ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+          IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Object, Constant: null) (Syntax: 'Nothing')
+            ILiteralExpression (OperationKind.LiteralExpression, Type: null, Constant: null) (Syntax: 'Nothing')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of TupleExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_UserDefinedConversionToTupleType()
+            Dim source = <![CDATA[
+Imports System
+
+Class C
+    Private ReadOnly _x As Integer
+    Public Sub New(x As Integer)
+        _x = x
+    End Sub
+
+    Public Shared Widening Operator CType(x As (Integer, String)) As C
+        Return New C(x.Item1)
+    End Operator
+
+    Public Shared Widening Operator CType(c As C) As (Integer, String)
+        Return (c._x, c._x.ToString)
+    End Operator
+
+    Public Sub M(c1 As C)
+        Dim t As (Integer, String) = c1'BIND:"Dim t As (Integer, String) = c1"
+    End Sub
+End Class]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'Dim t As (I ... tring) = c1')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 't')
+    Variables: Local_1: t As (System.Int32, System.String)
+    Initializer: IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: (System.Int32, System.String)) (Syntax: 'c1')
+        IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: Function C.op_Implicit(c As C) As (System.Int32, System.String)) (OperationKind.ConversionExpression, Type: C) (Syntax: 'c1')
+          IParameterReferenceExpression: c1 (OperationKind.ParameterReferenceExpression, Type: C) (Syntax: 'c1')
+]]>.Value
+
+            Dim expectedDiagnostics = String.Empty
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
+        <Fact, WorkItem(10856, "https://github.com/dotnet/roslyn/issues/10856")>
+        Public Sub TupleExpression_InvalidConversion()
+            Dim source = <![CDATA[
+Class C
+    Private ReadOnly _x As Integer
+    Public Sub New(x As Integer)
+        _x = x
+    End Sub
+
+    Public Shared Widening Operator CType(value As Integer) As C
+        Return New C(value)
+    End Operator
+
+    Public Shared Widening Operator CType(c As C) As Integer
+        Return CShort(c._x)
+    End Operator
+
+    Public Shared Widening Operator CType(c As C) As String
+        Return c._x.ToString()
+    End Operator
+
+    Public Sub M(c1 As C)
+        Dim t As (Short, String) = (New C(0), c1)'BIND:"Dim t As (Short, String) = (New C(0), c1)"
+    End Sub
+End Class
+
+]]>.Value
+
+            Dim expectedOperationTree = <![CDATA[
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'Dim t As (S ... w C(0), c1)')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 't')
+    Variables: Local_1: t As (System.Int16, System.String)
+    Initializer: ITupleExpression (OperationKind.TupleExpression, Type: (System.Int16, c1 As System.String), IsInvalid) (Syntax: '(New C(0), c1)')
+        Elements(2): IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.Int16, IsInvalid) (Syntax: 'New C(0)')
+            IObjectCreationExpression (Constructor: Sub C..ctor(x As System.Int32)) (OperationKind.ObjectCreationExpression, Type: C) (Syntax: 'New C(0)')
+              Arguments(1): IArgument (ArgumentKind.Explicit, Matching Parameter: x) (OperationKind.Argument) (Syntax: '0')
+                  ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0) (Syntax: '0')
+          IConversionExpression (ConversionKind.Basic, Implicit) (OperationKind.ConversionExpression, Type: System.String) (Syntax: 'c1')
+            IConversionExpression (ConversionKind.OperatorMethod, Implicit) (OperatorMethod: Function C.op_Implicit(c As C) As System.String) (OperationKind.ConversionExpression, Type: C) (Syntax: 'c1')
+              IParameterReferenceExpression: c1 (OperationKind.ParameterReferenceExpression, Type: C) (Syntax: 'c1')
+]]>.Value
+
+            Dim expectedDiagnostics = <![CDATA[
+BC30311: Value of type 'C' cannot be converted to 'Short'.
+        Dim t As (Short, String) = (New C(0), c1)'BIND:"Dim t As (Short, String) = (New C(0), c1)"
+                                    ~~~~~~~~
+]]>.Value
+
+            VerifyOperationTreeAndDiagnosticsForTest(Of LocalDeclarationStatementSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+    End Class
+End Namespace

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1100,6 +1100,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Visit(operation.MaximumValue, "Max");
         }
 
+        public override void VisitTupleExpression(ITupleExpression operation)
+        {
+            LogString(nameof(ITupleExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            VisitArray(operation.Elements, "Elements", logElementCount: true);
+        }
+
         #endregion
     }
 }

--- a/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
+++ b/src/Test/Utilities/Portable/Compilation/TestOperationWalker.cs
@@ -512,5 +512,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             base.VisitInvalidExpression(operation);
         }
+
+        public override void VisitTupleExpression(ITupleExpression operation)
+        {
+            base.VisitTupleExpression(operation);
+        }
     }
 }


### PR DESCRIPTION
Fixes #10856

```
    public interface ITupleExpression : IOperation
    {
        /// <summary>
        /// Elements for tuple expression.
        /// </summary>
        ImmutableArray<IOperation> Elements { get; }
    }
```
