### PR TITLE
Show a description when suggesting names

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -37,7 +37,7 @@ public class MyClass
     MyClass $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "MyClass", glyph: (int)Glyph.MethodPublic, expectedDescriptionOrNull: CSharpFeaturesResources.suggested_name);
+            await VerifyItemExistsAsync(markup, "MyClass", glyph: (int)Glyph.MethodPublic);
             await VerifyItemExistsAsync(markup, "myClass", glyph: (int)Glyph.FieldPublic);
             await VerifyItemExistsAsync(markup, "GetMyClass", glyph: (int)Glyph.MethodPublic);
         }
@@ -440,6 +440,18 @@ public class C
 }
 ";
             await VerifyNoItemsExistAsync(markup);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void TestDescription()
+        {
+            var markup = @"
+public class MyClass
+{
+    MyClass $$
+}
+";
+            await VerifyItemExistsAsync(markup, "MyClass", glyph: (int)Glyph.MethodPublic, expectedDescriptionOrNull: CSharpFeaturesResources.Suggested_name);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Completion.Providers;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders;
@@ -36,7 +37,7 @@ public class MyClass
     MyClass $$
 }
 ";
-            await VerifyItemExistsAsync(markup, "MyClass", glyph: (int)Glyph.MethodPublic);
+            await VerifyItemExistsAsync(markup, "MyClass", glyph: (int)Glyph.MethodPublic, expectedDescriptionOrNull: CSharpFeaturesResources.suggested_name);
             await VerifyItemExistsAsync(markup, "myClass", glyph: (int)Glyph.FieldPublic);
             await VerifyItemExistsAsync(markup, "GetMyClass", glyph: (int)Glyph.MethodPublic);
         }

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -983,9 +983,9 @@ namespace Microsoft.CodeAnalysis.CSharp {
         /// <summary>
         ///   Looks up a localized string similar to (Suggested name).
         /// </summary>
-        internal static string suggested_name {
+        internal static string Suggested_name {
             get {
-                return ResourceManager.GetString("suggested_name", resourceCulture);
+                return ResourceManager.GetString("Suggested_name", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CSharpFeaturesResources {
@@ -977,6 +977,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string struct_name {
             get {
                 return ResourceManager.GetString("struct_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (Suggested name).
+        /// </summary>
+        internal static string suggested_name {
+            get {
+                return ResourceManager.GetString("suggested_name", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -521,4 +521,7 @@
   <data name="Autoselect_disabled_due_to_member_declaration" xml:space="preserve">
     <value>Autoselect disabled due to member declaration</value>
   </data>
+  <data name="suggested_name" xml:space="preserve">
+    <value>(Suggested name)</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -521,7 +521,7 @@
   <data name="Autoselect_disabled_due_to_member_declaration" xml:space="preserve">
     <value>Autoselect disabled due to member declaration</value>
   </data>
-  <data name="suggested_name" xml:space="preserve">
+  <data name="Suggested_name" xml:space="preserve">
     <value>(Suggested name)</value>
   </data>
 </root>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -191,7 +191,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         CompletionItem CreateCompletionItem(string name, Glyph glyph, string sortText)
         {
-            return CommonCompletionItem.Create(name, CompletionItemRules.Default, glyph: glyph, sortText: sortText);
+            return CommonCompletionItem.Create(
+                name, 
+                CompletionItemRules.Default, 
+                glyph: glyph, 
+                sortText: sortText, 
+                description: CSharpFeaturesResources.suggested_name.ToSymbolDisplayParts());
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 CompletionItemRules.Default, 
                 glyph: glyph, 
                 sortText: sortText, 
-                description: CSharpFeaturesResources.suggested_name.ToSymbolDisplayParts());
+                description: CSharpFeaturesResources.Suggested_name.ToSymbolDisplayParts());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19200

**Customer scenario**

Customer is typing a name and intellisense suggests names. There's no description in the tooltip that is shown on those completion items.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/19200

**Workarounds, if any**

None

**Risk**

Very low, we simply add a resource string to the constructed completion items

**Performance impact**

Very low, we're passing a string resource into a constructor.

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

New feature, didn't have a design for the tooltip.

**How was the bug found?**

Dogfooding
