### PR TITLE
Add launchSettings.json to CSharp Symbol test project

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Symbol/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles":
+  {
+    "CSharpCompilerSymbolTest":
+    {
+      "commandName": "Executable",
+      "executablePath": "$(XUnitPath)",
+      "commandLineArgs": "$(XUnitArguments)"
+    }
+  }
+}


### PR DESCRIPTION
This is an infrastructure change so that we can run compiler symbol tests.
If this PR is ok, then I will do the same for other test projects that have been updated to new project system.

@dotnet/roslyn-infrastructure for review.
FYI @srivatsn @sharwell 