### PR TITLE
made open file only analyzer to run properly for fix all and suppression.

### DIFF
--- a/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             string initialMarkup, TestParameters parameters)
         {
             var workspace = TestWorkspace.IsWorkspaceElement(initialMarkup)
-                 ? TestWorkspace.Create(initialMarkup)
+                 ? TestWorkspace.Create(initialMarkup, openDocuments: false)
                  : CreateWorkspaceFromFile(initialMarkup, parameters);
 
             workspace.ApplyOptions(parameters.options);

--- a/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
+++ b/src/Features/Core/Portable/Diagnostics/AnalyzerHelper.cs
@@ -59,6 +59,25 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return false;
         }
 
+        public static bool ContainsOpenFileOnlyAnalyzers(this CompilationWithAnalyzers analyzerDriverOpt, Workspace workspace)
+        {
+            if (analyzerDriverOpt == null)
+            {
+                // not Roslyn. no open file only analyzers
+                return false;
+            }
+
+            foreach (var analyzer in analyzerDriverOpt.Analyzers)
+            {
+                if (analyzer.IsOpenFileOnly(workspace))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static bool HasNonHiddenDescriptor(this DiagnosticAnalyzerService service, DiagnosticAnalyzer analyzer, Project project)
         {
             // most of analyzers, number of descriptor is quite small, so this should be cheap.

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
@@ -91,7 +91,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeInProcAsync(
                 CompilationWithAnalyzers analyzerDriver, Project project, CancellationToken cancellationToken)
             {
-                if (analyzerDriver.Analyzers.Length == 0)
+                if (analyzerDriver == null ||
+                    analyzerDriver.Analyzers.Length == 0)
                 {
                     // quick bail out
                     return DiagnosticAnalysisResultMap.Create(ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty, ImmutableDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo>.Empty);
@@ -152,6 +153,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private CompilationWithAnalyzers CreateAnalyzerDriver(CompilationWithAnalyzers analyzerDriver, Func<DiagnosticAnalyzer, bool> predicate)
             {
                 var analyzers = analyzerDriver.Analyzers.Where(predicate).ToImmutableArray();
+                if (analyzers.Length == 0)
+                {
+                    // return null since we can't create CompilationWithAnalyzers with 0 analyzers
+                    return null;
+                }
+
                 return analyzerDriver.Compilation.WithAnalyzers(analyzers, analyzerDriver.AnalysisOptions);
             }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// Return all diagnostics that belong to given project for the given StateSets (analyzers) either from cache or by calculating them
             /// </summary>
             public async Task<ProjectAnalysisData> GetProjectAnalysisDataAsync(
-                CompilationWithAnalyzers analyzerDriverOpt, Project project, IEnumerable<StateSet> stateSets, bool ignoreFullAnalysisOptions, CancellationToken cancellationToken)
+                CompilationWithAnalyzers analyzerDriverOpt, Project project, IEnumerable<StateSet> stateSets, bool forceAnalyzerRun, CancellationToken cancellationToken)
             {
                 using (Logger.LogBlock(FunctionId.Diagnostics_ProjectDiagnostic, GetProjectLogMessage, project, stateSets, cancellationToken))
                 {
@@ -102,13 +102,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         var version = await GetDiagnosticVersionAsync(project, cancellationToken).ConfigureAwait(false);
                         var existingData = await ProjectAnalysisData.CreateAsync(project, stateSets, avoidLoadingData, cancellationToken).ConfigureAwait(false);
 
-                        if (existingData.Version == version)
+                        // we can't return here if we have open file only analyzers sine saved data for open file only analyzer
+                        // is wrong. (since it only contains info on open files rather than whole project)
+                        if (existingData.Version == version && !analyzerDriverOpt.ContainsOpenFileOnlyAnalyzers(project.Solution.Workspace))
                         {
                             return existingData;
                         }
 
                         // perf optimization. check whether we want to analyze this project or not.
-                        if (!await FullAnalysisEnabledAsync(project, ignoreFullAnalysisOptions, cancellationToken).ConfigureAwait(false))
+                        if (!await FullAnalysisEnabledAsync(project, forceAnalyzerRun, cancellationToken).ConfigureAwait(false))
                         {
                             return new ProjectAnalysisData(project.Id, VersionStamp.Default, existingData.Result, ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty);
                         }
@@ -181,14 +183,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     //       this can happen since caller could have created the driver with different set of analyzers that are different
                     //       than what we used to create the cache.
                     var version = await GetDiagnosticVersionAsync(project, cancellationToken).ConfigureAwait(false);
-                    if (TryReduceAnalyzersToRun(analyzerDriverOpt, version, existing, out var analyzersToRun))
+                    if (TryReduceAnalyzersToRun(analyzerDriverOpt, project, version, existing, out var analyzersToRun))
                     {
                         // it looks like we can reduce the set. create new CompilationWithAnalyzer.
                         // if we reduced to 0, we just pass in null for analyzer drvier. it could be reduced to 0
                         // since we might have up to date results for analyzers from compiler but not for 
                         // workspace analyzers.
-                        var analyzerDriverWithReducedSet = 
-                            analyzersToRun.Length == 0 ? 
+                        var analyzerDriverWithReducedSet =
+                            analyzersToRun.Length == 0 ?
                                 null : await _owner._compilationManager.CreateAnalyzerDriverAsync(
                                         project, analyzersToRun, analyzerDriverOpt.AnalysisOptions.ReportSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
@@ -228,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private bool TryReduceAnalyzersToRun(
-                CompilationWithAnalyzers analyzerDriverOpt, VersionStamp version,
+                CompilationWithAnalyzers analyzerDriverOpt, Project project, VersionStamp version,
                 ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> existing,
                 out ImmutableArray<DiagnosticAnalyzer> analyzers)
             {
@@ -245,13 +247,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 foreach (var analyzer in existingAnalyzers)
                 {
                     if (existing.TryGetValue(analyzer, out var analysisResult) &&
-                        analysisResult.Version == version)
+                        analysisResult.Version == version &&
+                        !analyzer.IsOpenFileOnly(project.Solution.Workspace))
                     {
                         // we already have up to date result.
                         continue;
                     }
 
                     // analyzer that is out of date.
+                    // open file only analyzer is always out of date for project wide data
                     builder.Add(analyzer);
                 }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -397,8 +397,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // unlike the suppressed (disabled) analyzer, we will include hidden diagnostic only analyzers here.
                 var analyzerDriverOpt = await Owner._compilationManager.CreateAnalyzerDriverAsync(project, stateSets, IncludeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
-                var ignoreFullAnalysisOptions = true;
-                var result = await Owner._executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, ignoreFullAnalysisOptions, cancellationToken).ConfigureAwait(false);
+                var forceAnalyzerRun = true;
+                var result = await Owner._executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, forceAnalyzerRun, cancellationToken).ConfigureAwait(false);
 
                 foreach (var stateSet in stateSets)
                 {
@@ -444,7 +444,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 // Here, we don't care what kind of analyzer (StateSet) is given. 
                 // We just create and use AnalyzerDriver with the given analyzer (StateSet). 
-                var ignoreFullAnalysisOptions = true;
+                var forceAnalyzerRun = true;
                 var analyzerDriverOpt = await Owner._compilationManager.CreateAnalyzerDriverAsync(project, stateSets, IncludeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
                 if (documentId != null)
@@ -462,7 +462,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                             }
                         case AnalysisKind.NonLocal:
                             {
-                                var nonLocalDocumentResult = await Owner._executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, ignoreFullAnalysisOptions, cancellationToken).ConfigureAwait(false);
+                                var nonLocalDocumentResult = await Owner._executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, forceAnalyzerRun, cancellationToken).ConfigureAwait(false);
                                 var analysisResult = nonLocalDocumentResult.GetResult(stateSet.Analyzer);
                                 return GetResult(analysisResult, AnalysisKind.NonLocal, documentId);
                             }
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 Contract.ThrowIfFalse(kind == AnalysisKind.NonLocal);
-                var projectResult = await Owner._executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, ignoreFullAnalysisOptions, cancellationToken).ConfigureAwait(false);
+                var projectResult = await Owner._executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, forceAnalyzerRun, cancellationToken).ConfigureAwait(false);
                 return projectResult.GetResult(stateSet.Analyzer).Others;
             }
         }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -84,8 +84,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var includeSuppressedDiagnostics = true;
                 var analyzerDriverOpt = await _compilationManager.CreateAnalyzerDriverAsync(project, activeAnalyzers, includeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
-                var ignoreFullAnalysisOptions = false;
-                var result = await _executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, ignoreFullAnalysisOptions, cancellationToken).ConfigureAwait(false);
+                var forceAnalyzerRun = false;
+                var result = await _executor.GetProjectAnalysisDataAsync(analyzerDriverOpt, project, stateSets, forceAnalyzerRun, cancellationToken).ConfigureAwait(false);
                 if (result.FromCache)
                 {
                     RaiseProjectDiagnosticsIfNeeded(project, stateSets, result.Result);

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -157,7 +157,10 @@ End Class";
                 var project = workspace.CurrentSolution.Projects.First();
 
                 var executor = (ICodeAnalysisDiagnosticAnalyzerExecutor)new DiagnosticAnalyzerExecutor(new MyUpdateSource(workspace)).CreateService(workspace.Services);
-                var analyzerDriver = (await project.GetCompilationAsync()).WithAnalyzers(analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray());
+                var analyzerDriver = (await project.GetCompilationAsync()).WithAnalyzers(
+                        analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray(),
+                        new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Options, project.Solution));
+
                 var result = await executor.AnalyzeAsync(analyzerDriver, project, CancellationToken.None);
 
                 var analyzerResult = result.AnalysisResult[analyzerDriver.Analyzers[0]];
@@ -175,7 +178,10 @@ End Class";
             var analyzerReference = new AnalyzerFileReference(analyzerType.Assembly.Location, new TestAnalyzerAssemblyLoader());
             var project = workspace.CurrentSolution.GetProject(projectId).AddAnalyzerReference(analyzerReference);
 
-            var analyzerDriver = (await project.GetCompilationAsync()).WithAnalyzers(analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray());
+            var analyzerDriver = (await project.GetCompilationAsync()).WithAnalyzers(
+                    analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray(),
+                    new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Options, project.Solution));
+
             var result = await executor.AnalyzeAsync(analyzerDriver, project, cancellationToken);
 
             return result.AnalysisResult[analyzerDriver.Analyzers[0]];


### PR DESCRIPTION
**Customer scenario**

User apply "fix all" on a solution or invoke "add suppression" from error list for an error, but VS doesn't do anything.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/399140

**Workarounds, if any**

use fix/suppression on open file. but it means user can not run these in bulk.

**Risk**

Low. 

code change is not that complicate. most of changes are plumbing to flow down a flag. actual fix is running those in proc only analyzers in proc at the end rather than either filter them out or run in OOP.

**Performance impact**

it now runs fixers it used to not due to this bug. but that is necessary cost to provide the fix.

**Is this a regression from a previous update?**

Yes.

when OpenFileOnly analyzer concept is added to certain analyzers, those analyzer got regressed.

we had test to cover fix all, but test always used Open Files that is why this bug didnt get caught. changed test to not use open files for fix all case.

**Root cause analysis:**

I basically missed the case where OpenFileOnly analyzers can be used for whole project if "Fix All" is used. so didn't add support for OpenFileOnly analyzers for "Fix All" (error list suppression basically use same code path)

**How was the bug found?**

customer report, dogfooding.
