### PR TITLE
Skip projects with failed design time builds when populating Roslyn for or DPL

### DIFF
--- a/src/VisualStudio/Core/Next/ProjectSystem/DeferredProjectWorkspaceService.cs
+++ b/src/VisualStudio/Core/Next/ProjectSystem/DeferredProjectWorkspaceService.cs
@@ -37,14 +37,22 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
 
             // NOTE: Anycode gives us the project references as if they were command line arguments with
             // "/ProjectReference:" prepended.  Strip that off here.
-            var result = ImmutableDictionary.CreateRange(
-                commandLineInfos.Select(kvp => KeyValuePair.Create(
-                    kvp.Key,
-                    new DeferredProjectInformation(
-                        kvp.Value.TargetPath,
-                        kvp.Value.CommandLineArgs,
-                        kvp.Value.ProjectReferences.Select(p => p.Substring("/ProjectReference:".Length)).ToImmutableArray()))));
-            return result;
+            var builder = ImmutableDictionary.CreateBuilder<string, DeferredProjectInformation>();
+            foreach (var (path, cli) in commandLineInfos)
+            {
+                if (string.IsNullOrEmpty(cli.TargetPath) ||
+                    cli.CommandLineArgs.IsDefault)
+                {
+                    continue;
+                }
+
+                builder.Add(path, new DeferredProjectInformation(
+                    cli.TargetPath,
+                    cli.CommandLineArgs,
+                    cli.ProjectReferences.Select(p => p.Substring("/ProjectReference:".Length)).ToImmutableArray()));
+            }
+
+            return builder.ToImmutableDictionary();
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

A customer with Lightweight solution load enabled opens a solution containing a project where anycode's design time build fails (including any project where the targeting pack isn't installed, or a .NET Core project that targets multiple frameworks). 

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/432432

**Workarounds, if any**

Disable DPL.  It might be hard to know what triggered this crash

**Risk**

Low - we just check for invalid project information and skip it.  This restores previous behavior, because `GetManagedCommandLineInfoAsync()` didn't use to return these projects.

**Performance impact**

Low - just adding null checks before passing data along.

**Is this a regression from a previous update?**

Yes - the platform deliberately started passing these through so that we can trigger a full load in these cases, but that change is still pending and not in Preview 2.  (See https://github.com/dotnet/roslyn/pull/19606).

**Root cause analysis:**

Planned change that wasn't complete.

**How was the bug found?**

Internal test cases, and a couple of ad-hoc testing results.
