### PR TITLE
Ignore tuple name and dynamicness differences in computing constant value for as operator on nullable tuple

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - post VS2017.md
@@ -19,3 +19,5 @@ Consider the case where the type of `a` is `System.Func<bool>` and you write `va
   1. `bool M(int? i) => i is long l; // error CS8121: An expression of type 'int?' cannot be handled by a pattern of type 'long'.`
   2. and other cases where the integral types are not the same
   3. the same error can occur in other pattern-matching contexts (i.e. `switch`)
+
+ - https://github.com/dotnet/roslyn/issues/17963 In C# 7.0 and before C# 7.1, the compiler used to consider tuple element name differences and dynamic-ness differences as significant when using the "as" operator with a nullable tuple type. For instance, `(1, 1) as (int, int x)?` and `(1, new object()) as (int, dynamic)?` would always be considered `null`. The compiler now produces the correct value, instead of `null`, and no "always null" warning.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2981,7 +2981,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     //    The value is always false.
 
                     Debug.Assert(targetType.IsNullableType());
-                    return (operandType == targetType.GetNullableUnderlyingType()) ? ConstantValue.True : ConstantValue.False;
+                    return operandType.Equals(targetType.GetNullableUnderlyingType(), TypeCompareKind.IgnoreDynamicAndTupleNames)
+                        ? ConstantValue.True : ConstantValue.False;
 
                 default:
                 case ConversionKind.ImplicitDynamic:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2981,7 +2981,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     //    The value is always false.
 
                     Debug.Assert(targetType.IsNullableType());
-                    return operandType.Equals(targetType.GetNullableUnderlyingType(), TypeCompareKind.IgnoreDynamicAndTupleNames)
+                    return operandType.Equals(targetType.GetNullableUnderlyingType(), TypeCompareKind.AllIgnoreOptions)
                         ? ConstantValue.True : ConstantValue.False;
 
                 default:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -22940,6 +22940,28 @@ class P
 
         [Fact]
         [WorkItem(17963, "https://github.com/dotnet/roslyn/issues/17963")]
+        public void NullableTupleInAsOperator2()
+        {
+            var source =
+@"
+class P
+{
+    static void M()
+    {
+        var x = (a: 1, b: 1) as (int c, int d)?;
+        var y = (1, 1) as (int, long)?;
+    }
+}";
+            var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (7,17): warning CS0458: The result of the expression is always 'null' of type '(int, long)?'
+                //         var y = (1, 1) as (int, long)?;
+                Diagnostic(ErrorCode.WRN_AlwaysNull, "(1, 1) as (int, long)?").WithArguments("(int, long)?").WithLocation(7, 17)
+                );
+        }
+
+        [Fact]
+        [WorkItem(17963, "https://github.com/dotnet/roslyn/issues/17963")]
         public void NullableTupleInIsOperator()
         {
             var source =
@@ -22974,6 +22996,27 @@ class P
                 // (6,34): error CS0165: Use of unassigned local variable 'a'
                 //         var x1 = (1, 1) is (int, int a)?;
                 Diagnostic(ErrorCode.ERR_UseDefViolation, "int a").WithArguments("a").WithLocation(6, 34)
+                );
+        }
+
+        [Fact]
+        [WorkItem(17963, "https://github.com/dotnet/roslyn/issues/17963")]
+        public void NullableTupleInIsOperator2()
+        {
+            var source =
+@"
+class P
+{
+    static void M()
+    {
+        var x1 = (1, 1) is System.Nullable<(int, int a)>;
+    }
+}";
+            var comp = CreateStandardCompilation( source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (6,18): warning CS0183: The given expression is always of the provided ('(int, int a)?') type
+                //         var x1 = (1, 1) is System.Nullable<(int, int a)>;
+                Diagnostic(ErrorCode.WRN_IsAlwaysTrue, "(1, 1) is System.Nullable<(int, int a)>").WithArguments("(int, int a)?").WithLocation(6, 18)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -22930,12 +22930,12 @@ class P
         var x1 = (1, 1) as (int, int a)?;
         var x2 = (1, 1) as (int, int)?;
         var x3 = (1, new object()) as (int, dynamic)?;
-        Console.Write(x1 != null && x2 != null & x3 != null);
+        Console.Write($""{x1} {x2} {x3}"");
     }
 }";
             var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "True");
+            CompileAndVerify(comp, expectedOutput: "(1, 1) (1, 1) (1, System.Object)");
         }
 
         [Fact]


### PR DESCRIPTION

**Customer scenario**
Use the "as" operator on a tuple type, such that the type on the right is a matching nullable tuple type, but with some subtle differences (tuple names or dynamic-ness). For example: `(1, 1) as (int, int x)?`
This currently gives a warning and returns null, but should succeed and return a non-null value.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/17963

**Workarounds, if any**
Avoid such subtle differences.

**Risk**
**Performance impact**
Low. This is a very localized fixed in handling of "as" operator, to compare types ignoring such subtle differences, instead of an exact type comparison.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
This permutation was not tested.

**How was the bug found?**
Reported by customer (Reshetnikov)

@gafter @dotnet/roslyn-compiler for review.