### PR TITLE
Enable NuGet debugging

### DIFF
--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -265,7 +265,7 @@ function Restore-Project([string]$fileName, [string]$nuget, [string]$msbuildDir)
         $filePath = Join-Path $repoDir $fileName
     }
 
-    Exec-Block { & $nuget restore -verbosity quiet -configfile $nugetConfig -MSBuildPath $msbuildDir -Project2ProjectTimeOut 1200 $filePath }
+    Exec-Block { & $nuget restore -verbosity quiet -configfile $nugetConfig -MSBuildPath $msbuildDir -Project2ProjectTimeOut 1200 $filePath } | Write-Host
 }
 
 # Restore all of the projects that the repo consumes

--- a/build/scripts/cibuild.ps1
+++ b/build/scripts/cibuild.ps1
@@ -110,7 +110,11 @@ try {
 
     if (-not $skipRestore) { 
         Write-Host "Running restore"
+
+        # Temporary work around to help NuGet team debug a restore issue
+        ${env:NUGET_SHOW_STACK}="true"
         Restore-All -msbuildDir $msbuildDir 
+        Remove-Item env:\NUGET_SHOW_STACK
     }
 
     # Ensure the binaries directory exists because msbuild can fail when part of the path to LogFile isn't present.


### PR DESCRIPTION
Temporarily enable NuGet debugging to help NuGet team track down a debugging issue.

