### PR TITLE
add F# language name and error prefix

### DIFF
--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -665,6 +665,7 @@ Microsoft.CodeAnalysis.Semantics.UnaryOperationKind.UnsignedPrefixIncrement = 77
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.OperationKind> operationKinds) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationBlockEndAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationBlockAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.SemanticModel.GetOperationCore(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.IOperation
+const Microsoft.CodeAnalysis.LanguageNames.FSharp = "F#" -> string
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.Visit(Microsoft.CodeAnalysis.IOperation operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitAddressOfExpression(Microsoft.CodeAnalysis.Semantics.IAddressOfExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitArgument(Microsoft.CodeAnalysis.Semantics.IArgument operation) -> void

--- a/src/Compilers/Core/Portable/Symbols/LanguageNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/LanguageNames.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.Text;
-
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
@@ -18,5 +16,10 @@ namespace Microsoft.CodeAnalysis
         /// The common name used for the Visual Basic language.
         /// </summary>
         public const string VisualBasic = "Visual Basic";
+
+        /// <summary>
+        /// The common name used for the F# language.
+        /// </summary>
+        public const string FSharp = "F#";
     }
 }

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -12,7 +12,6 @@ using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
-using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.CPS
 {
@@ -28,6 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             {
                 new KeyValuePair<string, string> (LanguageNames.CSharp, "CS"),
                 new KeyValuePair<string, string> (LanguageNames.VisualBasic, "BC"),
+                new KeyValuePair<string, string> (LanguageNames.FSharp, "FS"),
             });
 
         [ImportingConstructor]


### PR DESCRIPTION
This will enable a temporary [hack in the project system](https://github.com/dotnet/project-system/blob/360a009390105ad50695ae595ddb62dbd56b87b3/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs#L278) to be removed and lets F# projects better participate in CPS and error list scenarios.  This is one of the few remaining pieces to migrating F# to CPS.

**NOTE:** This PR is a prerequisite to dotnet/project-system#2244 which removes the hack from the project system side.

@Srivatsn @KevinRansom @dotnet/roslyn-ide