### PR TITLE
7x speedup on many SymbolFinder calls.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -17,7 +17,6 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
     using SymbolAndProjectIdSet = HashSet<SymbolAndProjectId<INamedTypeSymbol>>;
-
     using RelatedTypeCache = ConditionalWeakTable<Solution, ConcurrentDictionary<(SymbolKey, IImmutableSet<Project>), AsyncLazy<ImmutableArray<(SymbolKey, ProjectId)>>>>;
 
     /// <summary>
@@ -47,6 +46,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         // Kept as a cache so that clients who make many calls into us won't end up computing
         // the same data over and over again.  Will be let go the moment the solution they're
         // based off of is no longer alive.
+        //
+        // Importantly, the caches only store SymbolKeys and Ids.  As such, they will not hold
+        // any Symbols or Compilations alive.
 
         private static readonly RelatedTypeCache s_typeToImmediatelyDerivedClassesMap = new RelatedTypeCache();
         private static readonly RelatedTypeCache s_typeToTransitivelyDerivedClassesMap = new RelatedTypeCache();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
@@ -17,8 +14,6 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.FindSymbols
 {
     using SymbolAndProjectIdSet = HashSet<SymbolAndProjectId<INamedTypeSymbol>>;
-
-    using RelatedTypeCache = ConditionalWeakTable<Solution, ConcurrentDictionary<INamedTypeSymbol, AsyncLazy<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>>>>;
 
     /// <summary>
     /// Provides helper methods for finding dependent types (derivations, implementations, 
@@ -43,44 +38,17 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static readonly ObjectPool<SymbolAndProjectIdSet> s_setPool = new ObjectPool<SymbolAndProjectIdSet>(
             () => new SymbolAndProjectIdSet(SymbolAndProjectIdComparer<INamedTypeSymbol>.SymbolEquivalenceInstance));
 
-        // Caches from a types to their related types (in the context of a specific solution).
-        // Kept as a cache so that clients who make many calls into us won't end up computing
-        // the same data over and over again.  Will be let go the moment the solution they're
-        // based off of is no longer alive.
-
-        private static readonly RelatedTypeCache s_typeToImmediatelyDerivedClassesMap = new RelatedTypeCache();
-        private static readonly RelatedTypeCache s_typeToTransitivelyDerivedClassesMap = new RelatedTypeCache();
-        private static readonly RelatedTypeCache s_typeToTransitivelyImplementingTypesMap = new RelatedTypeCache();
-        private static readonly RelatedTypeCache s_typeToImmediatelyDerivedAndImplementingTypesMap = new RelatedTypeCache();
-
-        public static async Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTypesFromCacheOrComputeAsync(
-            INamedTypeSymbol type,
-            Solution solution,
-            RelatedTypeCache cache,
-            Func<CancellationToken, Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>>> findAsync,
-            CancellationToken cancellationToken)
-        {
-            var dictionary = cache.GetOrCreateValue(solution);
-            var lazy = dictionary.GetOrAdd(type, new AsyncLazy<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>>(
-               asynchronousComputeFunction: findAsync, cacheResult: true));
-
-            return await lazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
-        }
-
         /// <summary>
         /// Used for implementing the Inherited-By relation for progression.
         /// </summary>
-        public static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindImmediatelyDerivedClassesAsync(
+        internal static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindImmediatelyDerivedClassesAsync(
             INamedTypeSymbol type,
             Solution solution,
             CancellationToken cancellationToken)
         {
-            return FindTypesFromCacheOrComputeAsync(
-                type, solution, s_typeToImmediatelyDerivedClassesMap,
-                c => FindDerivedClassesAsync(
-                    SymbolAndProjectId.Create(type, projectId: null), solution, projects: null,
-                    transitive: false, cancellationToken: c),
-                cancellationToken);
+            return FindDerivedClassesAsync(
+                SymbolAndProjectId.Create(type, projectId: null), solution, projects: null,
+                transitive: false, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -92,12 +60,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             IImmutableSet<Project> projects,
             CancellationToken cancellationToken)
         {
-            return FindTypesFromCacheOrComputeAsync(
-                type, solution, s_typeToTransitivelyDerivedClassesMap,
-                c => FindDerivedClassesAsync(
-                    SymbolAndProjectId.Create(type, projectId: null), solution, projects,
-                    transitive: true, cancellationToken: c),
-                cancellationToken);
+            return FindDerivedClassesAsync(
+                SymbolAndProjectId.Create(type, projectId: null), solution, projects,
+                transitive: true, cancellationToken: cancellationToken);
         }
 
         private static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindDerivedClassesAsync(
@@ -130,19 +95,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// Implementation of <see cref="SymbolFinder.FindImplementationsAsync(SymbolAndProjectId, Solution, IImmutableSet{Project}, CancellationToken)"/> for 
         /// <see cref="INamedTypeSymbol"/>s
         /// </summary>
-        public static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingTypesAsync(
-            INamedTypeSymbol type,
-            Solution solution,
-            IImmutableSet<Project> projects,
-            CancellationToken cancellationToken)
-        {
-            return FindTypesFromCacheOrComputeAsync(
-                type, solution, s_typeToTransitivelyImplementingTypesMap,
-                c => FindTransitivelyImplementingTypesWorkerAsync(type, solution, projects, c),
-                cancellationToken);
-        }
-
-        private static async Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingTypesWorkerAsync(
+        public static async Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindTransitivelyImplementingTypesAsync(
             INamedTypeSymbol type,
             Solution solution,
             IImmutableSet<Project> projects,
@@ -160,17 +113,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// <summary>
         /// Used for implementing the Inherited-By relation for progression.
         /// </summary>
-        public static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindImmediatelyDerivedAndImplementingTypesAsync(
+        internal static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindImmediatelyDerivedAndImplementingTypesAsync(
             INamedTypeSymbol type,
             Solution solution,
             CancellationToken cancellationToken)
         {
-            return FindTypesFromCacheOrComputeAsync(
-                type, solution, s_typeToImmediatelyDerivedAndImplementingTypesMap,
-                c => FindDerivedAndImplementingTypesAsync(
-                    SymbolAndProjectId.Create(type, projectId: null), solution, projects: null,
-                    transitive: false, cancellationToken: c),
-                cancellationToken);
+            return FindDerivedAndImplementingTypesAsync(
+                SymbolAndProjectId.Create(type, projectId: null), solution, projects: null,
+                transitive: false, cancellationToken: cancellationToken);
         }
 
         private static Task<ImmutableArray<SymbolAndProjectId<INamedTypeSymbol>>> FindDerivedAndImplementingTypesAsync(
@@ -603,8 +553,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var typesToSearchFor = CreateSymbolAndProjectIdSet();
             typesToSearchFor.AddAll(sourceAndMetadataTypes);
 
-            var caseSensitive = project.LanguageServices.GetService<ISyntaxFactsService>().IsCaseSensitive;
-            var inheritanceQuery = new InheritanceQuery(sourceAndMetadataTypes, caseSensitive);
+            var inheritanceQuery = new InheritanceQuery(sourceAndMetadataTypes);
 
             // As long as there are new types to search for, keep looping.
             while (typesToSearchFor.Count > 0)
@@ -613,10 +562,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 inheritanceQuery.TypeNames.AddRange(typesToSearchFor.Select(c => c.Symbol.Name));
 
                 // Search all the documents of this project in parallel.
-                var tasks = project.Documents.Select(d => Task.Run(() => FindImmediatelyInheritingTypesInDocumentAsync(
+                var tasks = project.Documents.Select(d => FindImmediatelyInheritingTypesInDocumentAsync(
                     d, typesToSearchFor, inheritanceQuery,
                     cachedModels, cachedInfos, 
-                    sourceTypeImmediatelyMatches, cancellationToken), cancellationToken)).ToArray();
+                    sourceTypeImmediatelyMatches, cancellationToken)).ToArray();
 
                 await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -771,13 +720,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             public readonly HashSet<string> TypeNames;
 
-            public InheritanceQuery(SymbolAndProjectIdSet sourceAndMetadataTypes, bool caseSensitive)
+            public InheritanceQuery(SymbolAndProjectIdSet sourceAndMetadataTypes)
             {
                 DerivesFromSystemObject = sourceAndMetadataTypes.Any(t => t.Symbol.SpecialType == SpecialType.System_Object);
                 DerivesFromSystemValueType = sourceAndMetadataTypes.Any(t => t.Symbol.SpecialType == SpecialType.System_ValueType);
                 DerivesFromSystemEnum = sourceAndMetadataTypes.Any(t => t.Symbol.SpecialType == SpecialType.System_Enum);
                 DerivesFromSystemMulticastDelegate = sourceAndMetadataTypes.Any(t => t.Symbol.SpecialType == SpecialType.System_MulticastDelegate);
-                TypeNames = caseSensitive ? new HashSet<string>() : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                TypeNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -74,6 +74,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     new AsyncLazy<ImmutableArray<(SymbolKey, ProjectId)>>(
                         async c =>
                         {
+                            // If we're the code that is actually computing the symbols, then just 
+                            // take our result and store it in the outer frame.  That way the caller
+                            // doesn't need to incur the cost of deserializing the symbol keys that
+                            // we're create right below this.
                             result = await findAsync(c).ConfigureAwait(false);
                             return result.SelectAsArray(t => (t.Symbol.GetSymbolKey(), t.ProjectId));
                         },

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -607,7 +607,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             var inheritanceQuery = new InheritanceQuery(sourceAndMetadataTypes, caseSensitive);
 
             var schedulerPair = new ConcurrentExclusiveSchedulerPair(
-                TaskScheduler.Default, maxConcurrencyLevel: Math.Max(1, Environment.ProcessorCount * 2));
+                TaskScheduler.Default, maxConcurrencyLevel: Math.Max(1, Environment.ProcessorCount));
 
             // As long as there are new types to search for, keep looping.
             while (typesToSearchFor.Count > 0)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/19827
