### PR TITLE
Make ILambdaExpression.Type and IUnboundLambdaExpression.Type return …

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -358,7 +358,11 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             bool isInvalid = unboundLambda.HasErrors;
             SyntaxNode syntax = unboundLambda.Syntax;
-            ITypeSymbol type = unboundLambda.Type;
+            // This matches the SemanticModel implementation. This is because in VB, anonymous lambdas, by themselves,
+            // do not have a type. To get the type of a lambda expression in the SemanticModel, you need to look at
+            // TypeInfo.ConvertedType, rather than TypeInfo.Type. We replicate that behavior here. To get the type of
+            // an IUnboundLambdaExpression, you need to look at the parent IConversionExpression.
+            ITypeSymbol type = null;
             Optional<object> constantValue = ConvertToOptional(unboundLambda.ConstantValue);
             return new UnboundLambdaExpression(isInvalid, syntax, type, constantValue);
         }
@@ -369,7 +373,11 @@ namespace Microsoft.CodeAnalysis.Semantics
             Lazy<IBlockStatement> body = new Lazy<IBlockStatement>(() => (IBlockStatement)Create(boundLambda.Body));
             bool isInvalid = boundLambda.HasErrors;
             SyntaxNode syntax = boundLambda.Syntax;
-            ITypeSymbol type = boundLambda.Type;
+            // This matches the SemanticModel implementation. This is because in VB, anonymous lambdas, by themselves,
+            // do not have a type. To get the type of a lambda expression in the SemanticModel, you need to look at
+            // TypeInfo.ConvertedType, rather than TypeInfo.Type. We replicate that behavior here. To get the type of
+            // an ILambdaExpression, you need to look at the parent IConversionExpression.
+            ITypeSymbol type = null;
             Optional<object> constantValue = ConvertToOptional(boundLambda.ConstantValue);
             return new LazyLambdaExpression(signature, body, isInvalid, syntax, type, constantValue);
         }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             bool isInvalid = unboundLambda.HasErrors;
             SyntaxNode syntax = unboundLambda.Syntax;
-            // This matches the SemanticModel implementation. This is because in VB, anonymous lambdas, by themselves,
+            // This matches the SemanticModel implementation. This is because in VB, lambdas by themselves
             // do not have a type. To get the type of a lambda expression in the SemanticModel, you need to look at
             // TypeInfo.ConvertedType, rather than TypeInfo.Type. We replicate that behavior here. To get the type of
             // an IUnboundLambdaExpression, you need to look at the parent IConversionExpression.
@@ -373,7 +373,7 @@ namespace Microsoft.CodeAnalysis.Semantics
             Lazy<IBlockStatement> body = new Lazy<IBlockStatement>(() => (IBlockStatement)Create(boundLambda.Body));
             bool isInvalid = boundLambda.HasErrors;
             SyntaxNode syntax = boundLambda.Syntax;
-            // This matches the SemanticModel implementation. This is because in VB, anonymous lambdas, by themselves,
+            // This matches the SemanticModel implementation. This is because in VB, lambdas by themselves
             // do not have a type. To get the type of a lambda expression in the SemanticModel, you need to look at
             // TypeInfo.ConvertedType, rather than TypeInfo.Type. We replicate that behavior here. To get the type of
             // an ILambdaExpression, you need to look at the parent IConversionExpression.

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IParameterReferenceExpression.cs
@@ -133,7 +133,7 @@ IOperation:  (OperationKind.None) (Syntax: 'from cust i ... t cust.Name')
                   Children(1): IParameterReferenceExpression: customers (OperationKind.ParameterReferenceExpression, Type: System.Collections.Generic.List<Customer>) (Syntax: 'customers')
             IArgument (ArgumentKind.Explicit, Matching Parameter: selector) (OperationKind.Argument) (Syntax: 'cust.Name')
               IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.Func<Customer, System.String>) (Syntax: 'cust.Name')
-                ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: System.Func<Customer, System.String>) (Syntax: 'cust.Name')
+                ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: null) (Syntax: 'cust.Name')
                   IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: 'cust.Name')
                     IReturnStatement (OperationKind.ReturnStatement) (Syntax: 'cust.Name')
                       IPropertyReferenceExpression: System.String Customer.Name { get; set; } (OperationKind.PropertyReferenceExpression, Type: System.String) (Syntax: 'cust.Name')
@@ -215,7 +215,7 @@ class Class
 ";
             string expectedOperationTree = @"
 IOperation:  (OperationKind.None) (Syntax: 'new Action( ... })')
-  Children(1): ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: System.Action) (Syntax: '() => ... }')
+  Children(1): ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: null) (Syntax: '() => ... }')
       IBlockStatement (2 statements) (OperationKind.BlockStatement) (Syntax: '{ ... }')
         IExpressionStatement (OperationKind.ExpressionStatement) (Syntax: 'a();')
           IInvocationExpression (virtual void System.Action.Invoke()) (OperationKind.InvocationExpression, Type: System.Void) (Syntax: 'a()')


### PR DESCRIPTION
…null, to be consistent with the SemanticModel. This fixes https://github.com/dotnet/roslyn/issues/8851. Tagging @dotnet/analyzer-ioperation for review.
