### PR TITLE
explicitly add current process's dump in the non-fatal watson

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/WatsonReporter.cs
@@ -28,7 +28,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             TelemetryService.DefaultSession.PostFault(
                 eventName: FunctionId.NonFatalWatson.GetEventName(),
                 description: description,
-                exceptionObject: exception);
+                exceptionObject: exception,
+                gatherEventDetails: arg =>
+                {
+                    arg.AddProcessDump(System.Diagnostics.Process.GetCurrentProcess().Id);
+
+                    // 0 means send watson, otherwise, cancel watson
+                    // we always send watson since dump itself can have valuable data
+                    return 0;
+                });
         }
 
         /// <summary>
@@ -43,7 +51,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 eventName: FunctionId.NonFatalWatson.GetEventName(),
                 description: description,
                 exceptionObject: exception,
-                gatherEventDetails: callback);
+                gatherEventDetails: arg =>
+                {
+                    // always add current processes dump
+                    arg.AddProcessDump(System.Diagnostics.Process.GetCurrentProcess().Id);
+                    return callback(arg);
+                });
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Telemetry/WatsonReporter.cs
@@ -43,7 +43,15 @@ namespace Microsoft.CodeAnalysis.Remote.Telemetry
             SessionOpt?.PostFault(
                 eventName: FunctionId.NonFatalWatson.GetEventName(),
                 description: description,
-                exceptionObject: exception);
+                exceptionObject: exception,
+                gatherEventDetails: arg =>
+                {
+                    arg.AddProcessDump(System.Diagnostics.Process.GetCurrentProcess().Id);
+
+                    // 0 means send watson, otherwise, cancel watson
+                    // we always send watson since dump itself can have valuable data
+                    return 0;
+                });
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

There will be no user experience affected by this change. 

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/19785

**Workarounds, if any**

There is no workaround, unless telemetry team who owns the NFW API change this behavior.

**Risk**

Low. I dont expect this change to break product.

**Performance impact**

NFW might take longer time than before if it is taking a dump

**Is this a regression from a previous update?**

No

**Root cause analysis:**

official NFW API we use don't include current process's dump in NFW by default.

**How was the bug found?**

dogfooding.
