### PR TITLE
Add documentation link to NuGet package descriptions

### DIFF
--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
@@ -4,6 +4,8 @@
     <id>Microsoft.CodeAnalysis.CSharp</id>
     <description>
       .NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
+
+      More details at https://github.com/dotnet/roslyn/wiki/NuGet-packages
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.CSharp.nuspec
@@ -5,7 +5,7 @@
     <description>
       .NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
 
-      More details at https://github.com/dotnet/roslyn/wiki/NuGet-packages
+      More details at https://aka.ms/roslyn-packages
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -6,7 +6,7 @@
     <description>
       .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
 
-      More details at https://github.com/dotnet/roslyn/wiki/NuGet-packages
+      More details at https://aka.ms/roslyn-packages
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.CSharp" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Compilers.nuspec
@@ -5,6 +5,8 @@
     <summary>.NET Compiler Platform ("Roslyn")</summary>
     <description>
       .NET Compiler Platform ("Roslyn"). Install this package to get both C# and Visual Basic support. Install either of the dependencies directly to get one of the languages separately.
+
+      More details at https://github.com/dotnet/roslyn/wiki/NuGet-packages
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.CSharp" version="[$version$]" />

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
@@ -4,6 +4,8 @@
     <id>Microsoft.CodeAnalysis.VisualBasic</id>
     <description>
       .NET Compiler Platform ("Roslyn") support for Visual Basic, Microsoft.CodeAnalysis.VisualBasic.dll.
+
+      More details at https://github.com/dotnet/roslyn/wiki/NuGet-packages
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="$version$" />

--- a/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.VisualBasic.nuspec
@@ -5,7 +5,7 @@
     <description>
       .NET Compiler Platform ("Roslyn") support for Visual Basic, Microsoft.CodeAnalysis.VisualBasic.dll.
 
-      More details at https://github.com/dotnet/roslyn/wiki/NuGet-packages
+      More details at https://aka.ms/roslyn-packages
     </description>
     <dependencies>
       <dependency id="Microsoft.CodeAnalysis.Common" version="$version$" />


### PR DESCRIPTION
Doc-only change to 3 compiler nuget packages.

**Customer scenario**

Navigate to https://www.nuget.org/packages/Microsoft.Net.Compilers/ or another compiler package. There you will see a 1-line description of the package.
This PR adds a link to our wiki, so that we can document packages more thoroughly.
For instance, see this [question](https://stackoverflow.com/questions/42583579/what-version-of-the-compiler-is-in-a-microsoft-net-compilers-package) about the correspondance between package version and language version.

:memo: The nuspec format only allows plain text in the `<description>`. 

@dotnet/roslyn-compiler @jasonmalinowski for review.

Relates to https://github.com/dotnet/roslyn/issues/19659