### PR TITLE
Fix crash in deconstruction on cast of tuple type

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -134,10 +134,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (right.Kind == BoundKind.Conversion)
             {
                 var tupleConversion = (BoundConversion)right;
-                if (IsTupleExpression(tupleConversion.Operand.Kind))
+                if ((tupleConversion.Conversion.Kind == ConversionKind.ImplicitTupleLiteral || tupleConversion.Conversion.Kind == ConversionKind.Identity)
+                    && IsTupleExpression(tupleConversion.Operand.Kind))
                 {
-                    Debug.Assert(tupleConversion.Conversion.Kind == ConversionKind.ImplicitTupleLiteral ||
-                        tupleConversion.Conversion.Kind == ConversionKind.Identity);
                     return ((BoundTupleExpression)tupleConversion.Operand).Arguments;
                 }
             }
@@ -145,6 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Example:
             // var (x, y) = GetTuple();
             // var (x, y) = ((byte, byte)) (1, 2);
+            // var (a, _) = ((short, short))((int, int))(1L, 2L);
             if (right.Type.IsTupleType)
             {
                 inInit = false;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 rightParts = ((BoundTupleExpression)right).Arguments;
             }
-            else if (right.Kind == BoundKind.Conversion)
+            else if (right.Kind == BoundKind.Conversion && ((BoundConversion)right).Operand.Kind == BoundKind.ConvertedTupleLiteral)
             {
                 var tupleConversion = (BoundConversion)right;
                 Debug.Assert(tupleConversion.Conversion.Kind == ConversionKind.ImplicitTupleLiteral ||

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -107,41 +107,56 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ImmutableArray<BoundExpression> GetRightParts(BoundExpression right, Conversion conversion,
             ref ArrayBuilder<LocalSymbol> temps, DeconstructionSideEffects effects, ref bool inInit)
         {
-            ImmutableArray<BoundExpression> rightParts;
-
+            // Example:
+            // var (x, y) = new Point(1, 2);
             var deconstructionInfo = conversion.DeconstructionInfo;
             if (!deconstructionInfo.IsDefault)
             {
-                Debug.Assert(right.Kind != BoundKind.TupleLiteral && right.Kind != BoundKind.ConvertedTupleLiteral);
+                Debug.Assert(!IsTupleExpression(right.Kind));
 
                 BoundExpression evaluationResult = EvaluateSideEffectingArgumentToTemp(VisitExpression(right),
                     inInit ? effects.init : effects.deconstructions, ref temps);
 
-                rightParts = InvokeDeconstructMethod(deconstructionInfo, evaluationResult, effects.deconstructions, ref temps);
                 inInit = false;
-            }
-            else if (right.Kind == BoundKind.TupleLiteral || right.Kind == BoundKind.ConvertedTupleLiteral)
-            {
-                rightParts = ((BoundTupleExpression)right).Arguments;
-            }
-            else if (right.Kind == BoundKind.Conversion && ((BoundConversion)right).Operand.Kind == BoundKind.ConvertedTupleLiteral)
-            {
-                var tupleConversion = (BoundConversion)right;
-                Debug.Assert(tupleConversion.Conversion.Kind == ConversionKind.ImplicitTupleLiteral ||
-                    tupleConversion.Conversion.Kind == ConversionKind.Identity);
-                rightParts = ((BoundTupleExpression)tupleConversion.Operand).Arguments;
-            }
-            else if (right.Type.IsTupleType)
-            {
-                rightParts = AccessTupleFields(VisitExpression(right), temps, effects.deconstructions);
-                inInit = false;
-            }
-            else
-            {
-                throw ExceptionUtilities.Unreachable;
+                return InvokeDeconstructMethod(deconstructionInfo, evaluationResult, effects.deconstructions, ref temps);
             }
 
-            return rightParts;
+            // Example:
+            // var (x, y) = (1, 2);
+            if (IsTupleExpression(right.Kind))
+            {
+                return ((BoundTupleExpression)right).Arguments;
+            }
+
+            // Example:
+            // (byte x, byte y) = (1, 2);
+            // (int x, string y) = (1, null);
+            if (right.Kind == BoundKind.Conversion)
+            {
+                var tupleConversion = (BoundConversion)right;
+                if (IsTupleExpression(tupleConversion.Operand.Kind))
+                {
+                    Debug.Assert(tupleConversion.Conversion.Kind == ConversionKind.ImplicitTupleLiteral ||
+                        tupleConversion.Conversion.Kind == ConversionKind.Identity);
+                    return ((BoundTupleExpression)tupleConversion.Operand).Arguments;
+                }
+            }
+
+            // Example:
+            // var (x, y) = GetTuple();
+            // var (x, y) = ((byte, byte)) (1, 2);
+            if (right.Type.IsTupleType)
+            {
+                inInit = false;
+                return AccessTupleFields(VisitExpression(right), temps, effects.deconstructions);
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        private static bool IsTupleExpression(BoundKind kind)
+        {
+            return kind == BoundKind.TupleLiteral || kind == BoundKind.ConvertedTupleLiteral;
         }
 
         // This returns accessors and may create a temp for the tuple, but will not create temps for the tuple elements.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -7315,10 +7315,11 @@ class D
             var source = @"
 class C
 {
+    static int A { set { System.Console.Write(""A ""); } }
+    static int B { set { System.Console.Write(""B""); } }
     static void Main()
     {
-        var (a, b) = ((byte, byte))(new C(), new D());
-        System.Console.Write($""{a} {b}"");
+        (A, B) = ((byte, byte))(new C(), new D());
     }
     public static explicit operator byte(C c) { System.Console.Write(""Convert ""); return 1; }
     public C() { System.Console.Write(""C ""); }
@@ -7328,7 +7329,7 @@ class D
     public static explicit operator byte(D c) { System.Console.Write(""Convert2 ""); return 2; }
     public D() { System.Console.Write(""D ""); }
 }";
-            CompileAndVerify(source, expectedOutput: @"C Convert D Convert2 1 2", additionalRefs: s_valueTupleRefs);
+            CompileAndVerify(source, expectedOutput: @"C Convert D Convert2 A B", additionalRefs: s_valueTupleRefs);
         }
 
         [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -7289,6 +7289,49 @@ class C
         }
 
         [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]
+        public void TupleCastInDeconstruction2()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var t = (new C(), new D());
+        var (a, b) = ((byte, byte))t;
+        System.Console.Write($""{a} {b}"");
+    }
+    public static explicit operator byte(C c) { System.Console.Write(""Convert ""); return 1; }
+}
+class D
+{
+    public static explicit operator byte(D c) { System.Console.Write(""Convert2 ""); return 2; }
+}";
+            CompileAndVerify(source, expectedOutput: @"Convert Convert2 1 2", additionalRefs: s_valueTupleRefs);
+        }
+
+        [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]
+        public void TupleCastInDeconstruction3()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var (a, b) = ((byte, byte))(new C(), new D());
+        System.Console.Write($""{a} {b}"");
+    }
+    public static explicit operator byte(C c) { System.Console.Write(""Convert ""); return 1; }
+    public C() { System.Console.Write(""C ""); }
+}
+class D
+{
+    public static explicit operator byte(D c) { System.Console.Write(""Convert2 ""); return 2; }
+    public D() { System.Console.Write(""D ""); }
+}";
+            CompileAndVerify(source, expectedOutput: @"C Convert D Convert2 1 2", additionalRefs: s_valueTupleRefs);
+        }
+
+        [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]
         public void UserDefinedCastInDeconstruction()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -7333,6 +7333,21 @@ class D
         }
 
         [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]
+        public void TupleCastInDeconstruction4()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var (a, _) = ((short, short))((int, int))(1L, 2L);
+        System.Console.Write($""{a}"");
+    }
+}";
+            CompileAndVerify(source, expectedOutput: @"1", additionalRefs: s_valueTupleRefs);
+        }
+
+        [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]
         public void UserDefinedCastInDeconstruction()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -7297,8 +7297,8 @@ class C
     static void Main()
     {
         var t = (new C(), new D());
-        var (a, b) = ((byte, byte))t;
-        System.Console.Write($""{a} {b}"");
+        var (a, _) = ((byte, byte))t;
+        System.Console.Write($""{a}"");
     }
     public static explicit operator byte(C c) { System.Console.Write(""Convert ""); return 1; }
 }
@@ -7306,7 +7306,7 @@ class D
 {
     public static explicit operator byte(D c) { System.Console.Write(""Convert2 ""); return 2; }
 }";
-            CompileAndVerify(source, expectedOutput: @"Convert Convert2 1 2", additionalRefs: s_valueTupleRefs);
+            CompileAndVerify(source, expectedOutput: @"Convert Convert2 1", additionalRefs: s_valueTupleRefs);
         }
 
         [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1632,7 +1632,7 @@ class Program
 this.set(2)
 ";
 
-            var comp = CreateCompilationWithCustomILSource(source, ilSource,  references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithCustomILSource(source, ilSource, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput: expectedOutput).VerifyDiagnostics();
         }
 
@@ -7270,6 +7270,42 @@ class Program
 ";
             string expectedOutput = @"1";
             CompileAndVerify(source, expectedOutput: expectedOutput);
+        }
+
+        [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]
+        public void TupleCastInDeconstruction()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var t = (1, 2);
+        var (a, b) = ((byte, byte))t;
+        System.Console.Write($""{a} {b}"");
+    }
+}";
+            CompileAndVerify(source, expectedOutput: @"1 2", additionalRefs: s_valueTupleRefs);
+        }
+
+        [Fact, WorkItem(19398, "https://github.com/dotnet/roslyn/issues/19398")]
+        public void UserDefinedCastInDeconstruction()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var c = new C();
+        var (a, b) = ((byte, byte))c;
+        System.Console.Write($""{a} {b}"");
+    }
+    public static explicit operator (byte, byte)(C c)
+    {
+        return (3, 4);
+    }
+}";
+            CompileAndVerify(source, expectedOutput: @"3 4", additionalRefs: s_valueTupleRefs);
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**
The compiler crashes when you type the code below (involving a tuple cast in a deconstruction):
```C#
var t = (1, 2);
var (a, b) = ((byte, byte))t;
```

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/19398

**Workarounds, if any**
The user can take the cast out of the deconstruction:
```C#
var t2 = ((byte, byte))t;
var (a, b) = t2;
```

**Risk**
**Performance impact**
Low. This is a one-line change localized in deconstruction logic.

**Is this a regression from a previous update?**
Yes. This bug didn't exist in C# 7 deconstructions. I introduced it when refactoring much of the deconstruction code to optimize the IL that is produced.

**How was the bug found?**
Found by Chuck and also reported by internal user (Daofa Li).

@dotnet/roslyn-compiler for review. Thanks
