### PR TITLE
Pass a project when creating an invisible editor

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/FindReferences/VisualStudioDefinitionsAndReferencesFactory.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.FindReferences
         private string GetSourceLine(string filePath, int lineNumber)
         {
             using (var invisibleEditor = new InvisibleEditor(
-                _serviceProvider, filePath, needsSave: false, needsUndoDisabled: false))
+                _serviceProvider, filePath, projectOpt: null, needsSave: false, needsUndoDisabled: false))
             {
                 var vsTextLines = invisibleEditor.VsTextLines;
                 if (vsTextLines != null &&

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -28,6 +28,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private OLE.Interop.IOleUndoManager _manager;
         private readonly bool _needsUndoRestored;
 
+        /// <remarks>
+        /// <para>The optional project is used to obtain an <see cref="IVsProject"/> 1nstance. When this instance is
+        /// provided, Visual Studio will use <see cref="IVsProject.IsDocumentInProject"/> to attempt to locate the
+        /// specified file within a project. If no project is specified, Visual Studio falls back to using
+        /// <see cref="IVsUIShellOpenDocument4.IsDocumentInAProject2"/>, which performs a much slower query of all
+        /// projects in the solution.</para>
+        /// </remarks>
         public InvisibleEditor(IServiceProvider serviceProvider, string filePath, IVisualStudioHostProject projectOpt, bool needsSave, bool needsUndoDisabled)
         {
             _serviceProvider = serviceProvider;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -28,15 +28,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private OLE.Interop.IOleUndoManager _manager;
         private readonly bool _needsUndoRestored;
 
-        public InvisibleEditor(IServiceProvider serviceProvider, string filePath, bool needsSave, bool needsUndoDisabled)
+        public InvisibleEditor(IServiceProvider serviceProvider, string filePath, IVisualStudioHostProject projectOpt, bool needsSave, bool needsUndoDisabled)
         {
             _serviceProvider = serviceProvider;
             _filePath = filePath;
             _needsSave = needsSave;
 
             var invisibleEditorManager = (IIntPtrReturningVsInvisibleEditorManager)serviceProvider.GetService(typeof(SVsInvisibleEditorManager));
+            var vsProject = projectOpt?.Hierarchy as IVsProject;
             var invisibleEditorPtr = IntPtr.Zero;
-            Marshal.ThrowExceptionForHR(invisibleEditorManager.RegisterInvisibleEditor(filePath, null, 0, null, out invisibleEditorPtr));
+            Marshal.ThrowExceptionForHR(invisibleEditorManager.RegisterInvisibleEditor(filePath, vsProject, 0, null, out invisibleEditorPtr));
 
             try
             {

--- a/src/VisualStudio/Core/Impl/CodeModel/TextManagerAdapter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/TextManagerAdapter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 return null;
             }
 
-            using (var invisibleEditor = new InvisibleEditor(fileCodeModel.ServiceProvider, hostDocument.FilePath, needsSave: false, needsUndoDisabled: false))
+            using (var invisibleEditor = new InvisibleEditor(fileCodeModel.ServiceProvider, hostDocument.FilePath, hostDocument.Project, needsSave: false, needsUndoDisabled: false))
             {
                 var vsTextLines = invisibleEditor.VsTextLines;
 

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.LanguageServices
                 }
             }
 
-            return new InvisibleEditor(DeferredState.ServiceProvider, hostDocument.FilePath, needsSave, needsUndoDisabled);
+            return new InvisibleEditor(DeferredState.ServiceProvider, hostDocument.FilePath, hostDocument.Project, needsSave, needsUndoDisabled);
         }
 
         private static bool TryResolveSymbol(ISymbol symbol, Project project, CancellationToken cancellationToken, out ISymbol resolvedSymbol, out Project resolvedProject)


### PR DESCRIPTION
This change substantially reduces the amount of work required to locate a document within the solution (file path to hierarchy+itemid).

* Time to apply Fix All from #19895: 2:45 mins
* Time to apply Fix All after this change: 1:32 mins

## Ask Mode

**Customer scenario**

A customer applies a Fix All operation which affects many files in a large solution. (Not specific to any particular code fix.)

**Bugs this fixes:**

Derived from #19900 as the safe option for 15.3 (provides some but not all possible benefits).

**Workarounds, if any**

Wait longer.

**Risk**

Low. This feature adds a hint for a lookup, but valid information is not required in order for the underlying operation to succeed (falls back to slow case when information is not available).

**Performance impact**

This is a substantial performance improvement for Fix All operations.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

No performance tests covering large-scale operations (yet).

**How was the bug found?**

Internal testing.