### PR TITLE
Inlude Git commit in our NuGet packages

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -76,12 +76,17 @@
 
   <Choose>
     <When Condition="'$(OfficialBuild)' != 'true'">
-      <!-- On non-official builds we don't burn in a git sha.  In large part because it
-           hurts our determinism efforts as binaries which should be the same between
+      <!-- On non-official builds we don't burn in the actual git sha.  In large part because 
+           it hurts our determinism efforts as binaries which should be the same between
            builds will not (due to developers building against different HEAD
-           values). -->
+           values). 
+
+           Using a valid SHA as parts of our down stream tooling (example NuGet packaging) expect 
+           a value that is a legal SHA. Using 42 as the base as it will be recognizable as 
+           incorrect in the same way our assembly version numbers
+           -->
       <PropertyGroup>
-        <GitHeadSha>&lt;developer build&gt;</GitHeadSha>
+        <GitHeadSha>42424242424</GitHeadSha>
       </PropertyGroup>
     </When>
     <When Condition="'$(BUILD_SOURCEVERSION)' != ''">

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -5441,7 +5441,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.".Trim(),
         }
 
         [Theory,
-            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (<developer build>)",
+            InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (42424242)",
                 "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)"),
             InlineData("Microsoft (R) Visual C# Compiler version A.B.C.D (ABCDEF01)",
                 "Microsoft (R) Visual C# Compiler version A.B.C.D (HASH)"),
@@ -5456,8 +5456,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.".Trim(),
 
         private static string ReplaceCommitHash(string s)
         {
-            // open paren, followed by either <developer build> or 8 hex, followed by close paren
-            return Regex.Replace(s, "(\\((<developer build>|[a-fA-F0-9]{8})\\))", "(HASH)");
+            // open paren, followed by 8 hex, followed by close paren
+            return Regex.Replace(s, "(\\(([a-fA-F0-9]{8})\\))", "(HASH)");
         }
 
         [Fact]
@@ -5466,7 +5466,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.".Trim(),
             Assert.Null(CommonCompiler.ExtractShortCommitHash(null));
             Assert.Equal("", CommonCompiler.ExtractShortCommitHash(""));
             Assert.Equal("<", CommonCompiler.ExtractShortCommitHash("<"));
-            Assert.Equal("<developer build>", CommonCompiler.ExtractShortCommitHash("<developer build>"));
             Assert.Equal("1", CommonCompiler.ExtractShortCommitHash("1"));
             Assert.Equal("1234567", CommonCompiler.ExtractShortCommitHash("1234567"));
             Assert.Equal("12345678", CommonCompiler.ExtractShortCommitHash("12345678"));

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -3010,7 +3010,7 @@ class A { }
                 // (1,8): error CS1029: #error: 'version'
                 // #error version
                 Diagnostic(ErrorCode.ERR_ErrorDirective, "version").WithArguments("version").WithLocation(1, 8),
-                // (1,8): error CS8304: Compiler version: '42.42.42.42424 (<developer build>)'. Language version: 4.
+                // (1,8): error CS8304: Compiler version: '42.42.42.42424 (42424242)'. Language version: 4.
                 // #error version
                 Diagnostic(ErrorCode.ERR_CompilerAndLanguageVersion, "version").WithArguments(GetExpectedVersion(), "4").WithLocation(1, 8)
                 );

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -141,8 +141,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static string ExtractShortCommitHash(string hash)
         {
-            // leave "<developer build>" alone, but truncate SHA to 8 characters
-            if (hash != null && hash.Length >= 8 && hash[0] != '<')
+            if (hash != null && hash.Length >= 8)
             {
                 return hash.Substring(0, 8);
             }

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -245,7 +245,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         End Sub
 
         <Theory,
-            InlineData("Microsoft (R) Visual Basic Compiler version A.B.C.D (<developer build>)",
+            InlineData("Microsoft (R) Visual Basic Compiler version A.B.C.D (42424242)",
                        "Microsoft (R) Visual Basic Compiler version A.B.C.D (HASH)"),
             InlineData("Microsoft (R) Visual Basic Compiler version A.B.C.D (ABCDEF01)",
                        "Microsoft (R) Visual Basic Compiler version A.B.C.D (HASH)"),
@@ -258,7 +258,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         End Sub
 
         Private Shared Function ReplaceCommitHash(s As String) As String
-            Return Regex.Replace(s, "(\((<developer build>|[a-fA-F0-9]{8})\))", "(HASH)")
+            Return Regex.Replace(s, "(\(([a-fA-F0-9]{8})\))", "(HASH)")
         End Function
 
         <Fact>

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -32,7 +32,11 @@ var BuildVersion = Args[1].Trim();
 var BuildingReleaseNugets = IsReleaseVersion(BuildVersion);
 var NuspecDirPath = Path.Combine(SolutionRoot, "src/NuGet");
 var OutDir = Path.GetFullPath(Args[2]).TrimEnd('\\');
-var CommitUrl = $"https://github.com/dotnet/roslyn/commit/{Args[3]}";
+
+// In developer builds the commit sha is <developer build>. Need to make sure
+// we escape the values so that 
+var CommitSha = Args[3].Replace("<", "").Replace(">", "");
+var CommitUrl = $"https://github.com/dotnet/roslyn/commit/{CommitSha}";
 
 var LicenseUrlRedist = @"http://go.microsoft.com/fwlink/?LinkId=529443";
 var LicenseUrlNonRedist = @"http://go.microsoft.com/fwlink/?LinkId=529444";

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -9,9 +9,9 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml.Linq;
 
-string usage = @"usage: BuildNuGets.csx <binaries-dir> <build-version> <output-directory>";
+string usage = @"usage: BuildNuGets.csx <binaries-dir> <build-version> <output-directory> <git sha>";
 
-if (Args.Count() != 3)
+if (Args.Count() != 4)
 {
     Console.WriteLine(usage);
     Environment.Exit(1);
@@ -32,6 +32,7 @@ var BuildVersion = Args[1].Trim();
 var BuildingReleaseNugets = IsReleaseVersion(BuildVersion);
 var NuspecDirPath = Path.Combine(SolutionRoot, "src/NuGet");
 var OutDir = Path.GetFullPath(Args[2]).TrimEnd('\\');
+var CommitUrl = $"https://github.com/dotnet/roslyn/commit/{Args[3]}";
 
 var LicenseUrlRedist = @"http://go.microsoft.com/fwlink/?LinkId=529443";
 var LicenseUrlNonRedist = @"http://go.microsoft.com/fwlink/?LinkId=529444";
@@ -206,6 +207,7 @@ int PackFiles(string[] nuspecFiles, string licenseUrl)
         { "tags", Tags },
         { "emptyDirPath", emptyDir },
         { "additionalFilesPath", NuGetAdditionalFilesPath }
+        { "commitUrl", CommitUrl },
     };
 
     foreach (var dependencyVersion in dependencyVersions)

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -32,11 +32,7 @@ var BuildVersion = Args[1].Trim();
 var BuildingReleaseNugets = IsReleaseVersion(BuildVersion);
 var NuspecDirPath = Path.Combine(SolutionRoot, "src/NuGet");
 var OutDir = Path.GetFullPath(Args[2]).TrimEnd('\\');
-
-// In developer builds the commit sha is <developer build>. Need to make sure
-// we escape the values so that 
-var CommitSha = Args[3].Replace("<", "").Replace(">", "");
-var CommitUrl = $"https://github.com/dotnet/roslyn/commit/{CommitSha}";
+var CommitUrl = $"https://github.com/dotnet/roslyn/commit/{Args[3]}";
 
 var LicenseUrlRedist = @"http://go.microsoft.com/fwlink/?LinkId=529443";
 var LicenseUrlNonRedist = @"http://go.microsoft.com/fwlink/?LinkId=529444";

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -206,8 +206,8 @@ int PackFiles(string[] nuspecFiles, string licenseUrl)
         { "projectURL", ProjectURL },
         { "tags", Tags },
         { "emptyDirPath", emptyDir },
-        { "additionalFilesPath", NuGetAdditionalFilesPath }
-        { "commitUrl", CommitUrl },
+        { "additionalFilesPath", NuGetAdditionalFilesPath },
+        { "commitUrl", CommitUrl }
     };
 
     foreach (var dependencyVersion in dependencyVersions)

--- a/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
@@ -6,6 +6,8 @@
     <description>
         Contains the build task and targets used by MSBuild to run the C# and VB compilers.
         Supports using VBCSCompiler on Windows.
+
+        This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.CodeStyle.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.CodeStyle.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.CodeStyle</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") code style analyzers for C#.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
     </dependencies>
 

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Features.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.Features</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for creating C# editing experiences.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Features" version="$version$" />
       <dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="$version$" />

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
@@ -3,9 +3,6 @@
   <metadata>
     <id>Microsoft.CodeAnalysis.CSharp.Scripting</id>
     <summary>Microsoft .NET Compiler Platform ("Roslyn") CSharp scripting package.</summary>
-    <summary>
-      Microsoft .NET Compiler Platform ("Roslyn") CSharp scripting package.
-    </summary>
     <description>This package was built from the source at $commitUrl$</description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Scripting.nuspec
@@ -3,10 +3,10 @@
   <metadata>
     <id>Microsoft.CodeAnalysis.CSharp.Scripting</id>
     <summary>Microsoft .NET Compiler Platform ("Roslyn") CSharp scripting package.</summary>
-    <description>
+    <summary>
       Microsoft .NET Compiler Platform ("Roslyn") CSharp scripting package.
-    </description>
-
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.Workspaces.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp.Workspaces</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for analyzing C# projects and solutions.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.CSharp" version="[$version$]" />
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.CSharp</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
 
       More details at https://aka.ms/roslyn-packages
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />
     </dependencies>

--- a/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Common.nuspec
@@ -5,6 +5,8 @@
     <summary>A shared package used by the Microsoft .NET Compiler Platform ("Roslyn").</summary>
     <description>
       A shared package used by the Microsoft .NET Compiler Platform ("Roslyn"). Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+
+      This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -7,6 +7,8 @@
       .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
 
       More details at https://aka.ms/roslyn-packages
+
+      This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.CSharp" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.Text.nuspec
@@ -2,11 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.EditorFeatures.Text</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for working with Visual Studio text buffers.
+    </summary>
+    <description>
+      Supported Platforms:
+      - .NET Framework 4.6
 
-Supported Platforms:
-- .NET Framework 4.6
+      This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.EditorFeatures.nuspec
@@ -2,11 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.CodeAnalysis.EditorFeatures</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for editor features inside the Visual Studio editor..
+    </summary>
+    <description>
+      Supported Platforms:
+      - .NET Framework 4.6
       
-Supported Platforms:
-- .NET Framework 4.6
+      This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Features" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Features.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.Features</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for creating editing experiences.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="$version$" />
     </dependencies>

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Razor.ServiceHub.nuspec
@@ -10,6 +10,8 @@
 
 Supported Platforms:
 - .NET Framework 4.6
+
+    This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.ServiceHub.nuspec
@@ -10,6 +10,8 @@
 
 Supported Platforms:
 - .NET Framework 4.6
+
+    This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Remote.Workspaces.nuspec
@@ -10,6 +10,8 @@
 
 Supported Platforms:
 - .NET Framework 4.6
+
+    This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.Common.nuspec
@@ -5,6 +5,8 @@
     <summary>Microsoft .NET Compiler Platform ("Roslyn") shared scripting package.</summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") shared scripting package. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+
+      This package was built from the source at $commitUrl$
     </description>
 
     <language>en-US</language>

--- a/src/NuGet/Microsoft.CodeAnalysis.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Scripting.nuspec
@@ -5,6 +5,8 @@
     <summary>Microsoft .NET Compiler Platform ("Roslyn") CSharp and VB scripting package.</summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") CSharp and VB scripting package.
+
+      This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.CSharp.Scripting" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.CodeStyle.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.CodeStyle</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") code style analyzers for Visual Basic.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
     </dependencies>
 

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Features.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Features.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.Features</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for creating Visual Basic editing experiences.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Features" version="$version$" />
       <dependency id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="$version$" />

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Scripting.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Scripting.nuspec
@@ -5,6 +5,8 @@
     <summary>Microsoft .NET Compiler Platform ("Roslyn") Visual Basic scripting package.</summary>
     <description>
       Microsoft .NET Compiler Platform ("Roslyn") Visual Basic scripting package.
+      
+      This package was built from the source at $commitUrl$
     </description>
 
     <language>en-US</language>

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Workspaces.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.Workspaces.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic.Workspaces</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for analyzing Visual Basic projects and solutions.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.VisualBasic" version="[$version$]" />
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="3.3">
     <id>Microsoft.CodeAnalysis.VisualBasic</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for Visual Basic, Microsoft.CodeAnalysis.VisualBasic.dll.
 
       More details at https://aka.ms/roslyn-packages
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="$version$" />
     </dependencies>

--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -7,6 +7,8 @@
     </summary>
     <description>
       A shared package used by the .NET Compiler Platform ("Roslyn") including support for analyzing projects and solutions. Do not install this package manually, it will be added as a prerequisite by other packages that require it.
+
+      This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <group targetFramework="netstandard1.3">

--- a/src/NuGet/Microsoft.CodeAnalysis.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.nuspec
@@ -12,6 +12,8 @@
         - "Microsoft.CodeAnalysis.Compilers" (both compilers)       
         - "Microsoft.CodeAnalysis.CSharp" (only the C# compiler)      
         - "Microsoft.CodeAnalysis.VisualBasic (only the VB compiler)
+
+      This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="[$version$]" />

--- a/src/NuGet/Microsoft.NETCore.Compilers.nuspec
+++ b/src/NuGet/Microsoft.NETCore.Compilers.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.NETCore.Compilers</id>
-    <description>
+    <summary>
       CoreCLR-compatible versions of the C# and VB compilers for use in MSBuild.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.CSharp.Interactive.netcore</id>
-    <description>
+    <summary>
       CoreCLR-compatible version of csi.exe.
 
       Supported Platforms:
       - .NET Core (NETCoreApp1.0)
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.netcore.nuspec
@@ -2,9 +2,10 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.Compilers.netcore</id>
-    <description>
+    <summary>
       CoreCLR-compatible versions of the C# and VB compilers.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.Net.Compilers</id>
-    <description>
+    <summary>
     .Net Compilers package. Referencing this package will cause the project to be built using the specific version of the C# and Visual Basic compilers contained in the package, as opposed to any system installed version.
 
     This package can be used to compile code targeting any platform, but can only be run using the desktop .NET 4.6+ Full Framework.
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
@@ -2,7 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.IntegrationTest.Utilities</id>
-    <description>Utility methods used to run Visual Studio integration tests.</description>
+    <summary>Utility methods used to run Visual Studio integration tests.</summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <version>$version$</version>

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.Next.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.Next.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.LanguageServices.Next</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
 
 Supported Platforms:
 - .NET Framework 4.6
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Remote.ServiceHub" version="[$version$]" />
       <dependency id="Microsoft.CodeAnalysis.Remote.Workspaces" version="[$version$]" />

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient.nuspec
@@ -2,11 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for Visual Studio "15".
+    </summary>
+    <description>
+      Supported Platforms:
+        - .NET Framework 4.6
 
-Supported Platforms:
-- .NET Framework 4.6
+        This package was built from the source at $commitUrl$
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.VisualStudio.LanguageServices.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.LanguageServices.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Microsoft.VisualStudio.LanguageServices</id>
-    <description>
+    <summary>
       .NET Compiler Platform ("Roslyn") support for Visual Studio.
       
 Supported Platforms:
 - .NET Framework 4.6
-    </description>
+    </summary>
+    <description>This package was built from the source at $commitUrl$</description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis" version="[$version$]" />
     </dependencies>

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -5,13 +5,13 @@
 
   <Target Name="Build">
     <!-- NuGetPerBuildPreReleaseVersion -->
-    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPerBuildPreReleaseVersion) $(OutputPath)NuGet\PerBuildPreRelease" Condition="'$(NuGetPerBuildPreReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPerBuildPreReleaseVersion) $(OutputPath)NuGet\PerBuildPreRelease $(GitHeadSha)" Condition="'$(NuGetPerBuildPreReleaseVersion)' != ''" />
 
     <!-- NuGetPreReleaseVersion -->
-    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPreReleaseVersion) $(OutputPath)NuGet\PreRelease" Condition="'$(NuGetPreReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPreReleaseVersion) $(OutputPath)NuGet\PreRelease $(GitHeadSha)" Condition="'$(NuGetPreReleaseVersion)' != ''" />
 
     <!-- NuGetReleaseVersion -->
-    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetReleaseVersion) $(OutputPath)NuGet\Release" Condition="'$(NuGetReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetReleaseVersion) $(OutputPath)NuGet\Release $(GitHeadSha)" Condition="'$(NuGetReleaseVersion)' != ''" />
   </Target>
 
   <Target Name="Clean">

--- a/src/NuGet/NuGet.proj
+++ b/src/NuGet/NuGet.proj
@@ -5,13 +5,13 @@
 
   <Target Name="Build">
     <!-- NuGetPerBuildPreReleaseVersion -->
-    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPerBuildPreReleaseVersion) $(OutputPath)NuGet\PerBuildPreRelease $(GitHeadSha)" Condition="'$(NuGetPerBuildPreReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPerBuildPreReleaseVersion) $(OutputPath)NuGet\PerBuildPreRelease &quot;$(GitHeadSha)&quot;" Condition="'$(NuGetPerBuildPreReleaseVersion)' != ''" />
 
     <!-- NuGetPreReleaseVersion -->
-    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPreReleaseVersion) $(OutputPath)NuGet\PreRelease $(GitHeadSha)" Condition="'$(NuGetPreReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetPreReleaseVersion) $(OutputPath)NuGet\PreRelease &quot;$(GitHeadSha)&quot;" Condition="'$(NuGetPreReleaseVersion)' != ''" />
 
     <!-- NuGetReleaseVersion -->
-    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetReleaseVersion) $(OutputPath)NuGet\Release $(GitHeadSha)" Condition="'$(NuGetReleaseVersion)' != ''" />
+    <Exec Command="$(OutputPath)Exes\csi\csi.exe $(MSBuildThisFileDirectory)BuildNuGets.csx $(OutputPath) $(NuGetReleaseVersion) $(OutputPath)NuGet\Release &quot;$(GitHeadSha)&quot;" Condition="'$(NuGetReleaseVersion)' != ''" />
   </Target>
 
   <Target Name="Clean">


### PR DESCRIPTION
This change adds the git commit which produced the NuGet package to the
description section.  This makes it easy to both

- Determine what source is included in a NuGet
- Determine if a given change is included in our NuGet

Lacking this only way to understand which commit produced a NuGet is to
download the NuGet, crack open the binary and look at the version we
embed into the PE.  This allows us to see the version on the NuGet page
itself.

