### PR TITLE
Fix crash when creating IArgument for `__arglist` argument

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ArrayBuilder<LocalSymbol> temporariesBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
             rewrittenArguments = _factory.MakeTempsForDiscardArguments(rewrittenArguments, temporariesBuilder);
 
-            if (CanSkipRewriting(rewrittenArguments, methodOrIndexer, expanded, argsToParamsOpt, invokedAsExtensionMethod, out var isComReceiver))
+            if (CanSkipRewriting(rewrittenArguments, methodOrIndexer, expanded, argsToParamsOpt, invokedAsExtensionMethod, out var isComReceiver, out var isVarArg))
             {
                 temps = temporariesBuilder.ToImmutableAndFree();
                 return rewrittenArguments;
@@ -515,12 +515,31 @@ namespace Microsoft.CodeAnalysis.CSharp
             //
             // If neither of those are the case then we can just take an early out.
 
-
-            if (CanSkipRewriting(arguments, methodOrIndexer, expanded, argsToParamsOpt, invokedAsExtensionMethod, out var isComReceiver))
-            {                                                                                  
+            if (CanSkipRewriting(arguments, methodOrIndexer, expanded, argsToParamsOpt, invokedAsExtensionMethod, out var isComReceiver, out bool isVarArg))
+            {
                 // In this case, the invocation is not in expanded form and there's no named argument provided.
                 // So we just return list of arguments as is.
-                return arguments.ZipAsArray(methodOrIndexer.GetParameters(), (a, p) => BoundCall.CreateArgumentOperation(ArgumentKind.Explicit, p, a));
+
+                ImmutableArray<ParameterSymbol> parameters = methodOrIndexer.GetParameters();
+                ArrayBuilder<IArgument> argumentsBuilder = ArrayBuilder<IArgument>.GetInstance(arguments.Length);
+
+                int i = 0;
+                for (; i < parameters.Length; ++i)
+                {
+                    argumentsBuilder.Add(BoundCall.CreateArgumentOperation(ArgumentKind.Explicit, parameters[i], arguments[i]));
+                }
+
+                if (isVarArg)
+                {
+                    // TODO: In case of __arglist, we might have more arguments than parameters, 
+                    //       set the parameter to null for __arglist argument for now.
+                    //       https://github.com/dotnet/roslyn/issues/19673
+                    Debug.Assert(parameters.Length == arguments.Length - 1);
+
+                    argumentsBuilder.Add(BoundCall.CreateArgumentOperation(ArgumentKind.Explicit, null, arguments[i]));
+                }
+
+                return argumentsBuilder.ToImmutableAndFree();
             }                                                                                                                   
 
             return BuildArgumentsInEvaluationOrder(syntax, 
@@ -539,7 +558,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool expanded,
             ImmutableArray<int> argsToParamsOpt,
             bool invokedAsExtensionMethod,
-            out bool isComReceiver)
+            out bool isComReceiver,
+            out bool isVarArg)
         {
             // An applicable "vararg" method could not possibly be applicable in its expanded
             // form, and cannot possibly have named arguments or used optional parameters, 
@@ -551,6 +571,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(argsToParamsOpt.IsDefault);
                 Debug.Assert(!expanded);
                 isComReceiver = false;
+                isVarArg = true;
                 return true;
             }
 
@@ -558,7 +579,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     ((MethodSymbol)methodOrIndexer).Parameters[0].Type as NamedTypeSymbol :
                                     methodOrIndexer.ContainingType;
 
-            isComReceiver = (object)receiverNamedType != null && receiverNamedType.IsComImport; 
+            isComReceiver = (object)receiverNamedType != null && receiverNamedType.IsComImport;
+            isVarArg = false;
 
             return rewrittenArguments.Length == methodOrIndexer.GetParameterCount() &&
                 argsToParamsOpt.IsDefault &&

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IArgument.cs
@@ -991,6 +991,45 @@ IInvocationExpression ( void P.M2(System.String x)) (OperationKind.InvocationExp
         }
 
         [Fact]
+        public void VarArgsCall()
+        {
+            string source = @"
+using System;
+
+public class P
+{
+    void M()
+    {
+        /*<bind>*/Console.Write(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, __arglist(5))/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IInvocationExpression (static void System.Console.Write(System.String format, System.Object arg0, System.Object arg1, System.Object arg2, System.Object arg3, __arglist)) (OperationKind.InvocationExpression, Type: System.Void) (Syntax: 'Console.Wri ... arglist(5))')
+  Arguments(6): IArgument (ArgumentKind.Explicit, Matching Parameter: format) (OperationKind.Argument) (Syntax: '""{0} {1} {2} {3} {4}""')
+      ILiteralExpression (OperationKind.LiteralExpression, Type: System.String, Constant: ""{0} {1} {2} {3} {4}"") (Syntax: '""{0} {1} {2} {3} {4}""')
+    IArgument (ArgumentKind.Explicit, Matching Parameter: arg0) (OperationKind.Argument) (Syntax: '1')
+      IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: System.Object) (Syntax: '1')
+        ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+    IArgument (ArgumentKind.Explicit, Matching Parameter: arg1) (OperationKind.Argument) (Syntax: '2')
+      IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: System.Object) (Syntax: '2')
+        ILiteralExpression (Text: 2) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 2) (Syntax: '2')
+    IArgument (ArgumentKind.Explicit, Matching Parameter: arg2) (OperationKind.Argument) (Syntax: '3')
+      IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: System.Object) (Syntax: '3')
+        ILiteralExpression (Text: 3) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 3) (Syntax: '3')
+    IArgument (ArgumentKind.Explicit, Matching Parameter: arg3) (OperationKind.Argument) (Syntax: '4')
+      IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: System.Object) (Syntax: '4')
+        ILiteralExpression (Text: 4) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 4) (Syntax: '4')
+    IArgument (ArgumentKind.Explicit, Matching Parameter: null) (OperationKind.Argument, IsInvalid) (Syntax: '__arglist(5)')
+      IOperation:  (OperationKind.None) (Syntax: '__arglist(5)')
+        Children(1): ILiteralExpression (Text: 5) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 5) (Syntax: '5')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
         public void InvalidConversionForDefaultArgument_InSource()
         {
             string source = @"


### PR DESCRIPTION
A more appropriate fix is proposed in #19673, which would require more interface change, This PR just fix the crash.

**Customer scenario**

When users install IOperation based analyzer that examines `IInvocationExpression`, and their source contains calls to methods with `__arglist` argument, the analyzer will crash.

**Bugs this fixes:**

**Workarounds, if any**

Disable related analyzers.

**Risk**

Low. This change only impacts IOperation code path.

**Performance impact**

None.

**Is this a regression from a previous update?**

Yes. We didn't handle `__arglist` argument correctly before, but we didn't crash either. This is caused by change in #19237 

**Root cause analysis:**

When creating `IArgument` operations for a method invocation, we assumed the numbers of argument expressions and parameter symbols are identical for method with `__arglist`, which isn't true: the `__arglist` argument has no corresponding parameter. 

**How was the bug found?**

Running tests in roslyn analyzer repo using the latest roslyn build.

@dotnet/analyzer-ioperation @AlekseyTs @cston 
