### PR TITLE
Revert "Remove DSRN VSIX prereq"

### DIFF
--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -48,5 +48,6 @@
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.DiaSymReader.Native" Version="[15.0,16.0)" DisplayName="Windows PDB reader/writer" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
**Customer scenario**

The prerequisite was previously removed to unblock dogfooding on pre-15.3 VS builds. Now that we require 15.3 for Roslyn dogfooding we can add the prerequisite back.

Reverts commit 821daaf669fd66830cecc3e0da653163da7029c7.

**Bugs this fixes:**

Fixes https://github.com/dotnet/roslyn/issues/19305.

**Workarounds, if any**

none.

**Risk**

Small.

**Performance impact**

None.

**Is this a regression from a previous update?**

**Root cause analysis:**

**How was the bug found?**

Dogfooding.