### PR TITLE
Run GitLink with a standard helper

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -8,7 +8,7 @@
     <EnvDTEVersion>8.0.1</EnvDTEVersion>
     <EnvDTE80Version>8.0.0</EnvDTE80Version>
     <FakeSignVersion>0.9.2</FakeSignVersion>
-    <GitLinkVersion>3.0.0-unstable0085</GitLinkVersion>
+    <GitLinkVersion>3.0.0-unstable0090</GitLinkVersion>
     <LibGit2SharpVersion>0.22.0</LibGit2SharpVersion>
     <ManagedEsentVersion>1.9.4</ManagedEsentVersion>
     <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>

--- a/src/Tools/MicroBuild/run-gitlink.ps1
+++ b/src/Tools/MicroBuild/run-gitlink.ps1
@@ -22,7 +22,7 @@ try {
                 $name = [IO.Path]::ChangeExtension($v, ".pdb")
                 $pdbPath = Join-Path $configDir $name
                 Write-Host "`t$pdbPath"
-                Exec-Block { & $gitlink -u "https://github.com/dotnet/roslyn" $pdbPath } | Write-Host
+                Exec-Block { & $gitlink -u "https://github.com/dotnet/roslyn" --baseDir $repoDir $pdbPath } | Write-Host
             }
         }
     }

--- a/src/Tools/MicroBuild/run-gitlink.ps1
+++ b/src/Tools/MicroBuild/run-gitlink.ps1
@@ -22,13 +22,7 @@ try {
                 $name = [IO.Path]::ChangeExtension($v, ".pdb")
                 $pdbPath = Join-Path $configDir $name
                 Write-Host "`t$pdbPath"
-
-                $output = & $gitlink -u "https://github.com/dotnet/roslyn" $pdbPath
-                if (-not $?) {
-                    Write-Host "Error!!!"
-                    Write-Host $output
-                    exit 1
-                }
+                Exec-Block { & $gitlink -u "https://github.com/dotnet/roslyn" $pdbPath } | Write-Host
             }
         }
     }
@@ -36,6 +30,6 @@ try {
     exit 0
 }
 catch [exception] {
-    write-host $_.Exception
+    Write-Host $_.Exception
     exit 1
 }


### PR DESCRIPTION
Infrastructure Only

Change our GitLink invocation code to use on of our standard process spawning helpers.  Currently looking at some
potential bugs in our source server support.  Want to eliminate a potential corner case that our old error handling
could have hidden.
