### PR TITLE
Add support for implementing interface members in derived interfaces by using explicit implementation syntax.

### DIFF
--- a/docs/features/DefaultInterfaceImplementation.md
+++ b/docs/features/DefaultInterfaceImplementation.md
@@ -43,6 +43,13 @@ class Test1 : I1
 
 - Declaring types within interfaces. **Protected** and **protected internal** accessibility is not supported.
 
+- Implementing interface methods in derived interfaces by using explicit implementation syntax, accessibility is private, allowed modifiers: **extern** and **async**.
+
+- Implementing interface properties and indexers in derived interfaces by using explicit implementation syntax, accessibility is private, allowed modifiers: **extern**.
+
+- Implementing interface events in derived interfaces by using explicit implementation syntax, accessibility is private, no allowed modifiers.
+
+
 **Open issues and work items** are tracked in https://github.com/dotnet/roslyn/issues/17952.
 
 **Parts of ECMA-335 that become obsolete/inaccurate/incomplete**

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4040,7 +4040,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: explicit interface declaration can only be declared in a class or struct.
+        ///   Looks up a localized string similar to &apos;{0}&apos;: explicit interface declaration can only be declared in a class, struct or interface.
         /// </summary>
         internal static string ERR_ExplicitInterfaceImplementationInNonClassOrStruct {
             get {
@@ -5831,6 +5831,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; cannot implement interface member &apos;{1}&apos; in type &apos;{2}&apos; because feature &apos;{3}&apos; is not available in C# {4}. Please use language version {5} or greater..
+        /// </summary>
+        internal static string ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember {
+            get {
+                return ResourceManager.GetString("ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to { expected.
         /// </summary>
         internal static string ERR_LbraceExpected {
@@ -5935,15 +5944,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_LookupInTypeVariable {
             get {
                 return ResourceManager.GetString("ERR_LookupInTypeVariable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;: an entry point cannot be marked with the &apos;async&apos; modifier.
-        /// </summary>
-        internal static string ERR_MainCantBeAsync {
-            get {
-                return ResourceManager.GetString("ERR_MainCantBeAsync", resourceCulture);
             }
         }
         
@@ -6304,6 +6304,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_ModuleEmitFailure {
             get {
                 return ResourceManager.GetString("ERR_ModuleEmitFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Interface member &apos;{0}&apos; does not have most specific implementation. Neither &apos;{1}&apos;, nor &apos;{2}&apos; are most specific..
+        /// </summary>
+        internal static string ERR_MostSpecificImplementationIsNotFound {
+            get {
+                return ResourceManager.GetString("ERR_MostSpecificImplementationIsNotFound", resourceCulture);
             }
         }
         
@@ -6882,18 +6891,16 @@ namespace Microsoft.CodeAnalysis.CSharp {
                 return ResourceManager.GetString("ERR_NonInvocableMemberCalled", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Async Main methods must return Task or Task&lt;int&gt;.
+        ///   Looks up a localized string similar to A void or int returning entry point cannot be async.
         /// </summary>
-        internal static string ERR_NonTaskMainCantBeAsync
-        {
-            get
-            {
+        internal static string ERR_NonTaskMainCantBeAsync {
+            get {
                 return ResourceManager.GetString("ERR_NonTaskMainCantBeAsync", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot embed interop types from assembly &apos;{0}&apos; because it is missing the &apos;{1}&apos; attribute..
         /// </summary>
@@ -9899,7 +9906,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
                 return ResourceManager.GetString("IDS_Covariantly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to 
         ///                              Visual C# Compiler Options
@@ -9913,10 +9920,8 @@ namespace Microsoft.CodeAnalysis.CSharp {
         ///                               /t:winexe)
         /// /target:library        [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string IDS_CSCHelp
-        {
-            get
-            {
+        internal static string IDS_CSCHelp {
+            get {
                 return ResourceManager.GetString("IDS_CSCHelp", resourceCulture);
             }
         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -6308,7 +6308,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Interface member &apos;{0}&apos; does not have most specific implementation. Neither &apos;{1}&apos;, nor &apos;{2}&apos; are most specific..
+        ///   Looks up a localized string similar to Interface member &apos;{0}&apos; does not have a most specific implementation. Neither &apos;{1}&apos;, nor &apos;{2}&apos; are most specific..
         /// </summary>
         internal static string ERR_MostSpecificImplementationIsNotFound {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5091,7 +5091,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>'{0}' does not implement interface member '{1}'. '{2}' cannot implicitly implement a non-public member.</value>
   </data>
   <data name="ERR_MostSpecificImplementationIsNotFound" xml:space="preserve">
-    <value>Interface member '{0}' does not have most specific implementation. Neither '{1}', nor '{2}' are most specific.</value>
+    <value>Interface member '{0}' does not have a most specific implementation. Neither '{1}', nor '{2}' are most specific.</value>
   </data>
   <data name="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember" xml:space="preserve">
     <value>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version {5} or greater.</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1503,7 +1503,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>'{0}': containing type does not implement interface '{1}'</value>
   </data>
   <data name="ERR_ExplicitInterfaceImplementationInNonClassOrStruct" xml:space="preserve">
-    <value>'{0}': explicit interface declaration can only be declared in a class or struct</value>
+    <value>'{0}': explicit interface declaration can only be declared in a class, struct or interface</value>
   </data>
   <data name="ERR_MemberNameSameAsType" xml:space="preserve">
     <value>'{0}': member names cannot be the same as their enclosing type</value>
@@ -5089,5 +5089,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_ImplicitImplementationOfNonPublicInterfaceMember" xml:space="preserve">
     <value>'{0}' does not implement interface member '{1}'. '{2}' cannot implicitly implement a non-public member.</value>
+  </data>
+  <data name="ERR_MostSpecificImplementationIsNotFound" xml:space="preserve">
+    <value>Interface member '{0}' does not have most specific implementation. Neither '{1}', nor '{2}' are most specific.</value>
+  </data>
+  <data name="ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember" xml:space="preserve">
+    <value>'{0}' cannot implement interface member '{1}' in type '{2}' because feature '{3}' is not available in C# {4}. Please use language version {5} or greater.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -316,11 +316,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             CheckDefinitionInvariant();
 
-            if (this.IsInterface)
-            {
-                yield break;
-            }
-
             PEModuleBuilder moduleBeingBuilt = (PEModuleBuilder)context.Module;
 
             foreach (var member in this.GetMembers())
@@ -337,6 +332,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         {
                             yield return new Microsoft.Cci.MethodImplementation(method, moduleBeingBuilt.TranslateOverriddenMethodReference(implemented, (CSharpSyntaxNode)context.SyntaxNodeOpt, context.Diagnostics));
                         }
+                    }
+
+                    if (this.IsInterface)
+                    {
+                        continue;
                     }
 
                     if (method.RequiresExplicitOverride())
@@ -366,6 +366,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         }
                     }
                 }
+            }
+
+            if (this.IsInterface)
+            {
+                yield break;
             }
 
             var syntheticMethods = moduleBeingBuilt.GetSynthesizedMethods(this);

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1496,6 +1496,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         // This PR can be used to find the relevant code and test files: https://github.com/dotnet/roslyn/pull/18045.
         ERR_DefaultInterfaceImplementationModifier = 8503,
         ERR_ImplicitImplementationOfNonPublicInterfaceMember = 8504,
+        ERR_MostSpecificImplementationIsNotFound = 8505,
 
+        // PROTOTYPE(DefaultInterfaceImplementation): Should add this error code to the list monitored by the UpgradeProject code fixer.
+        // This PR can be used to find the relevant code and test files: https://github.com/dotnet/roslyn/pull/18045.
+        ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember = 8506,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -176,12 +176,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var memberLocation = implementingMember.Locations[0];
             var containingType = implementingMember.ContainingType;
-            var containingTypeKind = containingType.TypeKind;
 
-            if (containingTypeKind != TypeKind.Class && containingTypeKind != TypeKind.Struct)
+            switch (containingType.TypeKind)
             {
-                diagnostics.Add(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, memberLocation, implementingMember);
-                return null;
+                case TypeKind.Class:
+                case TypeKind.Struct:
+                case TypeKind.Interface:
+                    break;
+
+                default:
+                    diagnostics.Add(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, memberLocation, implementingMember);
+                    return null;
             }
 
             if (!explicitInterfaceType.IsInterfaceType())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ModifierUtils.cs
@@ -94,9 +94,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal static DeclarationModifiers AdjustModifiersForAnInterfaceMember(DeclarationModifiers mods, bool hasBody)
+        internal static DeclarationModifiers AdjustModifiersForAnInterfaceMember(DeclarationModifiers mods, bool hasBody, bool isExplicitInterfaceImplementation)
         {
-            if ((mods & (DeclarationModifiers.Static | DeclarationModifiers.Private | DeclarationModifiers.Virtual | DeclarationModifiers.Abstract)) == 0)
+            if ((mods & (DeclarationModifiers.Static | DeclarationModifiers.Private | DeclarationModifiers.Virtual | DeclarationModifiers.Abstract)) == 0 &&
+                !isExplicitInterfaceImplementation)
             {
                 if (hasBody || (mods & (DeclarationModifiers.Extern | DeclarationModifiers.Sealed)) != 0)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                    DiagnosticBag diagnostics, out bool modifierErrors)
         {
             bool isInterface = this.ContainingType.IsInterface;
-            var defaultAccess = isInterface ? DeclarationModifiers.Public : DeclarationModifiers.Private;
+            var defaultAccess = isInterface && !explicitInterfaceImplementation ? DeclarationModifiers.Public : DeclarationModifiers.Private;
             var defaultInterfaceImplementationModifiers = DeclarationModifiers.None;
 
             // Check that the set of modifiers is allowed
@@ -458,7 +458,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Proper errors must have been reported by now.
             if (isInterface)
             {
-                mods = ModifierUtils.AdjustModifiersForAnInterfaceMember(mods, !isFieldLike);
+                mods = ModifierUtils.AdjustModifiersForAnInterfaceMember(mods, !isFieldLike, explicitInterfaceImplementation);
             }
 
             return mods;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldLikeEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldLikeEventSymbol.cs
@@ -80,9 +80,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Don't initialize this.type - we'll just use the type of the field (which is lazy and handles var)
             }
 
-            if (inInterfaceType && !this.IsAbstract && !this.IsExtern)
+            if (inInterfaceType)
             {
-                diagnostics.Add(ErrorCode.ERR_EventNeedsBothAccessors, this.Locations[0], this);
+                if (this.IsExtern)
+                {
+                    if (!ContainingAssembly.RuntimeSupportsDefaultInterfaceImplementation)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, this.Locations[0]);
+                    }
+                }
+                else if (!this.IsAbstract)
+                {
+                    diagnostics.Add(ErrorCode.ERR_EventNeedsBothAccessors, this.Locations[0], this);
+                }
             }
 
             // Accessors will assume that Type is available.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -390,7 +390,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        // TODO (tomat): sealed
         internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
         {
             if (IsExplicitInterfaceImplementation && _containingType.IsInterface)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -393,6 +393,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // TODO (tomat): sealed
         internal override bool IsMetadataNewSlot(bool ignoreInterfaceImplementationChanges = false)
         {
+            if (IsExplicitInterfaceImplementation && _containingType.IsInterface)
+            {
+                // All implementations of methods from base interfaces should omit the newslot bit to ensure no new vtable slot is allocated.
+                return false;
+            }
+
             // If C# and the runtime don't agree on the overridden method,
             // then we will mark the method as newslot and specify the
             // override explicitly (see GetExplicitImplementationOverrides
@@ -1560,18 +1566,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         protected void CheckModifiersForBody(SyntaxNode declarationSyntax, Location location, DiagnosticBag diagnostics)
         {
-            if (_containingType.IsInterface)
-            {
-                Binder.CheckFeatureAvailability(declarationSyntax, MessageID.IDS_DefaultInterfaceImplementation, diagnostics, location);
-
-                if (!ContainingAssembly.RuntimeSupportsDefaultInterfaceImplementation)
-                {
-                    // PROTOTYPE(DefaultInterfaceImplementation): It looks like some flavor of static members was supported by
-                    //                                            legacy runtimes. Should we suppress this error for them?
-                    diagnostics.Add(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, location);
-                }
-            }
-
             if (IsExtern && !IsAbstract)
             {
                 diagnostics.Add(ErrorCode.ERR_ExternHasBody, location, this);
@@ -1582,6 +1576,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             // Do not report error for IsAbstract && IsExtern. Dev10 reports CS0180 only
             // in that case ("member cannot be both extern and abstract").
+        }
+
+        protected void CheckFeatureAvailabilityAndRuntimeSupport(SyntaxNode declarationSyntax, Location location, bool hasBody, DiagnosticBag diagnostics)
+        {
+            if (_containingType.IsInterface)
+            {
+                if (hasBody || IsExplicitInterfaceImplementation)
+                {
+                    Binder.CheckFeatureAvailability(declarationSyntax, MessageID.IDS_DefaultInterfaceImplementation, diagnostics, location);
+                }
+
+                if ((hasBody || IsExtern) && !ContainingAssembly.RuntimeSupportsDefaultInterfaceImplementation)
+                {
+                    // PROTOTYPE(DefaultInterfaceImplementation): It looks like some flavor of static members was supported by
+                    //                                            legacy runtimes. Should we suppress this error for them?
+                    diagnostics.Add(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, location);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.MakeFlags(MethodKind.PropertyGet, declarationModifiers, returnsVoid: false, isExtensionMethod: false,
                 isMetadataVirtualIgnoringModifiers: explicitInterfaceImplementations.Any());
 
-            CheckFeatureAvailabilityAndRuntimeSupport(syntax, location, true, diagnostics);
+            CheckFeatureAvailabilityAndRuntimeSupport(syntax, location, hasBody: true, diagnostics: diagnostics);
             CheckModifiersForBody(syntax, location, diagnostics);
 
             var info = ModifierUtils.CheckAccessibility(this.DeclarationModifiers);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -162,6 +162,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.MakeFlags(MethodKind.PropertyGet, declarationModifiers, returnsVoid: false, isExtensionMethod: false,
                 isMetadataVirtualIgnoringModifiers: explicitInterfaceImplementations.Any());
 
+            CheckFeatureAvailabilityAndRuntimeSupport(syntax, location, true, diagnostics);
             CheckModifiersForBody(syntax, location, diagnostics);
 
             var info = ModifierUtils.CheckAccessibility(this.DeclarationModifiers);
@@ -227,6 +228,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // returnsVoid argument to MakeFlags is ignored.
             this.MakeFlags(methodKind, declarationModifiers, returnsVoid: false, isExtensionMethod: false,
                 isMetadataVirtualIgnoringModifiers: explicitInterfaceImplementations.Any());
+
+            CheckFeatureAvailabilityAndRuntimeSupport(syntax, location, hasBody || hasExpressionBody, diagnostics);
 
             if (hasBody || hasExpressionBody)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -743,7 +743,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                    Location location, DiagnosticBag diagnostics, out bool modifierErrors)
         {
             bool isInterface = this.ContainingType.IsInterface;
-            var defaultAccess = isInterface ? DeclarationModifiers.Public : DeclarationModifiers.Private;
+            var defaultAccess = isInterface && !isExplicitInterfaceImplementation ? DeclarationModifiers.Public : DeclarationModifiers.Private;
 
             // Check that the set of modifiers is allowed
             var allowedModifiers = DeclarationModifiers.Unsafe;
@@ -775,7 +775,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // check it against language version below.
                     defaultAccess = DeclarationModifiers.None;
 
-                    allowedModifiers |= allowedAccess | DeclarationModifiers.Extern;
+                    allowedModifiers |= allowedAccess;
                     defaultInterfaceImplementationModifiers |= DeclarationModifiers.Sealed |
                                                                DeclarationModifiers.Abstract |
                                                                (isIndexer ? 0 : DeclarationModifiers.Static) |
@@ -785,11 +785,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (!isInterface)
-            {
-                allowedModifiers |=
-                    DeclarationModifiers.Extern;
-            }
+            allowedModifiers |= DeclarationModifiers.Extern;
 
             var mods = ModifierUtils.MakeAndCheckNontypeMemberModifiers(modifiers, defaultAccess, allowedModifiers, location, diagnostics, out modifierErrors);
 
@@ -803,7 +799,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // Proper errors must have been reported by now.
             if (isInterface)
             {
-                mods = ModifierUtils.AdjustModifiersForAnInterfaceMember(mods, accessorsHaveImplementation);
+                mods = ModifierUtils.AdjustModifiersForAnInterfaceMember(mods, accessorsHaveImplementation, isExplicitInterfaceImplementation);
             }
 
             if (isIndexer)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -911,6 +911,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
 #if !DEBUG
+            // Don't optimize in DEBUG for better coverage for the GetInterfaceLocation function. 
             if (useSiteDiagnostics != null)
 #endif
             {
@@ -953,8 +954,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if ((object)conflict1 != null)
             {
-                Debug.Assert(((object)implicitImpl == null));
-                Debug.Assert(((object)conflict1 != null));
+                Debug.Assert((object)implicitImpl == null);
+                Debug.Assert((object)conflict2 != null);
                 diagnostics.Add(ErrorCode.ERR_MostSpecificImplementationIsNotFound, GetInterfaceLocation(interfaceMember, implementingType),
                                 interfaceMember, conflict1, conflict2);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -430,6 +430,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        internal ImmutableHashSet<NamedTypeSymbol> InterfacesAndTheirBaseInterfacesWithDefinitionUseSiteDiagnostics(ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            var result = InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics;
+
+            foreach (var iface in result)
+            {
+                iface.OriginalDefinition.AddUseSiteDiagnostics(ref useSiteDiagnostics);
+            }
+
+            return result;
+        }
+
         // Note: Unlike MakeAllInterfaces, this doesn't need to be virtual. It depends on
         // AllInterfaces for its implementation, so it will pick up all changes to MakeAllInterfaces
         // indirectly.
@@ -469,6 +481,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!interfaceMember.IsImplementableInterfaceMember())
             {
                 return null;
+            }
+
+            if (this.IsInterfaceType())
+            {
+                return FindMostSpecificImplementation(interfaceMember, (NamedTypeSymbol)this);
             }
 
             return FindImplementationForInterfaceMemberWithDiagnostics(interfaceMember).Symbol;
@@ -781,6 +798,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <returns>The implementing property or null, if there isn't one.</returns>
         private static Symbol ComputeImplementationForInterfaceMember(Symbol interfaceMember, TypeSymbol implementingType, DiagnosticBag diagnostics)
         {
+            Debug.Assert(!implementingType.IsInterfaceType());
             Debug.Assert(interfaceMember.Kind == SymbolKind.Method || interfaceMember.Kind == SymbolKind.Property || interfaceMember.Kind == SymbolKind.Event);
             Debug.Assert(interfaceMember.IsImplementableInterfaceMember());
 
@@ -809,8 +827,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Symbol closestMismatch = null;
             bool canBeImplementedImplicitly = interfaceMember.DeclaredAccessibility == Accessibility.Public && !interfaceMember.IsEventOrPropertyWithNonPublicAccessor();
             TypeSymbol implementingBaseOpt = null; // Calculated only if canBeImplementedImplicitly == true
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
-            for (TypeSymbol currType = implementingType; (object)currType != null; currType = currType.BaseTypeNoUseSiteDiagnostics)
+            for (TypeSymbol currType = implementingType; (object)currType != null; currType = currType.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics))
             {
                 // NOTE: In the case of PE symbols, it is possible to see an explicit implementation
                 // on a type that does not declare the corresponding interface (or one of its
@@ -834,7 +853,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (!seenTypeDeclaringInterface || 
                     (!canBeImplementedImplicitly && (object)implementingBaseOpt == null))
                 {
-                    if (currType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Contains(interfaceType))
+                    if (currType.InterfacesAndTheirBaseInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics).Contains(interfaceType))
                     {
                         seenTypeDeclaringInterface = true;
 
@@ -888,17 +907,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if ((object)implicitImpl == null && seenTypeDeclaringInterface)
             {
                 // Check for default interface implementations
-                if (!interfaceMember.IsAbstract)
-                {
-                    implicitImpl = interfaceMember;
-                }
+                implicitImpl = FindMostSpecificImplementation(interfaceMember, implementingType, ref useSiteDiagnostics, diagnostics);
+            }
+
+#if !DEBUG
+            if (useSiteDiagnostics != null)
+#endif
+            {
+                diagnostics.Add(GetInterfaceLocation(interfaceMember, implementingType), useSiteDiagnostics);
             }
 
             if ((object)implicitImpl != null)
             {
                 if (!canBeImplementedImplicitly && !implicitImpl.ContainingType.IsInterface)
                 {
-                    if (interfaceMember.Kind == SymbolKind.Method && 
+                    if (interfaceMember.Kind == SymbolKind.Method &&
                         (object)implementingBaseOpt == null) // Otherwise any approprite errors are going to be reported for the base.
                     {
                         diagnostics.Add(ErrorCode.ERR_ImplicitImplementationOfNonPublicInterfaceMember, GetInterfaceLocation(interfaceMember, implementingType),
@@ -918,6 +941,111 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return implicitImpl;
+        }
+
+        private static Symbol FindMostSpecificImplementation(Symbol interfaceMember, TypeSymbol implementingType,
+                                                             ref HashSet<DiagnosticInfo> useSiteDiagnostics,
+                                                             DiagnosticBag diagnostics)
+        {
+            Symbol implicitImpl = FindMostSpecificImplementation(interfaceMember,
+                                                          implementingType,
+                                                          ref useSiteDiagnostics, out Symbol conflict1, out Symbol conflict2);
+
+            if ((object)conflict1 != null)
+            {
+                Debug.Assert(((object)implicitImpl == null));
+                Debug.Assert(((object)conflict1 != null));
+                diagnostics.Add(ErrorCode.ERR_MostSpecificImplementationIsNotFound, GetInterfaceLocation(interfaceMember, implementingType),
+                                interfaceMember, conflict1, conflict2);
+            }
+            else
+            {
+                Debug.Assert(((object)conflict2 == null));
+                // PROTOTYPE(DefaultInterfaceImplementation): We might need to do extra consistency check for events/properties and their 
+                //                                            accessors. Need to verify if what CheckForImplementationOfCorrespondingPropertyOrEvent
+                //                                            is doing should be applicable here as well.
+            }
+
+            return implicitImpl;
+        }
+
+        private static Symbol FindMostSpecificImplementation(Symbol interfaceMember, NamedTypeSymbol implementingInterface)
+        {
+            HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+            var implementingMember = FindImplementationInInterface(interfaceMember, implementingInterface) ??
+                                     FindMostSpecificImplementation(interfaceMember, implementingInterface,
+                                                                    ref useSiteDiagnostics,
+                                                                    out var _, out var _);
+            return implementingMember;
+        }
+
+        /// <summary>
+        /// One implementation M1 is considered more specific than another implementation M2 
+        /// if M1 is declared on interface T1, M2 is declared on interface T2, and 
+        /// T1 contains T2 among its direct or indirect interfaces.
+        /// </summary>
+        private static Symbol FindMostSpecificImplementation(Symbol interfaceMember,
+                                                             TypeSymbol implementingType, 
+                                                             ref HashSet<DiagnosticInfo> useSiteDiagnostics, 
+                                                             out Symbol conflictingImplementation1,
+                                                             out Symbol conflictingImplementation2)
+        {
+            conflictingImplementation1 = null;
+            conflictingImplementation2 = null;
+            Symbol implementation = null;
+
+            foreach (var interfaceType in implementingType.AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics))
+            {
+                Symbol candidate = FindImplementationInInterface(interfaceMember, interfaceType);
+
+                if ((object)candidate != null)
+                {
+                    if ((object)implementation == null)
+                    {
+                        implementation = candidate;
+                    }
+                    else if(!implementation.ContainingType.ImplementsInterface(interfaceType, ref useSiteDiagnostics))
+                    {
+                        // we have a conflict
+                        conflictingImplementation1 = implementation;
+                        conflictingImplementation2 = candidate;
+                        implementation = null;
+                        break;
+                    }
+                }
+            }
+
+            return implementation;
+        }
+
+        private static Symbol FindImplementationInInterface(Symbol interfaceMember, NamedTypeSymbol interfaceType)
+        {
+            Debug.Assert(interfaceType.IsInterface);
+
+            if (interfaceMember.ContainingType == interfaceType)
+            {
+                if (!interfaceMember.IsAbstract)
+                {
+                    return interfaceMember;
+                }
+
+                return null;
+            }
+
+            foreach (Symbol member in interfaceType.GetMembersUnordered())
+            {
+                if (member.Kind != interfaceMember.Kind)
+                {
+                    continue;
+                }
+
+                if (member.GetExplicitInterfaceImplementations().Contains(interfaceMember))
+                {
+                    return member;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -1100,6 +1228,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         private static void ReportImplicitImplementationMatchDiagnostics(Symbol interfaceMember, TypeSymbol implementingType, Symbol implicitImpl, DiagnosticBag diagnostics)
         {
+            if (implicitImpl.ContainingType.IsInterface)
+            {
+                if (interfaceMember.Kind == SymbolKind.Method && implementingType.ContainingModule != implicitImpl.ContainingModule)
+                {
+                    // The default implementation is coming from a different module, which means that we probably didn't check
+                    // for the required runtime capability or language version
+
+                    LanguageVersion requiredVersion = MessageID.IDS_DefaultInterfaceImplementation.RequiredVersion();
+                    LanguageVersion? availableVersion = implementingType.DeclaringCompilation?.LanguageVersion;
+                    if (requiredVersion > availableVersion)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_LanguageVersionDoesNotSupportDefaultInterfaceImplementationForMember,
+                                        GetInterfaceLocation(interfaceMember, implementingType),
+                                        implicitImpl, interfaceMember, implementingType,
+                                        MessageID.IDS_DefaultInterfaceImplementation.Localize(),
+                                        availableVersion.GetValueOrDefault().ToDisplayString(),
+                                        new CSharpRequiredLanguageVersion(requiredVersion));
+                    }
+
+                    if (!implementingType.ContainingAssembly.RuntimeSupportsDefaultInterfaceImplementation)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember,
+                                        GetInterfaceLocation(interfaceMember, implementingType),
+                                        implicitImpl, interfaceMember, implementingType);
+                    }
+                }
+
+                return;
+            }
+
             if (interfaceMember.Kind == SymbolKind.Method)
             {
                 var interfaceMethod = (MethodSymbol)interfaceMember;
@@ -1126,24 +1284,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     else
                     {
                         ReportAnyMismatchedConstraints(interfaceMethod, implementingType, implicitImplMethod, diagnostics);
-                    }
-                }
-
-                if (implicitImpl.ContainingType.IsInterface && implementingType.ContainingModule != implicitImpl.ContainingModule)
-                {
-                    // PROTOTYPE(DefaultInterfaceImplementation): Should we check language version as well?
-                    // Usually, it is done based on specific syntax that targets a new feature, but in this case
-                    // no special syntax is used. Also, partial types can have declarations coming from different 
-                    // trees with different options. We could use options from the tree the result of 
-                    // GetInterfaceLocation() is based on.
-
-                    // The default implementation is coming from a different module, which means that we probably won't check
-                    // for the required runtime capability
-                    if (!implementingType.ContainingAssembly.RuntimeSupportsDefaultInterfaceImplementation)
-                    {
-                        diagnostics.Add(ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementationForMember,
-                                        GetInterfaceLocation(interfaceMember, implementingType),
-                                        implicitImpl, interfaceMember, implementingType);
                     }
                 }
             }
@@ -1250,8 +1390,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert((object)implementingType != null);
             var @interface = interfaceMember.ContainingType;
-            SourceMemberContainerTypeSymbol snt = implementingType as SourceMemberContainerTypeSymbol;
-            return snt.GetImplementsLocation(@interface) ?? implementingType.Locations[0];
+
+            SourceMemberContainerTypeSymbol snt = null;
+            if (implementingType.InterfacesAndTheirBaseInterfacesNoUseSiteDiagnostics.Contains(@interface))
+            {
+                snt = implementingType as SourceMemberContainerTypeSymbol;
+            }
+
+            return snt?.GetImplementsLocation(@interface) ?? implementingType.Locations[0];
         }
 
         private static void ReportAnyMismatchedConstraints(MethodSymbol interfaceMethod, TypeSymbol implementingType, MethodSymbol implicitImpl, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2169,16 +2169,22 @@ class C<T> : System.Attribute { }";
 {
     partial void I.M();
 }";
-            CreateStandardCompilation(source).VerifyDiagnostics(
+            CreateStandardCompilation(source, parseOptions: TestOptions.Regular7).VerifyDiagnostics(
                 // (3,20): error CS0754: A partial method may not explicitly implement an interface method
                 //     partial void I.M();
-                Diagnostic(ErrorCode.ERR_PartialMethodNotExplicit, "M"),
+                Diagnostic(ErrorCode.ERR_PartialMethodNotExplicit, "M").WithLocation(3, 20),
                 // (3,20): error CS0751: A partial method must be declared within a partial class or partial struct
                 //     partial void I.M();
-                Diagnostic(ErrorCode.ERR_PartialMethodOnlyInPartialClass, "M"),
-                // (3,20): error CS0541: 'I.M()': explicit interface declaration can only be declared in a class or struct
+                Diagnostic(ErrorCode.ERR_PartialMethodOnlyInPartialClass, "M").WithLocation(3, 20),
+                // (3,20): error CS8107: Feature 'default interface implementation' is not available in C# 7. Please use language version 7.1 or greater.
                 //     partial void I.M();
-                Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "M").WithArguments("I.M()")
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "M").WithArguments("default interface implementation", "7.1").WithLocation(3, 20),
+                // (3,18): error CS0540: 'I.M()': containing type does not implement interface 'I'
+                //     partial void I.M();
+                Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I").WithArguments("I.M()", "I").WithLocation(3, 18),
+                // (3,20): error CS0539: 'I.M()' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     partial void I.M();
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "M").WithArguments("I.M()").WithLocation(3, 20)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -23892,19 +23892,19 @@ class Test12 : I8
                     Assert.True(compilation3.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
 
                     compilation3.VerifyDiagnostics(
-                // (2,15): error CS8505: Interface member 'I1.M1()' does not have most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.M1()' does not have a most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.M1()", "I2.I1.M1()", "I3.I1.M1()").WithLocation(2, 15),
-                // (5,15): error CS8505: Interface member 'I1.M1()' does not have most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
+                // (5,15): error CS8505: Interface member 'I1.M1()' does not have a most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
                 // class Test2 : I7
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I7").WithArguments("I1.M1()", "I2.I1.M1()", "I3.I1.M1()").WithLocation(5, 15),
-                // (8,15): error CS8505: Interface member 'I1.M1()' does not have most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
+                // (8,15): error CS8505: Interface member 'I1.M1()' does not have a most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
                 // class Test3 : I1, I2, I3, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.M1()", "I2.I1.M1()", "I3.I1.M1()").WithLocation(8, 15),
-                // (11,15): error CS8505: Interface member 'I1.M1()' does not have most specific implementation. Neither 'I5.I1.M1()', nor 'I4.I1.M1()' are most specific.
+                // (11,15): error CS8505: Interface member 'I1.M1()' does not have a most specific implementation. Neither 'I5.I1.M1()', nor 'I4.I1.M1()' are most specific.
                 // class Test4 : I1, I2, I3, I5, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.M1()", "I5.I1.M1()", "I4.I1.M1()").WithLocation(11, 15),
-                // (14,15): error CS8505: Interface member 'I1.M1()' does not have most specific implementation. Neither 'I5.I1.M1()', nor 'I4.I1.M1()' are most specific.
+                // (14,15): error CS8505: Interface member 'I1.M1()' does not have a most specific implementation. Neither 'I5.I1.M1()', nor 'I4.I1.M1()' are most specific.
                 // class Test5 : I8
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I8").WithArguments("I1.M1()", "I5.I1.M1()", "I4.I1.M1()").WithLocation(14, 15)
                         );
@@ -24025,7 +24025,7 @@ class Test1 : I2, I3
             Assert.True(compilation2.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
 
             compilation2.VerifyDiagnostics(
-                // (2,15): error CS8505: Interface member 'I1.M1()' does not have most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.M1()' does not have a most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.M1()", "I2.I1.M1()", "I3.I1.M1()").WithLocation(2, 15),
                 // (2,15): error CS0738: 'Test1' does not implement interface member 'I1.M1()'. 'Test1.M1()' cannot implement 'I1.M1()' because it does not have the matching return type of 'void'.
@@ -24038,7 +24038,7 @@ class Test1 : I2, I3
             Assert.True(compilation3.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
 
             compilation3.VerifyDiagnostics(
-                // (2,15): error CS8505: Interface member 'I1.M1()' does not have most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.M1()' does not have a most specific implementation. Neither 'I2.I1.M1()', nor 'I3.I1.M1()' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.M1()", "I2.I1.M1()", "I3.I1.M1()").WithLocation(2, 15),
                 // (2,15): error CS0738: 'Test1' does not implement interface member 'I1.M1()'. 'Test1.M1()' cannot implement 'I1.M1()' because it does not have the matching return type of 'void'.
@@ -25359,19 +25359,19 @@ class Test12 : I8
             ValidatePropertyImplementationInDerived_12(source1, source5,
                 new DiagnosticDescription[]
                 {
-                // (2,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(2, 15),
-                // (5,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (5,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test2 : I7
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I7").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(5, 15),
-                // (8,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (8,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test3 : I1, I2, I3, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(8, 15),
-                // (11,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I5.I1.M1', nor 'I4.I1.M1' are most specific.
+                // (11,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I5.I1.M1', nor 'I4.I1.M1' are most specific.
                 // class Test4 : I1, I2, I3, I5, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.M1", "I5.I1.M1", "I4.I1.M1").WithLocation(11, 15),
-                // (14,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I5.I1.M1', nor 'I4.I1.M1' are most specific.
+                // (14,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I5.I1.M1', nor 'I4.I1.M1' are most specific.
                 // class Test5 : I8
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I8").WithArguments("I1.M1", "I5.I1.M1", "I4.I1.M1").WithLocation(14, 15)
                 }
@@ -25608,7 +25608,7 @@ class Test1 : I2, I3
             ValidatePropertyImplementationInDerived_13(source1, source2,
                 new DiagnosticDescription[]
                 {
-                // (2,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(2, 15),
                 // (2,15): error CS0738: 'Test1' does not implement interface member 'I1.M1'. 'Test1.M1' cannot implement 'I1.M1' because it does not have the matching return type of 'int'.
@@ -26859,19 +26859,19 @@ class Test12 : I8
                     Assert.True(compilation3.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
 
                     compilation3.VerifyDiagnostics(
-                // (2,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(2, 15),
-                // (5,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (5,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test2 : I7
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I7").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(5, 15),
-                // (8,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (8,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test3 : I1, I2, I3, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(8, 15),
-                // (11,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I5.I1.M1', nor 'I4.I1.M1' are most specific.
+                // (11,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I5.I1.M1', nor 'I4.I1.M1' are most specific.
                 // class Test4 : I1, I2, I3, I5, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.M1", "I5.I1.M1", "I4.I1.M1").WithLocation(11, 15),
-                // (14,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I5.I1.M1', nor 'I4.I1.M1' are most specific.
+                // (14,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I5.I1.M1', nor 'I4.I1.M1' are most specific.
                 // class Test5 : I8
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I8").WithArguments("I1.M1", "I5.I1.M1", "I4.I1.M1").WithLocation(14, 15)
                         );
@@ -26970,7 +26970,7 @@ class Test1 : I2, I3
             Assert.True(compilation2.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
 
             compilation2.VerifyDiagnostics(
-                // (2,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(2, 15),
                 // (2,15): error CS0738: 'Test1' does not implement interface member 'I1.M1'. 'Test1.M1' cannot implement 'I1.M1' because it does not have the matching return type of 'Action'.
@@ -26983,7 +26983,7 @@ class Test1 : I2, I3
             Assert.True(compilation3.Assembly.RuntimeSupportsDefaultInterfaceImplementation);
 
             compilation3.VerifyDiagnostics(
-                // (2,15): error CS8505: Interface member 'I1.M1' does not have most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.M1' does not have a most specific implementation. Neither 'I2.I1.M1', nor 'I3.I1.M1' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.M1", "I2.I1.M1", "I3.I1.M1").WithLocation(2, 15),
                 // (2,15): error CS0738: 'Test1' does not implement interface member 'I1.M1'. 'Test1.M1' cannot implement 'I1.M1' because it does not have the matching return type of 'Action'.
@@ -27930,37 +27930,37 @@ class Test12 : I8
             ValidatePropertyImplementationInDerived_12(source1, source5,
                 new DiagnosticDescription[]
                 {
-                // (2,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I2.I1.this[int]', nor 'I3.I1.this[int]' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I2.I1.this[int]', nor 'I3.I1.this[int]' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.this[int]", "I2.I1.this[int]", "I3.I1.this[int]").WithLocation(2, 15),
-                // (5,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I2.I1.this[int]', nor 'I3.I1.this[int]' are most specific.
+                // (5,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I2.I1.this[int]', nor 'I3.I1.this[int]' are most specific.
                 // class Test2 : I7
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I7").WithArguments("I1.this[int]", "I2.I1.this[int]", "I3.I1.this[int]").WithLocation(5, 15),
-                // (8,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I2.I1.this[int]', nor 'I3.I1.this[int]' are most specific.
+                // (8,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I2.I1.this[int]', nor 'I3.I1.this[int]' are most specific.
                 // class Test3 : I1, I2, I3, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.this[int]", "I2.I1.this[int]", "I3.I1.this[int]").WithLocation(8, 15),
-                // (11,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I5.I1.this[int]', nor 'I4.I1.this[int]' are most specific.
+                // (11,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I5.I1.this[int]', nor 'I4.I1.this[int]' are most specific.
                 // class Test4 : I1, I2, I3, I5, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.this[int]", "I5.I1.this[int]", "I4.I1.this[int]").WithLocation(11, 15),
-                // (14,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I5.I1.this[int]', nor 'I4.I1.this[int]' are most specific.
+                // (14,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I5.I1.this[int]', nor 'I4.I1.this[int]' are most specific.
                 // class Test5 : I8
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I8").WithArguments("I1.this[int]", "I5.I1.this[int]", "I4.I1.this[int]").WithLocation(14, 15)
                 },
                 new DiagnosticDescription[]
                 {
-                // (2,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I2.I1.Item[int]', nor 'I3.I1.Item[int]' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I2.I1.Item[int]', nor 'I3.I1.Item[int]' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.this[int]", "I2.I1.Item[int]", "I3.I1.Item[int]").WithLocation(2, 15),
-                // (5,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I2.I1.Item[int]', nor 'I3.I1.Item[int]' are most specific.
+                // (5,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I2.I1.Item[int]', nor 'I3.I1.Item[int]' are most specific.
                 // class Test2 : I7
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I7").WithArguments("I1.this[int]", "I2.I1.Item[int]", "I3.I1.Item[int]").WithLocation(5, 15),
-                // (8,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I2.I1.Item[int]', nor 'I3.I1.Item[int]' are most specific.
+                // (8,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I2.I1.Item[int]', nor 'I3.I1.Item[int]' are most specific.
                 // class Test3 : I1, I2, I3, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.this[int]", "I2.I1.Item[int]", "I3.I1.Item[int]").WithLocation(8, 15),
-                // (11,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I5.I1.Item[int]', nor 'I4.I1.Item[int]' are most specific.
+                // (11,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I5.I1.Item[int]', nor 'I4.I1.Item[int]' are most specific.
                 // class Test4 : I1, I2, I3, I5, I4
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I1").WithArguments("I1.this[int]", "I5.I1.Item[int]", "I4.I1.Item[int]").WithLocation(11, 15),
-                // (14,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I5.I1.Item[int]', nor 'I4.I1.Item[int]' are most specific.
+                // (14,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I5.I1.Item[int]', nor 'I4.I1.Item[int]' are most specific.
                 // class Test5 : I8
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I8").WithArguments("I1.this[int]", "I5.I1.Item[int]", "I4.I1.Item[int]").WithLocation(14, 15)
                 }
@@ -27999,7 +27999,7 @@ class Test1 : I2, I3
             ValidatePropertyImplementationInDerived_13(source1, source2,
                 new DiagnosticDescription[]
                 {
-                // (2,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I2.I1.this[int]', nor 'I3.I1.this[int]' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I2.I1.this[int]', nor 'I3.I1.this[int]' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.this[int]", "I2.I1.this[int]", "I3.I1.this[int]").WithLocation(2, 15),
                 // (2,15): error CS0738: 'Test1' does not implement interface member 'I1.this[int]'. 'Test1.this[int]' cannot implement 'I1.this[int]' because it does not have the matching return type of 'int'.
@@ -28008,7 +28008,7 @@ class Test1 : I2, I3
                 },
                 new DiagnosticDescription[]
                 {
-                // (2,15): error CS8505: Interface member 'I1.this[int]' does not have most specific implementation. Neither 'I2.I1.Item[int]', nor 'I3.I1.Item[int]' are most specific.
+                // (2,15): error CS8505: Interface member 'I1.this[int]' does not have a most specific implementation. Neither 'I2.I1.Item[int]', nor 'I3.I1.Item[int]' are most specific.
                 // class Test1 : I2, I3
                 Diagnostic(ErrorCode.ERR_MostSpecificImplementationIsNotFound, "I2").WithArguments("I1.this[int]", "I2.I1.Item[int]", "I3.I1.Item[int]").WithLocation(2, 15),
                 // (2,15): error CS0738: 'Test1' does not implement interface member 'I1.this[int]'. 'Test1.this[int]' cannot implement 'I1.this[int]' because it does not have the matching return type of 'int'.

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -9426,13 +9426,19 @@ public class Clx
     }
 }
 ";
-            CreateStandardCompilation(text).VerifyDiagnostics(
-                // (12,19): error CS0541: 'x.IFace2.P': explicit interface declaration can only be declared in a class or struct
-                //         int IFace.P { set; } //CS0541
-                Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "P").WithArguments("x.IFace2.P"),
-                // (11,20): error CS0541: 'x.IFace2.F()': explicit interface declaration can only be declared in a class or struct
+            CreateStandardCompilation(text, parseOptions: TestOptions.Regular7).VerifyDiagnostics(
+                // (11,20): error CS8107: Feature 'default interface implementation' is not available in C# 7. Please use language version 7.1 or greater.
                 //         void IFace.F();   // CS0541
-                Diagnostic(ErrorCode.ERR_ExplicitInterfaceImplementationInNonClassOrStruct, "F").WithArguments("x.IFace2.F()")
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "F").WithArguments("default interface implementation", "7.1").WithLocation(11, 20),
+                // (12,23): error CS8107: Feature 'default interface implementation' is not available in C# 7. Please use language version 7.1 or greater.
+                //         int IFace.P { set; } //CS0541
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "set").WithArguments("default interface implementation", "7.1").WithLocation(12, 23),
+                // (12,23): error CS0501: 'IFace2.IFace.P.set' must declare a body because it is not marked abstract, extern, or partial
+                //         int IFace.P { set; } //CS0541
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "set").WithArguments("x.IFace2.x.IFace.P.set").WithLocation(12, 23),
+                // (11,20): error CS0501: 'IFace2.IFace.F()' must declare a body because it is not marked abstract, extern, or partial
+                //         void IFace.F();   // CS0541
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "F").WithArguments("x.IFace2.x.IFace.F()").WithLocation(11, 20)
                 );
         }
 


### PR DESCRIPTION
@dotnet/roslyn-compiler Please review.