### PR TITLE
Handle the case where a project doesn't have an output directory set.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -109,6 +109,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 outputDirectory = FileUtilities.ResolveRelativePath(outputDirectory, containingDirectoryPathOpt);
             }
 
+            if (outputDirectory == null || targetFileName == null)
+            {
+                return false;
+            }
+
             binOutputPath = FileUtilities.NormalizeAbsolutePath(Path.Combine(outputDirectory, targetFileName));
             return true;
         }

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
@@ -202,5 +202,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 project.Disconnect()
             End Using
         End Sub
+
+        <WpfFact()>
+        <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
+        <WorkItem(18098, "https://github.com/dotnet/roslyn/issues/18098")>
+        Sub NullBinPath()
+            Using environment = New TestEnvironment()
+                Dim project = CreateVisualBasicProjectWithNullBinPath(environment, "Test")
+
+                Dim compilerOptions = CreateMinimalCompilerOptions(project)
+                project.SetCompilerOptions(compilerOptions)
+
+                ' Mostly, we're just validating that we didn't crash on the way here
+                Assert.NotNull(project)
+                Assert.Null(project.BinOutputPath)
+                project.Disconnect()
+            End Using
+
+        End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/MockHierarchy.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/MockHierarchy.vb
@@ -22,11 +22,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
         Private ReadOnly _eventSinks As New Dictionary(Of UInteger, IVsHierarchyEvents)
         Private ReadOnly _hierarchyItems As New Dictionary(Of UInteger, String)
 
-        Public Sub New(projectName As String, projectBinPath As String, projectCapabilities As String)
+        Public Sub New(projectName As String,
+                       projectFilePath As String,
+                       projectBinPath As String,
+                       projectCapabilities As String)
             _projectName = projectName
             _projectBinPath = projectBinPath
             _projectCapabilities = projectCapabilities
-            _hierarchyItems.Add(CType(VSConstants.VSITEMID.Root, UInteger), projectName)
+            _hierarchyItems.Add(CType(VSConstants.VSITEMID.Root, UInteger), projectFilePath)
         End Sub
 
         Public Sub RenameProject(projectName As String)

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.IO
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
@@ -29,6 +30,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
         Private ReadOnly _projectTracker As VisualStudioProjectTracker
         Private ReadOnly _serviceProvider As MockServiceProvider
         Private ReadOnly _workspace As TestWorkspace
+        Private ReadOnly _projectFilePaths As New List(Of String)
 
         Public Sub New(Optional solutionIsFullyLoaded As Boolean = True)
             ' As a policy, if anything goes wrong don't use exception filters, just throw exceptions for the
@@ -87,10 +89,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
 
             _workspace.Dispose()
             _projectTracker.Dispose()
+
+            For Each filePath In _projectFilePaths
+                File.Delete(filePath)
+            Next
         End Sub
 
+        Private Function CreateProjectFile(projectName As String) As String
+            Dim dir = Path.Combine(Path.GetTempPath, Guid.NewGuid().ToString("N"))
+            Directory.CreateDirectory(dir)
+            Dim result = Path.Combine(dir, projectName + ".vbproj")
+            File.WriteAllText(result, "<Project></Project>")
+            _projectFilePaths.Add(result)
+            Return result
+        End Function
+
         Public Function CreateHierarchy(projectName As String, projectBinPath As String, projectCapabilities As String) As IVsHierarchy
-            Return New MockHierarchy(projectName, projectBinPath, projectCapabilities)
+            Return New MockHierarchy(projectName, CreateProjectFile(projectName), projectBinPath, projectCapabilities)
         End Function
 
         Public Function GetUpdatedCompilationOptionOfSingleProject() As CompilationOptions

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/VisualBasicHelpers/VisualBasicHelpers.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/VisualBasicHelpers/VisualBasicHelpers.vb
@@ -18,6 +18,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Vi
                                                           New VisualBasicCommandLineParserService())
         End Function
 
+        Public Function CreateVisualBasicProjectWithNullBinPath(environment As TestEnvironment, projectName As String) As VisualBasicProjectShimWithServices
+            Return New VisualBasicProjectShimWithServices(environment.ProjectTracker,
+                                                          MockCompilerHost.FullFrameworkCompilerHost,
+                                                          projectName,
+                                                          environment.CreateHierarchy(projectName, projectBinPath:=Nothing, projectCapabilities:="VB"),
+                                                          environment.ServiceProvider,
+                                                          New VisualBasicCommandLineParserService())
+        End Function
+
         Public Function CreateMinimalCompilerOptions(project As VisualBasicProjectShimWithServices) As VBCompilerOptions
             Dim options As VBCompilerOptions = Nothing
             options.wszExeName = project.ProjectSystemName + ".exe"


### PR DESCRIPTION
**Customer scenario**

Opening a project where the `OutputPath` property (or one of the things it can be calculated from), isn't set causes VS to crash.

**Bugs this fixes:**

Fixes #18098 and internal bug 294569.

**Workarounds, if any**

Modify project file to have output path set.

**Risk**

Low - we already have other codepaths that handle output path being `null`.

**Performance impact**

Low - just a null check.

**Is this a regression from a previous update?**

Unclear if it's a regression between VS 2015 and VS 2017.  Watson only shows hits in VS 2017, and this code did change to support DPL and CPS. 

**Root cause analysis:**

It's not expected that a project wouldn't have an output path set.  A unit test was added to cover this case going forward.

**How was the bug found?**

Watson and customer report.
