### PR TITLE
Fix bug in closure rewriting

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -104,17 +104,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             _spansBuilder = ArrayBuilder<SourceSpan>.GetInstance();
             TypeSymbol payloadElementType = methodBodyFactory.SpecialType(SpecialType.System_Boolean);
             _payloadType = ArrayTypeSymbol.CreateCSharpArray(methodBodyFactory.Compilation.Assembly, payloadElementType);
-            _methodPayload = methodBodyFactory.SynthesizedLocal(_payloadType, kind: SynthesizedLocalKind.InstrumentationPayload, syntax: methodBody.Syntax);
             _diagnostics = diagnostics;
             _debugDocumentProvider = debugDocumentProvider;
             _methodBodyFactory = methodBodyFactory;
 
+            // Set the factory context to generate nodes for the current method
+            var oldMethod = methodBodyFactory.CurrentMethod;
+            methodBodyFactory.CurrentMethod = method;
+
+            _methodPayload = methodBodyFactory.SynthesizedLocal(_payloadType, kind: SynthesizedLocalKind.InstrumentationPayload, syntax: methodBody.Syntax);
             // The first point indicates entry into the method and has the span of the method definition.
             SyntaxNode syntax = MethodDeclarationIfAvailable(methodBody.Syntax);
             if (!method.IsImplicitlyDeclared)
             {
                 _methodEntryInstrumentation = AddAnalysisPoint(syntax, SkipAttributes(syntax), methodBodyFactory);
             }
+
+            // Restore context
+            methodBodyFactory.CurrentMethod = oldMethod;
         }
 
         private static bool IsExcludedFromCodeCoverage(MethodSymbol method)

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -547,11 +547,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // mark the variable as captured in each enclosing lambda up to the variable's point of declaration.
                     while ((object)lambda != null &&
                            symbol != lambda &&
-                           symbol.ContainingSymbol != lambda)
+                           symbol.ContainingSymbol != lambda &&
+                           // Necessary because the EE can insert non-closure synthesized method symbols
+                           IsClosure(lambda))
                     {
                         CapturedVariablesByLambda.Add(lambda, symbol);
                         lambda = lambda.ContainingSymbol as MethodSymbol;
                     }
+                }
+            }
+
+            private static bool IsClosure(MethodSymbol symbol)
+            {
+                switch (symbol.MethodKind)
+                {
+                    case MethodKind.LambdaMethod:
+                    case MethodKind.LocalFunction:
+                        return true;
+
+                    default:
+                        return false;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -546,26 +546,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // mark the variable as captured in each enclosing lambda up to the variable's point of declaration.
                     while ((object)lambda != null &&
-                           IsLambdaOrLocalFunction(lambda) &&
                            symbol != lambda &&
                            symbol.ContainingSymbol != lambda)
                     {
                         CapturedVariablesByLambda.Add(lambda, symbol);
                         lambda = lambda.ContainingSymbol as MethodSymbol;
                     }
-                }
-            }
-
-            private static bool IsLambdaOrLocalFunction(MethodSymbol method)
-            {
-                switch (method.MethodKind)
-                {
-                    case MethodKind.AnonymousFunction:
-                    case MethodKind.LocalFunction:
-                        return true;
-
-                    default:
-                        return false;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public readonly HashSet<MethodSymbol> MethodsConvertedToDelegates = new HashSet<MethodSymbol>();
 
             /// <summary>
-            /// True if the method signature can't be rewritten to contain ref/out parameters.
+            /// True if the method signature can be rewritten to contain ref/out parameters.
             /// </summary>
             public bool CanTakeRefParameters(MethodSymbol closure) => !(closure.IsAsync
                                                                         || closure.IsIterator
@@ -533,25 +533,39 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private void ReferenceVariable(SyntaxNode syntax, Symbol symbol)
             {
-                var localSymbol = symbol as LocalSymbol;
-                if ((object)localSymbol != null && localSymbol.IsConst)
+                if (symbol is LocalSymbol localSymbol && localSymbol.IsConst)
                 {
                     // "constant variables" need not be captured
                     return;
                 }
 
-                // using generic MethodSymbol here and not LambdaSymbol because of local functions
-                MethodSymbol lambda = _currentParent as MethodSymbol;
                 // "symbol == lambda" could happen if we're recursive
-                if ((object)lambda != null && symbol != lambda && symbol.ContainingSymbol != lambda)
+                if (_currentParent is MethodSymbol lambda && symbol != lambda && symbol.ContainingSymbol != lambda)
                 {
                     CapturedVariables.Add(symbol, syntax);
 
                     // mark the variable as captured in each enclosing lambda up to the variable's point of declaration.
-                    for (; (object)lambda != null && symbol != lambda && symbol.ContainingSymbol != lambda; lambda = lambda.ContainingSymbol as MethodSymbol)
+                    while ((object)lambda != null &&
+                           IsLambdaOrLocalFunction(lambda) &&
+                           symbol != lambda &&
+                           symbol.ContainingSymbol != lambda)
                     {
                         CapturedVariablesByLambda.Add(lambda, symbol);
+                        lambda = lambda.ContainingSymbol as MethodSymbol;
                     }
+                }
+            }
+
+            private static bool IsLambdaOrLocalFunction(MethodSymbol method)
+            {
+                switch (method.MethodKind)
+                {
+                    case MethodKind.AnonymousFunction:
+                    case MethodKind.LocalFunction:
+                        return true;
+
+                    default:
+                        return false;
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -332,9 +332,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var closure in closures)
             {
                 var capturedVars = _analysis.CapturedVariablesByLambda[closure];
+                bool canTakeRefParams = _analysis.CanTakeRefParameters(closure);
 
-                if (closure.MethodKind == MethodKind.LocalFunction &&
-                    OnlyCapturesThis((LocalFunctionSymbol)closure, capturedVars))
+                if (canTakeRefParams && OnlyCapturesThis((LocalFunctionSymbol)closure, capturedVars))
                 {
                     continue;
                 }
@@ -343,6 +343,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     BoundNode scope;
                     if (!_analysis.VariableScope.TryGetValue(captured, out scope))
+                    {
+                        continue;
+                    }
+
+                    // If this is a local function that can take ref params, skip
+                    // frame creation for local function calls. This is semantically
+                    // important because otherwise we may create a struct frame which
+                    // is empty, which crashes in emit.
+                    // This is not valid for lambdas or local functions which can't take
+                    // take ref params since they will be lowered into their own frames.
+                    if (canTakeRefParams && captured.Kind == SymbolKind.Method)
                     {
                         continue;
                     }
@@ -1338,15 +1349,34 @@ namespace Microsoft.CodeAnalysis.CSharp
                     closureKind = ClosureKind.Static;
                     closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
                 }
-                structClosures = default(ImmutableArray<TypeSymbol>);
+                structClosures = default;
             }
             else
             {
+                // GetStructClosures is currently overly aggressive in gathering
+                // closures since the only information it has at this point is
+                // NeedsParentFrame, which doesn't say what exactly is needed from
+                // the parent frame. If `this` is captured, that's enough to mark
+                // NeedsParentFrame for the current closure, so we need to gather
+                // struct closures for all intermediate frames, even if they only
+                // strictly need `this`.
+                if (_analysis.CanTakeRefParameters(node.Symbol))
+                {
+                    lambdaScope = _analysis.ScopeParent[node.Body];
+                    _ = _frames.TryGetValue(lambdaScope, out containerAsFrame);
+                    structClosures = GetStructClosures(
+                        containerAsFrame: containerAsFrame,
+                        lambdaScope: lambdaScope);
+                }
+                else
+                {
+                    structClosures = default;
+                }
+
                 containerAsFrame = null;
                 translatedLambdaContainer = _topLevelMethod.ContainingType;
                 closureKind = ClosureKind.ThisOnly;
                 closureOrdinal = LambdaDebugInfo.ThisOnlyClosureOrdinal;
-                structClosures = default(ImmutableArray<TypeSymbol>);
             }
 
             // Move the body of the lambda to a freshly generated synthetic method on its frame.

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -1364,9 +1364,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     lambdaScope = _analysis.ScopeParent[node.Body];
                     _ = _frames.TryGetValue(lambdaScope, out containerAsFrame);
-                    structClosures = GetStructClosures(
-                        containerAsFrame: containerAsFrame,
-                        lambdaScope: lambdaScope);
+                    structClosures = GetStructClosures(containerAsFrame, lambdaScope);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -31,7 +31,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class CodeGenLocalFunctionTests : CSharpTestBase
     {
         [Fact]
-        public void IntermediateStructClosures()
+        [WorkItem(18814, "https://github.com/dotnet/roslyn/issues/18814")]
+        [WorkItem(18918, "https://github.com/dotnet/roslyn/issues/18918")]
+        public void IntermediateStructClosures1()
         {
             CompileAndVerify(@"
 using System;
@@ -75,6 +77,32 @@ class C
 @"0
 1");
         }
+
+        [Fact]
+        [WorkItem(18814, "https://github.com/dotnet/roslyn/issues/18814")]
+        [WorkItem(18918, "https://github.com/dotnet/roslyn/issues/18918")]
+        public void IntermediateStructClosures2()
+        {
+            CompileAndVerify(@"
+class C
+{
+    int _x;
+    void M()
+    {
+        int y = 0;
+        void L1()
+        {
+            void L2()
+            {
+                int z = 0;
+                int L3() => z + _x;
+            }
+            y++;
+        }
+    }
+}");
+        }
+
         [Fact]
         [WorkItem(18814, "https://github.com/dotnet/roslyn/issues/18814")]
         public void Repro18814()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         [WorkItem(18918, "https://github.com/dotnet/roslyn/issues/18918")]
         public void IntermediateStructClosures1()
         {
-            CompileAndVerify(@"
+            var verifier = CompileAndVerify(@"
 using System;
 class C
 {
@@ -76,6 +76,60 @@ class C
 }", expectedOutput: 
 @"0
 1");
+            // L1
+            verifier.VerifyIL("C.<M>g__L12_0(ref C.<>c__DisplayClass2_1)", @"
+{
+  // Code size       13 (0xd)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""C C.<>c__DisplayClass2_1.<>4__this""
+  IL_0006:  ldarg.0
+  IL_0007:  call       ""void C.<M>g__L22_1(ref C.<>c__DisplayClass2_1)""
+  IL_000c:  ret
+}");
+            // L2
+            verifier.VerifyIL("C.<M>g__L22_1(ref C.<>c__DisplayClass2_1)", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  call       ""void C.<M>g__L32_2(ref C.<>c__DisplayClass2_1)""
+  IL_0007:  ret
+}");
+            // Skip some... L5
+            verifier.VerifyIL("C.<M>g__L52_4(ref C.<>c__DisplayClass2_1, ref C.<>c__DisplayClass2_0)", @"
+{
+  // Code size        9 (0x9)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  call       ""int C.<M>g__L62_5(ref C.<>c__DisplayClass2_1, ref C.<>c__DisplayClass2_0)""
+  IL_0007:  pop
+  IL_0008:  ret
+}");
+            // L6
+            verifier.VerifyIL("C.<M>g__L62_5(ref C.<>c__DisplayClass2_1, ref C.<>c__DisplayClass2_0)", @"
+{
+  // Code size       35 (0x23)
+  .maxstack  4
+  .locals init (int V_0)
+  IL_0000:  ldarg.1
+  IL_0001:  ldfld      ""int C.<>c__DisplayClass2_0.var2""
+  IL_0006:  ldarg.1
+  IL_0007:  ldfld      ""C C.<>c__DisplayClass2_0.<>4__this""
+  IL_000c:  ldarg.1
+  IL_000d:  ldfld      ""C C.<>c__DisplayClass2_0.<>4__this""
+  IL_0012:  ldfld      ""int C._x""
+  IL_0017:  stloc.0
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.1
+  IL_001a:  add
+  IL_001b:  stfld      ""int C._x""
+  IL_0020:  ldloc.0
+  IL_0021:  add
+  IL_0022:  ret
+}");
         }
 
         [Fact]


### PR DESCRIPTION
When lowering local functions that capture struct frames, the frames are
added as ref parameters to the lowered method. Normally, when the local
function captures variables from multiple levels up the intermediate
closures are also rewritten to take the ref parameters. However, if one
of the intermediate closures captures no variables, the closure
conversion code can skip adding ref environments to that closure. This
can cause the inner-most closure to no longer have access to all of the
ref structs it expects, which crashes the compiler.

Fixes #18814, #18918

**Customer scenario**

The minimal repro:

```csharp
class C
{
    int _x;
    void M()
    {
        int y = 0;
        void L1()
        {
            void L2()
            {
                int z = 0;
                int L3() => z + _x;
            }
            y++;
        }
    }
}
```

This crashes the compiler. 

**Bugs this fixes:**

#18814, #18918, https://devdiv.visualstudio.com/DevDiv/_workitems?id=285651

**Workarounds, if any**

None

**Risk**

This change is conservative in that it only adds extra struct parameters that may not be used.

**Performance impact**

Low. Allocates an extra array that grows with the depth of nested local functions.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This is a somewhat complex local function scenario. The bug is due to information mismatch
between the analysis phase, frame creation, and rewriting. Analysis currently uses the 
NeedsParentFrame list to track closure nesting. This is one bit of information per scope, which
isn't enough to properly check the coherence of frame capturing at the point of rewriting, which
is where the frame capturing is actually done.

If frame capturing analysis were moved into the analysis phase this could be more easily validated
and make bugs like this much less likely to be found by users.

**How was the bug found?**

Customer reported.
