### PR TITLE
Allow 'none' to be the severity for options in .editorconfig

### DIFF
--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
@@ -81,7 +81,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         {
             switch (value.Trim())
             {
-                case EditorConfigSeverityStrings.Silent: notification = NotificationOption.None; return true;
+                case EditorConfigSeverityStrings.None:
+                case EditorConfigSeverityStrings.Silent:
+                    notification = NotificationOption.None;
+                    return true;
+
                 case EditorConfigSeverityStrings.Suggestion: notification = NotificationOption.Suggestion; return true;
                 case EditorConfigSeverityStrings.Warning: notification = NotificationOption.Warning; return true;
                 case EditorConfigSeverityStrings.Error: notification = NotificationOption.Error; return true;

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_NamingRule.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigNamingStyleParser_NamingRule.cs
@@ -49,7 +49,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
         {
             switch (ruleSeverity)
             {
-                case EditorConfigSeverityStrings.Silent: return DiagnosticSeverity.Hidden;
+                case EditorConfigSeverityStrings.None:
+                case EditorConfigSeverityStrings.Silent:
+                    return DiagnosticSeverity.Hidden;
+
                 case EditorConfigSeverityStrings.Suggestion: return DiagnosticSeverity.Info;
                 case EditorConfigSeverityStrings.Warning: return DiagnosticSeverity.Warning;
                 case EditorConfigSeverityStrings.Error: return DiagnosticSeverity.Error;

--- a/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigSeverityStrings.cs
+++ b/src/Workspaces/Core/Portable/NamingStyles/EditorConfig/EditorConfigSeverityStrings.cs
@@ -4,6 +4,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal static class EditorConfigSeverityStrings
     {
+        public const string None = "none";
         public const string Silent = "silent";
         public const string Suggestion = "suggestion";
         public const string Warning = "warning";

--- a/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
+++ b/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
@@ -11,11 +11,13 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
     public class EditorConfigCodeStyleParserTests
     {
         [Theory]
+        [InlineData("true:none", true, DiagnosticSeverity.Hidden)]
         [InlineData("true:silent", true, DiagnosticSeverity.Hidden)]
         [InlineData("true:suggestion", true, DiagnosticSeverity.Info)]
         [InlineData("true:warning", true, DiagnosticSeverity.Warning)]
         [InlineData("true:error", true, DiagnosticSeverity.Error)]
         [InlineData("true", false, DiagnosticSeverity.Hidden)]
+        [InlineData("false:none", false, DiagnosticSeverity.Hidden)]
         [InlineData("false:silent", false, DiagnosticSeverity.Hidden)]
         [InlineData("false:suggestion", false, DiagnosticSeverity.Info)]
         [InlineData("false:warning", false, DiagnosticSeverity.Warning)]


### PR DESCRIPTION
Fixes #19675

Even we were [not using this correctly](https://github.com/dotnet/roslyn/blob/master/.editorconfig#L61-L63). After this fix, reality aligns with expectations. 👍 

## Ask Mode

**Customer scenario**

A user adds a setting to **.editorconfig** with the value `true:none`, in accordance with our public documentation. The value is ignored.

**Bugs this fixes:**

Fixes #19675

**Workarounds, if any**

Work with everyone who already created a **.editorconfig** file prior to now with a setting that has the value `true:none` to instead use the value recognized by the settings parser, `true:silent`.

**Risk**

Low. Also, the prior values are still supported for compatibility.

**Performance impact**

Negligible. Added a new value to an existing string lookup in a map.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

The difference between `false:silent` and `true:silent` in our current experience is minimal.

**How was the bug found?**

Internal customer reported.
