### PR TITLE
make new features dependent on 7.2 version

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -196,12 +196,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Checks are in the LanguageParser unless otherwise noted.
             switch (feature)
             {
-                //PROTOTYPE(readonlyRefs): these are all 7.2 features we need to update this.
-                // C# 7.1 features.
+                // C# 7.2 features.
                 case MessageID.IDS_FeatureReadonlyReferences:
                 case MessageID.IDS_FeatureRefStructs:
                 case MessageID.IDS_FeatureReadOnlyStructs:
-                    return LanguageVersion.CSharp7_1;
+                    return LanguageVersion.CSharp7_2;
 
                 // C# 7.1 features.
                 case MessageID.IDS_FeatureAsyncMain:

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2879,9 +2879,9 @@ public class Test
 }";
 
             ParseAndValidate(code, new CSharpParseOptions(LanguageVersion.CSharp7),
-                // (4,29): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.1 or greater.
+                // (4,29): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
                 //     public void DoSomething(in int x) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "in").WithArguments("readonly references", "7.1")
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "in").WithArguments("readonly references", "7.2").WithLocation(4, 29)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ReadOnlyStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ReadOnlyStructs.cs
@@ -73,15 +73,15 @@ class Program
 
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
-                // (4,5): error CS8107: Feature 'readonly structs' is not available in C# 7. Please use language version 7.1 or greater.
+                // (4,5): error CS8107: Feature 'readonly structs' is not available in C# 7. Please use language version 7.2 or greater.
                 //     readonly struct S1{}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly structs", "7.1").WithLocation(4, 5),
-                // (6,12): error CS8107: Feature 'readonly structs' is not available in C# 7. Please use language version 7.1 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly structs", "7.2").WithLocation(4, 5),
+                // (6,12): error CS8107: Feature 'readonly structs' is not available in C# 7. Please use language version 7.2 or greater.
                 //     public readonly struct S2{}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly structs", "7.1").WithLocation(6, 12),
-                // (8,5): error CS8107: Feature 'readonly structs' is not available in C# 7. Please use language version 7.1 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly structs", "7.2").WithLocation(6, 12),
+                // (8,5): error CS8107: Feature 'readonly structs' is not available in C# 7. Please use language version 7.2 or greater.
                 //     readonly public struct S3{}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly structs", "7.1").WithLocation(8, 5)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly structs", "7.2").WithLocation(8, 5)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyReturnsTests.cs
@@ -40,18 +40,18 @@ unsafe class Program
 
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
-                // (4,18): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.1 or greater.
+                // (4,18): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
                 //     delegate ref readonly int D1();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.1").WithLocation(4, 18),
-                // (6,16): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.1 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.2").WithLocation(4, 18),
+                // (6,16): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
                 //     static ref readonly T M<T>()
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.1").WithLocation(6, 16),
-                // (11,24): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.1 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.2").WithLocation(6, 16),
+                // (11,24): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
                 //     public virtual ref readonly int* P1 => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.1").WithLocation(11, 24),
-                // (13,16): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.1 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.2").WithLocation(11, 24),
+                // (13,16): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
                 //     public ref readonly int[][] this[int i] => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.1")
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.2").WithLocation(13, 16)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefReadonlyReturnsTests.cs
@@ -38,20 +38,20 @@ unsafe class Program
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
-                // (4,18): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
+                // (4,18): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     delegate ref readonly int D1();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.2").WithLocation(4, 18),
-                // (6,16): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(4, 18),
+                // (6,16): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     static ref readonly T M<T>()
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.2").WithLocation(6, 16),
-                // (11,24): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(6, 16),
+                // (11,24): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public virtual ref readonly int* P1 => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.2").WithLocation(11, 24),
-                // (13,16): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(11, 24),
+                // (13,16): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public ref readonly int[][] this[int i] => throw null;
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "readonly").WithArguments("readonly references", "7.2").WithLocation(13, 16)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(13, 16)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RefStructs.cs
@@ -49,12 +49,12 @@ class Program
 
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7), options: TestOptions.DebugDll);
             comp.VerifyDiagnostics(
-                // (4,5): error CS8107: Feature 'ref structs' is not available in C# 7. Please use language version 7.1 or greater.
+                // (4,5): error CS8107: Feature 'ref structs' is not available in C# 7. Please use language version 7.2 or greater.
                 //     ref struct S1{}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.1").WithLocation(4, 5),
-                // (6,12): error CS8107: Feature 'ref structs' is not available in C# 7. Please use language version 7.1 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(4, 5),
+                // (6,12): error CS8107: Feature 'ref structs' is not available in C# 7. Please use language version 7.2 or greater.
                 //     public ref struct S2{}
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.1").WithLocation(6, 12)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "ref").WithArguments("ref structs", "7.2").WithLocation(6, 12)
             );
         }
 
@@ -106,7 +106,7 @@ class Program
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp7_1), options: TestOptions.DebugDll);
+            var comp = CreateCompilationWithMscorlib45(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest), options: TestOptions.DebugDll);
             comp.VerifyDiagnostics();
         }
     }


### PR DESCRIPTION
We were initially using 7.1, mostly because 7.2 was not available at the time.
Should use 7.2 now.