### PR TITLE
Update CreateProjectInfo to accept relative analyzer paths

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/CommandLineProject.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/CommandLineProject.cs
@@ -36,8 +36,10 @@ namespace Microsoft.CodeAnalysis
             var metadataService = tmpWorkspace.Services.GetRequiredService<IMetadataService>();
 
             // we only support file paths in /r command line arguments
+            var relativePathResolver =
+                new RelativePathResolver(commandLineArguments.ReferencePaths, commandLineArguments.BaseDirectory);
             var commandLineMetadataReferenceResolver = new WorkspaceMetadataFileReferenceResolver(
-                metadataService, new RelativePathResolver(commandLineArguments.ReferencePaths, commandLineArguments.BaseDirectory));
+                metadataService, relativePathResolver);
 
             var analyzerLoader = tmpWorkspace.Services.GetRequiredService<IAnalyzerService>().GetLoader();
             var xmlFileResolver = new XmlFileResolver(commandLineArguments.BaseDirectory);
@@ -54,7 +56,7 @@ namespace Microsoft.CodeAnalysis
             // resolve all analyzer references.
             foreach (var path in commandLineArguments.AnalyzerReferences.Select(r => r.FilePath))
             {
-                analyzerLoader.AddDependencyLocation(path);
+                analyzerLoader.AddDependencyLocation(relativePathResolver.ResolvePath(path, baseFilePath: null));
             }
 
             var boundAnalyzerReferences = commandLineArguments.ResolveAnalyzerReferences(analyzerLoader);

--- a/src/Workspaces/CoreTest/WorkspaceTests/CommandLineProjectTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceTests/CommandLineProjectTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -109,6 +110,21 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var secondDoc = info.AdditionalDocuments.Single();
             Assert.Equal("foo.cs", firstDoc.Name);
             Assert.Equal("bar.cs", secondDoc.Name);
+        }
+
+        [Fact]
+        public void TestAnalyzerReferences()
+        {
+            var pathToAssembly = typeof(object).Assembly.Location;
+            var assemblyBaseDir = Path.GetDirectoryName(pathToAssembly);
+            var relativePath = Path.Combine(".", Path.GetFileName(pathToAssembly));
+            string commandLine = @"foo.cs /a:" + relativePath;
+            var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, assemblyBaseDir);
+
+            var firstDoc = info.Documents.Single();
+            var analyzerRef = info.AnalyzerReferences.First();
+            Assert.Equal("foo.cs", firstDoc.Name);
+            Assert.Equal(pathToAssembly, analyzerRef.FullPath);
         }
     }
 }


### PR DESCRIPTION
I try to use CommandLineProject.CreateProjectInfo to create a ProjectInfo from a command line that contains an analyzer reference:
```
/analyzer:..\\packages\\Microsoft.CodeAnalysis.Analyzers.1.1.0\\analyzers\\dotnet\\cs\\Microsoft.CodeAnalysis.Analyzers.dll
```

Roslyn 1.3.4 successfully handles such references, however  Roslyn 2.2.0  does not convert a relative path 
to an absolute path for analyzer references. Thus creation of ProjectInfo fails with an exception:
```
System.ArgumentException occurred
  HResult=0x80070057
  Message=Absolute path expected.
  Source=Microsoft.CodeAnalysis.Workspaces
  StackTrace:
   at Roslyn.Utilities.CompilerPathUtilities.RequireAbsolutePath(String path, String argumentName) in G:\csharp\roslyn\src\Workspaces\Core\Portable\Utilities\CompilerUtilities\CompilerPathUtilities.cs:line 19
   at Microsoft.CodeAnalysis.AnalyzerAssemblyLoader.AddDependencyLocation(String fullPath) in G:\csharp\roslyn\src\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.cs:line 30
   at Microsoft.CodeAnalysis.CommandLineProject.CreateProjectInfo(String projectName, String language, IEnumerable`1 commandLineArgs, String projectDirectory, Workspace workspace) in G:\csharp\roslyn\src\Workspaces\Core\Desktop\Workspace\CommandLineProject.cs:line 57
   at Microsoft.CodeAnalysis.CommandLineProject.CreateProjectInfo(String projectName, String language, String commandLine, String baseDirectory, Workspace workspace) in G:\csharp\roslyn\src\Workspaces\Core\Desktop\Workspace\CommandLineProject.cs:line 179
   at OpenCmdLineTestNuget.Program.Main(String[] args) in C:\Users\vedun\Documents\Visual Studio 
```

To resolve the issue I have changed
```
 analyzerLoader.AddDependencyLocation(path) // path to an analyzer reference
```
to
```
analyzerLoader.AddDependencyLocation(relativePathResolver.ResolvePath(path, null))
```

**Bugs this fixes:**

Fixes #20187

**Risk**

The patch affects only code that does not work properly anyway.

**Performance impact**

No performance impact

**Is this a regression from a previous update?**

Yes, 1.3.4 -> 2.2.0 regression.
**Root cause analysis:**

Roslyn does not have a test that checks creation of ProjectInfo from a command line with analyzer references.

**How was the bug found?**

Migration from 1.3.4 to 2.2.0 breaks our internal tests.


