### PR TITLE
Handle I/O errors when writing in Emit and EmitDifference

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -4333,8 +4333,8 @@ class C
                 pdbStream.BreakHow = BrokenStream.BreakHowType.ThrowOnWrite;
                 var result = compilation.Emit(output, pdbStream, options: EmitOptions.Default.WithDebugInformationFormat(DebugInformationFormat.PortablePdb));
                 result.Diagnostics.Verify(
-                    // error CS8104: An error occurred while writing the output file: System.IO.IOException: I/O error occurred.
-                    Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments(pdbStream.ThrownException.ToString()).WithLocation(1, 1)
+                    // error CS0041: Unexpected error writing debug information -- 'I/O error occurred.'
+                    Diagnostic(ErrorCode.FTL_DebugEmitFailure).WithArguments("I/O error occurred.").WithLocation(1, 1)
                     );
             }
         }

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2720,6 +2720,11 @@ namespace Microsoft.CodeAnalysis
                     diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PdbWritingFailed, Location.None, e.Message));
                     return null;
                 }
+                catch (Cci.PeWritingException e)
+                {
+                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PeWritingFailure, Location.None, e.InnerException.ToString()));
+                    return null;
+                }
                 catch (PermissionSetFileReadException e)
                 {
                     diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PermissionSetAttributeFileReadError, Location.None, e.FileName, e.PropertyName, e.Message));

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1757,8 +1757,15 @@ namespace Microsoft.Cci
             rootBuilder.Serialize(metadataBuilder, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
             metadataSizes = rootBuilder.Sizes;
 
-            ilBuilder.WriteContentTo(ilStream);
-            metadataBuilder.WriteContentTo(metadataStream);
+            try
+            {
+                ilBuilder.WriteContentTo(ilStream);
+                metadataBuilder.WriteContentTo(metadataStream);
+            }
+            catch (Exception e) when (!(e is OperationCanceledException))
+            {
+                throw new PeWritingException(e);
+            }
 
             if (portablePdbStreamOpt != null)
             {
@@ -1769,7 +1776,15 @@ namespace Microsoft.Cci
 
                 var portablePdbBlob = new BlobBuilder();
                 portablePdbBuilder.Serialize(portablePdbBlob);
-                portablePdbBlob.WriteContentTo(portablePdbStreamOpt);
+
+                try
+                {
+                    portablePdbBlob.WriteContentTo(portablePdbStreamOpt);
+                }
+                catch (Exception e) when (!(e is OperationCanceledException))
+                {
+                    throw new PdbWritingException(e);
+                }
             }
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -160,7 +160,14 @@ namespace Microsoft.Cci
                     Stream portablePdbStream = getPortablePdbStreamOpt();
                     if (portablePdbStream != null)
                     {
-                        portablePdbBlob.WriteContentTo(portablePdbStream);
+                        try
+                        {
+                            portablePdbBlob.WriteContentTo(portablePdbStream);
+                        }
+                        catch (Exception e) when (!(e is OperationCanceledException))
+                        {
+                            throw new PeWritingException(e);
+                        }
                     }
                 }
             }

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Cci
                         }
                         catch (Exception e) when (!(e is OperationCanceledException))
                         {
-                            throw new PeWritingException(e);
+                            throw new PdbWritingException(e);
                         }
                     }
                 }


### PR DESCRIPTION
This is a follow-up on https://github.com/dotnet/roslyn/pull/19360
Some calls to WriteContentTo were not yet guarded.
Fixes https://github.com/dotnet/roslyn/issues/20091

@AlekseyTs @tmat @dotnet/roslyn-compiler for review (15.6). Thanks