### PR TITLE
Update System.Compression.Zip version to prevent downgrade warnings

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -162,7 +162,7 @@
     <SystemIdentityModelTokensJwtVersion>5.0.0</SystemIdentityModelTokensJwtVersion>
     <SystemIOVersion>4.3.0</SystemIOVersion>
     <SystemIOCompressionVersion>4.3.0</SystemIOCompressionVersion>
-    <SystemIOCompressionZipFileVersion>4.0.1</SystemIOCompressionZipFileVersion>
+    <SystemIOCompressionZipFileVersion>4.3.0</SystemIOCompressionZipFileVersion>
     <SystemIOFileSystemVersion>4.3.0</SystemIOFileSystemVersion>
     <SystemIOFileSystemDriveInfoVersion>4.3.0</SystemIOFileSystemDriveInfoVersion>
     <SystemIOFileSystemPrimitivesVersion>4.3.0</SystemIOFileSystemPrimitivesVersion>


### PR DESCRIPTION
Fixes package downgrade warnings in roslyn-internal

Tag @dotnet/roslyn-ide @jaredpar 
Not sure if this needs to go through ask mode, but doubt it as this package is not consumed by any shipping projects.
See https://ci.dot.net/job/Private/job/dotnet_roslyn-internal/job/master/job/windows_debug_eta_prtest/583/ for an example of package downgrade warnings.