### PR TITLE
Compiler should not remove MyClass identifier

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/SimplifyTypeNames/SimplifyTypeNamesTests.vb
@@ -2421,6 +2421,39 @@ End Class",
 End Class")
         End Function
 
+        <WorkItem(19498, "https://github.com/dotnet/roslyn/issues/19498")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        Public Async Function TestMyClassShouldNotBeRemoved() As Task
+            Await TestMissingInRegularAndScriptAsync(
+"Class SomeType
+    Overridable Sub Test()
+    End Sub
+    Overridable Sub Test2()
+        [|MyClass|].Test()
+    End Sub
+End Class")
+        End Function
+
+        <WorkItem(19498, "https://github.com/dotnet/roslyn/issues/19498")>
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
+        Public Async Function TestMyClassShouldBeRemoved() As Task
+            Await TestInRegularAndScriptAsync(
+"Class SomeType
+    Sub Test()
+    End Sub
+    Sub Test2()
+        [|MyClass|].Test()
+    End Sub
+End Class",
+"Class SomeType
+    Sub Test()
+    End Sub
+    Sub Test2()
+        Test()
+    End Sub
+End Class")
+        End Function
+
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSimplifyTypeNames)>
         Public Async Function TestAppropriateDiagnosticOnMissingQualifier() As Task
             Await TestDiagnosticSeverityAndCountAsync(

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicSimplifyTypeNamesDiagnosticAnalyzer.vb
@@ -82,6 +82,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
                 diagnosticId = IDEDiagnosticIds.PreferIntrinsicPredefinedTypeInMemberAccessDiagnosticId
             ElseIf expression.Kind = SyntaxKind.SimpleMemberAccessExpression Then
                 Dim memberAccess = DirectCast(expression, MemberAccessExpressionSyntax)
+                Dim method = model.GetMemberGroup(expression)
+                If method.Length = 1 Then
+                    Dim symbol = method.First()
+                    If (symbol.IsOverrides Or symbol.IsOverridable) And memberAccess.Expression.Kind = SyntaxKind.MyClassExpression Then
+                        Return False
+                    End If
+                End If
                 diagnosticId = If(memberAccess.Expression.Kind = SyntaxKind.MeExpression,
                     IDEDiagnosticIds.RemoveQualificationDiagnosticId,
                     IDEDiagnosticIds.SimplifyMemberAccessDiagnosticId)


### PR DESCRIPTION
see issue https://github.com/dotnet/roslyn/issues/19498
Adds a test case for the lack of a suggested fix and also adds a
condition to the test suite to handle the lack of actions.

**Customer scenario**
In Visual Basic when using the MyClass identifier Roslyn suggests a code fix/action to remove the identifier. This changes the semantics of the code. Example and further explanation in the issue

**Bugs this fixes:**
#19498 

**Workarounds, if any**
Don't use the suggested action

**Risk**
By my estimate this is low risk.

**Performance impact**
Low. Adds a new branch / if statement.

**Is this a regression from a previous update?**
Not sure.

**Root cause analysis:**
There was no test case for this scenario. There's seems to be a lack of negative test cases by my cursory check to test scenarios where actions/fixes should not be suggested.

**How was the bug found?**
Don't know
