### PR TITLE
changed behavior of LastDesignTimeBuildSucceeded following suggestion…

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -871,6 +871,7 @@
     <InternalsVisibleToTest Include="Microsoft.CodeAnalysis.Scripting.Destkop.UnitTests" />
     <InternalsVisibleToTest Include="Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests" />
     <InternalsVisibleToTest Include="Microsoft.CodeAnalysis.CSharp.Scripting.Desktop.UnitTests" />
+    <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.CSharp.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor2.UnitTests" />
   </ItemGroup>

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.CSharp.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.CSharp.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 await TestAddFieldAsync(input, expected,
                     type: GetTypeSymbol(typeof(string)),
                     accessibility: Accessibility.Private,
-                    modifiers: new DeclarationModifiers(isStatic: true));
+                    modifiers: new Editing.DeclarationModifiers(isStatic: true));
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var input = "class [|C|] { }";
                 var expected = "class C { public unsafe int F; }";
                 await TestAddFieldAsync(input, expected,
-                    modifiers: new DeclarationModifiers(isUnsafe: true),
+                    modifiers: new Editing.DeclarationModifiers(isUnsafe: true),
                     type: GetTypeSymbol(typeof(int)));
             }
 
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var input = "class [|C|] { }";
                 var expected = "class C { static C() { } }";
                 await TestAddConstructorAsync(input, expected,
-                    modifiers: new DeclarationModifiers(isStatic: true));
+                    modifiers: new Editing.DeclarationModifiers(isStatic: true));
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration), WorkItem(544082, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544082")]
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var input = "namespace [|N|] { }";
                 var expected = "namespace N { public static class C { } }";
                 await TestAddNamedTypeAsync(input, expected,
-                    modifiers: new DeclarationModifiers(isStatic: true));
+                    modifiers: new Editing.DeclarationModifiers(isStatic: true));
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration), WorkItem(544405, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544405")]
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var expected = "namespace N { private sealed class C { } }";
                 await TestAddNamedTypeAsync(input, expected,
                     accessibility: Accessibility.Private,
-                    modifiers: new DeclarationModifiers(isSealed: true));
+                    modifiers: new Editing.DeclarationModifiers(isSealed: true));
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration), WorkItem(544405, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544405")]
@@ -188,7 +188,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var expected = "namespace N { protected internal abstract class C { } }";
                 await TestAddNamedTypeAsync(input, expected,
                     accessibility: Accessibility.ProtectedOrInternal,
-                    modifiers: new DeclarationModifiers(isAbstract: true));
+                    modifiers: new Editing.DeclarationModifiers(isAbstract: true));
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var expected = "namespace N { public struct S { } }";
                 await TestAddNamedTypeAsync(input, expected,
                     name: "S",
-                    modifiers: new DeclarationModifiers(isSealed: true),
+                    modifiers: new Editing.DeclarationModifiers(isSealed: true),
                     accessibility: Accessibility.Public,
                     typeKind: TypeKind.Struct);
             }
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 await TestAddDelegateTypeAsync(input, expected,
                     returnType: typeof(int),
                     parameters: Parameters(Parameter(typeof(string), "s")),
-                    modifiers: new DeclarationModifiers(isSealed: true));
+                    modifiers: new Editing.DeclarationModifiers(isSealed: true));
             }
 
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var input = "class [|C|] { }";
                 var expected = "class C { public unsafe event System.Action E; }";
                 await TestAddEventAsync(input, expected,
-                    modifiers: new DeclarationModifiers(isUnsafe: true),
+                    modifiers: new Editing.DeclarationModifiers(isUnsafe: true),
                     codeGenerationOptions: new CodeGenerationOptions(addImports: false));
             }
 
@@ -319,7 +319,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var input = "struct [|S|] { }";
                 var expected = "struct S { public static int M() { $$ } }";
                 await TestAddMethodAsync(input, expected,
-                    modifiers: new DeclarationModifiers(isStatic: true),
+                    modifiers: new Editing.DeclarationModifiers(isStatic: true),
                     returnType: typeof(int),
                     statements: "return 0;");
             }
@@ -331,7 +331,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var expected = "class C { public sealed override int GetHashCode() { $$ } }";
                 await TestAddMethodAsync(input, expected,
                     name: "GetHashCode",
-                    modifiers: new DeclarationModifiers(isOverride: true, isSealed: true),
+                    modifiers: new Editing.DeclarationModifiers(isOverride: true, isSealed: true),
                     returnType: typeof(int),
                     statements: "return 0;");
             }
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var input = "abstract class [|C|] { }";
                 var expected = "abstract class C { public abstract int M(); }";
                 await TestAddMethodAsync(input, expected,
-                    modifiers: new DeclarationModifiers(isAbstract: true),
+                    modifiers: new Editing.DeclarationModifiers(isAbstract: true),
                     returnType: typeof(int));
             }
 
@@ -374,7 +374,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var expected = "class C { protected virtual int M() { $$ } }";
                 await TestAddMethodAsync(input, expected,
                     accessibility: Accessibility.Protected,
-                    modifiers: new DeclarationModifiers(isVirtual: true),
+                    modifiers: new Editing.DeclarationModifiers(isVirtual: true),
                     returnType: typeof(int),
                     statements: "return 0;");
             }
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 var expected = "class C { public unsafe new string ToString() { $$ } }";
                 await TestAddMethodAsync(input, expected,
                     name: "ToString",
-                    modifiers: new DeclarationModifiers(isNew: true, isUnsafe: true),
+                    modifiers: new Editing.DeclarationModifiers(isNew: true, isUnsafe: true),
                     returnType: typeof(string),
                     statements: "return String.Empty;");
             }
@@ -400,7 +400,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     name: "M",
                     returnType: typeof(void),
                     parameters: Parameters(Parameter(typeof(int), "i")),
-                    modifiers: new DeclarationModifiers(isUnsafe: true),
+                    modifiers: new Editing.DeclarationModifiers(isUnsafe: true),
                     explicitInterface: s => s.LookupSymbols(input.IndexOf('M'), null, "M").First() as IMethodSymbol);
             }
 
@@ -638,7 +638,7 @@ class C
                 var expected = "class C { public unsafe int P { get; internal set; } }";
                 await TestAddPropertyAsync(input, expected,
                     type: typeof(int),
-                    modifiers: new DeclarationModifiers(isUnsafe: true),
+                    modifiers: new Editing.DeclarationModifiers(isUnsafe: true),
                     setterAccessibility: Accessibility.Internal);
             }
 
@@ -961,7 +961,7 @@ class C { }";
 }";
                 var eol = SyntaxFactory.EndOfLine(@"");
                 var newModifiers = new[] { SyntaxFactory.Token(SyntaxKind.InternalKeyword).WithLeadingTrivia(eol) }.Concat(
-                    CreateModifierTokens(new DeclarationModifiers(isSealed: true, isPartial: true), LanguageNames.CSharp));
+                    CreateModifierTokens(new Editing.DeclarationModifiers(isSealed: true, isPartial: true), LanguageNames.CSharp));
 
                 await TestUpdateDeclarationAsync<ClassDeclarationSyntax>(input, expected, modifiers: newModifiers);
             }
@@ -1019,7 +1019,7 @@ public static class C
     public int f;
     public int f2;
 }";
-                var getField = CreateField(Accessibility.Public, new DeclarationModifiers(), typeof(int), "f2");
+                var getField = CreateField(Accessibility.Public, new Editing.DeclarationModifiers(), typeof(int), "f2");
                 var getMembers = ImmutableArray.Create(getField);
                 await TestUpdateDeclarationAsync<ClassDeclarationSyntax>(
                     input, expected, getNewMembers: getMembers);
@@ -1045,7 +1045,7 @@ public static class C
     // Comment 1
     public static char F() { return 0; }
 }";
-                var getField = CreateField(Accessibility.Public, new DeclarationModifiers(), typeof(int), "f2");
+                var getField = CreateField(Accessibility.Public, new Editing.DeclarationModifiers(), typeof(int), "f2");
                 var getMembers = ImmutableArray.Create(getField);
                 await TestUpdateDeclarationAsync<ClassDeclarationSyntax>(input, expected, getNewMembers: getMembers, declareNewMembersAtTop: true);
             }

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Func<SemanticModel, ITypeSymbol> type = null,
             string name = "F",
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
             bool ignoreTrivia = true,
             bool hasConstantValue = false,
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             string name = "C",
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
             ImmutableArray<SyntaxNode> statements = default(ImmutableArray<SyntaxNode>),
             ImmutableArray<SyntaxNode> baseArguments = default(ImmutableArray<SyntaxNode>),
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             string name = "M",
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             Type returnType = null,
             Func<SemanticModel, IMethodSymbol> explicitInterface = null,
             ImmutableArray<ITypeParameterSymbol> typeParameters = default(ImmutableArray<ITypeParameterSymbol>),
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             CodeGenerationOperatorKind[] operatorKinds,
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             Type returnType = null,
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
             string statements = null,
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string initial,
             CodeGenerationOperatorKind operatorKind,
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             Type returnType = null,
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
             string statements = null,
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             Func<SemanticModel, IParameterSymbol> fromType,
             bool isImplicit = false,
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             string statements = null,
             CodeGenerationOptions codeGenerationOptions = default(CodeGenerationOptions),
             bool ignoreTrivia = true)
@@ -303,7 +303,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             string name = "D",
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             Type returnType = null,
             ImmutableArray<ITypeParameterSymbol> typeParameters = default(ImmutableArray<ITypeParameterSymbol>),
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
@@ -332,7 +332,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string name = "E",
             ImmutableArray<AttributeData> attributes = default(ImmutableArray<AttributeData>),
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters = default(ImmutableArray<Func<SemanticModel, IParameterSymbol>>),
             Type type = null,
             Func<SemanticModel, IEventSymbol> explicitInterfaceSymbol = null,
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string name = "P",
             Accessibility defaultAccessibility = Accessibility.Public,
             Accessibility setterAccessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             string getStatements = null,
             string setStatements = null,
             Type type = null,
@@ -408,7 +408,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 IMethodSymbol getAccessor = CodeGenerationSymbolFactory.CreateMethodSymbol(
                     default(ImmutableArray<AttributeData>),
                     defaultAccessibility,
-                    new DeclarationModifiers(isAbstract: getStatements == null),
+                    new Editing.DeclarationModifiers(isAbstract: getStatements == null),
                     typeSymbol,
                     false,
                     null,
@@ -419,7 +419,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 IMethodSymbol setAccessor = CodeGenerationSymbolFactory.CreateMethodSymbol(
                     default(ImmutableArray<AttributeData>),
                     setterAccessibility,
-                    new DeclarationModifiers(isAbstract: setStatements == null),
+                    new Editing.DeclarationModifiers(isAbstract: setStatements == null),
                     GetTypeSymbol(typeof(void))(context.SemanticModel),
                     false,
                     null,
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             string expected,
             string name = "C",
             Accessibility accessibility = Accessibility.Public,
-            DeclarationModifiers modifiers = default(DeclarationModifiers),
+            Editing.DeclarationModifiers modifiers = default(Editing.DeclarationModifiers),
             TypeKind typeKind = TypeKind.Class,
             ImmutableArray<ITypeParameterSymbol> typeParameters = default(ImmutableArray<ITypeParameterSymbol>),
             INamedTypeSymbol baseType = null,
@@ -645,7 +645,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
         }
 
         private static ImmutableArray<IParameterSymbol> GetParameterSymbols(ImmutableArray<Func<SemanticModel, IParameterSymbol>> parameters, TestContext context)
-            => parameters.IsDefault 
+            => parameters.IsDefault
                 ? default(ImmutableArray<IParameterSymbol>)
                 : parameters.SelectAsArray(p => p(context.SemanticModel));
 
@@ -656,7 +656,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
 
         private static ImmutableArray<ISymbol> GetSymbols(ImmutableArray<Func<SemanticModel, ISymbol>> members, TestContext context)
         {
-            return members == null 
+            return members == null
                 ? default(ImmutableArray<ISymbol>)
                 : members.SelectAsArray(m => m(context.SemanticModel));
         }
@@ -665,10 +665,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
         {
             return s => CodeGenerationSymbolFactory.CreateFieldSymbol(
                 default(ImmutableArray<AttributeData>), Accessibility.Public,
-                new DeclarationModifiers(), GetTypeSymbol(typeof(int))(s), name, value != null, value);
+                new Editing.DeclarationModifiers(), GetTypeSymbol(typeof(int))(s), name, value != null, value);
         }
 
-        internal static Func<SemanticModel, ISymbol> CreateField(Accessibility accessibility, DeclarationModifiers modifiers, Type type, string name)
+        internal static Func<SemanticModel, ISymbol> CreateField(Accessibility accessibility, Editing.DeclarationModifiers modifiers, Type type, string name)
         {
             return s => CodeGenerationSymbolFactory.CreateFieldSymbol(
                 default(ImmutableArray<AttributeData>), accessibility,
@@ -685,7 +685,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             return s => s == null ? null : s.Compilation.GetTypeByMetadataName(typeMetadataName);
         }
 
-        internal static IEnumerable<SyntaxToken> CreateModifierTokens(DeclarationModifiers modifiers, string language)
+        internal static IEnumerable<SyntaxToken> CreateModifierTokens(Editing.DeclarationModifiers modifiers, string language)
         {
             if (language == LanguageNames.CSharp)
             {


### PR DESCRIPTION
… on https://github.com/dotnet/roslyn/issues/19626

**Customer scenario**

User opened a solution which contains a project that contains design time build errors. due to that various parts of VS won't work as expected since the project itself is in unknown state. 

for example, "fix all" sometimes doesn't work. errors come and go as project changes its state as design time build get fixed by automatic nuget restore and etc.

this is to reduce confusion on such occasions.

same info is on the bug, but here are new user experience.

"If LastDesignTimeBuildSucceeded=false then

We still get syntax errors from the compiler. (NB: these might not be entirely accurate since we might not have the right language version. I think that’s fine.)
We don’t get semantic errors from the compiler. This means fixes driven from those are broken, but I think that’s fine. Consider “remove unused usings” – most definitely unsafe to invoke.
We still run third party analyzers and code fixes triggered from them. We expect them to respect the flag if needed."

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/19626

**Workarounds, if any**

for some cases, user can fix all design time build. some other cases, there is no workaround.

**Risk**

I don't believe this will cause crash since code change is quite straight forward. but this do change existing behavior on this error case. 

**Performance impact**

before, since we dropped projects that have issues, user wouldn't see us doing anything for such broken projects, now we do same work for the broken projects as we have done to good projects. 

but it would be same cost as the same solution without any design time build issues.

**Is this a regression from a previous update?**

NO

**Root cause analysis:**

this is not fixing a code defect. rather we heard some customer feedback and changing our error handling behavior to meet their requests.

**How was the bug found?**

customer report. dogfooding feedback and etc.