### PR TITLE
Check for bad dynamic arguments to local function

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -641,8 +641,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(queryClause == null);
 
             var validResult = resolution.OverloadResolutionResult.ValidResult;
+            var args = resolution.AnalyzedArguments.Arguments.ToImmutable();
 
-            var args = resolution.AnalyzedArguments.Arguments;
+            ReportBadDynamicArguments(syntax, args, diagnostics, queryClause);
+
             var localFunction = validResult.Member;
             var methodResult = validResult.Result;
 
@@ -659,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var lastParamIndex = parameters.Length - 1;
 
-                for (int i = 0; i < args.Count; ++i)
+                for (int i = 0; i < args.Length; ++i)
                 {
                     var arg = args[i];
                     if (arg.HasDynamicType() &&


### PR DESCRIPTION
**Customer scenario**

Call local function with lambda containing dynamic arguments.

**Bugs this fixes:**

#19778

**Workarounds, if any**

Cast lambda argument to specific delegate type.

**Risk**

Low

**Performance impact**

Low. The change only affects local functions with dynamic parameters.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Customer reported.