### PR TITLE
added booster to make OOP normal priority if fix all is invoked.

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticArguments.cs
@@ -7,6 +7,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// </summary>
     internal class DiagnosticArguments
     {
+        public bool ForcedAnalysis;
         public bool ReportSuppressedDiagnostics;
         public bool LogAnalyzerExecutionTime;
         public ProjectId ProjectId;
@@ -18,12 +19,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public DiagnosticArguments(
+            bool forcedAnalysis,
             bool reportSuppressedDiagnostics,
             bool logAnalyzerExecutionTime,
             ProjectId projectId,
             Checksum optionSetChecksum,
             string[] analyzerIds)
         {
+            ForcedAnalysis = forcedAnalysis;
             ReportSuppressedDiagnostics = reportSuppressedDiagnostics;
             LogAnalyzerExecutionTime = logAnalyzerExecutionTime;
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                             return new ProjectAnalysisData(project.Id, VersionStamp.Default, existingData.Result, ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty);
                         }
 
-                        var result = await ComputeDiagnosticsAsync(analyzerDriverOpt, project, stateSets, existingData.Result, cancellationToken).ConfigureAwait(false);
+                        var result = await ComputeDiagnosticsAsync(analyzerDriverOpt, project, stateSets, forceAnalyzerRun, existingData.Result, cancellationToken).ConfigureAwait(false);
 
                         // if project is not loaded successfully, get rid of any semantic errors from compiler analyzer
                         // * NOTE * previously when project is not loaded successfully, we actually dropped doing anything on the project, but now
@@ -190,8 +190,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             /// <summary>
             /// Return all diagnostics that belong to given project for the given StateSets (analyzers) by calculating them
             /// </summary>
-            public async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> ComputeDiagnosticsAsync(
-                CompilationWithAnalyzers analyzerDriverOpt, Project project, IEnumerable<StateSet> stateSets, CancellationToken cancellationToken)
+            private async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> ComputeDiagnosticsAsync(
+                CompilationWithAnalyzers analyzerDriverOpt, Project project, IEnumerable<StateSet> stateSets, bool forcedAnalysis, CancellationToken cancellationToken)
             {
                 try
                 {
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     if (analyzerDriverOpt != null)
                     {
                         // calculate regular diagnostic analyzers diagnostics
-                        var compilerResult = await AnalyzeAsync(analyzerDriverOpt, project, cancellationToken).ConfigureAwait(false);
+                        var compilerResult = await AnalyzeAsync(analyzerDriverOpt, project, forcedAnalysis, cancellationToken).ConfigureAwait(false);
                         result = compilerResult.AnalysisResult;
 
                         // record telemetry data
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private async Task<ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>> ComputeDiagnosticsAsync(
-                CompilationWithAnalyzers analyzerDriverOpt, Project project, IEnumerable<StateSet> stateSets,
+                CompilationWithAnalyzers analyzerDriverOpt, Project project, IEnumerable<StateSet> stateSets, bool forcedAnalysis,
                 ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult> existing, CancellationToken cancellationToken)
             {
                 try
@@ -238,12 +238,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                                 null : await _owner._compilationManager.CreateAnalyzerDriverAsync(
                                         project, analyzersToRun, analyzerDriverOpt.AnalysisOptions.ReportSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
-                        var result = await ComputeDiagnosticsAsync(analyzerDriverWithReducedSet, project, stateSets, cancellationToken).ConfigureAwait(false);
+                        var result = await ComputeDiagnosticsAsync(analyzerDriverWithReducedSet, project, stateSets, forcedAnalysis, cancellationToken).ConfigureAwait(false);
                         return MergeExistingDiagnostics(version, existing, result);
                     }
 
                     // we couldn't reduce the set.
-                    return await ComputeDiagnosticsAsync(analyzerDriverOpt, project, stateSets, cancellationToken).ConfigureAwait(false);
+                    return await ComputeDiagnosticsAsync(analyzerDriverOpt, project, stateSets, forcedAnalysis, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
                 {
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private async Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeAsync(
-                CompilationWithAnalyzers analyzerDriver, Project project, CancellationToken cancellationToken)
+                CompilationWithAnalyzers analyzerDriver, Project project, bool forcedAnalysis, CancellationToken cancellationToken)
             {
                 // quick bail out
                 if (analyzerDriver.Analyzers.Length == 0)
@@ -559,7 +559,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 var executor = project.Solution.Workspace.Services.GetService<ICodeAnalysisDiagnosticAnalyzerExecutor>();
-                return await executor.AnalyzeAsync(analyzerDriver, project, cancellationToken).ConfigureAwait(false);
+                return await executor.AnalyzeAsync(analyzerDriver, project, forcedAnalysis, cancellationToken).ConfigureAwait(false);
             }
 
             private IEnumerable<DiagnosticData> ConvertToLocalDiagnosticsWithCompilation(Document targetDocument, IEnumerable<Diagnostic> diagnostics, TextSpan? span = null)

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -201,7 +201,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 if (_projectResultCache == null)
                 {
                     // execute whole project as one shot and cache the result.
-                    _projectResultCache = await _owner._executor.ComputeDiagnosticsAsync(_analyzerDriverOpt, _project, _stateSets, cancellationToken).ConfigureAwait(false);
+                    var forceAnalyzerRun = true;
+                    var analysisResult = await _owner._executor.GetProjectAnalysisDataAsync(_analyzerDriverOpt, _project, _stateSets, forceAnalyzerRun, cancellationToken).ConfigureAwait(false);
+
+                    _projectResultCache = analysisResult.Result;
                 }
 
                 if (!_projectResultCache.TryGetValue(analyzer, out var result))

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/ICodeAnalysisDiagnosticAnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/ICodeAnalysisDiagnosticAnalyzerExecutor.cs
@@ -15,6 +15,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
     /// </summary>
     internal interface ICodeAnalysisDiagnosticAnalyzerExecutor : IWorkspaceService
     {
-        Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeAsync(CompilationWithAnalyzers analyzerDriver, Project project, CancellationToken cancellationToken);
+        Task<DiagnosticAnalysisResultMap<DiagnosticAnalyzer, DiagnosticAnalysisResult>> AnalyzeAsync(CompilationWithAnalyzers analyzerDriver, Project project, bool forcedAnalysis, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Test.Next/Remote/JsonConverterTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/JsonConverterTests.cs
@@ -59,6 +59,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         public void TestDiagnosticArguments()
         {
             var arguments = new DiagnosticArguments(
+                forcedAnalysis: false,
                 reportSuppressedDiagnostics: true,
                 logAnalyzerExecutionTime: false,
                 projectId: ProjectId.CreateNewId("project"),
@@ -67,7 +68,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             VerifyJsonSerialization(arguments, (x, y) =>
             {
-                if (x.ReportSuppressedDiagnostics == y.ReportSuppressedDiagnostics &&
+                if (x.ForcedAnalysis == y.ForcedAnalysis &&
+                    x.ReportSuppressedDiagnostics == y.ReportSuppressedDiagnostics &&
                     x.LogAnalyzerExecutionTime == y.LogAnalyzerExecutionTime &&
                     x.ProjectId == y.ProjectId &&
                     x.OptionSetChecksum == y.OptionSetChecksum &&

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -161,7 +161,7 @@ End Class";
                         analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray(),
                         new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Options, project.Solution));
 
-                var result = await executor.AnalyzeAsync(analyzerDriver, project, CancellationToken.None);
+                var result = await executor.AnalyzeAsync(analyzerDriver, project, forcedAnalysis: false, cancellationToken: CancellationToken.None);
 
                 var analyzerResult = result.AnalysisResult[analyzerDriver.Analyzers[0]];
 
@@ -182,7 +182,7 @@ End Class";
                     analyzerReference.GetAnalyzers(project.Language).Where(a => a.GetType() == analyzerType).ToImmutableArray(),
                     new WorkspaceAnalyzerOptions(project.AnalyzerOptions, project.Solution.Options, project.Solution));
 
-            var result = await executor.AnalyzeAsync(analyzerDriver, project, cancellationToken);
+            var result = await executor.AnalyzeAsync(analyzerDriver, project, forcedAnalysis: true, cancellationToken: cancellationToken);
 
             return result.AnalysisResult[analyzerDriver.Analyzers[0]];
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -25,8 +25,16 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_CalculateDiagnosticsAsync, arguments.ProjectId.DebugName, CancellationToken))
             {
+                IDisposable booster = null;
+
                 try
                 {
+                    if (arguments.ForcedAnalysis)
+                    {
+                        // if this analysis is explicitly asked by user, boost priority of this request
+                        booster = UserOperationBooster.Boost();
+                    }
+
                     // entry point for diagnostic service
                     var solution = await GetSolutionAsync().ConfigureAwait(false);
 
@@ -49,6 +57,11 @@ namespace Microsoft.CodeAnalysis.Remote
                     // rpc connection has closed.
                     // this can happen if client side cancelled the
                     // operation
+                }
+                finally
+                {
+                    // if this request has been boosted, let it go
+                    booster?.Dispose();
                 }
             }
         }


### PR DESCRIPTION
**Customer scenario**

User invoked a "fix all" and how long it takes are vary based on what else is going on the machine since OOP is run as low priority process.

this change boost priority of the process for "Fix All" request. this should make OOP to respond to requests faster.

**Bugs this fixes:**

No bug yet.

**Workarounds, if any**

no workaround.

**Risk**

All changes are plumbing except calling UserOperationBooster.Boost() so, risk should be quite low. and this only happens for user initiated "Fix All"

**Performance impact**

This should make "Fix All" to have reliable perf regardless how busy the machine is.

**Is this a regression from a previous update?**

No, 

**Root cause analysis:**

OOP runs as low priority process. and it has a way to boost its priority for user initialized request, but we didn't do that for "Fix all". this change should make it to boost for "Fix All"

How did we miss it?  What tests are we adding to guard against it in the future?

this is not a regression.

**How was the bug found?**

Dogfooding.
