### PR TITLE
Ensure that IOperations nodes within a C# local function are part of …

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
@@ -854,16 +854,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     partial class BoundLocalFunctionStatement
     {
-        protected override OperationKind StatementKind => OperationKind.LocalFunctionStatement;
+        protected override OperationKind StatementKind => OperationKind.None;
+
+        protected override ImmutableArray<IOperation> Children => ImmutableArray.Create<IOperation>(this.Body);
 
         public override void Accept(OperationVisitor visitor)
         {
-            visitor.VisitLocalFunctionStatement(this);
+            visitor.VisitNoneOperation(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
-            return visitor.VisitLocalFunctionStatement(this, argument);
+            return visitor.VisitNoneOperation(this, argument);
         }
     }
 

--- a/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationVisitor.cs
@@ -389,11 +389,6 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             DefaultVisit(operation);
         }
-
-        public virtual void VisitLocalFunctionStatement(IOperation operation)
-        {
-            DefaultVisit(operation);
-        }
     }
 
     /// <summary>
@@ -786,11 +781,6 @@ namespace Microsoft.CodeAnalysis.Semantics
         }
 
         public virtual TResult VisitInvalidExpression(IInvalidExpression operation, TArgument argument)
-        {
-            return DefaultVisit(operation, argument);
-        }
-
-        public virtual TResult VisitLocalFunctionStatement(IOperation operation, TArgument argument)
         {
             return DefaultVisit(operation, argument);
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -804,7 +804,6 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitLabelStatement(Mi
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitLambdaExpression(Microsoft.CodeAnalysis.Semantics.ILambdaExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitLateBoundMemberReferenceExpression(Microsoft.CodeAnalysis.Semantics.ILateBoundMemberReferenceExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitLiteralExpression(Microsoft.CodeAnalysis.Semantics.ILiteralExpression operation) -> void
-virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitLocalFunctionStatement(Microsoft.CodeAnalysis.IOperation operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitLocalReferenceExpression(Microsoft.CodeAnalysis.Semantics.ILocalReferenceExpression operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitLockStatement(Microsoft.CodeAnalysis.Semantics.ILockStatement operation) -> void
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor.VisitMethodBindingExpression(Microsoft.CodeAnalysis.Semantics.IMethodBindingExpression operation) -> void
@@ -880,7 +879,6 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.Vi
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitLambdaExpression(Microsoft.CodeAnalysis.Semantics.ILambdaExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitLateBoundMemberReferenceExpression(Microsoft.CodeAnalysis.Semantics.ILateBoundMemberReferenceExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitLiteralExpression(Microsoft.CodeAnalysis.Semantics.ILiteralExpression operation, TArgument argument) -> TResult
-virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitLocalFunctionStatement(Microsoft.CodeAnalysis.IOperation operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitLocalReferenceExpression(Microsoft.CodeAnalysis.Semantics.ILocalReferenceExpression operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitLockStatement(Microsoft.CodeAnalysis.Semantics.ILockStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitMethodBindingExpression(Microsoft.CodeAnalysis.Semantics.IMethodBindingExpression operation, TArgument argument) -> TResult

--- a/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Portable/Compilation/OperationTreeVerifier.cs
@@ -1058,12 +1058,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Visit(operation.IfFalseStatement, "IfFalse");
         }
 
-        public override void VisitLocalFunctionStatement(IOperation operation)
-        {
-            LogString(nameof(VisitLocalFunctionStatement));
-            LogCommonPropertiesAndNewLine(operation);
-        }
-
         private void LogCaseClauseCommon(ICaseClause operation)
         {
             var kindStr = $"{nameof(CaseKind)}.{operation.CaseKind}";


### PR DESCRIPTION
…the operation tree

**Customer scenario**

Analysis of any code within a local function with IOperation analyzers will produce false or missing diagnostics, as the operation tree doesn't contain any operation nodes within the BoundLocalFunctionStatement. This can be a dogfood blocker for IOperation analyzers on real world code - we had few false reports due this on the Roslyn repo as we use this new language feature, and corresponding rules had to be disabled in the repo.

**Bugs this fixes:**

Workaround for https://github.com/dotnet/roslyn/issues/19902

**Workarounds, if any**

Disable or uninstall IOperation based analyzers

**Risk**

Low risk. We are following the common pattern for not yet implemented IOperation feature API for 15.3 - we don't yet provide rich IOperation API for the new language feature, but ensure that any descendant operation nodes are still included in the Operation tree.

**Performance impact**

None

**Is this a regression from a previous update?**

No, this never worked before.

**Root cause analysis:**

We missed this while adding unit tests because BoundLocalFunctionStatement actually returns OperationKind.LocalFunctionStatement, but there is no corresponding IOperation API for local functions.

**How was the bug found?**

Dogfooding.
