### PR TITLE
Fix 397704 null ref in dpl

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -604,7 +604,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var workspaceProjectContextFactory = componentModel.GetService<IWorkspaceProjectContextFactory>();
 
             var dte = _serviceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
-            var solutionConfig = (EnvDTE80.SolutionConfiguration2)dte.Solution.SolutionBuild.ActiveConfiguration;
+            var solutionConfig = (EnvDTE80.SolutionConfiguration2)dte?.Solution?.SolutionBuild?.ActiveConfiguration;
 
             OutputToOutputWindow($"Getting project information - start");
             var start = DateTimeOffset.UtcNow;
@@ -613,7 +613,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             // Note that `solutionConfig` may be null. For example: if the solution doesn't actually
             // contain any projects.
-            if (solutionConfig != null)
+            if (solutionConfig?.Name != null && solutionConfig?.PlatformName != null)
             {
                 // Capture the context so that we come back on the UI thread, and do the actual project creation there.
                 var deferredProjectWorkspaceService = _workspaceServices.GetService<IDeferredProjectWorkspaceService>();

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Windows.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -596,51 +597,59 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private async Task PopulateWorkspaceFromDeferredProjectInfoAsync(
             CancellationToken cancellationToken)
         {
-            // NOTE: We need to check cancellationToken after each await, in case the user has
-            // already closed the solution.
-            AssertIsForeground();
-
-            var componentModel = _serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
-            var workspaceProjectContextFactory = componentModel.GetService<IWorkspaceProjectContextFactory>();
-
-            var dte = _serviceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
-            var solutionConfig = (EnvDTE80.SolutionConfiguration2)dte?.Solution?.SolutionBuild?.ActiveConfiguration;
-
-            OutputToOutputWindow($"Getting project information - start");
             var start = DateTimeOffset.UtcNow;
+            OutputToOutputWindow($"Getting project information - start");
 
-            var projectInfos = SpecializedCollections.EmptyReadOnlyDictionary<string, DeferredProjectInformation>();
-
-            // Note that `solutionConfig` may be null. For example: if the solution doesn't actually
-            // contain any projects.
-            if (solutionConfig?.Name != null && solutionConfig?.PlatformName != null)
+            try
             {
-                // Capture the context so that we come back on the UI thread, and do the actual project creation there.
-                var deferredProjectWorkspaceService = _workspaceServices.GetService<IDeferredProjectWorkspaceService>();
-                projectInfos = await deferredProjectWorkspaceService.GetDeferredProjectInfoForConfigurationAsync(
-                    $"{solutionConfig.Name}|{solutionConfig.PlatformName}",
-                    cancellationToken).ConfigureAwait(true);
-            }
+                // NOTE: We need to check cancellationToken after each await, in case the user has
+                // already closed the solution.
+                AssertIsForeground();
 
-            AssertIsForeground();
-            cancellationToken.ThrowIfCancellationRequested();
-            OutputToOutputWindow($"Getting project information - done (took {DateTimeOffset.UtcNow - start})");
+                var componentModel = _serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
+                var workspaceProjectContextFactory = componentModel.GetService<IWorkspaceProjectContextFactory>();
 
-            OutputToOutputWindow($"Creating projects - start");
-            start = DateTimeOffset.UtcNow;
-            var targetPathsToProjectPaths = BuildTargetPathMap(projectInfos);
-            var analyzerAssemblyLoader = _workspaceServices.GetRequiredService<IAnalyzerService>().GetLoader();
-            foreach (var projectFilename in projectInfos.Keys)
-            {
+                var dte = _serviceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
+                var solutionConfig = (EnvDTE80.SolutionConfiguration2)dte?.Solution?.SolutionBuild?.ActiveConfiguration;
+
+
+                var projectInfos = SpecializedCollections.EmptyReadOnlyDictionary<string, DeferredProjectInformation>();
+
+                // Note that `solutionConfig` may be null. For example: if the solution doesn't actually
+                // contain any projects.
+                if (solutionConfig?.Name != null && solutionConfig?.PlatformName != null)
+                {
+                    // Capture the context so that we come back on the UI thread, and do the actual project creation there.
+                    var deferredProjectWorkspaceService = _workspaceServices.GetService<IDeferredProjectWorkspaceService>();
+                    projectInfos = await deferredProjectWorkspaceService.GetDeferredProjectInfoForConfigurationAsync(
+                        $"{solutionConfig.Name}|{solutionConfig.PlatformName}",
+                        cancellationToken).ConfigureAwait(true);
+                }
+
+                AssertIsForeground();
                 cancellationToken.ThrowIfCancellationRequested();
-                GetOrCreateProjectFromArgumentsAndReferences(
-                    workspaceProjectContextFactory,
-                    analyzerAssemblyLoader,
-                    projectFilename,
-                    projectInfos,
-                    targetPathsToProjectPaths);
+                OutputToOutputWindow($"Getting project information - done (took {DateTimeOffset.UtcNow - start})");
+
+                OutputToOutputWindow($"Creating projects - start");
+                start = DateTimeOffset.UtcNow;
+                var targetPathsToProjectPaths = BuildTargetPathMap(projectInfos);
+                var analyzerAssemblyLoader = _workspaceServices.GetRequiredService<IAnalyzerService>().GetLoader();
+                foreach (var projectFilename in projectInfos.Keys)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    GetOrCreateProjectFromArgumentsAndReferences(
+                        workspaceProjectContextFactory,
+                        analyzerAssemblyLoader,
+                        projectFilename,
+                        projectInfos,
+                        targetPathsToProjectPaths);
+                }
+                OutputToOutputWindow($"Creating projects - done (took {DateTimeOffset.UtcNow - start})");
             }
-            OutputToOutputWindow($"Creating projects - done (took {DateTimeOffset.UtcNow - start})");
+            catch (Exception ex) when (FatalError.ReportUnlessCanceled(ex))
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
 
             OutputToOutputWindow($"Pushing to workspace - start");
             start = DateTimeOffset.UtcNow;


### PR DESCRIPTION
Fix internal bug 397704 - A NullReferenceException reported by Watson.

Unfortunately, it's an async method, so I can't tell what's null.  Protect against a couple of things that maybe could be null, and add an exception filter to get better crash dumps if it's not one of them.

<details>
**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
</details>