### PR TITLE
Remove strong reference to AnalyzerOptions in the analyzer manager ex…

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerManager.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // Task to compute the scope was cancelled.
                 // Clear the entry in scope map for analyzer, so we can attempt a retry.
-                analyzerExecutionContext.ClearCompilationScopeMap(analyzerExecutor.AnalyzerOptions, analyzerExecutor.Compilation);
+                analyzerExecutionContext.ClearCompilationScopeMap(analyzerExecutor.Compilation);
 
                 analyzerExecutor.CancellationToken.ThrowIfCancellationRequested();
                 return await GetCompilationAnalysisScopeCoreAsync(sessionScope, analyzerExecutor, analyzerExecutionContext).ConfigureAwait(false);


### PR DESCRIPTION
…ecution context

Fixes #20065

**Customer scenario**

Performance: We are leaking solution instances in preview workspace (which is created every time we invoke a lightbulb preview). See https://github.com/dotnet/roslyn/issues/20065#issue-234071975 for details.

**Bugs this fixes:**

Fixes #20065 

**Workarounds, if any**

N/A

**Risk**

Low, as we are not changing any functionality here. Instead of having a `Dictionary<AnalyzerOptions, ConditionalWeakTable<Compilation, Task<HostCompilationStartAnalysisScope>>>` with strong reference to AnalyzerOptions, we now use a `ConditionalWeakTable<Compilation, Dictionary<AnalyzerOptions, Task<HostCompilationStartAnalysisScope>>>`, which has a weak reference and will let go AnalyzerOptions instance once the compilation is GC'ed.

**Performance impact**

This should improve performance as we are preventing a leak of solutions in preview workspace.

**Is this a regression from a previous update?**

Yes, we recently refactored the WorkspaceAnalyzerOptions to strongly hold onto the solution snapshot. This was needed to fix an IDE race. This in turn is causing the map in question here to leak these solution instances.

**Root cause analysis:**

We don't have tests to catch and prevent leaks. We are going to further improve the design in this area when we tackle #2830 in 15.6, so we prevent such regressions in future.

**How was the bug found?**

Dogfooding.