### PR TITLE
Avoid throwing cancellation exceptions in common inner loops

### DIFF
--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -468,6 +468,16 @@ namespace Microsoft.CodeAnalysis.PooledObjects
             _builder.AddRange(items, length);
         }
 
+        public void AddRange<TSource>(TSource[] items, Func<TSource, T> selector)
+        {
+            var start = _builder.Count;
+            _builder.Count += items.Length;
+            for (int i = 0; i < items.Length; i++)
+            {
+                _builder[start + i] = selector(items[i]);
+            }
+        }
+
         public void Clip(int limit)
         {
             Debug.Assert(limit <= Count);

--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                                 : service.SearchProjectAsync(project, _searchPattern, _cancellationToken);
 
                             var results = await searchTask.ConfigureAwait(false);
-                            if (results != null)
+                            if (results != null && !_cancellationToken.IsCancellationRequested)
                             {
                                 foreach (var result in results)
                                 {

--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
@@ -180,6 +180,12 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                 return UpdateSymbolTreeInfoAsync(project, cancellationToken);
             }
 
+            /// <remarks>
+            /// <para>In the event cancellation is requested, this operation may complete in the
+            /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+            /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+            /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+            /// </remarks>
             private async Task UpdateSymbolTreeInfoAsync(Project project, CancellationToken cancellationToken)
             {
                 if (!project.SupportsCompilation)
@@ -218,6 +224,12 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                 }
             }
 
+            /// <remarks>
+            /// <para>In the event cancellation is requested, this operation may complete in the
+            /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+            /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+            /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+            /// </remarks>
             private Task UpdateReferencesAync(Project project, CancellationToken cancellationToken)
             {
                 // Process all metadata references in parallel.
@@ -228,9 +240,21 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                 return Task.WhenAll(tasks);
             }
 
+            /// <remarks>
+            /// <para>In the event cancellation is requested, this operation may complete in the
+            /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+            /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+            /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+            /// </remarks>
             private async Task UpdateReferenceAsync(
                 Project project, PortableExecutableReference reference, CancellationToken cancellationToken)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    // Avoid throwing more exceptions than necessary
+                    return;
+                }
+
                 var key = GetReferenceKey(reference);
                 if (key == null)
                 {

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.InProcess.cs
@@ -20,6 +20,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private static ConditionalWeakTable<Project, Tuple<string, ImmutableArray<SearchResult>>> s_lastProjectSearchCache =
             new ConditionalWeakTable<Project, Tuple<string, ImmutableArray<SearchResult>>>();
 
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         public static Task<ImmutableArray<INavigateToSearchResult>> SearchProjectInCurrentProcessAsync(
             Project project, string searchPattern, CancellationToken cancellationToken)
         {
@@ -27,6 +33,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 project, searchDocument: null, pattern: searchPattern, cancellationToken: cancellationToken);
         }
 
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         public static Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentInCurrentProcessAsync(
             Document document, string searchPattern, CancellationToken cancellationToken)
         {
@@ -34,6 +46,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                 document.Project, document, searchPattern, cancellationToken);
         }
 
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         private static async Task<ImmutableArray<INavigateToSearchResult>> FindSearchResultsAsync(
             Project project, Document searchDocument, string pattern, CancellationToken cancellationToken)
         {
@@ -64,6 +82,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                         ? ComputeSearchResultsAsync(project, searchDocument, nameMatcher, containerMatcherOpt, nameMatches, containerMatches, cancellationToken)
                         : TryFilterPreviousSearchResultsAsync(project, searchDocument, pattern, nameMatcher, containerMatcherOpt, nameMatches, containerMatches, cancellationToken);
 
+                    // The return value from the previous calls is only valid if cancellation was not requested.
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return ImmutableArray<INavigateToSearchResult>.Empty;
+                    }
+
                     var searchResults = await task.ConfigureAwait(false);
                     return ImmutableArray<INavigateToSearchResult>.CastUp(searchResults);
                 }
@@ -75,6 +99,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             }
         }
 
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         private static async Task<ImmutableArray<SearchResult>> TryFilterPreviousSearchResultsAsync(
             Project project, Document searchDocument, string pattern,
             PatternMatcher nameMatcher, PatternMatcher containerMatcherOpt,
@@ -106,6 +136,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                     nameMatches, containerMatches, cancellationToken).ConfigureAwait(false);
             }
 
+            // The return value from the previous calls is only valid if cancellation was not requested.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return ImmutableArray<SearchResult>.Empty;
+            }
+
             // Would like to use CWT.AddOrUpdate. But that is not available on the 
             // version of .Net that we're using.  So we need to take lock as we're
             // making multiple mutations.
@@ -118,6 +154,12 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             return searchResults;
         }
 
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         private static ImmutableArray<SearchResult> FilterPreviousResults(
             ImmutableArray<SearchResult> previousResults,
             PatternMatcher nameMatcher, PatternMatcher containerMatcherOpt,
@@ -128,17 +170,28 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
             foreach (var previousResult in previousResults)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return ImmutableArray<SearchResult>.Empty;
+                }
+
                 var document = previousResult.Document;
                 var info = previousResult.DeclaredSymbolInfo;
 
                 AddResultIfMatch(
                     document, info, nameMatcher, containerMatcherOpt, 
-                    nameMatches, containerMatches, result, cancellationToken);
+                    nameMatches, containerMatches, result);
             }
 
             return result.ToImmutableAndFree();
         }
 
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         private static async Task<ImmutableArray<SearchResult>> ComputeSearchResultsAsync(
             Project project, Document searchDocument,
             PatternMatcher nameMatcher, PatternMatcher containerMatcherOpt,
@@ -153,16 +206,25 @@ namespace Microsoft.CodeAnalysis.NavigateTo
                     continue;
                 }
 
-                cancellationToken.ThrowIfCancellationRequested();
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return ImmutableArray<SearchResult>.Empty;
+                }
+
                 var declarationInfo = await document.GetSyntaxTreeIndexAsync(cancellationToken).ConfigureAwait(false);
 
                 foreach (var declaredSymbolInfo in declarationInfo.DeclaredSymbolInfos)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return ImmutableArray<SearchResult>.Empty;
+                    }
+
                     AddResultIfMatch(
                         document, declaredSymbolInfo,
                         nameMatcher, containerMatcherOpt, 
                         nameMatches, containerMatches, 
-                        result, cancellationToken);
+                        result);
                 }
             }
 
@@ -173,12 +235,11 @@ namespace Microsoft.CodeAnalysis.NavigateTo
             Document document, DeclaredSymbolInfo declaredSymbolInfo,
             PatternMatcher nameMatcher, PatternMatcher containerMatcherOpt,
             ArrayBuilder<PatternMatch> nameMatches, ArrayBuilder<PatternMatch> containerMatches, 
-            ArrayBuilder<SearchResult> result, CancellationToken cancellationToken)
+            ArrayBuilder<SearchResult> result)
         {
             nameMatches.Clear();
             containerMatches.Clear();
 
-            cancellationToken.ThrowIfCancellationRequested();
             if (nameMatcher.AddMatches(declaredSymbolInfo.Name, nameMatches) &&
                 containerMatcherOpt?.AddMatches(declaredSymbolInfo.FullyQualifiedContainerName, containerMatches) != false)
             {

--- a/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/INavigateToSearchService.cs
@@ -9,7 +9,20 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 {
     internal interface INavigateToSearchService : ILanguageService
     {
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         Task<ImmutableArray<INavigateToSearchResult>> SearchProjectAsync(Project project, string searchPattern, CancellationToken cancellationToken);
+
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         Task<ImmutableArray<INavigateToSearchResult>> SearchDocumentAsync(Document document, string searchPattern, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -226,7 +226,14 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                     try
                     {
-                        return await funcAsync(value, cancellationToken).ConfigureAwait(false);
+                        var result = await funcAsync(value, cancellationToken).ConfigureAwait(false);
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            // The result might not be valid
+                            return default;
+                        }
+
+                        return result;
                     }
                     catch (OperationCanceledException)
                     {

--- a/src/Workspaces/Core/Portable/SolutionCrawler/IIncrementalAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/IIncrementalAnalyzer.cs
@@ -19,7 +19,21 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         Task DocumentResetAsync(Document document, CancellationToken cancellationToken);
 
         Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken);
+
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken);
+
+        /// <remarks>
+        /// <para>In the event cancellation is requested, this operation may complete in the
+        /// <see cref="TaskStatus.Canceled"/> or <see cref="TaskStatus.RanToCompletion"/> state. In the latter case,
+        /// the result of this method is not guaranteed to be complete or valid; callers are expected to check the
+        /// status of the <paramref name="cancellationToken"/> prior to using the results.</para>
+        /// </remarks>
         Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken);
 
         void RemoveDocument(DocumentId documentId);


### PR DESCRIPTION
Avoids many thousands of cancellation exceptions by exiting hot inner loops without an exception and moving the exception to a higher level in the call hierarchy. Improves the experience debugging Roslyn without changing the cancellation behavior or hurting performance.

:memo: These exceptions were found by observing the stack traces in PerfView.