### PR TITLE
[Perf] Optimize IsOrContainsAccessibleAttribute

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -565,7 +565,16 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return true;
             }
 
-            return namespaceOrType.GetMembers().Any(nt => nt.IsOrContainsAccessibleAttribute(withinType, withinAssembly));
+            // PERF: Avoid allocating a lambda capture as this method is recursive
+            foreach (var namedType in namespaceOrType.GetTypeMembers())
+            {
+                if (namedType.IsOrContainsAccessibleAttribute(withinType, withinAssembly))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public static IEnumerable<IPropertySymbol> GetValidAnonymousTypeProperties(this ISymbol symbol)


### PR DESCRIPTION
the AbstractRecommendationService does a filter for which symbols should be included. Given this is called from ShouldIncludeSymbol, with this change we gain:
1. Fewer iterations, as an Attribute is a type declaration, so GetMembers -> GetTypeMembers should give us fewer items to work with
2. One less lambda capture by unrolling the foreach loop.

**Customer scenario**

https://gist.github.com/Therzok/4a168d452c6dcd5cd9ac0ee9cf25ae0e

The stacktrace above details how these issues were found.

**Risk**

Risk is low. IsAttribute() can only be true on type members.

**Performance impact**

Improves performance

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

¯\_(ツ)_/¯, not a functionality change, but an optimization.

**How was the bug found?**

Profiling VSfM.
