### PR TITLE
Disable SDK's AssemblyInfo file generation, since it conflicts with our own

### DIFF
--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -22,6 +22,9 @@
     <Features>strict,IOperation</Features>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <SignAssembly>true</SignAssembly>
+    <!-- The new SDK introduced a GenerateAssemblyInfo target, which is disabled by GenerateAssemblyInfo=false.
+         Otherwise, it writes to the same file (GeneratedAssemblyInfoFile) as our GenerateAssemblyInfoFile target.
+         Follow-up issue to reconcile the two: https://github.com/dotnet/roslyn/issues/19645 -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseRoslynAnalyzers Condition="'$(UseRoslynAnalyzers)' == ''">true</UseRoslynAnalyzers>
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$(RepoRoot)Binaries\</BaseOutputPath>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -22,6 +22,7 @@
     <Features>strict,IOperation</Features>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <SignAssembly>true</SignAssembly>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseRoslynAnalyzers Condition="'$(UseRoslynAnalyzers)' == ''">true</UseRoslynAnalyzers>
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$(RepoRoot)Binaries\</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>


### PR DESCRIPTION
The new SDK has a target "GenerateAssemblyInfo" which writes to the same file (`GeneratedAssemblyInfoFile`) as our "GenerateAssemblyInfoFile" target.

While it may be good to reconcile the two, I am disabling the one from the SDK for now.
Follow-up issue: :https://github.com/dotnet/roslyn/issues/19645 

Fixes https://github.com/dotnet/roslyn/issues/19556
Fixes https://github.com/dotnet/roslyn/issues/19245

@jaredpar @jasonmalinowski @dotnet/roslyn-infrastructure 