### PR TITLE
Add VB LanguageVersion 15.6

### DIFF
--- a/docs/compilers/Visual Basic/CommandLine.md
+++ b/docs/compilers/Visual Basic/CommandLine.md
@@ -52,7 +52,7 @@
 | **LANGUAGE**
 | `/define:`*symbol_list* | Declare global conditional compilation symbol(s). *symbol_list* is *name*`=`*value*`,`...  (Short form: `/d`)
 | `/imports:`*import_list* | Declare global Imports for namespaces in referenced metadata files. *import_list* is *namespace*`,`...
-| `/langversion:`*number* | Specify language version: `9`&#124;`9.0`&#124;`10`&#124;`10.0`&#124;`11`&#124;`11.0`&#124;`12`&#124;`12.0`&#124;`13`&#124;`13.0`&#124;`14`&#124;`14.0`&#124;`15`&#124;`15.0`&#124;`15.3`. The default is `15` and the latest is `15.3`.
+| `/langversion:`*number* | Specify language version: `9`&#124;`9.0`&#124;`10`&#124;`10.0`&#124;`11`&#124;`11.0`&#124;`12`&#124;`12.0`&#124;`13`&#124;`13.0`&#124;`14`&#124;`14.0`&#124;`15`&#124;`15.0`&#124;`15.3`&#124;`15.6`. The default is `15` and the latest is `15.6`.
 | `/optionexplicit`{`+`&#124;`-`} | Require explicit declaration of variables.
 | `/optioninfer`{`+`&#124;`-`} | Allow type inference of variables.
 | `/rootnamespace`:*string* | Specifies the root Namespace for all top-level type declarations.

--- a/src/Compilers/VisualBasic/Portable/LanguageVersion.vb
+++ b/src/Compilers/VisualBasic/Portable/LanguageVersion.vb
@@ -16,6 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         VisualBasic14 = 14
         VisualBasic15 = 15
         VisualBasic15_3 = 1503
+        VisualBasic15_6 = 1506
         Latest = Integer.MaxValue
     End Enum
 
@@ -30,7 +31,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     LanguageVersion.VisualBasic12,
                     LanguageVersion.VisualBasic14,
                     LanguageVersion.VisualBasic15,
-                    LanguageVersion.VisualBasic15_3
+                    LanguageVersion.VisualBasic15_3,
+                    LanguageVersion.VisualBasic15_6
 
                     Return True
             End Select
@@ -56,6 +58,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return "15.0"
                 Case LanguageVersion.VisualBasic15_3
                     Return "15.3"
+                Case LanguageVersion.VisualBasic15_6
+                    Return "15.6"
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(value)
             End Select
@@ -72,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function MapSpecifiedToEffectiveVersion(version As LanguageVersion) As LanguageVersion
             Select Case version
                 Case LanguageVersion.Latest
-                    Return LanguageVersion.VisualBasic15_3
+                    Return LanguageVersion.VisualBasic15_6
                 Case LanguageVersion.Default
                     Return LanguageVersion.VisualBasic15
                 Case Else
@@ -101,6 +105,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return "15"
                 Case LanguageVersion.VisualBasic15_3
                     Return "15.3"
+                Case LanguageVersion.VisualBasic15_6
+                    Return "15.6"
                 Case LanguageVersion.Default
                     Return "default"
                 Case LanguageVersion.Latest
@@ -135,6 +141,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     result = LanguageVersion.VisualBasic15
                 Case "15.3"
                     result = LanguageVersion.VisualBasic15_3
+                Case "15.6"
+                    result = LanguageVersion.VisualBasic15_6
                 Case "default"
                     result = LanguageVersion.Default
                 Case "latest"

--- a/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
+++ b/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
@@ -5,7 +5,7 @@ Imports System.Collections.Immutable
 Namespace Microsoft.CodeAnalysis.VisualBasic
     Public Module PredefinedPreprocessorSymbols
 
-        Friend Const CurrentVersionNumber = 15.6
+        Friend ReadOnly CurrentVersionNumber As Double = Double.Parse(LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().GetErrorName())
 
         ''' <summary>
         ''' Adds predefined preprocessor symbols VBC_VER and TARGET to given list of preprocessor symbols if not included yet.

--- a/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
+++ b/src/Compilers/VisualBasic/Portable/PredefinedPreprocessorSymbols.vb
@@ -1,14 +1,11 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
     Public Module PredefinedPreprocessorSymbols
 
-        Friend Const CurrentVersionNumber = 15.3
+        Friend Const CurrentVersionNumber = 15.6
 
         ''' <summary>
         ''' Adds predefined preprocessor symbols VBC_VER and TARGET to given list of preprocessor symbols if not included yet.

--- a/src/Compilers/VisualBasic/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/VisualBasic/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic15_3 = 1503 -> Microsoft.CodeAnalysis.VisualBasic.LanguageVersion
+Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic15_6 = 1506 -> Microsoft.CodeAnalysis.VisualBasic.LanguageVersion
 Microsoft.CodeAnalysis.VisualBasic.LanguageVersionFacts
 Microsoft.CodeAnalysis.VisualBasic.LanguageVersionFacts.MapSpecifiedToEffectiveVersion(version As Microsoft.CodeAnalysis.VisualBasic.LanguageVersion) -> Microsoft.CodeAnalysis.VisualBasic.LanguageVersion
 Microsoft.CodeAnalysis.VisualBasic.LanguageVersionFacts.ToDisplayString(version As Microsoft.CodeAnalysis.VisualBasic.LanguageVersion) -> String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5132,7 +5132,7 @@
                                   import_list:namespace,...
 /langversion:&lt;number&gt;             Specify language version: 
                                   9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|default|latest
+                                  15.0|15.3|15.6|default|latest
 /optionexplicit[+|-]              Require explicit declaration of variables.
 /optioninfer[+|-]                 Allow type inference of variables.
 /rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1615,7 +1615,7 @@ End Module").Path
             Assert.Equal(False, parsedArgs.CompilationOptions.OptionInfer)
         End Sub
 
-        Private Const s_VBC_VER As Double = PredefinedPreprocessorSymbols.CurrentVersionNumber
+        Private ReadOnly s_VBC_VER As Double = PredefinedPreprocessorSymbols.CurrentVersionNumber
 
         <Fact>
         Public Sub LanguageVersionAdded_Canary()
@@ -1625,7 +1625,6 @@ End Module").Path
             ' - update the IDE drop-down for selecting Language Version (not yet supported in VB)
             ' - update all the tests that call this canary
             ' - update the command-line documentation (CommandLine.md)
-            ' - update the current version number (<see cref="PredefinedPreprocessorSymbols.CurrentVersionNumber"/>)
             AssertEx.SetEqual({"default", "9", "10", "11", "12", "14", "15", "15.3", "15.6", "latest"},
                 System.Enum.GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString()))
             ' For minor versions, the format should be "x.y", such as "15.3"

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1097,6 +1097,10 @@ End Module").Path
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.VisualBasic15_3, parsedArgs.ParseOptions.LanguageVersion)
 
+            parsedArgs = DefaultParse({"/langVERSION:15.6", "a.vb"}, _baseDirectory)
+            parsedArgs.Errors.Verify()
+            Assert.Equal(LanguageVersion.VisualBasic15_6, parsedArgs.ParseOptions.LanguageVersion)
+
             ' The canary check is a reminder that this test needs to be updated when a language version is added
             LanguageVersionAdded_Canary()
 
@@ -1108,7 +1112,7 @@ End Module").Path
             parsedArgs = DefaultParse({"/langVERSION:latest", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
             Assert.Equal(LanguageVersion.Latest, parsedArgs.ParseOptions.SpecifiedLanguageVersion)
-            Assert.Equal(LanguageVersion.VisualBasic15_3, parsedArgs.ParseOptions.LanguageVersion)
+            Assert.Equal(LanguageVersion.VisualBasic15_6, parsedArgs.ParseOptions.LanguageVersion)
 
             ' default: "current version"
             parsedArgs = DefaultParse({"a.vb"}, _baseDirectory)
@@ -1617,12 +1621,12 @@ End Module").Path
         Public Sub LanguageVersionAdded_Canary()
             ' When a new version is added, this test will break. This list must be checked:
             ' - update the command-line error for bad /langver flag (<see cref="ERRID.IDS_VBCHelp"/>)
-            ' - update the "UpgradeProject" codefixer
-            ' - update the IDE drop-down for selecting Language Version
-            ' - update legacy project system to pass Language Version from MSBuild to IDE (see CVbcMSBuildHostObject::SetLanguageVersion)
+            ' - update the "UpgradeProject" codefixer (not yet supported in VB)
+            ' - update the IDE drop-down for selecting Language Version (not yet supported in VB)
             ' - update all the tests that call this canary
             ' - update the command-line documentation (CommandLine.md)
-            AssertEx.SetEqual({"default", "9", "10", "11", "12", "14", "15", "15.3", "latest"},
+            ' - update the current version number (<see cref="PredefinedPreprocessorSymbols.CurrentVersionNumber"/>)
+            AssertEx.SetEqual({"default", "9", "10", "11", "12", "14", "15", "15.3", "15.6", "latest"},
                 System.Enum.GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString()))
             ' For minor versions, the format should be "x.y", such as "15.3"
         End Sub
@@ -1641,7 +1645,8 @@ End Module").Path
                 "12.0",
                 "14.0",
                 "15.0",
-                "15.3"
+                "15.3",
+                "15.6"
              }
 
             AssertEx.SetEqual(versions, errorCodes)
@@ -1661,7 +1666,8 @@ End Module").Path
             Assert.Equal(LanguageVersion.VisualBasic15, LanguageVersion.Default.MapSpecifiedToEffectiveVersion())
 
             Assert.Equal(LanguageVersion.VisualBasic15_3, LanguageVersion.VisualBasic15_3.MapSpecifiedToEffectiveVersion())
-            Assert.Equal(LanguageVersion.VisualBasic15_3, LanguageVersion.Latest.MapSpecifiedToEffectiveVersion())
+            Assert.Equal(LanguageVersion.VisualBasic15_6, LanguageVersion.VisualBasic15_6.MapSpecifiedToEffectiveVersion())
+            Assert.Equal(LanguageVersion.VisualBasic15_6, LanguageVersion.Latest.MapSpecifiedToEffectiveVersion())
 
             ' The canary check is a reminder that this test needs to be updated when a language version is added
             LanguageVersionAdded_Canary()
@@ -1681,6 +1687,7 @@ End Module").Path
             InlineData("15", True, LanguageVersion.VisualBasic15),
             InlineData("15.0", True, LanguageVersion.VisualBasic15),
             InlineData("15.3", True, LanguageVersion.VisualBasic15_3),
+            InlineData("15.6", True, LanguageVersion.VisualBasic15_6),
             InlineData("DEFAULT", True, LanguageVersion.Default),
             InlineData("default", True, LanguageVersion.Default),
             InlineData("LATEST", True, LanguageVersion.Latest),

--- a/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/MSBuildWorkspaceTests.cs
@@ -24,6 +24,7 @@ using CS = Microsoft.CodeAnalysis.CSharp;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
 
 using static Microsoft.CodeAnalysis.UnitTests.SolutionGeneration;
+using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
@@ -597,7 +598,7 @@ class C1
                 .ReplaceFileElement(@"VisualBasicProject\VisualBasicProject.vbproj", "LangVersion", "Latest"));
 
             var project = MSBuildWorkspace.Create().OpenProjectAsync(GetSolutionFileName(@"VisualBasicProject\VisualBasicProject.vbproj")).Result;
-            Assert.Equal(VB.LanguageVersion.VisualBasic15_3, ((VB.VisualBasicParseOptions)project.ParseOptions).LanguageVersion);
+            Assert.Equal(VB.LanguageVersion.Latest.MapSpecifiedToEffectiveVersion(), ((VB.VisualBasicParseOptions)project.ParseOptions).LanguageVersion);
             Assert.Equal(VB.LanguageVersion.Latest, ((VB.VisualBasicParseOptions)project.ParseOptions).SpecifiedLanguageVersion);
         }
 


### PR DESCRIPTION
In preparation for dev15.6 work. Corresponding change for C#: https://github.com/dotnet/roslyn/issues/19846.

@dotnet/roslyn-compiler for review. Thanks