### PR TITLE
Use the correct treatment flight name for analyzer A/B test

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Experimentation/AnalyzerVsixSuggestedActionCallback.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Experimentation/AnalyzerVsixSuggestedActionCallback.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Experimentation
     [Export(typeof(ISuggestedActionCallback))]
     internal class AnalyzerVsixSuggestedActionCallback : ForegroundThreadAffinitizedObject, ISuggestedActionCallback
     {
-        private const string AnalyzerEnabledFlight = @"LiveCA/LiveCAcf";
+        private const string AnalyzerEnabledFlight = @"LiveCA";
         private const string AnalyzerVsixHyperlink = @"https://go.microsoft.com/fwlink/?linkid=849061";
         private static readonly Guid FxCopAnalyzersPackageGuid = Guid.Parse("{4A41D270-A97F-4639-A352-28732FC410E4}");
 


### PR DESCRIPTION
**Customer scenario**

When the user uses 3 quick fixes, we need to check to see if the flight is enabled. Right now, we're checking for the incorrect flight, and it will never return true.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn/issues/19764.

**Workarounds, if any**

None.

**Risk**

Very small. This changes one string to the correct value.

**Performance impact**

None. This changes a private const string.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Review from @PavelUstinovMS.