### PR TITLE
Move language settings after SDK import

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -200,6 +200,10 @@
     </When>
   </Choose>
 
+  <ItemGroup Condition="'$(ProjectLanguage)' == 'CSharp' AND '$(TargetNetFX20)' == 'true'">
+    <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
+  </ItemGroup>
+
   <ItemDefinitionGroup Condition="'$(_CopyReferences)' == 'false'">
     <Reference>
       <Private>False</Private>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -69,7 +69,6 @@
       {RawFileName};
     </AssemblySearchPaths>
 
-    <NoWarn>$(NoWarn);1701</NoWarn>
     <RoslynNetSdkRootPath>$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\</RoslynNetSdkRootPath> 
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
@@ -77,7 +76,7 @@
   <!-- Windows specific settings -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <BaseNuGetRuntimeIdentifier>win7</BaseNuGetRuntimeIdentifier>
-    <DebugType>pdbonly</DebugType>
+    <RoslynDebugType>full</RoslynDebugType>
     <UseSharedCompilation>true</UseSharedCompilation>
 
     <!-- Presently our code can build on machines with Dev14 or Dev15 but only successfully deploy
@@ -93,7 +92,7 @@
 
   <!-- Unix specific settings -->
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <DebugType>portable</DebugType>
+    <RoslynDebugType>portable</RoslynDebugType>
   </PropertyGroup>
 
   <!--
@@ -121,7 +120,39 @@
     <VisualBasicCoreTargetsPath>$(BootstrapBuildPath)\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
   </PropertyGroup>
 
-  <!-- Language specifc settings -->
+  <!-- During bootstrap builds it's important to load our bootstrap tasks before doing any
+       other imports (which could load a same named DLL) -->
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"
+             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
+             Condition="'$(BootstrapBuildPath)' != ''" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"
+             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
+             Condition="'$(BootstrapBuildPath)' != ''" />
+  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.ValidateBootstrap"
+             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
+             Condition="'$(BootstrapBuildPath)' != ''" />
+
+  <!-- This file is imported by all projects at the beginning of the project files -->
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"
+          Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') AND '$(RoslynSdkProject)' != 'true'" />
+
+  <Import Project="$(RoslynNetSdkRootPath)Sdk.props" Condition="'$(RoslynSdkProject)' == 'true'" />
+
+  <Import Project="$(RoslynDiagnosticsPropsFilePath)" Condition="'$(UseRoslynAnalyzers)' == 'true' AND Exists('$(RoslynDiagnosticsPropsFilePath)')" />
+
+  <ImportGroup Label="WindowsImports" Condition="'$(OS)' == 'Windows_NT'">
+    <Import Project="$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(VisualStudioBuildToolsVersion)\build\Microsoft.VsSDK.BuildTools.props" />
+  </ImportGroup>
+
+  <Import Project="$(ToolsetCompilerPropsFilePath)" Condition="Exists('$(ToolsetCompilerPropsFilePath)') AND '$(BootstrapBuildPath)' == ''" />
+
+  <!-- 
+    Language specifc settings 
+    
+    These deliberately come after importing the core targets. That way we can assure these are 
+    the final settings, and not over written by core targets. Certain versions of the SDK for 
+    example do exactly that.
+    -->
   <Choose>
     <!-- VB specific settings -->
     <When Condition="'$(MSBuildProjectExtension)' == '.vbproj' OR '$(Language)' == 'VB' OR '$(ProjectLanguage)' == 'VB'">
@@ -175,7 +206,7 @@
                       and hence suppress this warning until we get closer to release and a more
                       thorough documentation story
         -->
-        <NoWarn>$(NoWarn);1591</NoWarn>
+        <NoWarn>$(NoWarn);1591;1701</NoWarn>
         <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
         <MSBuildTargetsLanguageName>CSharp</MSBuildTargetsLanguageName>
       </PropertyGroup>
@@ -205,45 +236,7 @@
     </When>
   </Choose>
 
-  <ItemGroup Condition="'$(ProjectLanguage)' == 'CSharp' AND '$(TargetNetFX20)' == 'true'">
-    <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
-  </ItemGroup>
-
-  <!-- During bootstrap builds it's important to load our bootstrap tasks before doing any
-       other imports (which could load a same named DLL) -->
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"
-             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
-             Condition="'$(BootstrapBuildPath)' != ''" />
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Vbc"
-             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
-             Condition="'$(BootstrapBuildPath)' != ''" />
-  <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.ValidateBootstrap"
-             AssemblyFile="$(BootstrapBuildPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
-             Condition="'$(BootstrapBuildPath)' != ''" />
-
-  <!-- This file is imported by all projects at the beginning of the project files -->
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"
-          Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') AND '$(RoslynSdkProject)' != 'true'" />
-
-  <Import Project="$(RoslynNetSdkRootPath)Sdk.props" Condition="'$(RoslynSdkProject)' == 'true'" />
-
-  <Import Project="$(RoslynDiagnosticsPropsFilePath)" Condition="'$(UseRoslynAnalyzers)' == 'true' AND Exists('$(RoslynDiagnosticsPropsFilePath)')" />
-
-  <ImportGroup Label="WindowsImports" Condition="'$(OS)' == 'Windows_NT'">
-    <Import Project="$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\$(VisualStudioBuildToolsVersion)\build\Microsoft.VsSDK.BuildTools.props" />
-  </ImportGroup>
-
-  <Import Project="$(ToolsetCompilerPropsFilePath)" Condition="Exists('$(ToolsetCompilerPropsFilePath)') AND '$(BootstrapBuildPath)' == ''" />
-
-  <!-- The Sdk props will set the rootnamespace to the assembly name when the property
-       is empty.  Need to override this after  -->
-  <PropertyGroup Condition="'$(RoslynSdkProject)' == 'true'" >
-    <DebugType>full</DebugType>
-    <RootNamespace Condition="'$(MSBuildTargetsLanguageName)' == 'VisualBasic'"></RootNamespace>
-    <DefineConstants Condition="'$(InitialDefineConstants)' != ''">$(InitialDefineConstants)</DefineConstants>
-
-    <!-- The NoWarn property is still being unconditionally set.  https://github.com/dotnet/sdk/issues/752 -->
-    <OptionStrict>On</OptionStrict>
-    <NoWarn>$(NoWarn);1591</NoWarn>
+  <PropertyGroup>
+    <DebugType>$(RoslynDebugType)</DebugType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The new SDK unconditionally sets a number of MSBulid properties
including many that we depend on in Roslyn.  This is a break from the
old MSBuild behavior which respected initial values.

https://github.com/dotnet/sdk/issues/752

The behavior in 2.0 is changing to go back to the old model of
respecting initial values.  Roslyn though continues to often use the SDK
installed with Visual Studio.  That can be a variety of values from 2.0
prebuilds, to various drops of 1.0.

As a result the success / failure of our build can depend a lot on which
version of VS is installed and by consequence which new SDK comes with
it.  Subtle differences in the SDK can change the values we end up
compiling with in our project.  We've been guarding against this
by directly re-setting values we knew to be overidden in some version
of the SDK.

Now though I'm worried this isn't an adequete solution for the following
reasons.

- Just this week I got new warnings in the build by using a new VS
- The Microbuild lab is aggressively grabbing new builds of VS which
means the VS SDK is also potentially changing.

After some thought I decided to simply move all of our langauge specific
settings after we import the core targets.  Given that we
unconditionally set the values it becomes irrelevant what the SDK does
or does not respect.

