### PR TITLE
Fix Extract Method operations within an event accessor

### DIFF
--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.StatementResult.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpSelectionResult.StatementResult.cs
@@ -71,13 +71,23 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 switch (node)
                 {
                     case AccessorDeclarationSyntax access:
-                        // property case
+                        // property or event case
                         if (access.Parent == null || access.Parent.Parent == null)
                         {
                             return null;
                         }
 
-                        return ((IPropertySymbol)semanticModel.GetDeclaredSymbol(access.Parent.Parent)).Type;
+                        switch (semanticModel.GetDeclaredSymbol(access.Parent.Parent))
+                        {
+                            case IPropertySymbol propertySymbol:
+                                return propertySymbol.Type;
+
+                            case IEventSymbol eventSymbol:
+                                return eventSymbol.Type;
+
+                            default:
+                                return null;
+                        }
 
                     case MethodDeclarationSyntax method:
                         return semanticModel.GetDeclaredSymbol(method).ReturnType;

--- a/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
+++ b/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
@@ -73,6 +73,13 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 {
                     key = new Key(dataFlowIn, /*dataFlowOut*/ true, alwaysAssigned, variableDeclared, readInside, writtenInside, readOutside, writtenOutside);
                 }
+
+                // interesting case in invalid code (bug #19136)
+                // variable is passed by reference, and another argument is an out variable with the same name
+                if (dataFlowIn && variableDeclared)
+                {
+                    key = new Key(/*dataFlowIn:*/ false, dataFlowOut, alwaysAssigned, variableDeclared, readInside, writtenInside, readOutside, writtenOutside);
+                }
             }
 
             Contract.ThrowIfFalse(s_matrix.ContainsKey(key));


### PR DESCRIPTION
Fixes #17474
Closes #19136

## Ask Mode

**Customer scenario**

Uses the light bulb while a selection is present in certain code. A non-fatal exception occurs in the Extract Method refactoring and the gold bar appears.

**Bugs this fixes:**

Fixes #17474
Closes #19136 (the behavior is sub-optimal, but a proper solution can wait for #19958) 

**Workarounds, if any**

None

**Risk**

Low. The changed code paths only affect the failing scenario.

**Performance impact**

This change should not have any impact on performance.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

* Failure to test all code constructs
* Failure to account for erroneous code in testing

**How was the bug found?**

Internal customer report
