### PR TITLE
Allow use of named parameters in non-trailing positions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -283,6 +283,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // matching Dev10 compiler behavior.
                 bool hadError = false;
 
+                // Only report the first "non-trailing named args required C# 7.2" error,
+                // so as to avoid "cascading" errors.
+                bool hadLangVersionError = false;
+
                 var shouldHaveName = false;
 
                 foreach (var argument in attributeArgumentList.Arguments)
@@ -295,10 +299,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         // Constructor argument
-                        hadError |= this.BindArgumentAndName(
+                        this.BindArgumentAndName(
                             boundConstructorArguments,
                             diagnostics,
-                            hadError,
+                            ref hadError,
+                            ref hadLangVersionError,
                             argument,
                             BindArgumentExpression(diagnostics, argument.Expression, RefKind.None, allowArglist: false),
                             argument.NameColon,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2284,7 +2284,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     case BoundKind.PropertyAccess:
                     case BoundKind.IndexerAccess:
-                        CheckIsVariable(argumentSyntax, arg, BindValueKind.RefOrOut, false, diagnostics);
+                        hadError = CheckIsVariable(argumentSyntax, arg, BindValueKind.RefOrOut, false, diagnostics);
                         return;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2207,17 +2207,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool allowArglist,
             bool isDelegateCreation = false)
         {
-            // Only report the first "duplicate name" or "named before positional" error, 
-            // so as to avoid "cascading" errors.
-            bool hadError = false;
-
             // Only report the first "non-trailing named args required C# 7.2" error,
             // so as to avoid "cascading" errors.
             bool hadLangVersionError = false;
 
             foreach (var argumentSyntax in arguments)
             {
-                BindArgumentAndName(result, diagnostics, ref hadError, ref hadLangVersionError,
+                BindArgumentAndName(result, diagnostics, ref hadLangVersionError,
                     argumentSyntax, allowArglist, isDelegateCreation: isDelegateCreation);
             }
         }
@@ -2252,7 +2248,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void BindArgumentAndName(
             AnalyzedArguments result,
             DiagnosticBag diagnostics,
-            ref bool hadError,
             ref bool hadLangVersionError,
             ArgumentSyntax argumentSyntax,
             bool allowArglist,
@@ -2269,7 +2264,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindArgumentAndName(
                 result,
                 diagnostics,
-                ref hadError,
                 ref hadLangVersionError,
                 argumentSyntax,
                 boundArgument,
@@ -2277,14 +2271,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 refKind);
 
             // check for ref/out property/indexer, only needed for 1 parameter version
-            if (!hadError && isDelegateCreation && origRefKind != RefKind.None && result.Arguments.Count == 1)
+            if (!result.HadAnalysisError && isDelegateCreation && origRefKind != RefKind.None && result.Arguments.Count == 1)
             {
                 var arg = result.Argument(0);
                 switch (arg.Kind)
                 {
                     case BoundKind.PropertyAccess:
                     case BoundKind.IndexerAccess:
-                        hadError = !CheckIsVariable(argumentSyntax, arg, BindValueKind.RefOrOut, false, diagnostics);
+                        result.HadAnalysisError = !CheckIsVariable(argumentSyntax, arg, BindValueKind.RefOrOut, false, diagnostics);
                         return;
                 }
             }
@@ -2438,7 +2432,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void BindArgumentAndName(
             AnalyzedArguments result,
             DiagnosticBag diagnostics,
-            ref bool hadError,
             ref bool hadLangVersionError,
             CSharpSyntaxNode argumentSyntax,
             BoundExpression boundArgumentExpression,
@@ -2498,15 +2491,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                if (hasNameCollision)
+                if (hasNameCollision && !result.HadAnalysisError)
                 {
-                    if (!hadError)
-                    {
-                        // CS: Named argument '{0}' cannot be specified multiple times
-                        Error(diagnostics, ErrorCode.ERR_DuplicateNamedArgument, nameColonSyntax.Name, name);
-
-                        hadError = true;
-                    }
+                    // CS: Named argument '{0}' cannot be specified multiple times
+                    Error(diagnostics, ErrorCode.ERR_DuplicateNamedArgument, nameColonSyntax.Name, name);
+                    result.HadAnalysisError = true;
                 }
 
                 result.Names.Add(nameColonSyntax.Name);
@@ -3310,6 +3299,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (initializerArgumentListOpt != null)
                 {
                     this.BindArgumentsAndNames(initializerArgumentListOpt, diagnostics, analyzedArguments, allowArglist: true);
+                    diagnostics = analyzedArguments.AvoidCascading(diagnostics);
                 }
 
                 NamedTypeSymbol initializerType = containingType;
@@ -3525,6 +3515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             try
             {
                 BindArgumentsAndNames(node.ArgumentList, diagnostics, analyzedArguments, isDelegateCreation: true);
+                diagnostics = analyzedArguments.AvoidCascading(diagnostics);
 
                 bool hasErrors = false;
                 if (analyzedArguments.HasErrors)
@@ -3695,6 +3686,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // new C(__arglist()) is legal
                 BindArgumentsAndNames(node.ArgumentList, diagnostics, analyzedArguments, allowArglist: true);
+                diagnostics = analyzedArguments.AvoidCascading(diagnostics);
 
                 // No point in performing overload resolution if the type is static or a tuple literal.  
                 // Just return a bad expression containing the arguments.
@@ -4712,6 +4704,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             try
             {
                 BindArgumentsAndNames(node.ArgumentList, diagnostics, analyzedArguments, allowArglist: false);
+                diagnostics = analyzedArguments.AvoidCascading(diagnostics);
 
                 if (analyzedArguments.Arguments.Count > 0)
                 {
@@ -4733,6 +4726,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             AnalyzedArguments analyzedArguments = AnalyzedArguments.GetInstance();
             BindArgumentsAndNames(node.ArgumentList, diagnostics, analyzedArguments);
+            diagnostics = analyzedArguments.AvoidCascading(diagnostics);
+
             bool hasArguments = analyzedArguments.Arguments.Count > 0;
             analyzedArguments.Free();
 
@@ -6319,6 +6314,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             try
             {
                 BindArgumentsAndNames(argumentList, diagnostics, analyzedArguments);
+                diagnostics = analyzedArguments.AvoidCascading(diagnostics);
 
                 if (receiver.Kind == BoundKind.PropertyGroup)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2284,7 +2284,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     case BoundKind.PropertyAccess:
                     case BoundKind.IndexerAccess:
-                        hadError = CheckIsVariable(argumentSyntax, arg, BindValueKind.RefOrOut, false, diagnostics);
+                        hadError = !CheckIsVariable(argumentSyntax, arg, BindValueKind.RefOrOut, false, diagnostics);
                         return;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 boundExpression = CheckValue(boundExpression, BindValueKind.RValueOrMethodGroup, diagnostics);
                 string name = boundExpression.Kind == BoundKind.MethodGroup ? GetName(node.Expression) : null;
                 BindArgumentsAndNames(node.ArgumentList, diagnostics, analyzedArguments, allowArglist: true);
-                result = BindInvocationExpression(node, node.Expression, name, boundExpression, analyzedArguments, diagnostics);
+                result = BindInvocationExpression(node, node.Expression, name, boundExpression, analyzedArguments, analyzedArguments.AvoidCascading(diagnostics));
             }
 
             analyzedArguments.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 boundExpression = CheckValue(boundExpression, BindValueKind.RValueOrMethodGroup, diagnostics);
                 string name = boundExpression.Kind == BoundKind.MethodGroup ? GetName(node.Expression) : null;
                 BindArgumentsAndNames(node.ArgumentList, diagnostics, analyzedArguments, allowArglist: true);
-                result = BindInvocationExpression(node, node.Expression, name, boundExpression, analyzedArguments, analyzedArguments.AvoidCascading(diagnostics));
+                result = BindInvocationExpression(node, node.Expression, name, boundExpression, analyzedArguments, diagnostics);
             }
 
             analyzedArguments.Free();

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -69,9 +69,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if ((object)delegateInvokeMethodOpt != null)
             {
-                var analyzedArguments = new AnalyzedArguments();
+                var analyzedArguments = AnalyzedArguments.GetInstance();
                 GetDelegateArguments(source.Syntax, analyzedArguments, delegateInvokeMethodOpt.Parameters, binder.Compilation);
                 var resolution = binder.ResolveMethodGroup(source, analyzedArguments, isMethodGroupConversion: true, inferWithDynamic: true, useSiteDiagnostics: ref useSiteDiagnostics);
+                analyzedArguments.Free();
                 return resolution;
             }
             else

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
@@ -15,7 +15,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly ArrayBuilder<IdentifierNameSyntax> Names;
         public readonly ArrayBuilder<RefKind> RefKinds;
         public bool IsExtensionMethodInvocation;
-        public bool HadAnalysisError;
         private ThreeState _lazyHasDynamicArgument;
 
         internal AnalyzedArguments()
@@ -31,7 +30,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Names.Clear();
             this.RefKinds.Clear();
             this.IsExtensionMethodInvocation = false;
-            this.HadAnalysisError = false;
             _lazyHasDynamicArgument = ThreeState.Unknown;
         }
 
@@ -51,11 +49,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return syntax == null ? null : syntax.Identifier.ValueText;
         }
         
-        public DiagnosticBag AvoidCascading(DiagnosticBag bag)
-        {
-            return HadAnalysisError ? new DiagnosticBag() : bag;
-        }
-
         public ImmutableArray<string> GetNames()
         {
             int count = this.Names.Count;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
@@ -2,9 +2,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -65,6 +62,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.RequiredParameterMissing, 0, parameterPosition, default(ImmutableArray<int>));
         }
 
+        public static ArgumentAnalysisResult BadNonTrailingNamedArgument(int argumentPosition)
+        {
+            return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.BadNonTrailingNamedArgument, argumentPosition, 0, default(ImmutableArray<int>));
+        }
+
         public static ArgumentAnalysisResult NormalForm(ImmutableArray<int> argsToParamsOpt)
         {
             return new ArgumentAnalysisResult(ArgumentAnalysisResultKind.Normal, 0, 0, argsToParamsOpt);
@@ -98,6 +100,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
                 case ArgumentAnalysisResultKind.RequiredParameterMissing:
                     s += "Invalid because parameter " + ParameterPosition + " has no corresponding argument.";
+                    break;
+                case ArgumentAnalysisResultKind.BadNonTrailingNamedArgument:
+                    s += "Invalid because named argument " + ParameterPosition + " is used out of position but some following argument(s) are not named.";
                     break;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResultKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResultKind.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal enum ArgumentAnalysisResultKind : byte
@@ -14,6 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         FirstInvalid = NoCorrespondingParameter,
         NoCorrespondingNamedParameter,
         RequiredParameterMissing,
-        NameUsedForPositional
+        NameUsedForPositional,
+        BadNonTrailingNamedArgument // if a named argument refers to a different position, all following arguments must be named
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberAnalysisResult.cs
@@ -153,6 +153,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return RequiredParameterMissing(argAnalysis.ParameterPosition);
                 case ArgumentAnalysisResultKind.NameUsedForPositional:
                     return NameUsedForPositional(argAnalysis.ArgumentPosition);
+                case ArgumentAnalysisResultKind.BadNonTrailingNamedArgument:
+                    return BadNonTrailingNamedArgument(argAnalysis.ArgumentPosition);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(argAnalysis.Kind);
             }
@@ -162,6 +164,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return new MemberAnalysisResult(
                 MemberResolutionKind.NameUsedForPositional,
+                ImmutableArray.Create<int>(argumentPosition),
+                default(ImmutableArray<int>),
+                default(ImmutableArray<Conversion>));
+        }
+
+        public static MemberAnalysisResult BadNonTrailingNamedArgument(int argumentPosition)
+        {
+            return new MemberAnalysisResult(
+                MemberResolutionKind.BadNonTrailingNamedArgument,
                 ImmutableArray.Create<int>(argumentPosition),
                 default(ImmutableArray<int>),
                 default(ImmutableArray<Conversion>));

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberResolutionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MemberResolutionKind.cs
@@ -57,6 +57,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         NameUsedForPositional,
 
         /// <summary>
+        /// The candidate member was rejected because a named argument was used out-of-position and followed by unnamed arguments.
+        /// </summary>
+        BadNonTrailingNamedArgument,
+
+        /// <summary>
         /// The candidate member was rejected because it is not supported by the language or cannot be used 
         /// given the current set of assembly references.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -595,6 +595,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         case MemberResolutionKind.ConstructedParameterFailedConstraintCheck:
                         case MemberResolutionKind.NoCorrespondingNamedParameter:
                         case MemberResolutionKind.UseSiteError:
+                        case MemberResolutionKind.BadNonTrailingNamedArgument:
                             return true;
                     }
                     break;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Find the first named argument which is used out-of-position or a params parameter
             int foundPosition = -1;
-            int length = argsToParameters.Length;
+            int length = arguments.Arguments.Count;
             for (int i = 0; i < length;  i++)
             {
                 if (arguments.Name(i) != null && 
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var name = arguments.Names[argumentPosition];
                 for (int p = 0; p < memberParameters.Length; ++p)
                 {
-                    // p is initialized to zero; it ok for a named argument to "correspond" to
+                    // p is initialized to zero; it is ok for a named argument to "correspond" to
                     // _any_ parameter (not just the parameters past the point of positional arguments)
                     if (memberParameters[p].Name == name.Identifier.ValueText)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // _any_ parameter (not just the parameters past the point of positional arguments)
                     if (memberParameters[p].Name == name.Identifier.ValueText)
                     {
-                        if (isValidParams && memberParameters[p].IsParams)
+                        if (isValidParams && p == memberParameters.Length - 1)
                         {
                             seenNamedParams = true;
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // (1) Is there any named argument used out-of-position and followed by unnamed arguments?
 
-            int? badNonTrailingNamedArgument = CheckForBadNonTrailingNamedArgument(symbol, arguments, argsToParameters, parameters);
+            int? badNonTrailingNamedArgument = CheckForBadNonTrailingNamedArgument(arguments, argsToParameters, parameters);
             if (badNonTrailingNamedArgument != null)
             {
                 return ArgumentAnalysisResult.BadNonTrailingNamedArgument(badNonTrailingNamedArgument.Value);
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ArgumentAnalysisResult.NormalForm(argsToParameters.ToImmutableArray());
         }
 
-        private static int? CheckForBadNonTrailingNamedArgument(Symbol symbol, AnalyzedArguments arguments, ParameterMap argsToParameters, ImmutableArray<ParameterSymbol> parameters)
+        private static int? CheckForBadNonTrailingNamedArgument(AnalyzedArguments arguments, ParameterMap argsToParameters, ImmutableArray<ParameterSymbol> parameters)
         {
             // Is there any named argument used out-of-position and followed by unnamed arguments?
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1736,6 +1736,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Named argument &apos;{0}&apos; is used out-of-position but is followed by an unnamed argument.
+        /// </summary>
+        internal static string ERR_BadNonTrailingNamedArgument {
+            get {
+                return ResourceManager.GetString("ERR_BadNonTrailingNamedArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Declaration is not valid; use &apos;{0} operator &lt;dest-type&gt; (...&apos; instead.
         /// </summary>
         internal static string ERR_BadOperatorSyntax {
@@ -6425,7 +6434,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Named argument specifications must appear after all fixed arguments have been specified.
+        ///   Looks up a localized string similar to Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments..
         /// </summary>
         internal static string ERR_NamedArgumentSpecificationBeforeFixedArgument {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3783,7 +3783,7 @@ You should consider suppressing the warning only if you're sure that you don't w
     <value>Inconsistent accessibility: event type '{1}' is less accessible than event '{0}'</value>
   </data>
   <data name="ERR_NamedArgumentSpecificationBeforeFixedArgument" xml:space="preserve">
-    <value>Named argument specifications must appear after all fixed arguments have been specified</value>
+    <value>Named argument specifications must appear after all fixed arguments have been specified. Please use language version {0} or greater to allow non-trailing named arguments.</value>
   </data>
   <data name="ERR_BadNamedArgument" xml:space="preserve">
     <value>The best overload for '{0}' does not have a parameter named '{1}'</value>
@@ -3796,6 +3796,9 @@ You should consider suppressing the warning only if you're sure that you don't w
   </data>
   <data name="ERR_NamedArgumentUsedInPositional" xml:space="preserve">
     <value>Named argument '{0}' specifies a parameter for which a positional argument has already been given</value>
+  </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
   </data>
   <data name="ERR_DefaultValueUsedWithAttributes" xml:space="preserve">
     <value>Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1493,6 +1493,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         #region diagnostics introduced for C# 7.2
         ERR_FeatureNotAvailableInVersion7_2 = 8320,
         WRN_UnreferencedLocalFunction = 8321,
+        ERR_BadNonTrailingNamedArgument = 8322,
         #endregion diagnostics introduced for C# 7.2
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -132,6 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureGenericPatternMatching = MessageBase + 12720,
         IDS_FeatureAsyncMain = MessageBase + 12721,
         IDS_LangVersions = MessageBase +  12722,
+        IDS_FeatureNonTrailingNamedArguments = MessageBase + 12723,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -188,6 +189,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Checks are in the LanguageParser unless otherwise noted.
             switch (feature)
             {
+                // C# 7.2 features.
+                case MessageID.IDS_FeatureNonTrailingNamedArguments:
+                    return LanguageVersion.CSharp7_2;
+
                 // C# 7.1 features.
                 case MessageID.IDS_FeatureAsyncMain:
                 case MessageID.IDS_FeatureDefaultLiteral:

--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -276,5 +276,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return self < MessageID.IDS_FeatureInferredTupleNames.RequiredVersion();
         }
+
+        internal static bool AllowNonTrailingNamedArguments(this LanguageVersion self)
+        {
+            return self >= MessageID.IDS_FeatureNonTrailingNamedArguments.RequiredVersion();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -3858,9 +3858,9 @@ public class Test
 
             compilation.VerifyDiagnostics(
                 // (3,39): error CS0643: 'AllowMultiple' duplicate named attribute argument
-                Diagnostic(ErrorCode.ERR_DuplicateNamedAttributeArgument, "AllowMultiple = false").WithArguments("AllowMultiple").WithLocation(3, 39),
-                // (3,2): error CS7036: There is no argument given that corresponds to the required formal parameter 'validOn' of 'System.AttributeUsageAttribute.AttributeUsageAttribute(System.AttributeTargets)'
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "AttributeUsage(AllowMultiple = true, AllowMultiple = false)").WithArguments("validOn", "System.AttributeUsageAttribute.AttributeUsageAttribute(System.AttributeTargets)").WithLocation(3, 2));
+                // [AttributeUsage(AllowMultiple = true, AllowMultiple = false)]
+                Diagnostic(ErrorCode.ERR_DuplicateNamedAttributeArgument, "AllowMultiple = false").WithArguments("AllowMultiple").WithLocation(3, 39)
+                );
         }
 
         [WorkItem(541059, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541059")]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -4362,6 +4362,12 @@ namespace AttributeTest
                 // (7,27): error CS1016: Named attribute argument expected
                 //     [A(3, z: 5, X = 6, y: 1)]
                 Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "1").WithLocation(7, 27),
+                // (8,17): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //     [A(3, z: 5, 1)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "1").WithArguments("7.2").WithLocation(8, 17),
+                // (8,11): error CS8321: Named argument 'z' is used out-of-position but is followed by an unnamed argument
+                //     [A(3, z: 5, 1)]
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "z").WithArguments("z").WithLocation(8, 11),
                 // (9,24): error CS1016: Named attribute argument expected
                 //     [A(3, 1, X = 6, z: 5)]
                 Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "5").WithLocation(9, 24),
@@ -4370,10 +4376,8 @@ namespace AttributeTest
                 Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "0").WithLocation(10, 15),
                 // (11,18): error CS1016: Named attribute argument expected
                 //     [A(X = 6, x: 0)]
-                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "0").WithLocation(11, 18),
-                // (8,17): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
-                //     [A(3, z: 5, 1)]
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "1").WithLocation(8, 17));
+                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "0").WithLocation(11, 18)
+                );
         }
 
         [WorkItem(541877, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541877")]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -4357,7 +4357,7 @@ namespace AttributeTest
     }
 }
 ";
-            var compilation = CreateStandardCompilation(source);
+            var compilation = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1);
             compilation.VerifyDiagnostics(
                 // (7,27): error CS1016: Named attribute argument expected
                 //     [A(3, z: 5, X = 6, y: 1)]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests.cs
@@ -3859,7 +3859,10 @@ public class Test
             compilation.VerifyDiagnostics(
                 // (3,39): error CS0643: 'AllowMultiple' duplicate named attribute argument
                 // [AttributeUsage(AllowMultiple = true, AllowMultiple = false)]
-                Diagnostic(ErrorCode.ERR_DuplicateNamedAttributeArgument, "AllowMultiple = false").WithArguments("AllowMultiple").WithLocation(3, 39)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedAttributeArgument, "AllowMultiple = false").WithArguments("AllowMultiple").WithLocation(3, 39),
+                // (3,2): error CS7036: There is no argument given that corresponds to the required formal parameter 'validOn' of 'AttributeUsageAttribute.AttributeUsageAttribute(AttributeTargets)'
+                // [AttributeUsage(AllowMultiple = true, AllowMultiple = false)]
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "AttributeUsage(AllowMultiple = true, AllowMultiple = false)").WithArguments("validOn", "System.AttributeUsageAttribute.AttributeUsageAttribute(System.AttributeTargets)").WithLocation(3, 2)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
                     numberFluentCalls = 225;
                     break;
                 case 64 when !isDebug:
-                    numberFluentCalls = 630;
+                    numberFluentCalls = 620;
                     break;
                 default:
                     throw new Exception($"unexpected pointer size {IntPtr.Size}");

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -37,14 +37,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
                     numberFluentCalls = 225;
                     break;
                 case 64 when !isDebug:
-                    numberFluentCalls = 640;
+                    numberFluentCalls = 630;
                     break;
                 default:
                     throw new Exception($"unexpected pointer size {IntPtr.Size}");
             }
 
-            // xunit.runner.console\2.2.0-beta4-build3444\tools\xunit.console.exe "<path>\CSharpCompilerEmitTest\Roslyn.Compilers.CSharp.Emit.UnitTests.dll"  -noshadow -verbose -class "Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.EndToEndTests" 
-            // xunit.runner.console\2.2.0-beta4-build3444\tools\xunit.console.x86.exe "<path>\CSharpCompilerEmitTest\Roslyn.Compilers.CSharp.Emit.UnitTests.dll"  -noshadow -verbose -class "Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.EndToEndTests" 
+            // <path>\xunit.console.exe "<path>\CSharpCompilerEmitTest\Roslyn.Compilers.CSharp.Emit.UnitTests.dll"  -noshadow -verbose -class "Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.EndToEndTests"
+            // <path>\xunit.console.x86.exe "<path>\CSharpCompilerEmitTest\Roslyn.Compilers.CSharp.Emit.UnitTests.dll"  -noshadow -verbose -class "Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.EndToEndTests"
             // Un-comment loop below and use above commands to figure out the new limits
             //for (int i = 0; i < numberFluentCalls; i = i + 10)
             //{

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
 {
-    public class EndToEndTests: EmitMetadataTestBase
+    public class EndToEndTests : EmitMetadataTestBase
     {
         // This test is a canary attempting to make sure that we don't regress the # of fluent calls that 
         // the compiler can handle.
@@ -25,51 +25,65 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             bool isDebug = false;
 #endif
 
-            switch (IntPtr.Size * 8) {
+            switch (IntPtr.Size * 8)
+            {
                 case 32 when isDebug:
                     numberFluentCalls = 510;
                     break;
                 case 32 when !isDebug:
-                    numberFluentCalls = 1600;
+                    numberFluentCalls = 1370;
                     break;
                 case 64 when isDebug:
                     numberFluentCalls = 225;
                     break;
                 case 64 when !isDebug:
-                    numberFluentCalls = 710;
+                    numberFluentCalls = 640;
                     break;
                 default:
                     throw new Exception($"unexpected pointer size {IntPtr.Size}");
             }
 
-            
-            var builder = new StringBuilder();
-            builder.AppendLine(
-    @"class C {
+            // xunit.runner.console\2.2.0-beta4-build3444\tools\xunit.console.exe "<path>\CSharpCompilerEmitTest\Roslyn.Compilers.CSharp.Emit.UnitTests.dll"  -noshadow -verbose -class "Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.EndToEndTests" 
+            // xunit.runner.console\2.2.0-beta4-build3444\tools\xunit.console.x86.exe "<path>\CSharpCompilerEmitTest\Roslyn.Compilers.CSharp.Emit.UnitTests.dll"  -noshadow -verbose -class "Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.EndToEndTests" 
+            // Un-comment loop below and use above commands to figure out the new limits
+            //for (int i = 0; i < numberFluentCalls; i = i + 10)
+            //{
+            //    Console.WriteLine($"Depth: {i}");
+            //    tryCompileDeepFluentCalls(i);
+            //}
+
+            tryCompileDeepFluentCalls(numberFluentCalls);
+
+            void tryCompileDeepFluentCalls(int depth)
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine(
+        @"class C {
     C M(string x) { return this; }
     void M2() {
         new C()
 ");
-            for (int i = 0; i < numberFluentCalls; i++)
-            {
-                builder.AppendLine(@"            .M(""test"")");
-            }
-            builder.AppendLine(
-               @"            .M(""test"");
+                for (int i = 0; i < depth; i++)
+                {
+                    builder.AppendLine(@"            .M(""test"")");
+                }
+                builder.AppendLine(
+                   @"            .M(""test"");
     }
 }");
 
-            var source = builder.ToString();
+                var source = builder.ToString();
 
-            var thread = new System.Threading.Thread(() =>
-            {
-                var options = new CSharpCompilationOptions(outputKind: OutputKind.DynamicallyLinkedLibrary, concurrentBuild: false);
-                var compilation = CreateStandardCompilation(source, options: options);
-                compilation.VerifyDiagnostics();
-                compilation.EmitToArray();
-            }, 0);
-            thread.Start();
-            thread.Join();
+                var thread = new System.Threading.Thread(() =>
+                {
+                    var options = new CSharpCompilationOptions(outputKind: OutputKind.DynamicallyLinkedLibrary, concurrentBuild: false);
+                    var compilation = CreateStandardCompilation(source, options: options);
+                    compilation.VerifyDiagnostics();
+                    compilation.EmitToArray();
+                }, 0);
+                thread.Start();
+                thread.Join();
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EndToEndTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
                     numberFluentCalls = 510;
                     break;
                 case 32 when !isDebug:
-                    numberFluentCalls = 1370;
+                    numberFluentCalls = 1350;
                     break;
                 case 64 when isDebug:
                     numberFluentCalls = 225;

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -82,6 +82,7 @@
     <Compile Include="FlowAnalysis\TryLockUsingStatementTests.cs" />
     <Compile Include="IOperation\IOperationTests_IVariableDeclaration.cs" />
     <Compile Include="Semantics\FuzzTests.cs" />
+    <Compile Include="Semantics\NonTrailingNamedArgumentsTests.cs" />
     <Compile Include="Semantics\OverloadResolutionPerfTests.cs" />
     <Compile Include="Semantics\PatternMatchingTests_Global.cs" />
     <Compile Include="Semantics\BindingAsyncTasklikeMoreTests.cs" />

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2127,7 +2127,10 @@ namespace System.ServiceModel
             CreateStandardCompilation(source).VerifyDiagnostics(
                 // (7,13): error CS1740: Named argument 'arg' cannot be specified multiple times
                 //             arg: null);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13),
+                // (5,9): error CS1501: No overload for method 'M' takes 3 arguments
+                //         M("",
+                Diagnostic(ErrorCode.ERR_BadArgCount, "M").WithArguments("M", "3").WithLocation(5, 9)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2127,10 +2127,7 @@ namespace System.ServiceModel
             CreateStandardCompilation(source).VerifyDiagnostics(
                 // (7,13): error CS1740: Named argument 'arg' cannot be specified multiple times
                 //             arg: null);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13),
-                // (5,9): error CS1501: No overload for method 'M' takes 3 arguments
-                //         M("",
-                Diagnostic(ErrorCode.ERR_BadArgCount, "M").WithArguments("M", "3").WithLocation(5, 9)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "arg").WithArguments("arg").WithLocation(7, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
@@ -1231,7 +1231,7 @@ class C
         d.Foo(System.Console.WriteLine());
     }
 }";
-            var comp = CreateCompilationWithMscorlibAndSystemCore(source);
+            var comp = CreateCompilationWithMscorlibAndSystemCore(source, parseOptions: TestOptions.Regular7_1);
             comp.VerifyDiagnostics(
                 // (7,15): error CS1978: Cannot use an expression of type '__arglist' as an argument to a dynamically dispatched operation.
                 //         d.Foo(__arglist(123, 456));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
@@ -1235,16 +1235,17 @@ class C
             comp.VerifyDiagnostics(
                 // (7,15): error CS1978: Cannot use an expression of type '__arglist' as an argument to a dynamically dispatched operation.
                 //         d.Foo(__arglist(123, 456));
-                Diagnostic(ErrorCode.ERR_BadDynamicMethodArg, "__arglist(123, 456)").WithArguments("__arglist"),
-                // (8,31): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
+                Diagnostic(ErrorCode.ERR_BadDynamicMethodArg, "__arglist(123, 456)").WithArguments("__arglist").WithLocation(7, 15),
+                // (8,31): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         d.Foo(x: 123, y: 456, 789);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "789"),
-                // (9,19): error CS0165: Use of unassigned local variable 'z'
-                //         d.Foo(ref z);
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z"),
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "789").WithArguments("7.2").WithLocation(8, 31),
                 // (10,15): error CS1978: Cannot use an expression of type 'void' as an argument to a dynamically dispatched operation.
                 //         d.Foo(System.Console.WriteLine());
-                Diagnostic(ErrorCode.ERR_BadDynamicMethodArg, "System.Console.WriteLine()").WithArguments("void"));
+                Diagnostic(ErrorCode.ERR_BadDynamicMethodArg, "System.Console.WriteLine()").WithArguments("void").WithLocation(10, 15),
+                // (9,19): error CS0165: Use of unassigned local variable 'z'
+                //         d.Foo(ref z);
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z").WithLocation(9, 19)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -172,9 +172,9 @@ class C : Middle
                 // (37,15): error CS1739: The best overload for 'Foo' does not have a parameter named 'optParam3'
                 //         c.Foo(optParam3: 333, reqParam1: 111 , optParam2: 222, optParam1: 1111); 
                 Diagnostic(ErrorCode.ERR_BadNamedArgument, "optParam3").WithArguments("Foo", "optParam3").WithLocation(37, 15),
-                // (39,30): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
+                // (39,30): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         c.Foo(optArg1: 3333, 11111);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "11111").WithLocation(39, 30),
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "11111").WithArguments("7.2").WithLocation(39, 30),
                 // (39,15): error CS1739: The best overload for 'Foo' does not have a parameter named 'optArg1'
                 //         c.Foo(optArg1: 3333, 11111);
                 Diagnostic(ErrorCode.ERR_BadNamedArgument, "optArg1").WithArguments("Foo", "optArg1").WithLocation(39, 15)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -168,7 +168,7 @@ class C : Middle
         c.Foo(optArg1: 3333, 11111);
     }
 }";
-            CreateStandardCompilation(source).VerifyDiagnostics(
+            CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1).VerifyDiagnostics(
                 // (37,15): error CS1739: The best overload for 'Foo' does not have a parameter named 'optParam3'
                 //         c.Foo(optParam3: 333, reqParam1: 111 , optParam2: 222, optParam1: 1111); 
                 Diagnostic(ErrorCode.ERR_BadNamedArgument, "optParam3").WithArguments("Foo", "optParam3").WithLocation(37, 15),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -302,9 +302,9 @@ class C
                 // (4,19): error CS0231: A params parameter must be the last parameter in a formal parameter list
                 //     static void M(params int[] x, int y)
                 Diagnostic(ErrorCode.ERR_ParamsLast, "params int[] x").WithLocation(4, 19),
-                // (9,14): error CS1503: Argument 1: cannot convert from 'int' to 'int'
+                // (9,14): error CS1503: Argument 1: cannot convert from 'int' to 'params int[]'
                 //         M(x: 1, 2);
-                Diagnostic(ErrorCode.ERR_BadArgType, "1").WithArguments("1", "int", "int").WithLocation(9, 14)
+                Diagnostic(ErrorCode.ERR_BadArgType, "1").WithArguments("1", "int", "params int[]").WithLocation(9, 14)
                 );
 
             var tree = comp.SyntaxTrees.First();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -320,19 +320,21 @@ class C
 {
     static void M(int x, params int[] y)
     {
+        System.Console.Write($""x={x} y[0]={y[0]} y.Length={y.Length}"");
     }
     static void Main()
     {
         M(y: 1, x: 2);
     }
 }";
-            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest);
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.RegularLatest, options: TestOptions.DebugExe);
             comp.VerifyDiagnostics();
+            CompileAndVerify(comp, expectedOutput: "x=2 y[0]=1 y.Length=1");
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
             var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
-            var invocation = nodes.OfType<InvocationExpressionSyntax>().Single();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
             Assert.Equal("M(y: 1, x: 2)", invocation.ToString());
             Assert.Equal("void C.M(System.Int32 x, params System.Int32[] y)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -1,0 +1,418 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    [CompilerTrait(CompilerFeature.NonTrailingNamedArgs)]
+    public class NonTrailingNamedArgumentsTests : CompilingTestBase
+    {
+        [Fact]
+        public void TestSimple()
+        {
+            var source = @"
+class C
+{
+    static void M(int a, int b)
+    {
+        System.Console.Write($""First {a} {b}. "");
+    }
+    static void M(long b, long a)
+    {
+        System.Console.Write($""Second {b} {a}. "");
+    }
+    static void Main()
+    {
+        M(a: 1, 2);
+        M(3, a: 4);
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "First 1 2. Second 3 4.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+
+            var tree = verifier.Compilation.SyntaxTrees.First();
+            var model = verifier.Compilation.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var firstInvocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(2);
+            Assert.Equal("M(a: 1, 2)", firstInvocation.ToString());
+            Assert.Equal("void C.M(System.Int32 a, System.Int32 b)",
+                model.GetSymbolInfo(firstInvocation).Symbol.ToTestDisplayString());
+
+            var secondInvocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(3);
+            Assert.Equal("M(3, a: 4)", secondInvocation.ToString());
+            Assert.Equal("void C.M(System.Int64 b, System.Int64 a)",
+                model.GetSymbolInfo(secondInvocation).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestPositionalUnaffected()
+        {
+            var source = @"
+class C
+{
+    static void M(int first, int other)
+    {
+        System.Console.Write($""{first} {other}"");
+    }
+    static void Main()
+    {
+        M(1, first: 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (10,14): error CS1744: Named argument 'first' specifies a parameter for which a positional argument has already been given
+                //         M(1, first: 2);
+                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "first").WithArguments("first").WithLocation(10, 14)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
+            Assert.Equal("M(1, first: 2)", invocation.ToString());
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+        }
+
+        [Fact]
+        public void TestPositionalUnaffected2()
+        {
+            var source = @"
+class C
+{
+    static void M(int a, int b, int c = 1)
+    {
+        System.Console.Write($""M {a} {b}"");
+    }
+    static void Main()
+    {
+        M(c: 1, 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (10,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'a' of 'C.M(int, int, int)'
+                //         M(c: 1, 2);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("a", "C.M(int, int, int)").WithLocation(10, 9)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
+            Assert.Equal("M(c: 1, 2)", invocation.ToString());
+            AssertEx.Equal(new[] { "void C.M(System.Int32 a, System.Int32 b, [System.Int32 c = 1])" },
+                model.GetSymbolInfo(invocation).CandidateSymbols.Select(c => c.ToTestDisplayString()));
+        }
+
+        [Fact]
+        public void TestNamedParams()
+        {
+            var source = @"
+class C
+{
+    static void M(params int[] x)
+    {
+    }
+    static void Main()
+    {
+        M(x: 1, 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (9,11): error CS8321: Named argument 'x' is used out-of-position but is followed by an unnamed argument
+                //         M(x: 1, 2);
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "x").WithArguments("x").WithLocation(9, 11)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().Single();
+            Assert.Equal("M(x: 1, 2)", invocation.ToString());
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol); // PROTOTYPE(non-trailing)
+        }
+
+        [Fact]
+        public void TestNamedParams2()
+        {
+            var source = @"
+class C
+{
+    static void M(params int[] x)
+    {
+    }
+    static void Main()
+    {
+        M(x: 1, x: 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (9,17): error CS1740: Named argument 'x' cannot be specified multiple times
+                //         M(x: 1, x: 2);
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(9, 17)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().Single();
+            Assert.Equal("M(x: 1, x: 2)", invocation.ToString());
+            Assert.Equal("void C.M(params System.Int32[] x)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestNamedParams3()
+        {
+            var source = @"
+class C
+{
+    static void M(int x, params int[] y)
+    {
+    }
+    static void Main()
+    {
+        M(y: 1, 2);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (9,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'x' of 'C.M(int, params int[])'
+                //         M(y: 1, 2);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("x", "C.M(int, params int[])").WithLocation(9, 9)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().Single();
+            Assert.Equal("M(y: 1, 2)", invocation.ToString());
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+        }
+
+        [Fact]
+        public void TestBadNonTrailing()
+        {
+            var source = @"
+class C
+{
+    static void M(int a = 1, int b = 2, int c = 3)
+    {
+        System.Console.Write($""First {a} {b}. "");
+    }
+    static void Main()
+    {
+        int valueB = 2;
+        int valueC = 3;
+        M(c: valueC, valueB);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (12,11): error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
+                //         M(c: valueC, valueB);
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "c").WithArguments("c").WithLocation(12, 11)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var firstInvocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
+            Assert.Equal("M(c: valueC, valueB)", firstInvocation.ToString());
+            Assert.Null(model.GetSymbolInfo(firstInvocation).Symbol);
+            Assert.Equal(CandidateReason.OverloadResolutionFailure, model.GetSymbolInfo(firstInvocation).CandidateReason);
+            Assert.Equal("void C.M([System.Int32 a = 1], [System.Int32 b = 2], [System.Int32 c = 3])",
+                model.GetSymbolInfo(firstInvocation).CandidateSymbols.Single().ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestBadNonTrailing2()
+        {
+            var source = @"
+class C
+{
+    static void M(int a = 1, int b = 2, int c = 3)
+    {
+    }
+    static void M(long c = 1, long b = 2)
+    {
+        System.Console.Write($""Second {c} {b}. "");
+    }
+    static void Main()
+    {
+        int valueB = 2;
+        int valueC = 3;
+        M(c: valueC, valueB);
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "Second 3 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+
+            var tree = verifier.Compilation.SyntaxTrees.First();
+            var model = verifier.Compilation.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
+            Assert.Equal("M(c: valueC, valueB)", invocation.ToString());
+            Assert.Equal("void C.M([System.Int64 c = 1], [System.Int64 b = 2])",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestBadNonTrailing3()
+        {
+            var source = @"
+class C
+{
+    static void M(long a = 1, long b = 2, long c = 3)
+    {
+    }
+    static void M(int c = 1, int b = 2)
+    {
+        System.Console.Write($""Second {c} {b}."");
+    }
+    static void Main()
+    {
+        int valueB = 2;
+        int valueC = 3;
+        M(c: valueC, valueB);
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "Second 3 2.", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+
+            var tree = verifier.Compilation.SyntaxTrees.First();
+            var model = verifier.Compilation.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<InvocationExpressionSyntax>().ElementAt(1);
+            Assert.Equal("M(c: valueC, valueB)", invocation.ToString());
+            Assert.Equal("void C.M([System.Int32 c = 1], [System.Int32 b = 2])",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestParams()
+        {
+            var source = @"
+class C
+{
+    static void M(int a, int b, params int[] c)
+    {
+    }
+    static void Main()
+    {
+        M(b: 2, 3, 4);
+    }
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (9,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'a' of 'C.M(int, int, params int[])'
+                //         M(b: 2, 3, 4);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("a", "C.M(int, int, params int[])").WithLocation(9, 9)
+                );
+        }
+
+        [Fact]
+        public void TestParams2()
+        {
+            var source = @"
+class C
+{
+    static void M(int a, int b, params int[] c)
+    {
+        System.Console.Write($""{a} {b} {c[0]} {c[1]} Length:{c.Length}"");
+    }
+    static void Main()
+    {
+        M(1, b: 2, 3, 4);
+    }
+}";
+            var verifier = CompileAndVerify(source, expectedOutput: "1 2 3 4 Length:2", parseOptions: TestOptions.Regular7_2);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TestInAttribute()
+        {
+            var source = @"
+using System;
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+public class MyAttribute : Attribute
+{
+    public int P { get; set; }
+	public MyAttribute(bool condition, int other) { }
+}
+
+[MyAttribute(condition: true, 42)]
+[MyAttribute(condition: true, P = 1, 42)]
+[MyAttribute(42, condition: true)]
+public class C
+{
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (12,38): error CS1016: Named attribute argument expected
+                // [MyAttribute(condition: true, P = 1, 42)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "42").WithLocation(12, 38),
+                // (13,18): error CS1744: Named argument 'condition' specifies a parameter for which a positional argument has already been given
+                // [MyAttribute(42, condition: true)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "condition").WithArguments("condition").WithLocation(13, 18)
+                );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+            var invocation = nodes.OfType<AttributeSyntax>().ElementAt(1);
+            Assert.Equal("MyAttribute(condition: true, 42)", invocation.ToString());
+            Assert.Equal("MyAttribute..ctor(System.Boolean condition, System.Int32 other)",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestInAttribute2()
+        {
+            var source = @"
+using System;
+
+[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+public class MyAttribute : Attribute
+{
+    public int P { get; set; }
+	public MyAttribute(int a = 1, int b = 2, int c = 3) { }
+}
+
+[MyAttribute(c:3, 2)]
+[MyAttribute(P=1, c:3, 2)]
+public class C
+{
+}";
+            var comp = CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_2);
+            comp.VerifyDiagnostics(
+                // (11,14): error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
+                // [MyAttribute(c:3, 2)]
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "c").WithArguments("c").WithLocation(11, 14),
+                // (12,21): error CS1016: Named attribute argument expected
+                // [MyAttribute(P=1, c:3, 2)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "3").WithLocation(12, 21),
+                // (12,24): error CS1016: Named attribute argument expected
+                // [MyAttribute(P=1, c:3, 2)]
+                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "2").WithLocation(12, 24),
+                // (12,19): error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
+                // [MyAttribute(P=1, c:3, 2)]
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "c").WithArguments("c").WithLocation(12, 19)
+                );
+        }
+
+        // PROTOTYPE(non-trailing) add the error code to UpgradeProject code fixer
+        // new C(...)
+        // Constructor(...) : this(...)
+        // delegate invocation
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.cs
@@ -218,7 +218,10 @@ class C
                 Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(9, 17),
                 // (9,23): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         M(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "3").WithArguments("7.2").WithLocation(9, 23)
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "3").WithArguments("7.2").WithLocation(9, 23),
+                // (9,17): error CS8321: Named argument 'x' is used out-of-position but is followed by an unnamed argument
+                //         M(x: 1, x: 2, 3);
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "x").WithArguments("x").WithLocation(9, 17)
                 );
 
             var tree = comp.SyntaxTrees.First();
@@ -544,7 +547,10 @@ public class C
                 Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "3").WithLocation(12, 21),
                 // (12,24): error CS1016: Named attribute argument expected
                 // [MyAttribute(P=1, c:3, 2)]
-                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "2").WithLocation(12, 24)
+                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "2").WithLocation(12, 24),
+                // (12,19): error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
+                // [MyAttribute(P=1, c:3, 2)]
+                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "c").WithArguments("c").WithLocation(12, 19)
                 );
         }
 
@@ -563,7 +569,10 @@ class C
             comp.VerifyDiagnostics(
                 // (6,17): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         M(x: 1, x: 2, __arglist());
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 17)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 17),
+                // (6,11): error CS1739: The best overload for 'M' does not have a parameter named 'x'
+                //         M(x: 1, x: 2, __arglist());
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("M", "x").WithLocation(6, 11)
                 );
         }
 
@@ -601,7 +610,10 @@ class C
             comp.VerifyDiagnostics(
                 // (4,22): error CS1740: Named argument 'x' cannot be specified multiple times
                 //     C() : this(x: 1, x: 2, 3) { }
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(4, 22)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(4, 22),
+                // (4,16): error CS1739: The best overload for '.ctor' does not have a parameter named 'x'
+                //     C() : this(x: 1, x: 2, 3) { }
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments(".ctor", "x").WithLocation(4, 16)
                 );
         }
 
@@ -620,7 +632,10 @@ class C
             comp.VerifyDiagnostics(
                 // (6,21): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         new C(x: 1, x: 2, 3);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 21)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 21),
+                // (6,15): error CS1739: The best overload for 'C' does not have a parameter named 'x'
+                //         new C(x: 1, x: 2, 3);
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("C", "x").WithLocation(6, 15)
                 );
         }
 
@@ -641,7 +656,10 @@ class C
             comp.VerifyDiagnostics(
                 // (8,38): error CS1740: Named argument 'x' cannot be specified multiple times
                 //         System.Console.Write(c[x: 1, x: 2, 3]);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(8, 38)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(8, 38),
+                // (8,32): error CS1739: The best overload for 'this' does not have a parameter named 'x'
+                //         System.Console.Write(c[x: 1, x: 2, 3]);
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "x").WithArguments("this", "x").WithLocation(8, 32)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -18610,10 +18610,7 @@ public class Cls
             compilation.VerifyDiagnostics(
                 // (7,25): error CS1740: Named argument 'y' cannot be specified multiple times
                 //         Test1(y: ref x, y: out var y);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "y").WithArguments("y").WithLocation(7, 25),
-                // (7,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'x' of 'Cls.Test1(int, ref int)'
-                //         Test1(y: ref x, y: out var y);
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test1").WithArguments("x", "Cls.Test1(int, ref int)").WithLocation(7, 9)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "y").WithArguments("y").WithLocation(7, 25)
                 );
 
             var tree = compilation.SyntaxTrees.Single();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -18610,7 +18610,10 @@ public class Cls
             compilation.VerifyDiagnostics(
                 // (7,25): error CS1740: Named argument 'y' cannot be specified multiple times
                 //         Test1(y: ref x, y: out var y);
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "y").WithArguments("y").WithLocation(7, 25)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "y").WithArguments("y").WithLocation(7, 25),
+                // (7,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'x' of 'Cls.Test1(int, ref int)'
+                //         Test1(y: ref x, y: out var y);
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test1").WithArguments("x", "Cls.Test1(int, ref int)").WithLocation(7, 9)
                 );
 
             var tree = compilation.SyntaxTrees.Single();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -2425,18 +2425,18 @@ class Test : System.Attribute
                 // (6,18): error CS0103: The name 'var' does not exist in the current context
                 //     [Test(p: out var x5)]
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "var").WithArguments("var").WithLocation(6, 18),
-                // (6,18): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
+                // (6,18): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //     [Test(p: out var x5)]
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "var").WithLocation(6, 18),
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "var").WithArguments("7.2").WithLocation(6, 18),
                 // (6,22): error CS0103: The name 'x5' does not exist in the current context
                 //     [Test(p: out var x5)]
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "x5").WithArguments("x5").WithLocation(6, 22),
                 // (6,6): error CS1729: 'Test' does not contain a constructor that takes 3 arguments
                 //     [Test(p: out var x5)]
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Test(p: out var x5)").WithArguments("Test", "3").WithLocation(6, 6),
-                // (7,18): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
+                // (7,18): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //     [Test(p: out int x6)]
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "int").WithLocation(7, 18),
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "int").WithArguments("7.2").WithLocation(7, 18),
                 // (7,22): error CS0103: The name 'x6' does not exist in the current context
                 //     [Test(p: out int x6)]
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "x6").WithArguments("x6").WithLocation(7, 22),
@@ -18570,9 +18570,9 @@ public class Cls
                                                             parseOptions: TestOptions.Regular);
 
             compilation.VerifyDiagnostics(
-                // (6,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
+                // (6,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
                 //         Test1(x: 1, out var y);
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "out var y").WithLocation(6, 21),
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "out var y").WithArguments("7.2").WithLocation(6, 21),
                 // (6,25): error CS1620: Argument 2 must be passed with the 'ref' keyword
                 //         Test1(x: 1, out var y);
                 Diagnostic(ErrorCode.ERR_BadArgRef, "var y").WithArguments("2", "ref").WithLocation(6, 25)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -2363,7 +2363,7 @@ class Test : System.Attribute
     public Test(out int p) { p = 100; }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular7_1);
             compilation.VerifyDiagnostics(
                 // (4,11): error CS1041: Identifier expected; 'out' is a keyword
                 //     [Test(out var x3)]
@@ -18567,7 +18567,7 @@ public class Cls
 }";
             var compilation = CreateStandardCompilation(text,
                                                             options: TestOptions.ReleaseExe,
-                                                            parseOptions: TestOptions.Regular);
+                                                            parseOptions: TestOptions.Regular7_1);
 
             compilation.VerifyDiagnostics(
                 // (6,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -15681,16 +15681,19 @@ class C
 public class C
 {
     public static int Main()
-        {
-            Test(age: 5,"""");
+    {
+        Test(age: 5,"""");
         return 0;
-        }
-    public static void Test(int age , string Name)
+    }
+    public static void Test(int age, string Name)
     { }
-
 }";
-            DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
-                new ErrorDescription[] { new ErrorDescription { Code = 1738, Line = 6, Column = 25 } });
+            var comp = CreateStandardCompilation(text, parseOptions: TestOptions.Regular6);
+            comp.VerifyDiagnostics(
+                // (6,21): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         Test(age: 5,"");
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, @"""""").WithArguments("7.2").WithLocation(6, 21)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -15750,7 +15750,10 @@ public class C
             compilation.VerifyDiagnostics(
                 // (6,29): error CS1740: Named argument 'Name' cannot be specified multiple times
                 //             Test(Name: "5", Name: "");
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 29)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 29),
+                // (6,13): error CS7036: There is no argument given that corresponds to the required formal parameter 'age' of 'C.Test(int, string)'
+                //             Test(Name: "5", Name: "");
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test").WithArguments("age", "C.Test(int, string)").WithLocation(6, 13)
                 );
         }
 
@@ -21954,12 +21957,18 @@ public class Program
                 // (11,42): error CS0206: A property or indexer may not be passed as an out or ref parameter
                 //         var d = new Func<string, string>(ref BarP, BarP.Invoke);
                 Diagnostic(ErrorCode.ERR_RefProperty, "ref BarP").WithArguments("Program.BarP").WithLocation(11, 42),
+                // (11,46): error CS0149: Method name expected
+                //         var d = new Func<string, string>(ref BarP, BarP.Invoke);
+                Diagnostic(ErrorCode.ERR_MethodNameExpected, "BarP, BarP.Invoke").WithLocation(11, 46),
                 // (12,42): error CS0149: Method name expected
                 //         var e = new Func<string, string>(BarP, ref BarP.Invoke);
                 Diagnostic(ErrorCode.ERR_MethodNameExpected, "BarP, ref BarP.Invoke").WithLocation(12, 42),
                 // (13,42): error CS0206: A property or indexer may not be passed as an out or ref parameter
                 //         var f = new Func<string, string>(ref BarP, ref BarP.Invoke);
-                Diagnostic(ErrorCode.ERR_RefProperty, "ref BarP").WithArguments("Program.BarP").WithLocation(13, 42)
+                Diagnostic(ErrorCode.ERR_RefProperty, "ref BarP").WithArguments("Program.BarP").WithLocation(13, 42),
+                // (13,46): error CS0149: Method name expected
+                //         var f = new Func<string, string>(ref BarP, ref BarP.Invoke);
+                Diagnostic(ErrorCode.ERR_MethodNameExpected, "BarP, ref BarP.Invoke").WithLocation(13, 46)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -15750,10 +15750,7 @@ public class C
             compilation.VerifyDiagnostics(
                 // (6,29): error CS1740: Named argument 'Name' cannot be specified multiple times
                 //             Test(Name: "5", Name: "");
-                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 29),
-                // (6,13): error CS7036: There is no argument given that corresponds to the required formal parameter 'age' of 'C.Test(int, string)'
-                //             Test(Name: "5", Name: "");
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Test").WithArguments("age", "C.Test(int, string)").WithLocation(6, 13)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "Name").WithArguments("Name").WithLocation(6, 29)
                 );
         }
 
@@ -21957,18 +21954,13 @@ public class Program
                 // (11,42): error CS0206: A property or indexer may not be passed as an out or ref parameter
                 //         var d = new Func<string, string>(ref BarP, BarP.Invoke);
                 Diagnostic(ErrorCode.ERR_RefProperty, "ref BarP").WithArguments("Program.BarP").WithLocation(11, 42),
-                // (11,46): error CS0149: Method name expected
-                //         var d = new Func<string, string>(ref BarP, BarP.Invoke);
-                Diagnostic(ErrorCode.ERR_MethodNameExpected, "BarP, BarP.Invoke").WithLocation(11, 46),
                 // (12,42): error CS0149: Method name expected
                 //         var e = new Func<string, string>(BarP, ref BarP.Invoke);
                 Diagnostic(ErrorCode.ERR_MethodNameExpected, "BarP, ref BarP.Invoke").WithLocation(12, 42),
                 // (13,42): error CS0206: A property or indexer may not be passed as an out or ref parameter
                 //         var f = new Func<string, string>(ref BarP, ref BarP.Invoke);
-                Diagnostic(ErrorCode.ERR_RefProperty, "ref BarP").WithArguments("Program.BarP").WithLocation(13, 42),
-                // (13,46): error CS0149: Method name expected
-                //         var f = new Func<string, string>(ref BarP, ref BarP.Invoke);
-                Diagnostic(ErrorCode.ERR_MethodNameExpected, "BarP, ref BarP.Invoke").WithLocation(13, 46));
+                Diagnostic(ErrorCode.ERR_RefProperty, "ref BarP").WithArguments("Program.BarP").WithLocation(13, 42)
+                );
         }
 
         [WorkItem(538430, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538430")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -832,21 +832,30 @@ class Derived : Base
 }";
             CreateStandardCompilation(source).VerifyDiagnostics(
                 // (7,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'y' of 'C.this[int, long]'
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "c[0]").WithArguments("y", "C.this[int, long]"),
+                //         c[0] = c[0, 0, 0]; //wrong number of arguments
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "c[0]").WithArguments("y", "C.this[int, long]").WithLocation(7, 9),
                 // (7,16): error CS1501: No overload for method 'this' takes 3 arguments
-                Diagnostic(ErrorCode.ERR_BadArgCount, "c[0, 0, 0]").WithArguments("this", "3"),
+                //         c[0] = c[0, 0, 0]; //wrong number of arguments
+                Diagnostic(ErrorCode.ERR_BadArgCount, "c[0, 0, 0]").WithArguments("this", "3").WithLocation(7, 16),
                 // (8,11): error CS1503: Argument 1: cannot convert from 'bool' to 'int'
-                Diagnostic(ErrorCode.ERR_BadArgType, "true").WithArguments("1", "bool", "int"),
+                //         c[true, 1] = c[y: 1, x: long.MaxValue]; //wrong argument types
+                Diagnostic(ErrorCode.ERR_BadArgType, "true").WithArguments("1", "bool", "int").WithLocation(8, 11),
                 // (8,33): error CS1503: Argument 2: cannot convert from 'long' to 'int'
-                Diagnostic(ErrorCode.ERR_BadArgType, "long.MaxValue").WithArguments("2", "long", "int"),
+                //         c[true, 1] = c[y: 1, x: long.MaxValue]; //wrong argument types
+                Diagnostic(ErrorCode.ERR_BadArgType, "long.MaxValue").WithArguments("2", "long", "int").WithLocation(8, 33),
                 // (9,14): error CS1744: Named argument 'x' specifies a parameter for which a positional argument has already been given
-                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "x").WithArguments("x"),
-                // (9,30): error CS1738: Named argument specifications must appear after all fixed arguments have been specified
-                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2"),
+                //         c[1, x: 1] = c[x: 1, 2]; //bad mix of named and positional
+                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "x").WithArguments("x").WithLocation(9, 14),
+                // (9,30): error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
+                //         c[1, x: 1] = c[x: 1, 2]; //bad mix of named and positional
+                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "2").WithArguments("7.2").WithLocation(9, 30),
                 // (10,14): error CS1739: The best overload for 'this' does not have a parameter named 'q'
-                Diagnostic(ErrorCode.ERR_BadNamedArgument, "q").WithArguments("this", "q"),
+                //         this[q: 1, r: 2] = base[0]; //bad parameter names / no indexer
+                Diagnostic(ErrorCode.ERR_BadNamedArgument, "q").WithArguments("this", "q").WithLocation(10, 14),
                 // (10,28): error CS0021: Cannot apply indexing with [] to an expression of type 'object'
-                Diagnostic(ErrorCode.ERR_BadIndexLHS, "base[0]").WithArguments("object"));
+                //         this[q: 1, r: 2] = base[0]; //bad parameter names / no indexer
+                Diagnostic(ErrorCode.ERR_BadIndexLHS, "base[0]").WithArguments("object").WithLocation(10, 28)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexerTests.cs
@@ -830,7 +830,7 @@ class Derived : Base
         this[q: 1, r: 2] = base[0]; //bad parameter names / no indexer
     }
 }";
-            CreateStandardCompilation(source).VerifyDiagnostics(
+            CreateStandardCompilation(source, parseOptions: TestOptions.Regular7_1).VerifyDiagnostics(
                 // (7,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'y' of 'C.this[int, long]'
                 //         c[0] = c[0, 0, 0]; //wrong number of arguments
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "c[0]").WithArguments("y", "C.this[int, long]").WithLocation(7, 9),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -11067,10 +11067,8 @@ public class Test
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (2,39): error CS0643: 'AllowMultiple' duplicate named attribute argument
                 // [AttributeUsage(AllowMultiple = true, AllowMultiple = false)]
-                Diagnostic(ErrorCode.ERR_DuplicateNamedAttributeArgument, "AllowMultiple = false").WithArguments("AllowMultiple").WithLocation(2, 39),
-                // (2,2): error CS7036: There is no argument given that corresponds to the required formal parameter 'validOn' of 'System.AttributeUsageAttribute.AttributeUsageAttribute(System.AttributeTargets)'
-                // [AttributeUsage(AllowMultiple = true, AllowMultiple = false)]
-                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "AttributeUsage(AllowMultiple = true, AllowMultiple = false)").WithArguments("validOn", "System.AttributeUsageAttribute.AttributeUsageAttribute(System.AttributeTargets)").WithLocation(2, 2));
+                Diagnostic(ErrorCode.ERR_DuplicateNamedAttributeArgument, "AllowMultiple = false").WithArguments("AllowMultiple").WithLocation(2, 39)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -11067,7 +11067,10 @@ public class Test
             CreateStandardCompilation(text).VerifyDiagnostics(
                 // (2,39): error CS0643: 'AllowMultiple' duplicate named attribute argument
                 // [AttributeUsage(AllowMultiple = true, AllowMultiple = false)]
-                Diagnostic(ErrorCode.ERR_DuplicateNamedAttributeArgument, "AllowMultiple = false").WithArguments("AllowMultiple").WithLocation(2, 39)
+                Diagnostic(ErrorCode.ERR_DuplicateNamedAttributeArgument, "AllowMultiple = false").WithArguments("AllowMultiple").WithLocation(2, 39),
+                // (2,2): error CS7036: There is no argument given that corresponds to the required formal parameter 'validOn' of 'AttributeUsageAttribute.AttributeUsageAttribute(AttributeTargets)'
+                // [AttributeUsage(AllowMultiple = true, AllowMultiple = false)]
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "AttributeUsage(AllowMultiple = true, AllowMultiple = false)").WithArguments("validOn", "System.AttributeUsageAttribute.AttributeUsageAttribute(System.AttributeTargets)").WithLocation(2, 2)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -1730,10 +1730,8 @@ namespace x
                 Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "b").WithLocation(9, 15),
                 // (9,15): error CS0103: The name 'b' does not exist in the current context
                 //     [Foo(a=5, b)]
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "b").WithArguments("b").WithLocation(9, 15),
-                //(9,6): error CS1729: 'FooAttribute' does not contain a constructor that takes 1 arguments
-                //     [Foo(a=5, b)]
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Foo(a=5, b)").WithArguments("x.FooAttribute", "1").WithLocation(9, 6));
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "b").WithArguments("b").WithLocation(9, 15)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -1730,7 +1730,10 @@ namespace x
                 Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "b").WithLocation(9, 15),
                 // (9,15): error CS0103: The name 'b' does not exist in the current context
                 //     [Foo(a=5, b)]
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "b").WithArguments("b").WithLocation(9, 15)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "b").WithArguments("b").WithLocation(9, 15),
+                // (9,6): error CS1729: 'FooAttribute' does not contain a constructor that takes 1 arguments
+                //     [Foo(a=5, b)]
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Foo(a=5, b)").WithArguments("x.FooAttribute", "1").WithLocation(9, 6)
                 );
         }
 

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpParseOptions Regular6 = Regular.WithLanguageVersion(LanguageVersion.CSharp6);
         public static readonly CSharpParseOptions Regular7 = Regular.WithLanguageVersion(LanguageVersion.CSharp7);
         public static readonly CSharpParseOptions Regular7_1 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_1);
+        public static readonly CSharpParseOptions Regular7_2 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_2);
         public static readonly CSharpParseOptions RegularWithDocumentationComments = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Diagnose);
 
         private static readonly SmallDictionary<string, string> s_experimentalFeatures = new SmallDictionary<string, string> { };

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
@@ -17,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public static readonly CSharpParseOptions Regular7 = Regular.WithLanguageVersion(LanguageVersion.CSharp7);
         public static readonly CSharpParseOptions Regular7_1 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_1);
         public static readonly CSharpParseOptions Regular7_2 = Regular.WithLanguageVersion(LanguageVersion.CSharp7_2);
+        public static readonly CSharpParseOptions RegularLatest = Regular.WithLanguageVersion(LanguageVersion.Latest);
         public static readonly CSharpParseOptions RegularWithDocumentationComments = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Diagnose);
 
         private static readonly SmallDictionary<string, string> s_experimentalFeatures = new SmallDictionary<string, string> { };

--- a/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
+++ b/src/Test/Utilities/Portable/Traits/CompilerFeature.cs
@@ -22,5 +22,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         Patterns,
         DefaultLiteral,
         AsyncMain,
+        NonTrailingNamedArgs,
     }
 }


### PR DESCRIPTION
This allows invoking `M(first: 1, 2, 3)` on `void M(int first, bool second, params int[] third)`.

When overload resolution considers each candidate, it maps each argument to a corresponding parameter. Previously this would always report an error if a named argument is non-trailing.
Now, it is ok, as long as the corresponding parameter is found at the same position as the argument (ie. the name doesn't change correspondance) and the parameter is not params (disallow `M(1, 2, third: 3, 4)`).

Relates to this [language proposal](https://github.com/dotnet/csharplang/blob/master/proposals/non-trailing-named-arguments.md)
