### PR TITLE
Disallow unary operators on default literal

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -485,6 +485,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundLiteral(node, ConstantValue.Create(kind == BinaryOperatorKind.Equal), GetSpecialType(SpecialType.System_Boolean, diagnostics, node));
             }
 
+            if ((left.IsLiteralDefault() || right.IsLiteralDefault()) && !isEquality)
+            {
+                Error(diagnostics, ErrorCode.ERR_BadOpOnNullOrDefault, node, node.OperatorToken.Text, "default");
+                return new BoundBinaryOperator(node, kind, left, right, ConstantValue.NotAvailable, null, LookupResultKind.Empty, GetBinaryOperatorErrorType(kind, diagnostics, node), true);
+            }
+
             // SPEC: For an operation of one of the forms x == null, null == x, x != null, null != x,
             // SPEC: where x is an expression of nullable type, if operator overload resolution
             // SPEC: fails to find an applicable operator, the result is instead computed from
@@ -2185,7 +2191,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Dev10 does not allow unary prefix operators to be applied to the null literal
                 // (or other typeless expressions).
-                Error(diagnostics, ErrorCode.ERR_BadUnaryOpOnNullOrDefault, node, operatorText, operand.Display);
+                Error(diagnostics, ErrorCode.ERR_BadOpOnNullOrDefault, node, operatorText, operand.Display);
             }
 
             // If the operand is bad, avoid generating cascading errors.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2180,7 +2180,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             UnaryOperatorKind kind = SyntaxKindToUnaryOperatorKind(node.Kind());
 
-            bool isOperandTypeNull = operand.IsLiteralNull();
+            bool isOperandTypeNull = operand.IsLiteralNull() || operand.IsLiteralDefault();
             if (isOperandTypeNull)
             {
                 // Dev10 does not allow unary prefix operators to be applied to the null literal

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2185,7 +2185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Dev10 does not allow unary prefix operators to be applied to the null literal
                 // (or other typeless expressions).
-                Error(diagnostics, ErrorCode.ERR_BadUnaryOp, node, operatorText, operand.Display);
+                Error(diagnostics, ErrorCode.ERR_BadUnaryOpOnNullOrDefault, node, operatorText, operand.Display);
             }
 
             // If the operand is bad, avoid generating cascading errors.

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1970,6 +1970,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Operator &apos;{0}&apos; cannot be applied to operand &apos;{1}&apos;.
+        /// </summary>
+        internal static string ERR_BadUnaryOpOnNullOrDefault {
+            get {
+                return ResourceManager.GetString("ERR_BadUnaryOpOnNullOrDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Overloaded unary operator &apos;{0}&apos; takes one parameter.
         /// </summary>
         internal static string ERR_BadUnOpArgs {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -305,6 +305,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Operator &apos;{0}&apos; is ambiguous on operands &apos;default&apos; and &apos;default&apos;.
+        /// </summary>
+        internal static string ERR_AmbigBinaryOpsOnDefault {
+            get {
+                return ResourceManager.GetString("ERR_AmbigBinaryOpsOnDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The call is ambiguous between the following methods or properties: &apos;{0}&apos; and &apos;{1}&apos;.
         /// </summary>
         internal static string ERR_AmbigCall {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1736,6 +1736,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Operator &apos;{0}&apos; cannot be applied to operand &apos;{1}&apos;.
+        /// </summary>
+        internal static string ERR_BadOpOnNullOrDefault {
+            get {
+                return ResourceManager.GetString("ERR_BadOpOnNullOrDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to  The parameter modifier &apos;out&apos; cannot be used with &apos;this&apos; .
         /// </summary>
         internal static string ERR_BadOutWithThis {
@@ -1966,15 +1975,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_BadUnaryOperatorSignature {
             get {
                 return ResourceManager.GetString("ERR_BadUnaryOperatorSignature", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Operator &apos;{0}&apos; cannot be applied to operand &apos;{1}&apos;.
-        /// </summary>
-        internal static string ERR_BadUnaryOpOnNullOrDefault {
-            get {
-                return ResourceManager.GetString("ERR_BadUnaryOpOnNullOrDefault", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -453,6 +453,9 @@
   <data name="ERR_AmbigBinaryOps" xml:space="preserve">
     <value>Operator '{0}' is ambiguous on operands of type '{1}' and '{2}'</value>
   </data>
+  <data name="ERR_AmbigBinaryOpsOnDefault" xml:space="preserve">
+    <value>Operator '{0}' is ambiguous on operands 'default' and 'default'</value>
+  </data>
   <data name="ERR_AmbigUnaryOp" xml:space="preserve">
     <value>Operator '{0}' is ambiguous on an operand of type '{1}'</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -426,6 +426,9 @@
   <data name="ERR_BadUnaryOp" xml:space="preserve">
     <value>Operator '{0}' cannot be applied to operand of type '{1}'</value>
   </data>
+  <data name="ERR_BadUnaryOpOnNullOrDefault" xml:space="preserve">
+    <value>Operator '{0}' cannot be applied to operand '{1}'</value>
+  </data>
   <data name="ERR_ThisInStaticMeth" xml:space="preserve">
     <value>Keyword 'this' is not valid in a static property, static method, or static field initializer</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -426,7 +426,7 @@
   <data name="ERR_BadUnaryOp" xml:space="preserve">
     <value>Operator '{0}' cannot be applied to operand of type '{1}'</value>
   </data>
-  <data name="ERR_BadUnaryOpOnNullOrDefault" xml:space="preserve">
+  <data name="ERR_BadOpOnNullOrDefault" xml:space="preserve">
     <value>Operator '{0}' cannot be applied to operand '{1}'</value>
   </data>
   <data name="ERR_ThisInStaticMeth" xml:space="preserve">

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1486,6 +1486,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_DefaultLiteralNotValid = 8312,
         WRN_DefaultInSwitch = 8313,
         ERR_PatternWrongGenericTypeInVersion = 8314,
+        ERR_AmbigBinaryOpsOnDefault = 8315,
 
         #endregion diagnostics introduced for C# 7.1
     }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1481,7 +1481,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_NoRefOutWhenRefOnly = 8308,
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 8309,
-        // Available = 8310,
+        ERR_BadUnaryOpOnNullOrDefault = 8310,
         ERR_BadDynamicMethodArgDefaultLiteral = 8311,
         ERR_DefaultLiteralNotValid = 8312,
         WRN_DefaultInSwitch = 8313,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1481,7 +1481,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_NoRefOutWhenRefOnly = 8308,
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 8309,
-        ERR_BadUnaryOpOnNullOrDefault = 8310,
+        ERR_BadOpOnNullOrDefault = 8310,
         ERR_BadDynamicMethodArgDefaultLiteral = 8311,
         ERR_DefaultLiteralNotValid = 8312,
         WRN_DefaultInSwitch = 8313,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -1059,13 +1059,13 @@ namespace X
                 Diagnostic(ErrorCode.ERR_BadUnaryOp, "!q").WithArguments("!", "object").WithLocation(9, 17),
                 // (12,26): error CS8310: Operator '-' cannot be applied to operand '<null>'
                 //             object obj = -null; // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "-null").WithArguments("-", "<null>").WithLocation(12, 26),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "-null").WithArguments("-", "<null>").WithLocation(12, 26),
                 // (13,19): error CS8310: Operator '!' cannot be applied to operand '<null>'
                 //             obj = !null; // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(13, 19),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(13, 19),
                 // (14,19): error CS8310: Operator '~' cannot be applied to operand '<null>'
                 //             obj = ~null; // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "~null").WithArguments("~", "<null>").WithLocation(14, 19),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "~null").WithArguments("~", "<null>").WithLocation(14, 19),
                 // (16,13): error CS0023: Operator '++' cannot be applied to operand of type 'object'
                 //             obj++; // CS0023
                 Diagnostic(ErrorCode.ERR_BadUnaryOp, "obj++").WithArguments("++", "object").WithLocation(16, 13),
@@ -1074,7 +1074,7 @@ namespace X
                 Diagnostic(ErrorCode.ERR_BadUnaryOp, "--obj").WithArguments("--", "object").WithLocation(17, 13),
                 // (18,20): error CS8310: Operator '+' cannot be applied to operand '<null>'
                 //             return +null; // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "+null").WithArguments("+", "<null>").WithLocation(18, 20)
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "+null").WithArguments("+", "<null>").WithLocation(18, 20)
                 );
         }
 
@@ -1102,16 +1102,16 @@ public class Test
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (6,19): error CS8310: Operator '!' cannot be applied to operand '<null>'
                 //         bool? b = !null;   // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(6, 19),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(6, 19),
                 // (7,18): error CS8310: Operator '~' cannot be applied to operand '<null>'
                 //         int? n = ~null;    // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "~null").WithArguments("~", "<null>").WithLocation(7, 18),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "~null").WithArguments("~", "<null>").WithLocation(7, 18),
                 // (8,20): error CS8310: Operator '+' cannot be applied to operand '<null>'
                 //         float? f = +null;  // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "+null").WithArguments("+", "<null>").WithLocation(8, 20),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "+null").WithArguments("+", "<null>").WithLocation(8, 20),
                 // (9,19): error CS8310: Operator '-' cannot be applied to operand '<null>'
                 //         long? u = -null;   // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "-null").WithArguments("-", "<null>").WithLocation(9, 19)
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "-null").WithArguments("-", "<null>").WithLocation(9, 19)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -1055,19 +1055,27 @@ namespace X
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (9,17): error CS0023: Operator '!' cannot be applied to operand of type 'object'
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!q").WithArguments("!", "object"),
-                // (12,26): error CS0023: Operator '-' cannot be applied to operand of type '<null>'
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "-null").WithArguments("-", "<null>"),
-                // (13,19): error CS0023: Operator '!' cannot be applied to operand of type '<null>'
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!null").WithArguments("!", "<null>"),
-                // (14,19): error CS0023: Operator '~' cannot be applied to operand of type '<null>'
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "~null").WithArguments("~", "<null>"),
+                //             if (!q) // CS0023
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!q").WithArguments("!", "object").WithLocation(9, 17),
+                // (12,26): error CS8310: Operator '-' cannot be applied to operand '<null>'
+                //             object obj = -null; // CS0023
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "-null").WithArguments("-", "<null>").WithLocation(12, 26),
+                // (13,19): error CS8310: Operator '!' cannot be applied to operand '<null>'
+                //             obj = !null; // CS0023
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(13, 19),
+                // (14,19): error CS8310: Operator '~' cannot be applied to operand '<null>'
+                //             obj = ~null; // CS0023
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "~null").WithArguments("~", "<null>").WithLocation(14, 19),
                 // (16,13): error CS0023: Operator '++' cannot be applied to operand of type 'object'
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "obj++").WithArguments("++", "object"),
+                //             obj++; // CS0023
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "obj++").WithArguments("++", "object").WithLocation(16, 13),
                 // (17,13): error CS0023: Operator '--' cannot be applied to operand of type 'object'
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "--obj").WithArguments("--", "object"),
-                // (18,20): error CS0023: Operator '+' cannot be applied to operand of type '<null>'
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "+null").WithArguments("+", "<null>"));
+                //             --obj; // CS0023
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "--obj").WithArguments("--", "object").WithLocation(17, 13),
+                // (18,20): error CS8310: Operator '+' cannot be applied to operand '<null>'
+                //             return +null; // CS0023
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "+null").WithArguments("+", "<null>").WithLocation(18, 20)
+                );
         }
 
         [WorkItem(539590, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539590")]
@@ -1092,18 +1100,19 @@ public class Test
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (6,19): error CS0023: Operator '!' cannot be applied to operand of type '<null>'
+                // (6,19): error CS8310: Operator '!' cannot be applied to operand '<null>'
                 //         bool? b = !null;   // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!null").WithArguments("!", "<null>"),
-                // (7,18): error CS0023: Operator '~' cannot be applied to operand of type '<null>'
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(6, 19),
+                // (7,18): error CS8310: Operator '~' cannot be applied to operand '<null>'
                 //         int? n = ~null;    // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "~null").WithArguments("~", "<null>"),
-                // (8,20): error CS0023: Operator '+' cannot be applied to operand of type '<null>'
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "~null").WithArguments("~", "<null>").WithLocation(7, 18),
+                // (8,20): error CS8310: Operator '+' cannot be applied to operand '<null>'
                 //         float? f = +null;  // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "+null").WithArguments("+", "<null>"),
-                // (9,19): error CS0023: Operator '-' cannot be applied to operand of type '<null>'
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "+null").WithArguments("+", "<null>").WithLocation(8, 20),
+                // (9,19): error CS8310: Operator '-' cannot be applied to operand '<null>'
                 //         long? u = -null;   // CS0023
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "-null").WithArguments("-", "<null>"));
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "-null").WithArguments("-", "<null>").WithLocation(9, 19)
+                );
         }
 
         [WorkItem(539590, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539590")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -338,18 +338,18 @@ class C<T>
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
-                // (6,17): error CS0023: Operator '+' cannot be applied to operand of type 'default'
+                // (6,17): error CS8310: Operator '+' cannot be applied to operand 'default'
                 //         var a = +default;
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "+default").WithArguments("+", "default").WithLocation(6, 17),
-                // (7,17): error CS0023: Operator '-' cannot be applied to operand of type 'default'
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "+default").WithArguments("+", "default").WithLocation(6, 17),
+                // (7,17): error CS8310: Operator '-' cannot be applied to operand 'default'
                 //         var b = -default;
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "-default").WithArguments("-", "default").WithLocation(7, 17),
-                // (8,17): error CS0023: Operator '~' cannot be applied to operand of type 'default'
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "-default").WithArguments("-", "default").WithLocation(7, 17),
+                // (8,17): error CS8310: Operator '~' cannot be applied to operand 'default'
                 //         var c = ~default;
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "~default").WithArguments("~", "default").WithLocation(8, 17),
-                // (9,17): error CS0023: Operator '!' cannot be applied to operand of type 'default'
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "~default").WithArguments("~", "default").WithLocation(8, 17),
+                // (9,17): error CS8310: Operator '!' cannot be applied to operand 'default'
                 //         var d = !default;
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!default").WithArguments("!", "default").WithLocation(9, 17)
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!default").WithArguments("!", "default").WithLocation(9, 17)
                 );
         }
 
@@ -971,15 +971,15 @@ class C
     {
         if (!default)
         {
-            System.Console.WriteLine(""reached"");
+            throw null;
         }
     }
 }";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (6,13): error CS0023: Operator '!' cannot be applied to operand of type 'default'
+                // (6,13): error CS8310: Operator '!' cannot be applied to operand 'default'
                 //         if (!default)
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!default").WithArguments("!", "default").WithLocation(6, 13)
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!default").WithArguments("!", "default").WithLocation(6, 13)
                 );
 
             var tree = comp.SyntaxTrees.First();
@@ -1008,10 +1008,10 @@ class C
             comp.VerifyDiagnostics(
                 // (6,13): error CS0023: Operator '!' cannot be applied to operand of type 'method group'
                 //         if (!Main || !null)
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!Main").WithArguments("!", "method group"),
-                // (6,22): error CS0023: Operator '!' cannot be applied to operand of type '<null>'
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!Main").WithArguments("!", "method group").WithLocation(6, 13),
+                // (6,22): error CS8310: Operator '!' cannot be applied to operand '<null>'
                 //         if (!Main || !null)
-                Diagnostic(ErrorCode.ERR_BadUnaryOp, "!null").WithArguments("!", "<null>").WithLocation(6, 22)
+                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(6, 22)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -340,16 +340,16 @@ class C<T>
             comp.VerifyDiagnostics(
                 // (6,17): error CS8310: Operator '+' cannot be applied to operand 'default'
                 //         var a = +default;
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "+default").WithArguments("+", "default").WithLocation(6, 17),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "+default").WithArguments("+", "default").WithLocation(6, 17),
                 // (7,17): error CS8310: Operator '-' cannot be applied to operand 'default'
                 //         var b = -default;
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "-default").WithArguments("-", "default").WithLocation(7, 17),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "-default").WithArguments("-", "default").WithLocation(7, 17),
                 // (8,17): error CS8310: Operator '~' cannot be applied to operand 'default'
                 //         var c = ~default;
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "~default").WithArguments("~", "default").WithLocation(8, 17),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "~default").WithArguments("~", "default").WithLocation(8, 17),
                 // (9,17): error CS8310: Operator '!' cannot be applied to operand 'default'
                 //         var d = !default;
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!default").WithArguments("!", "default").WithLocation(9, 17)
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "!default").WithArguments("!", "default").WithLocation(9, 17)
                 );
         }
 
@@ -743,14 +743,301 @@ class C
     static void Main()
     {
         int i = checked(default);
-        int j = checked(default + 4);
-        System.Console.Write($""{i} {j}"");
+        System.Console.Write($""{i}"");
     }
 }
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "0 4");
+            CompileAndVerify(comp, expectedOutput: "0");
+        }
+
+        [Fact]
+        public void InChecked2()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        int j = checked(default + 4);
+        System.Console.Write($""{j}"");
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (6,25): error CS8310: Operator '+' cannot be applied to operand 'default'
+                //         int j = checked(default + 4);
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default + 4").WithArguments("+", "default").WithLocation(6, 25)
+                );
+        }
+
+        [Fact]
+        public void TestBinaryOperators()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        var a = default + default;
+        var b = default - default;
+        var c = default & default;
+        var d = default | default;
+        var e = default ^ default;
+        var f = default * default;
+        var g = default / default;
+        var h = default % default;
+        var i = default >> default;
+        var j = default << default;
+        var k = default > default;
+        var l = default < default;
+        var m = default >= default;
+        var n = default <= default;
+        var o = default == default; // ambiguous
+        var p = default != default; // ambiguous
+        var q = default && default;
+        var r = default || default;
+        var s = default ?? default;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (6,17): error CS8310: Operator '+' cannot be applied to operand 'default'
+                //         var a = default + default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default + default").WithArguments("+", "default").WithLocation(6, 17),
+                // (7,17): error CS8310: Operator '-' cannot be applied to operand 'default'
+                //         var b = default - default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default - default").WithArguments("-", "default").WithLocation(7, 17),
+                // (8,17): error CS8310: Operator '&' cannot be applied to operand 'default'
+                //         var c = default & default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default & default").WithArguments("&", "default").WithLocation(8, 17),
+                // (9,17): error CS8310: Operator '|' cannot be applied to operand 'default'
+                //         var d = default | default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default | default").WithArguments("|", "default").WithLocation(9, 17),
+                // (10,17): error CS8310: Operator '^' cannot be applied to operand 'default'
+                //         var e = default ^ default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default ^ default").WithArguments("^", "default").WithLocation(10, 17),
+                // (11,17): error CS8310: Operator '*' cannot be applied to operand 'default'
+                //         var f = default * default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default * default").WithArguments("*", "default").WithLocation(11, 17),
+                // (12,17): error CS8310: Operator '/' cannot be applied to operand 'default'
+                //         var g = default / default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default / default").WithArguments("/", "default").WithLocation(12, 17),
+                // (13,17): error CS8310: Operator '%' cannot be applied to operand 'default'
+                //         var h = default % default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default % default").WithArguments("%", "default").WithLocation(13, 17),
+                // (14,17): error CS8310: Operator '>>' cannot be applied to operand 'default'
+                //         var i = default >> default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default >> default").WithArguments(">>", "default").WithLocation(14, 17),
+                // (15,17): error CS8310: Operator '<<' cannot be applied to operand 'default'
+                //         var j = default << default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default << default").WithArguments("<<", "default").WithLocation(15, 17),
+                // (16,17): error CS8310: Operator '>' cannot be applied to operand 'default'
+                //         var k = default > default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default > default").WithArguments(">", "default").WithLocation(16, 17),
+                // (17,17): error CS8310: Operator '<' cannot be applied to operand 'default'
+                //         var l = default < default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default < default").WithArguments("<", "default").WithLocation(17, 17),
+                // (18,17): error CS8310: Operator '>=' cannot be applied to operand 'default'
+                //         var m = default >= default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default >= default").WithArguments(">=", "default").WithLocation(18, 17),
+                // (19,17): error CS8310: Operator '<=' cannot be applied to operand 'default'
+                //         var n = default <= default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default <= default").WithArguments("<=", "default").WithLocation(19, 17),
+                // (20,17): error CS0034: Operator '==' is ambiguous on operands of type 'default' and 'default'
+                //         var o = default == default;
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default == default").WithArguments("==", "default", "default").WithLocation(20, 17),
+                // (21,17): error CS0034: Operator '!=' is ambiguous on operands of type 'default' and 'default'
+                //         var p = default != default;
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default != default").WithArguments("!=", "default", "default").WithLocation(21, 17),
+                // (24,17): error CS0019: Operator '??' cannot be applied to operands of type 'default' and 'default'
+                //         var s = default ?? default;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default ?? default").WithArguments("??", "default", "default").WithLocation(24, 17)
+                );
+        }
+
+        [Fact]
+        public void TestBinaryOperators2()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        var a = default + 1;
+        var b = default - 1;
+        var c = default & 1;
+        var d = default | 1;
+        var e = default ^ 1;
+        var f = default * 1;
+        var g = default / 1;
+        var h = default % 1;
+        var i = default >> 1;
+        var j = default << 1;
+        var k = default > 1;
+        var l = default < 1;
+        var m = default >= 1;
+        var n = default <= 1;
+        var o = default == 1; // ok
+        var p = default != 1; // ok
+        var q = default && 1;
+        var r = default || 1;
+        var s = default ?? 1;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (6,17): error CS8310: Operator '+' cannot be applied to operand 'default'
+                //         var a = default + 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default + 1").WithArguments("+", "default").WithLocation(6, 17),
+                // (7,17): error CS8310: Operator '-' cannot be applied to operand 'default'
+                //         var b = default - 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default - 1").WithArguments("-", "default").WithLocation(7, 17),
+                // (8,17): error CS8310: Operator '&' cannot be applied to operand 'default'
+                //         var c = default & 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default & 1").WithArguments("&", "default").WithLocation(8, 17),
+                // (9,17): error CS8310: Operator '|' cannot be applied to operand 'default'
+                //         var d = default | 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default | 1").WithArguments("|", "default").WithLocation(9, 17),
+                // (10,17): error CS8310: Operator '^' cannot be applied to operand 'default'
+                //         var e = default ^ 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default ^ 1").WithArguments("^", "default").WithLocation(10, 17),
+                // (11,17): error CS8310: Operator '*' cannot be applied to operand 'default'
+                //         var f = default * 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default * 1").WithArguments("*", "default").WithLocation(11, 17),
+                // (12,17): error CS8310: Operator '/' cannot be applied to operand 'default'
+                //         var g = default / 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default / 1").WithArguments("/", "default").WithLocation(12, 17),
+                // (13,17): error CS8310: Operator '%' cannot be applied to operand 'default'
+                //         var h = default % 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default % 1").WithArguments("%", "default").WithLocation(13, 17),
+                // (14,17): error CS8310: Operator '>>' cannot be applied to operand 'default'
+                //         var i = default >> 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default >> 1").WithArguments(">>", "default").WithLocation(14, 17),
+                // (15,17): error CS8310: Operator '<<' cannot be applied to operand 'default'
+                //         var j = default << 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default << 1").WithArguments("<<", "default").WithLocation(15, 17),
+                // (16,17): error CS8310: Operator '>' cannot be applied to operand 'default'
+                //         var k = default > 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default > 1").WithArguments(">", "default").WithLocation(16, 17),
+                // (17,17): error CS8310: Operator '<' cannot be applied to operand 'default'
+                //         var l = default < 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default < 1").WithArguments("<", "default").WithLocation(17, 17),
+                // (18,17): error CS8310: Operator '>=' cannot be applied to operand 'default'
+                //         var m = default >= 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default >= 1").WithArguments(">=", "default").WithLocation(18, 17),
+                // (19,17): error CS8310: Operator '<=' cannot be applied to operand 'default'
+                //         var n = default <= 1;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default <= 1").WithArguments("<=", "default").WithLocation(19, 17),
+                // (22,17): error CS0019: Operator '&&' cannot be applied to operands of type 'default' and 'int'
+                //         var q = default && 1;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default && 1").WithArguments("&&", "default", "int").WithLocation(22, 17),
+                // (23,17): error CS0019: Operator '||' cannot be applied to operands of type 'default' and 'int'
+                //         var r = default || 1;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default || 1").WithArguments("||", "default", "int").WithLocation(23, 17),
+                // (20,13): warning CS0219: The variable 'o' is assigned but its value is never used
+                //         var o = default == 1; // ok
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "o").WithArguments("o").WithLocation(20, 13),
+                // (21,13): warning CS0219: The variable 'p' is assigned but its value is never used
+                //         var p = default != 1; // ok
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "p").WithArguments("p").WithLocation(21, 13)
+                );
+        }
+
+        [Fact]
+        public void TestBinaryOperators3()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        var a = 1 + default;
+        var b = 1 - default;
+        var c = 1 & default;
+        var d = 1 | default;
+        var e = 1 ^ default;
+        var f = 1 * default;
+        var g = 1 / default;
+        var h = 1 % default;
+        var i = 1 >> default;
+        var j = 1 << default;
+        var k = 1 > default;
+        var l = 1 < default;
+        var m = 1 >= default;
+        var n = 1 <= default;
+        var o = 1 == default; // ok
+        var p = 1 != default; // ok
+        var q = 1 && default;
+        var r = 1 || default;
+        var s = 1 ?? default;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
+            comp.VerifyDiagnostics(
+                // (6,17): error CS8310: Operator '+' cannot be applied to operand 'default'
+                //         var a = 1 + default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 + default").WithArguments("+", "default").WithLocation(6, 17),
+                // (7,17): error CS8310: Operator '-' cannot be applied to operand 'default'
+                //         var b = 1 - default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 - default").WithArguments("-", "default").WithLocation(7, 17),
+                // (8,17): error CS8310: Operator '&' cannot be applied to operand 'default'
+                //         var c = 1 & default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 & default").WithArguments("&", "default").WithLocation(8, 17),
+                // (9,17): error CS8310: Operator '|' cannot be applied to operand 'default'
+                //         var d = 1 | default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 | default").WithArguments("|", "default").WithLocation(9, 17),
+                // (10,17): error CS8310: Operator '^' cannot be applied to operand 'default'
+                //         var e = 1 ^ default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 ^ default").WithArguments("^", "default").WithLocation(10, 17),
+                // (11,17): error CS8310: Operator '*' cannot be applied to operand 'default'
+                //         var f = 1 * default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 * default").WithArguments("*", "default").WithLocation(11, 17),
+                // (12,17): error CS8310: Operator '/' cannot be applied to operand 'default'
+                //         var g = 1 / default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 / default").WithArguments("/", "default").WithLocation(12, 17),
+                // (13,17): error CS8310: Operator '%' cannot be applied to operand 'default'
+                //         var h = 1 % default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 % default").WithArguments("%", "default").WithLocation(13, 17),
+                // (14,17): error CS8310: Operator '>>' cannot be applied to operand 'default'
+                //         var i = 1 >> default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 >> default").WithArguments(">>", "default").WithLocation(14, 17),
+                // (15,17): error CS8310: Operator '<<' cannot be applied to operand 'default'
+                //         var j = 1 << default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 << default").WithArguments("<<", "default").WithLocation(15, 17),
+                // (16,17): error CS8310: Operator '>' cannot be applied to operand 'default'
+                //         var k = 1 > default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 > default").WithArguments(">", "default").WithLocation(16, 17),
+                // (17,17): error CS8310: Operator '<' cannot be applied to operand 'default'
+                //         var l = 1 < default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 < default").WithArguments("<", "default").WithLocation(17, 17),
+                // (18,17): error CS8310: Operator '>=' cannot be applied to operand 'default'
+                //         var m = 1 >= default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 >= default").WithArguments(">=", "default").WithLocation(18, 17),
+                // (19,17): error CS8310: Operator '<=' cannot be applied to operand 'default'
+                //         var n = 1 <= default;
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 <= default").WithArguments("<=", "default").WithLocation(19, 17),
+                // (22,17): error CS0019: Operator '&&' cannot be applied to operands of type 'int' and 'default'
+                //         var q = 1 && default;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "1 && default").WithArguments("&&", "int", "default").WithLocation(22, 17),
+                // (23,17): error CS0019: Operator '||' cannot be applied to operands of type 'int' and 'default'
+                //         var r = 1 || default;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "1 || default").WithArguments("||", "int", "default").WithLocation(23, 17),
+                // (24,17): error CS0019: Operator '??' cannot be applied to operands of type 'int' and 'default'
+                //         var s = 1 ?? default;
+                Diagnostic(ErrorCode.ERR_BadBinaryOps, "1 ?? default").WithArguments("??", "int", "default").WithLocation(24, 17),
+                // (20,13): warning CS0219: The variable 'o' is assigned but its value is never used
+                //         var o = 1 == default; // ok
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "o").WithArguments("o").WithLocation(20, 13),
+                // (21,13): warning CS0219: The variable 'p' is assigned but its value is never used
+                //         var p = 1 != default; // ok
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "p").WithArguments("p").WithLocation(21, 13)
+                );
         }
 
         [Fact]
@@ -762,7 +1049,7 @@ struct S
     int field;
     static void Main()
     {
-        S s = new S(40) + default;
+        S s = new S(40);
         s += new S(2);
         s += default;
         System.Console.Write(s);
@@ -780,13 +1067,9 @@ struct S
             var model = comp.GetSemanticModel(tree);
             var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
 
-            var first = nodes.OfType<LiteralExpressionSyntax>().ElementAt(1);
-            Assert.Equal("new S(40) + default", first.Parent.ToString());
-            Assert.Equal("S", model.GetTypeInfo(first).Type.ToTestDisplayString());
-
-            var second = nodes.OfType<LiteralExpressionSyntax>().ElementAt(3);
-            Assert.Equal("s += default", second.Parent.ToString());
-            Assert.Equal("S", model.GetTypeInfo(second).Type.ToTestDisplayString());
+            var defaultLiteral = nodes.OfType<LiteralExpressionSyntax>().ElementAt(2);
+            Assert.Equal("s += default", defaultLiteral.Parent.ToString());
+            Assert.Equal("S", model.GetTypeInfo(defaultLiteral).Type.ToTestDisplayString());
         }
 
         [Fact]
@@ -874,6 +1157,9 @@ class C
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
+                // (12,37): error CS8310: Operator '|' cannot be applied to operand 'default'
+                //             System.Console.Write($"{true | default} {i} {b}");
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "true | default").WithArguments("|", "default").WithLocation(12, 37),
                 // (15,40): warning CS7095: Filter expression is a constant, consider removing the filter
                 //         catch (System.Exception) when (default)
                 Diagnostic(ErrorCode.WRN_FilterIsConstant, "default").WithLocation(15, 40),
@@ -881,7 +1167,6 @@ class C
                 //             System.Console.Write("catch");
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "System").WithLocation(17, 13)
                 );
-            //CompileAndVerify(comp, expectedOutput: "True 2 False"); // PEVerify failed with Branch out of the method. Follow-up issue: https://github.com/dotnet/roslyn/issues/18678
         }
 
         [Fact]
@@ -979,7 +1264,7 @@ class C
             comp.VerifyDiagnostics(
                 // (6,13): error CS8310: Operator '!' cannot be applied to operand 'default'
                 //         if (!default)
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!default").WithArguments("!", "default").WithLocation(6, 13)
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "!default").WithArguments("!", "default").WithLocation(6, 13)
                 );
 
             var tree = comp.SyntaxTrees.First();
@@ -1011,7 +1296,7 @@ class C
                 Diagnostic(ErrorCode.ERR_BadUnaryOp, "!Main").WithArguments("!", "method group").WithLocation(6, 13),
                 // (6,22): error CS8310: Operator '!' cannot be applied to operand '<null>'
                 //         if (!Main || !null)
-                Diagnostic(ErrorCode.ERR_BadUnaryOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(6, 22)
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "!null").WithArguments("!", "<null>").WithLocation(6, 22)
                 );
         }
 
@@ -1416,8 +1701,11 @@ class C
 }
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "0 1");
+            comp.VerifyDiagnostics(
+                // (5,16): error CS8310: Operator '+' cannot be applied to operand 'default'
+                //     OneEntry = default + 1
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default + 1").WithArguments("+", "default").WithLocation(5, 16)
+                );
         }
 
         [Fact]
@@ -1438,8 +1726,11 @@ class C
 }
 ";
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "0 1");
+            comp.VerifyDiagnostics(
+                // (5,16): error CS8310: Operator '+' cannot be applied to operand 'default'
+                //     OneEntry = default + 1
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default + 1").WithArguments("+", "default").WithLocation(5, 16)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/TargetTypedDefaultTests.cs
@@ -771,6 +771,13 @@ class C
                 //         int j = checked(default + 4);
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default + 4").WithArguments("+", "default").WithLocation(6, 25)
                 );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+            var addition = nodes.OfType<BinaryExpressionSyntax>().Single();
+            Assert.Null(model.GetSymbolInfo(addition).Symbol);
         }
 
         [Fact]
@@ -847,21 +854,21 @@ class C
                 // (19,17): error CS8310: Operator '<=' cannot be applied to operand 'default'
                 //         var n = default <= default;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default <= default").WithArguments("<=", "default").WithLocation(19, 17),
-                // (20,17): error CS0034: Operator '==' is ambiguous on operands of type 'default' and 'default'
+                // (20,17): error CS8315: Operator '==' is ambiguous on operands 'default' and 'default'
                 //         var o = default == default; // ambiguous
-                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default == default").WithArguments("==", "default", "default").WithLocation(20, 17),
-                // (21,17): error CS0034: Operator '!=' is ambiguous on operands of type 'default' and 'default'
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "default == default").WithArguments("==").WithLocation(20, 17),
+                // (21,17): error CS8315: Operator '!=' is ambiguous on operands 'default' and 'default'
                 //         var p = default != default; // ambiguous
-                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default != default").WithArguments("!=", "default", "default").WithLocation(21, 17),
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "default != default").WithArguments("!=").WithLocation(21, 17),
                 // (22,17): error CS8310: Operator '&&' cannot be applied to operand 'default'
                 //         var q = default && default;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default && default").WithArguments("&&", "default").WithLocation(22, 17),
                 // (23,17): error CS8310: Operator '||' cannot be applied to operand 'default'
                 //         var r = default || default;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default || default").WithArguments("||", "default").WithLocation(23, 17),
-                // (24,17): error CS0019: Operator '??' cannot be applied to operands of type 'default' and 'default'
+                // (24,17): error CS8310: Operator '??' cannot be applied to operand 'default'
                 //         var s = default ?? default;
-                Diagnostic(ErrorCode.ERR_BadBinaryOps, "default ?? default").WithArguments("??", "default", "default").WithLocation(24, 17)
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "default ?? default").WithArguments("??", "default").WithLocation(24, 17)
                 );
         }
 
@@ -1034,9 +1041,9 @@ class C
                 // (23,17): error CS8310: Operator '||' cannot be applied to operand 'default'
                 //         var r = 1 || default;
                 Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 || default").WithArguments("||", "default").WithLocation(23, 17),
-                // (24,17): error CS0019: Operator '??' cannot be applied to operands of type 'int' and 'default'
+                // (24,17): error CS8310: Operator '??' cannot be applied to operand 'default'
                 //         var s = 1 ?? default;
-                Diagnostic(ErrorCode.ERR_BadBinaryOps, "1 ?? default").WithArguments("??", "int", "default").WithLocation(24, 17),
+                Diagnostic(ErrorCode.ERR_BadOpOnNullOrDefault, "1 ?? default").WithArguments("??", "default").WithLocation(24, 17),
                 // (20,13): warning CS0219: The variable 'o' is assigned but its value is never used
                 //         var o = 1 == default; // ok
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "o").WithArguments("o").WithLocation(20, 13),
@@ -1861,12 +1868,12 @@ class C
 
             var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics(
-                // (6,33): error CS0034: Operator '==' is ambiguous on operands of type 'default' and 'default'
+                // (6,33): error CS8315: Operator '==' is ambiguous on operands 'default' and 'default'
                 //         System.Console.Write($"{default == default} {default != default}");
-                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default == default").WithArguments("==", "default", "default").WithLocation(6, 33),
-                // (6,54): error CS0034: Operator '!=' is ambiguous on operands of type 'default' and 'default'
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "default == default").WithArguments("==").WithLocation(6, 33),
+                // (6,54): error CS8315: Operator '!=' is ambiguous on operands 'default' and 'default'
                 //         System.Console.Write($"{default == default} {default != default}");
-                Diagnostic(ErrorCode.ERR_AmbigBinaryOps, "default != default").WithArguments("!=", "default", "default").WithLocation(6, 54)
+                Diagnostic(ErrorCode.ERR_AmbigBinaryOpsOnDefault, "default != default").WithArguments("!=").WithLocation(6, 54)
                 );
         }
 


### PR DESCRIPTION
**Customer scenario**
Disallow uses of unary operator on the default literal:
```C#
        var a = +default;
        var b = -default;
        var c = ~default;
        var d = !default;
```

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/19848

**Risk**
**Performance impact**
Low. We just check for "default" literal when binding unary operators and bind as an error node.

**Is this a regression from a previous update?**
No, this relates to a yet unshipped feature.

**Root cause analysis:**
I actually tested for one unary operator (`!default`) and at the time it seemed reasonable to allow it. But I can't remember our rationale. Such code doesn't seem useful.

**How was the bug found?**
Suggestion from preview user.

@gafter @dotnet/roslyn-compiler for review.