### PR TITLE
Add extra logging to BuildBoss

### DIFF
--- a/src/Tools/BuildBoss/Program.cs
+++ b/src/Tools/BuildBoss/Program.cs
@@ -13,6 +13,20 @@ namespace BuildBoss
     {
         internal static int Main(string[] args)
         {
+            try
+            {
+                return MainCore(args);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Unhandled exception: {ex.Message}");
+                Console.WriteLine(ex.StackTrace);
+                return 1;
+            }
+        }
+
+        private static int MainCore(string[] args)
+        { 
             if (args.Length == 0)
             { 
                 Usage();


### PR DESCRIPTION
See the following PR for motivation here

> https://github.com/dotnet/roslyn/pull/19787

Essentially the windows build correctness leg is failing due to an error
in BuildBoss.  There is no output associated with this error, just a
failing return code.

Looking at the BuildBoss code the only plausible explanation for this
behavior is an unhandled exception.  Added code to catch this case and
print out a reasonable error when it occurs.
