### PR TITLE
Enable integration tests to write out to the test log

### DIFF
--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractEditorTest.cs
@@ -4,27 +4,29 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests
 {
     public abstract class AbstractEditorTest : AbstractIntegrationTest
     {
-        protected AbstractEditorTest(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        protected AbstractEditorTest(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
         }
 
-        protected AbstractEditorTest(VisualStudioInstanceFactory instanceFactory, string solutionName)
-            : this(instanceFactory, solutionName, WellKnownProjectTemplates.ClassLibrary)
+        protected AbstractEditorTest(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper, string solutionName)
+            : this(instanceFactory, testOutputHelper, solutionName, WellKnownProjectTemplates.ClassLibrary)
         {
         }
 
         protected AbstractEditorTest(
             VisualStudioInstanceFactory instanceFactory,
+            ITestOutputHelper testOutputHelper,
             string solutionName,
             string projectTemplate)
-           : base(instanceFactory)
+           : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.SolutionExplorer.CreateSolution(solutionName);
             VisualStudio.SolutionExplorer.AddProject(new ProjectUtils.Project(ProjectName), projectTemplate, LanguageName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractIntegrationTest.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using System;
 using System.Threading;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests
 {
@@ -19,9 +20,9 @@ namespace Roslyn.VisualStudio.IntegrationTests
         private VisualStudioInstanceContext _visualStudioContext;
 
         protected AbstractIntegrationTest(
-            VisualStudioInstanceFactory instanceFactory)
+            VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
         {
-            _visualStudioContext = instanceFactory.GetNewOrUsedInstance(SharedIntegrationHostFixture.RequiredPackageIds);
+            _visualStudioContext = instanceFactory.GetNewOrUsedInstance(SharedIntegrationHostFixture.RequiredPackageIds, testOutputHelper.WriteLine);
             VisualStudio = _visualStudioContext.Instance;
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractInteractiveWindowTest.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/AbstractInteractiveWindowTest.cs
@@ -2,13 +2,14 @@
 
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests
 {
     public abstract class AbstractInteractiveWindowTest : AbstractIntegrationTest
     {
-        protected AbstractInteractiveWindowTest(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        protected AbstractInteractiveWindowTest(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             ClearInteractiveWindow();
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpAddMissingReference.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpAddMissingReference.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Other
@@ -96,8 +97,8 @@ class Program
 
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpAddMissingReference(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpAddMissingReference(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.SolutionExplorer.CreateSolution("ReferenceErrors", solutionElement: XElement.Parse(
                 "<Solution>" +

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpAutomaticBraceCompletion.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpAutomaticBraceCompletion.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpAutomaticBraceCompletion(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpAutomaticBraceCompletion))
+        public CSharpAutomaticBraceCompletion(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpAutomaticBraceCompletion))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpBuild.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpBuild : AbstractIntegrationTest
     {
-        public CSharpBuild(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpBuild(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.SolutionExplorer.CreateSolution(nameof(CSharpBuild));
             VisualStudio.SolutionExplorer.AddProject(new ProjectUtils.Project("TestProj"), WellKnownProjectTemplates.ConsoleApplication, LanguageNames.CSharp);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpChangeSignatureDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpChangeSignatureDialog.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -16,8 +17,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 
         private ChangeSignatureDialog_OutOfProc ChangeSignatureDialog => VisualStudio.ChangeSignatureDialog;
 
-        public CSharpChangeSignatureDialog(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpChangeSignatureDialog))
+        public CSharpChangeSignatureDialog(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpChangeSignatureDialog))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpClassification.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpClassification.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpClassification(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpClassification))
+        public CSharpClassification(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpClassification))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -17,8 +18,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpCodeActions(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpCodeActions))
+        public CSharpCodeActions(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpCodeActions))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpEncapsulateField.cs
@@ -4,14 +4,15 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpEncapsulateField : AbstractEditorTest
     {
-        public CSharpEncapsulateField(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpEncapsulateField))
+        public CSharpEncapsulateField(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpEncapsulateField))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListCommon.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListCommon.cs
@@ -5,13 +5,14 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     public class CSharpErrorListCommon : AbstractEditorTest
     {
-        public CSharpErrorListCommon(VisualStudioInstanceFactory instanceFactor, string templateName)
-            : base(instanceFactor, nameof(CSharpErrorListCommon), templateName)
+        public CSharpErrorListCommon(VisualStudioInstanceFactory instanceFactor, ITestOutputHelper testOutputHelper, string templateName)
+            : base(instanceFactor, testOutputHelper, nameof(CSharpErrorListCommon), templateName)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListDesktop.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListDesktop.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpErrorListDesktop : CSharpErrorListCommon
     {
-        public CSharpErrorListDesktop(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, WellKnownProjectTemplates.ClassLibrary)
+        public CSharpErrorListDesktop(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.ClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpErrorListNetCore.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpErrorListNetCore : CSharpErrorListCommon
     {
-        public CSharpErrorListNetCore(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
+        public CSharpErrorListNetCore(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractInterfaceDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractInterfaceDialog.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -16,8 +17,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 
         private ExtractInterfaceDialog_OutOfProc ExtractInterfaceDialog => VisualStudio.ExtractInterfaceDialog;
 
-        public CSharpExtractInterfaceDialog(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpExtractInterfaceDialog))
+        public CSharpExtractInterfaceDialog(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpExtractInterfaceDialog))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractMethod.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpExtractMethod.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -32,8 +33,8 @@ public class Program
 
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpExtractMethod(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpExtractMethod))
+        public CSharpExtractMethod(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpExtractMethod))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpF1Help.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpF1Help.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpF1Help(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpF1Help))
+        public CSharpF1Help(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpF1Help))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFindReferences.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFindReferences.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -16,8 +17,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpFindReferences(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpFindReferences))
+        public CSharpFindReferences(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpFindReferences))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpFormatting.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -14,8 +15,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpFormatting(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpFormatting))
+        public CSharpFormatting(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpFormatting))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGenerateFromUsage.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGenerateFromUsage.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpGenerateFromUsage(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpGenerateFromUsage))
+        public CSharpGenerateFromUsage(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpGenerateFromUsage))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGenerateTypeDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGenerateTypeDialog.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -16,8 +17,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 
         private GenerateTypeDialog_OutOfProc GenerateTypeDialog => VisualStudio.GenerateTypeDialog;
 
-        public CSharpGenerateTypeDialog(VisualStudioInstanceFactory instanceFactory)
-                    : base(instanceFactory, nameof(CSharpGenerateTypeDialog))
+        public CSharpGenerateTypeDialog(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+                    : base(instanceFactory, testOutputHelper, nameof(CSharpGenerateTypeDialog))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToDefinition.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToDefinition.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -15,8 +16,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpGoToDefinition(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpGoToDefinition))
+        public CSharpGoToDefinition(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpGoToDefinition))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpGoToImplementation.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpGoToImplementation(VisualStudioInstanceFactory instanceFactory)
-                    : base(instanceFactory, nameof(CSharpGoToImplementation))
+        public CSharpGoToImplementation(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+                    : base(instanceFactory, testOutputHelper, nameof(CSharpGoToImplementation))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpIntelliSense.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpIntelliSense(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpIntelliSense))
+        public CSharpIntelliSense(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpIntelliSense))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs
@@ -4,14 +4,15 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpInteractive : AbstractInteractiveWindowTest
     {
-        public CSharpInteractive(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpInteractive(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveAsyncOutput.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveAsyncOutput.cs
@@ -2,14 +2,15 @@
 
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpInteractiveAsyncOutput : AbstractInteractiveWindowTest
     {
-        public CSharpInteractiveAsyncOutput(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpInteractiveAsyncOutput(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveBoxSelection.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveBoxSelection.cs
@@ -3,14 +3,15 @@
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpInteractiveBoxSelection : AbstractInteractiveWindowTest
     {
-        public CSharpInteractiveBoxSelection(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpInteractiveBoxSelection(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.InteractiveWindow.SubmitText("#cls");
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveCommands.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveCommands.cs
@@ -3,14 +3,15 @@
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpInteractiveCommands : AbstractInteractiveWindowTest
     {
-        public CSharpInteractiveCommands(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpInteractiveCommands(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveDirectives.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveDirectives.cs
@@ -3,14 +3,15 @@
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpInteractiveDirectives : AbstractInteractiveWindowTest
     {
-        public CSharpInteractiveDirectives(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpInteractiveDirectives(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveFormsAndWpf.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractiveFormsAndWpf.cs
@@ -3,14 +3,15 @@
 using System.Windows.Automation;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpInteractiveFormsAndWpf : AbstractInteractiveWindowTest
     {
-        public CSharpInteractiveFormsAndWpf(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpInteractiveFormsAndWpf(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.InteractiveWindow.SubmitText(@"#r ""System.Windows.Forms""
 #r ""WindowsBase""

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpKeywordHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpKeywordHighlighting.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -18,8 +19,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpKeywordHighlighting(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpKeywordHighlighting))
+        public CSharpKeywordHighlighting(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpKeywordHighlighting))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpNavigateTo.cs
@@ -5,8 +5,8 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
-
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -15,8 +15,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpNavigateTo(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpNavigateTo))
+        public CSharpNavigateTo(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpNavigateTo))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpNavigationBar.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpNavigationBar.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -28,8 +29,8 @@ struct S
 
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpNavigationBar(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpNavigationBar))
+        public CSharpNavigationBar(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpNavigationBar))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpOrganizing.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpOrganizing.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpOrganizing(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpOrganizing))
+        public CSharpOrganizing(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpOrganizing))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpOutlining.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpOutlining.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -17,8 +18,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpOutlining(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpOutlining))
+        public CSharpOutlining(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpOutlining))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpQuickInfo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpQuickInfo.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpQuickInfo(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpQuickInfo))
+        public CSharpQuickInfo(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpQuickInfo))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReferenceHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReferenceHighlighting.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -17,8 +18,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpReferenceHighlighting(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpReferenceHighlighting))
+        public CSharpReferenceHighlighting(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpReferenceHighlighting))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -20,8 +21,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 
         private InlineRenameDialog_OutOfProc InlineRenameDialog => VisualStudio.InlineRenameDialog;
 
-        public CSharpRename(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpRename))
+        public CSharpRename(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpRename))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplClassification.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplClassification.cs
@@ -3,14 +3,15 @@
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpReplClassification : AbstractInteractiveWindowTest
     {
-        public CSharpReplClassification(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpReplClassification(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpReplIdeFeatures : AbstractInteractiveWindowTest
     {
-        public CSharpReplIdeFeatures(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpReplIdeFeatures(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.Workspace.SetUseSuggestionMode(true);
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIntellisense.cs
@@ -4,14 +4,15 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpReplIntellisense : AbstractInteractiveWindowTest
     {
-        public CSharpReplIntellisense(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpReplIntellisense(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.Workspace.SetUseSuggestionMode(true);
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSendToInteractive.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -14,8 +15,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         private const string FileName = "test.cs";
 
-        public CSharpSendToInteractive(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public CSharpSendToInteractive(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.SolutionExplorer.CreateSolution(SolutionName);
             var project = new Project(ProjectName);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSignatureHelp.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSignatureHelp.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpSignatureHelp(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpSignatureHelp))
+        public CSharpSignatureHelp(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpSignatureHelp))
         {
 
         }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesCommon.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesCommon.cs
@@ -2,13 +2,14 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     public abstract class CSharpSquigglesCommon : AbstractEditorTest
     {
-        public CSharpSquigglesCommon(VisualStudioInstanceFactory instanceFactory, string projectTemplate)
-            :base(instanceFactory, nameof(CSharpSquigglesCommon), projectTemplate)
+        public CSharpSquigglesCommon(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper, string projectTemplate)
+            :base(instanceFactory, testOutputHelper, nameof(CSharpSquigglesCommon), projectTemplate)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesDesktop.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesDesktop.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpSquigglesDesktop : CSharpSquigglesCommon
     {
-        public CSharpSquigglesDesktop(VisualStudioInstanceFactory instanceFactory)
-            :base(instanceFactory, WellKnownProjectTemplates.ClassLibrary)
+        public CSharpSquigglesDesktop(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.ClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpSquigglesNetCore.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class CSharpSquigglesNetCore : CSharpSquigglesCommon
     {
-        public CSharpSquigglesNetCore(VisualStudioInstanceFactory instanceFactory)
-            :base(instanceFactory, WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
+        public CSharpSquigglesNetCore(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpWinForms.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
     {
         protected override string LanguageName => LanguageNames.CSharp;
 
-        public CSharpWinForms(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(CSharpWinForms), WellKnownProjectTemplates.WinFormsApplication)
+        public CSharpWinForms(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(CSharpWinForms), WellKnownProjectTemplates.WinFormsApplication)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicAddMissingReference.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicAddMissingReference.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -104,8 +105,8 @@ End Module";
 
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicAddMissingReference(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public BasicAddMissingReference(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.SolutionExplorer.CreateSolution("ReferenceErrors", solutionElement: XElement.Parse(
                 "<Solution>" +

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicAutomaticBraceCompletion.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicAutomaticBraceCompletion.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicAutomaticBraceCompletion(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicAutomaticBraceCompletion))
+        public BasicAutomaticBraceCompletion(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicAutomaticBraceCompletion))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicBuild.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicBuild.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -11,8 +12,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class BasicBuild : AbstractIntegrationTest
     {
-        public BasicBuild(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory)
+        public BasicBuild(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.SolutionExplorer.CreateSolution(nameof(BasicBuild));
             var testProj = new ProjectUtils.Project("TestProj");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicChangeSignatureDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicChangeSignatureDialog.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -17,8 +18,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 
         private ChangeSignatureDialog_OutOfProc ChangeSignatureDialog => VisualStudio.ChangeSignatureDialog;
 
-        public BasicChangeSignatureDialog(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicChangeSignatureDialog))
+        public BasicChangeSignatureDialog(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicChangeSignatureDialog))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicClassification.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicClassification.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicClassification(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicClassification))
+        public BasicClassification(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicClassification))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicCodeActions.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicCodeActions(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicCodeActions))
+        public BasicCodeActions(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicCodeActions))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEditAndContinue.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -14,7 +15,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         private const string module1FileName = "Module1.vb";
 
-        public BasicEditAndContinue(VisualStudioInstanceFactory instanceFactory) : base(instanceFactory)
+        public BasicEditAndContinue(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.SolutionExplorer.CreateSolution(nameof(BasicBuild));
             var testProj = new ProjectUtils.Project("TestProj");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEncapsulateField.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEncapsulateField.cs
@@ -4,14 +4,15 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Basic
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class BasicEncapsulateField : AbstractEditorTest
     {
-        public BasicEncapsulateField(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicEncapsulateField))
+        public BasicEncapsulateField(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicEncapsulateField))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEndConstruct.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicEndConstruct.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicEndConstruct(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicEndConstruct))
+        public BasicEndConstruct(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicEndConstruct))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicErrorListCommon.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicErrorListCommon.cs
@@ -5,13 +5,14 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
     public class BasicErrorListCommon : AbstractEditorTest
     {
-        public BasicErrorListCommon(VisualStudioInstanceFactory instanceFactor, string templateName)
-            : base(instanceFactor, nameof(BasicErrorListCommon), templateName)
+        public BasicErrorListCommon(VisualStudioInstanceFactory instanceFactor, ITestOutputHelper testOutputHelper, string templateName)
+            : base(instanceFactor, testOutputHelper, nameof(BasicErrorListCommon), templateName)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicErrorListDesktop.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicErrorListDesktop.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class BasicErrorListDesktop : BasicErrorListCommon
     {
-        public BasicErrorListDesktop(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, WellKnownProjectTemplates.ClassLibrary)
+        public BasicErrorListDesktop(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.ClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicErrorListNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicErrorListNetCore.cs
@@ -3,13 +3,14 @@
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
     public class BasicErrorListNetCore : BasicErrorListCommon
     {
-        public BasicErrorListNetCore(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, WellKnownProjectTemplates.VisualBasicNetCoreClassLibrary)
+        public BasicErrorListNetCore(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.VisualBasicNetCoreClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExpressionEvaluator.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExpressionEvaluator.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -12,7 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicExpressionEvaluator(VisualStudioInstanceFactory instanceFactory) : base(instanceFactory)
+        public BasicExpressionEvaluator(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper)
         {
             VisualStudio.SolutionExplorer.CreateSolution(nameof(BasicBuild));
             var testProj = new ProjectUtils.Project("TestProj");

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExtractInterfaceDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExtractInterfaceDialog.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -16,8 +17,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 
         private ExtractInterfaceDialog_OutOfProc ExtractInterfaceDialog => VisualStudio.ExtractInterfaceDialog;
 
-        public BasicExtractInterfaceDialog(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicExtractInterfaceDialog))
+        public BasicExtractInterfaceDialog(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicExtractInterfaceDialog))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExtractMethod.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicExtractMethod.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Basic
 {
@@ -36,8 +37,8 @@ End Module";
 
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicExtractMethod(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicExtractMethod))
+        public BasicExtractMethod(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicExtractMethod))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicF1Help.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicF1Help.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Basic
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.Basic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicF1Help(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicF1Help))
+        public BasicF1Help(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicF1Help))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicFindReferences.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicFindReferences.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Common;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -16,8 +17,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicFindReferences(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicFindReferences))
+        public BasicFindReferences(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicFindReferences))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicFormatting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicFormatting.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -15,8 +16,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicFormatting(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicFormatting))
+        public BasicFormatting(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicFormatting))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateConstructorDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateConstructorDialog.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -15,8 +16,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicGenerateConstructorDialog(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicGenerateConstructorDialog))
+        public BasicGenerateConstructorDialog(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicGenerateConstructorDialog))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateEqualsAndGetHashCodeDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateEqualsAndGetHashCodeDialog.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -15,8 +16,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicGenerateEqualsAndGetHashCodeDialog(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicGenerateEqualsAndGetHashCodeDialog))
+        public BasicGenerateEqualsAndGetHashCodeDialog(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicGenerateEqualsAndGetHashCodeDialog))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateFromUsage.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateFromUsage.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicGenerateFromUsage(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicGenerateFromUsage))
+        public BasicGenerateFromUsage(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicGenerateFromUsage))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateTypeDialog.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGenerateTypeDialog.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -16,8 +17,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 
         private GenerateTypeDialog_OutOfProc GenerateTypeDialog => VisualStudio.GenerateTypeDialog;
 
-        public BasicGenerateTypeDialog(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicGenerateTypeDialog))
+        public BasicGenerateTypeDialog(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicGenerateTypeDialog))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToDefinition.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToDefinition.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicGoToDefinition(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicGoToDefinition))
+        public BasicGoToDefinition(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicGoToDefinition))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToImplementation.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicGoToImplementation.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicGoToImplementation(VisualStudioInstanceFactory instanceFactory)
-                    : base(instanceFactory, nameof(BasicGoToImplementation))
+        public BasicGoToImplementation(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+                    : base(instanceFactory, testOutputHelper, nameof(BasicGoToImplementation))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicIntelliSense.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicIntelliSense.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicIntelliSense(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicIntelliSense))
+        public BasicIntelliSense(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicIntelliSense))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicKeywordHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicKeywordHighlighting.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Basic
 {
@@ -14,8 +15,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.Basic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicKeywordHighlighting(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicKeywordHighlighting))
+        public BasicKeywordHighlighting(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicKeywordHighlighting))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicLineCommit.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjName = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils.Project;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -14,8 +15,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicLineCommit(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicLineCommit))
+        public BasicLineCommit(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicLineCommit))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicNavigateTo.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -13,8 +14,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicNavigateTo(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicNavigateTo))
+        public BasicNavigateTo(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicNavigateTo))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicNavigationBar.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicNavigationBar.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Basic
 {
@@ -25,8 +26,8 @@ End Structure";
 
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicNavigationBar(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicNavigationBar))
+        public BasicNavigationBar(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicNavigationBar))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicOrganizing.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicOrganizing.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Basic
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.Basic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicOrganizing(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicOrganizing))
+        public BasicOrganizing(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicOrganizing))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicOutlining.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicOutlining.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Basic
 {
@@ -16,8 +17,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.Basic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicOutlining(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicOutlining))
+        public BasicOutlining(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicOutlining))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicQuickInfo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicQuickInfo.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicQuickInfo(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicQuickInfo))
+        public BasicQuickInfo(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicQuickInfo))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicReferenceHighlighting.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicReferenceHighlighting.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Basic
 {
@@ -17,8 +18,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.Basic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicReferenceHighlighting(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicReferenceHighlighting))
+        public BasicReferenceHighlighting(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicReferenceHighlighting))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicRename.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
@@ -18,8 +19,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 
         private InlineRenameDialog_OutOfProc InlineRenameDialog => VisualStudio.InlineRenameDialog;
 
-        public BasicRename(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicRename))
+        public BasicRename(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicRename))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicSignatureHelp.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicSignatureHelp.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.CSharp
 {
@@ -62,8 +63,8 @@ Class C
 End Class
 ";
 
-        public BasicSignatureHelp(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicSignatureHelp))
+        public BasicSignatureHelp(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicSignatureHelp))
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicSquigglesCommon.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicSquigglesCommon.cs
@@ -2,13 +2,14 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
     public abstract class BasicSquigglesCommon : AbstractEditorTest
     {
-        public BasicSquigglesCommon(VisualStudioInstanceFactory instanceFactory, string projectTemplate)
-            :base(instanceFactory, nameof(BasicSquigglesCommon), projectTemplate)
+        public BasicSquigglesCommon(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper, string projectTemplate)
+            :base(instanceFactory, testOutputHelper, nameof(BasicSquigglesCommon), projectTemplate)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicSquigglesDesktop.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicSquigglesDesktop.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class BasicSquigglesDesktop : BasicSquigglesCommon
     {
-        public BasicSquigglesDesktop(VisualStudioInstanceFactory instanceFactory)
-            :base(instanceFactory, WellKnownProjectTemplates.ClassLibrary)
+        public BasicSquigglesDesktop(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.ClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicSquigglesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicSquigglesNetCore.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class BasicSquigglesNetCore : BasicSquigglesCommon
     {
-        public BasicSquigglesNetCore(VisualStudioInstanceFactory instanceFactory)
-            :base(instanceFactory, WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
+        public BasicSquigglesNetCore(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            :base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicWinForms.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicWinForms.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Input;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
@@ -14,8 +15,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
     {
         protected override string LanguageName => LanguageNames.VisualBasic;
 
-        public BasicWinForms(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, nameof(BasicWinForms), WellKnownProjectTemplates.WinFormsApplication)
+        public BasicWinForms(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, nameof(BasicWinForms), WellKnownProjectTemplates.WinFormsApplication)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspaceBase.cs
@@ -3,14 +3,15 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Workspace
 {
     public abstract class WorkspaceBase : AbstractEditorTest
     {
-        public WorkspaceBase(VisualStudioInstanceFactory instanceFactory, string projectTemplate)
-            : base(instanceFactory, nameof(WorkspaceBase), projectTemplate)
+        public WorkspaceBase(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper, string projectTemplate)
+            : base(instanceFactory, testOutputHelper, nameof(WorkspaceBase), projectTemplate)
         {
             DefaultProjectTemplate = projectTemplate;
             VisualStudio.Workspace.SetFullSolutionAnalysis(true);

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesDesktop.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesDesktop.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Workspace
@@ -11,8 +12,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class WorkspacesDesktop : WorkspaceBase
     {
-        public WorkspacesDesktop(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, WellKnownProjectTemplates.ClassLibrary)
+        public WorkspacesDesktop(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.ClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesNetCore.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils;
 
 namespace Roslyn.VisualStudio.IntegrationTests.Workspace
@@ -12,8 +13,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
     [Collection(nameof(SharedIntegrationHostFixture))]
     public class WorkspacesNetCore : WorkspaceBase
     {
-        public WorkspacesNetCore(VisualStudioInstanceFactory instanceFactory)
-            : base(instanceFactory, WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
+        public WorkspacesNetCore(VisualStudioInstanceFactory instanceFactory, ITestOutputHelper testOutputHelper)
+            : base(instanceFactory, testOutputHelper, WellKnownProjectTemplates.CSharpNetCoreClassLibrary)
         {
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/App.config
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/App.config
@@ -10,7 +10,7 @@
   <userSettings>
     <Microsoft.VisualStudio.IntegrationTest.Utilities.Settings>
       <setting name="VsProductVersion" serializeAs="String">
-        <value>15.0</value>
+        <value>15</value>
       </setting>
       <setting name="VsRootSuffix" serializeAs="String">
         <value>RoslynDev</value>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/FirstChanceExceptionLogger.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/FirstChanceExceptionLogger.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.IntegrationTest.Utilities
+{
+    internal sealed class FirstChanceExceptionLogger : IDisposable
+    {
+        private readonly string _testName;
+        private readonly Action<string> _logAction;
+
+        public FirstChanceExceptionLogger(string testName, Action<string> logAction)
+        {
+            _testName = testName;
+            _logAction = logAction;
+
+            AppDomain.CurrentDomain.FirstChanceException += FirstChanceExceptionHandler;
+        }
+
+        private void FirstChanceExceptionHandler(object sender, FirstChanceExceptionEventArgs eventArgs)
+        {
+            try
+            {
+                var assemblyPath = typeof(FirstChanceExceptionLogger).Assembly.Location;
+                var assemblyDirectory = Path.GetDirectoryName(assemblyPath);
+                var fileName = $"{_testName}-{eventArgs.Exception.GetType().Name}-{DateTime.Now:HH.mm.ss}.png";
+
+                _logAction?.Invoke($"First Chance Exception: {eventArgs.Exception.Message}");
+                _logAction?.Invoke($"{eventArgs.Exception.StackTrace}");
+
+                var fullPath = Path.Combine(assemblyDirectory, "xUnitResults", "Screenshots", fileName);
+
+                ScreenshotService.TakeScreenshot(fullPath);
+
+                _logAction?.Invoke($"Screenshot logged to {fullPath} for first chance exception above.");
+            }
+            catch (Exception)
+            {
+                // Per the AppDomain.FirstChanceException contract we must catch and deal with all exceptions that arise in the handler.
+                // Otherwise, we are likely to end up with recursive calls into this method until we overflow the stack.
+            }
+        }
+
+        public void Dispose()
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= FirstChanceExceptionHandler;
+        }
+    }
+}

--- a/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/IntegrationHelper.cs
@@ -458,7 +458,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         {
             object dte = null;
             var monikers = new IMoniker[1];
-            var vsProgId = VisualStudioInstanceFactory.VsProgId;
 
             NativeMethods.GetRunningObjectTable(0, out var runningObjectTable);
             runningObjectTable.EnumRunning(out var enumMoniker);
@@ -484,16 +483,14 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 moniker.GetDisplayName(bindContext, null, out var fullDisplayName);
 
                 // FullDisplayName will look something like: <ProgID>:<ProccessId>
-                if (!int.TryParse(fullDisplayName.Split(':').Last(), out var displayNameProcessId))
+                var displayNameParts = fullDisplayName.Split(':');
+                if (!int.TryParse(displayNameParts.Last(), out var displayNameProcessId))
                 {
                     continue;
                 }
 
-                var displayName = fullDisplayName.Substring(0, (fullDisplayName.Length - (displayNameProcessId.ToString().Length + 1)));
-                var fullProgId = vsProgId.StartsWith("!") ? vsProgId : $"!{vsProgId}";
-
-                if (displayName.Equals(fullProgId, StringComparison.OrdinalIgnoreCase) &&
-                    (displayNameProcessId == process.Id))
+                if (displayNameParts[0].StartsWith("!VisualStudio.DTE", StringComparison.OrdinalIgnoreCase) &&
+                    displayNameProcessId == process.Id)
                 {
                     runningObjectTable.GetObject(moniker, out dte);
                 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Settings.Designer.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("15.0")]
+        [global::System.Configuration.DefaultSettingValueAttribute("15")]
         public string VsProductVersion {
             get {
                 return ((string)(this["VsProductVersion"]));

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Settings.settings
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="VsProductVersion" Type="System.String" Scope="User">
-      <Value Profile="(Default)">15.0</Value>
+      <Value Profile="(Default)">15</Value>
     </Setting>
     <Setting Name="VsRootSuffix" Type="System.String" Scope="User">
       <Value Profile="(Default)">RoslynDev</Value>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -20,8 +20,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
     {
         public static readonly string VsProductVersion = Settings.Default.VsProductVersion;
 
-        public static readonly string VsProgId = $"VisualStudio.DTE.{VsProductVersion}";
-
         public static readonly string VsLaunchArgs = $"{(string.IsNullOrWhiteSpace(Settings.Default.VsRootSuffix) ? "/log" : $"/rootsuffix {Settings.Default.VsRootSuffix}")} /log";
 
         /// <summary>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -33,6 +33,7 @@
     <Compile Include="Common\ProjectUtilities.cs" />
     <Compile Include="Common\Reference.cs" />
     <Compile Include="Common\Signature.cs" />
+    <Compile Include="FirstChanceExceptionLogger.cs" />
     <Compile Include="Helper.cs" />
     <Compile Include="HostWaitHelper.cs" />
     <Compile Include="InProcess\Debugger_InProc.cs" />


### PR DESCRIPTION
Right now if a first chance exception happened, we would log a screenshot. But we wouldn't log the text or stack of the exception, which might be useful for debugging. This does that now too.