### PR TITLE
Don't crash and send an NFW if debugger contenttype does not match

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -83,7 +85,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             {
                 var contextBuffer = EditorAdaptersFactoryService.GetDataBuffer(buffer);
 
-                Contract.ThrowIfFalse(contextBuffer.ContentType.IsOfType(this.ContentTypeName));
+                if (!contextBuffer.ContentType.IsOfType(this.ContentTypeName))
+                {
+                    FatalError.ReportWithoutCrash(
+                        new ArgumentException($"Expected content type {this.ContentTypeName} " +
+                        $"but got buffer of content type {contextBuffer.ContentType}"));
+
+                    return VSConstants.E_FAIL;
+                }
 
                 var context = CreateContext(view, textView, debuggerBuffer, contextBuffer, currentStatementSpan);
                 if (context.TryInitialize())

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.IVsImmediateStatementCompletion2.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 {
@@ -81,6 +82,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             if (buffer != null)
             {
                 var contextBuffer = EditorAdaptersFactoryService.GetDataBuffer(buffer);
+
+                Contract.ThrowIfFalse(contextBuffer.ContentType.IsOfType(this.ContentTypeName));
+
                 var context = CreateContext(view, textView, debuggerBuffer, contextBuffer, currentStatementSpan);
                 if (context.TryInitialize())
                 {


### PR DESCRIPTION
We've received watsons that indicate that a VB file is being set as the
"context buffer" for C# debugger intellisense. It appears that this
would only happen if the debuggered called us with a buffer of the wrong
content type. Add an assertion that the content type is correct.

Related to
https://devdiv.visualstudio.com/DevDiv/_workitems?id=397711&_a=edit&triage=true

Tag @dotnet/roslyn-ide 