### PR TITLE
Infer Exception type when typing throw expression

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -537,6 +537,44 @@ class Variable
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(17256, "https://github.com/dotnet/roslyn/issues/17256")>
+        Public Async Function TestThrowExpression() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+class C
+{
+    public object Foo()
+    {
+        return null ?? throw new$$
+    }
+}]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertSelectedCompletionItem(displayText:="Exception", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(17256, "https://github.com/dotnet/roslyn/issues/17256")>
+        Public Async Function TestThrowStatement() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+using System;
+class C
+{
+    public object Foo()
+    {
+        throw new$$
+    }
+}]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertSelectedCompletionItem(displayText:="Exception", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -163,6 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case SimpleLambdaExpressionSyntax simpleLambdaExpression: return InferTypeInSimpleLambdaExpression(simpleLambdaExpression);
                     case SwitchLabelSyntax switchLabel: return InferTypeInSwitchLabel(switchLabel);
                     case SwitchStatementSyntax switchStatement: return InferTypeInSwitchStatement(switchStatement);
+                    case ThrowExpressionSyntax throwExpression: return InferTypeInThrowExpression(throwExpression);
                     case ThrowStatementSyntax throwStatement: return InferTypeInThrowStatement(throwStatement);
                     case UsingStatementSyntax usingStatement: return InferTypeInUsingStatement(usingStatement);
                     case WhileStatementSyntax whileStatement: return InferTypeInWhileStatement(whileStatement);
@@ -1969,6 +1970,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 return SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(this.Compilation.GetSpecialType(SpecialType.System_Int32)));
+            }
+
+            private IEnumerable<TypeInferenceInfo> InferTypeInThrowExpression(ThrowExpressionSyntax throwExpression, SyntaxToken? previousToken = null)
+            {
+                // If we have a position, it has to be after the 'throw' keyword.
+                if (previousToken.HasValue && previousToken.Value != throwExpression.ThrowKeyword)
+                {
+                    return SpecializedCollections.EmptyEnumerable<TypeInferenceInfo>();
+                }
+
+                return SpecializedCollections.SingletonEnumerable(new TypeInferenceInfo(this.Compilation.ExceptionType()));
             }
 
             private IEnumerable<TypeInferenceInfo> InferTypeInThrowStatement(ThrowStatementSyntax throwStatement, SyntaxToken? previousToken = null)


### PR DESCRIPTION
**Customer scenario**
When typing a throw expression, IntelliSense should offer to complete with exception types after "throw new ". Currently, the completion doesn't appear.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/17256

**Workarounds, if any**
Type, rather than expect assistance from completion.

**Risk**
**Performance impact**
Low. This adds inference of the type to be Exception in a throw expression, mirroring the logic for throw statements.

**Is this a regression from a previous update?**
No.

**Root cause analysis:**
Probably didn't do sufficient IDE validation for new language feature (throw expression).

**How was the bug found?**
Reported by customer.

@CyrusNajmabadi @roslyn-ide @gafter for review.