### PR TITLE
Optimize Checksum memory usage

### DIFF
--- a/src/VisualStudio/Core/Test.Next/Remote/JsonConverterTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/JsonConverterTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Execution;
+using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.TodoComments;
 using Newtonsoft.Json;
@@ -22,7 +23,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public void TestChecksum()
         {
-            VerifyJsonSerialization(new Checksum(Guid.NewGuid().ToByteArray()));
+            var checksum = Checksum.Create(WellKnownSynchronizationKind.Null, ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray()));
+            VerifyJsonSerialization(checksum);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
@@ -130,7 +132,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         [Fact, Trait(Traits.Feature, Traits.Features.RemoteHost)]
         public void TestPinnedSolutionInfo()
         {
-            VerifyJsonSerialization(new PinnedSolutionInfo(scopeId: 10, fromPrimaryBranch: false, solutionChecksum: new Checksum(new byte[] { 1, 2, 3, 4, 5, 6 })), (x, y) =>
+            var checksum = Checksum.Create(WellKnownSynchronizationKind.Null, ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray()));
+            VerifyJsonSerialization(new PinnedSolutionInfo(scopeId: 10, fromPrimaryBranch: false, solutionChecksum: checksum), (x, y) =>
             {
                 return (x.ScopeId == y.ScopeId && x.FromPrimaryBranch == y.FromPrimaryBranch && x.SolutionChecksum == y.SolutionChecksum) ? 0 : 1;
             });

--- a/src/VisualStudio/Core/Test.Next/Services/AssetServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetServiceTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Remote.DebugUtil;
+using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Roslyn.VisualStudio.Next.UnitTests.Mocks;
@@ -22,7 +24,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         public async Task TestAssets()
         {
             var sessionId = 0;
-            var checksum = new Checksum(Guid.NewGuid().ToByteArray());
+            var checksum = Checksum.Create(WellKnownSynchronizationKind.Null, ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray()));
             var data = new object();
 
             var storage = new AssetStorage();

--- a/src/VisualStudio/Core/Test.Next/Services/AssetStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/AssetStorageTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Remote;
+using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Test.Utilities;
 using Roslyn.VisualStudio.Next.UnitTests.Mocks;
 using Xunit;
@@ -27,7 +29,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         {
             var storage = new AssetStorage();
 
-            var checksum = new Checksum(Guid.NewGuid().ToByteArray());
+            var checksum = Checksum.Create(WellKnownSynchronizationKind.Null, ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray()));
             var data = new object();
 
             Assert.True(storage.TryAddAsset(checksum, data));
@@ -41,7 +43,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         {
             var storage = new AssetStorage(cleanupInterval: TimeSpan.FromMilliseconds(1), purgeAfter: TimeSpan.FromMilliseconds(2));
 
-            var checksum = new Checksum(Guid.NewGuid().ToByteArray());
+            var checksum = Checksum.Create(WellKnownSynchronizationKind.Null, ImmutableArray.CreateRange(Guid.NewGuid().ToByteArray()));
             var data = new object();
 
             Assert.True(storage.TryAddAsset(checksum, data));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -16,12 +16,13 @@ namespace Microsoft.CodeAnalysis
     {
         public static readonly Checksum Null = new Checksum(Array.Empty<byte>());
 
+        /// <summary>
+        /// This structure stores the 20-byte SHA 1 hash as an inline value rather than requiring the use of
+        /// <c>byte[]</c>.
+        /// </summary>
         [StructLayout(LayoutKind.Explicit, Size = 20)]
         private struct Sha1Hash : IEquatable<Sha1Hash>
         {
-            [FieldOffset(0)]
-            public unsafe fixed byte Value[20];
-
             [FieldOffset(0)]
             private long Data1;
 
@@ -32,14 +33,10 @@ namespace Microsoft.CodeAnalysis
             private int Data3;
 
             public static bool operator ==(Sha1Hash x, Sha1Hash y)
-            {
-                return x.Equals(y);
-            }
+                => x.Equals(y);
 
             public static bool operator !=(Sha1Hash x, Sha1Hash y)
-            {
-                return !x.Equals(y);
-            }
+                => !x.Equals(y);
 
             public void WriteTo(ObjectWriter writer)
             {
@@ -64,14 +61,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             public override bool Equals(object obj)
-            {
-                if (!(obj is Sha1Hash other))
-                {
-                    return false;
-                }
-
-                return Equals(other);
-            }
+                => obj is Sha1Hash other && Equals(other);
 
             public bool Equals(Sha1Hash other)
             {
@@ -117,14 +107,10 @@ namespace Microsoft.CodeAnalysis
         }
 
         public override bool Equals(object obj)
-        {
-            return Equals(obj as Checksum);
-        }
+            => Equals(obj as Checksum);
 
         public override int GetHashCode()
-        {
-            return _checkSum.GetHashCode();
-        }
+            => _checkSum.GetHashCode();
 
         public override unsafe string ToString()
         {
@@ -148,14 +134,10 @@ namespace Microsoft.CodeAnalysis
         }
 
         public void WriteTo(ObjectWriter writer)
-        {
-            _checkSum.WriteTo(writer);
-        }
+            => _checkSum.WriteTo(writer);
 
         public static Checksum ReadFrom(ObjectReader reader)
-        {
-            return new Checksum(Sha1Hash.ReadFrom(reader));
-        }
+            => new Checksum(Sha1Hash.ReadFrom(reader));
 
         public static string GetChecksumLogInfo(Checksum checksum)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -16,61 +16,6 @@ namespace Microsoft.CodeAnalysis
     {
         public static readonly Checksum Null = new Checksum(Array.Empty<byte>());
 
-        /// <summary>
-        /// This structure stores the 20-byte SHA 1 hash as an inline value rather than requiring the use of
-        /// <c>byte[]</c>.
-        /// </summary>
-        [StructLayout(LayoutKind.Explicit, Size = 20)]
-        private struct Sha1Hash : IEquatable<Sha1Hash>
-        {
-            [FieldOffset(0)]
-            private long Data1;
-
-            [FieldOffset(8)]
-            private long Data2;
-
-            [FieldOffset(16)]
-            private int Data3;
-
-            public static bool operator ==(Sha1Hash x, Sha1Hash y)
-                => x.Equals(y);
-
-            public static bool operator !=(Sha1Hash x, Sha1Hash y)
-                => !x.Equals(y);
-
-            public void WriteTo(ObjectWriter writer)
-            {
-                writer.WriteInt64(Data1);
-                writer.WriteInt64(Data2);
-                writer.WriteInt32(Data3);
-            }
-
-            public static Sha1Hash ReadFrom(ObjectReader reader)
-            {
-                Sha1Hash result = default;
-                result.Data1 = reader.ReadInt64();
-                result.Data2 = reader.ReadInt64();
-                result.Data3 = reader.ReadInt32();
-                return result;
-            }
-
-            public override int GetHashCode()
-            {
-                // The checksum is already a hash. Just read a 4-byte value to get a well-distributed hash code.
-                return (int)Data1;
-            }
-
-            public override bool Equals(object obj)
-                => obj is Sha1Hash other && Equals(other);
-
-            public bool Equals(Sha1Hash other)
-            {
-                return Data1 == other.Data1
-                    && Data2 == other.Data2
-                    && Data3 == other.Data3;
-            }
-        }
-
         private Sha1Hash _checkSum;
 
         public unsafe Checksum(byte[] checksum)
@@ -147,6 +92,61 @@ namespace Microsoft.CodeAnalysis
         public static string GetChecksumsLogInfo(IEnumerable<Checksum> checksums)
         {
             return string.Join("|", checksums.Select(c => c.ToString()));
+        }
+
+        /// <summary>
+        /// This structure stores the 20-byte SHA 1 hash as an inline value rather than requiring the use of
+        /// <c>byte[]</c>.
+        /// </summary>
+        [StructLayout(LayoutKind.Explicit, Size = 20)]
+        private struct Sha1Hash : IEquatable<Sha1Hash>
+        {
+            [FieldOffset(0)]
+            private long Data1;
+
+            [FieldOffset(8)]
+            private long Data2;
+
+            [FieldOffset(16)]
+            private int Data3;
+
+            public static bool operator ==(Sha1Hash x, Sha1Hash y)
+                => x.Equals(y);
+
+            public static bool operator !=(Sha1Hash x, Sha1Hash y)
+                => !x.Equals(y);
+
+            public void WriteTo(ObjectWriter writer)
+            {
+                writer.WriteInt64(Data1);
+                writer.WriteInt64(Data2);
+                writer.WriteInt32(Data3);
+            }
+
+            public static Sha1Hash ReadFrom(ObjectReader reader)
+            {
+                Sha1Hash result = default;
+                result.Data1 = reader.ReadInt64();
+                result.Data2 = reader.ReadInt64();
+                result.Data3 = reader.ReadInt32();
+                return result;
+            }
+
+            public override int GetHashCode()
+            {
+                // The checksum is already a hash. Just read a 4-byte value to get a well-distributed hash code.
+                return (int)Data1;
+            }
+
+            public override bool Equals(object obj)
+                => obj is Sha1Hash other && Equals(other);
+
+            public bool Equals(Sha1Hash other)
+            {
+                return Data1 == other.Data1
+                    && Data2 == other.Data2
+                    && Data3 == other.Data3;
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Checksum.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
@@ -15,14 +16,94 @@ namespace Microsoft.CodeAnalysis
     {
         public static readonly Checksum Null = new Checksum(Array.Empty<byte>());
 
-        private readonly byte[] _checkSum;
-        private int _lazyHash;
-
-        public Checksum(byte[] checksum)
+        [StructLayout(LayoutKind.Explicit, Size = 20)]
+        private struct Sha1Hash : IEquatable<Sha1Hash>
         {
-            // 0 means it is not initialized
-            _lazyHash = 0;
-            _checkSum = checksum;
+            [FieldOffset(0)]
+            public unsafe fixed byte Value[20];
+
+            [FieldOffset(0)]
+            private long Data1;
+
+            [FieldOffset(8)]
+            private long Data2;
+
+            [FieldOffset(16)]
+            private int Data3;
+
+            public static bool operator ==(Sha1Hash x, Sha1Hash y)
+            {
+                return x.Equals(y);
+            }
+
+            public static bool operator !=(Sha1Hash x, Sha1Hash y)
+            {
+                return !x.Equals(y);
+            }
+
+            public void WriteTo(ObjectWriter writer)
+            {
+                writer.WriteInt64(Data1);
+                writer.WriteInt64(Data2);
+                writer.WriteInt32(Data3);
+            }
+
+            public static Sha1Hash ReadFrom(ObjectReader reader)
+            {
+                Sha1Hash result = default;
+                result.Data1 = reader.ReadInt64();
+                result.Data2 = reader.ReadInt64();
+                result.Data3 = reader.ReadInt32();
+                return result;
+            }
+
+            public override int GetHashCode()
+            {
+                // The checksum is already a hash. Just read a 4-byte value to get a well-distributed hash code.
+                return (int)Data1;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is Sha1Hash other))
+                {
+                    return false;
+                }
+
+                return Equals(other);
+            }
+
+            public bool Equals(Sha1Hash other)
+            {
+                return Data1 == other.Data1
+                    && Data2 == other.Data2
+                    && Data3 == other.Data3;
+            }
+        }
+
+        private Sha1Hash _checkSum;
+
+        public unsafe Checksum(byte[] checksum)
+        {
+            if (checksum.Length == 0)
+            {
+                _checkSum = default;
+                return;
+            }
+            else if (checksum.Length != sizeof(Sha1Hash))
+            {
+                throw new ArgumentException($"{nameof(checksum)} must be a SHA-1 hash", nameof(checksum));
+            }
+
+            fixed (byte* data = checksum)
+            {
+                _checkSum = *(Sha1Hash*)data;
+            }
+        }
+
+        private Checksum(Sha1Hash hash)
+        {
+            _checkSum = hash;
         }
 
         public bool Equals(Checksum other)
@@ -32,20 +113,7 @@ namespace Microsoft.CodeAnalysis
                 return false;
             }
 
-            if (_checkSum.Length != other._checkSum.Length)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < _checkSum.Length; i++)
-            {
-                if (_checkSum[i] != other._checkSum[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return _checkSum == other._checkSum;
         }
 
         public override bool Equals(object obj)
@@ -55,31 +123,18 @@ namespace Microsoft.CodeAnalysis
 
         public override int GetHashCode()
         {
-            if (_lazyHash == 0)
-            {
-                _lazyHash = CalculateHashCode();
-            }
-
-            return _lazyHash;
+            return _checkSum.GetHashCode();
         }
 
-        public override string ToString()
+        public override unsafe string ToString()
         {
-            return Convert.ToBase64String(_checkSum);
-        }
-
-        private int CalculateHashCode()
-        {
-            // lazily calculate hash for checksum
-            var hash = _checkSum.Length;
-
-            for (var i = 0; i < _checkSum.Length; i++)
+            var data = new byte[sizeof(Sha1Hash)];
+            fixed (byte* dataPtr = data)
             {
-                hash = Hash.Combine((int)_checkSum[i], hash);
+                *(Sha1Hash*)dataPtr = _checkSum;
             }
 
-            // make sure we never return 0
-            return hash == 0 ? 1 : hash;
+            return Convert.ToBase64String(data);
         }
 
         public static bool operator ==(Checksum left, Checksum right)
@@ -94,12 +149,12 @@ namespace Microsoft.CodeAnalysis
 
         public void WriteTo(ObjectWriter writer)
         {
-            writer.WriteValue(_checkSum);
+            _checkSum.WriteTo(writer);
         }
 
         public static Checksum ReadFrom(ObjectReader reader)
         {
-            return new Checksum((byte[])reader.ReadValue());
+            return new Checksum(Sha1Hash.ReadFrom(reader));
         }
 
         public static string GetChecksumLogInfo(Checksum checksum)


### PR DESCRIPTION
Based on review of heap dumps from OOM conditions, I found the following patterns with the use of `Checksum`:

1. There tend to be many instances, on the order of ~75,000
2. References to `Checksum` appear to be densely populated when they appear in arrays (few `null` elements)
3. References to `Checksum` rarely point to the same target instance

The first commit inlines the 20-byte hash data, eliminates an unnecessary field for storing a 32-bit hash code, and optimizes the operations on this data. Direct savings for the observed cases are ~1.5MiB memory, with indirect savings in the form of notably reduced fragmentation and removal of a layer of indirection during the use of these objects.