### PR TITLE
Track down NuGet cache corruption

### DIFF
--- a/build/scripts/cibuild.ps1
+++ b/build/scripts/cibuild.ps1
@@ -88,6 +88,13 @@ function Redirect-Temp() {
     ${env:TMP} = $temp
 }
 
+# Temporary code to help track down a NuGet cache corruption bug.
+# https://github.com/dotnet/roslyn/issues/19882
+function Test-NuGetCache([string]$place) {
+    Write-Host "Testing NuGet cache: $place"
+    Exec-Block { & ".\build\scripts\test-nuget-cache.ps1" }
+}
+
 try {
     . (Join-Path $PSScriptRoot "build-utils.ps1")
     Push-Location $repoDir
@@ -108,6 +115,8 @@ try {
     $msbuildDir = Split-Path -parent $msbuild
     $configDir = Join-Path $binariesDIr $buildConfiguration
 
+    Test-NuGetCache "start of CI"
+
     if (-not $skipRestore) { 
         Write-Host "Running restore"
 
@@ -115,6 +124,8 @@ try {
         ${env:NUGET_SHOW_STACK}="true"
         Restore-All -msbuildDir $msbuildDir 
         Remove-Item env:\NUGET_SHOW_STACK
+
+        Test-NuGetCache "after restore"
     }
 
     # Ensure the binaries directory exists because msbuild can fail when part of the path to LogFile isn't present.
@@ -212,5 +223,7 @@ catch {
     exit 1
 }
 finally {
+    Test-NuGetCache "end of ci"
+
     Pop-Location
 }

--- a/build/scripts/test-nuget-cache.ps1
+++ b/build/scripts/test-nuget-cache.ps1
@@ -1,0 +1,71 @@
+<#
+
+This script exists to help us track down the NuGet cache corruption bug that is showing up 
+in Jenkins.  It will look for critical files in the NuGet which have been zerod out.
+
+https://github.com/dotnet/roslyn/issues/19882
+
+#>
+
+[CmdletBinding(PositionalBinding=$false)]
+param ()
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+function Test-ZeroFile([string]$filePath) {
+    $bytes = [IO.File]::ReadAllBytes($filePath)
+    if ($bytes.Length -eq 0) {
+        return $false
+    }
+
+    foreach ($b in $bytes) { 
+        if ($b -ne 0) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Go() {
+    Push-Location (Get-PackagesDir)
+    try {
+        $failed = @()
+        foreach ($filePath in Get-ChildItem -re -in *.nuspec,*proj,*settings,*targets) {
+            if (Test-Path $filePath -PathType Container) {
+                continue;
+            }
+
+            if (Test-ZeroFile $filePath) { 
+                Write-Host "Testing $filePath FAILED"
+                $failed += $filePath
+            } 
+            else { 
+                Write-Host "Testing $filePath passed"
+            }
+        }
+
+        if ($failed.Length -gt 0) { 
+            Write-Host "Detected zero'd out files in Nuget cache"
+            foreach ($f in $failed) { 
+                Write-Host "`t$f"
+            }
+
+            exit 1
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+try { 
+    . (Join-Path $PSScriptRoot "build-utils.ps1")
+    Go
+    exit 0
+}
+catch {
+    Write-Host $_
+    exit 1
+}


### PR DESCRIPTION
Infrastructure only 

This change should help us pin down why we are seeing NuGet cache
corruption issues in our Jenkins job.  It adds a check to three places
in our script:

- Start
- Post restore
- End

Depending on when this check fails it should give us a better picture of
where the corruption is occuring.

https://github.com/dotnet/roslyn/issues/19882
