### PR TITLE
Make VSI Lightbulb failures more diagnosable

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/LightBulbHelper.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/LightBulbHelper.cs
@@ -20,6 +20,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 HostWaitHelper.PumpingWait(Task.Delay(TimeSpan.FromSeconds(1)));
 
                 return broker.IsLightBulbSessionActive(view);
-            }, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(20));
+            }, TimeSpan.FromSeconds(0), TimeSpan.MaxValue);
     }
 }


### PR DESCRIPTION
Remove the timeout from lightbulb waiting. This will enable the test
infrastructure to take a screenshot and a VS dump if the test times out
because the lightbulb has not appeared.

Related to https://github.com/dotnet/roslyn/issues/19350

Test-only, no approval required.

Tag @dotnet/roslyn-ide 