### PR TITLE
Harden MiscellaneousFilesWorkspace against events from other threads

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -32,7 +32,7 @@
       <!-- The user specified a build number, so we should use that. -->
       <PropertyGroup>
         <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>
-        <BuildVersion>1.3.5.$([MSBuild]::Subtract($(BuildNumber.Split('.')[0]), 8800))</BuildVersion>
+        <BuildVersion>1.3.6.$([MSBuild]::Subtract($(BuildNumber.Split('.')[0]), 8800))</BuildVersion>
       </PropertyGroup>
     </When>
 
@@ -41,7 +41,7 @@
           This happens if the build template does not pass BuildNumber down to MSBuild. -->
       <PropertyGroup>
         <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>
-        <BuildVersion>1.3.5.0</BuildVersion>
+        <BuildVersion>1.3.6.0</BuildVersion>
       </PropertyGroup>
     </When>
 
@@ -71,8 +71,8 @@
       $(BuildNumberSuffix.Split('.')[1].PadLeft(2,'0'))
     </BuildNumberPart2>
 
-    <NuGetReleaseVersion>1.3.5</NuGetReleaseVersion>
-    <NuGetPreReleaseVersion>1.3.5-beta1</NuGetPreReleaseVersion>
+    <NuGetReleaseVersion>1.3.6</NuGetReleaseVersion>
+    <NuGetPreReleaseVersion>1.3.6-beta1</NuGetPreReleaseVersion>
     <NuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(NuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</NuGetPerBuildPreReleaseVersion>
   </PropertyGroup>
   


### PR DESCRIPTION
This is a cherry-pick of d0cd0e2c427e9a, and the change to the Registration_WorkspaceChanged from b19fcfe8b92ec5e that it implicitly relied on as well.

Tagging @dotnet/roslyn-ide for review. This is a fix we're taking for Dev14 servicing. This code already shipped as a part of Dev15 but a quick look to verify my merge resolution wasn't screwy would be appreciated.