### PR TITLE
Avoid adding additional files that are duplicates of sources

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -762,19 +762,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             project = (AbstractProject)projectContext;
             projectContext.SetOptions(projectInfo.CommandLineArguments.Join(" "));
 
-            var addedSourceFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var addedSourceOrAdditionalFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var sourceFile in commandLineArguments.SourceFiles)
             {
-                if (addedSourceFilePaths.Add(sourceFile.Path))
+                if (addedSourceOrAdditionalFilePaths.Add(sourceFile.Path))
                 {
                     projectContext.AddSourceFile(sourceFile.Path);
                 }
             }
 
-            var addedAdditionalFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var additionalFile in commandLineArguments.AdditionalFiles)
             {
-                if (addedAdditionalFilePaths.Add(additionalFile.Path))
+                if (addedSourceOrAdditionalFilePaths.Add(additionalFile.Path))
                 {
                     projectContext.AddAdditionalFile(additionalFile.Path);
                 }


### PR DESCRIPTION
We end up putting them in the same dictionary.

Small follow-up to https://github.com/dotnet/roslyn/pull/19889.  @davkean mentioned that we need to avoid source files and additional files that overlap, not just within each category.

Tagging @MattGertz for approval.