### PR TITLE
Source packages cleanup

### DIFF
--- a/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
+++ b/src/Dependencies/CodeAnalysis.Debugging/CustomDebugInfoReader.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
-using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 #pragma warning disable RS0010 // Avoid using cref tags with a prefix

--- a/src/Dependencies/PooledObjects/ArrayBuilder.cs
+++ b/src/Dependencies/PooledObjects/ArrayBuilder.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.Collections;
 
 namespace Microsoft.CodeAnalysis.PooledObjects
 {

--- a/src/Dependencies/PooledObjects/PooledDictionary.cs
+++ b/src/Dependencies/PooledObjects/PooledDictionary.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.PooledObjects
 {

--- a/src/Dependencies/PooledObjects/PooledHashSet.cs
+++ b/src/Dependencies/PooledObjects/PooledHashSet.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.PooledObjects
 {

--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -379,7 +379,7 @@ exit |= DoWork(NonRedistPackageNames, LicenseUrlNonRedist);
 exit |= DoWork(TestPackageNames, LicenseUrlTest);
 exit |= DoWork(SourcePackageNames, LicenseUrlSource);
 
-var allPackageNames = RedistPackageNames.Concat(NonRedistPackageNames).Concat(TestPackageNames).ToArray();
+var allPackageNames = RedistPackageNames.Concat(NonRedistPackageNames).Concat(TestPackageNames).Concat(SourcePackageNames).ToArray();
 var roslynPackageNames = GetRoslynPackageNames(allPackageNames);
 GeneratePublishingConfig(roslynPackageNames);
 

--- a/src/NuGet/Microsoft.CodeAnalysis.Debugging.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Debugging.nuspec
@@ -24,6 +24,6 @@
   </metadata>
   <files>
     <file src="$srcDirPath$\Dependencies\CodeAnalysis.Debugging\**\*.cs" target="contentFiles/cs/netstandard1.3" />
-    <file src="$srcDirPath$\Dependencies\CodeAnalysis.Debugging\**\*.cs" target="contentFiles/cs/net35" />
+    <file src="$srcDirPath$\Dependencies\CodeAnalysis.Debugging\**\*.cs" target="contentFiles/cs/net45" />
   </files>
 </package>

--- a/src/NuGet/Microsoft.CodeAnalysis.PooledObjects.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.PooledObjects.nuspec
@@ -21,6 +21,6 @@
   </metadata>
   <files>
     <file src="$srcDirPath$\Dependencies\PooledObjects\**\*.cs" target="contentFiles/cs/netstandard1.3" />
-    <file src="$srcDirPath$\Dependencies\PooledObjects\**\*.cs" target="contentFiles/cs/net35" />
+    <file src="$srcDirPath$\Dependencies\PooledObjects\**\*.cs" target="contentFiles/cs/net45" />
   </files>
 </package>


### PR DESCRIPTION
Remove unused usings.
Include source packages in list of packages published to myget.
Target net45 instead of net35 -- the source depends on SRM and SCI but they are not available for net35 