### PR TITLE
Catch and log IO exceptions

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5795,6 +5795,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error writing to an output file -- &apos;{0}&apos;.
+        /// </summary>
+        internal static string ERR_IOException {
+            get {
+                return ResourceManager.GetString("ERR_IOException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Yield statements may not appear at the top level in interactive code..
         /// </summary>
         internal static string ERR_IteratorInInteractive {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -408,6 +408,9 @@
   <data name="ERR_OutputWriteFailed" xml:space="preserve">
     <value>Could not write to output file '{0}' -- '{1}'</value>
   </data>
+  <data name="ERR_IOException" xml:space="preserve">
+    <value>Could not write to one of the output files -- '{0}'</value>
+  </data>
   <data name="ERR_MultipleEntryPoints" xml:space="preserve">
     <value>Program has more than one entry point defined. Compile with /main to specify the type that contains the entry point.</value>
   </data>
@@ -3292,6 +3295,9 @@ Give the compiler some way to differentiate the methods. For example, you can gi
   </data>
   <data name="ERR_CantOpenFileWrite" xml:space="preserve">
     <value>Cannot open '{0}' for writing -- '{1}'</value>
+  </data>
+  <data name="ERR_IOException" xml:space="preserve">
+    <value>Error writing to an output file -- '{0}'</value>
   </data>
   <data name="ERR_BadBaseNumber" xml:space="preserve">
     <value>Invalid image base number '{0}'</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1491,6 +1491,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #region diagnostics introduced for C# 7.2
         ERR_FeatureNotAvailableInVersion7_2 = 8320,
+        ERR_IOException = 8221,
         #endregion diagnostics introduced for C# 7.2
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -137,6 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override int ERR_NoSourceFile => (int)ErrorCode.ERR_NoSourceFile;
         public override int ERR_CantOpenFileWrite => (int)ErrorCode.ERR_CantOpenFileWrite;
         public override int ERR_OutputWriteFailed => (int)ErrorCode.ERR_OutputWriteFailed;
+        public override int ERR_IOException => (int)ErrorCode.ERR_IOException;
         public override int WRN_NoConfigNotOnCommandLine => (int)ErrorCode.WRN_NoConfigNotOnCommandLine;
         public override int ERR_BinaryFile => (int)ErrorCode.ERR_BinaryFile;
         public override int WRN_AnalyzerCannotBeCreated => (int)ErrorCode.WRN_AnalyzerCannotBeCreated;

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -829,6 +829,10 @@ namespace Microsoft.CodeAnalysis
                     return Failed;
                 }
             }
+            catch (IOException e)
+            {
+                MessageProvider.ReportIOException(e, consoleOutput);
+            }
             finally
             {
                 // At this point analyzers are already complete in which case this is a no-op.  Or they are 

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -150,6 +150,7 @@ namespace Microsoft.CodeAnalysis
         public abstract int ERR_NoSourceFile { get; }
         public abstract int ERR_CantOpenFileWrite { get; }
         public abstract int ERR_OutputWriteFailed { get; }
+        public abstract int ERR_IOException { get; }
         public abstract int WRN_NoConfigNotOnCommandLine { get; }
         public abstract int ERR_BinaryFile { get; }
         public abstract int WRN_UnableToLoadAnalyzer { get; }
@@ -229,6 +230,18 @@ namespace Microsoft.CodeAnalysis
             if (consoleOutput != null)
             {
                 var diagnostic = new DiagnosticInfo(this, ERR_OutputWriteFailed, filePath, e.Message);
+                consoleOutput.WriteLine(diagnostic.ToString(consoleOutput.FormatProvider));
+            }
+        }
+
+        /// <summary>
+        /// Takes an exception produced while writing to a file stream and produces a diagnostic.
+        /// </summary>
+        public void ReportIOException(IOException e, TextWriter consoleOutput)
+        {
+            if (consoleOutput != null)
+            {
+                var diagnostic = new DiagnosticInfo(this, ERR_IOException, e.Message);
                 consoleOutput.WriteLine(diagnostic.ToString(consoleOutput.FormatProvider));
             }
         }

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1734,6 +1734,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_NoRefOutWhenRefOnly = 37300
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 37301
 
+        ERR_IOException = 37302
+
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000
         WRN_InvalidOverrideDueToTupleNames2 = 40001

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -183,6 +183,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Public Overrides ReadOnly Property ERR_IOException As Integer
+            Get
+                Return ERRID.ERR_IOException
+            End Get
+        End Property
+
         Public Overrides ReadOnly Property WRN_NoConfigNotOnCommandLine As Integer
             Get
                 Return ERRID.WRN_NoConfigInResponseFile

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
      Global.Microsoft.VisualBasic.HideModuleNameAttribute()>  _
@@ -6500,6 +6500,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property ERR_InvOutsideProc() As String
             Get
                 Return ResourceManager.GetString("ERR_InvOutsideProc", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Error writing to an output file: {0}.
+        '''</summary>
+        Friend ReadOnly Property ERR_IOException() As String
+            Get
+                Return ResourceManager.GetString("ERR_IOException", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -219,6 +219,9 @@
   <data name="ERR_CantOpenFileWrite" xml:space="preserve">
     <value>can't open '{0}' for writing: {1}</value>
   </data>
+  <data name="ERR_IOException" xml:space="preserve">
+    <value>Error writing to an output file: {0}</value>
+  </data>
   <data name="ERR_BadCodepage" xml:space="preserve">
     <value>code page '{0}' is invalid or not installed</value>
   </data>

--- a/src/Test/Utilities/Portable/Mocks/TestMessageProvider.cs
+++ b/src/Test/Utilities/Portable/Mocks/TestMessageProvider.cs
@@ -84,6 +84,11 @@ namespace Roslyn.Test.Utilities
             get { throw new NotImplementedException(); }
         }
 
+        public override int ERR_IOException
+        {
+            get { throw new NotImplementedException(); }
+        }
+
         public override int WRN_NoConfigNotOnCommandLine
         {
             get { throw new NotImplementedException(); }


### PR DESCRIPTION
Fixes Watson https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=403647

The main goals are to avoid a crash and give the user an indication of the root cause.

I manually verified the fix by injecting such an exception. The error produced is error `CS8221: Error writing to an output file -- '... exception message ...'`.

@dotnet/roslyn-compiler for review (15.6).