### PR TITLE
Revert "allow waiters to be consumed from internal VS tests"

### DIFF
--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -430,10 +430,6 @@ Public Class BuildDevDivInsertionFiles
             Next
         Next
 
-        ' Finally, include these to allow the waiters to be imported and consumed in VS tests.
-        filesToInsert.Add(New NugetFileInfo("Dlls\Diagnostics\Roslyn.Hosting.Diagnostics.dll"))
-        filesToInsert.Add(New NugetFileInfo("Vsix\VisualStudioIntegrationTestSetup\Microsoft.VisualStudio.IntegrationTest.Setup.vsix"))
-
         ProcessVsixFiles(filesToInsert, dependencies)
 
         ' Generate Roslyn.nuspec:


### PR DESCRIPTION
Reverts dotnet/roslyn#17152

Signing is hard and to unblock code flow this is being backed out.

@jasonmalinowski 