### PR TITLE
Do not allow ReadValue to return while a stream is still being read

### DIFF
--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -138,8 +138,15 @@ namespace Roslyn.Utilities
                     _cancellationToken,
                     TaskCreationOptions.LongRunning,
                     TaskScheduler.Default);
-                task.Wait(_cancellationToken);
-                value = task.Result;
+
+                // We must not proceed until the additional task completes. After returning from a read, the underlying
+                // stream providing access to raw memory will be closed; if this occurs before the separate thread
+                // completes its read then an access violation can occur attempting to read from unmapped memory.
+                //
+                // CANCELLATION: If cancellation is required, DO NOT attempt to cancel the operation by cancelling this
+                // wait. Cancellation must only be implemented by modifying 'task' to cancel itself in a timely manner
+                // so the wait can complete.
+                value = task.GetAwaiter().GetResult();
             }
             else
             {

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -487,7 +487,15 @@ namespace Roslyn.Utilities
                         _cancellationToken,
                         TaskCreationOptions.LongRunning,
                         TaskScheduler.Default);
-                    task.Wait();
+
+                    // We must not proceed until the additional task completes. After returning from a write, the underlying
+                    // stream providing access to raw memory will be closed; if this occurs before the separate thread
+                    // completes its write then an access violation can occur attempting to write to unmapped memory.
+                    //
+                    // CANCELLATION: If cancellation is required, DO NOT attempt to cancel the operation by cancelling this
+                    // wait. Cancellation must only be implemented by modifying 'task' to cancel itself in a timely manner
+                    // so the wait can complete.
+                    task.GetAwaiter().GetResult();
                 }
                 else
                 {
@@ -747,7 +755,15 @@ namespace Roslyn.Utilities
                         _cancellationToken,
                         TaskCreationOptions.LongRunning,
                         TaskScheduler.Default);
-                    task.Wait(_cancellationToken);
+
+                    // We must not proceed until the additional task completes. After returning from a write, the underlying
+                    // stream providing access to raw memory will be closed; if this occurs before the separate thread
+                    // completes its write then an access violation can occur attempting to write to unmapped memory.
+                    //
+                    // CANCELLATION: If cancellation is required, DO NOT attempt to cancel the operation by cancelling this
+                    // wait. Cancellation must only be implemented by modifying 'task' to cancel itself in a timely manner
+                    // so the wait can complete.
+                    task.GetAwaiter().GetResult();
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #19761

## Ask Mode

**Customer scenario**

The specific steps to encounter this issue are not completely clear. It appears to involve working in a file which has a deeply nested structure. When the bug arises, Visual Studio may read from a pointer which has been freed, resulting in corruption of internal data structures or an access violation.

**Bugs this fixes:**

Fixes #19761
Fixes #20170

**Workarounds, if any**

None.

**Risk**

The change made here is theoretically capable of producing either a deadlock or a performance regression. Neither of these seems likely from the particular change, and the situations we are avoiding are certainly worse (stack overflow or heap corruption). @CyrusNajmabadi Can you provide an evaluation of the risk for this change?

**Performance impact**

This change disables a cancellation point in the code, which could in some cases cause a regression related to serialization performance. However, this cancellation point was implemented as a recursion guard, not a proper cancellation point, so it's likely we were not relying on its behavior as the latter for performance.

**Is this a regression from a previous update?**

Yes, this bug was introduced in #16798 (specifically 6427a2b5e66913a752889860ca28ddb284be4973) for release 15.1.

**Root cause analysis:**

The code accessing unmanaged memory is extremely performance sensitive, so most checks capable of detecting this concurrency bug early have too much overhead for deployment.

**How was the bug found?**

Internal customer report.
