### PR TITLE
Optimize fast path for "Use 'var'" code style

### DIFF
--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -83,8 +83,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                 var declaration = (ForEachStatementSyntax)declarationStatement;
                 declaredType = declaration.Type;
 
-                state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
-                shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                shouldAnalyze = ShouldAnalyzeForEachStatement(declaration, semanticModel, cancellationToken);
+
+                if (shouldAnalyze)
+                {
+                    state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
+                    shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                }
             }
             else
             {
@@ -107,7 +112,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         private Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode declaration, TextSpan diagnosticSpan) =>
             Diagnostic.Create(descriptor, declaration.SyntaxTree.GetLocation(diagnosticSpan));
 
-        private bool ShouldAnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+        protected virtual bool ShouldAnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
             // implict type is applicable only for local variables and
             // such declarations cannot have multiple declarators and
@@ -121,5 +126,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                    variableDeclaration.Variables.Count == 1 &&
                    variableDeclaration.Variables.Single().Initializer.IsKind(SyntaxKind.EqualsValueClause);
         }
+
+        protected virtual bool ShouldAnalyzeForEachStatement(ForEachStatementSyntax forEachStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
+            => true;
     }
 }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
@@ -28,6 +28,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         {
         }
 
+        protected override bool ShouldAnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (!variableDeclaration.Type.IsVar)
+            {
+                // If the type is not 'var', this analyze has no work to do
+                return false;
+            }
+
+            // The base analyzer may impose further limitations
+            return base.ShouldAnalyzeVariableDeclaration(variableDeclaration, semanticModel, cancellationToken);
+        }
+
+        protected override bool ShouldAnalyzeForEachStatement(ForEachStatementSyntax forEachStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (!forEachStatement.Type.IsVar)
+            {
+                // If the type is not 'var', this analyze has no work to do
+                return false;
+            }
+
+            // The base analyzer may impose further limitations
+            return base.ShouldAnalyzeForEachStatement(forEachStatement, semanticModel, cancellationToken);
+        }
+
         protected override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
         {
             var stylePreferences = state.TypeStylePreference;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -29,6 +30,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         {
         }
 
+        protected override bool ShouldAnalyzeVariableDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (variableDeclaration.Type.IsVar)
+            {
+                // If the type is already 'var', this analyze has no work to do
+                return false;
+            }
+
+            // The base analyzer may impose further limitations
+            return base.ShouldAnalyzeVariableDeclaration(variableDeclaration, semanticModel, cancellationToken);
+        }
+
+        protected override bool ShouldAnalyzeForEachStatement(ForEachStatementSyntax forEachStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (forEachStatement.Type.IsVar)
+            {
+                // If the type is already 'var', this analyze has no work to do
+                return false;
+            }
+
+            // The base analyzer may impose further limitations
+            return base.ShouldAnalyzeForEachStatement(forEachStatement, semanticModel, cancellationToken);
+        }
+
         protected override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
         {
             var stylePreferences = state.TypeStylePreference;
@@ -56,12 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
         protected override bool TryAnalyzeVariableDeclaration(TypeSyntax typeName, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken, out TextSpan issueSpan)
         {
-            // If it is already var, return.
-            if (typeName.IsTypeInferred(semanticModel))
-            {
-                issueSpan = default(TextSpan);
-                return false;
-            }
+            Debug.Assert(!typeName.IsVar, "'var' special case should have prevented analysis of this variable.");
 
             var candidateReplacementNode = SyntaxFactory.IdentifierName("var");
             var candidateIssueSpan = typeName.Span;


### PR DESCRIPTION
| Scenario | Improvement (sec) | Improvement (%) |
| --- | --- | --- |
| Use `IsVar` instead of `IsTypeInferred` (original attempt) | 0.1 | 0.1% |
| Avoid analysis altogether (current attempt) | 20 | 15% |

## Ask Mode

**Customer scenario**

Apply a Fix All operation related to type style (Use `var`, or avoid `var`). The operation takes a long time in large solutions.

**Bugs this fixes:**

This is a measurable, observable improvement to [Code fix for solution is really slow](https://developercommunity.visualstudio.com/content/problem/67372/code-fix-for-solution-is-really-slow.html). @onovotny provided additional clarification that "Use 'var'" was the code fix in question.

**Workarounds, if any**

Wait longer.

**Risk**

Low. This change eliminates an analysis for a case where it is readily observed that the analysis is unnecessary.

**Performance impact**

15% improvement to Fix All in solution for this code fix; details provided above.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Failure to profile code fixes on large solutions.

**How was the bug found?**

Reported by @onovotny on VS Feedback.
