### PR TITLE
Suppress IDE0004 for switch case label when casting is required

### DIFF
--- a/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/Semantics/SpeculationAnalyzerTests.cs
@@ -340,6 +340,54 @@ class Program
 }           ", "Directions.South", semanticChanges: false);
         }
 
+        [Fact, WorkItem(19987, "https://github.com/dotnet/roslyn/issues/19987")]
+        public void SpeculationAnalyzerSwitchCaseWithRedundantCast()
+        {
+            Test(@"
+class Program
+{
+    static void Main(string[] arts)
+    {
+        var x = 1f;
+        switch (x)
+        {
+            case [|(float) 1|]:
+                System.Console.WriteLine(""one"");
+                break;
+
+            default:
+                System.Console.WriteLine(""not one"");
+                break;
+        }
+    }
+}
+            ", "1", semanticChanges: false);
+        }
+
+        [Fact, WorkItem(19987, "https://github.com/dotnet/roslyn/issues/19987")]
+        public void SpeculationAnalyzerSwitchCaseWithRequiredCast()
+        {
+            Test(@"
+class Program
+{
+    static void Main(string[] arts)
+    {
+        object x = 1f;
+        switch (x)
+        {
+            case [|(float) 1|]: // without the case, object x does not match int 1
+                System.Console.WriteLine(""one"");
+                break;
+
+            default:
+                System.Console.WriteLine(""not one"");
+                break;
+        }
+    }
+}
+            ", "1", semanticChanges: true);
+        }
+
         protected override SyntaxTree Parse(string text)
         {
             return SyntaxFactory.ParseSyntaxTree(text);

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 var newCaseSwitchLabel = (CaseSwitchLabelSyntax)currentReplacedNode;
 
                 // If case label is changing, then need to check if the semantics will change for the switch expression.  
-                // e.g. if switch expression is "object x = 1f", "case 1:" and "case (float) 1:" are different.
+                // e.g. if switch expression is "switch(x)" where "object x = 1f", then "case 1:" and "case (float) 1:" are different.
                 var originalCaseType = this.OriginalSemanticModel.GetTypeInfo(previousOriginalNode, this.CancellationToken).Type;
                 var newCaseType = this.SpeculativeSemanticModel.GetTypeInfo(previousReplacedNode, this.CancellationToken).Type;
 
@@ -402,12 +402,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 var originalConversion = this.OriginalSemanticModel.ClassifyConversion(oldSwitchStatement.Expression, originalCaseType);
                 var newConversion = this.SpeculativeSemanticModel.ClassifyConversion(newSwitchStatement.Expression, newCaseType);
                 
+                // if conversion only exists for either original or new, then semantics changed.
                 if (originalConversion.Exists != newConversion.Exists)
                 {
                     return true;
                 }
 
-                // if the conversions are equal and the target types are different, then semantics changed.
+                // Same conversion cannot result in both originalCaseType and newCaseType, which means the semantics changed
+                // (since originalCaseType != newCaseType)
                 return originalConversion == newConversion;
             }
             else if (currentOriginalNode.Kind() == SyntaxKind.SwitchStatement)

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -379,6 +379,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                     }
                 }
             }
+            else if (currentOriginalNode.Kind() == SyntaxKind.CaseSwitchLabel)
+            {
+                var originalCaseSwitchLabel = (CaseSwitchLabelSyntax)currentOriginalNode;
+                var newCaseSwitchLabel = (CaseSwitchLabelSyntax)currentReplacedNode;
+
+                // If case label is changing, then need to check if the semantics will change for the switch expression.  
+                // e.g. if switch expression is "object x = 1f", "case 1:" and "case (float) 1:" are different.
+                var originalCaseType = this.OriginalSemanticModel.GetTypeInfo(previousOriginalNode, this.CancellationToken).Type;
+                var newCaseType = this.SpeculativeSemanticModel.GetTypeInfo(previousReplacedNode, this.CancellationToken).Type;
+
+                if (originalCaseType == newCaseType)
+                    return false;
+
+                var oldSwitchStatement = originalCaseSwitchLabel?.Parent?.Parent as SwitchStatementSyntax;
+                var newSwitchStatement = newCaseSwitchLabel?.Parent?.Parent as SwitchStatementSyntax;
+                if (oldSwitchStatement == null || newSwitchStatement == null)
+                {
+                    return false;
+                }
+
+                var originalConversion = this.OriginalSemanticModel.ClassifyConversion(oldSwitchStatement.Expression, originalCaseType);
+                var newConversion = this.SpeculativeSemanticModel.ClassifyConversion(newSwitchStatement.Expression, newCaseType);
+                
+                if (originalConversion.Exists != newConversion.Exists)
+                {
+                    return true;
+                }
+
+                // if the conversions are equal and the target types are different, then semantics changed.
+                return originalConversion == newConversion;
+            }
             else if (currentOriginalNode.Kind() == SyntaxKind.SwitchStatement)
             {
                 var originalSwitchStatement = (SwitchStatementSyntax)currentOriginalNode;

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -392,12 +392,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 if (originalCaseType == newCaseType)
                     return false;
 
-                var oldSwitchStatement = originalCaseSwitchLabel?.Parent?.Parent as SwitchStatementSyntax;
-                var newSwitchStatement = newCaseSwitchLabel?.Parent?.Parent as SwitchStatementSyntax;
-                if (oldSwitchStatement == null || newSwitchStatement == null)
-                {
-                    return false;
-                }
+                var oldSwitchStatement = (SwitchStatementSyntax) originalCaseSwitchLabel.Parent.Parent;
+                var newSwitchStatement = (SwitchStatementSyntax) newCaseSwitchLabel.Parent.Parent;
 
                 var originalConversion = this.OriginalSemanticModel.ClassifyConversion(oldSwitchStatement.Expression, originalCaseType);
                 var newConversion = this.SpeculativeSemanticModel.ClassifyConversion(newSwitchStatement.Expression, newCaseType);

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -392,8 +392,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 if (originalCaseType == newCaseType)
                     return false;
 
-                var oldSwitchStatement = (SwitchStatementSyntax) originalCaseSwitchLabel.Parent.Parent;
-                var newSwitchStatement = (SwitchStatementSyntax) newCaseSwitchLabel.Parent.Parent;
+                var oldSwitchStatement = (SwitchStatementSyntax)originalCaseSwitchLabel.Parent.Parent;
+                var newSwitchStatement = (SwitchStatementSyntax)newCaseSwitchLabel.Parent.Parent;
 
                 var originalConversion = this.OriginalSemanticModel.ClassifyConversion(oldSwitchStatement.Expression, originalCaseType);
                 var newConversion = this.SpeculativeSemanticModel.ClassifyConversion(newSwitchStatement.Expression, newCaseType);


### PR DESCRIPTION
Fixes #19987

**Customer scenario**

Explicit casting used in `switch` case label is sometimes incorrectly given IDE0004 (Cast is redundant) in Visual Studio, and users could incorrectly follow the suggestion, which changes the behaviour of the program.
A specific scenario described at #19987  

**Bugs this fixes:**

#19987 

**Workarounds, if any**

Ignore IDE suggestion.

**Risk**


**Performance impact**

Low, as there is no complexity change. Only an additional check for switch case label. 

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

There was no unit test for this specific case before (probably rarely used scenario). Tests added in this PR branch.

**How was the bug found?**

#19987 (🔗Originally reported by [Thomas Castiglione](https://developercommunity.visualstudio.com/users/21348/873dad1a-b02f-4f5a-8da9-37ef170c009b.html))