### PR TITLE
Switch to InteractiveWindow 2.3.0 release

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -78,7 +78,7 @@
     <MicrosoftVisualStudioImageCatalogVersion>15.0.26507-alpha</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioImagingVersion>15.0.26507-alpha</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>14.3.25407</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
-    <MicrosoftVisualStudioInteractiveWindowVersion>2.0.0-rc3-61304-01</MicrosoftVisualStudioInteractiveWindowVersion>
+    <MicrosoftVisualStudioInteractiveWindowVersion>2.3.0</MicrosoftVisualStudioInteractiveWindowVersion>
     <MicrosoftVisualStudioLanguageCallHierarchyVersion>15.0.26507-alpha</MicrosoftVisualStudioLanguageCallHierarchyVersion>
     <MicrosoftVisualStudioLanguageIntellisenseVersion>15.0.26507-alpha</MicrosoftVisualStudioLanguageIntellisenseVersion>
     <MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>15.0.26507-alpha</MicrosoftVisualStudioLanguageNavigateToInterfacesVersion>


### PR DESCRIPTION
Use the release package. Roslyn uses this package only for building as a reference assembly. The Interactive Window VSIX is inserted directly to VS.