### PR TITLE
Force load projects that failed design time builds, not ones that opt out of LSL

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -636,7 +636,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var start = DateTimeOffset.UtcNow;
             var solution4 = (IVsSolution4)_vsSolution;
             var solution7 = (IVsSolution7)_vsSolution;
-            var projectInfosOfProjectsThatFailed = projectInfos.Where(pi => DesignTimeBuildFailed(pi.Value) && !solution7.IsDeferredProjectLoadAllowed(pi.Key));
+            var projectInfosOfProjectsThatFailed = projectInfos.Where(pi => DesignTimeBuildFailed(pi.Value) && solution7.IsDeferredProjectLoadAllowed(pi.Key));
             var guidsOfProjectsThatFailed = projectInfosOfProjectsThatFailed.Select(pi => GetProjectGuid(pi.Key)).ToArray();
             OutputToOutputWindow($"\tForcing load of {guidsOfProjectsThatFailed.Length} projects.");
             OutputListToOutputWindow("\tIncluding ", projectInfosOfProjectsThatFailed.Select(pi => pi.Key));


### PR DESCRIPTION
**Customer scenario**

Open a solution with Lightweight solution load enabled, that has project whose design time builds fail.  Roslyn is supposed to trigger a full load of those projects so that either: the legacy design time build works, or it reports appropriate diagnostics.  Unfortunately, a typo mean that we did that only for projects that *also* opt out of LSL.

**Bugs this fixes:**

Fixes #19407 

**Workarounds, if any**

Disable LSL for the solution.

**Risk**

Low - this is new code, and very specific to LSL

**Performance impact**

None - just changing a condition.

**Is this a regression from a previous update?**

No - this was introduced very recently in the first attempt to fix this, just had a typo.

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

Validating further LSL scenarios.