### PR TITLE
FindRefs not cascading to interface impls with structs.

### DIFF
--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
             }
         }
 
-        [WpfFact]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/14444")]
         public async Task TestPreviewDiagnosticTaggerInPreviewPane()
         {
             using (var workspace = TestWorkspace.CreateCSharp("class { }", exportProvider: EditorServicesUtil.ExportProvider))

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.OrdinaryMethodSymbols.vb
@@ -2875,5 +2875,55 @@ End Class
 
             Await TestAPIAndFeature(input)
         End Function
+
+        <WorkItem(428072, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/428072")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestInterfaceMethodImplementedInStruct1() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+    public interface IFoo
+    {
+        void {|Definition:$$Foo|}();
+    }
+
+    public struct MyStruct : IFoo
+    {
+        public void {|Definition:Foo|}()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
+
+        <WorkItem(428072, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/428072")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        Public Async Function TestInterfaceMethodImplementedInStruct2() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+    public interface IFoo
+    {
+        void {|Definition:Foo|}();
+    }
+
+    public struct MyStruct : IFoo
+    {
+        public void {|Definition:$$Foo|}()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -106,7 +106,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 transitive: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // We only want implementing types here, not derived interfaces.
-            return derivedAndImplementingTypes.WhereAsArray(t => t.Symbol.TypeKind == TypeKind.Class);
+            return derivedAndImplementingTypes.WhereAsArray(
+                t => t.Symbol.TypeKind == TypeKind.Class || t.Symbol.TypeKind == TypeKind.Struct);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://developercommunity.visualstudio.com/content/problem/33577/when-implementing-an-interface-in-a-struct-cant-fi.html
