### PR TITLE
Compact C# 7.1 error codes

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1468,25 +1468,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_VoidInTuple = 8210,
         #endregion more stragglers for C# 7
 
-        #region diagnostics introduced for C# 7.1
-
-        ERR_Merge_conflict_marker_encountered = 8300,
-        ERR_InvalidPreprocessingSymbol = 8301,
-        ERR_FeatureNotAvailableInVersion7_1 = 8302,
-        ERR_LanguageVersionCannotHaveLeadingZeroes = 8303,
-        ERR_CompilerAndLanguageVersion = 8304,
-        WRN_Experimental = 8305,
-        ERR_TupleInferredNamesNotAvailable = 8306,
-        ERR_TypelessTupleInAs = 8307,
-
-        ERR_NoRefOutWhenRefOnly = 8308,
-        ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 8309,
-        // Available = 8310,
-        ERR_BadDynamicMethodArgDefaultLiteral = 8311,
-        ERR_DefaultLiteralNotValid = 8312,
-        WRN_DefaultInSwitch = 8313,
-        ERR_PatternWrongGenericTypeInVersion = 8314,
-
-        #endregion diagnostics introduced for C# 7.1
+        #region diagnostics for C# 7.1
+        ERR_Merge_conflict_marker_encountered = 8211,
+        ERR_InvalidPreprocessingSymbol = 8212,
+        ERR_FeatureNotAvailableInVersion7_1 = 8213,
+        ERR_LanguageVersionCannotHaveLeadingZeroes = 8214,
+        ERR_CompilerAndLanguageVersion = 8215,
+        WRN_Experimental = 8216,
+        ERR_TupleInferredNamesNotAvailable = 8217,
+        ERR_TypelessTupleInAs = 8218,
+        ERR_NoRefOutWhenRefOnly = 8219,
+        ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 8220,
+        ERR_BadDynamicMethodArgDefaultLiteral = 8221,
+        ERR_DefaultLiteralNotValid = 8222,
+        WRN_DefaultInSwitch = 8223,
+        ERR_PatternWrongGenericTypeInVersion = 8224,
+        #endregion diagnostics for C# 7.1
     }
 }

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -23,12 +23,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
         private const string CS8026 = nameof(CS8026); // error CS8026: Feature is not available in C# 5. Please use language version X or greater.
         private const string CS8059 = nameof(CS8059); // error CS8059: Feature is not available in C# 6. Please use language version X or greater.
         private const string CS8107 = nameof(CS8107); // error CS8059: Feature is not available in C# 7.0. Please use language version X or greater.
-        private const string CS8302 = nameof(CS8302); // error CS8302: Feature is not available in C# 7.1. Please use language version X or greater.
-        private const string CS8306 = nameof(CS8306); // error CS8306: ... Please use language version 7.1 or greater to access a un-named element by its inferred name.
-        private const string CS8314 = nameof(CS8314); // error CS9003: An expression of type '{0}' cannot be handled by a pattern of type '{1}' in C# {2}. Please use language version {3} or greater.
+        private const string CS8213 = nameof(CS8213); // error CS8213: Feature is not available in C# 7.1. Please use language version X or greater.
+        private const string CS8217 = nameof(CS8217); // error CS8217: ... Please use language version 7.1 or greater to access a un-named element by its inferred name.
+        private const string CS8224 = nameof(CS8224); // error CS8224: An expression of type '{0}' cannot be handled by a pattern of type '{1}' in C# {2}. Please use language version {3} or greater.
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302, CS8306, CS8314);
+            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8213, CS8217, CS8224);
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;
         public override string UpgradeAllProjectsResource => CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0;


### PR DESCRIPTION
We normally compact the error codes when getting close to release.
This does not affect users, except that it will keep our error codes below 5 digits for little while longer.

Fixes https://github.com/dotnet/roslyn/issues/19523
@dotnet/roslyn-compiler for review.