### PR TITLE
Assert that we have actually subscribed before calling EnsureSubscription

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
@@ -57,6 +57,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public void EnsureSubscription()
         {
+            Contract.ThrowIfTrue(_fileChangeCookie == s_none);
+
             // make sure we have file notification subscribed
             var unused = _fileChangeCookie.Value;
         }


### PR DESCRIPTION
@Pilchie realized we didn't have this, and it's a good idea.

**Review:** @dotnet/roslyn-ide