### PR TITLE
Fix code generation for duplicate events

### DIFF
--- a/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/TestHelpers.vb
@@ -55,7 +55,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
             End Using
         End Function
 
-        Public Async Function AssertGeneratedResultIsAsync(workspaceElement As XElement, leftItemToSelectText As String, rightItemToSelectText As String, expectedText As XElement) As Tasks.Task
+        Public Function AssertGeneratedResultIsAsync(workspaceElement As XElement, leftItemToSelectText As String, rightItemToSelectText As String, expectedText As XElement) As Tasks.Task
+            Dim selectRightItem As Func(Of IList(Of NavigationBarItem), NavigationBarItem)
+            selectRightItem = Function(items) items.Single(Function(i) i.Text = rightItemToSelectText)
+            Return AssertGeneratedResultIsAsync(workspaceElement, leftItemToSelectText, selectRightItem, expectedText)
+        End Function
+
+        Public Async Function AssertGeneratedResultIsAsync(workspaceElement As XElement, leftItemToSelectText As String, selectRightItem As Func(Of IList(Of NavigationBarItem), NavigationBarItem), expectedText As XElement) As Tasks.Task
             Using workspace = TestWorkspace.Create(workspaceElement)
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim snapshot = (Await document.GetTextAsync()).FindCorrespondingEditorTextSnapshot()
@@ -66,7 +72,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigationBar
                 items.Do(Sub(i) i.InitializeTrackingSpans(snapshot))
 
                 Dim leftItem = items.Single(Function(i) i.Text = leftItemToSelectText)
-                Dim rightItem = leftItem.ChildItems.Single(Function(i) i.Text = rightItemToSelectText)
+                Dim rightItem = selectRightItem(leftItem.ChildItems)
 
                 Dim contextLocation = (Await document.GetSyntaxTreeAsync()).GetLocation(New TextSpan(0, 0))
                 Dim generateCodeItem = DirectCast(rightItem, AbstractGenerateCodeItem)

--- a/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
+++ b/src/EditorFeatures/Test2/NavigationBar/VisualBasicNavigationBarTests.vb
@@ -749,6 +749,35 @@ End Class
                 </Result>)
         End Function
 
+        <WpfFact>
+        <WorkItem(18792, "https://github.com/dotnet/roslyn/issues/18792")>
+        <Trait(Traits.Feature, Traits.Features.NavigationBar)>
+        Public Async Function TestGenerateEventHandlerWithDuplicate() As Task
+            Await AssertGeneratedResultIsAsync(
+                <Workspace>
+                    <Project Language="Visual Basic" CommonReferences="true">
+                        <Document>
+Public Class ExampleClass
+    Public Event ExampleEvent()
+    Public Event ExampleEvent()
+End Class
+                        </Document>
+                    </Project>
+                </Workspace>,
+                "(ExampleClass Events)",
+                Function(items) items.First(Function(i) i.Text = "ExampleEvent"),
+                <Result>
+Public Class ExampleClass
+    Public Event ExampleEvent()
+    Public Event ExampleEvent()
+
+    Private Sub ExampleClass_ExampleEvent() Handles Me.ExampleEvent
+
+    End Sub
+End Class
+                </Result>)
+        End Function
+
         <Fact, Trait(Traits.Feature, Traits.Features.NavigationBar)>
         Public Async Function TestNoListedEventToGenerateWithInvalidTypeName() As Task
             Await AssertItemsAreAsync(

--- a/src/EditorFeatures/VisualBasic/NavigationBar/AbstractGenerateCodeItem.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/AbstractGenerateCodeItem.vb
@@ -32,6 +32,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
             Dim codeGenerationOptions As New CodeGenerationOptions(contextLocation, generateMethodBodies:=True)
 
             Dim newDocument = Await GetGeneratedDocumentCoreAsync(document, codeGenerationOptions, cancellationToken).ConfigureAwait(False)
+            If newDocument Is Nothing Then
+                Return document
+            End If
 
             newDocument = Simplifier.ReduceAsync(newDocument, Simplifier.Annotation, Nothing, cancellationToken).WaitAndGetResult(cancellationToken)
 

--- a/src/EditorFeatures/VisualBasic/NavigationBar/GenerateEventHandlerItem.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/GenerateEventHandlerItem.vb
@@ -25,8 +25,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
 
         Protected Overrides Async Function GetGeneratedDocumentCoreAsync(document As Document, codeGenerationOptions As CodeGenerationOptions, cancellationToken As CancellationToken) As Task(Of Document)
             Dim compilation = Await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(False)
-            Dim eventSymbol = TryCast(_eventSymbolKey.Resolve(compilation).Symbol, IEventSymbol)
-            Dim destinationType = TryCast(_destinationTypeSymbolKey.Resolve(compilation).Symbol, INamedTypeSymbol)
+            Dim eventSymbol = TryCast(_eventSymbolKey.Resolve(compilation).GetAnySymbol(), IEventSymbol)
+            Dim destinationType = TryCast(_destinationTypeSymbolKey.Resolve(compilation).GetAnySymbol(), INamedTypeSymbol)
 
             If eventSymbol Is Nothing OrElse destinationType Is Nothing Then
                 Return Nothing


### PR DESCRIPTION
@dotnet/roslyn-ide for review

## Ask Mode

**Customer scenario**

A developer declares multiple events in a VB class, and then attempts to generate code for one of them via the Type and Member Dropdown bars. Visual Studio crashes.

**Bugs this fixes:**

Fixes #18792

**Workarounds, if any**

Remove the duplicate event before generating code.

**Risk**

Minimal. This code implements a direct correction for the known issue as well as a "safety net" which avoids related crashes (should cases exist) by silently avoiding the code generation step.

**Performance impact**

This change should not impact performance.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Failed to unit test features with invalid code.

**How was the bug found?**

Customer feedback
