### PR TITLE
Several optimizations

### DIFF
--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -3616,7 +3616,7 @@ namespace Microsoft.Cci
             return pooled.ToStringAndFree();
         }
 
-        private void SerializePermissionSet(IEnumerable<ICustomAttribute> permissionSet, BlobBuilder writer)
+        private void SerializePermissionSet(ImmutableArray<ICustomAttribute> permissionSet, BlobBuilder writer)
         {
             EmitContext context = this.Context;
             foreach (ICustomAttribute customAttribute in permissionSet)

--- a/src/Compilers/Core/Portable/RuleSet/RuleSet.cs
+++ b/src/Compilers/Core/Portable/RuleSet/RuleSet.cs
@@ -151,9 +151,9 @@ namespace Microsoft.CodeAnalysis
                 // Copy every rule in the ruleset and change the action if there's a stricter one.
                 foreach (var item in effectiveRuleset.SpecificDiagnosticOptions)
                 {
-                    if (effectiveSpecificOptions.ContainsKey(item.Key))
+                    if (effectiveSpecificOptions.TryGetValue(item.Key, out var value))
                     {
-                        if (IsStricterThan(item.Value, effectiveSpecificOptions[item.Key]))
+                        if (IsStricterThan(item.Value, value))
                         {
                             effectiveSpecificOptions[item.Key] = item.Value;
                         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ToolTipProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/ToolTipProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Threading;
@@ -128,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 return text;
             }
 
-            private static TextBlock GetTextBlock(IEnumerable<TaggedText> parts, ClassificationTypeMap typeMap)
+            private static TextBlock GetTextBlock(ImmutableArray<TaggedText> parts, ClassificationTypeMap typeMap)
             {
                 var result = new TextBlock() { TextWrapping = TextWrapping.Wrap };
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -163,16 +163,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 
             var sections = await descriptionService.ToDescriptionGroupsAsync(workspace, semanticModel, token.SpanStart, symbols.AsImmutable(), cancellationToken).ConfigureAwait(false);
 
+            ImmutableArray<TaggedText> parts;
+
             var mainDescriptionBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.MainDescription))
+            if (sections.TryGetValue(SymbolDescriptionGroups.MainDescription, out parts))
             {
-                mainDescriptionBuilder.AddRange(sections[SymbolDescriptionGroups.MainDescription]);
+                mainDescriptionBuilder.AddRange(parts);
             }
 
             var typeParameterMapBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.TypeParameterMap))
+            if (sections.TryGetValue(SymbolDescriptionGroups.TypeParameterMap, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.TypeParameterMap];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     typeParameterMapBuilder.AddLineBreak();
@@ -181,9 +182,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
 
             var anonymousTypesBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.AnonymousTypes))
+            if (sections.TryGetValue(SymbolDescriptionGroups.AnonymousTypes, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.AnonymousTypes];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     anonymousTypesBuilder.AddLineBreak();
@@ -192,9 +192,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
 
             var usageTextBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.AwaitableUsageText))
+            if (sections.TryGetValue(SymbolDescriptionGroups.AwaitableUsageText, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.AwaitableUsageText];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     usageTextBuilder.AddRange(parts);
@@ -207,9 +206,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
 
             var exceptionsTextBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.Exceptions))
+            if (sections.TryGetValue(SymbolDescriptionGroups.Exceptions, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.Exceptions];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     exceptionsTextBuilder.AddRange(parts);
@@ -250,10 +248,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             ISyntaxFactsService syntaxFactsService,
             CancellationToken cancellationToken)
         {
-            if (sections.ContainsKey(SymbolDescriptionGroups.Documentation))
+            if (sections.TryGetValue(SymbolDescriptionGroups.Documentation, out var parts))
             {
                 var documentationBuilder = new List<TaggedText>();
-                documentationBuilder.AddRange(sections[SymbolDescriptionGroups.Documentation]);
+                documentationBuilder.AddRange(parts);
                 return CreateClassifiableDeferredContent(documentationBuilder);
             }
             else if (symbols.Any())

--- a/src/EditorFeatures/Core/Implementation/Suggestions/FixAll/FixAllGetFixesService.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/FixAll/FixAllGetFixesService.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             }
         }
 
-        private ImmutableArray<CodeActionOperation> GetNewFixAllOperations(IEnumerable<CodeActionOperation> operations, Solution newSolution, CancellationToken cancellationToken)
+        private ImmutableArray<CodeActionOperation> GetNewFixAllOperations(ImmutableArray<CodeActionOperation> operations, Solution newSolution, CancellationToken cancellationToken)
         {
             var result = ArrayBuilder<CodeActionOperation>.GetInstance();
             var foundApplyChanges = false;

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             /// always show up last after all other fixes (and refactorings) for the selected line of code.
             /// </remarks>
             private static ImmutableArray<SuggestedActionSet> PrioritizeFixGroups(
-                IDictionary<CodeFixGroupKey, IList<SuggestedAction>> map, IList<CodeFixGroupKey> order)
+                IDictionary<CodeFixGroupKey, IList<SuggestedAction>> map, ImmutableArray<CodeFixGroupKey> order)
             {
                 var sets = ArrayBuilder<SuggestedActionSet>.GetInstance();
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CrefCompletionProvider.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private IEnumerable<CompletionItem> CreateCompletionItems(
-            Workspace workspace, SemanticModel semanticModel, IEnumerable<ISymbol> symbols, SyntaxToken token, TextSpan itemSpan, int position, ImmutableDictionary<string, string> options)
+            Workspace workspace, SemanticModel semanticModel, ImmutableArray<ISymbol> symbols, SyntaxToken token, TextSpan itemSpan, int position, ImmutableDictionary<string, string> options)
         {
             var builder = SharedPools.Default<StringBuilder>().Allocate();
             try

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -156,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private async Task<IEnumerable<(string, SymbolKind)>> GetRecommendedNamesAsync(
-            IEnumerable<IEnumerable<string>> baseNames,
+            ImmutableArray<IEnumerable<string>> baseNames,
             NameDeclarationInfo declarationInfo,
             CSharpSyntaxContext context,
             Document document,

--- a/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/WrapperCodeFixProvider.cs
@@ -40,14 +40,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
             }
         }
 
-        private void RegisterSuppressionFixes(CodeFixContext context, IEnumerable<CodeFix> suppressionFixes)
+        private static void RegisterSuppressionFixes(CodeFixContext context, ImmutableArray<CodeFix> suppressionFixes)
         {
-            if (suppressionFixes != null)
+            foreach (var suppressionFix in suppressionFixes)
             {
-                foreach (var suppressionFix in suppressionFixes)
-                {
-                    context.RegisterCodeFix(suppressionFix.Action, suppressionFix.Diagnostics);
-                }
+                context.RegisterCodeFix(suppressionFix.Action, suppressionFix.Diagnostics);
             }
         }
 

--- a/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
@@ -135,14 +135,13 @@ namespace Microsoft.CodeAnalysis.Completion
 
             AddDocumentationPart(textContentBuilder, symbol, semanticModel, position, formatter, cancellationToken);
 
-            if (sections.ContainsKey(SymbolDescriptionGroups.AwaitableUsageText))
+            if (sections.TryGetValue(SymbolDescriptionGroups.AwaitableUsageText, out var value))
             {
-                textContentBuilder.AddRange(sections[SymbolDescriptionGroups.AwaitableUsageText]);
+                textContentBuilder.AddRange(value);
             }
 
-            if (sections.ContainsKey(SymbolDescriptionGroups.AnonymousTypes))
+            if (sections.TryGetValue(SymbolDescriptionGroups.AnonymousTypes, out var parts))
             {
-                var parts = sections[SymbolDescriptionGroups.AnonymousTypes];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     textContentBuilder.AddLineBreak();

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -400,9 +400,9 @@ namespace Microsoft.CodeAnalysis.Completion
             return item;
         }
 
-        private Dictionary<CompletionProvider, int> GetCompletionProviderToIndex(IEnumerable<CompletionProvider> completionProviders)
+        private static Dictionary<CompletionProvider, int> GetCompletionProviderToIndex(ImmutableArray<CompletionProvider> completionProviders)
         {
-            var result = new Dictionary<CompletionProvider, int>();
+            var result = new Dictionary<CompletionProvider, int>(completionProviders.Length);
 
             int i = 0;
             foreach (var completionProvider in completionProviders)

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -96,9 +96,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         protected CompletionItem GetItem(string n)
         {
-            if (_tagMap.ContainsKey(n))
+            if (_tagMap.TryGetValue(n, out var value))
             {
-                var value = _tagMap[n];
                 return CreateCompletionItem(n, value[0], value[1]);
             }
 

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
@@ -202,16 +202,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return SpecializedCollections.EmptyEnumerable<DiagnosticData>();
         }
 
-        private static IEnumerable<DiagnosticData> FilterSuppressedDiagnostics(IEnumerable<DiagnosticData> diagnostics)
+        private static IEnumerable<DiagnosticData> FilterSuppressedDiagnostics(ImmutableArray<DiagnosticData> diagnostics)
         {
-            if (diagnostics != null)
+            foreach (var diagnostic in diagnostics)
             {
-                foreach (var diagnostic in diagnostics)
+                if (!diagnostic.IsSuppressed)
                 {
-                    if (!diagnostic.IsSuppressed)
-                    {
-                        yield return diagnostic;
-                    }
+                    yield return diagnostic;
                 }
             }
         }

--- a/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/FullyQualify/AbstractFullyQualifyCodeFixProvider.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.FullyQualify
         }
 
         private static IEnumerable<SymbolResult> GetContainers(
-            IEnumerable<SymbolResult> symbols, Compilation compilation)
+            ImmutableArray<SymbolResult> symbols, Compilation compilation)
         {
             foreach (var symbolResult in symbols)
             {

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -152,17 +152,17 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         internal void WaitUntilCompletion_ForTestingPurposesOnly(Workspace workspace, ImmutableArray<IIncrementalAnalyzer> workers)
         {
-            if (_documentWorkCoordinatorMap.ContainsKey(workspace))
+            if (_documentWorkCoordinatorMap.TryGetValue(workspace, out var coordinator))
             {
-                _documentWorkCoordinatorMap[workspace].WaitUntilCompletion_ForTestingPurposesOnly(workers);
+                coordinator.WaitUntilCompletion_ForTestingPurposesOnly(workers);
             }
         }
 
         internal void WaitUntilCompletion_ForTestingPurposesOnly(Workspace workspace)
         {
-            if (_documentWorkCoordinatorMap.ContainsKey(workspace))
+            if (_documentWorkCoordinatorMap.TryGetValue(workspace, out var coordinator))
             {
-                _documentWorkCoordinatorMap[workspace].WaitUntilCompletion_ForTestingPurposesOnly();
+                coordinator.WaitUntilCompletion_ForTestingPurposesOnly();
             }
         }
 
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
-        private bool TryGetProvider(
+        private static bool TryGetProvider(
             string kind,
             ImmutableArray<Lazy<IIncrementalAnalyzerProvider, IncrementalAnalyzerProviderMetadata>> lazyProviders,
             out Lazy<IIncrementalAnalyzerProvider, IncrementalAnalyzerProviderMetadata> lazyProvider)

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -465,7 +465,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         RemoveDocument(this.Analyzers, documentId);
                     }
 
-                    private static void RemoveDocument(IEnumerable<IIncrementalAnalyzer> analyzers, DocumentId documentId)
+                    private static void RemoveDocument(ImmutableArray<IIncrementalAnalyzer> analyzers, DocumentId documentId)
                     {
                         foreach (var analyzer in analyzers)
                         {

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -348,11 +348,11 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             _console.Out.WriteLine();
         }
 
-        private void DisplayDiagnostics(IEnumerable<Diagnostic> diagnostics)
+        private void DisplayDiagnostics(ImmutableArray<Diagnostic> diagnostics)
         {
             const int MaxDisplayCount = 5;
 
-            var errorsAndWarnings = diagnostics.ToArray();
+            var errorsAndWarnings = diagnostics;
 
             // by severity, then by location
             var ordered = errorsAndWarnings.OrderBy((d1, d2) =>

--- a/src/Tools/RepoUtil/ConsumesCommand.cs
+++ b/src/Tools/RepoUtil/ConsumesCommand.cs
@@ -68,7 +68,7 @@ namespace RepoUtil
             return GetFloatingPackages("toolset", _repoData.FloatingToolsetPackages);
         }
 
-        private JProperty GetFloatingPackages(string name, IEnumerable<NuGetPackage> packages)
+        private JProperty GetFloatingPackages(string name, ImmutableArray<NuGetPackage> packages)
         {
             var obj = new JObject();
             foreach (var package in packages)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/ConstructorGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/ConstructorGenerator.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -101,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 : SyntaxFactory.ConstructorInitializer(kind).WithArgumentList(GenerateArgumentList(arguments));
         }
 
-        private static ArgumentListSyntax GenerateArgumentList(IList<SyntaxNode> arguments)
+        private static ArgumentListSyntax GenerateArgumentList(ImmutableArray<SyntaxNode> arguments)
         {
             return SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments.Select(ArgumentGenerator.GenerateArgument)));
         }

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
@@ -198,19 +198,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var leadingTrivia = token.LeadingTrivia;
             var trailingTrivia = token.TrailingTrivia;
 
-            if (_trailingTriviaMap.ContainsKey(token))
+            if (_trailingTriviaMap.TryGetValue(token, out var tt))
             {
                 // okay, we have this situation
                 // token|trivia
-                trailingTrivia = _trailingTriviaMap[token];
+                trailingTrivia = tt;
                 hasChanges = true;
             }
 
-            if (_leadingTriviaMap.ContainsKey(token))
+            if (_leadingTriviaMap.TryGetValue(token, out var lt))
             {
                 // okay, we have this situation
                 // trivia|token
-                leadingTrivia = _leadingTriviaMap[token];
+                leadingTrivia = lt;
                 hasChanges = true;
             }
 

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
@@ -538,7 +538,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             }
         }
 
-        private void CheckDocuments(IEnumerable<DocumentFileInfo> docs, string projectFilePath, ProjectId projectId)
+        private void CheckDocuments(ImmutableArray<DocumentFileInfo> docs, string projectFilePath, ProjectId projectId)
         {
             var paths = new HashSet<string>();
             foreach (var doc in docs)

--- a/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/AbstractCodeCleanerService.cs
@@ -319,7 +319,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup
         /// <summary>
         /// Make sure annotations are positioned outside of any spans. If not, merge two adjacent spans to one.
         /// </summary>
-        private ImmutableArray<TextSpan> GetNonOverlappingSpans(ISyntaxFactsService syntaxFactsService, SyntaxNode root, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
+        private ImmutableArray<TextSpan> GetNonOverlappingSpans(ISyntaxFactsService syntaxFactsService, SyntaxNode root, ImmutableArray<TextSpan> spans, CancellationToken cancellationToken)
         {
             // Create interval tree for spans
             var intervalTree = SimpleIntervalTree.Create(TextSpanIntervalIntrospector.Instance, spans);

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -805,7 +805,7 @@ namespace Microsoft.CodeAnalysis.Editing
 
             return Attribute(
                 name: this.TypeExpression(attribute.AttributeClass),
-                attributeArguments: args.Count > 0 ? args : null);
+                attributeArguments: args.Length > 0 ? args.AsEnumerable() : null);
         }
 
         private IEnumerable<SyntaxNode> GetSymbolAttributes(ISymbol symbol)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -263,9 +263,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 var toProcess = projectIdsToProcess.Pop();
 
-                if (projectIdsToReferencingSubmissionIds.ContainsKey(toProcess))
+                if (projectIdsToReferencingSubmissionIds.TryGetValue(toProcess, out var referencingSubmissionIds))
                 {
-                    foreach (var pId in projectIdsToReferencingSubmissionIds[toProcess])
+                    foreach (var pId in referencingSubmissionIds)
                     {
                         if (!dependentProjects.Any(dp => dp.ProjectId == pId))
                         {

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_MapCreation.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_MapCreation.cs
@@ -158,16 +158,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         private void AddSymbolTasks(
             ConcurrentSet<SymbolAndProjectId> result,
-            IEnumerable<SymbolAndProjectId> symbols,
+            ImmutableArray<SymbolAndProjectId> symbols,
             List<Task> symbolTasks)
         {
-            if (symbols != null)
+            foreach (var child in symbols)
             {
-                foreach (var child in symbols)
-                {
-                    _cancellationToken.ThrowIfCancellationRequested();
-                    symbolTasks.Add(Task.Run(() => DetermineAllSymbolsCoreAsync(child, result), _cancellationToken));
-                }
+                _cancellationToken.ThrowIfCancellationRequested();
+                symbolTasks.Add(Task.Run(() => DetermineAllSymbolsCoreAsync(child, result), _cancellationToken));
             }
         }
 

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileDiffMergingSession.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         private async Task<LinkedFileMergeResult> MergeLinkedDocumentGroupAsync(
-            IEnumerable<DocumentId> allLinkedDocuments,
+            ImmutableArray<DocumentId> allLinkedDocuments,
             IEnumerable<DocumentId> linkedDocumentGroup,
             LinkedFileDiffMergingSessionInfo sessionInfo,
             IMergeConflictHandler mergeConflictHandler,
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         private IEnumerable<TextChange> MergeChangesWithMergeFailComments(
-            IEnumerable<TextChange> mergedChanges,
+            ImmutableArray<TextChange> mergedChanges,
             IEnumerable<TextChange> commentChanges,
             IList<TextSpan> mergeConflictResolutionSpans,
             LinkedFileGroupSessionInfo groupSessionInfo)

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.Text;
 
@@ -8,12 +9,12 @@ namespace Microsoft.CodeAnalysis
 {
     internal sealed class LinkedFileMergeResult
     {
-        public IEnumerable<DocumentId> DocumentIds { get; internal set; }
+        public ImmutableArray<DocumentId> DocumentIds { get; internal set; }
         public SourceText MergedSourceText { get; internal set; }
         public IEnumerable<TextSpan> MergeConflictResolutionSpans { get; }
         public bool HasMergeConflicts { get { return MergeConflictResolutionSpans.Any(); } }
 
-        public LinkedFileMergeResult(IEnumerable<DocumentId> documentIds, SourceText mergedSourceText, IEnumerable<TextSpan> mergeConflictResolutionSpans)
+        public LinkedFileMergeResult(ImmutableArray<DocumentId> documentIds, SourceText mergedSourceText, IEnumerable<TextSpan> mergeConflictResolutionSpans)
         {
             DocumentIds = documentIds;
             MergedSourceText = mergedSourceText;

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictingIdentifierTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictingIdentifierTracker.cs
@@ -33,9 +33,8 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
             string name = token.ValueText;
 
-            if (_currentIdentifiersInScope.ContainsKey(name))
+            if (_currentIdentifiersInScope.TryGetValue(name, out var conflictingTokens))
             {
-                var conflictingTokens = _currentIdentifiersInScope[name];
                 conflictingTokens.Add(token);
 
                 // If at least one of the identifiers is the one we're renaming,

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
@@ -130,9 +130,9 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                 return _documentToModifiedSpansMap[documentId].First(t => t.oldSpan == originalSpan).newSpan;
             }
 
-            if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+            if (_documentToComplexifiedSpansMap.TryGetValue(documentId, out var complexifiedSpans))
             {
-                return _documentToComplexifiedSpansMap[documentId].First(c => c.OriginalSpan.Contains(originalSpan)).NewSpan;
+                return complexifiedSpans.First(c => c.OriginalSpan.Contains(originalSpan)).NewSpan;
             }
 
             // The RenamedSpansTracker doesn't currently track unresolved conflicts for
@@ -206,14 +206,14 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     // Simplification may have removed escaping and formatted whitespace.  We need to update
                     // our list of modified spans accordingly
-                    if (_documentToModifiedSpansMap.ContainsKey(documentId))
+                    if (_documentToModifiedSpansMap.TryGetValue(documentId, out var modifiedSpans))
                     {
-                        _documentToModifiedSpansMap[documentId].Clear();
+                        modifiedSpans.Clear();
                     }
 
-                    if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+                    if (_documentToComplexifiedSpansMap.TryGetValue(documentId, out var complexifiedSpans))
                     {
-                        _documentToComplexifiedSpansMap[documentId].Clear();
+                        complexifiedSpans.Clear();
                     }
 
                     var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -269,17 +269,17 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         internal Dictionary<TextSpan, TextSpan> GetModifiedSpanMap(DocumentId documentId)
         {
             var result = new Dictionary<TextSpan, TextSpan>();
-            if (_documentToModifiedSpansMap.ContainsKey(documentId))
+            if (_documentToModifiedSpansMap.TryGetValue(documentId, out var modifiedSpans))
             {
-                foreach (var pair in _documentToModifiedSpansMap[documentId])
+                foreach (var pair in modifiedSpans)
                 {
                     result[pair.Item1] = pair.Item2;
                 }
             }
 
-            if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+            if (_documentToComplexifiedSpansMap.TryGetValue(documentId, out var complexifiedSpans))
             {
-                foreach (var complexifiedSpan in _documentToComplexifiedSpansMap[documentId])
+                foreach (var complexifiedSpan in complexifiedSpans)
                 {
                     foreach (var pair in complexifiedSpan.ModifiedSubSpans)
                     {
@@ -293,9 +293,9 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
         internal IEnumerable<(TextSpan oldSpan, TextSpan newSpan)> GetComplexifiedSpans(DocumentId documentId)
         {
-            if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+            if (_documentToComplexifiedSpansMap.TryGetValue(documentId, out var complexifiedSpans))
             {
-                return _documentToComplexifiedSpansMap[documentId].Select(c => (c.OriginalSpan, c.NewSpan));
+                return complexifiedSpans.Select(c => (c.OriginalSpan, c.NewSpan));
             }
 
             return SpecializedCollections.EmptyEnumerable<(TextSpan oldSpan, TextSpan newSpan)>();

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -110,15 +110,15 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         private static ImmutableArray<ITypeParameterSymbol> RenameTypeParameters(
-            IList<ITypeParameterSymbol> typeParameters,
+            ImmutableArray<ITypeParameterSymbol> typeParameters,
             IList<string> newNames,
             ITypeGenerator typeGenerator)
         {
             // We generate the type parameter in two passes.  The first creates the new type
             // parameter.  The second updates the constraints to point at this new type parameter.
-            var newTypeParameters = new List<CodeGenerationTypeParameterSymbol>();
-            var mapping = new Dictionary<ITypeSymbol, ITypeSymbol>();
-            for (int i = 0; i < typeParameters.Count; i++)
+            var newTypeParameters = new List<CodeGenerationTypeParameterSymbol>(typeParameters.Length);
+            var mapping = new Dictionary<ITypeSymbol, ITypeSymbol>(typeParameters.Length);
+            for (int i = 0; i < typeParameters.Length; i++)
             {
                 var typeParameter = typeParameters[i];
 

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis
         private static IEnumerable<INamedTypeSymbol> InstantiateTypes(
             Compilation compilation,
             bool ignoreAssemblyKey,
-            IEnumerable<INamedTypeSymbol> types,
+            ImmutableArray<INamedTypeSymbol> types,
             int arity,
             ImmutableArray<SymbolKeyResolution> typeArgumentKeys)
         {

--- a/src/Workspaces/Core/Portable/Utilities/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ImmutableArrayExtensions.cs
@@ -39,11 +39,11 @@ namespace Roslyn.Utilities
         internal static ImmutableArray<T> ToImmutableArrayOrEmpty<T>(this ImmutableArray<T> items)
             => items.IsDefault ? ImmutableArray<T>.Empty : items;
 
-        internal static IReadOnlyList<T> ToImmutableReadOnlyListOrEmpty<T>(this IEnumerable<T> items)
+        internal static ImmutableArray<T> ToImmutableReadOnlyListOrEmpty<T>(this IEnumerable<T> items)
         {
             if (items is ImmutableArray<T> array && !array.IsDefault)
             {
-                return (IReadOnlyList<T>)items;
+                return array;
             }
             else
             {


### PR DESCRIPTION
Passing around an `ImmutableArray<T>` as an `IEnumerable<T>` not only causes boxing, it also disables the efficient `GetEnumerator()` implementation and the optimized LINQ extension methods.

The first commit fixes several of those issues.

Guarding indexing into a `Dictionary<TKey, TValue>` with a call to `ContainsKey(TKey)` causes the dictionary to be searched twice. This can be avoided by using `TryGetValue(TKey, out TValue)`.

The second commit fixes several of those issues.

**Risk**

The first commit has no effect on the public API of the assemblies that are modified.
The second commit only modifies the way in which a method is implemented, not its signature.

I believe the risk to be very low.

**Performance impact**

Performance should improve for the reasons described above.

**How was the bug found?**

These are just a few of the issues found using our diagnostic analyzers available on https://marketplace.visualstudio.com/items?itemName=vs-publisher-363830.U2UConsultPerformanceCodeAnalyzersforC7