### PR TITLE
Intercept access to interface members known to be not-supported by the target runtime.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -457,10 +457,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// overload resolution.
         /// </summary>
         /// <returns>
-        /// True if there is any error.
+        /// True if there is any error, except lack of runtime support errors.
         /// </returns>
         private bool MemberGroupFinalValidation(BoundExpression receiverOpt, MethodSymbol methodSymbol, SyntaxNode node, DiagnosticBag diagnostics, bool invokedAsExtensionMethod)
         {
+            CheckRuntimeSupportForSymbolAccess(node, methodSymbol, diagnostics);
+
             if (MemberGroupFinalValidationAccessibilityChecks(receiverOpt, methodSymbol, node, diagnostics, invokedAsExtensionMethod))
             {
                 return true;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -6091,7 +6091,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 WarnOnAccessOfOffDefault(node, receiver, diagnostics);
             }
 
+            CheckRuntimeSupportForSymbolAccess(node, propertySymbol, diagnostics);
+
             return new BoundPropertyAccess(node, receiver, propertySymbol, lookupResult, propertySymbol.Type, hasErrors: (hasErrors || hasError));
+        }
+
+        private void CheckRuntimeSupportForSymbolAccess(SyntaxNode node, Symbol symbol, DiagnosticBag diagnostics)
+        {
+            if (!symbol.IsStatic && symbol.ContainingType.IsInterface && !symbol.IsImplementableInterfaceMember() &&
+                !Compilation.Assembly.RuntimeSupportsDefaultInterfaceImplementation)
+            {
+                Error(diagnostics, ErrorCode.ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation, node);
+            }
         }
 
         private BoundExpression BindEventAccess(
@@ -6112,6 +6123,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 WarnOnAccessOfOffDefault(node, receiver, diagnostics);
             }
+
+            CheckRuntimeSupportForSymbolAccess(node, eventSymbol, diagnostics);
 
             return new BoundEventAccess(node, receiver, eventSymbol, isUsableAsField, lookupResult, eventSymbol.Type, hasErrors: (hasErrors || hasError));
         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -5975,7 +5975,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; specified for Main method must be a valid non-generic class or struct.
+        ///   Looks up a localized string similar to &apos;{0}&apos; specified for Main method must be a valid non-generic class or struct or interface.
         /// </summary>
         internal static string ERR_MainClassNotClass {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2510,7 +2510,7 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
     <value>Could not find '{0}' specified for Main method</value>
   </data>
   <data name="ERR_MainClassNotClass" xml:space="preserve">
-    <value>'{0}' specified for Main method must be a valid non-generic class or struct</value>
+    <value>'{0}' specified for Main method must be a valid non-generic class or struct or interface</value>
   </data>
   <data name="ERR_NoMainInClass" xml:space="preserve">
     <value>'{0}' does not have a suitable static Main method</value>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1427,7 +1427,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     mainType = mainTypeOrNamespace as NamedTypeSymbol;
-                    if ((object)mainType == null || mainType.IsGenericType || (mainType.TypeKind != TypeKind.Class && mainType.TypeKind != TypeKind.Struct))
+                    if ((object)mainType == null || mainType.IsGenericType || (mainType.TypeKind != TypeKind.Class && mainType.TypeKind != TypeKind.Struct && !mainType.IsInterface))
                     {
                         diagnostics.Add(ErrorCode.ERR_MainClassNotClass, mainTypeOrNamespace.Locations.First(), mainTypeOrNamespace);
                         return null;

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1802,21 +1802,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static SyntaxToken GetImplicitConstructorBodyToken(CSharpSyntaxNode containerNode)
         {
-            var kind = containerNode.Kind();
-            switch (kind)
-            {
-                case SyntaxKind.ClassDeclaration:
-                    return ((ClassDeclarationSyntax)containerNode).OpenBraceToken;
-                case SyntaxKind.InterfaceDeclaration:
-                    return ((InterfaceDeclarationSyntax)containerNode).OpenBraceToken;
-                case SyntaxKind.StructDeclaration:
-                    return ((StructDeclarationSyntax)containerNode).OpenBraceToken;
-                case SyntaxKind.EnumDeclaration:
-                    // We're not going to find any non-default ctors, but we'll look anyway.
-                    return ((EnumDeclarationSyntax)containerNode).OpenBraceToken;
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(kind);
-            }
+            return ((BaseTypeDeclarationSyntax)containerNode).OpenBraceToken;
         }
 
         internal static BoundCall GenerateObjectConstructorInitializer(MethodSymbol constructor, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -251,7 +251,7 @@ namespace N { namespace M { } }
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseExe.WithMainTypeName("N.M"));
             compilation.VerifyDiagnostics(
-                // (2,25): error CS1556: 'N.M' specified for Main method must be a valid non-generic class or struct
+                // (2,25): error CS1556: 'N.M' specified for Main method must be a valid non-generic class or struct or interface
                 Diagnostic(ErrorCode.ERR_MainClassNotClass, "M").WithArguments("N.M"));
         }
 
@@ -269,7 +269,7 @@ class C<T>
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseExe.WithMainTypeName("C.D"));
             compilation.VerifyDiagnostics(
-                // (4,12): error CS1556: 'C<T>.D' specified for Main method must be a valid non-generic class or struct
+                // (4,12): error CS1556: 'C<T>.D' specified for Main method must be a valid non-generic class or struct or interface
                 Diagnostic(ErrorCode.ERR_MainClassNotClass, "D").WithArguments("C<T>.D"));
         }
 
@@ -343,7 +343,7 @@ public static class E
             // Dev10 reports: CS1555: Could not find 'D.DD' specified for Main method
             compilation = CreateStandardCompilation(cs, options: TestOptions.ReleaseExe.WithMainTypeName("D.DD"));
             compilation.VerifyDiagnostics(
-                // (18,25): error CS1556: 'D<T>.DD' specified for Main method must be a valid non-generic class or struct
+                // (18,25): error CS1556: 'D<T>.DD' specified for Main method must be a valid non-generic class or struct or interface
                 Diagnostic(ErrorCode.ERR_MainClassNotClass, "DD").WithArguments("D<T>.DD"));
         }
 
@@ -420,7 +420,7 @@ public class A
 }";
             // Dev10 reports CS1555: Could not find 'A.B.C' specified for Main method
             CreateStandardCompilation(source, options: TestOptions.ReleaseExe.WithMainTypeName("A.B.C")).VerifyDiagnostics(
-                // (14,11): error CS1556: 'A.B<T>.C' specified for Main method must be a valid non-generic class or struct
+                // (14,11): error CS1556: 'A.B<T>.C' specified for Main method must be a valid non-generic class or struct or interface
                 Diagnostic(ErrorCode.ERR_MainClassNotClass, "C").WithArguments("A.B<T>.C"));
         }
 
@@ -465,7 +465,7 @@ class C<T>
 ";
             var compilation = CreateStandardCompilation(source, options: TestOptions.ReleaseExe.WithMainTypeName("C"));
             compilation.VerifyDiagnostics(
-                // (7,7): error CS1556: 'C<T>' specified for Main method must be a valid non-generic class or struct
+                // (7,7): error CS1556: 'C<T>' specified for Main method must be a valid non-generic class or struct or interface
                 Diagnostic(ErrorCode.ERR_MainClassNotClass, "C").WithArguments("C<T>"));
         }
 
@@ -709,8 +709,10 @@ interface I { }
                 options: TestOptions.ReleaseExe.WithMainTypeName("I"));
 
             compilation.VerifyDiagnostics(
-                // (4,11): error CS1556: 'I' specified for Main method must be a valid class or struct
-                Diagnostic(ErrorCode.ERR_MainClassNotClass, "I").WithArguments("I"));
+                // (4,11): error CS1558: 'I' does not have a suitable static Main method
+                // interface I { }
+                Diagnostic(ErrorCode.ERR_NoMainInClass, "I").WithArguments("I").WithLocation(4, 11)
+                );
         }
 
         [Fact]


### PR DESCRIPTION
@dotnet/roslyn-compiler Please review.