### PR TITLE
Avoid re-verifying semantics of nodes that cannot influence each other

### DIFF
--- a/src/Features/CSharp/Portable/UseDefaultLiteral/CSharpUseDefaultLiteralCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseDefaultLiteral/CSharpUseDefaultLiteralCodeFixProvider.cs
@@ -51,6 +51,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDefaultLiteral
             var originalNodes = diagnostics.SelectAsArray(
                 d => (DefaultExpressionSyntax)originalRoot.FindNode(d.Location.SourceSpan, getInnermostNodeForTie: true));
 
+            // This code fix will not make changes that affect the semantics of a statement or declaration. Therefore,
+            // we can skip the expensive verification step in cases where only one default expression appears within the
+            // group.
+            var nodesBySemanticBoundary = originalNodes.GroupBy(node => GetSemanticBoundary(node));
+            var nodesToVerify = nodesBySemanticBoundary.Where(group => group.Skip(1).Any()).Flatten().ToSet();
+
             // We're going to be continually editing this tree.  Track all the nodes we
             // care about so we can find them across each edit.
             document = document.WithSyntaxRoot(originalRoot.TrackNodes(originalNodes));
@@ -60,8 +66,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDefaultLiteral
             foreach (var originalDefaultExpression in originalNodes)
             {
                 var defaultExpression = currentRoot.GetCurrentNode(originalDefaultExpression);
+                var skipVerification = !nodesToVerify.Contains(originalDefaultExpression);
 
-                if (defaultExpression.CanReplaceWithDefaultLiteral(parseOptions, options, semanticModel, cancellationToken))
+                if (skipVerification || defaultExpression.CanReplaceWithDefaultLiteral(parseOptions, options, semanticModel, cancellationToken))
                 {
                     var replacement = SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression)
                                                    .WithTriviaFrom(defaultExpression);
@@ -74,6 +81,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDefaultLiteral
             }
 
             editor.ReplaceNode(originalRoot, currentRoot);
+        }
+
+        private static SyntaxNode GetSemanticBoundary(DefaultExpressionSyntax node)
+        {
+            // Notes:
+            // 1. Syntax which doesn't fall into one of the "safe buckets" will get placed into a single group keyed off
+            //    the root of the tree. If more than one such node exists in the document, all will be verified.
+            // 2. Cannot include ArgumentSyntax because it could affect generic argument inference.
+            return node.FirstAncestorOrSelf<SyntaxNode>(n =>
+                n is StatementSyntax
+                || n is ParameterSyntax
+                || n is VariableDeclaratorSyntax
+                || n.Parent == null);
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction


### PR DESCRIPTION
I verified that the applied results on Roslyn.sln are identical before and after this change.

Time to fix all "Use default expression" in Roslyn.sln:

| Implementation | Time to open preview | Time to apply changes |
| --- | --- | --- |
| master branch (05480ee495766eaa198ec3d207867fad5adcc655) | 2:18 min | 2:52 min |
| This branch | 1:35 min | 2:43 min |

:bulb: I filed #19900 to address the time to apply changes.

## Ask Mode

**Customer scenario**

Apply the new **Use Default Literal** code fix to a codebase containing a large number of default expressions.

**Bugs this fixes:**

Closes #19817.

**Workarounds, if any**

Wait longer.

**Risk**

This is much lower risk than a implementation of #19817 as originally described would be, for both correctness and maintainability. This optimization leverages the following language aspects:

1. It assumes that the analyzer only reports diagnostics for cases where a conversion from `default(T)`&rarr;`default` *in isolation* would not change the inferred type of the expression.
2. It assumes that all inference operations (type inference, overload resolution) cannot impact each other across certain boundaries, specifically the following:
    * Parameters
    * Statements
    * Variable declarators
    * Files

**Performance impact**

This change substantially improves performance of code helping users migrate to a specific new feature of C# 7.1.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

We were aware of the performance limitations and originally opted for the safest path forward. Follow-up investigation revealed an area of low-hanging fruit with relatively low risk.

**How was the bug found?**

Internal dogfooding.