### PR TITLE
Fix renaming of files with the new project system

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
@@ -32,7 +32,8 @@ namespace Roslyn.VisualStudio.IntegrationTests
             // Winforms and XAML do not open text files on creation
             // so these editor tasks will not work if that is the project template being used.
             if (projectTemplate != WellKnownProjectTemplates.WinFormsApplication &&
-                projectTemplate != WellKnownProjectTemplates.WpfApplication)
+                projectTemplate != WellKnownProjectTemplates.WpfApplication &&
+                projectTemplate != WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
             {
                 VisualStudio.Workspace.SetUseSuggestionMode(false);
                 ClearEditor();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
@@ -87,5 +87,20 @@ End Module");
             VisualStudio.Editor.InvokeQuickInfo();
             Assert.Equal("Sub‎ Program.M‎(p‎ As‎ Object‎)‎ ‎(‎+‎ 1‎ overload‎)", VisualStudio.Editor.GetQuickInfo());
         }
+
+        [Fact]
+        public void RenamingOpenFiles()
+        {
+            var project = new ProjectUtils.Project(ProjectName);
+            VisualStudio.SolutionExplorer.AddFile(project, "BeforeRename.cs", open: true);
+            
+            // Verify we are connected to the project before...
+            Assert.Contains(ProjectName, VisualStudio.Editor.GetProjectNavBarItems());
+
+            VisualStudio.SolutionExplorer.RenameFile(project, "BeforeRename.cs", "AfterRename.cs");
+
+            // ...and after.
+            Assert.Contains(ProjectName, VisualStudio.Editor.GetProjectNavBarItems());
+        }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -659,14 +659,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void OpenFileWithDesigner(string projectName, string relativeFilePath)
         {
-            var filePath = GetFilePath(projectName, relativeFilePath);
-            var fileName = Path.GetFileName(filePath);
-            var project = _solution.Projects.Cast<EnvDTE.Project>().First(x => x.Name == projectName);
-            var window = project.ProjectItems.Item(fileName).Open(EnvDTE.Constants.vsViewKindDesigner);
+            var projectItem = GetProjectItem(projectName, relativeFilePath);
+            var window = projectItem.Open(EnvDTE.Constants.vsViewKindDesigner);
             window.Activate();
 
             var dte = GetDTE();
-            while (!dte.ActiveWindow.Caption.Contains(fileName))
+            while (!dte.ActiveWindow.Caption.Contains(projectItem.Name))
             {
                 Thread.Yield();
             }
@@ -674,13 +672,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void OpenFile(string projectName, string relativeFilePath)
         {
-            var filePath = GetFilePath(projectName, relativeFilePath);
-            var fileName = Path.GetFileName(filePath);
+            var filePath = GetAbsolutePathForProjectRelativeFilePath(projectName, relativeFilePath);
 
             ExecuteCommand(WellKnownCommandNames.File_OpenFile, filePath);
 
             var dte = GetDTE();
-            while (!dte.ActiveWindow.Caption.Contains(fileName))
+            while (!dte.ActiveWindow.Caption.Contains(Path.GetFileName(filePath)))
             {
                 Thread.Yield();
             }
@@ -688,54 +685,74 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
         public void CloseFile(string projectName, string relativeFilePath, bool saveFile)
         {
-            var filePath = GetFilePath(projectName, relativeFilePath);
-            var fileName = Path.GetFileName(filePath);
-
-            var dte = GetDTE();
-            var documents = dte.Documents.Cast<EnvDTE.Document>();
-            var fileToClose = documents.FirstOrDefault(document => document.Name.Equals(fileName));
-            if (fileToClose == null)
-            {
-                throw new InvalidOperationException($"File '{fileName}' not closed because it couldn't be found.  Available files: {string.Join(", ", documents.Select(x => x.Name))}.");
-            }
+            var document = GetOpenDocument(projectName, relativeFilePath);
             if (saveFile)
             {
-                SaveFile(fileName);
-                fileToClose.Close(EnvDTE.vsSaveChanges.vsSaveChangesYes);
+                SaveFileWithExtraValidation(document);
+                document.Close(EnvDTE.vsSaveChanges.vsSaveChangesYes);
             }
             else
             {
-                fileToClose.Close(EnvDTE.vsSaveChanges.vsSaveChangesNo);
+                document.Close(EnvDTE.vsSaveChanges.vsSaveChangesNo);
             }
+        }
+
+        private EnvDTE.Document GetOpenDocument(string projectName, string relativeFilePath)
+        {
+            var filePath = GetAbsolutePathForProjectRelativeFilePath(projectName, relativeFilePath);
+            var documents = GetDTE().Documents.Cast<EnvDTE.Document>();
+            var document = documents.FirstOrDefault(d => d.FullName == filePath);
+
+            if (document == null)
+            {
+                throw new InvalidOperationException($"Open document '{filePath} could not be found. Available documents: {string.Join(", ", documents.Select(x => x.FullName))}.");
+            }
+
+            return document;
+        }
+
+        private EnvDTE.ProjectItem GetProjectItem(string projectName, string relativeFilePath)
+        {
+            var projects = _solution.Projects.Cast<EnvDTE.Project>();
+            var project = projects.FirstOrDefault(x => x.Name == projectName);
+
+            if (project == null)
+            {
+                throw new InvalidOperationException($"Project '{projectName} could not be found. Available projects: {string.Join(", ", projects.Select(x => x.Name))}.");
+            }
+
+            var projectPath = Path.GetDirectoryName(project.FullName);
+            var fullFilePath = Path.Combine(projectPath, relativeFilePath);
+
+            var projectItems = project.ProjectItems.Cast<EnvDTE.ProjectItem>();
+            var document = projectItems.FirstOrDefault(d => d.FileNames[1].Equals(fullFilePath));
+
+            if (document == null)
+            {
+                throw new InvalidOperationException($"File '{fullFilePath}' could not be found.  Available files: {string.Join(", ", projectItems.Select(x => x.FileNames[1]))}.");
+            }
+
+            return document;
         }
 
         public void SaveFile(string projectName, string relativeFilePath)
         {
-            var filePath = GetFilePath(projectName, relativeFilePath);
-            var fileName = Path.GetFileName(filePath);
-            SaveFile(fileName);
+            SaveFileWithExtraValidation(GetOpenDocument(projectName, relativeFilePath));
         }
 
-        private static void SaveFile(string fileName)
+        private static void SaveFileWithExtraValidation(EnvDTE.Document document)
         {
-            var dte = GetDTE();
-            var fileToSave = dte.Documents.Cast<EnvDTE.Document>().FirstOrDefault(document => document.Name.Equals(fileName));
-            if (fileToSave == null)
-            {
-                var fileNames = dte.Documents.Cast<EnvDTE.Document>().Select(d => d.Name);
-                throw new InvalidOperationException($"File '{fileName}' not saved because it couldn't be found.  Available files: {string.Join(", ", fileNames)}.");
-            }
-            var textDocument = (EnvDTE.TextDocument)fileToSave.Object(nameof(EnvDTE.TextDocument));
+            var textDocument = (EnvDTE.TextDocument)document.Object(nameof(EnvDTE.TextDocument));
             var currentTextInDocument = textDocument.StartPoint.CreateEditPoint().GetText(textDocument.EndPoint);
-            var fullPath = fileToSave.FullName;
-            fileToSave.Save();
+            var fullPath = document.FullName;
+            document.Save();
             if (File.ReadAllText(fullPath) != currentTextInDocument)
             {
                 throw new InvalidOperationException("The text that we thought we were saving isn't what we saved!");
             }
         }
 
-        private string GetFilePath(string projectName, string relativeFilePath)
+        private string GetAbsolutePathForProjectRelativeFilePath(string projectName, string relativeFilePath)
         {
             var project = _solution.Projects.Cast<EnvDTE.Project>().First(x => x.Name == projectName);
             var projectPath = Path.GetDirectoryName(project.FullName);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -410,7 +410,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
             if (open)
             {
-                projectItem.Open();
+                OpenFile(projectName, fileName);
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -120,6 +120,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return references;
         }
 
+        public void RenameFile(string projectName, string oldFileName, string newFileName)
+        {
+            var projectItem = GetProjectItem(projectName, oldFileName);
+
+            projectItem.Name = newFileName;
+        }
+
         public void EditProjectFile(string projectName)
         {
             var solutionExplorer = ((DTE2)GetDTE()).ToolWindows.SolutionExplorer;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -90,6 +90,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void OpenFile(ProjectUtils.Project project, string fileName)
             => _inProc.OpenFile(project.Name, fileName);
 
+        public void RenameFile(ProjectUtils.Project project, string oldFileName, string newFileName)
+            => _inProc.RenameFile(project.Name, oldFileName, newFileName);
+
         public void CloseFile(ProjectUtils.Project project, string fileName, bool saveFile)
             => _inProc.CloseFile(project.Name, fileName, saveFile);
 


### PR DESCRIPTION
With the legacy project system, it just so happened that a file rename would be updated in the RDT prior to the project system removing the file under the old name and adding it under the new name. The new
project system doesn't guarantee such an ordering (nor does it have any reason to -- either ordering is perfectly reasonable), so let's handle that too.

@srivatsn, @jmarolf, @davkean for review and also suggestions for testing. I'd like to write an integration test over in this repo, but it looks like all our tests are disabled at this point due to flakiness reasons. Do we think there's any chance I can easily write a stable test for this?

**Customer scenario:** rename an open file. After that, all IDE features stop working properly until you close and reopen the file.
**Bugs this fixes:** dotnet/roslyn#19389.
**Workarounds, if any:** close and reopen the file afterwards.
**Risk**: moderate. Ordering fixes here always can result in other issues.
**Performance impact:** none. Only impacts the file rename case.
**Is this a regression from a previous update?** It's an oversight in this code that just happened to work with the old language service.
**How was the bug found?** dogfooding.
