### PR TITLE
Some performance and reliability fixes around file change tracking

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(typeof(FileChangeTracker).Name);
+                throw new ObjectDisposedException(nameof(FileChangeTracker));
             }
 
             Contract.ThrowIfTrue(_fileChangeCookie != s_none);
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(typeof(FileChangeTracker).Name);
+                throw new ObjectDisposedException(nameof(FileChangeTracker));
             }
 
             // there is a slight chance that we haven't subscribed to the service yet so we subscribe and unsubscribe


### PR DESCRIPTION
**Reviewing commit by commit is strongly advised.**

*Perf:* We were creating a bunch of tasks on the thread pool, all of which ultimately contended on the single lock that exists inside of the current implementation of IVsFileChangeEx. That's silly, so let's just only try to do one of the background subscriptions at a time. We also don't need to wait on the UI thread when adding analyzers.

*Reliability:* We were crashing when some transient file system exceptions were happening. We'll now swallow those. Other exceptions will still crash the process.