### PR TITLE
Fix LinkVSSDKEmbeddableAssemblies target

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -329,7 +329,7 @@
   <!-- This is a copy of the Microsoft.VisualStudio.SDK.EmbedInteropTypes NuGet package, but only the list of
        assemblies that we need. The package includes things like EnvDTE which are reasonable for consumers, but
        strange since we actually _implement_ DTE and use it as an exchange type with generics in a few places. -->
-  <Target Name="LinkVSSDKEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
+  <Target Name="LinkVSSDKEmbeddableAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences" >
     <ItemGroup>
       <ReferencePath Condition="'%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable' OR
                                 '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0' OR


### PR DESCRIPTION
Infrastructure only change.

Fixes a  build issue caused by a recent change in msbuild. According to discussion on  https://github.com/Microsoft/msbuild/issues/2134 the target is not quite correct.

Symptom:
F5 in Roslyn.sln doesn't work with latest dogfood bits.

Activity log:
```
LegacySitePackage failed for package [CSharpPackage]Source: 'Microsoft.VisualStudio.LanguageServices' Description: Could not load file or assembly 'Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
File name: 'Microsoft.Internal.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService.AbstractPackage`2.Initialize()
   at Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService.CSharpPackage.Initialize()
   at Microsoft.VisualStudio.Shell.Package.Microsoft.VisualStudio.Shell.Interop.IVsPackage.SetSite(IServiceProvider sp)
```
