### PR TITLE
Allow use of named parameters in non-trailing positions (VB)

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -2040,10 +2040,6 @@ ProduceBoundNode:
                         End If
 
                         If paramIndex = candidate.ParameterCount - 1 AndAlso candidate.Parameters(paramIndex).IsParamArray Then
-                            ' ERRID_NamedParamArrayArgument
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedParamArrayArgument)
-                            someArgumentsBad = True
-                            positionalArguments += 1
                             Exit For
                         End If
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -2009,168 +2009,163 @@ ProduceBoundNode:
 
             Try
                 '§11.8.2 Applicable Methods
-                '1.	First, match each positional argument in order to the list of method parameters. 
-                'If there are more positional arguments than parameters and the last parameter is not a paramarray, the method is not applicable. 
-                'Otherwise, the paramarray parameter is expanded with parameters of the paramarray element type to match the number of positional arguments. 
-                'If a positional argument is omitted, the method is not applicable.
-                ' !!! Not sure about the last sentence: "If a positional argument is omitted, the method is not applicable."
-                ' !!! Dev10 allows omitting positional argument as long as the corresponding parameter is optional.
+                'PROTOTYPE(non-trailing)
 
-                Dim positionalArguments As Integer = 0
-                Dim paramIndex = 0
                 Dim someArgumentsBad As Boolean = False
                 Dim someParamArrayArgumentsBad As Boolean = False
+                Dim seenOutOfPositionNamedArgumentIndex As Integer = -1
 
                 Dim candidateSymbol As Symbol = candidate.UnderlyingSymbol
                 Dim candidateIsExtension As Boolean = candidate.IsExtensionMethod
 
                 For i As Integer = 0 To arguments.Length - 1 Step 1
 
-                    If Not argumentNames.IsDefault AndAlso argumentNames(i) IsNot Nothing AndAlso
-                        OverloadResolution.NamedArgumentMustBeTrailing(candidate, argumentNames(i), paramIndex) Then
+                    Dim paramIndex As Integer
 
-                        If Not OverloadResolution.AreTrailingArgumentsNamed(argumentNames, paramIndex) Then
-                            ReportDiagnostic(diagnostics, arguments(i).Syntax, ERRID.ERR_BadNonTrailingNamedArgument, argumentNames(i))
-                            Return
-                        End If
+                    If Not argumentNames.IsDefault AndAlso argumentNames(i) IsNot Nothing Then
+                        ' A named argument
 
-                        Exit For
-                    End If
+                        Debug.Assert(argumentNames(i).Length > 0)
 
-                    If paramIndex = candidate.ParameterCount Then
-                        If Not someArgumentsBad Then
+                        'If argumentNames(i) Is Nothing AndAlso
+                        'Not Me.Compilation.LanguageVersion.AllowNonTrailingNamedArguments() Then
+
+                        '    ' Unnamed argument follows named arguments, parser should have detected an error.
+                        '    Debug.Assert(arguments(i).Syntax.Parent.ContainsDiagnostics)
+                        '    Return
+                        'End If
+
+                        If Not candidate.TryGetNamedParamIndex(argumentNames(i), paramIndex) Then
+                            ' ERRID_NamedParamNotFound1
+                            ' ERRID_NamedParamNotFound2
                             If Not includeMethodNameInErrorMessages Then
-                                ReportDiagnostic(diagnostics, arguments(i).Syntax, ERRID.ERR_TooManyArgs)
+                                ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedParamNotFound1, argumentNames(i))
                             ElseIf candidateIsExtension Then
-                                ReportDiagnostic(diagnostics, arguments(i).Syntax,
-                                                 ERRID.ERR_TooManyArgs2,
-                                                 candidateSymbol, candidateSymbol.ContainingType)
+                                ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
+                                             ERRID.ERR_NamedParamNotFound3, argumentNames(i),
+                                             candidateSymbol, candidateSymbol.ContainingType)
                             Else
-                                ReportDiagnostic(diagnostics, arguments(i).Syntax,
-                                                 ERRID.ERR_TooManyArgs1, If(representCandidateInDiagnosticsOpt, candidateSymbol))
+                                ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
+                                             ERRID.ERR_NamedParamNotFound2, argumentNames(i), If(representCandidateInDiagnosticsOpt, candidateSymbol))
                             End If
 
                             someArgumentsBad = True
+                            Continue For
                         End If
 
-                    ElseIf paramIndex = candidate.ParameterCount - 1 AndAlso
-                           candidate.Parameters(paramIndex).IsParamArray Then
-
-                        ' Collect ParamArray arguments
-                        While i < arguments.Length
-
-                            If Not argumentNames.IsDefault AndAlso argumentNames(i) IsNot Nothing Then
-                                ' First named argument
-                                Exit While
-                            End If
-
-                            If arguments(i).Kind = BoundKind.OmittedArgument Then
-                                ReportDiagnostic(diagnostics, arguments(i).Syntax, ERRID.ERR_OmittedParamArrayArgument)
-                                someParamArrayArgumentsBad = True
-                            Else
-                                paramArrayItems.Add(i)
-                            End If
-
-                            positionalArguments += 1
-                            i += 1
-                        End While
-
-                        Exit For
-
-                    Else
-                        parameterToArgumentMap(paramIndex) = i
-                        paramIndex += 1
-                    End If
-
-                    positionalArguments += 1
-                Next
-
-                Dim skippedSomeArguments As Boolean = False
-
-                '§11.8.2 Applicable Methods
-                '2.	Next, match each named argument to a parameter with the given name. 
-                'If one of the named arguments fails to match, matches a paramarray parameter, 
-                'or matches an argument already matched with another positional or named argument, 
-                'the method is not applicable.
-                For i As Integer = positionalArguments To arguments.Length - 1 Step 1
-
-                    Debug.Assert(argumentNames(i) Is Nothing OrElse argumentNames(i).Length > 0)
-
-                    If argumentNames(i) Is Nothing AndAlso
-                        Not Me.Compilation.LanguageVersion.AllowNonTrailingNamedArguments() Then
-
-                        ' Unnamed argument follows named arguments, parser should have detected an error.
-                        Debug.Assert(arguments(i).Syntax.Parent.ContainsDiagnostics)
-                        Return
-                    End If
-
-                    If Not candidate.TryGetNamedParamIndex(argumentNames(i), paramIndex) Then
-                        ' ERRID_NamedParamNotFound1
-                        ' ERRID_NamedParamNotFound2
-                        If Not includeMethodNameInErrorMessages Then
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedParamNotFound1, argumentNames(i))
-                        ElseIf candidateIsExtension Then
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
-                                             ERRID.ERR_NamedParamNotFound3, argumentNames(i),
-                                             candidateSymbol, candidateSymbol.ContainingType)
-                        Else
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
-                                             ERRID.ERR_NamedParamNotFound2, argumentNames(i), If(representCandidateInDiagnosticsOpt, candidateSymbol))
-                        End If
-
-                        someArgumentsBad = True
-                        Continue For
-                    End If
-
-                    If paramIndex = candidate.ParameterCount - 1 AndAlso
+                        If paramIndex = candidate.ParameterCount - 1 AndAlso
                         candidate.Parameters(paramIndex).IsParamArray Then
-                        ' ERRID_NamedParamArrayArgument
-                        ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedParamArrayArgument)
-                        someArgumentsBad = True
-                        Continue For
-                    End If
+                            ' ERRID_NamedParamArrayArgument
+                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedParamArrayArgument)
+                            someArgumentsBad = True
+                            Continue For
+                        End If
 
-                    If parameterToArgumentMap(paramIndex) <> -1 AndAlso arguments(parameterToArgumentMap(paramIndex)).Kind <> BoundKind.OmittedArgument Then
-                        ' ERRID_NamedArgUsedTwice1
-                        ' ERRID_NamedArgUsedTwice2
-                        ' ERRID_NamedArgUsedTwice3
-                        If Not includeMethodNameInErrorMessages Then
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedArgUsedTwice1, argumentNames(i))
-                        ElseIf candidateIsExtension Then
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
+                        If parameterToArgumentMap(paramIndex) <> -1 Then
+                            someArgumentsBad = True
+
+                            If arguments(parameterToArgumentMap(paramIndex)).Kind <> BoundKind.OmittedArgument Then
+                                ' ERRID_NamedArgUsedTwice1
+                                ' ERRID_NamedArgUsedTwice2
+                                ' ERRID_NamedArgUsedTwice3
+                                If Not includeMethodNameInErrorMessages Then
+                                    ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedArgUsedTwice1, argumentNames(i))
+                                ElseIf candidateIsExtension Then
+                                    ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
                                              ERRID.ERR_NamedArgUsedTwice3, argumentNames(i),
                                              candidateSymbol, candidateSymbol.ContainingType)
-                        Else
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
+                                Else
+                                    ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
                                              ERRID.ERR_NamedArgUsedTwice2, argumentNames(i), If(representCandidateInDiagnosticsOpt, candidateSymbol))
+                                End If
+
+                                Continue For
+                            Else
+                                ' It is an error for a named argument to specify
+                                ' a value for an explicitly omitted positional argument.
+
+                                'ERRID_NamedArgAlsoOmitted1
+                                'ERRID_NamedArgAlsoOmitted2
+                                'ERRID_NamedArgAlsoOmitted3
+                                If Not includeMethodNameInErrorMessages Then
+                                    ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedArgAlsoOmitted1, argumentNames(i))
+                                ElseIf candidateIsExtension Then
+                                    ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
+                                                 ERRID.ERR_NamedArgAlsoOmitted3, argumentNames(i),
+                                                 candidateSymbol, candidateSymbol.ContainingType)
+                                Else
+                                    ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
+                                                 ERRID.ERR_NamedArgAlsoOmitted2, argumentNames(i), If(representCandidateInDiagnosticsOpt, candidateSymbol))
+                                End If
+                            End If
+                        End If
+                        If paramIndex <> i Then
+                            seenOutOfPositionNamedArgumentIndex = i
                         End If
 
-                        someArgumentsBad = True
-                        Continue For
-                    End If
+                        parameterToArgumentMap(paramIndex) = i
 
-                    ' It is an error for a named argument to specify
-                    ' a value for an explicitly omitted positional argument.
-                    If paramIndex < positionalArguments Then
-                        'ERRID_NamedArgAlsoOmitted1
-                        'ERRID_NamedArgAlsoOmitted2
-                        'ERRID_NamedArgAlsoOmitted3
-                        If Not includeMethodNameInErrorMessages Then
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax), ERRID.ERR_NamedArgAlsoOmitted1, argumentNames(i))
-                        ElseIf candidateIsExtension Then
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
-                                             ERRID.ERR_NamedArgAlsoOmitted3, argumentNames(i),
-                                             candidateSymbol, candidateSymbol.ContainingType)
+                    Else
+                        ' A positional argument
+                        paramIndex = i
+
+                        If seenOutOfPositionNamedArgumentIndex <> -1 Then
+                            ' Unnamed arguments after an out-of-position named argument cannot correspond to any parameters
+                            ReportDiagnostic(diagnostics, arguments(seenOutOfPositionNamedArgumentIndex).Syntax, ERRID.ERR_BadNonTrailingNamedArgument, argumentNames(seenOutOfPositionNamedArgumentIndex))
+                            Exit For
+                        End If
+
+                        If paramIndex = candidate.ParameterCount Then
+                            If Not someArgumentsBad Then
+                                If Not includeMethodNameInErrorMessages Then
+                                    ReportDiagnostic(diagnostics, arguments(i).Syntax, ERRID.ERR_TooManyArgs)
+                                ElseIf candidateIsExtension Then
+                                    ReportDiagnostic(diagnostics, arguments(i).Syntax,
+                                                 ERRID.ERR_TooManyArgs2,
+                                                 candidateSymbol, candidateSymbol.ContainingType)
+                                Else
+                                    ReportDiagnostic(diagnostics, arguments(i).Syntax,
+                                                 ERRID.ERR_TooManyArgs1, If(representCandidateInDiagnosticsOpt, candidateSymbol))
+                                End If
+
+                                someArgumentsBad = True
+                                Exit For
+                            End If
+
+                        ElseIf paramIndex = candidate.ParameterCount - 1 AndAlso
+                           candidate.Parameters(paramIndex).IsParamArray Then
+
+                            ' Collect ParamArray arguments
+                            While i < arguments.Length
+
+                                If Not argumentNames.IsDefault AndAlso argumentNames(i) IsNot Nothing Then
+                                    ' First named argument
+                                    Exit While
+                                End If
+
+                                If arguments(i).Kind = BoundKind.OmittedArgument Then
+                                    ReportDiagnostic(diagnostics, arguments(i).Syntax, ERRID.ERR_OmittedParamArrayArgument)
+                                    someParamArrayArgumentsBad = True
+                                Else
+                                    paramArrayItems.Add(i)
+                                End If
+
+                                i += 1
+                            End While
+
+                            Exit For
+
                         Else
-                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(i).Syntax),
-                                             ERRID.ERR_NamedArgAlsoOmitted2, argumentNames(i), If(representCandidateInDiagnosticsOpt, candidateSymbol))
+                            parameterToArgumentMap(paramIndex) = i
                         End If
-
-                        someArgumentsBad = True
                     End If
-
-                    parameterToArgumentMap(paramIndex) = i
                 Next
+
+
+                ' ------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+
 
                 ' Check whether type inference failed
                 If candidateAnalysisResult.TypeArgumentInferenceDiagnosticsOpt IsNot Nothing Then
@@ -2387,11 +2382,6 @@ ProduceBoundNode:
                     ' Argument nothing when the argument syntax is missing or BoundKind.OmittedArgument when the argument list contains commas
                     ' for the missing syntax so we have to test for both.
                     If argument Is Nothing OrElse argument.Kind = BoundKind.OmittedArgument Then
-
-                        If argument Is Nothing AndAlso skippedSomeArguments Then
-                            someArgumentsBad = True
-                            Continue For
-                        End If
 
                         'See Section 3 of §11.8.2 Applicable Methods
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -2112,8 +2112,7 @@ ProduceBoundNode:
                     If argumentNames(i) Is Nothing Then
                         ' Unnamed argument follows out-of-position named arguments
                         If Not someArgumentsBad Then
-                            Dim blameLocation = DirectCast(arguments(seenOutOfPositionNamedArgIndex).Syntax.Parent, SimpleArgumentSyntax).NameColonEquals.Name
-                            ReportDiagnostic(diagnostics, blameLocation,
+                            ReportDiagnostic(diagnostics, GetNamedArgumentIdentifier(arguments(seenOutOfPositionNamedArgIndex).Syntax),
                                          ERRID.ERR_BadNonTrailingNamedArgument, argumentNames(seenOutOfPositionNamedArgIndex))
                         End If
                         Return

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1735,6 +1735,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 37301
 
         ERR_BadNonTrailingNamedArgument = 37302
+        ERR_ExpectedNamedArgumentInAttributeList = 37303
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1734,6 +1734,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_NoRefOutWhenRefOnly = 37300
         ERR_NoNetModuleOutputWhenRefOutOrRefOnly = 37301
 
+        ERR_BadNonTrailingNamedArgument = 37302
+
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000
         WRN_InvalidOverrideDueToTupleNames2 = 40001

--- a/src/Compilers/VisualBasic/Portable/LanguageVersion.vb
+++ b/src/Compilers/VisualBasic/Portable/LanguageVersion.vb
@@ -159,6 +159,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Function DisallowInferredTupleElementNames(self As LanguageVersion) As Boolean
             Return self < Feature.InferredTupleNames.GetLanguageVersion()
         End Function
+
+        <Extension>
+        Friend Function AllowNonTrailingNamedArguments(self As LanguageVersion) As Boolean
+            Return self >= Feature.NonTrailingNamedArguments.GetLanguageVersion()
+        End Function
     End Module
 
     Friend Class VisualBasicRequiredLanguageVersion

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -1313,7 +1313,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         ' File: Parser.cpp
         ' Lines: 16304 - 16304
         ' ParenthesizedArgumentList .Parser::ParseParenthesizedArguments( [ _Inout_ bool& ErrorInConstruct ] )
-        Friend Function ParseParenthesizedArguments(Optional RedimOrNewParent As Boolean = False) As ArgumentListSyntax
+        Friend Function ParseParenthesizedArguments(Optional RedimOrNewParent As Boolean = False, Optional attributeListParent As Boolean = False) As ArgumentListSyntax
             Debug.Assert(CurrentToken.Kind = SyntaxKind.OpenParenToken, "should be at tkLParen.")
 
             Dim arguments As CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList(Of ArgumentSyntax) = Nothing
@@ -1324,7 +1324,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
             TryGetTokenAndEatNewLine(SyntaxKind.OpenParenToken, openParen)
 
             Dim unexpected As GreenNode = Nothing
-            arguments = ParseArguments(unexpected, RedimOrNewParent)
+            arguments = ParseArguments(unexpected, RedimOrNewParent, attributeListParent)
 
             If Not TryEatNewLineAndGetToken(SyntaxKind.CloseParenToken, closeParen, createIfMissing:=False) Then
                 ' On error, peek for ")" with "(". If ")" seen before
@@ -1477,8 +1477,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     'argumentName = SyntaxFactory.IdentifierName(InternalSyntaxFactory.MissingIdentifier())
                     'colonEquals = InternalSyntaxFactory.MissingPunctuation(SyntaxKind.ColonEqualsToken)
 
-                    ' PROTOTYPE(non-trailing) give an error without recommended language version
-                    argument = ReportSyntaxError(argument, ERRID.ERR_ExpectedNamedArgument, "PROTOTYPE(non-trailing)")
+                    argument = ReportSyntaxError(argument, ERRID.ERR_ExpectedNamedArgumentInAttributeList)
 
                 ElseIf Not allowNonTrailingNamedArguments Then
                     argument = ReportSyntaxError(argument, ERRID.ERR_ExpectedNamedArgument,

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -1477,7 +1477,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
         End Function
 
-        ''' <summary>After VB15.6 it is possible to use named arguments in non-trailing position, except in attribute lists (where it remains disallowed)</summary>
+        ''' <summary>After VB15.5 it is possible to use named arguments in non-trailing position, except in attribute lists (where it remains disallowed)</summary>
         Private Shared Function ReportNonTrailingNamedArgumentIfNeeded(argument As ArgumentSyntax, seenNames As Boolean, allowNonTrailingNamedArguments As Boolean) As ArgumentSyntax
             If Not seenNames OrElse allowNonTrailingNamedArguments Then
                 Return argument

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -5583,7 +5583,7 @@ checkNullable:
                         typeName = ResyncAt(typeName, SyntaxKind.GreaterThanToken)
 
                     ElseIf CurrentToken.Kind = SyntaxKind.OpenParenToken Then
-                        arguments = ParseParenthesizedArguments()
+                        arguments = ParseParenthesizedArguments(attributeListParent:=True)
                     End If
 
                     Dim attribute As AttributeSyntax = SyntaxFactory.Attribute(optionalTarget, typeName, arguments)

--- a/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Return LanguageVersion.VisualBasic15_3
 
                 Case Feature.NonTrailingNamedArguments
-                    Return LanguageVersion.VisualBasic15_6
+                    Return LanguageVersion.VisualBasic15_5
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(feature)

--- a/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParserFeature.vb
@@ -34,6 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
         Tuples
         IOperation
         InferredTupleNames
+        NonTrailingNamedArguments
     End Enum
 
     Friend Module FeatureExtensions
@@ -89,6 +90,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
                 Case Feature.InferredTupleNames
                     Return LanguageVersion.VisualBasic15_3
+
+                Case Feature.NonTrailingNamedArguments
+                    Return LanguageVersion.VisualBasic15_6
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(feature)

--- a/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/OverloadResolution.vb
@@ -2685,121 +2685,99 @@ Done:
                 argsToParams = ArrayBuilder(Of Integer).GetInstance(arguments.Length, -1)
             End If
 
-            paramArrayItems = Nothing
 
             If candidate.IsExpandedParamArrayForm Then
                 paramArrayItems = ArrayBuilder(Of Integer).GetInstance()
+            Else
+                paramArrayItems = Nothing
             End If
 
             '§11.8.2 Applicable Methods
-            '1.	First, match each positional argument in order to the list of method parameters. 
-            'If there are more positional arguments than parameters and the last parameter is not a paramarray, the method is not applicable. 
-            'Otherwise, the paramarray parameter is expanded with parameters of the paramarray element type to match the number of positional arguments. 
-            'If a positional argument is omitted, the method is not applicable.
-            ' !!! Not sure about the last sentence: "If a positional argument is omitted, the method is not applicable."
-            ' !!! Dev10 allows omitting positional argument as long as the corresponding parameter is optional.
+            'PROTOTYPE(non-trailing)
 
-            Dim positionalArguments As Integer = 0
-            Dim paramIndex = 0
+            Dim seenOutOfPositionNamedArgument = False
 
-            For i As Integer = 0 To arguments.Length - 1 Step 1
+            For argIndex As Integer = 0 To arguments.Length - 1 Step 1
 
-                If Not argumentNames.IsDefault AndAlso argumentNames(i) IsNot Nothing AndAlso
-                    NamedArgumentMustBeTrailing(candidate.Candidate, argumentNames(i), paramIndex) Then
+                Dim paramIndex As Integer
 
-                    If Not AreTrailingArgumentsNamed(argumentNames, paramIndex) Then
+                If Not argumentNames.IsDefault AndAlso argumentNames(argIndex) IsNot Nothing Then
+                    ' A named argument
+
+                    If Not candidate.Candidate.TryGetNamedParamIndex(argumentNames(argIndex), paramIndex) Then
+                        ' ERRID_NamedParamNotFound1
+                        ' ERRID_NamedParamNotFound2
                         candidate.State = CandidateAnalysisResultState.ArgumentMismatch
                         GoTo Bailout
                     End If
-
-                    Exit For
-                End If
-
-                positionalArguments += 1
-
-                If argsToParams IsNot Nothing Then
-                    argsToParams(i) = paramIndex
-                End If
-
-                If arguments(i).Kind = BoundKind.OmittedArgument Then
 
                     If paramIndex = candidate.Candidate.ParameterCount - 1 AndAlso
-                       candidate.Candidate.Parameters(paramIndex).IsParamArray Then
-                        ' Omitted ParamArray argument at the call site
-                        ' ERRID_OmittedParamArrayArgument
+                        candidate.Candidate.Parameters(paramIndex).IsParamArray Then
+                        ' ERRID_NamedParamArrayArgument
                         candidate.State = CandidateAnalysisResultState.ArgumentMismatch
                         GoTo Bailout
-                    Else
-                        paramIndex += 1
                     End If
 
-                ElseIf (candidate.IsExpandedParamArrayForm AndAlso
-                    paramIndex = candidate.Candidate.ParameterCount - 1) Then
+                    If parameterToArgumentMap(paramIndex) <> -1 Then
+                        ' ERRID_NamedArgUsedTwice1
+                        ' ERRID_NamedArgUsedTwice2
+                        ' ERRID_NamedArgUsedTwice3
+                        candidate.State = CandidateAnalysisResultState.ArgumentMismatch
+                        GoTo Bailout
+                    End If
 
-                    paramArrayItems.Add(i)
+                    ' It is an error for a named argument to specify
+                    ' a value for an explicitly omitted positional argument.
+                    If paramIndex < argIndex AndAlso Not seenOutOfPositionNamedArgument Then
+                        ' ERRID_NamedArgAlsoOmitted1
+                        ' ERRID_NamedArgAlsoOmitted2
+                        ' ERRID_NamedArgAlsoOmitted3
+                        candidate.State = CandidateAnalysisResultState.ArgumentMismatch
+                        GoTo Bailout
+                    End If
+
+
+                    If paramIndex <> argIndex Then
+                        seenOutOfPositionNamedArgument = True
+                    End If
+
+                    parameterToArgumentMap(paramIndex) = argIndex
+
                 Else
-                    parameterToArgumentMap(paramIndex) = i
-                    paramIndex += 1
-                End If
-            Next
+                    ' A positional argument
+                    paramIndex = argIndex
 
-            '§11.8.2 Applicable Methods
-            '2.	Next, match each named argument to a parameter with the given name. 
-            'If one of the named arguments fails to match, matches a paramarray parameter, 
-            'or matches an argument already matched with another positional or named argument, 
-            'the method is not applicable.
-            For i As Integer = positionalArguments To arguments.Length - 1 Step 1
+                    If seenOutOfPositionNamedArgument Then
+                        ' Unnamed arguments after an out-of-position named argument cannot correspond to any parameters
+                        ' ERR_BadNonTrailingNamedArgument
+                        candidate.State = CandidateAnalysisResultState.ArgumentMismatch
+                        GoTo Bailout
+                    End If
 
-                Debug.Assert(argumentNames(i) Is Nothing OrElse argumentNames(i).Length > 0)
+                    If arguments(argIndex).Kind = BoundKind.OmittedArgument Then
 
-                If argumentNames(i) Is Nothing Then
-                    ' Unnamed argument follows named arguments, parser should have detected an error.
-                    candidate.State = CandidateAnalysisResultState.ArgumentMismatch
-                    GoTo Bailout
-                    'Continue For
-                End If
+                        If argIndex >= candidate.Candidate.ParameterCount - 1 AndAlso
+                           candidate.Candidate.Parameters(candidate.Candidate.ParameterCount - 1).IsParamArray Then
+                            ' Omitted ParamArray argument at the call site
+                            ' ERRID_OmittedParamArrayArgument
+                            candidate.State = CandidateAnalysisResultState.ArgumentMismatch
+                            GoTo Bailout
+                        End If
 
-                If Not candidate.Candidate.TryGetNamedParamIndex(argumentNames(i), paramIndex) Then
-                    ' ERRID_NamedParamNotFound1
-                    ' ERRID_NamedParamNotFound2
-                    candidate.State = CandidateAnalysisResultState.ArgumentMismatch
-                    GoTo Bailout
-                    'Continue For
+                    ElseIf (candidate.IsExpandedParamArrayForm AndAlso
+                        argIndex >= candidate.Candidate.ParameterCount - 1) Then
+
+                        paramArrayItems.Add(argIndex)
+                    Else
+                        parameterToArgumentMap(paramIndex) = argIndex
+                    End If
                 End If
 
                 If argsToParams IsNot Nothing Then
-                    argsToParams(i) = paramIndex
+                    Dim lastParamIndex = candidate.Candidate.ParameterCount - 1
+                    argsToParams(argIndex) = Math.Min(paramIndex, lastParamIndex)
                 End If
 
-                If paramIndex = candidate.Candidate.ParameterCount - 1 AndAlso
-                    candidate.Candidate.Parameters(paramIndex).IsParamArray Then
-                    ' ERRID_NamedParamArrayArgument
-                    candidate.State = CandidateAnalysisResultState.ArgumentMismatch
-                    GoTo Bailout
-                    'Continue For
-                End If
-
-                If parameterToArgumentMap(paramIndex) <> -1 Then
-                    ' ERRID_NamedArgUsedTwice1
-                    ' ERRID_NamedArgUsedTwice2
-                    ' ERRID_NamedArgUsedTwice3
-                    candidate.State = CandidateAnalysisResultState.ArgumentMismatch
-                    GoTo Bailout
-                    'Continue For
-                End If
-
-                ' It is an error for a named argument to specify
-                ' a value for an explicitly omitted positional argument.
-                If paramIndex < positionalArguments Then
-                    'ERRID_NamedArgAlsoOmitted1
-                    'ERRID_NamedArgAlsoOmitted2
-                    'ERRID_NamedArgAlsoOmitted3
-                    candidate.State = CandidateAnalysisResultState.ArgumentMismatch
-                    GoTo Bailout
-                    'Continue For
-                End If
-
-                parameterToArgumentMap(paramIndex) = i
             Next
 
             If argsToParams IsNot Nothing Then
@@ -2815,30 +2793,6 @@ Bailout:
             End If
 
         End Sub
-
-        Friend Shared Function NamedArgumentMustBeTrailing(candidate As Candidate, argumentName As String, paramIndex As Integer) As Boolean
-            Dim correspondingParamIndex As Integer
-            If Not candidate.TryGetNamedParamIndex(argumentName, correspondingParamIndex) Then
-                Return True
-            End If
-
-            ' Named arguments on a ParamArray parameter must be trailing
-            If paramIndex < candidate.ParameterCount AndAlso candidate.Parameters(paramIndex).IsParamArray Then
-                Return True
-            End If
-
-            ' Out-of-position named arguments must be trailing
-            Return correspondingParamIndex <> paramIndex
-        End Function
-
-        Friend Shared Function AreTrailingArgumentsNamed(argumentNames As ImmutableArray(Of String), paramIndex As Integer) As Boolean
-            For j As Integer = paramIndex + 1 To argumentNames.Length - 1 Step 1
-                If argumentNames(j) Is Nothing Then
-                    Return False
-                End If
-            Next
-            Return True
-        End Function
 
         ''' <summary>
         ''' Match candidate's parameters to arguments §11.8.2 Applicable Methods.

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -1369,6 +1369,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Named argument &apos;{0}&apos; is used out-of-position but is followed by an unnamed argument.
+        '''</summary>
+        Friend ReadOnly Property ERR_BadNonTrailingNamedArgument() As String
+            Get
+                Return ResourceManager.GetString("ERR_BadNonTrailingNamedArgument", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Nullable types are not allowed in conditional compilation expressions..
         '''</summary>
         Friend ReadOnly Property ERR_BadNullTypeInCCExpression() As String
@@ -4251,7 +4260,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Named argument expected..
+        '''  Looks up a localized string similar to Named argument expected. Please use language version {0} or greater to use non-trailing named arguments..
         '''</summary>
         Friend ReadOnly Property ERR_ExpectedNamedArgument() As String
             Get

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -4269,6 +4269,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Named argument expected..
+        '''</summary>
+        Friend ReadOnly Property ERR_ExpectedNamedArgumentInAttributeList() As String
+            Get
+                Return ResourceManager.GetString("ERR_ExpectedNamedArgumentInAttributeList", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to &apos;For&apos; must end with a matching &apos;Next&apos;..
         '''</summary>
         Friend ReadOnly Property ERR_ExpectedNext() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -715,7 +715,7 @@
     <value>'Exit' must be followed by 'Sub', 'Function', 'Property', 'Do', 'For', 'While', 'Select', or 'Try'.</value>
   </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
-    <value>Named argument expected.</value>
+    <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>
   <data name="ERR_BadMethodFlags1" xml:space="preserve">
     <value>'{0}' is not valid on a method declaration.</value>
@@ -5478,6 +5478,9 @@
   </data>
   <data name="ERR_NoNetModuleOutputWhenRefOutOrRefOnly" xml:space="preserve">
     <value>Cannot compile net modules when using /refout or /refonly.</value>
+  </data>
+  <data name="ERR_BadNonTrailingNamedArgument" xml:space="preserve">
+    <value>Named argument '{0}' is used out-of-position but is followed by an unnamed argument</value>
   </data>
   <data name="ERR_BadDocumentationMode" xml:space="preserve">
     <value>Provided documentation mode is unsupported or invalid: '{0}'.</value>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -714,6 +714,9 @@
   <data name="ERR_ExpectedExitKind" xml:space="preserve">
     <value>'Exit' must be followed by 'Sub', 'Function', 'Property', 'Do', 'For', 'While', 'Select', or 'Try'.</value>
   </data>
+  <data name="ERR_ExpectedNamedArgumentInAttributeList" xml:space="preserve">
+    <value>Named argument expected.</value>
+  </data>
   <data name="ERR_ExpectedNamedArgument" xml:space="preserve">
     <value>Named argument expected. Please use language version {0} or greater to use non-trailing named arguments.</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Semantic/BasicCompilerSemanticTest.vbproj
@@ -181,6 +181,7 @@
     <Compile Include="Semantics\SyntaxTreeRootTests.vb" />
     <Compile Include="Semantics\TooLongNameTests.vb" />
     <Compile Include="Semantics\TypeArgumentInference.vb" />
+    <Compile Include="Semantics\NonTrailingNamedArgumentsTests.vb" />
     <Compile Include="Semantics\TypeOfTests.vb" />
     <Compile Include="Semantics\UnaryOperators.vb" />
     <Compile Include="Semantics\UnstructuredExceptionHandling.vb" />

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -22172,13 +22172,10 @@ End Module
     </compilation>)
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
-BC30518: Overload resolution failed because no accessible 'M1' can be called with these arguments:
-        M1(x:=2, 3) 'BIND:"M1(x:=2, 3)"
-        ~~
-BC30241: Named argument expected.
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
         M1(x:=2, 3) 'BIND:"M1(x:=2, 3)"
                  ~
-BC30241: Named argument expected.
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
         M2(x:=2, 3)
                  ~
 </expected>)

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -22172,10 +22172,10 @@ End Module
     </compilation>, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15))
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         M1(x:=2, 3) 'BIND:"M1(x:=2, 3)"
                  ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         M2(x:=2, 3)
                  ~
 </expected>)

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -22169,7 +22169,7 @@ Module Module1
 
 End Module
     </file>
-    </compilation>)
+    </compilation>, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15))
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
 BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
@@ -7763,7 +7763,7 @@ End Module
         <WorkItem(542596, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542596")>
         <Fact()>
         Public Sub BindMethodInvocationWhenUnnamedArgFollowsNamed()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
     <compilation>
         <file name="a.vb">
 Module Module1
@@ -7778,13 +7778,15 @@ Module Module1
 End Module
         </file>
     </compilation>)
-
+            compilation.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+        M1(x:=2, 3) 'BIND:"M1(x:=2, 3)"
+                 ~
+                                               </errors>)
             Dim semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of InvocationExpressionSyntax)(compilation, "a.vb")
+            Assert.Equal("Sub Module1.M1(x As System.Int32, y As System.Int32)", semanticInfo.Symbol.ToTestDisplayString())
 
-            Assert.Equal(Nothing, semanticInfo.Symbol)
-
-
-            compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(
     <compilation>
         <file name="a.vb">
 Module Module1
@@ -7802,10 +7804,14 @@ Module Module1
 End Module
         </file>
     </compilation>)
-
+            compilation.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+        M1(x:=2, 3) 'BIND:"M1(x:=2, 3)"
+                 ~
+                                               </errors>)
             semanticInfo = CompilationUtils.GetSemanticInfoSummary(Of InvocationExpressionSyntax)(compilation, "a.vb")
 
-            Assert.Equal(Nothing, semanticInfo.Symbol)
+            Assert.Equal("Sub Module1.M1(x As System.Int32, y As System.Int32)", semanticInfo.Symbol.ToTestDisplayString())
 
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetExtendedSemanticInfoTests.vb
@@ -7779,7 +7779,7 @@ End Module
         </file>
     </compilation>)
             compilation.AssertTheseDiagnostics(<errors>
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         M1(x:=2, 3) 'BIND:"M1(x:=2, 3)"
                  ~
                                                </errors>)
@@ -7805,7 +7805,7 @@ End Module
         </file>
     </compilation>)
             compilation.AssertTheseDiagnostics(<errors>
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         M1(x:=2, 3) 'BIND:"M1(x:=2, 3)"
                  ~
                                                </errors>)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -28,7 +28,7 @@ End Class
 </compilation>
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
             comp.AssertTheseDiagnostics(<errors>
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         M(a:=1, 2)
                 ~
                                         </errors>)
@@ -54,7 +54,7 @@ End Class
     </file>
 </compilation>
             Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2. Second 3 4.",
-                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_6))
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_5))
             verifier.VerifyDiagnostics()
 
             Dim tree = verifier.Compilation.SyntaxTrees.First()
@@ -313,7 +313,7 @@ End Class
 BC30274: Parameter 'x' of 'Public Shared Sub M(x As Integer, y As Integer, z As Integer)' already has a matching argument.
         M(x:=1, x:=2, 3)
                 ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         M(x:=1, x:=2, 3)
                       ~
                                         </errors>)
@@ -705,7 +705,7 @@ End Module
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         M(y:=Nothing,)
                      ~
 </expected>)
@@ -760,13 +760,13 @@ End Class
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         System.Console.Write(P(index1:=1, 2))
                                           ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         System.Console.Write(P(index1:=1, ))
                                           ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         System.Console.Write(P(index1:=1, 0 to 5))
                                           ~
 BC32017: Comma, ')', or a valid expression continuation expected.

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -14,7 +14,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
     Public Class NonTrailingNamedArgumentsTests
         Inherits BasicTestBase
 
-        ReadOnly parseOptions As VisualBasicParseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_6)
+        ReadOnly latestParseOptions As VisualBasicParseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest)
+
+        <Fact>
+        Public Sub TestSimpleWithOldLangVer()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(a As Integer, b As Integer)
+    End Sub
+    Shared Sub Main()
+        M(a:=1, 2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+            comp.AssertTheseDiagnostics(<errors>
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+        M(a:=1, 2)
+                ~
+                                        </errors>)
+        End Sub
 
         <Fact>
         Public Sub TestSimple()
@@ -36,7 +58,7 @@ End Class
     </file>
 </compilation>
             Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2. Second 3 4.",
-                                            parseOptions:=parseOptions)
+                                            parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_6))
             verifier.VerifyDiagnostics()
 
             Dim tree = verifier.Compilation.SyntaxTrees.First()
@@ -68,7 +90,7 @@ Class C
 End Class
     </file>
 </compilation>
-            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=parseOptions)
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
             comp.AssertTheseDiagnostics(<errors>
 BC30455: Argument not specified for parameter 'other' of 'Public Shared Sub M(first As Integer, other As Integer)'.
         M(1, first:=2)
@@ -101,8 +123,14 @@ Class C
 End Class
     </file>
 </compilation>
-            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=parseOptions)
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
             comp.AssertTheseDiagnostics(<errors>
+BC30455: Argument not specified for parameter 'a' of 'Public Shared Sub M(a As Integer, b As Integer, [c As Integer = 1])'.
+        M(c:=1, 2)
+        ~
+BC30455: Argument not specified for parameter 'b' of 'Public Shared Sub M(a As Integer, b As Integer, [c As Integer = 1])'.
+        M(c:=1, 2)
+        ~
 BC37302: Named argument 'c' is used out-of-position but is followed by an unnamed argument
         M(c:=1, 2)
              ~
@@ -116,6 +144,238 @@ BC37302: Named argument 'c' is used out-of-position but is followed by an unname
             AssertEx.Equal({"Sub C.M(a As System.Int32, b As System.Int32, [c As System.Int32 = 1])"},
                 model.GetSymbolInfo(invocation).CandidateSymbols.Select(Function(c) c.ToTestDisplayString()))
         End Sub
+
+        <Fact>
+        Public Sub TestNamedParams()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(ByVal ParamArray c() As Integer)
+    End Sub
+    Shared Sub Main()
+        M(c:=1, 2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+
+            comp.AssertTheseDiagnostics(<errors>
+BC30587: Named argument cannot match a ParamArray parameter.
+        M(c:=1, 2)
+          ~
+                                        </errors>)
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().Single()
+            Assert.Equal("M(c:=1, 2)", invocation.ToString())
+            AssertEx.Equal({"Sub C.M(ParamArray c As System.Int32())"},
+                model.GetSymbolInfo(invocation).CandidateSymbols.Select(Function(c) c.ToTestDisplayString()))
+        End Sub
+
+        '        [Fact]
+        '        Public void TestNamedParams2()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M(params int[] x)
+        '    {
+        '    }
+        '    static void Main()
+        '    {
+        '        M(1, x: 2);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (9,14): Error CS1744: Named argument 'x' specifies a parameter for which a positional argument has already been given
+        '                //         M(1, x: 2);
+        '                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "x").WithArguments("x").WithLocation(9, 14)
+        '                );
+
+        '            var tree = comp.SyntaxTrees.First();
+        '            var model = comp.GetSemanticModel(tree);
+        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
+        '            Assert.Equal("M(1, x: 2)", invocation.ToString());
+        '            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+        '        }
+
+        '        [Fact]
+        '        Public void TestTwiceNamedParams()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M(params int[] x)
+        '    {
+        '    }
+        '    static void Main()
+        '    {
+        '        M(x: 1, x: 2);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (9,17): Error CS1740: Named argument 'x' cannot be specified multiple times
+        '                //         M(x: 1, x: 2);
+        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(9, 17)
+        '                );
+
+        '            var tree = comp.SyntaxTrees.First();
+        '            var model = comp.GetSemanticModel(tree);
+        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
+        '            Assert.Equal("M(x: 1, x: 2)", invocation.ToString());
+        '            Assert.Equal("void C.M(params System.Int32[] x)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        '        }
+
+        '        [Fact]
+        '        Public void TestTwiceNamedParamsWithOldLangVer()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M(int x, int y, int z)
+        '    {
+        '    }
+        '    static void Main()
+        '    {
+        '        M(x: 1, x: 2, 3);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.Regular7_1);
+        '            comp.VerifyDiagnostics(
+        '                // (9,17): Error CS1740: Named argument 'x' cannot be specified multiple times
+        '                //         M(x: 1, x: 2, 3);
+        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(9, 17),
+        '                // (9,23): Error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 Or greater To allow non-trailing named arguments.
+        '                //         M(x: 1, x: 2, 3);
+        '                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "3").WithArguments("7.2").WithLocation(9, 23)
+        '                );
+
+        '            var tree = comp.SyntaxTrees.First();
+        '            var model = comp.GetSemanticModel(tree);
+        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
+        '            Assert.Equal("M(x: 1, x: 2, 3)", invocation.ToString());
+        '            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+        '        }
+
+        '        [Fact]
+        '        Public void TestNamedParams3()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M(int x, params int[] y)
+        '    {
+        '    }
+        '    static void Main()
+        '    {
+        '        M(y: 1, 2);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (9,11): Error CS8321: Named argument 'y' is used out-of-position but is followed by an unnamed argument
+        '                //         M(y: 1, 2);
+        '                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "y").WithArguments("y").WithLocation(9, 11)
+        '                );
+
+        '            var tree = comp.SyntaxTrees.First();
+        '            var model = comp.GetSemanticModel(tree);
+        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
+        '            Assert.Equal("M(y: 1, 2)", invocation.ToString());
+        '            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+        '        }
+
+        '        [Fact]
+        '        Public void TestNamedParams4()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M(int x, params int[] y)
+        '    {
+        '    }
+        '    static void Main()
+        '    {
+        '        M(x: 1, y: 2, 3);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (9,9): Error CS1501: No overload For method 'M' takes 3 arguments
+        '                //         M(x: 1, y: 2, 3);
+        '                Diagnostic(ErrorCode.ERR_BadArgCount, "M").WithArguments("M", "3").WithLocation(9, 9)
+        '                );
+        '        }
+
+        '        [Fact]
+        '        Public void TestNamedInvalidParams()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M(params int[] x, int y)
+        '    {
+        '    }
+        '    static void Main()
+        '    {
+        '        M(x: 1, 2);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (4,19): Error CS0231: A params parameter must be the last parameter In a formal parameter list
+        '                //     static void M(params int[] x, int y)
+        '                Diagnostic(ErrorCode.ERR_ParamsLast, "params int[] x").WithLocation(4, 19),
+        '                // (9,14): Error CS1503 :  Argument 1: cannot convert from 'int' to 'int'
+        '                //         M(x: 1, 2);
+        '                Diagnostic(ErrorCode.ERR_BadArgType, "1").WithArguments("1", "int", "int").WithLocation(9, 14)
+        '                );
+
+        '            var tree = comp.SyntaxTrees.First();
+        '            var model = comp.GetSemanticModel(tree);
+        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
+        '            Assert.Equal("M(x: 1, 2)", invocation.ToString());
+        '            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
+        '        }
+
+        '        [Fact]
+        '        Public void TestNamedParams5()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M(int x, params int[] y)
+        '    {
+        '        System.Console.Write($""x={x} y[0]={y[0]} y.Length={y.Length}"");
+        '    }
+        '    static void Main()
+        '    {
+        '        M(y: 1, x: 2);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest, options: TestOptions.DebugExe);
+        '            comp.VerifyDiagnostics();
+        '            CompileAndVerify(comp, expectedOutput: "x=2 y[0]=1 y.Length=1");
+
+        '            var tree = comp.SyntaxTrees.First();
+        '            var model = comp.GetSemanticModel(tree);
+        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().ElementAt(1);
+        '            Assert.Equal("M(y: 1, x: 2)", invocation.ToString());
+        '            Assert.Equal("void C.M(System.Int32 x, params System.Int32[] y)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        '        }
+
 
         <Fact>
         Public Sub TestBadNonTrailing()
@@ -134,7 +394,7 @@ Class C
 End Class
     </file>
 </compilation>
-            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=parseOptions)
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
             comp.AssertTheseDiagnostics(<errors>
 BC37302: Named argument 'c' is used out-of-position but is followed by an unnamed argument
         M(c:=valueC, valueB)
@@ -153,7 +413,7 @@ BC37302: Named argument 'c' is used out-of-position but is followed by an unname
         End Sub
 
         <Fact>
-        Public Sub TestBadNonTrailing2()
+        Public Sub TestPickGoodOverload()
             Dim source =
 <compilation>
     <file name="Program.vb">
@@ -171,7 +431,7 @@ Class C
 End Class
     </file>
 </compilation>
-            Dim verifier = CompileAndVerify(source, expectedOutput:="Second 3 2.", parseOptions:=parseOptions)
+            Dim verifier = CompileAndVerify(source, expectedOutput:="Second 3 2.", parseOptions:=latestParseOptions)
             verifier.VerifyDiagnostics()
 
             Dim tree = verifier.Compilation.SyntaxTrees.First()
@@ -184,7 +444,7 @@ End Class
         End Sub
 
         <Fact>
-        Public Sub TestBadNonTrailing3()
+        Public Sub TestPickGoodOverload2()
             Dim source =
 <compilation>
     <file name="Program.vb">
@@ -202,7 +462,7 @@ Class C
 End Class
     </file>
 </compilation>
-            Dim verifier = CompileAndVerify(source, expectedOutput:="Second 3 2.", parseOptions:=parseOptions)
+            Dim verifier = CompileAndVerify(source, expectedOutput:="Second 3 2.", parseOptions:=latestParseOptions)
             verifier.VerifyDiagnostics()
 
             Dim tree = verifier.Compilation.SyntaxTrees.First()
@@ -228,8 +488,11 @@ Class C
 End Class
     </file>
 </compilation>
-            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source, parseOptions:=parseOptions)
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source, parseOptions:=latestParseOptions)
             comp.AssertTheseDiagnostics(<errors>
+BC30455: Argument not specified for parameter 'a' of 'Public Shared Sub M(a As Integer, b As Integer, ParamArray c As Integer())'.
+        M(b:=2, 3, 4)
+        ~
 BC37302: Named argument 'b' is used out-of-position but is followed by an unnamed argument
         M(b:=2, 3, 4)
              ~
@@ -251,8 +514,177 @@ Class C
 End Class
     </file>
 </compilation>
-            Dim verifier = CompileAndVerify(source, expectedOutput:="1 2 3 4 Length:2", parseOptions:=parseOptions)
+            Dim verifier = CompileAndVerify(source, expectedOutput:="1 2 3 4 Length:2", parseOptions:=latestParseOptions)
             verifier.VerifyDiagnostics()
         End Sub
+
+        '        [Fact]
+        '        Public void TestInAttribute()
+        '        {
+        '            var source = @"
+        'using System;
+
+        '[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+        'public class MyAttribute : Attribute
+        '{
+        '    public int P { get; set; }
+        '	public MyAttribute(bool condition, int other) { }
+        '}
+
+        '[MyAttribute(condition: true, 42)]
+        '[MyAttribute(condition: true, P = 1, 42)]
+        '[MyAttribute(42, condition: true)]
+        'public class C
+        '{
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (12,38): Error CS1016: Named attribute argument expected
+        '                // [MyAttribute(condition: true, P = 1, 42)]
+        '                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "42").WithLocation(12, 38),
+        '                // (13,18): Error CS1744: Named argument 'condition' specifies a parameter for which a positional argument has already been given
+        '                // [MyAttribute(42, condition: true)]
+        '                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "condition").WithArguments("condition").WithLocation(13, 18)
+        '                );
+
+        '            var tree = comp.SyntaxTrees.First();
+        '            var model = comp.GetSemanticModel(tree);
+        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+        '            var invocation = nodes.OfType < AttributeSyntax > ().ElementAt(1);
+        '            Assert.Equal("MyAttribute(condition: true, 42)", invocation.ToString());
+        '            Assert.Equal("MyAttribute..ctor(System.Boolean condition, System.Int32 other)",
+        '                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
+        '        }
+
+        '        [Fact]
+        '        Public void TestInAttribute2()
+        '        {
+        '            var source = @"
+        'using System;
+
+        '[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+        'public class MyAttribute : Attribute
+        '{
+        '    public int P { get; set; }
+        '	public MyAttribute(int a = 1, int b = 2, int c = 3) { }
+        '}
+
+        '[MyAttribute(c:3, 2)]
+        '[MyAttribute(P=1, c:3, 2)]
+        'public class C
+        '{
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (11,14): Error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
+        '                // [MyAttribute(c:3, 2)]
+        '                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "c").WithArguments("c").WithLocation(11, 14),
+        '                // (12,21): Error CS1016: Named attribute argument expected
+        '                // [MyAttribute(P=1, c:3, 2)]
+        '                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "3").WithLocation(12, 21),
+        '                // (12,24): Error CS1016: Named attribute argument expected
+        '                // [MyAttribute(P=1, c:3, 2)]
+        '                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "2").WithLocation(12, 24)
+        '                );
+        '        }
+
+        '        [Fact]
+        '        Public void TestErrorsDoNotCascadeInInvocation()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M()
+        '    {
+        '        M(x: 1, x: 2, __arglist());
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (6,17): Error CS1740: Named argument 'x' cannot be specified multiple times
+        '                //         M(x: 1, x: 2, __arglist());
+        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 17)
+        '                );
+        '        }
+
+        '        [Fact]
+        '        Public void TestErrorsDoNotCascadeInArglist()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    static void M()
+        '    {
+        '        M(__arglist(x: 1, x: 2, __arglist()));
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (6,27): Error CS1740: Named argument 'x' cannot be specified multiple times
+        '                //         M(__arglist(x: 1, x: 2, __arglist()));
+        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 27),
+        '                // (6,33): Error CS0226: An __arglist expression may only appear inside Of a Call Or New expression
+        '                //         M(__arglist(x: 1, x: 2, __arglist()));
+        '                Diagnostic(ErrorCode.ERR_IllegalArglist, "__arglist()").WithLocation(6, 33)
+        '                );
+        '        }
+
+        '        [Fact]
+        '        Public void TestErrorsDoNotCascadeInConstructorInitializer()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    C() : this(x: 1, x: 2, 3) { }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (4,22): Error CS1740: Named argument 'x' cannot be specified multiple times
+        '                //     C() : this(x: 1, x: 2, 3) { }
+        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(4, 22)
+        '                );
+        '        }
+
+        '        [Fact]
+        '        Public void TestErrorsDoNotCascadeInObjectCreation()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    void M()
+        '    {
+        '        new C(x: 1, x: 2, 3);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (6,21): Error CS1740: Named argument 'x' cannot be specified multiple times
+        '                //         New C(x: 1, x: 2, 3);
+        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 21)
+        '                );
+        '        }
+
+        '        [Fact]
+        '        Public void TestErrorsDoNotCascadeInElementAccess()
+        '        {
+        '            var source = @"
+        'class C
+        '{
+        '    int this[int i] { get { throw null; } set { throw null; } }
+        '    void M()
+        '    {
+        '        var c = new C();
+        '        System.Console.Write(c[x: 1, x: 2, 3]);
+        '    }
+        '}";
+        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
+        '            comp.VerifyDiagnostics(
+        '                // (8,38): Error CS1740: Named argument 'x' cannot be specified multiple times
+        '                //         System.Console.Write(c[x: 1, x: 2, 3]);
+        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(8, 38)
+        '                );
+        '        }
+        '    }
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -1,0 +1,258 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Roslyn.Test.Utilities
+Imports VB = Microsoft.CodeAnalysis.VisualBasic
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
+
+    <CompilerTrait(CompilerFeature.NonTrailingNamedArgs)>
+    Public Class NonTrailingNamedArgumentsTests
+        Inherits BasicTestBase
+
+        ReadOnly parseOptions As VisualBasicParseOptions = TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_6)
+
+        <Fact>
+        Public Sub TestSimple()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(a As Integer, b As Integer)
+        System.Console.Write($"First {a} {b}. ")
+    End Sub
+    Shared Sub M(b As Long, a As Long)
+        System.Console.Write($"Second {b} {a}. ")
+    End Sub
+    Shared Sub Main()
+        M(a:=1, 2)
+        M(3, a:=4)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="First 1 2. Second 3 4.",
+                                            parseOptions:=parseOptions)
+            verifier.VerifyDiagnostics()
+
+            Dim tree = verifier.Compilation.SyntaxTrees.First()
+            Dim model = verifier.Compilation.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim firstInvocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(2)
+            Assert.Equal("M(a:=1, 2)", firstInvocation.ToString())
+            Assert.Equal("Sub C.M(a As System.Int32, b As System.Int32)",
+                model.GetSymbolInfo(firstInvocation).Symbol.ToTestDisplayString())
+
+            Dim secondInvocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(3)
+            Assert.Equal("M(3, a:=4)", secondInvocation.ToString())
+            Assert.Equal("Sub C.M(b As System.Int64, a As System.Int64)",
+                model.GetSymbolInfo(secondInvocation).Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub TestPositionalUnaffected()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(first As Integer, other As Integer)
+        System.Console.Write($"{first} {other}")
+    End Sub
+    Shared Sub Main()
+        M(1, first:=2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=parseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC30455: Argument not specified for parameter 'other' of 'Public Shared Sub M(first As Integer, other As Integer)'.
+        M(1, first:=2)
+        ~
+BC30274: Parameter 'first' of 'Public Shared Sub M(first As Integer, other As Integer)' already has a matching argument.
+        M(1, first:=2)
+             ~~~~~
+                                        </errors>)
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(1)
+            Assert.Equal("M(1, first:=2)", invocation.ToString())
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
+
+        <Fact>
+        Public Sub TestPositionalUnaffected2()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(a As Integer, b As Integer, Optional c As Integer = 1)
+        System.Console.Write($"M {a} {b}")
+    End Sub
+    Shared Sub Main()
+        M(c:=1, 2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=parseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC37302: Named argument 'c' is used out-of-position but is followed by an unnamed argument
+        M(c:=1, 2)
+             ~
+                                        </errors>)
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(1)
+            Assert.Equal("M(c:=1, 2)", invocation.ToString())
+            AssertEx.Equal({"Sub C.M(a As System.Int32, b As System.Int32, [c As System.Int32 = 1])"},
+                model.GetSymbolInfo(invocation).CandidateSymbols.Select(Function(c) c.ToTestDisplayString()))
+        End Sub
+
+        <Fact>
+        Public Sub TestBadNonTrailing()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(Optional a As Integer = 1, Optional b As Integer = 2, Optional c As Integer = 3)
+        System.Console.Write($"First {a} {b}. ")
+    End Sub
+    Shared Sub Main()
+        Dim valueB = 2
+        Dim valueC = 3
+        M(c:=valueC, valueB)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=parseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC37302: Named argument 'c' is used out-of-position but is followed by an unnamed argument
+        M(c:=valueC, valueB)
+             ~~~~~~
+                                        </errors>)
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim firstInvocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(1)
+            Assert.Equal("M(c:=valueC, valueB)", firstInvocation.ToString())
+            Assert.Null(model.GetSymbolInfo(firstInvocation).Symbol)
+            Assert.Equal(CandidateReason.OverloadResolutionFailure, model.GetSymbolInfo(firstInvocation).CandidateReason)
+            Assert.Equal("Sub C.M([a As System.Int32 = 1], [b As System.Int32 = 2], [c As System.Int32 = 3])",
+                model.GetSymbolInfo(firstInvocation).CandidateSymbols.Single().ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub TestBadNonTrailing2()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(Optional a As Integer = 1, Optional b As Integer = 2, Optional c As Integer = 3)
+    End Sub
+    Shared Sub M(Optional c As Long = 1, Optional b As Long = 2)
+        System.Console.Write($"Second {c} {b}. ")
+    End Sub
+    Shared Sub Main()
+        Dim valueB = 2
+        Dim valueC = 3
+        M(c:=valueC, valueB)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="Second 3 2.", parseOptions:=parseOptions)
+            verifier.VerifyDiagnostics()
+
+            Dim tree = verifier.Compilation.SyntaxTrees.First()
+            Dim model = verifier.Compilation.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(1)
+            Assert.Equal("M(c:=valueC, valueB)", invocation.ToString())
+            Assert.Equal("Sub C.M([c As System.Int64 = 1], [b As System.Int64 = 2])",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub TestBadNonTrailing3()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(Optional a As Long = 1, Optional b As Long = 2, Optional c As Long = 3)
+    End Sub
+    Shared Sub M(Optional c As Integer = 1, Optional b As Integer = 2)
+        System.Console.Write($"Second {c} {b}.")
+    End Sub
+    Shared Sub Main()
+        Dim valueB = 2
+        Dim valueC = 3
+        M(c:=valueC, valueB)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="Second 3 2.", parseOptions:=parseOptions)
+            verifier.VerifyDiagnostics()
+
+            Dim tree = verifier.Compilation.SyntaxTrees.First()
+            Dim model = verifier.Compilation.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(1)
+            Assert.Equal("M(c:=valueC, valueB)", invocation.ToString())
+            Assert.Equal("Sub C.M([c As System.Int32 = 1], [b As System.Int32 = 2])",
+                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub TestParams()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(a As Integer, b As Integer, ParamArray c() As Integer)
+    End Sub
+    Shared Sub Main()
+        M(b:=2, 3, 4)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source, parseOptions:=parseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC37302: Named argument 'b' is used out-of-position but is followed by an unnamed argument
+        M(b:=2, 3, 4)
+             ~
+                                        </errors>)
+        End Sub
+
+        <Fact>
+        Public Sub TestParams2()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(a As Integer, b As Integer, ParamArray c() As Integer)
+        System.Console.Write($"{a} {b} {c(0)} {c(1)} Length:{c.Length}")
+    End Sub
+    Shared Sub Main()
+        M(1, b:=2, 3, 4)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim verifier = CompileAndVerify(source, expectedOutput:="1 2 3 4 Length:2", parseOptions:=parseOptions)
+            verifier.VerifyDiagnostics()
+        End Sub
+    End Class
+End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -1,12 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Test.Utilities
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
-Imports VB = Microsoft.CodeAnalysis.VisualBasic
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -125,15 +121,39 @@ End Class
 </compilation>
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
             comp.AssertTheseDiagnostics(<errors>
-BC30455: Argument not specified for parameter 'a' of 'Public Shared Sub M(a As Integer, b As Integer, [c As Integer = 1])'.
-        M(c:=1, 2)
-        ~
-BC30455: Argument not specified for parameter 'b' of 'Public Shared Sub M(a As Integer, b As Integer, [c As Integer = 1])'.
-        M(c:=1, 2)
-        ~
 BC37302: Named argument 'c' is used out-of-position but is followed by an unnamed argument
         M(c:=1, 2)
              ~
+                                        </errors>)
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(1)
+            Assert.Equal("M(c:=1, 2)", invocation.ToString())
+            AssertEx.Equal({"Sub C.M(a As System.Int32, b As System.Int32, [c As System.Int32 = 1])"},
+                model.GetSymbolInfo(invocation).CandidateSymbols.Select(Function(c) c.ToTestDisplayString()))
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
+
+        <Fact>
+        Public Sub TestPositionalUnaffected2WithOmitted()
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(a As Integer, b As Integer, Optional c As Integer = 1, Optional d As Integer = 2)
+        System.Console.Write($"M {a} {b}")
+    End Sub
+    Shared Sub Main()
+        M(c:=1, 2,)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+                                            // PROTOTYPE(non-trailing) crash
                                         </errors>)
 
             Dim tree = comp.SyntaxTrees.First()
@@ -176,206 +196,219 @@ BC30587: Named argument cannot match a ParamArray parameter.
                 model.GetSymbolInfo(invocation).CandidateSymbols.Select(Function(c) c.ToTestDisplayString()))
         End Sub
 
-        '        [Fact]
-        '        Public void TestNamedParams2()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M(params int[] x)
-        '    {
-        '    }
-        '    static void Main()
-        '    {
-        '        M(1, x: 2);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (9,14): Error CS1744: Named argument 'x' specifies a parameter for which a positional argument has already been given
-        '                //         M(1, x: 2);
-        '                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "x").WithArguments("x").WithLocation(9, 14)
-        '                );
+        <Fact>
+        Public Sub TestNamedParams2()
 
-        '            var tree = comp.SyntaxTrees.First();
-        '            var model = comp.GetSemanticModel(tree);
-        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
-        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
-        '            Assert.Equal("M(1, x: 2)", invocation.ToString());
-        '            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
-        '        }
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(ParamArray x() As Integer)
+    End Sub
+    Shared Sub Main()
+        M(1, x:=2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC30587: Named argument cannot match a ParamArray parameter.
+        M(1, x:=2)
+             ~
+                                        </errors>)
 
-        '        [Fact]
-        '        Public void TestTwiceNamedParams()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M(params int[] x)
-        '    {
-        '    }
-        '    static void Main()
-        '    {
-        '        M(x: 1, x: 2);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (9,17): Error CS1740: Named argument 'x' cannot be specified multiple times
-        '                //         M(x: 1, x: 2);
-        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(9, 17)
-        '                );
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().Single()
+            Assert.Equal("M(1, x:=2)", invocation.ToString())
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
 
-        '            var tree = comp.SyntaxTrees.First();
-        '            var model = comp.GetSemanticModel(tree);
-        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
-        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
-        '            Assert.Equal("M(x: 1, x: 2)", invocation.ToString());
-        '            Assert.Equal("void C.M(params System.Int32[] x)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
-        '        }
+        <Fact>
+        Public Sub TestTwiceNamedParams()
 
-        '        [Fact]
-        '        Public void TestTwiceNamedParamsWithOldLangVer()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M(int x, int y, int z)
-        '    {
-        '    }
-        '    static void Main()
-        '    {
-        '        M(x: 1, x: 2, 3);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.Regular7_1);
-        '            comp.VerifyDiagnostics(
-        '                // (9,17): Error CS1740: Named argument 'x' cannot be specified multiple times
-        '                //         M(x: 1, x: 2, 3);
-        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(9, 17),
-        '                // (9,23): Error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 Or greater To allow non-trailing named arguments.
-        '                //         M(x: 1, x: 2, 3);
-        '                Diagnostic(ErrorCode.ERR_NamedArgumentSpecificationBeforeFixedArgument, "3").WithArguments("7.2").WithLocation(9, 23)
-        '                );
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(ParamArray x() As Integer)
+    End Sub
+    Shared Sub Main()
+        M(x:=1, x:=2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC30587: Named argument cannot match a ParamArray parameter.
+        M(x:=1, x:=2)
+          ~
+BC30587: Named argument cannot match a ParamArray parameter.
+        M(x:=1, x:=2)
+                ~
+                                        </errors>)
 
-        '            var tree = comp.SyntaxTrees.First();
-        '            var model = comp.GetSemanticModel(tree);
-        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
-        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
-        '            Assert.Equal("M(x: 1, x: 2, 3)", invocation.ToString());
-        '            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
-        '        }
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().Single()
+            Assert.Equal("M(x:=1, x:=2)", invocation.ToString())
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
 
-        '        [Fact]
-        '        Public void TestNamedParams3()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M(int x, params int[] y)
-        '    {
-        '    }
-        '    static void Main()
-        '    {
-        '        M(y: 1, 2);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (9,11): Error CS8321: Named argument 'y' is used out-of-position but is followed by an unnamed argument
-        '                //         M(y: 1, 2);
-        '                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "y").WithArguments("y").WithLocation(9, 11)
-        '                );
+        <Fact>
+        Public Sub TestTwiceNamedParamsWithOldLangVer()
 
-        '            var tree = comp.SyntaxTrees.First();
-        '            var model = comp.GetSemanticModel(tree);
-        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
-        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
-        '            Assert.Equal("M(y: 1, 2)", invocation.ToString());
-        '            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
-        '        }
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(x As Integer, y As Integer, z As Integer)
+    End Sub
+    Shared Sub Main()
+        M(x:=1, x:=2, 3)
+    End Sub
+End Class
+    </file>
+</compilation>
 
-        '        [Fact]
-        '        Public void TestNamedParams4()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M(int x, params int[] y)
-        '    {
-        '    }
-        '    static void Main()
-        '    {
-        '        M(x: 1, y: 2, 3);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (9,9): Error CS1501: No overload For method 'M' takes 3 arguments
-        '                //         M(x: 1, y: 2, 3);
-        '                Diagnostic(ErrorCode.ERR_BadArgCount, "M").WithArguments("M", "3").WithLocation(9, 9)
-        '                );
-        '        }
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+            comp.AssertTheseDiagnostics(<errors>
+BC30274: Parameter 'x' of 'Public Shared Sub M(x As Integer, y As Integer, z As Integer)' already has a matching argument.
+        M(x:=1, x:=2, 3)
+                ~
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+        M(x:=1, x:=2, 3)
+                      ~
+                                        </errors>)
 
-        '        [Fact]
-        '        Public void TestNamedInvalidParams()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M(params int[] x, int y)
-        '    {
-        '    }
-        '    static void Main()
-        '    {
-        '        M(x: 1, 2);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (4,19): Error CS0231: A params parameter must be the last parameter In a formal parameter list
-        '                //     static void M(params int[] x, int y)
-        '                Diagnostic(ErrorCode.ERR_ParamsLast, "params int[] x").WithLocation(4, 19),
-        '                // (9,14): Error CS1503 :  Argument 1: cannot convert from 'int' to 'int'
-        '                //         M(x: 1, 2);
-        '                Diagnostic(ErrorCode.ERR_BadArgType, "1").WithArguments("1", "int", "int").WithLocation(9, 14)
-        '                );
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().Single()
+            Assert.Equal("M(x:=1, x:=2, 3)", invocation.ToString())
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
 
-        '            var tree = comp.SyntaxTrees.First();
-        '            var model = comp.GetSemanticModel(tree);
-        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
-        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().Single();
-        '            Assert.Equal("M(x: 1, 2)", invocation.ToString());
-        '            Assert.Null(model.GetSymbolInfo(invocation).Symbol);
-        '        }
+        <Fact>
+        Public Sub TestNamedParams3()
 
-        '        [Fact]
-        '        Public void TestNamedParams5()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M(int x, params int[] y)
-        '    {
-        '        System.Console.Write($""x={x} y[0]={y[0]} y.Length={y.Length}"");
-        '    }
-        '    static void Main()
-        '    {
-        '        M(y: 1, x: 2);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest, options: TestOptions.DebugExe);
-        '            comp.VerifyDiagnostics();
-        '            CompileAndVerify(comp, expectedOutput: "x=2 y[0]=1 y.Length=1");
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(x As Integer, ParamArray y() As Integer)
+    End Sub
+    Shared Sub Main()
+        M(y:=1, 2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC30587: Named argument cannot match a ParamArray parameter.
+        M(y:=1, 2)
+          ~
+                                        </errors>)
 
-        '            var tree = comp.SyntaxTrees.First();
-        '            var model = comp.GetSemanticModel(tree);
-        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
-        '            var invocation = nodes.OfType < InvocationExpressionSyntax > ().ElementAt(1);
-        '            Assert.Equal("M(y: 1, x: 2)", invocation.ToString());
-        '            Assert.Equal("void C.M(System.Int32 x, params System.Int32[] y)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
-        '        }
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().Single()
+            Assert.Equal("M(y:=1, 2)", invocation.ToString())
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
 
+        <Fact>
+        Public Sub TestNamedParams4()
+
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(x As Integer, ParamArray y() As Integer)
+    End Sub
+    Shared Sub Main()
+        M(x:=1, y:=2, 3)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC30587: Named argument cannot match a ParamArray parameter.
+        M(x:=1, y:=2, 3)
+                ~
+                                        </errors>)
+        End Sub
+
+        <Fact>
+        Public Sub TestNamedInvalidParams()
+
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+class C
+
+    Shared Sub M(ParamArray x() As Integer, y As Integer)
+    End Sub
+    Shared Sub Main()
+        M(x:=1, 2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors>
+BC30192: End of parameter list expected. Cannot define parameters after a paramarray parameter.
+    Shared Sub M(ParamArray x() As Integer, y As Integer)
+                                            ~~~~~~~~~~~~
+BC30311: Value of type 'Integer' cannot be converted to 'Integer()'.
+        M(x:=1, 2)
+             ~
+                                        </errors>)
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().Single()
+            Assert.Equal("M(x:=1, 2)", invocation.ToString())
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
+
+        <Fact>
+        Public Sub TestNamedParams5()
+
+            Dim source =
+<compilation>
+    <file name="Program.vb">
+Class C
+    Shared Sub M(x As Integer, ParamArray y() As Integer)
+        System.Console.Write($"x={x} y(0)={y(0)} y.Length={y.Length}")
+    End Sub
+    Shared Sub Main()
+        M(y:=1, x:=2)
+    End Sub
+End Class
+    </file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions, options:=TestOptions.DebugExe)
+            comp.AssertTheseDiagnostics(<errors>
+BC30587: Named argument cannot match a ParamArray parameter.
+        M(y:=1, x:=2)
+          ~
+                                        </errors>)
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(2)
+            Assert.Equal("M(y:=1, x:=2)", invocation.ToString())
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
 
         <Fact>
         Public Sub TestBadNonTrailing()
@@ -384,7 +417,7 @@ BC30587: Named argument cannot match a ParamArray parameter.
     <file name="Program.vb">
 Class C
     Shared Sub M(Optional a As Integer = 1, Optional b As Integer = 2, Optional c As Integer = 3)
-        System.Console.Write($"First {a} {b}. ")
+        System.Console.Write($"First a b. ")
     End Sub
     Shared Sub Main()
         Dim valueB = 2
@@ -490,9 +523,6 @@ End Class
 </compilation>
             Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(source, parseOptions:=latestParseOptions)
             comp.AssertTheseDiagnostics(<errors>
-BC30455: Argument not specified for parameter 'a' of 'Public Shared Sub M(a As Integer, b As Integer, ParamArray c As Integer())'.
-        M(b:=2, 3, 4)
-        ~
 BC37302: Named argument 'b' is used out-of-position but is followed by an unnamed argument
         M(b:=2, 3, 4)
              ~
@@ -518,173 +548,99 @@ End Class
             verifier.VerifyDiagnostics()
         End Sub
 
-        '        [Fact]
-        '        Public void TestInAttribute()
-        '        {
-        '            var source = @"
-        'using System;
+        <Fact>
+        Public Sub TestInAttribute()
 
-        '[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
-        'public class MyAttribute : Attribute
-        '{
-        '    public int P { get; set; }
-        '	public MyAttribute(bool condition, int other) { }
-        '}
+            Dim source =
+<compilation>
+    <file name="Program.vb"><![CDATA[
+Imports System
 
-        '[MyAttribute(condition: true, 42)]
-        '[MyAttribute(condition: true, P = 1, 42)]
-        '[MyAttribute(42, condition: true)]
-        'public class C
-        '{
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (12,38): Error CS1016: Named attribute argument expected
-        '                // [MyAttribute(condition: true, P = 1, 42)]
-        '                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "42").WithLocation(12, 38),
-        '                // (13,18): Error CS1744: Named argument 'condition' specifies a parameter for which a positional argument has already been given
-        '                // [MyAttribute(42, condition: true)]
-        '                Diagnostic(ErrorCode.ERR_NamedArgumentUsedInPositional, "condition").WithArguments("condition").WithLocation(13, 18)
-        '                );
+<AttributeUsage(AttributeTargets.All, AllowMultiple:=True)>
+Public Class MyAttribute
+    Inherits Attribute
 
-        '            var tree = comp.SyntaxTrees.First();
-        '            var model = comp.GetSemanticModel(tree);
-        '            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
-        '            var invocation = nodes.OfType < AttributeSyntax > ().ElementAt(1);
-        '            Assert.Equal("MyAttribute(condition: true, 42)", invocation.ToString());
-        '            Assert.Equal("MyAttribute..ctor(System.Boolean condition, System.Int32 other)",
-        '                model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString());
-        '        }
+    Public Dim P As Integer
+    Public Dim condition As Boolean
 
-        '        [Fact]
-        '        Public void TestInAttribute2()
-        '        {
-        '            var source = @"
-        'using System;
+    Public Sub New(condition As Boolean, other As Integer)
+    End Sub
+End Class
 
-        '[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
-        'public class MyAttribute : Attribute
-        '{
-        '    public int P { get; set; }
-        '	public MyAttribute(int a = 1, int b = 2, int c = 3) { }
-        '}
+<MyAttribute(condition:=true, 42)>
+<MyAttribute(condition:=true, P:=1, 42)>
+<MyAttribute(42, condition:=True)>
+Public Class C
+End Class
+    ]]></file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC30455: Argument not specified for parameter 'other' of 'Public Sub New(condition As Boolean, other As Integer)'.
+<MyAttribute(condition:=true, 42)>
+ ~~~~~~~~~~~
+BC37303: Named argument expected.
+<MyAttribute(condition:=true, 42)>
+                              ~~
+BC30455: Argument not specified for parameter 'other' of 'Public Sub New(condition As Boolean, other As Integer)'.
+<MyAttribute(condition:=true, P:=1, 42)>
+ ~~~~~~~~~~~
+BC37303: Named argument expected.
+<MyAttribute(condition:=true, P:=1, 42)>
+                                    ~~
+BC30455: Argument not specified for parameter 'other' of 'Public Sub New(condition As Boolean, other As Integer)'.
+<MyAttribute(42, condition:=True)>
+ ~~~~~~~~~~~
+                                        ]]></errors>)
 
-        '[MyAttribute(c:3, 2)]
-        '[MyAttribute(P=1, c:3, 2)]
-        'public class C
-        '{
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (11,14): Error CS8321: Named argument 'c' is used out-of-position but is followed by an unnamed argument
-        '                // [MyAttribute(c:3, 2)]
-        '                Diagnostic(ErrorCode.ERR_BadNonTrailingNamedArgument, "c").WithArguments("c").WithLocation(11, 14),
-        '                // (12,21): Error CS1016: Named attribute argument expected
-        '                // [MyAttribute(P=1, c:3, 2)]
-        '                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "3").WithLocation(12, 21),
-        '                // (12,24): Error CS1016: Named attribute argument expected
-        '                // [MyAttribute(P=1, c:3, 2)]
-        '                Diagnostic(ErrorCode.ERR_NamedArgumentExpected, "2").WithLocation(12, 24)
-        '                );
-        '        }
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim invocation = nodes.OfType(Of AttributeSyntax)().ElementAt(1)
+            Assert.Equal("MyAttribute(condition:=true, 42)", invocation.ToString())
+            Assert.Null(model.GetSymbolInfo(invocation).Symbol)
+        End Sub
 
-        '        [Fact]
-        '        Public void TestErrorsDoNotCascadeInInvocation()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M()
-        '    {
-        '        M(x: 1, x: 2, __arglist());
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (6,17): Error CS1740: Named argument 'x' cannot be specified multiple times
-        '                //         M(x: 1, x: 2, __arglist());
-        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 17)
-        '                );
-        '        }
+        <Fact>
+        Public Sub TestInAttribute2()
 
-        '        [Fact]
-        '        Public void TestErrorsDoNotCascadeInArglist()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    static void M()
-        '    {
-        '        M(__arglist(x: 1, x: 2, __arglist()));
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (6,27): Error CS1740: Named argument 'x' cannot be specified multiple times
-        '                //         M(__arglist(x: 1, x: 2, __arglist()));
-        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 27),
-        '                // (6,33): Error CS0226: An __arglist expression may only appear inside Of a Call Or New expression
-        '                //         M(__arglist(x: 1, x: 2, __arglist()));
-        '                Diagnostic(ErrorCode.ERR_IllegalArglist, "__arglist()").WithLocation(6, 33)
-        '                );
-        '        }
+            Dim source =
+<compilation>
+    <file name="Program.vb"><![CDATA[
+Imports System
 
-        '        [Fact]
-        '        Public void TestErrorsDoNotCascadeInConstructorInitializer()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    C() : this(x: 1, x: 2, 3) { }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (4,22): Error CS1740: Named argument 'x' cannot be specified multiple times
-        '                //     C() : this(x: 1, x: 2, 3) { }
-        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(4, 22)
-        '                );
-        '        }
+<AttributeUsage(AttributeTargets.All, AllowMultiple:=True)>
+Public Class MyAttribute
+    Inherits Attribute
 
-        '        [Fact]
-        '        Public void TestErrorsDoNotCascadeInObjectCreation()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    void M()
-        '    {
-        '        new C(x: 1, x: 2, 3);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (6,21): Error CS1740: Named argument 'x' cannot be specified multiple times
-        '                //         New C(x: 1, x: 2, 3);
-        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(6, 21)
-        '                );
-        '        }
+    Public Dim P As Integer
+    Public Dim c As Integer
+    Public Sub New()
+    End Sub
+End Class
 
-        '        [Fact]
-        '        Public void TestErrorsDoNotCascadeInElementAccess()
-        '        {
-        '            var source = @"
-        'class C
-        '{
-        '    int this[int i] { get { throw null; } set { throw null; } }
-        '    void M()
-        '    {
-        '        var c = new C();
-        '        System.Console.Write(c[x: 1, x: 2, 3]);
-        '    }
-        '}";
-        '            var comp = CreateStandardCompilation(source, parseOptions:  TestOptions.RegularLatest);
-        '            comp.VerifyDiagnostics(
-        '                // (8,38): Error CS1740: Named argument 'x' cannot be specified multiple times
-        '                //         System.Console.Write(c[x: 1, x: 2, 3]);
-        '                Diagnostic(ErrorCode.ERR_DuplicateNamedArgument, "x").WithArguments("x").WithLocation(8, 38)
-        '                );
-        '        }
-        '    }
+<MyAttribute(c:=3, 2)>
+<MyAttribute(P:=1, c:=3, 2)>
+Public Class C
+End Class
+    ]]></file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, parseOptions:=latestParseOptions)
+            comp.AssertTheseDiagnostics(<errors><![CDATA[
+BC30057: Too many arguments to 'Public Sub New()'.
+<MyAttribute(c:=3, 2)>
+                   ~
+BC37303: Named argument expected.
+<MyAttribute(c:=3, 2)>
+                   ~
+BC30057: Too many arguments to 'Public Sub New()'.
+<MyAttribute(P:=1, c:=3, 2)>
+                         ~
+BC37303: Named argument expected.
+<MyAttribute(P:=1, c:=3, 2)>
+                         ~
+                                        ]]></errors>)
+        End Sub
 
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/NonTrailingNamedArgumentsTests.vb
@@ -816,6 +816,8 @@ Class C
     Shared Sub Main()
         Dim c = New C(input1:=1, , 3)
         c = New C(input1:=1, , 0 to 4)
+        c = New C(input1:=1, , input3:=5)
+        c = New C(input1:=1, 0 to 6, input3:=7)
     End Sub
 End Class
     </file>
@@ -825,7 +827,7 @@ End Class
                 parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), options:=TestOptions.DebugExe)
 
             CompilationUtils.AssertNoDiagnostics(compilation)
-            CompileAndVerify(compilation, expectedOutput:="1 2 3. 1 2 4.")
+            CompileAndVerify(compilation, expectedOutput:="1 2 3. 1 2 4. 1 2 5. 1 6 7.")
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
@@ -3889,9 +3889,6 @@ BC30519: Overload resolution failed because no accessible 'F2' can be called wit
 </expected>)
         End Sub
 
-
-
-
         <Fact(), WorkItem(527622, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527622")>
         Public Sub NoisyDiagnostics()
 
@@ -3929,13 +3926,13 @@ End Class
     </file>
 </compilation>
 
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
 
             CompilationUtils.AssertTheseDiagnostics(compilation,
 <expected>
-BC30201: Expression expected.
+BC37302: Named argument 'y' is used out-of-position but is followed by an unnamed argument
         F4(y:=Nothing,)
-                      ~
+           ~
 BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
         F4(y:=Nothing,)
                       ~

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
@@ -3933,7 +3933,7 @@ End Class
 BC37302: Named argument 'y' is used out-of-position but is followed by an unnamed argument
         F4(y:=Nothing,)
            ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         F4(y:=Nothing,)
                       ~
 BC30198: ')' expected.

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
@@ -675,7 +675,6 @@ End Class
             Assert.Same(TestClass1_M5, result.Candidates(1).Candidate.UnderlyingSymbol)
             Assert.False(result.BestResult.HasValue)
 
-            'error BC30241: Named argument expected.
             'TestClass1.M4(x:=intVal, TestClass1Val)
             result = ResolveMethodOverloading(includeEliminatedCandidates:=True,
                 instanceMethods:={(TestClass1_M4)}.AsImmutableOrNull(),
@@ -688,9 +687,9 @@ End Class
 
             Assert.False(result.ResolutionIsLateBound)
             Assert.Equal(1, result.Candidates.Length)
-            Assert.Equal(CandidateAnalysisResultState.ArgumentMismatch, result.Candidates(0).State)
+            Assert.Equal(CandidateAnalysisResultState.Applicable, result.Candidates(0).State)
             Assert.Same(TestClass1_M4, result.Candidates(0).Candidate.UnderlyingSymbol)
-            Assert.False(result.BestResult.HasValue)
+            Assert.True(result.BestResult.HasValue)
 
             'error BC30057: Too many arguments to 'Public Shared Sub M2(Of T)()'.
             'TestClass1.M2(Of TestClass1)(intVal)
@@ -3937,7 +3936,7 @@ End Class
 BC30201: Expression expected.
         F4(y:=Nothing,)
                       ~
-BC30241: Named argument expected.
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
         F4(y:=Nothing,)
                       ~
 BC30198: ')' expected.

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/RedimStatementTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/RedimStatementTests.vb
@@ -58,9 +58,6 @@ BC30241: Named argument expected. Please use language version 15.6 or greater to
         ReDim b(a:=1, 2)
                       ~
 BC30075: Named arguments are not valid as array subscripts.
-        ReDim b(a:=1, 2)
-                      ~
-BC30075: Named arguments are not valid as array subscripts.
         ReDim Preserve b(a:=1, b:=2)
                          ~~~~
 BC30075: Named arguments are not valid as array subscripts.
@@ -87,7 +84,6 @@ BC30512: Option Strict On disallows implicit conversions from 'Decimal' to 'Inte
 BC30512: Option Strict On disallows implicit conversions from 'String' to 'Integer'.
         ReDim b(1D, "")
                     ~~
-    
 </errors>)
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/RedimStatementTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/RedimStatementTests.vb
@@ -54,7 +54,7 @@ End Class
 BC30075: Named arguments are not valid as array subscripts.
         ReDim b(a:=1, 2)
                 ~~~~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         ReDim b(a:=1, 2)
                       ~
 BC30075: Named arguments are not valid as array subscripts.

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/RedimStatementTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/RedimStatementTests.vb
@@ -54,7 +54,7 @@ End Class
 BC30075: Named arguments are not valid as array subscripts.
         ReDim b(a:=1, 2)
                 ~~~~
-BC30241: Named argument expected.
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
         ReDim b(a:=1, 2)
                       ~
 BC30075: Named arguments are not valid as array subscripts.

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseErrorTests.vb
@@ -1739,6 +1739,18 @@ BC30306: Array subscript expression missing.
                              </errors>)
     End Sub
 
+    <Fact()>
+    Public Sub BC30241ERR_ExpectedNamedArgument_VB15_6()
+        Dim code = <![CDATA[
+<Attr1(1, b:=2, 3, e:="Scen1")>
+Class Class1
+
+End Class
+            ]]>.Value
+
+        ParseAndVerify(code, LanguageVersion.VisualBasic15_6, False, Nothing) ' No parsing errors
+    End Sub
+
     ' old name - ParseInvalidDirective_ERR_ExpectedConditionalDirective
     <WorkItem(883737, "DevDiv/Personal")>
     <Fact()>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseErrorTests.vb
@@ -1728,28 +1728,34 @@ BC30306: Array subscript expression missing.
 
     <Fact()>
     Public Sub BC30241ERR_ExpectedNamedArgument()
-        Dim code = <![CDATA[
-                	<Attr1(1, b:=2, 3, e:="Scen1")> Class Class1
-
-	                End Class
-            ]]>.Value
-
-        ParseAndVerify(code, <errors>
-                                 <error id="37303"/>
-                             </errors>)
-    End Sub
-
-    <Fact()>
-    Public Sub BC30241ERR_ExpectedNamedArgument_VBLatest()
-        Dim code = <![CDATA[
+        Dim tree = Parse(<![CDATA[
 <Attr1(1, b:=2, 3, e:="Scen1")>
 Class Class1
 
 End Class
-            ]]>.Value
+]]>, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
 
-        ParseAndVerify(code, TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest),
-            Diagnostic(ERRID.ERR_ExpectedNamedArgumentInAttributeList, "").WithLocation(2, 17))
+        tree.AssertTheseDiagnostics(<errors><![CDATA[
+BC37303: Named argument expected.
+<Attr1(1, b:=2, 3, e:="Scen1")>
+                ~
+                                    ]]></errors>)
+    End Sub
+
+    <Fact()>
+    Public Sub BC30241ERR_ExpectedNamedArgument_VBLatest()
+        Dim tree = Parse(<![CDATA[
+<Attr1(1, b:=2, 3, e:="Scen1")>
+Class Class1
+
+End Class
+]]>, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest))
+
+        tree.AssertTheseDiagnostics(<errors><![CDATA[
+BC37303: Named argument expected.
+<Attr1(1, b:=2, 3, e:="Scen1")>
+                ~
+                                    ]]></errors>)
     End Sub
 
     ' old name - ParseInvalidDirective_ERR_ExpectedConditionalDirective

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseErrorTests.vb
@@ -1735,12 +1735,12 @@ BC30306: Array subscript expression missing.
             ]]>.Value
 
         ParseAndVerify(code, <errors>
-                                 <error id="30241"/>
+                                 <error id="37303"/>
                              </errors>)
     End Sub
 
     <Fact()>
-    Public Sub BC30241ERR_ExpectedNamedArgument_VB15_6()
+    Public Sub BC30241ERR_ExpectedNamedArgument_VBLatest()
         Dim code = <![CDATA[
 <Attr1(1, b:=2, 3, e:="Scen1")>
 Class Class1
@@ -1748,7 +1748,8 @@ Class Class1
 End Class
             ]]>.Value
 
-        ParseAndVerify(code, LanguageVersion.VisualBasic15_6, False, Nothing) ' No parsing errors
+        ParseAndVerify(code, TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest),
+            Diagnostic(ERRID.ERR_ExpectedNamedArgumentInAttributeList, "").WithLocation(2, 17))
     End Sub
 
     ' old name - ParseInvalidDirective_ERR_ExpectedConditionalDirective

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -1724,7 +1724,7 @@ Skip 2
                       End Class
             ]]>,
             <errors>
-                <error id="30241"/>
+                <error id="37303"/>
             </errors>)
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -1719,13 +1719,16 @@ Skip 2
     <WorkItem(887861, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseMoreErrorExpectedExpression30241()
-        ParseAndVerify(<![CDATA[
-                      <myattr2(1, "abc", prop:=42,true)> Class Scen15
-                      End Class
-            ]]>,
-            <errors>
-                <error id="37303"/>
-            </errors>)
+        Dim tree = Parse(<![CDATA[
+<myattr2(1, "abc", prop:=42,true)> Class Scen15
+End Class
+]]>, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+
+        tree.AssertTheseDiagnostics(<errors><![CDATA[
+BC37303: Named argument expected.
+<myattr2(1, "abc", prop:=42,true)> Class Scen15
+                            ~
+                                    ]]></errors>)
     End Sub
 
     <WorkItem(887741, "DevDiv/Personal")>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
@@ -7605,36 +7605,30 @@ Module M
     Dim y, z = Nothing
 End Module
 ]]>,
-            <errors>
-                <error id="32017"/>
-                <error id="30241"/>
-                <error id="30201"/>
-                <error id="30241"/>
-                <error id="30198"/>
-            </errors>)
+    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "").WithArguments("15.6").WithLocation(4, 1),
+    Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(4, 1),
+    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "z = Nothing").WithArguments("15.6").WithLocation(4, 12),
+    Diagnostic(ERRID.ERR_ExpectedRparen, "").WithLocation(4, 23))
+
         ParseAndVerify(<![CDATA[
 Module M
     Dim x = F(a:=False,
     Dim y()
 End Module
 ]]>,
-            <errors>
-                <error id="32017"/>
-                <error id="30241"/>
-                <error id="30201"/>
-            </errors>)
+    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "").WithArguments("15.6").WithLocation(4, 1),
+    Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(4, 1))
+
         ParseAndVerify(<![CDATA[
 Module M
     Dim x = F(a:=False,
     Dim y
 End Module
 ]]>,
-            <errors>
-                <error id="32017"/>
-                <error id="30241"/>
-                <error id="30201"/>
-                <error id="30198"/>
-            </errors>)
+    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "").WithArguments("15.6").WithLocation(4, 1),
+    Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(4, 1),
+    Diagnostic(ERRID.ERR_ExpectedRparen, "").WithLocation(4, 5))
+
         ParseAndVerify(<![CDATA[
 Module M
     Dim x = F(a:=False,
@@ -7642,10 +7636,13 @@ Module M
         c:=Nothing)
 End Module
 ]]>,
-            <errors>
-                <error id="32017"/>
-                <error id="30241"/>
-            </errors>)
+    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "b").WithArguments("15.6").WithLocation(4, 9),
+    Diagnostic(ERRID.ERR_ArgumentSyntax, "True").WithLocation(4, 11),
+    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "").WithArguments("15.6").WithLocation(4, 16),
+    Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(4, 16),
+    Diagnostic(ERRID.ERR_ExpectedRparen, "").WithLocation(4, 16),
+    Diagnostic(ERRID.ERR_ExpectedDeclaration, "c").WithLocation(5, 9))
+
     End Sub
 
     <WorkItem(649162, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/649162")>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
@@ -7599,49 +7599,87 @@ End Class
     <WorkItem(648998, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/648998")>
     <Fact()>
     Public Sub Bug648998()
-        ParseAndVerify(<![CDATA[
+        Dim tree = Parse(<![CDATA[
 Module M
     Dim x = F(a:=False,
     Dim y, z = Nothing
 End Module
-]]>,
-    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "").WithArguments("15.6").WithLocation(4, 1),
-    Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(4, 1),
-    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "z = Nothing").WithArguments("15.6").WithLocation(4, 12),
-    Diagnostic(ERRID.ERR_ExpectedRparen, "").WithLocation(4, 23))
+]]>, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+        tree.AssertTheseDiagnostics(<errors><![CDATA[
+BC30201: Expression expected.
+    Dim y, z = Nothing
+~
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+    Dim y, z = Nothing
+~
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+    Dim y, z = Nothing
+           ~~~~~~~~~~~
+BC30198: ')' expected.
+    Dim y, z = Nothing
+                      ~
+                                    ]]></errors>)
 
-        ParseAndVerify(<![CDATA[
+        tree = Parse(<![CDATA[
 Module M
     Dim x = F(a:=False,
     Dim y()
 End Module
-]]>,
-    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "").WithArguments("15.6").WithLocation(4, 1),
-    Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(4, 1))
+]]>, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+        tree.AssertTheseDiagnostics(<errors><![CDATA[
+BC30201: Expression expected.
+    Dim y()
+~
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+    Dim y()
+~
+                                    ]]></errors>)
 
-        ParseAndVerify(<![CDATA[
+        tree = Parse(<![CDATA[
 Module M
     Dim x = F(a:=False,
     Dim y
 End Module
-]]>,
-    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "").WithArguments("15.6").WithLocation(4, 1),
-    Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(4, 1),
-    Diagnostic(ERRID.ERR_ExpectedRparen, "").WithLocation(4, 5))
+]]>, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+        tree.AssertTheseDiagnostics(<errors><![CDATA[
+BC30201: Expression expected.
+    Dim y
+~
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+    Dim y
+~
+BC30198: ')' expected.
+    Dim y
+    ~
+                                    ]]></errors>)
 
-        ParseAndVerify(<![CDATA[
+        tree = Parse(<![CDATA[
 Module M
     Dim x = F(a:=False,
         b True,
         c:=Nothing)
 End Module
-]]>,
-    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "b").WithArguments("15.6").WithLocation(4, 9),
-    Diagnostic(ERRID.ERR_ArgumentSyntax, "True").WithLocation(4, 11),
-    Diagnostic(ERRID.ERR_ExpectedNamedArgument, "").WithArguments("15.6").WithLocation(4, 16),
-    Diagnostic(ERRID.ERR_ExpectedExpression, "").WithLocation(4, 16),
-    Diagnostic(ERRID.ERR_ExpectedRparen, "").WithLocation(4, 16),
-    Diagnostic(ERRID.ERR_ExpectedDeclaration, "c").WithLocation(5, 9))
+]]>, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
+        tree.AssertTheseDiagnostics(<errors><![CDATA[
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+        b True,
+        ~
+BC32017: Comma, ')', or a valid expression continuation expected.
+        b True,
+          ~~~~
+BC30198: ')' expected.
+        b True,
+               ~
+BC30201: Expression expected.
+        b True,
+               ~
+BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+        b True,
+               ~
+BC30188: Declaration expected.
+        c:=Nothing)
+        ~
+                                    ]]></errors>)
 
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseStatements.vb
@@ -7609,10 +7609,10 @@ End Module
 BC30201: Expression expected.
     Dim y, z = Nothing
 ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
     Dim y, z = Nothing
 ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
     Dim y, z = Nothing
            ~~~~~~~~~~~
 BC30198: ')' expected.
@@ -7630,7 +7630,7 @@ End Module
 BC30201: Expression expected.
     Dim y()
 ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
     Dim y()
 ~
                                     ]]></errors>)
@@ -7645,7 +7645,7 @@ End Module
 BC30201: Expression expected.
     Dim y
 ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
     Dim y
 ~
 BC30198: ')' expected.
@@ -7661,7 +7661,7 @@ Module M
 End Module
 ]]>, options:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.VisualBasic15_3))
         tree.AssertTheseDiagnostics(<errors><![CDATA[
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         b True,
         ~
 BC32017: Comma, ')', or a valid expression continuation expected.
@@ -7673,7 +7673,7 @@ BC30198: ')' expected.
 BC30201: Expression expected.
         b True,
                ~
-BC30241: Named argument expected. Please use language version 15.6 or greater to use non-trailing named arguments.
+BC30241: Named argument expected. Please use language version 15.5 or greater to use non-trailing named arguments.
         b True,
                ~
 BC30188: Declaration expected.


### PR DESCRIPTION
This is the VB counter-part to https://github.com/dotnet/roslyn/pull/20121

Relates to this [language proposal](https://github.com/dotnet/csharplang/blob/master/proposals/non-trailing-named-arguments.md)

The parser now allows non-trailing named arguments (if the LangVersion is 15.6 or above). Then in overload resolution, when each candidate is checked for applicability, the mapping from arguments to parameters works as usual. If a named argument is used to refer to a different position, then following arguments must be named too (otherwise the candidate will be rejected).
There is a variation of that rule for params: if the named argument is pointing to a ParamArray parameter, then it cannot be followed by any arguments (as named arguments are not possible, but unnamed arguments are also not possible).