### PR TITLE
Support automation of the completion tooltip

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ToolTipProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ToolTipProvider.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 using VSCompletion = Microsoft.VisualStudio.Language.Intellisense.Completion;
+using System.Windows.Automation;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.Presentation
 {
@@ -89,6 +90,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
 
                 var description = obj.Result;
                 this.Content = GetTextBlock(description.TaggedParts, _toolTipProvider._typeMap);
+
+                // As of https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/67974?_a=overview 
+                // the editor will pull AutomationProperties.Name from our UIElement and expose
+                // to automation.
+                AutomationProperties.SetName(this, description.Text);
             }
 
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ToolTipProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ToolTipProvider.cs
@@ -6,10 +6,11 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Documents;
-using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.VisualStudio.Language.Intellisense;
@@ -17,7 +18,6 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Utilities;
 using VSCompletion = Microsoft.VisualStudio.Language.Intellisense.Completion;
-using System.Windows.Automation;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.Presentation
 {
@@ -91,9 +91,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 var description = obj.Result;
                 this.Content = GetTextBlock(description.TaggedParts, _toolTipProvider._typeMap);
 
-                // As of https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/67974?_a=overview 
-                // the editor will pull AutomationProperties.Name from our UIElement and expose
-                // to automation.
+                // The editor will pull AutomationProperties.Name from our UIElement and expose
+                // it to automation.
                 AutomationProperties.SetName(this, description.Text);
             }
 


### PR DESCRIPTION
Because completion asynchronously computes descriptions, the default
text is "...". In order to present the description when available, we
have to set the AutomationProperties.Name on our tooltip UIElement.

Note @olegtk: I'm having trouble testing this because the automation focus moves to the text editor as soon as the tooltip comes up.
Tag @olegtk @dotnet/roslyn-ide @dpoeschl for review

**Customer scenario**

Customer is using a screen reader and wants to read the completion tooltip. Currently it is always set to `...`

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=433619&fullScreen=true&_a=edit

**Workarounds, if any**

None, there's no way to read the tooltip with a screen reader.

**Risk**

Low. Once we've computed the tooltip we set an automationproperty that the editor reads for us. 

**Performance impact**

None, we're setting a property using data we have to compute anyway.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Didn't test this accessibility scenario.

**How was the bug found?**

Accessibility testing.