### PR TITLE
List supported language versions

### DIFF
--- a/docs/compilers/CSharp/CommandLine.md
+++ b/docs/compilers/CSharp/CommandLine.md
@@ -50,7 +50,8 @@
 | `/checked`{`+`&#124;`-`} | Generate overflow checks
 | `/unsafe`{`+`&#124;`-`} | Allow 'unsafe' code
 | `/define:`*symbol list* | Define conditional compilation symbol(s) (Short form: `/d`)
-| `/langversion`:*string* | Specify language version mode: `ISO-1`, `ISO-2`, `3`, `4`, `5`, `6`, `7`, `7.1`, `7.2`, `Default` (latest major version), or `Latest` (latest version, including minor versions)
+| `/langversion:?` | Display the allowed values for language version
+| `/langversion`:*string* | Specify language version such as `default` (latest major version), or `latest` (latest version, including minor versions)
 | **SECURITY**
 | `/delaysign`{`+`&#124;`-`} | Delay-sign the assembly using only the public portion of the strong name key
 | `/keyfile:`*file* | Specify a strong name key file

--- a/docs/compilers/Visual Basic/CommandLine.md
+++ b/docs/compilers/Visual Basic/CommandLine.md
@@ -52,7 +52,8 @@
 | **LANGUAGE**
 | `/define:`*symbol_list* | Declare global conditional compilation symbol(s). *symbol_list* is *name*`=`*value*`,`...  (Short form: `/d`)
 | `/imports:`*import_list* | Declare global Imports for namespaces in referenced metadata files. *import_list* is *namespace*`,`...
-| `/langversion:`*number* | Specify language version: `9`&#124;`9.0`&#124;`10`&#124;`10.0`&#124;`11`&#124;`11.0`&#124;`12`&#124;`12.0`&#124;`13`&#124;`13.0`&#124;`14`&#124;`14.0`&#124;`15`&#124;`15.0`&#124;`15.3`&#124;`15.6`. The default is `15` and the latest is `15.6`.
+| `/langversion:?` | Display the allowed values for language version
+| `/langversion`:*string* | Specify language version such as `default` (latest major version), or `latest` (latest version, including minor versions)
 | `/optionexplicit`{`+`&#124;`-`} | Require explicit declaration of variables.
 | `/optioninfer`{`+`&#124;`-`} | Allow type inference of variables.
 | `/rootnamespace`:*string* | Specifies the root Namespace for all top-level type declarations.

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CSharpResources {
@@ -10454,6 +10454,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string IDS_Lambda {
             get {
                 return ResourceManager.GetString("IDS_Lambda", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Supported language versions:.
+        /// </summary>
+        internal static string IDS_LangVersions {
+            get {
+                return ResourceManager.GetString("IDS_LangVersions", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CSharpResources {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1241,7 +1241,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid option &apos;{0}&apos; for /langversion; must be ISO-1, ISO-2, Default, Latest or a valid version in range 1 to 7.2..
+        ///   Looks up a localized string similar to Invalid option &apos;{0}&apos; for /langversion. Use &apos;/langversion:?&apos; to list supported values..
         /// </summary>
         internal static string ERR_BadCompatMode {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4389,6 +4389,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_LogoLine1" xml:space="preserve">
     <value>{0} version {1}</value>
   </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
+  </data>
   <data name="IDS_LogoLine2" xml:space="preserve">
     <value>Copyright (C) Microsoft Corporation. All rights reserved.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4389,11 +4389,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_LogoLine1" xml:space="preserve">
     <value>{0} version {1}</value>
   </data>
-  <data name="IDS_LangVersions" xml:space="preserve">
-    <value>Supported language versions:</value>
-  </data>
   <data name="IDS_LogoLine2" xml:space="preserve">
     <value>Copyright (C) Microsoft Corporation. All rights reserved.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="IDS_CSCHelp" xml:space="preserve">
     <value>
@@ -4450,7 +4450,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
 
                         - CODE GENERATION -
  /debug[+|-]                   Emit debugging information
- /debug:{{full|pdbonly|portable|embedded}}
+ /debug:{full|pdbonly|portable|embedded}
                                Specify debugging type ('full' is default,
                                'portable' is a cross-platform format,
                                'embedded' is a cross-platform format embedded into
@@ -4484,7 +4484,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
  /langversion:&lt;string&gt;         Specify language version such as
                                `default` (latest major version), or
                                `latest` (latest version, including minor versions),
-                               or specific versions like `{0}` or `{1}`
+                               or specific versions like `6` or `7.1`
 
                         - SECURITY -
  /delaysign[+|-]               Delay-sign the assembly using only the public

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4450,7 +4450,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
 
                         - CODE GENERATION -
  /debug[+|-]                   Emit debugging information
- /debug:{full|pdbonly|portable|embedded}
+ /debug:{{full|pdbonly|portable|embedded}}
                                Specify debugging type ('full' is default,
                                'portable' is a cross-platform format,
                                'embedded' is a cross-platform format embedded into
@@ -4480,8 +4480,11 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
  /unsafe[+|-]                  Allow 'unsafe' code
  /define:&lt;symbol list&gt;         Define conditional compilation symbol(s) (Short
                                form: /d)
- /langversion:&lt;string&gt;         Specify language version mode: ISO-1, ISO-2, 3,
-                               4, 5, 6, 7.0, 7.1, 7.2, Default, or Latest
+ /langversion:?                Display the allowed values for language version
+ /langversion:&lt;string&gt;         Specify language version such as
+                               `default` (latest major version), or
+                               `latest` (latest version, including minor versions),
+                               or specific versions like `{0}` or `{1}`
 
                         - SECURITY -
  /delaysign[+|-]               Delay-sign the assembly using only the public

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2711,7 +2711,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>This warning occurs if the assembly attributes AssemblyKeyFileAttribute or AssemblyKeyNameAttribute found in source conflict with the /keyfile or /keycontainer command line option or key file name or key container specified in the Project Properties.</value>
   </data>
   <data name="ERR_BadCompatMode" xml:space="preserve">
-    <value>Invalid option '{0}' for /langversion; must be ISO-1, ISO-2, Default, Latest or a valid version in range 1 to 7.2.</value>
+    <value>Invalid option '{0}' for /langversion. Use '/langversion:?' to list supported values.</value>
   </data>
   <data name="ERR_DelegateOnConditional" xml:space="preserve">
     <value>Cannot create delegate with '{0}' because it or a method it overrides has a Conditional attribute</value>

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -54,6 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool displayLogo = true;
             bool displayHelp = false;
             bool displayVersion = false;
+            bool displayLangVersions = false;
             bool optimize = false;
             bool checkOverflow = false;
             bool allowUnsafe = false;
@@ -836,6 +837,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 // treat them as identifiers (behaviour in native compiler). This error helps users identify that breaking change.
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_LanguageVersionCannotHaveLeadingZeroes, value);
                             }
+                            else if (value == "?")
+                            {
+                                displayLangVersions = true;
+                            }
                             else if (!value.TryParse(out languageVersion))
                             {
                                 AddDiagnostic(diagnostics, ErrorCode.ERR_BadCompatMode, value);
@@ -1346,6 +1351,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 DisplayLogo = displayLogo,
                 DisplayHelp = displayHelp,
                 DisplayVersion = displayVersion,
+                DisplayLangVersions = displayLangVersions,
                 ManifestResources = managedResources.AsImmutable(),
                 CompilationOptions = options,
                 ParseOptions = parseOptions,

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -267,6 +267,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             consoleOutput.WriteLine();
         }
 
+        public override void PrintLangVersions(TextWriter consoleOutput)
+        {
+            consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_LangVersions, Culture));
+            var defaultVersion = LanguageVersion.Default.MapSpecifiedToEffectiveVersion();
+            var latestVersion = LanguageVersion.Latest.MapSpecifiedToEffectiveVersion();
+            foreach (LanguageVersion v in Enum.GetValues(typeof(LanguageVersion)))
+            {
+                if (v == defaultVersion)
+                {
+                    consoleOutput.WriteLine($"{v.ToDisplayString()} (default)");
+                }
+                else if (v == latestVersion)
+                {
+                    consoleOutput.WriteLine($"{v.ToDisplayString()} (latest)");
+                }
+                else if (v != LanguageVersion.Default && v != LanguageVersion.Latest)
+                {
+                    consoleOutput.WriteLine(v.ToDisplayString());
+                }
+            }
+            consoleOutput.WriteLine();
+        }
 
         internal override Type Type
         {

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -310,7 +310,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="consoleOutput"></param>
         public override void PrintHelp(TextWriter consoleOutput)
         {
-            consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_CSCHelp, Culture));
+            consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_CSCHelp, Culture),
+                LanguageVersion.Default.MapSpecifiedToEffectiveVersion().ToDisplayString(),
+                LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().ToDisplayString());
         }
 
         protected override bool TryGetCompilerDiagnosticCode(string diagnosticId, out uint code)

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     consoleOutput.WriteLine($"{v.ToDisplayString()} (latest)");
                 }
-                else if (v != LanguageVersion.Default && v != LanguageVersion.Latest)
+                else
                 {
                     consoleOutput.WriteLine(v.ToDisplayString());
                 }
@@ -310,9 +310,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="consoleOutput"></param>
         public override void PrintHelp(TextWriter consoleOutput)
         {
-            consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_CSCHelp, Culture),
-                LanguageVersion.Default.MapSpecifiedToEffectiveVersion().ToDisplayString(),
-                LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().ToDisplayString());
+            consoleOutput.WriteLine(ErrorFacts.GetMessage(MessageID.IDS_CSCHelp, Culture));
         }
 
         protected override bool TryGetCompilerDiagnosticCode(string diagnosticId, out uint code)

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -131,6 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureInferredTupleNames = MessageBase + 12719,
         IDS_FeatureGenericPatternMatching = MessageBase + 12720,
         IDS_FeatureAsyncMain = MessageBase + 12721,
+        IDS_LangVersions = MessageBase +  12722,
     }
 
     // Message IDs may refer to strings that need to be localized.

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1304,9 +1304,13 @@ d.cs
         [Fact]
         public void LangVersion_LangVersions()
         {
-            // TODO
             var args = DefaultParse(new[] { "/langversion:?" }, _baseDirectory);
-            args.Errors.Verify();
+            args.Errors.Verify(
+                // warning CS2008: No source files specified.
+                Diagnostic(ErrorCode.WRN_NoSources).WithLocation(1, 1),
+                // error CS1562: Outputs without source must have the /out option specified
+                Diagnostic(ErrorCode.ERR_OutputNeedsName).WithLocation(1, 1)
+                );
             Assert.True(args.DisplayLangVersions);
         }
 
@@ -1410,7 +1414,6 @@ d.cs
         public void LangVersion_ListLangVersions()
         {
             var dir = Temp.CreateDirectory();
-
             var outWriter = new StringWriter(CultureInfo.InvariantCulture);
             var csc = new MockCSharpCompiler(null, dir.Path, new[] { "/langversion:?" });
             int exitCode = csc.Run(outWriter);
@@ -1427,29 +1430,6 @@ d.cs
                 Assert.True(foundIndex > 0, $"Missing version '{version}'");
                 Assert.True(Array.IndexOf(acceptableSurroundingChar, actual[foundIndex - 1]) >= 0);
                 Assert.True(Array.IndexOf(acceptableSurroundingChar, actual[foundIndex + version.Length]) >= 0);
-            }
-        }
-
-        [Fact]
-        public void LanguageVersion_CommandLineUsage()
-        {
-            var expected = Enum.GetValues(typeof(LanguageVersion)).Cast<LanguageVersion>()
-                .Where(v => v != LanguageVersion.CSharp1 && v != LanguageVersion.CSharp2)
-                .Select(v => v.ToDisplayString());
-            string help = CSharpResources.IDS_CSCHelp;
-
-            var rangeStart = help.IndexOf("/langversion");
-            var rangeEnd = help.IndexOf("/delaysign");
-            Assert.True(rangeEnd > rangeStart);
-
-            string helpRange = help.Substring(rangeStart, rangeEnd - rangeStart).ToLowerInvariant();
-            var acceptableSurroundingChar = new[] { '\r', '\n', ',' , ' '};
-            foreach (var version in expected)
-            {
-                var foundIndex = helpRange.IndexOf(version);
-                Assert.True(foundIndex > 0, $"Missing version '{version}'");
-                Assert.True(Array.IndexOf(acceptableSurroundingChar, helpRange[foundIndex - 1]) >= 0);
-                Assert.True(Array.IndexOf(acceptableSurroundingChar, helpRange[foundIndex + version.Length]) >= 0);
             }
         }
 

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1274,8 +1274,9 @@ d.cs
         public void LangVersion_BadVersion(string value)
         {
             DefaultParse(new[] { $"/langversion:{value}", "a.cs" }, _baseDirectory).Errors.Verify(
-                // error CS1617: Invalid option 'XXX' for /langversion; must be ISO-1, ISO-2, Default, Latest or a valid version in range 1 to 7.1.
-                Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments(value).WithLocation(1, 1));
+                // error CS1617: Invalid option 'XXX' for /langversion. Use '/langversion:?' to list supported values.
+                Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments(value).WithLocation(1, 1)
+                );
         }
 
         [Theory]
@@ -9385,7 +9386,7 @@ class C
         {
             var parsedArgs = DefaultParse(new[] { "/langversion:1000", "a.cs" }, _baseDirectory);
             parsedArgs.Errors.Verify(
-                // error CS1617: Invalid option '1000' for /langversion; must be ISO-1, ISO-2, Default or an integer in range 1 to 6.
+                // error CS1617: Invalid option '1000' for /langversion. Use '/langversion:?' to list supported values.
                 Diagnostic(ErrorCode.ERR_BadCompatMode).WithArguments("1000").WithLocation(1, 1));
         }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
@@ -183,6 +183,12 @@ namespace Microsoft.CodeAnalysis
         public bool DisplayVersion { get; internal set; }
 
         /// <summary>
+        /// If true, prepend the compiler-supported language versions during
+        /// <see cref="CommonCompiler.Run"/>
+        /// </summary>
+        public bool DisplayLangVersions { get; internal set; }
+
+        /// <summary>
         /// The path to a Win32 resource.
         /// </summary>
         public string Win32ResourceFile { get; internal set; }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -78,6 +78,7 @@ namespace Microsoft.CodeAnalysis
         public abstract Compilation CreateCompilation(TextWriter consoleOutput, TouchedFileLogger touchedFilesLogger, ErrorLogger errorLoggerOpt);
         public abstract void PrintLogo(TextWriter consoleOutput);
         public abstract void PrintHelp(TextWriter consoleOutput);
+        public abstract void PrintLangVersions(TextWriter consoleOutput);
 
         /// <summary>
         /// Print compiler version
@@ -517,6 +518,12 @@ namespace Microsoft.CodeAnalysis
             if (Arguments.DisplayVersion)
             {
                 PrintVersion(consoleOutput);
+                return Succeeded;
+            }
+
+            if (Arguments.DisplayLangVersions)
+            {
+                PrintLangVersions(consoleOutput);
                 return Succeeded;
             }
 

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -913,3 +913,4 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.Vi
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitWhileUntilLoopStatement(Microsoft.CodeAnalysis.Semantics.IWhileUntilLoopStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitWithStatement(Microsoft.CodeAnalysis.Semantics.IWithStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitYieldBreakStatement(Microsoft.CodeAnalysis.Semantics.IReturnStatement operation, TArgument argument) -> TResult
+Microsoft.CodeAnalysis.CommandLineArguments.DisplayLangVersions.get -> bool

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -86,6 +86,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim displayLogo As Boolean = True
             Dim displayHelp As Boolean = False
             Dim displayVersion As Boolean = False
+            Dim displayLangVersions As Boolean = False
             Dim outputLevel As OutputLevel = OutputLevel.Normal
             Dim optimize As Boolean = False
             Dim checkOverflow As Boolean = True
@@ -821,13 +822,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         Case "langversion"
                             value = RemoveQuotesAndSlashes(value)
-                            If value Is Nothing Then
-                                AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "langversion", ":<number>")
-                                Continue For
-                            End If
-
                             If String.IsNullOrEmpty(value) Then
                                 AddDiagnostic(diagnostics, ERRID.ERR_ArgumentRequired, "langversion", ":<number>")
+                            ElseIf value = "?" Then
+                                displayLangVersions = True
                             Else
                                 If Not value.TryParse(languageVersion) Then
                                     AddDiagnostic(diagnostics, ERRID.ERR_InvalidSwitchValue, "langversion", value)
@@ -1407,6 +1405,7 @@ lVbRuntimePlus:
                 .DisplayLogo = displayLogo,
                 .DisplayHelp = displayHelp,
                 .DisplayVersion = displayVersion,
+                .DisplayLangVersions = displayLangVersions,
                 .ManifestResources = managedResources.AsImmutable(),
                 .CompilationOptions = options,
                 .ParseOptions = parseOptions,

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -200,7 +200,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="consoleOutput"></param>
         Public Overrides Sub PrintHelp(consoleOutput As TextWriter)
-            consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_VBCHelp, Culture))
+            consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_VBCHelp, Culture),
+                                    LanguageVersion.Default.MapSpecifiedToEffectiveVersion().ToDisplayString(),
+                                    LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().ToDisplayString())
         End Sub
 
         Public Overrides Sub PrintLangVersions(consoleOutput As TextWriter)

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -200,9 +200,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         ''' <param name="consoleOutput"></param>
         Public Overrides Sub PrintHelp(consoleOutput As TextWriter)
-            consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_VBCHelp, Culture),
-                                    LanguageVersion.Default.MapSpecifiedToEffectiveVersion().ToDisplayString(),
-                                    LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().ToDisplayString())
+            consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_VBCHelp, Culture))
         End Sub
 
         Public Overrides Sub PrintLangVersions(consoleOutput As TextWriter)
@@ -214,7 +212,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     consoleOutput.WriteLine($"{v.ToDisplayString()} (default)")
                 ElseIf v = latestVersion Then
                     consoleOutput.WriteLine($"{v.ToDisplayString()} (latest)")
-                ElseIf v <> LanguageVersion.Default AndAlso v <> LanguageVersion.Latest Then
+                Else
                     consoleOutput.WriteLine(v.ToDisplayString())
                 End If
             Next

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -203,6 +203,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_VBCHelp, Culture))
         End Sub
 
+        Public Overrides Sub PrintLangVersions(consoleOutput As TextWriter)
+            consoleOutput.WriteLine(ErrorFactory.IdToString(ERRID.IDS_LangVersions, Culture))
+            Dim defaultVersion = LanguageVersion.Default.MapSpecifiedToEffectiveVersion()
+            Dim latestVersion = LanguageVersion.Latest.MapSpecifiedToEffectiveVersion()
+            For Each v As LanguageVersion In System.Enum.GetValues(GetType(LanguageVersion))
+                If v = defaultVersion Then
+                    consoleOutput.WriteLine($"{v.ToDisplayString()} (default)")
+                ElseIf v = latestVersion Then
+                    consoleOutput.WriteLine($"{v.ToDisplayString()} (latest)")
+                ElseIf v <> LanguageVersion.Default AndAlso v <> LanguageVersion.Latest Then
+                    consoleOutput.WriteLine(v.ToDisplayString())
+                End If
+            Next
+            consoleOutput.WriteLine()
+        End Sub
+
         Protected Overrides Function TryGetCompilerDiagnosticCode(diagnosticId As String, ByRef code As UInteger) As Boolean
             Return CommonCompiler.TryGetCompilerDiagnosticCode(diagnosticId, "BC", code)
         End Function

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1977,7 +1977,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         IDS_LogoLine1 = 56007
         IDS_LogoLine2 = 56008
         IDS_VBCHelp = 56009
-        ' available: 56010
+        IDS_LangVersions = 56010
         IDS_ToolName = 56011
 
         ' Feature codes

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -12244,6 +12244,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Supported language versions:.
+        '''</summary>
+        Friend ReadOnly Property IDS_LangVersions() As String
+            Get
+                Return ResourceManager.GetString("IDS_LangVersions", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to {0} version {1}.
         '''</summary>
         Friend ReadOnly Property IDS_LogoLine1() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
      Global.Microsoft.VisualBasic.HideModuleNameAttribute()>  _

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5039,14 +5039,14 @@
   <data name="IDS_ToolName" xml:space="preserve">
     <value>Microsoft (R) Visual Basic Compiler</value>
   </data>
-  <data name="IDS_LangVersions" xml:space="preserve">
-    <value>Supported language versions:</value>
-  </data>
   <data name="IDS_LogoLine1" xml:space="preserve">
     <value>{0} version {1}</value>
   </data>
   <data name="IDS_LogoLine2" xml:space="preserve">
     <value>Copyright (C) Microsoft Corporation. All rights reserved.</value>
+  </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
   </data>
   <data name="IDS_VBCHelp" xml:space="preserve">
     <value>                  Visual Basic Compiler Options
@@ -5137,7 +5137,7 @@
 /langversion:&lt;string&gt;             Specify language version such as
                                   `default` (latest major version), or
                                   `latest` (latest version, including minor versions),
-                                  or specific versions like `{0}` or `{1}`
+                                  or specific versions like `14` or `15.3`
 /optionexplicit[+|-]              Require explicit declaration of variables.
 /optioninfer[+|-]                 Allow type inference of variables.
 /rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5133,9 +5133,11 @@
 /imports:&lt;import_list&gt;            Declare global Imports for namespaces in 
                                   referenced metadata files. 
                                   import_list:namespace,...
-/langversion:&lt;number&gt;             Specify language version: 
-                                  9|9.0|10|10.0|11|11.0|12|12.0|14|14.0|15|
-                                  15.0|15.3|15.6|default|latest
+/langversion:?                    Display the allowed values for language version
+/langversion:&lt;string&gt;             Specify language version such as
+                                  `default` (latest major version), or
+                                  `latest` (latest version, including minor versions),
+                                  or specific versions like `{0}` or `{1}`
 /optionexplicit[+|-]              Require explicit declaration of variables.
 /optioninfer[+|-]                 Allow type inference of variables.
 /rootnamespace:&lt;string&gt;           Specifies the root Namespace for all type 

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5039,6 +5039,9 @@
   <data name="IDS_ToolName" xml:space="preserve">
     <value>Microsoft (R) Visual Basic Compiler</value>
   </data>
+  <data name="IDS_LangVersions" xml:space="preserve">
+    <value>Supported language versions:</value>
+  </data>
   <data name="IDS_LogoLine1" xml:space="preserve">
     <value>{0} version {1}</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1710,8 +1710,7 @@ End Module").Path
             Assert.Equal(0, exitCode)
 
             Dim actual = outWriter.ToString()
-            Dim expected = {LanguageVersion.Default.MapSpecifiedToEffectiveVersion().ToDisplayString(),
-                LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().ToDisplayString()}
+            Dim expected = [Enum].GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString())
             Dim acceptableSurroundingChar = {CChar(vbCr), CChar(vbLf), "("c, ")"c, " "c}
 
             For Each v In expected

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1710,7 +1710,8 @@ End Module").Path
             Assert.Equal(0, exitCode)
 
             Dim actual = outWriter.ToString()
-            Dim expected = [Enum].GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString())
+            Dim expected = {LanguageVersion.Default.MapSpecifiedToEffectiveVersion().ToDisplayString(),
+                LanguageVersion.Latest.MapSpecifiedToEffectiveVersion().ToDisplayString()}
             Dim acceptableSurroundingChar = {CChar(vbCr), CChar(vbLf), "("c, ")"c, " "c}
 
             For Each v In expected
@@ -1719,29 +1720,6 @@ End Module").Path
                 Assert.True(Array.IndexOf(acceptableSurroundingChar, actual(foundIndex - 1)) >= 0)
                 Assert.True(Array.IndexOf(acceptableSurroundingChar, actual(foundIndex + v.Length)) >= 0)
             Next
-        End Sub
-
-        <Fact>
-        Public Sub LanguageVersion_CommandLineUsage()
-            Dim expected = [Enum].GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString())
-            Dim help = VBResources.IDS_VBCHelp
-
-            Dim rangeStart = help.IndexOf("/langversion")
-            Dim rangeEnd = help.IndexOf("/optionexplicit")
-            Assert.True(rangeEnd > rangeStart)
-
-            Dim helpRange = help.Substring(rangeStart, rangeEnd - rangeStart).ToLowerInvariant()
-            Dim acceptableSurroundingChar = {CChar(vbCr), CChar(vbLf), "|"c, " "c}
-
-            For Each v In expected
-                Dim foundIndex = helpRange.IndexOf(v)
-                Assert.True(foundIndex > 0, $"Missing version '{v}'")
-                Assert.True(Array.IndexOf(acceptableSurroundingChar, helpRange(foundIndex - 1)) >= 0)
-                Assert.True(Array.IndexOf(acceptableSurroundingChar, helpRange(foundIndex + v.Length)) >= 0)
-            Next
-
-            ' The canary check is a reminder that this test needs to be updated when a language version is added
-            LanguageVersionAdded_Canary()
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -1703,6 +1703,25 @@ End Module").Path
         End Sub
 
         <Fact>
+        Public Sub LanguageVersion_ListLangVersions()
+            Dim dir = Temp.CreateDirectory()
+            Dim outWriter As New StringWriter()
+            Dim exitCode As Integer = New MockVisualBasicCompiler(Nothing, dir.ToString(), {"/langversion:?"}).Run(outWriter, Nothing)
+            Assert.Equal(0, exitCode)
+
+            Dim actual = outWriter.ToString()
+            Dim expected = [Enum].GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString())
+            Dim acceptableSurroundingChar = {CChar(vbCr), CChar(vbLf), "("c, ")"c, " "c}
+
+            For Each v In expected
+                Dim foundIndex = actual.IndexOf(v)
+                Assert.True(foundIndex > 0, $"Missing version '{v}'")
+                Assert.True(Array.IndexOf(acceptableSurroundingChar, actual(foundIndex - 1)) >= 0)
+                Assert.True(Array.IndexOf(acceptableSurroundingChar, actual(foundIndex + v.Length)) >= 0)
+            Next
+        End Sub
+
+        <Fact>
         Public Sub LanguageVersion_CommandLineUsage()
             Dim expected = [Enum].GetValues(GetType(LanguageVersion)).Cast(Of LanguageVersion)().Select(Function(v) v.ToDisplayString())
             Dim help = VBResources.IDS_VBCHelp


### PR DESCRIPTION
Adds a `/langversion:?` option to command-line for csc and vbc and remove hard-coded list of language versions from help resource string.

Fixes https://github.com/dotnet/roslyn/issues/19753