### PR TITLE
Fix detection of Span types 

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -2061,7 +2061,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                     if (this.TypeKind == TypeKind.Struct)
                     {
-                        if (IsWellknownSpans())
+                        //PROTOTYPE(span): Span and ReadOnlySpan should have ByRefLike attribute, eventually.
+                        //                 For now assume that any "System.Span" and "System.ReadOnlySpan" structs 
+                        //                 are ByRefLike
+                        if (this.IsSpanType())
                         {
                             isByRefLike = ThreeState.True;
                         }
@@ -2106,27 +2109,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                 return uncommon.lazyIsReadOnly.Value();
             }
-        }
-
-        //PROTOTYPE(span): Span and ReadonlySpan should have spanLike marker.
-        //                 For now assume that any "System.Span" and "System.ReadOnlySpan" structs 
-        //                 are span-like
-        private bool IsWellknownSpans()
-        {
-            var originalDef = this.OriginalDefinition;
-
-            if (originalDef.Name != "Span" && originalDef.Name != "ReadonlySpan")
-            {
-                return false;
-            }
-
-            var ns = originalDef.ContainingSymbol as NamespaceSymbol;
-            if (ns?.Name != "System")
-            {
-                return false;
-            }
-
-            return ns.IsGlobalNamespace;
         }
 
         internal override bool HasDeclarativeSecurity

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1278,6 +1278,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (name.Length == length) && (string.Compare(name, 0, namespaceName, offset, length, comparison) == 0);
         }
 
+        internal static bool IsSpanType(this TypeSymbol type)
+        {
+            if ((type as NamedTypeSymbol)?.Arity != 1)
+            {
+                // must be a generic type of arity '1'
+                return false;
+            }
+
+            if (type.Name != "Span" && type.Name != "ReadOnlySpan")
+            {
+                // must be called "Span" or "ReadOnlySpan"
+                return false;
+            }
+
+            var ns = type.ContainingSymbol as NamespaceSymbol;
+            if (ns?.Name != "System")
+            {
+                // must be in "System" namespace
+                return false;
+            }
+
+            // the "System" must be in the global namespace
+            return ns.ContainingNamespace.IsGlobalNamespace;
+        }
+
         internal static bool IsNonGenericTaskType(this TypeSymbol type, CSharpCompilation compilation)
         {
             var namedType = type as NamedTypeSymbol;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -771,7 +771,36 @@ namespace System
     public struct RegularStruct<T>
     {
     }
+
+    // arity 0 - not a span
+    public struct Span 
+    {
+    }
+
+    // arity 2 - not a span
+    public struct Span<T, U> 
+    {
+        public ref T this[int i] => throw null;
+        public override int GetHashCode() => 1;
+    }
 }
+
+// nested
+public struct S1
+{
+    public struct Span<T> 
+    {
+        public ref T this[int i] => throw null;
+        public override int GetHashCode() => 1;
+    }
+}
+
+public struct Span<T> 
+{
+    public ref T this[int i] => throw null;
+    public override int GetHashCode() => 1;
+}
+
 ";
             var reference = CreateCompilation(
                 spanSourceNoRefs,
@@ -787,9 +816,13 @@ class Program
 {
     static void Main()
     {
-        object x = new Span<int>();
+        object x = new System.Span<int>();
         object y = new ReadOnlySpan<byte>();
-        object z = new RegularStruct<byte>();
+
+        object z1 = new Span();
+        object z2 = new Span<int, int>();
+        object z3 = new S1.Span<int>();
+        object z4 = new Span<int>();
     }
 }
 ";
@@ -800,8 +833,8 @@ class Program
 
             comp.VerifyDiagnostics(
                 // (8,20): error CS0029: Cannot implicitly convert type 'System.Span<int>' to 'object'
-                //         object x = new Span<int>();
-                Diagnostic(ErrorCode.ERR_NoImplicitConv, "new Span<int>()").WithArguments("System.Span<int>", "object").WithLocation(8, 20),
+                //         object x = new System.Span<int>();
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "new System.Span<int>()").WithArguments("System.Span<int>", "object").WithLocation(8, 20),
                 // (9,20): error CS0029: Cannot implicitly convert type 'System.ReadOnlySpan<byte>' to 'object'
                 //         object y = new ReadOnlySpan<byte>();
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "new ReadOnlySpan<byte>()").WithArguments("System.ReadOnlySpan<byte>", "object").WithLocation(9, 20)


### PR DESCRIPTION
The Spans that currently exist are not marked with ByRefLike attribute, so we assume that everything named `System.Span` and `System.ReadOnlySpan` as ByRefLike. 
It is a temporary measure that may not be needed in the final implementation.

We had 3 problems here:
- the casing for "ReadOnlySpan" was wrong.
- the check for "global namespace" was done at the wrong level.
- we did not have a test for this particular scenario 
(after "ref structs" were introduced we relied solely on that, which would not work with existing span types).
