### PR TITLE
Emit tuple names on property setter parameters

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedParameterSymbol.vb
@@ -233,6 +233,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return _name
             End Get
         End Property
+
+        Friend NotOverridable Overrides Sub AddSynthesizedAttributes(compilationState As ModuleCompilationState, ByRef attributes As ArrayBuilder(Of SynthesizedAttributeData))
+            Dim compilation = Me.DeclaringCompilation
+            If Type.ContainsTupleNames() AndAlso
+                compilation.HasTupleNamesAttributes AndAlso
+                compilation.CanEmitSpecialType(SpecialType.System_String) Then
+                AddSynthesizedAttribute(attributes, compilation.SynthesizeTupleNamesAttribute(Type))
+            End If
+        End Sub
     End Class
 
     ''' <summary>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Tuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_Tuples.vb
@@ -217,7 +217,7 @@ BC30652: Reference required to assembly 'mscorlib, Version=4.0.0.0, Culture=neut
                 </expected>)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/16829")>
+        <Fact>
         Public Sub RoundTrip()
             Dim comp = CreateCompilationWithMscorlib({s_tuplesTestSource}, options:=TestOptions.ReleaseDll, references:=s_valueTupleRefs)
             Dim sourceModule As ModuleSymbol = Nothing


### PR DESCRIPTION
Method implementation copy-translated from `SynthesizedParameterSymbol.cs`.

Note, I did the work of testing the logic in the if statement added/etc. (what happens when System.String is missing, etc.), before realizing that the exact functionality was already being tested elsewhere in `AttributeTests_Tuples.vb`.

Fixes #16829

I'm not sure if this will meet the bar - while it's incorrect metadata we're emitting, both commandline and IDE scenarios seem to work without this fix. I believe we currently take the tuple name off of the property symbol (this fix is adding the names to the underlying `set_` method). Let me know if it does have a chance of meeting the bar, and I'll fill out the template.

Ping @jcouv as they helped me figure out testing the lack of core types.