### PR TITLE
Properly 'go to implementation' when there are abstract overrides in the hierarchy

### DIFF
--- a/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
+++ b/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
@@ -413,5 +413,31 @@ class D : C
 
             Await TestAsync(workspace)
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <WorkItem(19700, "https://github.com/dotnet/roslyn/issues/19700")>
+        Public Async Function TestWithIntermediateAbstractOverrides() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+    abstract class A {
+        public virtual void $$[|M|]() { }
+    }
+    abstract class B : A {
+        public abstract override void M();
+    }
+    sealed class C1 : B {
+        public override void [|M|]() { }
+    }
+    sealed class C2 : A {
+        public override void [|M|]() => base.M();
+    }
+        </Document>
+    </Project>
+</Workspace>
+
+            Await TestAsync(workspace)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
+++ b/src/EditorFeatures/Test2/GoToImplementation/GoToImplementationTests.vb
@@ -46,7 +46,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToImplementation
             End Using
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestEmptyFile() As Task
             Dim workspace =
 <Workspace>
@@ -60,7 +60,7 @@ $$
             Await TestAsync(workspace, shouldSucceed:=False)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithSingleClass() As Task
             Dim workspace =
 <Workspace>
@@ -74,7 +74,7 @@ class [|$$C|] { }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithAbstractClass() As Task
             ' Since the class is abstract, it cannot be an implementation of itself. Compare to TestWithSingleClass
             ' above (where we count a class as an implementation of itself) or TestWithAbstractMethodImplementation
@@ -97,7 +97,7 @@ class [|D|] : C
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithSealedClass() As Task
             Dim workspace =
 <Workspace>
@@ -113,7 +113,7 @@ sealed class [|$$C|]
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithStruct() As Task
             Dim workspace =
 <Workspace>
@@ -129,7 +129,7 @@ struct [|$$C|]
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithEnum() As Task
             Dim workspace =
 <Workspace>
@@ -145,7 +145,7 @@ enum [|$$C|]
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithNonAbstractClass() As Task
             Dim workspace =
 <Workspace>
@@ -165,7 +165,7 @@ class [|D|] : C
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithSingleClassImplementation() As Task
             Dim workspace =
 <Workspace>
@@ -180,7 +180,7 @@ interface $$I { }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithTwoClassImplementations() As Task
             Dim workspace =
 <Workspace>
@@ -196,7 +196,7 @@ interface $$I { }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithOneMethodImplementation() As Task
             Dim workspace =
 <Workspace>
@@ -211,7 +211,7 @@ interface I { void $$M(); }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithOneEventImplementation() As Task
             Dim workspace =
 <Workspace>
@@ -228,7 +228,7 @@ interface I { event EventHandler $$E; }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithTwoMethodImplementations() As Task
             Dim workspace =
 <Workspace>
@@ -244,7 +244,7 @@ interface I { void $$M(); }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithNonInheritedImplementation() As Task
             Dim workspace =
 <Workspace>
@@ -260,7 +260,7 @@ interface I { void $$M(); }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         <WorkItem(6752, "https://github.com/dotnet/roslyn/issues/6752")>
         Public Async Function TestWithVirtualMethodImplementationWithInterfaceOnBaseClass() As Task
             Dim workspace =
@@ -277,7 +277,7 @@ interface I { void $$M(); }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         <WorkItem(6752, "https://github.com/dotnet/roslyn/issues/6752")>
         Public Async Function TestWithVirtualMethodImplementationWithInterfaceOnDerivedClass() As Task
             Dim workspace =
@@ -294,7 +294,7 @@ interface I { void $$M(); }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         <WorkItem(6752, "https://github.com/dotnet/roslyn/issues/6752")>
         Public Async Function TestWithVirtualMethodImplementationAndInterfaceImplementedOnDerivedType() As Task
             Dim workspace =
@@ -311,7 +311,7 @@ interface I { void $$M(); }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         <WorkItem(6752, "https://github.com/dotnet/roslyn/issues/6752")>
         Public Async Function TestWithAbstractMethodImplementation() As Task
             Dim workspace =
@@ -328,7 +328,7 @@ interface I { void $$M(); }
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithInterfaceMemberFromMetdataAtUseSite() As Task
             Dim workspace =
 <Workspace>
@@ -351,7 +351,7 @@ class C : IDisposable
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithSimpleMethod() As Task
             Dim workspace =
 <Workspace>
@@ -368,7 +368,7 @@ class C
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithOverridableMethodOnBase() As Task
             Dim workspace =
 <Workspace>
@@ -390,7 +390,7 @@ class D : C
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         Public Async Function TestWithOverridableMethodOnImplementation() As Task
             ' Our philosophy is to only show derived in this case, since we know the implementation of 
             ' D could never call C.M here
@@ -414,7 +414,7 @@ class D : C
             Await TestAsync(workspace)
         End Function
 
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToImplementation)>
         <WorkItem(19700, "https://github.com/dotnet/roslyn/issues/19700")>
         Public Async Function TestWithIntermediateAbstractOverrides() As Task
             Dim workspace =

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -102,12 +102,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         public static bool IsOverridable(this ISymbol symbol)
         {
-            return
-                symbol != null &&
-                symbol.ContainingType != null &&
-                symbol.ContainingType.TypeKind == TypeKind.Class &&
-                (symbol.IsVirtual || symbol.IsAbstract || symbol.IsOverride) &&
-                !symbol.IsSealed;
+            // Members can only have overrides if they are virtual, abstract or override and is not
+            // sealed.
+            return symbol?.ContainingType?.TypeKind == TypeKind.Class &&
+                   (symbol.IsVirtual || symbol.IsAbstract || symbol.IsOverride) &&
+                   !symbol.IsSealed;
         }
 
         public static bool IsImplementableMember(this ISymbol symbol)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19700
