### PR TITLE
get ParseOptions from ProjectState rather than calculate one itself

### DIFF
--- a/src/EditorFeatures/TestUtilities/TestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/TestExportProvider.cs
@@ -74,6 +74,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 typeof(VisualBasic.LanguageServices.VisualBasicContentTypeLanguageService),
                 typeof(CodeAnalysis.CSharp.Execution.CSharpOptionsSerializationService),
                 typeof(CodeAnalysis.VisualBasic.Execution.VisualBasicOptionsSerializationService),
+                typeof(CodeAnalysis.Execution.DesktopReferenceSerializationServiceFactory),
                 typeof(TestExportProvider)
             };
 

--- a/src/Workspaces/Core/Desktop/Execution/DesktopReferenceSerializationServiceFactory.cs
+++ b/src/Workspaces/Core/Desktop/Execution/DesktopReferenceSerializationServiceFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Execution
     /// this is desktop implementation of IReferenceSerializationService
     /// </summary>
     [ExportWorkspaceServiceFactory(typeof(IReferenceSerializationService), layer: ServiceLayer.Desktop), Shared]
-    internal class ReferenceSerializationServiceFactory : IWorkspaceServiceFactory
+    internal class DesktopReferenceSerializationServiceFactory : IWorkspaceServiceFactory
     {
         private static readonly SerializationAnalyzerAssemblyLoader s_loader = new SerializationAnalyzerAssemblyLoader();
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Persistence.cs
@@ -80,14 +80,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // any time the SyntaxTree could have changed.  Right now, that can only happen if the
             // text of the document changes, or the ParseOptions change.  So we get the checksums
             // for both of those, and merge them together to make the final checksum.
+            var projectChecksumState = await document.Project.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
+            var parseOptionsChecksum = projectChecksumState.ParseOptions;
 
             var documentChecksumState = await document.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
             var textChecksum = documentChecksumState.Text;
-
-            var parseOptions = document.Project.ParseOptions;
-            var serializer = new Serializer(document.Project.Solution.Workspace);
-            var parseOptionsChecksum = ChecksumCache.GetOrCreate(
-                parseOptions, _ => serializer.CreateChecksum(parseOptions, cancellationToken));
 
             return Checksum.Create(WellKnownSynchronizationKind.SyntaxTreeIndex, new[] { textChecksum, parseOptionsChecksum });
         }


### PR DESCRIPTION
**Customer scenario**

User changed a text and a few seconds later, VS might crash if the project that the file user changed belong to has certain characteristic. 

**Bugs this fixes:**

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=450950&_a=edit&triage=true

**Workarounds, if any**

There is no workaround user can do

**Risk**

Low. Fix is removing code and let it reuse data already calculated in other place. so risk should be pretty low. 

**Performance impact**

There should be no difference.

**Is this a regression from a previous update?**

No. this is new code we recently added in 15.3

**Root cause analysis:**

Didn't check null before using it for key in CWT

**How was the bug found?**

Watson