### PR TITLE
Disable integration tests while investigating

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -221,8 +221,8 @@ commitPullList.each { isPr ->
         }
       }
 
-      def triggerPhraseOnly = false
-      def triggerPhraseExtra = ""
+      def triggerPhraseOnly = true
+      def triggerPhraseExtra = "vsintegration"
       Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-dev15-3-preview2')
       Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
       addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)


### PR DESCRIPTION
Looks like there is still fall out from the licensing issue.  VS integration tests still failing
at 100% due to a timeout issue.  Change them to not run by default while we look into this.

Can still be run manually for testing with

test vsintegration please
