### PR TITLE
 Refout should emit properties and events that are explicitly implemented

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/EventSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/EventSymbolAdapter.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.Cci;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.Emit;
 
@@ -12,18 +13,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         #region IEventDefinition Members
 
-        IEnumerable<Cci.IMethodReference> Cci.IEventDefinition.Accessors
+        IEnumerable<Cci.IMethodReference> Cci.IEventDefinition.GetAccessors(EmitContext context)
         {
-            get
+            CheckDefinitionInvariant();
+
+            var addMethod = this.AddMethod;
+            Debug.Assert((object)addMethod != null);
+            if (addMethod.ShouldInclude(context))
             {
-                CheckDefinitionInvariant();
-
-                var addMethod = this.AddMethod;
-                Debug.Assert((object)addMethod != null);
                 yield return addMethod;
+            }
 
-                var removeMethod = this.RemoveMethod;
-                Debug.Assert((object)removeMethod != null);
+            var removeMethod = this.RemoveMethod;
+            Debug.Assert((object)removeMethod != null);
+            if (removeMethod.ShouldInclude(context))
+            {
                 yield return removeMethod;
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -290,9 +290,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         IEnumerable<Cci.IEventDefinition> Cci.ITypeDefinition.GetEvents(EmitContext context)
         {
             CheckDefinitionInvariant();
-            foreach (var e in GetEventsToEmit())
+            foreach (IEventDefinition e in GetEventsToEmit())
             {
-                if (e.ShouldInclude(context))
+                // If any accessor should be included, then the event should be included too
+                if (e.ShouldInclude(context) || !e.GetAccessors(context).IsEmpty())
                 {
                     yield return e;
                 }
@@ -719,10 +720,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             CheckDefinitionInvariant();
 
-            foreach (var property in this.GetPropertiesToEmit())
+            foreach (IPropertyDefinition property in this.GetPropertiesToEmit())
             {
                 Debug.Assert((object)property != null);
-                if (property.ShouldInclude(context))
+                // If any accessor should be included, then the property should be included too
+                if (property.ShouldInclude(context) || !property.GetAccessors(context).IsEmpty())
                 {
                     yield return property;
                 }
@@ -732,9 +734,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (generated != null)
             {
-                foreach (var m in generated)
+                foreach (IPropertyDefinition m in generated)
                 {
-                    if (m.ShouldInclude(context))
+                    if (m.ShouldInclude(context) || !m.GetAccessors(context).IsEmpty())
                     {
                         yield return m;
                     }

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -878,6 +878,25 @@ comp => comp.VerifyDiagnostics(
         }
 
         [Fact]
+        public void RefAssemblyClient_ExplicitPropertyImplementation()
+        {
+            VerifyRefAssemblyClient(@"
+public interface I
+{
+    int P { get; set; }
+}
+public class Base : I
+{
+    int I.P { get { throw null; } set { throw null; } }
+}",
+@"
+class Derived : Base, I
+{
+}",
+comp => comp.VerifyDiagnostics());
+        }
+
+        [Fact]
         public void RefAssemblyClient_EmitAllNestedTypes()
         {
             VerifyRefAssemblyClient(@"
@@ -1630,6 +1649,205 @@ public class PublicClass
                 compWithRef.SourceModule.GetReferencedAssemblySymbols().Last().GetAttributes().Select(a => a.AttributeClass.ToTestDisplayString()));
 
             MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitRefOnly));
+        }
+
+        [Fact]
+        public void RefAssembly_VerifyTypesAndMembersOnExplicitlyImplementedProperty()
+        {
+            string source = @"
+public interface I
+{
+    int P { get; set; }
+}
+public class C : I
+{
+    int I.P
+    {
+        get { throw null; }
+        set { throw null; }
+    }
+}
+";
+            CSharpCompilation comp = CreateCompilation(source, references: new[] { MscorlibRef },
+                options: TestOptions.DebugDll.WithDeterministic(true));
+
+            // verify metadata (types, members, attributes) of the regular assembly
+            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: true);
+
+            var realImage = comp.EmitToImageReference(EmitOptions.Default);
+            var compWithReal = CreateCompilation("", references: new[] { MscorlibRef, realImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyPropertyWasEmitted(compWithReal);
+
+            // verify metadata (types, members, attributes) of the metadata-only assembly
+            var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
+            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: true);
+
+            var metadataImage = comp.EmitToImageReference(emitMetadataOnly);
+            var compWithMetadata = CreateCompilation("", references: new[] { MscorlibRef, metadataImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyPropertyWasEmitted(compWithMetadata);
+
+            MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitMetadataOnly));
+
+            // verify metadata (types, members, attributes) of the ref assembly
+            var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+
+            var refImage = comp.EmitToImageReference(emitRefOnly);
+            var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyPropertyWasEmitted(compWithRef);
+
+            MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitRefOnly));
+
+            void verifyPropertyWasEmitted(CSharpCompilation input)
+            {
+                AssertEx.Equal(
+                    new[] { "<Module>", "I", "C" },
+                    input.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
+
+                AssertEx.Equal(
+                    new[] { "System.Int32 C.I.P.get", "void C.I.P.set", "C..ctor()", "System.Int32 C.I.P { get; set; }" },
+                    input.GetMember<NamedTypeSymbol>("C").GetMembers()
+                        .Select(m => m.ToTestDisplayString()));
+            }
+        }
+
+        [Fact]
+        public void RefAssembly_VerifyTypesAndMembersOnExplicitlyImplementedEvent()
+        {
+            string source = @"
+public interface I
+{
+    event System.Action E;
+}
+public class C : I
+{
+    event System.Action I.E
+    {
+        add { throw null; }
+        remove { throw null; }
+    }
+}
+";
+            CSharpCompilation comp = CreateCompilation(source, references: new[] { MscorlibRef },
+                options: TestOptions.DebugDll.WithDeterministic(true));
+
+            // verify metadata (types, members, attributes) of the regular assembly
+            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: true);
+
+            var realImage = comp.EmitToImageReference(EmitOptions.Default);
+            var compWithReal = CreateCompilation("", references: new[] { MscorlibRef, realImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyEventWasEmitted(compWithReal);
+
+            // verify metadata (types, members, attributes) of the metadata-only assembly
+            var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
+            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: true);
+
+            var metadataImage = comp.EmitToImageReference(emitMetadataOnly);
+            var compWithMetadata = CreateCompilation("", references: new[] { MscorlibRef, metadataImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyEventWasEmitted(compWithMetadata);
+
+            MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitMetadataOnly));
+
+            // verify metadata (types, members, attributes) of the ref assembly
+            var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+
+            var refImage = comp.EmitToImageReference(emitRefOnly);
+            var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyEventWasEmitted(compWithRef);
+
+            MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitRefOnly));
+
+            void verifyEventWasEmitted(CSharpCompilation input)
+            {
+                AssertEx.Equal(
+                    new[] { "<Module>", "I", "C" },
+                    input.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
+
+                AssertEx.Equal(
+                    new[] { "void C.I.E.add", "void C.I.E.remove", "C..ctor()", "event System.Action C.I.E" },
+                    input.GetMember<NamedTypeSymbol>("C").GetMembers()
+                        .Select(m => m.ToTestDisplayString()));
+            }
+        }
+
+        [Fact]
+        public void RefAssembly_VerifyTypesAndMembersOnExplicitlyImplementedIndexer()
+        {
+            string source = @"
+public interface I
+{
+    int this[int i] { get; set; }
+}
+public class C : I
+{
+    int I.this[int i]
+    {
+        get { throw null; }
+        set { throw null; }
+    }
+}
+";
+            CSharpCompilation comp = CreateCompilation(source, references: new[] { MscorlibRef },
+                options: TestOptions.DebugDll.WithDeterministic(true));
+
+            // verify metadata (types, members, attributes) of the regular assembly
+            CompileAndVerify(comp, emitOptions: EmitOptions.Default, verify: true);
+
+            var realImage = comp.EmitToImageReference(EmitOptions.Default);
+            var compWithReal = CreateCompilation("", references: new[] { MscorlibRef, realImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyIndexerWasEmitted(compWithReal);
+
+            // verify metadata (types, members, attributes) of the metadata-only assembly
+            var emitMetadataOnly = EmitOptions.Default.WithEmitMetadataOnly(true);
+            CompileAndVerify(comp, emitOptions: emitMetadataOnly, verify: true);
+
+            var metadataImage = comp.EmitToImageReference(emitMetadataOnly);
+            var compWithMetadata = CreateCompilation("", references: new[] { MscorlibRef, metadataImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyIndexerWasEmitted(compWithMetadata);
+
+            MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitMetadataOnly));
+
+            // verify metadata (types, members, attributes) of the ref assembly
+            var emitRefOnly = EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false);
+            CompileAndVerify(comp, emitOptions: emitRefOnly, verify: true);
+
+            var refImage = comp.EmitToImageReference(emitRefOnly);
+            var compWithRef = CreateCompilation("", references: new[] { MscorlibRef, refImage },
+                options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+
+            verifyIndexerWasEmitted(compWithRef);
+
+            MetadataReaderUtils.AssertEmptyOrThrowNull(comp.EmitToArray(emitRefOnly));
+
+            void verifyIndexerWasEmitted(CSharpCompilation input)
+            {
+                AssertEx.Equal(
+                    new[] { "<Module>", "I", "C" },
+                    input.SourceModule.GetReferencedAssemblySymbols().Last().GlobalNamespace.GetMembers().Select(m => m.ToDisplayString()));
+
+                AssertEx.Equal(
+                    new[] {"System.Int32 C.I.get_Item(System.Int32 i)", "void C.I.set_Item(System.Int32 i, System.Int32 value)",
+                        "C..ctor()", "System.Int32 C.I.Item[System.Int32 i] { get; set; }" },
+                    input.GetMember<NamedTypeSymbol>("C").GetMembers()
+                        .Select(m => m.ToTestDisplayString()));
+            }
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedEvent.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedEvent.cs
@@ -102,24 +102,21 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 get { return _caller; }
             }
 
-            IEnumerable<Cci.IMethodReference> Cci.IEventDefinition.Accessors
+            IEnumerable<Cci.IMethodReference> Cci.IEventDefinition.GetAccessors(EmitContext context)
             {
-                get
+                if (_adder != null)
                 {
-                    if (_adder != null)
-                    {
-                        yield return _adder;
-                    }
+                    yield return _adder;
+                }
 
-                    if (_remover != null)
-                    {
-                        yield return _remover;
-                    }
+                if (_remover != null)
+                {
+                    yield return _remover;
+                }
 
-                    if (_caller != null)
-                    {
-                        yield return _caller;
-                    }
+                if (_caller != null)
+                {
+                    yield return _caller;
                 }
             }
 

--- a/src/Compilers/Core/Portable/PEWriter/Members.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Members.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// A list of methods that are associated with the event.
         /// </summary>
-        IEnumerable<IMethodReference> Accessors { get; }
+        IEnumerable<IMethodReference> GetAccessors(EmitContext context);
 
         /// <summary>
         /// The method used to add a handler to the event.

--- a/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Cci
 
         public virtual void Visit(IEventDefinition eventDefinition)
         {
-            this.Visit(eventDefinition.Accessors);
+            this.Visit(eventDefinition.GetAccessors(Context));
             this.Visit(eventDefinition.GetType(Context));
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -2605,7 +2605,7 @@ namespace Microsoft.Cci
             foreach (IEventDefinition eventDef in this.GetEventDefs())
             {
                 var association = GetEventDefinitionHandle(eventDef);
-                foreach (IMethodReference accessorMethod in eventDef.Accessors)
+                foreach (IMethodReference accessorMethod in eventDef.GetAccessors(Context))
                 {
                     MethodSemanticsAttributes semantics;
                     if (accessorMethod == eventDef.Adder)

--- a/src/Compilers/VisualBasic/Portable/Emit/EventSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EventSymbolAdapter.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis.Emit
 Imports Microsoft.CodeAnalysis.VisualBasic.Emit
 
@@ -8,23 +9,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Partial Class EventSymbol
         Implements Cci.IEventDefinition
 
-        Private ReadOnly Property IEventDefinitionAccessors As IEnumerable(Of Cci.IMethodReference) Implements Cci.IEventDefinition.Accessors
-            Get
-                CheckDefinitionInvariant()
-                Dim addMethod = Me.AddMethod
-                Debug.Assert(addMethod IsNot Nothing)
+        Private Iterator Function IEventDefinitionAccessors(context As EmitContext) As IEnumerable(Of Cci.IMethodReference) Implements Cci.IEventDefinition.GetAccessors
+            CheckDefinitionInvariant()
 
-                Dim removeMethod = Me.RemoveMethod
-                Debug.Assert(removeMethod IsNot Nothing)
+            Dim addMethod = Me.AddMethod
+            Debug.Assert(addMethod IsNot Nothing)
+            If addMethod.ShouldInclude(context) Then
+                Yield addMethod
+            End If
 
-                Dim raiseMethod = Me.RaiseMethod
-                If raiseMethod IsNot Nothing Then
-                    Return {addMethod, removeMethod, raiseMethod}
-                Else
-                    Return {addMethod, removeMethod}
-                End If
-            End Get
-        End Property
+            Dim removeMethod = Me.RemoveMethod
+            Debug.Assert(removeMethod IsNot Nothing)
+            If removeMethod.ShouldInclude(context) Then
+                Yield removeMethod
+            End If
+
+            Dim raiseMethod = Me.RaiseMethod
+            If raiseMethod IsNot Nothing AndAlso raiseMethod.ShouldInclude(context) Then
+                Yield raiseMethod
+            End If
+        End Function
 
         Private ReadOnly Property IEventDefinitionAdder As Cci.IMethodReference Implements Cci.IEventDefinition.Adder
             Get

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -240,8 +240,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' must be declared in the module we are building
             CheckDefinitionInvariant()
 
-            For Each e In GetEventsToEmit()
-                If e.ShouldInclude(context) Then
+            For Each e As IEventDefinition In GetEventsToEmit()
+                If e.ShouldInclude(context) OrElse Not e.GetAccessors(context).IsEmpty() Then
                     Yield e
                 End If
             Next
@@ -737,9 +737,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' must be declared in the module we are building
             CheckDefinitionInvariant()
 
-            For Each [property] In Me.GetPropertiesToEmit()
+            For Each [property] As IPropertyDefinition In Me.GetPropertiesToEmit()
                 Debug.Assert([property] IsNot Nothing)
-                If [property].ShouldInclude(context) Then
+                If [property].ShouldInclude(context) OrElse Not [property].GetAccessors(context).IsEmpty() Then
                     Yield [property]
                 End If
             Next
@@ -747,7 +747,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim syntheticProperties = DirectCast(context.Module, PEModuleBuilder).GetSynthesizedProperties(Me)
             If syntheticProperties IsNot Nothing Then
                 For Each prop In syntheticProperties
-                    If prop.ShouldInclude(context) Then
+                    If prop.ShouldInclude(context) OrElse Not prop.GetAccessors(context).IsEmpty() Then
                         Yield prop
                     End If
                 Next


### PR DESCRIPTION
@dotnet/roslyn-compiler for review. Thanks

**Customer scenario**
Explicitly implement a property or an event. Currently, the ref assembly (wrongly) drops the property/event, while it retains the accessors. 

```C#
public class C : I
{
    int I.P // should be emitted in ref assembly metadata too
    {
        get { throw null; }
        set { throw null; }
    }
}
```

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/19892 (Thanks @AlekseyTs for thinking about it)

**Workarounds, if any**
Don't use the new `/refout` feature.

**Risk**
**Performance impact**
Low. We already check which property/event accessors should be emitted. Now the property/event will be emitted too, if any of its accessors needs to be emitted.

**Is this a regression from a previous update?**
No, this is a new feature (ref assemblies).

**Root cause analysis:**
Scenario was missed in testing new feature. Tests added.

**How was the bug found?**
Aleksey