### PR TITLE
Log telemetry if we see ITextBufferEdit.Apply() throwing exceptions

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -179,6 +179,7 @@
     <Compile Include="ReferenceHighlighting\Tags\WrittenReferenceHighlightTag.cs" />
     <Compile Include="ReferenceHighlighting\Tags\WrittenReferenceHighlightTagDefinition.cs" />
     <Compile Include="Implementation\InfoBar\EditorInfoBarService.cs" />
+    <Compile Include="Shared\Extensions\ITextBufferEditExtensions.cs" />
     <Compile Include="SymbolSearch\IAddReferenceDatabaseWrapper.cs" />
     <Compile Include="SymbolSearch\IDatabaseFactoryService.cs" />
     <Compile Include="SymbolSearch\IDelayService.cs" />

--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/BraceCompletionSessionProvider.BraceCompletionSession.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.BraceCompletion;
@@ -116,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
                         }
                         else
                         {
-                            snapshot = edit.Apply();
+                            snapshot = edit.ApplyAndLogExceptions();
                         }
                     }
 
@@ -166,7 +167,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
                                 // handle the command so the backspace does 
                                 // not go through since we've already cleared the braces
                                 handledCommand = true;
-                                edit.Apply();
+                                edit.ApplyAndLogExceptions();
                                 undo.Complete();
                                 EndSession();
                             }
@@ -222,7 +223,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
                                 {
                                     handledCommand = true;
 
-                                    edit.Apply();
+                                    edit.ApplyAndLogExceptions();
 
                                     MoveCaretToClosingPoint();
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractInlineRenameUndoManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractInlineRenameUndoManager.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     }
                 }
 
-                edit.Apply();
+                edit.ApplyAndLogExceptions();
                 if (!edit.HasEffectiveChanges && !this.UndoStack.Any())
                 {
                     transaction.Cancel();

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -346,7 +346,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                                 edit.Replace(change.Span.Start, change.Span.Length, change.NewText);
                             }
 
-                            edit.Apply();
+                            edit.ApplyAndLogExceptions();
                         }
                     });
 
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                             buffer.Replace(change.Span.ToSpan(), change.NewText);
                         }
 
-                        edit.Apply();
+                        edit.ApplyAndLogExceptions();
                     }
 
                     yield return new InlineRenameReplacement(replacement.Kind, replacement.OriginalSpan, trackingSpan.GetSpan(buffer.CurrentSnapshot).Span.ToTextSpan());

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     using (var textEdit = this.SubjectBuffer.CreateEdit(editOptions, reiteratedVersionNumber: null, editTag: null))
                     {
                         textEdit.Replace(mappedSpan.Span, adjustedNewText);
-                        textEdit.Apply();
+                        textEdit.ApplyAndLogExceptions();
                     }
 
                     // If the completion change requested a new position for the caret to go,
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                         textEdit.Replace(change.NewSpan, change.OldText);
                     }
 
-                    textEdit.Apply();
+                    textEdit.ApplyAndLogExceptions();
                 }
             }
         }

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextBufferEditExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextBufferEditExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
+{
+    internal static class ITextBufferEditExtensions
+    {
+        private static Exception s_lastException = null;
+
+        /// <summary>
+        /// Logs exceptions thrown during <see cref="ITextBufferEdit.Apply"/> as we look for issues.
+        /// </summary>
+        /// <param name="edit"></param>
+        /// <returns></returns>
+        public static ITextSnapshot ApplyAndLogExceptions(this ITextBufferEdit edit)
+        {
+            try
+            {
+                return edit.Apply();
+            }
+            catch (Exception e) when (ErrorReporting.FatalError.ReportWithoutCrash(e))
+            {
+                s_lastException = e;
+
+                // Since we don't know what is causing this yet, I don't feel safe that catching
+                // will not cause some further downstream failure. So we'll continue to propagate.
+                throw;
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Shared/Utilities/LinkedEditsTracker.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/LinkedEditsTracker.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
@@ -113,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
                     }
                 }
 
-                edit.Apply();
+                edit.ApplyAndLogExceptions();
             }
         }
     }

--- a/src/EditorFeatures/VisualBasic/EndConstructGeneration/VisualBasicEndConstructGenerationService.vb
+++ b/src/EditorFeatures/VisualBasic/EndConstructGeneration/VisualBasicEndConstructGenerationService.vb
@@ -301,7 +301,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
             Using edit = subjectBuffer.CreateEdit()
                 Dim aligningWhitespace = subjectBuffer.CurrentSnapshot.GetAligningWhitespace(state.TokenToLeft.Parent.Span.Start)
                 edit.Insert(state.CaretPosition, state.NewLineCharacter + aligningWhitespace)
-                edit.Apply()
+                edit.ApplyAndLogExceptions()
             End Using
 
             ' And now just send down a normal enter

--- a/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/FileChange.cs
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
                 using (var edit = _buffer.CreateEdit())
                 {
                     edit.Replace(child.GetSpan(), child.GetApplicableText());
-                    edit.Apply();
+                    edit.ApplyAndLogExceptions();
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/PreviewUpdater.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -88,7 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             using (var edit = TextView.TextBuffer.CreateEdit())
             {
                 edit.Replace(new Span(0, TextView.TextBuffer.CurrentSnapshot.Length), documentText);
-                edit.Apply();
+                edit.ApplyAndLogExceptions();
             }
 
             container = TextView.TextBuffer.AsTextContainer();

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.Undo;
 using Microsoft.CodeAnalysis.Text;
@@ -238,8 +239,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     {
                         edit.Replace(change.Span.Start, change.Span.Length, change.NewText);
                     }
-
-                    edit.Apply();
+                    
+                    edit.ApplyAndLogExceptions();
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -775,7 +775,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     affectedSpans.Add(currentVisibleSpanIndex);
                 }
 
-                edit.Apply();
+                edit.ApplyAndLogExceptions();
             }
         }
 


### PR DESCRIPTION
We believe that the primary cause of this exception (some issues around projection buffers) was worked around in d8f8dad3dd58 but we're still seeing issues so that's not the case. I'm also further not convinced
that change helped at all, because in many case we already fork buffers to work around the same issue.

This is just adding the ability to better catch the issue; we'll revert this once we figure out what's going on.

----

**Customer scenario:** Adding additional logging for an issue around edits. Scenario unknown at this point. Currently if the exception is thrown we don't capture any telemetry so we only see the downstream effects. We haven't yet gotten a dump that's actionable.
**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/378999
**Risk:** low. Just adding a try/catch that logs exceptions, and we rethrow it to avoid actually changing any behavior.
**Performance impact:** none.
**Is this a regression from a previous update?** We thought we had fixed this for RTM, but enough reports indicate that's not the case. Root cause still not understood.
**Root cause analysis:** Bug not understood yet.
**How was the bug found?** Customer reports and internal reports.
