### PR TITLE
Clarify that order of all parameters matters for determinism

### DIFF
--- a/docs/compilers/Deterministic Inputs.md
+++ b/docs/compilers/Deterministic Inputs.md
@@ -5,7 +5,7 @@ We are aiming to make the compilers ultimately deterministic (https://github.com
 
 The following are considered inputs to the compiler for the purpose of determinism:
 
-- The sequence of command-line flags
+- The sequence of command-line parameters
 - The contents of the compiler's `.rsp` response file.
 - The precise version of the compiler used, and its referenced assemblies
 - Current full directory path (you can reduce this to a relative path; see https://github.com/dotnet/roslyn/issues/949)


### PR DESCRIPTION
[As far as I can tell](https://github.com/dotnet/core/issues/469#issuecomment-302790740), the order of files specified on the command line of `csc` affects the output of the compiler. And while file names are command line *parameters*, I don't think they can be considered command line *flags*.