### PR TITLE
Don't pass duplicate files/references to Roslyn projects

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -762,14 +762,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             project = (AbstractProject)projectContext;
             projectContext.SetOptions(projectInfo.CommandLineArguments.Join(" "));
 
+            var addedSourceFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var sourceFile in commandLineArguments.SourceFiles)
             {
-                projectContext.AddSourceFile(sourceFile.Path);
+                if (addedSourceFilePaths.Add(sourceFile.Path))
+                {
+                    projectContext.AddSourceFile(sourceFile.Path);
+                }
             }
 
-            foreach (var sourceFile in commandLineArguments.AdditionalFiles)
+            var addedAdditionalFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var additionalFile in commandLineArguments.AdditionalFiles)
             {
-                projectContext.AddAdditionalFile(sourceFile.Path);
+                if (addedAdditionalFilePaths.Add(additionalFile.Path))
+                {
+                    projectContext.AddAdditionalFile(additionalFile.Path);
+                }
             }
 
             var metadataReferences = commandLineArguments.ResolveMetadataReferences(project.CurrentCompilationOptions.MetadataReferenceResolver).AsImmutable();
@@ -817,6 +825,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
+            var addedReferencePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var reference in metadataReferences)
             {
                 var path = GetReferencePath(reference);
@@ -827,9 +836,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     continue;
                 }
 
-                projectContext.AddMetadataReference(path, reference.Properties);
+                if (addedReferencePaths.Add(path))
+                {
+                    projectContext.AddMetadataReference(path, reference.Properties);
+                }
             }
 
+            var addedAnalyzerPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var reference in commandLineArguments.ResolveAnalyzerReferences(analyzerAssemblyLoader))
             {
                 var path = reference.FullPath;
@@ -840,7 +853,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         path);
                 }
 
-                projectContext.AddAnalyzerReference(path);
+                if (addedAnalyzerPaths.Add(path))
+                {
+                    projectContext.AddAnalyzerReference(path);
+                }
             }
 
             return (AbstractProject)projectContext;


### PR DESCRIPTION
**Customer scenario**

Having a project that specifies the same source file/reference/analyzer/additional file multiple times (or different things that resolve to the same thing), and opening that project with Lightweight solution load enabled crashes

**Bugs this fixes:**

Fixes #19405 

**Workarounds, if any**

Disable Lightweight solution load.  While possible, it may be hard to discover the link.

**Risk**

Low - limited to lightweight solution load code path, and simple HashSet checks.

**Performance impact**

Low - a few local HashSet objects and lookups for elements of a project.

**Is this a regression from a previous update?**

No - Lightweight solution load has always had this issue.

**Root cause analysis:**

The native project system already filters these out, but CPS and the DPL codepath didn't.

**How was the bug found?**

Internal partner reported against CPS, but we realized the same issue applies to DPL.
