### PR TITLE
Fix completion in AdhocWorkspace

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
@@ -32,9 +32,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey = default(char?), CancellationToken cancellationToken = default(CancellationToken))
         {
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var newDocument = await DetermineNewDocumentAsync(item, text, cancellationToken).ConfigureAwait(false);
-
+            var newDocument = await DetermineNewDocumentAsync(document, item, cancellationToken).ConfigureAwait(false);
             var newText = await newDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var newRoot = await newDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
@@ -90,14 +88,12 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return new TextChange(totalOldSpan, newText.ToString(totalNewSpan));
         }
 
-        private async Task<Document> DetermineNewDocumentAsync(CompletionItem completionItem, SourceText sourceText, CancellationToken cancellationToken)
+        private async Task<Document> DetermineNewDocumentAsync(Document document, CompletionItem completionItem, CancellationToken cancellationToken)
         {
-            // The span we're going to replace
-            var line = sourceText.Lines[MemberInsertionCompletionItem.GetLine(completionItem)];
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
-            //var sourceText = textSnapshot.AsText();
-            var document = sourceText.GetOpenDocumentInCurrentContextWithChanges();
-            Contract.ThrowIfNull(document);
+            // The span we're going to replace
+            var line = text.Lines[MemberInsertionCompletionItem.GetLine(completionItem)];
 
             // Annotate the line we care about so we can find it after adding usings
             var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
@@ -112,7 +108,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             var destinationSpan = ComputeDestinationSpan(insertionRoot, insertionText);
 
-            var finalText = insertionRoot.GetText(sourceText.Encoding).Replace(destinationSpan, insertionText.Trim());
+            var finalText = insertionRoot.GetText(text.Encoding)
+                .Replace(destinationSpan, insertionText.Trim());
 
             document = document.WithText(finalText);
             var newRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
I noticed this while working through an issue using the CompletionService in OmniSharp. Essentially, the `AbstractMemberInsertingCompletionProvider` was never updated to stop calling `GetOpenDocumentInCurrentContextWithChanges(...)` as it did in the era before the `CompletionService` when every provider was passed an `ITextView` and `ITextBuffer`. Nowadays, since there's a readily available Document, it can just use that.

Without this change, it breaks a scenario with AdhocWorkspace and other simple Workspace implementations. Essentially, `GetOpenDocumentInCurrentContextWithChanges(...)` allows the caller to retrieve a Document from a SourceText. It achieves this be calling `Workspace.TryGetWorkspace(...)` with the SourceText's SourceTextContainer. However, in the case of a standard SourceText, this is a StaticContainer that changes every time `SourceText.WithChanges(...)` is called. So, if the SourceText is updated for a particular Document in an AdhocWorkspace, calling `GetOpenDocumentInCurrentContextWithChanges(...)` on the new SourceText will fail because its container is different than the one that was initially registered with the Workspace.

cc @dotnet/roslyn-ide 