### PR TITLE
Skip hanging test TestTagsChangedForEntireFile

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticTaggerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
     public class SyntacticTaggerTests
     {
         [WorkItem(1032665, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1032665")]
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/19822"), Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task TestTagsChangedForEntireFile()
         {
             var code =


### PR DESCRIPTION
This is being tracked by https://github.com/dotnet/roslyn/issues/19822.

FYI to @dotnet/roslyn-ide, @jaredpar.