### PR TITLE
Updating the VisualStudioIntegrationTestUtilities to support builds where the installation version and DTE version don't match.

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/Settings.Designer.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -32,6 +32,18 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities {
             }
             set {
                 this["VsProductVersion"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("VisualStudio.DTE.15.0")]
+        public string VsProgId {
+            get {
+                return ((string)(this["VsProgId"]));
+            }
+            set {
+                this["VsProgId"] = value;
             }
         }
         

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Settings.settings
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Settings.settings
@@ -5,6 +5,9 @@
     <Setting Name="VsProductVersion" Type="System.String" Scope="User">
       <Value Profile="(Default)">15.0</Value>
     </Setting>
+    <Setting Name="VsProgId" Type="System.String" Scope="User">
+      <Value Profile="(Default)">VisualStudio.DTE.15.0</Value>
+    </Setting>
     <Setting Name="VsRootSuffix" Type="System.String" Scope="User">
       <Value Profile="(Default)">RoslynDev</Value>
     </Setting>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
     {
         public static readonly string VsProductVersion = Settings.Default.VsProductVersion;
 
-        public static readonly string VsProgId = $"VisualStudio.DTE.{VsProductVersion}";
+        public static readonly string VsProgId = Settings.Default.VsProgId;
 
         public static readonly string VsLaunchArgs = $"{(string.IsNullOrWhiteSpace(Settings.Default.VsRootSuffix) ? "/log" : $"/rootsuffix {Settings.Default.VsRootSuffix}")} /log";
 
@@ -253,7 +253,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
             throw new Exception(instanceFoundWithInvalidState ?
                                 "An instance matching the specified requirements was found but it was in an invalid state." :
-                                "There were no instances of Visual Studio 15.0 or later found that match the specified requirements.");
+                                $"There were no instances of Visual Studio {VsProductVersion} found that match the specified requirements.");
         }
 
         private static Process StartNewVisualStudioProcess(string installationPath)


### PR DESCRIPTION
This is a test only change. It is required to support running our integration tests against builds of VS where the Installation Version does not match the DTE Version used in the ProgId.