### PR TITLE
Stop handling quickinfo

### DIFF
--- a/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.QuickInfoSource.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.QuickInfoSource.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                     var args = new InvokeQuickInfoCommandArgs(textView, _subjectBuffer);
                     if (_commandHandler.TryGetController(args, out var controller))
                     {
-                        controller.InvokeQuickInfo(position.Value, trackMouse: true, augmentSession: session);
+                        controller.InvokeQuickInfo(position.Value, trackMouse: session.TrackMouse, augmentSession: session);
                     }
                 }
             }

--- a/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.cs
@@ -25,7 +25,6 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
     [Name("RoslynQuickInfoProvider")]
     internal partial class QuickInfoCommandHandlerAndSourceProvider :
         ForegroundThreadAffinitizedObject,
-        ICommandHandler<InvokeQuickInfoCommandArgs>,
         IQuickInfoSourceProvider
     {
         private readonly IIntelliSensePresenter<IQuickInfoPresenterSession, IQuickInfoSession> _presenter;
@@ -79,59 +78,6 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                 new AggregateAsynchronousOperationListener(_asyncListeners, FeatureAttribute.QuickInfo),
                 _providers);
             return true;
-        }
-
-        private bool TryGetControllerCommandHandler<TCommandArgs>(TCommandArgs args, out ICommandHandler<TCommandArgs> commandHandler)
-            where TCommandArgs : CommandArgs
-        {
-            AssertIsForeground();
-            if (!TryGetController(args, out var controller))
-            {
-                commandHandler = null;
-                return false;
-            }
-
-            commandHandler = (ICommandHandler<TCommandArgs>)controller;
-            return true;
-        }
-
-        private CommandState GetCommandStateWorker<TCommandArgs>(
-            TCommandArgs args,
-            Func<CommandState> nextHandler)
-            where TCommandArgs : CommandArgs
-        {
-            AssertIsForeground();
-            return TryGetControllerCommandHandler(args, out var commandHandler)
-                ? commandHandler.GetCommandState(args, nextHandler)
-                : nextHandler();
-        }
-
-        private void ExecuteCommandWorker<TCommandArgs>(
-            TCommandArgs args,
-            Action nextHandler)
-            where TCommandArgs : CommandArgs
-        {
-            AssertIsForeground();
-            if (!TryGetControllerCommandHandler(args, out var commandHandler))
-            {
-                nextHandler();
-            }
-            else
-            {
-                commandHandler.ExecuteCommand(args, nextHandler);
-            }
-        }
-
-        CommandState ICommandHandler<InvokeQuickInfoCommandArgs>.GetCommandState(InvokeQuickInfoCommandArgs args, Func<CommandState> nextHandler)
-        {
-            AssertIsForeground();
-            return GetCommandStateWorker(args, nextHandler);
-        }
-
-        void ICommandHandler<InvokeQuickInfoCommandArgs>.ExecuteCommand(InvokeQuickInfoCommandArgs args, Action nextHandler)
-        {
-            AssertIsForeground();
-            ExecuteCommandWorker(args, nextHandler);
         }
 
         public IQuickInfoSource TryCreateQuickInfoSource(ITextBuffer textBuffer)

--- a/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/QuickInfoCommandHandlerAndSourceProvider.cs
@@ -19,39 +19,35 @@ using Microsoft.VisualStudio.Utilities;
 namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
 {
     [Export]
-    [Export(typeof(IQuickInfoSourceProvider))]
     [Order(After = PredefinedQuickInfoPresenterNames.RoslynQuickInfoPresenter)]
-    [ExportCommandHandler(PredefinedCommandHandlerNames.QuickInfo, ContentTypeNames.RoslynContentType)]
+    [ContentType(ContentTypeNames.RoslynContentType)]
+    [Export(typeof(IQuickInfoSourceProvider))]
+    [Name("RoslynQuickInfoProvider")]
     internal partial class QuickInfoCommandHandlerAndSourceProvider :
         ForegroundThreadAffinitizedObject,
         ICommandHandler<InvokeQuickInfoCommandArgs>,
         IQuickInfoSourceProvider
     {
-        private readonly IInlineRenameService _inlineRenameService;
         private readonly IIntelliSensePresenter<IQuickInfoPresenterSession, IQuickInfoSession> _presenter;
         private readonly IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> _asyncListeners;
         private readonly IList<Lazy<IQuickInfoProvider, OrderableLanguageMetadata>> _providers;
 
         [ImportingConstructor]
         public QuickInfoCommandHandlerAndSourceProvider(
-            IInlineRenameService inlineRenameService,
             [ImportMany] IEnumerable<Lazy<IQuickInfoProvider, OrderableLanguageMetadata>> providers,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners,
             [ImportMany] IEnumerable<Lazy<IIntelliSensePresenter<IQuickInfoPresenterSession, IQuickInfoSession>, OrderableMetadata>> presenters)
-            : this(inlineRenameService,
-                   ExtensionOrderer.Order(presenters).Select(lazy => lazy.Value).FirstOrDefault(),
+            : this(ExtensionOrderer.Order(presenters).Select(lazy => lazy.Value).FirstOrDefault(),
                    providers, asyncListeners)
         {
         }
 
         // For testing purposes.
         public QuickInfoCommandHandlerAndSourceProvider(
-            IInlineRenameService inlineRenameService,
             IIntelliSensePresenter<IQuickInfoPresenterSession, IQuickInfoSession> presenter,
             [ImportMany] IEnumerable<Lazy<IQuickInfoProvider, OrderableLanguageMetadata>> providers,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
         {
-            _inlineRenameService = inlineRenameService;
             _providers = ExtensionOrderer.Order(providers);
             _asyncListeners = asyncListeners;
             _presenter = presenter;

--- a/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Execute.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Execute.cs
@@ -459,11 +459,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     ExecuteParameterInfo(subjectBuffer, contentType, executeNextCommandTarget);
                     break;
 
-                case VSConstants.VSStd2KCmdID.QUICKINFO:
-                    GCManager.UseLowLatencyModeForProcessingUserInput();
-                    ExecuteQuickInfo(subjectBuffer, contentType, executeNextCommandTarget);
-                    break;
-
                 case VSConstants.VSStd2KCmdID.RENAME:
                     GCManager.UseLowLatencyModeForProcessingUserInput();
                     ExecuteRename(subjectBuffer, contentType, executeNextCommandTarget);
@@ -643,13 +638,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         {
             CurrentHandlers.Execute(contentType,
                 args: new RenameCommandArgs(ConvertTextView(), subjectBuffer),
-                lastHandler: executeNextCommandTarget);
-        }
-
-        protected void ExecuteQuickInfo(ITextBuffer subjectBuffer, IContentType contentType, Action executeNextCommandTarget)
-        {
-            CurrentHandlers.Execute(contentType,
-                args: new InvokeQuickInfoCommandArgs(ConvertTextView(), subjectBuffer),
                 lastHandler: executeNextCommandTarget);
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Query.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.Query.cs
@@ -165,9 +165,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 case VSConstants.VSStd2KCmdID.PARAMINFO:
                     return QueryParameterInfoStatus(prgCmds);
 
-                case VSConstants.VSStd2KCmdID.QUICKINFO:
-                    return QueryQuickInfoStatus(prgCmds);
-
                 case VSConstants.VSStd2KCmdID.RENAME:
                     return QueryRenameStatus(ref pguidCmdGroup, commandCount, prgCmds, commandText);
 
@@ -342,12 +339,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             return GetCommandState(
                 (v, b) => new RenameCommandArgs(v, b),
                 ref pguidCmdGroup, commandCount, prgCmds, commandText);
-        }
-
-        private int QueryQuickInfoStatus(OLECMD[] prgCmds)
-        {
-            prgCmds[0].cmdf = (uint)(OLECMDF.OLECMDF_ENABLED | OLECMDF.OLECMDF_SUPPORTED);
-            return VSConstants.S_OK;
         }
 
         private int QueryParameterInfoStatus(OLECMD[] prgCmds)

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpQuickInfo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpQuickInfo.cs
@@ -17,7 +17,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914"), Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void QuickInfo_MetadataDocumentation()
         {
             SetUpEditor(@"
@@ -34,7 +34,7 @@ class Program
                 VisualStudio.Editor.GetQuickInfo());
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914"), Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void QuickInfo_Documentation()
         {
             SetUpEditor(@"
@@ -49,7 +49,7 @@ class Program$$
             Assert.Equal("class\u200e Program\r\nHello!", VisualStudio.Editor.GetQuickInfo());
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914"), Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void International()
         {
             SetUpEditor(@"
@@ -68,7 +68,7 @@ class العربية123
 This is an XML doc comment defined in code.", VisualStudio.Editor.GetQuickInfo());
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914"), Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void SectionOrdering()
         {
             SetUpEditor(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpReplIdeFeatures.cs
@@ -36,7 +36,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             VisualStudio.InteractiveWindow.Verify.CodeActionsNotShowing();
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914")]
         public void VerifyQuickInfoOnStringDocCommentsFromMetadata()
         {
             VisualStudio.InteractiveWindow.InsertCode("static void Foo(string[] args) { }");
@@ -46,7 +46,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.CSharp
             Assert.Equal("class‎ System‎.String", s);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914")]
         public void International()
         {
             VisualStudio.InteractiveWindow.InsertCode(@"delegate void العربية();

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicQuickInfo.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/VisualBasic/BasicQuickInfo.cs
@@ -17,7 +17,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.VisualBasic
         {
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914"), Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void QuickInfo1()
         {
             SetUpEditor(@"
@@ -30,7 +30,7 @@ End Class");
             Assert.Equal("Class\u200e System.String\r\nRepresents text as a sequence of UTF-16 code units.To browse the .NET Framework source code for this type, see the Reference Source.", VisualStudio.Editor.GetQuickInfo());
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914"), Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public void International()
         {
             SetUpEditor(@"

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesDesktop.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Workspace/WorkspacesDesktop.cs
@@ -34,7 +34,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.Workspace
             base.ProjectReference();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19914"), Trait(Traits.Feature, Traits.Features.Workspace)]
         public override void ProjectProperties()
         {
             VisualStudio.SolutionExplorer.CreateSolution(nameof(WorkspacesDesktop));


### PR DESCRIPTION
To address accessibility issues in 15.3, the editor is adding their own quick info command handler, meaning we can remove ours. Apart from changing MEF exports and removing dead code, this means we have to pass through the "TrackMouse" flag from the session that started us when starting a new session after our computation is complete.

Note that this also fixes https://github.com/dotnet/roslyn/issues/10661.

Tag @dotnet/roslyn-ide 