### PR TITLE
create dump files when VS instance crashes or hangs (integration tests)

### DIFF
--- a/src/Test/Utilities/Portable/FX/DumpProcRunner.cs
+++ b/src/Test/Utilities/Portable/FX/DumpProcRunner.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.CodeAnalysis.Test.Utilities
+{
+    public class ProcDumpRunner
+    {
+        public const string ProcDumpPathEnvironmentVariableKey = "ProcDumpPath";
+
+        private const string ProcDumpExeFileName = "procdump.exe";
+
+        // /accepteula command line option to automatically accept the Sysinternals license agreement.
+        // -ma	Write a 'Full' dump file. Includes All the Image, Mapped and Private memory.
+        // -e	Write a dump when the process encounters an unhandled exception. Include the 1 to create dump on first chance exceptions.
+        // -h	Write dump if process has a hung window (does not respond to window messages for at least 5 seconds).
+        // -t	Write a dump when the process terminates.
+        // -w 	Wait for the specified process to launch if it's not running.
+        private const string ProcDumpKeys = "/accepteula -ma -e -h -t -w";
+
+        /// <summary>
+        /// Starts procdump.exe against the process.
+        /// </summary>
+        /// <param name="processId">process id</param>
+        /// <param name="processName">process name</param>
+        /// <param name="loggingMethod">method to log diagnostics to</param>
+        /// <param name="destinationDirectory">destination directory for dumps</param>
+        public static void StartProcDump(int processId, string processName, string destinationDirectory, Action<string> loggingMethod)
+        {
+            var environmentVariables = Environment.GetEnvironmentVariables();
+            if (environmentVariables.Contains(ProcDumpPathEnvironmentVariableKey))
+            {
+                var procDumpPath = (string)environmentVariables[ProcDumpPathEnvironmentVariableKey];
+                var procDumpFilePath = Path.Combine(procDumpPath, ProcDumpExeFileName);
+
+                var dumpDirectory = Path.Combine(destinationDirectory, "Dumps");
+                Directory.CreateDirectory(dumpDirectory);
+
+                var procDumpProcess = Process.Start(procDumpFilePath, $" {ProcDumpKeys} {processId} {dumpDirectory}");
+                loggingMethod($"Launched ProcDump attached to {processName} (process Id: {processId})");
+            }
+            else
+            {
+                loggingMethod($"Environment variables do not contain {ProcDumpPathEnvironmentVariableKey} (path to procdump.exe). Will skip attaching procdump to VS instance.");
+            }
+        }
+    }
+}

--- a/src/Test/Utilities/Portable/FX/DumpProcRunner.cs
+++ b/src/Test/Utilities/Portable/FX/DumpProcRunner.cs
@@ -15,30 +15,27 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         // /accepteula command line option to automatically accept the Sysinternals license agreement.
         // -ma	Write a 'Full' dump file. Includes All the Image, Mapped and Private memory.
         // -e	Write a dump when the process encounters an unhandled exception. Include the 1 to create dump on first chance exceptions.
-        // -h	Write dump if process has a hung window (does not respond to window messages for at least 5 seconds).
         // -t	Write a dump when the process terminates.
         // -w 	Wait for the specified process to launch if it's not running.
-        private const string ProcDumpKeys = "/accepteula -ma -e -h -t -w";
+        private const string ProcDumpSwitches = "/accepteula -ma -e -t -w";
 
         /// <summary>
         /// Starts procdump.exe against the process.
         /// </summary>
+        /// <param name="procDumpPath">The path to the procdump executable</param>
         /// <param name="processId">process id</param>
         /// <param name="processName">process name</param>
         /// <param name="loggingMethod">method to log diagnostics to</param>
         /// <param name="destinationDirectory">destination directory for dumps</param>
-        public static void StartProcDump(int processId, string processName, string destinationDirectory, Action<string> loggingMethod)
+        public static void StartProcDump(string procDumpPath, int processId, string processName, string destinationDirectory, Action<string> loggingMethod)
         {
-            var environmentVariables = Environment.GetEnvironmentVariables();
-            if (environmentVariables.Contains(ProcDumpPathEnvironmentVariableKey))
+            if (!string.IsNullOrWhiteSpace(procDumpPath))
             {
-                var procDumpPath = (string)environmentVariables[ProcDumpPathEnvironmentVariableKey];
                 var procDumpFilePath = Path.Combine(procDumpPath, ProcDumpExeFileName);
-
                 var dumpDirectory = Path.Combine(destinationDirectory, "Dumps");
                 Directory.CreateDirectory(dumpDirectory);
 
-                var procDumpProcess = Process.Start(procDumpFilePath, $" {ProcDumpKeys} {processId} {dumpDirectory}");
+                var procDumpProcess = Process.Start(procDumpFilePath, $" {ProcDumpSwitches} {processId} \"{dumpDirectory}\"");
                 loggingMethod($"Launched ProcDump attached to {processName} (process Id: {processId})");
             }
             else

--- a/src/Test/Utilities/Portable/TestUtilities.csproj
+++ b/src/Test/Utilities/Portable/TestUtilities.csproj
@@ -129,6 +129,7 @@
     <Compile Include="FX\CappedStringWriter.cs" />
     <Compile Include="FX\CultureHelpers.cs" />
     <Compile Include="FX\DirectoryHelper.cs" />
+    <Compile Include="FX\DumpProcRunner.cs" />
     <Compile Include="FX\EncodingUtilities.cs" />
     <Compile Include="FX\EnsureEnglishUICulture.cs" />
     <Compile Include="FX\EnsureInvariantCulture.cs" />

--- a/src/Tools/Source/RunTests/ITestExecutor.cs
+++ b/src/Tools/Source/RunTests/ITestExecutor.cs
@@ -11,15 +11,19 @@ namespace RunTests
     internal struct TestExecutionOptions
     {
         internal string XunitPath { get; }
+        internal string ProcDumpPath { get; }
+        internal string LogFilePath { get; }
         internal string Trait { get; }
         internal string NoTrait { get; }
         internal bool UseHtml { get; }
         internal bool Test64 { get; }
         internal bool TestVsi { get; }
-
-        internal TestExecutionOptions(string xunitPath, string trait, string noTrait, bool useHtml, bool test64, bool testVsi)
+        
+        internal TestExecutionOptions(string xunitPath, string procDumpPath, string logFilePath, string trait, string noTrait, bool useHtml, bool test64, bool testVsi)
         {
             XunitPath = xunitPath;
+            ProcDumpPath = procDumpPath;
+            LogFilePath = logFilePath;
             Trait = trait;
             NoTrait = noTrait;
             UseHtml = useHtml;

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -68,7 +68,7 @@ namespace RunTests
         public string XunitPath { get; set; }
 
         /// <summary>
-        /// When set the log file ffor executing tests will be written to the prescribed location.
+        /// When set the log file for executing tests will be written to the prescribed location.
         /// </summary>
         public string LogFilePath { get; set; }
 

--- a/src/Tools/Source/RunTests/ProcessRunner.cs
+++ b/src/Tools/Source/RunTests/ProcessRunner.cs
@@ -41,19 +41,21 @@ namespace RunTests
             string workingDirectory = null,
             bool captureOutput = false,
             bool displayWindow = true,
-            Dictionary<string, string> environmentVariables = null)
+            Dictionary<string, string> environmentVariables = null,
+            Action<Process> onProcessStartHandler = null)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var taskCompletionSource = new TaskCompletionSource<ProcessOutput>();
-            var processStartInfo = CreateProcessStartInfo(executable, arguments, workingDirectory, captureOutput, displayWindow);
-            return CreateProcessTask(processStartInfo, lowPriority, taskCompletionSource, cancellationToken);
+            var processStartInfo = CreateProcessStartInfo(executable, arguments, workingDirectory, captureOutput, displayWindow, environmentVariables);
+            return CreateProcessTask(processStartInfo, lowPriority, taskCompletionSource, onProcessStartHandler, cancellationToken);
         }
 
         private static Task<ProcessOutput> CreateProcessTask(
             ProcessStartInfo processStartInfo,
             bool lowPriority,
             TaskCompletionSource<ProcessOutput> taskCompletionSource,
+            Action<Process> onProcessStartHandler,
             CancellationToken cancellationToken)
         {
             var errorLines = new List<string>();
@@ -112,6 +114,7 @@ namespace RunTests
                 });
 
             process.Start();
+            onProcessStartHandler?.Invoke(process);
 
             if (lowPriority)
             {

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Test.Utilities;
 
 namespace RunTests
 {
@@ -81,7 +82,16 @@ namespace RunTests
                 // an empty log just in case, so our runner will still fail.
                 File.Create(resultsFilePath).Close();
 
-                var dumpOutputFilePath = Path.Combine(resultsDir, $"{assemblyInfo.DisplayName}.dmp");
+                // Define environment variables for processes started via ProcessRunner.
+                var environmentVariables = new Dictionary<string, string>();
+                environmentVariables.Add(ProcDumpRunner.ProcDumpPathEnvironmentVariableKey, _options.ProcDumpPath);
+
+                // Set environment variables for the current process.
+                Environment.SetEnvironmentVariable(ProcDumpRunner.ProcDumpPathEnvironmentVariableKey, _options.ProcDumpPath);
+
+                var outputDirectory = _options.LogFilePath != null
+                    ? Path.GetDirectoryName(_options.LogFilePath)
+                    : Directory.GetCurrentDirectory();
 
                 var start = DateTime.UtcNow;
                 var xunitPath = _options.XunitPath;
@@ -91,7 +101,10 @@ namespace RunTests
                     lowPriority: false,
                     displayWindow: false,
                     captureOutput: true,
-                    cancellationToken: cancellationToken);
+                    cancellationToken: cancellationToken,
+                    environmentVariables: environmentVariables,
+                    onProcessStartHandler: (process) => ProcDumpRunner.StartProcDump(process.Id, process.ProcessName, outputDirectory, Logger.Log)
+                    );
                 var span = DateTime.UtcNow - start;
 
                 if (processOutput.ExitCode != 0)

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -100,8 +100,7 @@ namespace RunTests
                     captureOutput: true,
                     cancellationToken: cancellationToken,
                     environmentVariables: environmentVariables,
-                    onProcessStartHandler: (process) => ProcDumpRunner.StartProcDump(_options.ProcDumpPath, process.Id, process.ProcessName, outputDirectory, Logger.Log)
-                    );
+                    onProcessStartHandler: (process) => ProcDumpRunner.StartProcDump(_options.ProcDumpPath, process.Id, process.ProcessName, outputDirectory, Logger.Log));
                 var span = DateTime.UtcNow - start;
 
                 if (processOutput.ExitCode != 0)

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -86,9 +86,6 @@ namespace RunTests
                 var environmentVariables = new Dictionary<string, string>();
                 environmentVariables.Add(ProcDumpRunner.ProcDumpPathEnvironmentVariableKey, _options.ProcDumpPath);
 
-                // Set environment variables for the current process.
-                Environment.SetEnvironmentVariable(ProcDumpRunner.ProcDumpPathEnvironmentVariableKey, _options.ProcDumpPath);
-
                 var outputDirectory = _options.LogFilePath != null
                     ? Path.GetDirectoryName(_options.LogFilePath)
                     : Directory.GetCurrentDirectory();
@@ -103,7 +100,7 @@ namespace RunTests
                     captureOutput: true,
                     cancellationToken: cancellationToken,
                     environmentVariables: environmentVariables,
-                    onProcessStartHandler: (process) => ProcDumpRunner.StartProcDump(process.Id, process.ProcessName, outputDirectory, Logger.Log)
+                    onProcessStartHandler: (process) => ProcDumpRunner.StartProcDump(_options.ProcDumpPath, process.Id, process.ProcessName, outputDirectory, Logger.Log)
                     );
                 var span = DateTime.UtcNow - start;
 

--- a/src/Tools/Source/RunTests/Program.cs
+++ b/src/Tools/Source/RunTests/Program.cs
@@ -23,7 +23,7 @@ namespace RunTests
         internal const int ExitSuccess = 0;
         internal const int ExitFailure = 1;
 
-        private const long MaxTotalDumpSizeInMegabytes = 2048; 
+        private const long MaxTotalDumpSizeInMegabytes = 4096; 
 
         internal static int Main(string[] args)
         {
@@ -391,18 +391,15 @@ namespace RunTests
         {
             var directory = Directory.GetCurrentDirectory();
             var dumpFiles = Directory.EnumerateFiles(directory, "*.dmp", SearchOption.AllDirectories).ToArray();
-            long currentSize = 0;
+            long currentTotalSize = 0;
 
             foreach(var dumpFile in dumpFiles)
             {
                 long fileSizeInMegabytes = (new FileInfo(dumpFile).Length / 1024) / 1024;
-                if (currentSize + fileSizeInMegabytes > MaxTotalDumpSizeInMegabytes)
+                currentTotalSize += fileSizeInMegabytes;
+                if (currentTotalSize > MaxTotalDumpSizeInMegabytes)
                 {
                     File.Delete(dumpFile);
-                }
-                else
-                {
-                    currentSize += fileSizeInMegabytes;
                 }
             }
         }

--- a/src/Tools/Source/RunTests/RunTests.csproj
+++ b/src/Tools/Source/RunTests/RunTests.csproj
@@ -61,31 +61,10 @@
     <Compile Include="Program.cs" />
     <Compile Include="TestRunner.cs" />
     <Compile Include="ConsoleUtil.cs" />
+    <Compile Include="..\..\..\Test\Utilities\Portable\FX\DumpProcRunner.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.Json.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
-      <Project>{1ee8cad3-55f9-4d91-96b2-084641da9a6c}</Project>
-      <Name>CodeAnalysis</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\CSharpCodeAnalysis.csproj">
-      <Project>{b501a547-c911-4a05-ac6e-274a50dff30e}</Project>
-      <Name>CSharpCodeAnalysis</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\Compilers\Test\Resources\Core\CompilerTestResources.csproj">
-      <Project>{7fe6b002-89d8-4298-9b1b-0b5c247dd1fd}</Project>
-      <Name>CompilerTestResources</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\Compilers\VisualBasic\Portable\BasicCodeAnalysis.vbproj">
-      <Project>{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}</Project>
-      <Name>BasicCodeAnalysis</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\Test\Utilities\Portable\TestUtilities.csproj">
-      <Project>{ccbd3438-3e84-40a9-83ad-533f23bcfca5}</Project>
-      <Name>TestUtilities</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/Tools/Source/RunTests/RunTests.csproj
+++ b/src/Tools/Source/RunTests/RunTests.csproj
@@ -65,5 +65,11 @@
   <ItemGroup>
     <Compile Include="Program.Json.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Test\Utilities\Portable\TestUtilities.csproj">
+      <Project>{ccbd3438-3e84-40a9-83ad-533f23bcfca5}</Project>
+      <Name>TestUtilities</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="..\..\..\..\build\Targets\Imports.targets" />
 </Project>

--- a/src/Tools/Source/RunTests/RunTests.csproj
+++ b/src/Tools/Source/RunTests/RunTests.csproj
@@ -66,6 +66,22 @@
     <Compile Include="Program.Json.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
+      <Project>{1ee8cad3-55f9-4d91-96b2-084641da9a6c}</Project>
+      <Name>CodeAnalysis</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\CSharpCodeAnalysis.csproj">
+      <Project>{b501a547-c911-4a05-ac6e-274a50dff30e}</Project>
+      <Name>CSharpCodeAnalysis</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Compilers\Test\Resources\Core\CompilerTestResources.csproj">
+      <Project>{7fe6b002-89d8-4298-9b1b-0b5c247dd1fd}</Project>
+      <Name>CompilerTestResources</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Compilers\VisualBasic\Portable\BasicCodeAnalysis.vbproj">
+      <Project>{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}</Project>
+      <Name>BasicCodeAnalysis</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\Test\Utilities\Portable\TestUtilities.csproj">
       <Project>{ccbd3438-3e84-40a9-83ad-533f23bcfca5}</Project>
       <Name>TestUtilities</Name>

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpInteractive.cs
@@ -93,7 +93,7 @@ w.Content = g;");
             VisualStudio.InteractiveWindow.SubmitText("b = null; w.Close(); w = null;");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/19232")]
+        [Fact]
         public void TypingHelpDirectiveWorks()
         {
             VisualStudio.Workspace.SetUseSuggestionMode(true);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstance.cs
@@ -72,20 +72,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         /// </summary>
         public string InstallationPath { get; }
 
-        public string DumpDirectoryPath { get; }
-
-        private bool _exceptionHappened;
-
-        public VisualStudioInstance(Process hostProcess, DTE dte, ImmutableHashSet<string> supportedPackageIds, string installationPath, string dumpDirectoryPath)
+        public VisualStudioInstance(Process hostProcess, DTE dte, ImmutableHashSet<string> supportedPackageIds, string installationPath)
         {
             HostProcess = hostProcess;
             Dte = dte;
             SupportedPackageIds = supportedPackageIds;
             InstallationPath = installationPath;
-            DumpDirectoryPath = dumpDirectoryPath;
-
-            _exceptionHappened = false;
-            AppDomain.CurrentDomain.FirstChanceException += FirstChanceExceptionHandler;
 
             StartRemoteIntegrationService(dte);
 
@@ -189,16 +181,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             if (exitHostProcess)
             {
                 CloseHostProcess();
-
-                AppDomain.CurrentDomain.FirstChanceException -= FirstChanceExceptionHandler;
-
-                if (!_exceptionHappened)
-                {
-                    if (Directory.Exists(DumpDirectoryPath))
-                    {
-                        Directory.Delete(DumpDirectoryPath);
-                    }
-                }
             }
         }
 
@@ -269,11 +251,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             });
 
             return result;
-        }
-
-        private void FirstChanceExceptionHandler(object sender, FirstChanceExceptionEventArgs eventArgs)
-        {
-            _exceptionHappened = true;
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -156,7 +156,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
 
                 hostProcess = StartNewVisualStudioProcess(installationPath);
 
-                ProcDumpRunner.StartProcDump(hostProcess.Id, hostProcess.ProcessName, Path.Combine(GetAssemblyDirectory(), "xUnitResults"), s => Debug.WriteLine(s));
+                var procDumpPath = Environment.GetEnvironmentVariable(ProcDumpRunner.ProcDumpPathEnvironmentVariableKey);
+                ProcDumpRunner.StartProcDump(procDumpPath, hostProcess.Id, hostProcess.ProcessName, Path.Combine(GetAssemblyDirectory(), "xUnitResults"), s => Debug.WriteLine(s));
 
                 // We wait until the DTE instance is up before we're good
                 dte = IntegrationHelper.WaitForNotNullAsync(() => IntegrationHelper.TryLocateDteForProcess(hostProcess)).Result;

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using EnvDTE;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.IntegrationTest.Utilities.Interop;
 using Microsoft.VisualStudio.Setup.Configuration;
 using Process = System.Diagnostics.Process;
@@ -32,8 +33,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         private VisualStudioInstance _currentlyRunningInstance;
 
         private bool _hasCurrentlyActiveContext;
-
-        private const int MaxDumpCount = 5;
 
         static VisualStudioInstanceFactory()
         {
@@ -145,7 +144,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             DTE dte;
             ImmutableHashSet<string> supportedPackageIds;
             string installationPath;
-            string dumpDirectoryPath;
 
             if (shouldStartNewInstance)
             {
@@ -157,7 +155,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 installationPath = instance.GetInstallationPath();
 
                 hostProcess = StartNewVisualStudioProcess(installationPath);
-                dumpDirectoryPath = StartProcDump(hostProcess.Id);
+
+                ProcDumpRunner.StartProcDump(hostProcess.Id, hostProcess.ProcessName, Path.Combine(GetAssemblyDirectory(), "xUnitResults"), s => Debug.WriteLine(s));
 
                 // We wait until the DTE instance is up before we're good
                 dte = IntegrationHelper.WaitForNotNullAsync(() => IntegrationHelper.TryLocateDteForProcess(hostProcess)).Result;
@@ -174,12 +173,11 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                 dte = _currentlyRunningInstance.Dte;
                 supportedPackageIds = _currentlyRunningInstance.SupportedPackageIds;
                 installationPath = _currentlyRunningInstance.InstallationPath;
-                dumpDirectoryPath = _currentlyRunningInstance.DumpDirectoryPath;
 
                 _currentlyRunningInstance.Close(exitHostProcess: false);
             }
 
-            _currentlyRunningInstance = new VisualStudioInstance(hostProcess, dte, supportedPackageIds, installationPath, dumpDirectoryPath);
+            _currentlyRunningInstance = new VisualStudioInstance(hostProcess, dte, supportedPackageIds, installationPath);
         }
 
         private static ISetupConfiguration GetSetupConfiguration()
@@ -281,83 +279,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             Debug.WriteLine($"Launched a new instance of Visual Studio. (ID: {process.Id})");
 
             return process;
-        }
-
-        // Starts ProcDump against the processId.
-        // Returns the path to the dump directory.
-        private static string StartProcDump(int processId)
-        {
-            Debug.WriteLine("Ensuring ProcDump");
-            var procDumpFilePath = EnsureProcDump();
-            Debug.WriteLine("Ensured ProcDump");
-            var dumpDirectory = CreateDumpDirectory();
-            var currentDumpDirectory = Path.Combine(dumpDirectory, Guid.NewGuid().ToString());
-            if (Directory.EnumerateFiles(dumpDirectory, "*.*", SearchOption.AllDirectories).Count() < MaxDumpCount)
-            {
-                if (!Directory.Exists(currentDumpDirectory))
-                {
-                    Directory.CreateDirectory(currentDumpDirectory);
-                }
-
-                var procDumpProcess = Process.Start(procDumpFilePath, $" /accepteula -ma -e -h -t -w {processId} {currentDumpDirectory}");
-                Debug.WriteLine($"Launched ProcDump attached to {processId}");
-            }
-            else
-            {
-                Debug.WriteLine($"Dump directory created but number of dumps created by previous tests exceed the max dump count limit. No more dumps will be created during the session.");
-            }
-
-            return currentDumpDirectory;
-        }
-
-        // Ensure that procdump is available on the machine. 
-        // Returns the path to the file that contains the procdump binaries (both 32 and 64 bit)
-        private static string EnsureProcDump()
-        {
-            // Jenkins images default to having procdump installed in the root.  Use that if available to avoid
-            // an unnecessary download.
-            var defaultPath = @"c:\SysInternals\procdump.exe";
-            Debug.WriteLine($"Looking for {defaultPath}");
-            if (File.Exists(defaultPath))
-            {
-                Debug.WriteLine("Found");
-                return defaultPath;
-            }
-            Debug.WriteLine("Not found");
-
-            var assemblyDirectory = GetAssemblyDirectory();
-            var toolsDir = Path.Combine(assemblyDirectory, "Tools");
-            var outDir = Path.Combine(toolsDir, "ProcDump");
-            var filePath = Path.Combine(outDir, "procdump.exe");
-            Debug.WriteLine($"Looking for {filePath}");
-            if (!File.Exists(filePath))
-            {
-                Debug.WriteLine("Not found");
-                Debug.WriteLine($"Creating {outDir}");
-                Directory.CreateDirectory(outDir);
-                var zipFilePath = Path.Combine(toolsDir, "procdump.zip");
-                var client = new WebClient();
-                var url = "https://download.sysinternals.com/files/Procdump.zip";
-                Debug.WriteLine($"Downloading {url} to {zipFilePath}");
-                client.DownloadFile(url, zipFilePath);
-                Debug.WriteLine($"Extracting {zipFilePath} into {outDir}");
-                ZipFile.ExtractToDirectory(zipFilePath, outDir);
-            }
-            else
-            {
-                Debug.WriteLine("Found");
-            }
-
-            Debug.WriteLine($"ProcDump should be in {filePath}");
-            return filePath;
-        }
-
-        private static string CreateDumpDirectory()
-        {
-            var assemblyDirectory = GetAssemblyDirectory();
-            var fullPath = Path.Combine(assemblyDirectory, "xUnitResults", "Dumps");
-            Directory.CreateDirectory(fullPath);
-            return fullPath;
         }
 
         private static string GetAssemblyDirectory()

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -190,6 +190,10 @@
       <Project>{e2e889a5-2489-4546-9194-47c63e49eaeb}</Project>
       <Name>Diagnostics</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\Test\Utilities\Portable\TestUtilities.csproj">
+      <Project>{ccbd3438-3e84-40a9-83ad-533f23bcfca5}</Project>
+      <Name>TestUtilities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Workspaces.csproj">
       <Project>{5f8d2414-064a-4b3a-9b42-8e2a04246be5}</Project>
       <Name>Workspaces</Name>


### PR DESCRIPTION
Test infrastructure only

Trying to fix #19232. Assuming that it fails due to VS failures between tests.

@dotnet/roslyn-infrastructure please review
