### PR TITLE
Fix EditAndContinueDiagnosticUpdateSource.ReportDiagnostics to return correct set of documents

### DIFF
--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
 
@@ -66,6 +67,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
                 documentId: documentIdOpt));
         }
 
+        /// <summary>
+        /// Reports diagnostics.
+        /// </summary>
+        /// <returns>Returns ids of documents that belong to <paramref name="projectId"/> and containing one or more diagnostics.</returns>
         public ImmutableArray<DocumentId> ReportDiagnostics(object errorId, Solution solution, ProjectId projectId, IEnumerable<Diagnostic> diagnostics)
         {
             Debug.Assert(errorId != null);
@@ -73,14 +78,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             Debug.Assert(projectId != null);
 
             var updateEvent = DiagnosticsUpdated;
-            var documentIds = ArrayBuilder<DocumentId>.GetInstance();
+            var documentIds = PooledHashSet<DocumentId>.GetInstance();
             var documentDiagnosticData = ArrayBuilder<DiagnosticData>.GetInstance();
             var projectDiagnosticData = ArrayBuilder<DiagnosticData>.GetInstance();
             var project = solution.GetProject(projectId);
 
             foreach (var diagnostic in diagnostics)
             {
-                var documentOpt = solution.GetDocument(diagnostic.Location.SourceTree, projectId);
+                var documentOpt = solution.GetDocument(diagnostic.Location.SourceTree);
 
                 if (documentOpt != null)
                 {
@@ -89,7 +94,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
                         documentDiagnosticData.Add(DiagnosticData.Create(documentOpt, diagnostic));
                     }
 
-                    documentIds.Add(documentOpt.Id);
+                    // only add documents from the current project:
+                    if (documentOpt.Project.Id == projectId)
+                    {
+                        documentIds.Add(documentOpt.Id);
+                    }
                 }
                 else if (updateEvent != null)
                 {
@@ -119,9 +128,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
                     diagnostics: projectDiagnosticData.ToImmutable()));
             }
 
+            var result = documentIds.AsImmutableOrEmpty();
             documentDiagnosticData.Free();
             projectDiagnosticData.Free();
-            return documentIds.ToImmutableAndFree();
+            documentIds.Free();
+            return result;
         }
 
         internal ImmutableArray<DocumentId> ReportDiagnostics(DebuggingSession session, object errorId, ProjectId projectId, Solution solution, IEnumerable<Diagnostic> diagnostics)

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueDiagnosticUpdateSourceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueDiagnosticUpdateSourceTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
+{
+    public class EditAndContinueDiagnosticUpdateSourceTests
+    {
+        [Fact]
+        public void ReportDiagnostics()
+        {
+            var service = new DiagnosticService(SpecializedCollections.EmptyEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>>());
+            var source = new EditAndContinueDiagnosticUpdateSource(service);
+
+            var updates = new List<string>();
+
+            source.DiagnosticsUpdated += (object sender, DiagnosticsUpdatedArgs e) =>
+            {
+                updates.Add($"{e.Kind} p={e.ProjectId} d={e.DocumentId}: {string.Join(",", e.Diagnostics.Select(d => d.Id.ToString()))}");
+            };
+
+            var id = new object();
+
+            var srcC1 = "class C1 {}";
+            var srcC2 = "class C2 {}";
+            var srcD1 = "class D1 {}";
+            var srcD2 = "class D2 {}";
+            var docC1 = new TestHostDocument(srcC1, displayName: "DocC1");
+            var docC2 = new TestHostDocument(srcC2, displayName: "DocC2");
+            var docD1 = new TestHostDocument(srcD1, displayName: "DocD1");
+            var docD2 = new TestHostDocument(srcD2, displayName: "DocD2");
+
+            var workspace = new TestWorkspace();
+            var projC = new TestHostProject(workspace, "ProjC");
+            projC.AddDocument(docC1);
+            projC.AddDocument(docC2);
+            var projD = new TestHostProject(workspace, "ProjD");
+            projD.AddDocument(docD1);
+            projD.AddDocument(docD2);
+
+            workspace.AddTestProject(projC);
+            workspace.AddTestProject(projD);
+
+            var treeC1 = workspace.CurrentSolution.GetDocument(docC1.Id).GetSyntaxTreeAsync().Result;
+            var treeC2 = workspace.CurrentSolution.GetDocument(docC2.Id).GetSyntaxTreeAsync().Result;
+            var treeD1 = workspace.CurrentSolution.GetDocument(docD1.Id).GetSyntaxTreeAsync().Result;
+            var treeD2 = workspace.CurrentSolution.GetDocument(docD2.Id).GetSyntaxTreeAsync().Result;
+
+            var diagnostics = new[]
+            {
+                Diagnostic.Create(new DiagnosticDescriptor("TST0001", "title1", "message1", "category", DiagnosticSeverity.Error, true), Location.Create(treeC1, new TextSpan(1, 1))),
+                Diagnostic.Create(new DiagnosticDescriptor("TST0002", "title2", "message2", "category", DiagnosticSeverity.Error, true), Location.Create(treeC1, new TextSpan(1, 2))),
+                Diagnostic.Create(new DiagnosticDescriptor("TST0003", "title3", "message3", "category", DiagnosticSeverity.Error, true), Location.Create(treeD1, new TextSpan(1, 2))),
+                Diagnostic.Create(new DiagnosticDescriptor("TST0004", "title4", "message4", "category", DiagnosticSeverity.Error, true), Location.Create(treeD2, new TextSpan(1, 2))),
+            };
+
+            updates.Clear();
+            var actual = source.ReportDiagnostics(id, workspace.CurrentSolution, projC.Id, diagnostics);
+            AssertEx.Equal(new[] { docC1.Id }, actual);
+            AssertEx.Equal(new[]
+            {
+                $"DiagnosticsCreated p={projC.Id} d={docC1.Id}: TST0001,TST0002",
+                $"DiagnosticsCreated p={projC.Id} d={docD1.Id}: TST0003",
+                $"DiagnosticsCreated p={projC.Id} d={docD2.Id}: TST0004"
+            }, updates);
+
+            updates.Clear();
+            actual = source.ReportDiagnostics(id, workspace.CurrentSolution, projD.Id, diagnostics);
+            AssertEx.SetEqual(new[] { docD1.Id, docD2.Id }, actual);
+            AssertEx.Equal(new[]
+             {
+                $"DiagnosticsCreated p={projD.Id} d={docC1.Id}: TST0001,TST0002",
+                $"DiagnosticsCreated p={projD.Id} d={docD1.Id}: TST0003",
+                $"DiagnosticsCreated p={projD.Id} d={docD2.Id}: TST0004"
+            }, updates);
+        }
+    }
+}

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Diagnostics\SuppressMessageAttributeTests.cs" />
     <Compile Include="CodeFixes\ExtensionOrderingTests.cs" />
     <Compile Include="EditAndContinue\TraceLogTests.cs" />
+    <Compile Include="EditAndContinue\EditAndContinueDiagnosticUpdateSourceTests.cs" />
     <Compile Include="Extensions\SourceTextContainerExtensionsTests.cs" />
     <Compile Include="Preview\TestOnly_CompilerDiagnosticAnalyzerProviderService.cs" />
     <Compile Include="Structure\BlockStructureServiceTests.cs" />


### PR DESCRIPTION
**Customer scenario**

Edit and Continue errors might not appear or appear duplicated in Error List. 
If an error is missing from Error List it's hard to diagnose why EnC failed.

**Bugs this fixes:**

**Workarounds, if any**

None.

**Risk**

Small.

**Performance impact**

None.

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

Dogfooding. Some customers report EnC issues where the error is not displayed in Error List.
