### PR TITLE
Disallowing writeable state in readonly structs

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -791,7 +791,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Field-like events are not allowed in readonly structs..
+        ///   Looks up a localized string similar to Auto-implemented instance properties in readonly structs must be readonly..
         /// </summary>
         internal static string ERR_AutoPropsInRoStruct {
             get {
@@ -4571,7 +4571,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Instance fields of readonly structs must be readonly..
+        ///   Looks up a localized string similar to Field-like events are not allowed in readonly structs..
         /// </summary>
         internal static string ERR_FieldlikeEventsInRoStruct {
             get {
@@ -4580,7 +4580,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto-implemented instance properties in readonly structs must be readonly..
+        ///   Looks up a localized string similar to Instance fields of readonly structs must be readonly..
         /// </summary>
         internal static string ERR_FieldsInRoStruct {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -791,7 +791,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Instance fields of readonly structs must be readonly..
+        ///   Looks up a localized string similar to Field-like events are not allowed in readonly structs..
         /// </summary>
         internal static string ERR_AutoPropsInRoStruct {
             get {
@@ -4571,7 +4571,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Field-like events are not allowed in readonly structs..
+        ///   Looks up a localized string similar to Instance fields of readonly structs must be readonly..
         /// </summary>
         internal static string ERR_FieldlikeEventsInRoStruct {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CSharpResources {
@@ -787,6 +787,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_AutoPropertyMustOverrideSet {
             get {
                 return ResourceManager.GetString("ERR_AutoPropertyMustOverrideSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Instance fields of readonly structs must be readonly..
+        /// </summary>
+        internal static string ERR_AutoPropsInRoStruct {
+            get {
+                return ResourceManager.GetString("ERR_AutoPropsInRoStruct", resourceCulture);
             }
         }
         
@@ -4558,6 +4567,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_FieldInitRefNonstatic {
             get {
                 return ResourceManager.GetString("ERR_FieldInitRefNonstatic", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field-like events are not allowed in readonly structs..
+        /// </summary>
+        internal static string ERR_FieldlikeEventsInRoStruct {
+            get {
+                return ResourceManager.GetString("ERR_FieldlikeEventsInRoStruct", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-implemented instance properties in readonly structs must be readonly..
+        /// </summary>
+        internal static string ERR_FieldsInRoStruct {
+            get {
+                return ResourceManager.GetString("ERR_FieldsInRoStruct", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5123,4 +5123,13 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TypeReserved" xml:space="preserve">
     <value>The type name '{0}' is reserved to be used by the compiler.</value>
   </data>
+  <data name="ERR_FieldsInRoStruct" xml:space="preserve">
+    <value>Auto-implemented instance properties in readonly structs must be readonly.</value>
+  </data>
+  <data name="ERR_AutoPropsInRoStruct" xml:space="preserve">
+    <value>Instance fields of readonly structs must be readonly.</value>
+  </data>
+  <data name="ERR_FieldlikeEventsInRoStruct" xml:space="preserve">
+    <value>Field-like events are not allowed in readonly structs.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5127,9 +5127,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Auto-implemented instance properties in readonly structs must be readonly.</value>
   </data>
   <data name="ERR_AutoPropsInRoStruct" xml:space="preserve">
-    <value>Instance fields of readonly structs must be readonly.</value>
+    <value>Field-like events are not allowed in readonly structs.</value>
   </data>
   <data name="ERR_FieldlikeEventsInRoStruct" xml:space="preserve">
-    <value>Field-like events are not allowed in readonly structs.</value>
+    <value>Instance fields of readonly structs must be readonly.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5124,12 +5124,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>The type name '{0}' is reserved to be used by the compiler.</value>
   </data>
   <data name="ERR_FieldsInRoStruct" xml:space="preserve">
-    <value>Auto-implemented instance properties in readonly structs must be readonly.</value>
+    <value>Instance fields of readonly structs must be readonly.</value>
   </data>
   <data name="ERR_AutoPropsInRoStruct" xml:space="preserve">
-    <value>Field-like events are not allowed in readonly structs.</value>
+    <value>Auto-implemented instance properties in readonly structs must be readonly.</value>
   </data>
   <data name="ERR_FieldlikeEventsInRoStruct" xml:space="preserve">
-    <value>Instance fields of readonly structs must be readonly.</value>
+    <value>Field-like events are not allowed in readonly structs.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1509,6 +1509,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExplicitReservedAttr = 8412,
         ERR_TypeReserved = 8413,
 
+        //PROTOTYPE(ReadonlyRefs): make err IDs contiguous before merging to master. 
         ERR_FieldsInRoStruct = 8514,
         ERR_AutoPropsInRoStruct = 8515,
         ERR_FieldlikeEventsInRoStruct = 8516,

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1508,5 +1508,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_RefReturnReadonlyNotField2 = 8411,
         ERR_ExplicitReservedAttr = 8412,
         ERR_TypeReserved = 8413,
+
+        ERR_FieldsInRoStruct = 8514,
+        ERR_AutoPropsInRoStruct = 8515,
+        ERR_FieldlikeEventsInRoStruct = 8516,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldLikeEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldLikeEventSymbol.cs
@@ -79,6 +79,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Don't initialize this.type - we'll just use the type of the field (which is lazy and handles var)
             }
 
+            if (!IsStatic && ContainingType.IsReadOnly)
+            {
+                diagnostics.Add(ErrorCode.ERR_FieldlikeEventsInRoStruct, this.Locations[0]);
+            }
+
             // Accessors will assume that Type is available.
             _addMethod = new SynthesizedFieldLikeEventAccessorSymbol(this, isAdder: true);
             _removeMethod = new SynthesizedFieldLikeEventAccessorSymbol(this, isAdder: false);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFieldSymbol.cs
@@ -123,6 +123,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 diagnostics.Add(ErrorCode.ERR_InstanceMemberInStaticClass, ErrorLocation, this);
             }
+            else if (!IsStatic && !IsReadOnly && containingType.IsReadOnly)
+            {
+                diagnostics.Add(ErrorCode.ERR_FieldsInRoStruct, ErrorLocation);
+            }
 
             // TODO: Consider checking presence of core type System.Runtime.CompilerServices.IsVolatile 
             // if there is a volatile modifier. Perhaps an appropriate error should be reported if the 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _isAutoProperty = notRegularProperty && hasGetSyntax;
                 bool isReadOnly = hasGetSyntax && setSyntax == null;
 
-                if (_isAutoProperty  && !isReadOnly && !IsStatic && ContainingType.IsReadOnly)
+                if (_isAutoProperty && !isReadOnly && !IsStatic && ContainingType.IsReadOnly)
                 {
                     diagnostics.Add(ErrorCode.ERR_AutoPropsInRoStruct, location);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -179,6 +179,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _isAutoProperty = notRegularProperty && hasGetSyntax;
                 bool isReadOnly = hasGetSyntax && setSyntax == null;
 
+                if (_isAutoProperty  && !isReadOnly && !IsStatic && ContainingType.IsReadOnly)
+                {
+                    diagnostics.Add(ErrorCode.ERR_AutoPropsInRoStruct, location);
+                }
+
                 if (_isAutoProperty || hasInitializer)
                 {
                     if (_isAutoProperty)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1300,7 +1300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // the "System" must be in the global namespace
-            return ns.ContainingNamespace.IsGlobalNamespace;
+            return ns.ContainingNamespace?.IsGlobalNamespace == true;
         }
 
         internal static bool IsNonGenericTaskType(this TypeSymbol type, CSharpCompilation compilation)

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Semantics\PatternMatchingTests_Global.cs" />
     <Compile Include="Semantics\BindingAsyncTasklikeMoreTests.cs" />
     <Compile Include="Semantics\BindingAsyncTasklikeTests.cs" />
+    <Compile Include="Semantics\ReadOnlyStructsTests.cs" />
     <Compile Include="Semantics\TargetTypedDefaultTests.cs" />
     <Compile Include="Semantics\DeconstructionTests.cs" />
     <Compile Include="Semantics\ImportsTests.cs" />

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -1,0 +1,225 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    public class ReadOnlyStructsTests : CompilingTestBase
+    {
+        [Fact()]
+        public void WriteableInstanceAutoPropsInRoStructs()
+        {
+            var text = @"
+public readonly struct A
+{
+    // ok
+    int ro => 5;
+
+    // error
+    int rw {get; set;}
+
+    // ok
+    static int rws {get; set;}
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (8,9): error CS8515: Instance fields of readonly structs must be readonly.
+                //     int rw {get; set;}
+                Diagnostic(ErrorCode.ERR_AutoPropsInRoStruct, "rw").WithLocation(8, 9)
+    );
+        }
+
+        [Fact()]
+        public void WriteableInstanceFieldsInRoStructs()
+        {
+            var text = @"
+public readonly struct A
+{
+    // ok
+    public static int s;
+
+    // ok
+    public readonly int ro;
+
+    // error
+    int x;    
+
+    void AssignField()
+    {
+        // error
+        this.x = 1;
+
+        A a = default;
+        // OK
+        a.x = 2;
+    }
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (11,9): error CS8514: Auto-implemented instance properties in readonly structs must be readonly.
+                //     int x;    
+                Diagnostic(ErrorCode.ERR_FieldsInRoStruct, "x").WithLocation(11, 9),
+                // (16,9): error CS1604: Cannot assign to 'this' because it is read-only
+                //         this.x = 1;
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "this.x").WithArguments("this").WithLocation(16, 9)
+    );
+        }
+
+        [Fact()]
+        public void EventsInRoStructs()
+        {
+            var text = @"
+using System;
+
+public readonly struct A : I1
+{
+    //error
+    public event System.Action e;
+
+    //error
+    public event Action ei1;
+
+    //ok
+    public static event Action es;
+
+    A(int arg)
+    {
+        // ok
+        e = () => { };
+        ei1 = () => { };
+        es = () => { };
+        
+        // ok
+        M1(ref e);
+    }
+
+    //ok
+    event Action I1.ei2
+    {
+        add
+        {
+            throw new NotImplementedException();
+        }
+
+        remove
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    void AssignEvent()
+    {
+        // error
+        e = () => { };
+
+        // error
+        M1(ref e);
+    }
+
+    static void M1(ref System.Action arg)
+    {
+    }
+}
+
+interface I1
+{
+    event System.Action ei1;
+    event System.Action ei2;
+}
+";
+            CreateStandardCompilation(text).VerifyDiagnostics(
+                // (7,32): error CS8516: Field-like events are not allowed in readonly structs.
+                //     public event System.Action e;
+                Diagnostic(ErrorCode.ERR_FieldlikeEventsInRoStruct, "e").WithLocation(7, 32),
+                // (10,25): error CS8516: Field-like events are not allowed in readonly structs.
+                //     public event Action ei1;
+                Diagnostic(ErrorCode.ERR_FieldlikeEventsInRoStruct, "ei1").WithLocation(10, 25),
+                // (43,9): error CS1604: Cannot assign to 'this' because it is read-only
+                //         e = () => { };
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "e").WithArguments("this").WithLocation(43, 9),
+                // (46,16): error CS1604: Cannot assign to 'this' because it is read-only
+                //         M1(ref e);
+                Diagnostic(ErrorCode.ERR_AssgReadonlyLocal, "e").WithArguments("this").WithLocation(46, 16)
+    );
+        }
+
+        [Fact()]
+        public void UseWriteableInstanceFieldsInRoStructs()
+        {
+            var il = @"
+.class private auto ansi sealed beforefieldinit Microsoft.CodeAnalysis.EmbeddedAttribute
+       extends [mscorlib]System.Attribute
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Attribute::.ctor()
+    IL_0006:  ret
+  } // end of method EmbeddedAttribute::.ctor
+
+} // end of class Microsoft.CodeAnalysis.EmbeddedAttribute
+
+.class private auto ansi sealed beforefieldinit System.Runtime.CompilerServices.IsReadOnlyAttribute
+       extends [mscorlib]System.Attribute
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Attribute::.ctor()
+    IL_0006:  ret
+  } // end of method IsReadOnlyAttribute::.ctor
+
+} // end of class System.Runtime.CompilerServices.IsReadOnlyAttribute
+
+
+
+.class public sequential ansi sealed beforefieldinit S1
+       extends [mscorlib]System.ValueType
+{
+  .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 ) 
+
+   // WRITEABLE FIELD!!!
+  .field public int32 'field'
+
+} // end of class S1
+
+";
+
+            var csharp = @"
+public class Program 
+{ 
+    public static void Main() 
+    { 
+        S1 s = new S1();
+        s.field = 123;
+        System.Console.WriteLine(s.field);
+    }
+}
+";
+
+            var comp = CreateCompilationWithCustomILSource(csharp, il, options:TestOptions.ReleaseExe);
+            
+            comp.VerifyDiagnostics();
+            
+            CompileAndVerify(comp, expectedOutput:"123");
+        }
+
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
+    [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
     public class ReadOnlyStructsTests : CompilingTestBase
     {
         [Fact()]
@@ -19,20 +20,23 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             var text = @"
 public readonly struct A
 {
-    // ok
+    // ok   - no state
     int ro => 5;
+
+    // ok   - ro state
+    int ro1 {get;}
 
     // error
     int rw {get; set;}
 
-    // ok
+    // ok    - static
     static int rws {get; set;}
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (8,9): error CS8515: Instance fields of readonly structs must be readonly.
+                // (11,9): error CS8515: Instance fields of readonly structs must be readonly.
                 //     int rw {get; set;}
-                Diagnostic(ErrorCode.ERR_AutoPropsInRoStruct, "rw").WithLocation(8, 9)
+                Diagnostic(ErrorCode.ERR_AutoPropsInRoStruct, "rw").WithLocation(11, 9)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -34,7 +34,7 @@ public readonly struct A
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,9): error CS8515: Instance fields of readonly structs must be readonly.
+                // (11,9): error CS8515: Auto-implemented instance properties in readonly structs must be readonly.
                 //     int rw {get; set;}
                 Diagnostic(ErrorCode.ERR_AutoPropsInRoStruct, "rw").WithLocation(11, 9)
     );
@@ -67,7 +67,7 @@ public readonly struct A
 }
 ";
             CreateStandardCompilation(text).VerifyDiagnostics(
-                // (11,9): error CS8514: Auto-implemented instance properties in readonly structs must be readonly.
+                // (11,9): error CS8514: Instance fields of readonly structs must be readonly.
                 //     int x;    
                 Diagnostic(ErrorCode.ERR_FieldsInRoStruct, "x").WithLocation(11, 9),
                 // (16,9): error CS1604: Cannot assign to 'this' because it is read-only

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ReadOnlyStructsTests.cs
@@ -154,7 +154,6 @@ interface I1
     );
         }
 
-
         private static string ilreadonlyStructWithWriteableFieldIL = @"
 .class private auto ansi sealed beforefieldinit Microsoft.CodeAnalysis.EmbeddedAttribute
        extends [mscorlib]System.Attribute

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     /// <summary>
     /// this place is dedicated to binding related error tests
     /// </summary>
+    [CompilerTrait(CompilerFeature.ReadOnlyReferences)]
     public class SpanStackSafetyTests : CompilingTestBase
     {
         private static string spanSource = @"


### PR DESCRIPTION
== Disallowed:
- writeable instance fields
- writeable instance autoproperties
- field-like events     (very similar to autoproperties, but have no concept of "readonly")