### PR TITLE
optimized dictionary usage

### DIFF
--- a/src/Compilers/Core/Portable/RuleSet/RuleSet.cs
+++ b/src/Compilers/Core/Portable/RuleSet/RuleSet.cs
@@ -151,9 +151,9 @@ namespace Microsoft.CodeAnalysis
                 // Copy every rule in the ruleset and change the action if there's a stricter one.
                 foreach (var item in effectiveRuleset.SpecificDiagnosticOptions)
                 {
-                    if (effectiveSpecificOptions.ContainsKey(item.Key))
+                    if (effectiveSpecificOptions.TryGetValue(item.Key, out var value))
                     {
-                        if (IsStricterThan(item.Value, effectiveSpecificOptions[item.Key]))
+                        if (IsStricterThan(item.Value, value))
                         {
                             effectiveSpecificOptions[item.Key] = item.Value;
                         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractSemanticQuickInfoProvider.cs
@@ -163,16 +163,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 
             var sections = await descriptionService.ToDescriptionGroupsAsync(workspace, semanticModel, token.SpanStart, symbols.AsImmutable(), cancellationToken).ConfigureAwait(false);
 
+            ImmutableArray<TaggedText> parts;
+
             var mainDescriptionBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.MainDescription))
+            if (sections.TryGetValue(SymbolDescriptionGroups.MainDescription, out parts))
             {
-                mainDescriptionBuilder.AddRange(sections[SymbolDescriptionGroups.MainDescription]);
+                mainDescriptionBuilder.AddRange(parts);
             }
 
             var typeParameterMapBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.TypeParameterMap))
+            if (sections.TryGetValue(SymbolDescriptionGroups.TypeParameterMap, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.TypeParameterMap];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     typeParameterMapBuilder.AddLineBreak();
@@ -181,9 +182,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
 
             var anonymousTypesBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.AnonymousTypes))
+            if (sections.TryGetValue(SymbolDescriptionGroups.AnonymousTypes, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.AnonymousTypes];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     anonymousTypesBuilder.AddLineBreak();
@@ -192,9 +192,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
 
             var usageTextBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.AwaitableUsageText))
+            if (sections.TryGetValue(SymbolDescriptionGroups.AwaitableUsageText, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.AwaitableUsageText];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     usageTextBuilder.AddRange(parts);
@@ -207,9 +206,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
 
             var exceptionsTextBuilder = new List<TaggedText>();
-            if (sections.ContainsKey(SymbolDescriptionGroups.Exceptions))
+            if (sections.TryGetValue(SymbolDescriptionGroups.Exceptions, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.Exceptions];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     exceptionsTextBuilder.AddRange(parts);
@@ -250,10 +248,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             ISyntaxFactsService syntaxFactsService,
             CancellationToken cancellationToken)
         {
-            if (sections.ContainsKey(SymbolDescriptionGroups.Documentation))
+            if (sections.TryGetValue(SymbolDescriptionGroups.Documentation, out var parts))
             {
                 var documentationBuilder = new List<TaggedText>();
-                documentationBuilder.AddRange(sections[SymbolDescriptionGroups.Documentation]);
+                documentationBuilder.AddRange(parts);
                 return CreateClassifiableDeferredContent(documentationBuilder);
             }
             else if (symbols.Any())

--- a/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
@@ -135,14 +135,14 @@ namespace Microsoft.CodeAnalysis.Completion
 
             AddDocumentationPart(textContentBuilder, symbol, semanticModel, position, formatter, cancellationToken);
 
-            if (sections.ContainsKey(SymbolDescriptionGroups.AwaitableUsageText))
+            ImmutableArray<TaggedText> parts;
+            if (sections.TryGetValue(SymbolDescriptionGroups.AwaitableUsageText, out parts))
             {
-                textContentBuilder.AddRange(sections[SymbolDescriptionGroups.AwaitableUsageText]);
+                textContentBuilder.AddRange(parts);
             }
 
-            if (sections.ContainsKey(SymbolDescriptionGroups.AnonymousTypes))
+            if (sections.TryGetValue(SymbolDescriptionGroups.AnonymousTypes, out parts))
             {
-                var parts = sections[SymbolDescriptionGroups.AnonymousTypes];
                 if (!parts.IsDefaultOrEmpty)
                 {
                     textContentBuilder.AddLineBreak();

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -96,9 +96,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         protected CompletionItem GetItem(string n)
         {
-            if (_tagMap.ContainsKey(n))
+            if (_tagMap.TryGetValue(n, out var value))
             {
-                var value = _tagMap[n];
                 return CreateCompletionItem(n, value[0], value[1]);
             }
 

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -152,17 +152,17 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         internal void WaitUntilCompletion_ForTestingPurposesOnly(Workspace workspace, ImmutableArray<IIncrementalAnalyzer> workers)
         {
-            if (_documentWorkCoordinatorMap.ContainsKey(workspace))
+            if (_documentWorkCoordinatorMap.TryGetValue(workspace, out var coordinator))
             {
-                _documentWorkCoordinatorMap[workspace].WaitUntilCompletion_ForTestingPurposesOnly(workers);
+                coordinator.WaitUntilCompletion_ForTestingPurposesOnly(workers);
             }
         }
 
         internal void WaitUntilCompletion_ForTestingPurposesOnly(Workspace workspace)
         {
-            if (_documentWorkCoordinatorMap.ContainsKey(workspace))
+            if (_documentWorkCoordinatorMap.TryGetValue(workspace, out var coordinator))
             {
-                _documentWorkCoordinatorMap[workspace].WaitUntilCompletion_ForTestingPurposesOnly();
+                coordinator.WaitUntilCompletion_ForTestingPurposesOnly();
             }
         }
 

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -1546,8 +1546,8 @@ namespace BoundTreeGenerator
         {
             string genericType = GetGenericType(typeName);
 
-            if (_valueTypes.ContainsKey(genericType))
-                return _valueTypes[genericType];
+            if (_valueTypes.TryGetValue(genericType, out bool isValueType))
+                return isValueType;
             else
                 return false;
         }

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
@@ -195,22 +195,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // get token span
 
             // check whether we have trivia info belongs to this token
-            var leadingTrivia = token.LeadingTrivia;
-            var trailingTrivia = token.TrailingTrivia;
 
-            if (_trailingTriviaMap.ContainsKey(token))
+            if (_trailingTriviaMap.TryGetValue(token, out var trailingTrivia))
             {
                 // okay, we have this situation
                 // token|trivia
-                trailingTrivia = _trailingTriviaMap[token];
                 hasChanges = true;
             }
 
-            if (_leadingTriviaMap.ContainsKey(token))
+            if (_leadingTriviaMap.TryGetValue(token, out var leadingTrivia))
             {
                 // okay, we have this situation
                 // trivia|token
-                leadingTrivia = _leadingTriviaMap[token];
                 hasChanges = true;
             }
 
@@ -223,7 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return token;
         }
 
-        private SyntaxToken CreateNewToken(SyntaxTriviaList leadingTrivia, SyntaxToken token, SyntaxTriviaList trailingTrivia)
+        private static SyntaxToken CreateNewToken(SyntaxTriviaList leadingTrivia, SyntaxToken token, SyntaxTriviaList trailingTrivia)
         {
             return token.With(leadingTrivia, trailingTrivia);
         }

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaRewriter.cs
@@ -195,12 +195,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // get token span
 
             // check whether we have trivia info belongs to this token
-
             if (_trailingTriviaMap.TryGetValue(token, out var trailingTrivia))
             {
                 // okay, we have this situation
                 // token|trivia
                 hasChanges = true;
+            }
+            else
+            {
+                trailingTrivia = token.TrailingTrivia;
             }
 
             if (_leadingTriviaMap.TryGetValue(token, out var leadingTrivia))
@@ -208,6 +211,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 // okay, we have this situation
                 // trivia|token
                 hasChanges = true;
+            }
+            else
+            {
+                leadingTrivia = token.LeadingTrivia;
             }
 
             if (hasChanges)

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentProjectsFinder.cs
@@ -263,9 +263,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 var toProcess = projectIdsToProcess.Pop();
 
-                if (projectIdsToReferencingSubmissionIds.ContainsKey(toProcess))
+                if (projectIdsToReferencingSubmissionIds.TryGetValue(toProcess, out var submissionIds))
                 {
-                    foreach (var pId in projectIdsToReferencingSubmissionIds[toProcess])
+                    foreach (var pId in submissionIds)
                     {
                         if (!dependentProjects.Any(dp => dp.ProjectId == pId))
                         {

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictingIdentifierTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictingIdentifierTracker.cs
@@ -33,9 +33,8 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
             string name = token.ValueText;
 
-            if (_currentIdentifiersInScope.ContainsKey(name))
+            if (_currentIdentifiersInScope.TryGetValue(name, out var conflictingTokens))
             {
-                var conflictingTokens = _currentIdentifiersInScope[name];
                 conflictingTokens.Add(token);
 
                 // If at least one of the identifiers is the one we're renaming,

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
@@ -124,15 +124,15 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         // test only
         internal TextSpan GetResolutionTextSpan(TextSpan originalSpan, DocumentId documentId)
         {
-            if (_documentToModifiedSpansMap.ContainsKey(documentId) &&
-                _documentToModifiedSpansMap[documentId].Contains(t => t.oldSpan == originalSpan))
+            if (_documentToModifiedSpansMap.TryGetValue(documentId, out var modifiedSpans) &&
+                modifiedSpans.Contains(t => t.oldSpan == originalSpan))
             {
-                return _documentToModifiedSpansMap[documentId].First(t => t.oldSpan == originalSpan).newSpan;
+                return modifiedSpans.First(t => t.oldSpan == originalSpan).newSpan;
             }
 
-            if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+            if (_documentToComplexifiedSpansMap.TryGetValue(documentId, out var complexifiedSpans))
             {
-                return _documentToComplexifiedSpansMap[documentId].First(c => c.OriginalSpan.Contains(originalSpan)).NewSpan;
+                return complexifiedSpans.First(c => c.OriginalSpan.Contains(originalSpan)).NewSpan;
             }
 
             // The RenamedSpansTracker doesn't currently track unresolved conflicts for
@@ -206,14 +206,14 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     // Simplification may have removed escaping and formatted whitespace.  We need to update
                     // our list of modified spans accordingly
-                    if (_documentToModifiedSpansMap.ContainsKey(documentId))
+                    if (_documentToModifiedSpansMap.TryGetValue(documentId, out var modifiedSpans))
                     {
-                        _documentToModifiedSpansMap[documentId].Clear();
+                        modifiedSpans.Clear();
                     }
 
-                    if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+                    if (_documentToComplexifiedSpansMap.TryGetValue(documentId, out var complexifiedSpans))
                     {
-                        _documentToComplexifiedSpansMap[documentId].Clear();
+                        complexifiedSpans.Clear();
                     }
 
                     var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -269,17 +269,17 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         internal Dictionary<TextSpan, TextSpan> GetModifiedSpanMap(DocumentId documentId)
         {
             var result = new Dictionary<TextSpan, TextSpan>();
-            if (_documentToModifiedSpansMap.ContainsKey(documentId))
+            if (_documentToModifiedSpansMap.TryGetValue(documentId, out var modifiedSpans))
             {
-                foreach (var pair in _documentToModifiedSpansMap[documentId])
+                foreach (var pair in modifiedSpans)
                 {
                     result[pair.Item1] = pair.Item2;
                 }
             }
 
-            if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+            if (_documentToComplexifiedSpansMap.TryGetValue(documentId, out var complexifiedSpans))
             {
-                foreach (var complexifiedSpan in _documentToComplexifiedSpansMap[documentId])
+                foreach (var complexifiedSpan in complexifiedSpans)
                 {
                     foreach (var pair in complexifiedSpan.ModifiedSubSpans)
                     {
@@ -293,9 +293,9 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
         internal IEnumerable<(TextSpan oldSpan, TextSpan newSpan)> GetComplexifiedSpans(DocumentId documentId)
         {
-            if (_documentToComplexifiedSpansMap.ContainsKey(documentId))
+            if (_documentToComplexifiedSpansMap.TryGetValue(documentId, out var complexifiedSpans))
             {
-                return _documentToComplexifiedSpansMap[documentId].Select(c => (c.OriginalSpan, c.NewSpan));
+                return complexifiedSpans.Select(c => (c.OriginalSpan, c.NewSpan));
             }
 
             return SpecializedCollections.EmptyEnumerable<(TextSpan oldSpan, TextSpan newSpan)>();


### PR DESCRIPTION
Guarding indexing into a Dictionary<TKey, TValue> with a call to ContainsKey(TKey) causes the dictionary to be searched twice. This can be avoided by using TryGetValue(TKey, out TValue).

This pull request fixes several of those issues.

**Risk**

The pull request only modifies the way in which a method is implemented, not its signature.
I believe the risk to be very low.

**Performance impact**

Performance should improve for the reasons described above.