### PR TITLE
Fix IDE0009 false positive on expressions qualified with 'base.'

### DIFF
--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1028,5 +1028,57 @@ class A
 }",
 CodeStyleOptions.QualifyMethodAccess);
         }
+
+        [WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfBaseQualificationOnProperty()
+        {
+            await TestMissingAsyncWithOption(
+@"class Base
+{
+    protected virtual int Property { get; }
+}
+class Derived : Base
+{
+    protected override int Property { get { return [|base.Property|]; } }
+}",
+CodeStyleOptions.QualifyPropertyAccess);
+        }
+
+        [WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfBaseQualificationOnMethod()
+        {
+            await TestMissingAsyncWithOption(
+@"class Base
+{
+    protected virtual void M() { }
+}
+class Derived : Base
+{
+    protected override void M() { [|base.M()|]; }
+}",
+CodeStyleOptions.QualifyMethodAccess);
+        }
+
+        [WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfBaseQualificationOnEvent()
+        {
+            await TestMissingAsyncWithOption(
+@"class Base
+{
+    protected virtual event EventHandler Event;
+}
+class Derived : Base
+{
+    protected override event EventHandler Event 
+    {
+        add { [|base.Event|] += value; }
+        remove { }
+    }
+}",
+CodeStyleOptions.QualifyEventAccess);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
+++ b/src/EditorFeatures/CSharpTest/QualifyMemberAccess/QualifyMemberAccessTests.cs
@@ -1031,6 +1031,22 @@ CodeStyleOptions.QualifyMethodAccess);
 
         [WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
+        public async Task DoNotReportToQualify_IfBaseQualificationOnField()
+        {
+            await TestMissingAsyncWithOption(
+@"class Base
+{
+    protected int field;
+}
+class Derived : Base
+{
+    void M() { [|base.field|] = 0; }
+}",
+CodeStyleOptions.QualifyFieldAccess);
+        }
+
+        [WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)]
         public async Task DoNotReportToQualify_IfBaseQualificationOnProperty()
         {
             await TestMissingAsyncWithOption(

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -466,6 +466,37 @@ CodeStyleOptions.QualifyPropertyAccess, NotificationOption.Error)
 
         <WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_IfMyBaseQualificationOnField() As Task
+            Await TestMissingAsyncWithOption("
+Class Base
+    Protected Field As Integer
+End Class
+Class Derived
+    Inherits Base
+    Sub M()
+        [|MyBase.Field|] = 0
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
+
+        <WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_IfMyClassQualificationOnField() As Task
+            Await TestMissingAsyncWithOption("
+Class C
+    Private ReadOnly Field As Integer
+    Sub M()
+        [|MyClass.Field|] = 0
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyFieldAccess)
+        End Function
+
+        <WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
         Public Async Function DoNotReportToQualify_IfMyBaseQualificationOnProperty() As Task
             Await TestMissingAsyncWithOption("
 Class Base

--- a/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/QualifyMemberAccess/QualifyMemberAccessTests.vb
@@ -464,5 +464,71 @@ CodeStyleOptions.QualifyPropertyAccess, NotificationOption.Warning)
 CodeStyleOptions.QualifyPropertyAccess, NotificationOption.Error)
         End Function
 
+        <WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_IfMyBaseQualificationOnProperty() As Task
+            Await TestMissingAsyncWithOption("
+Class Base
+    Protected Overridable ReadOnly Property P As Integer
+End Class
+Class Derived
+    Inherits Base
+    Protected Overrides ReadOnly Property P As Integer
+        Get
+            Return [|MyBase.P|]
+        End Get
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_IfMyClassQualificationOnProperty() As Task
+            Await TestMissingAsyncWithOption("
+Class C
+    Dim i As Integer
+    Protected Overridable ReadOnly Property P As Integer
+    Sub M()
+        Me.i = [|MyClass.P|]
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyPropertyAccess)
+        End Function
+
+        <WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_IfMyBaseQualificationOnMethod() As Task
+            Await TestMissingAsyncWithOption("
+Class Base
+    Protected Overridable Sub M
+    End Sub
+End Class
+Class Derived
+    Inherits Base
+    Protected Overrides Sub M()
+        Get
+            Return [|MyBase.M|]()
+        End Get
+End Class
+",
+CodeStyleOptions.QualifyMethodAccess)
+        End Function
+
+        <WorkItem(17711, "https://github.com/dotnet/roslyn/issues/17711")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsQualifyMemberAccess)>
+        Public Async Function DoNotReportToQualify_IfMyClassQualificationOnMethod() As Task
+            Await TestMissingAsyncWithOption("
+Class C
+    Protected Overridable Sub M()
+    End Sub
+    Sub M2()
+        [|MyClass.M|]()
+    End Sub
+End Class
+",
+CodeStyleOptions.QualifyMethodAccess)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/QualifyMemberAccess/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -13,5 +13,9 @@ namespace Microsoft.CodeAnalysis.CSharp.QualifyMemberAccess
 
         protected override bool IsAlreadyQualifiedMemberAccess(SyntaxNode node)
             => node.IsKind(SyntaxKind.ThisExpression);
+
+        // If the member is already qualified with `base.`, it cannot be further qualified.
+        protected override bool CanMemberAccessBeQualified(SyntaxNode node)
+            => !node.IsKind(SyntaxKind.BaseExpression);
     }
 }

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -38,10 +38,10 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
         protected abstract string GetLanguageName();
 
         /// <summary>
-        /// Reports on whether the specified member is suitable for qualification. Some member access expressions cannot be qualififed;
+        /// Reports on whether the specified member is suitable for qualification. Some member access expressions cannot be qualified;
         /// for instance if they begin with <c>base.</c>, <c>MyBase.</c>, or <c>MyClass.</c>.
         /// </summary>
-        /// <returns>True if the member access can be qualfied; otherwise, False.</returns>
+        /// <returns>True if the member access can be qualified; otherwise, False.</returns>
         protected abstract bool CanMemberAccessBeQualified(SyntaxNode node);
 
         protected abstract bool IsAlreadyQualifiedMemberAccess(SyntaxNode node);

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -37,6 +37,13 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
 
         protected abstract string GetLanguageName();
 
+        /// <summary>
+        /// Reports on whether the specified member is suitable for qualification. Some member access expressions cannot be qualififed;
+        /// for instance if they begin with <c>base.</c>, <c>MyBase.</c>, or <c>MyClass.</c>.
+        /// </summary>
+        /// <returns>True if the member access can be qualfied; otherwise, False.</returns>
+        protected abstract bool CanMemberAccessBeQualified(SyntaxNode node);
+
         protected abstract bool IsAlreadyQualifiedMemberAccess(SyntaxNode node);
 
         private static MethodInfo s_registerMethod = typeof(AnalysisContext).GetTypeInfo().GetDeclaredMethod("RegisterOperationActionImmutableArrayInternal");
@@ -62,6 +69,12 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
 
             // if we're not referencing `this.` or `Me.` (e.g., a parameter, local, etc.)
             if (memberReference.Instance.Kind != OperationKind.InstanceReferenceExpression)
+            {
+                return;
+            }
+
+            // If we can't be qualified (e.g., because we're already qualified with `base.`), we're done.
+            if (CanMemberAccessBeQualified(memberReference.Instance.Syntax) == false)
             {
                 return;
             }

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -38,8 +38,9 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
         protected abstract string GetLanguageName();
 
         /// <summary>
-        /// Reports on whether the specified member is suitable for qualification. Some member access expressions cannot be qualified;
-        /// for instance if they begin with <c>base.</c>, <c>MyBase.</c>, or <c>MyClass.</c>.
+        /// Reports on whether the specified member is suitable for qualification. Some member
+        /// access expressions cannot be qualified; for instance if they begin with <c>base.</c>,
+        /// <c>MyBase.</c>, or <c>MyClass.</c>.
         /// </summary>
         /// <returns>True if the member access can be qualified; otherwise, False.</returns>
         protected abstract bool CanMemberAccessBeQualified(SyntaxNode node);
@@ -74,7 +75,7 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
             }
 
             // If we can't be qualified (e.g., because we're already qualified with `base.`), we're done.
-            if (CanMemberAccessBeQualified(memberReference.Instance.Syntax) == false)
+            if (!CanMemberAccessBeQualified(memberReference.Instance.Syntax))
             {
                 return;
             }

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
@@ -15,5 +15,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.QualifyMemberAccess
         Protected Overrides Function IsAlreadyQualifiedMemberAccess(node As SyntaxNode) As Boolean
             Return node.IsKind(SyntaxKind.MeExpression)
         End Function
+
+        Protected Overrides Function CanMemberAccessBeQualified(node As SyntaxNode) As Boolean
+            ' If the member is already qualified with `MyBase.`, or `MyClass.`, it cannot be further qualified.
+            Return Not (node.IsKind(SyntaxKind.MyBaseExpression) OrElse node.IsKind(SyntaxKind.MyClassExpression))
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
**Customer scenario**
See #17711 for details

**Bugs this fixes:**
Fixes #17711

**Workarounds, if any**
None

**Risk**
Low

**Performance impact**
Low perf impact because only a couple extra checks are done, with no loops.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Tests added. Missed because there were no tests initially for this.

**How was the bug found?**
Customer reported.