### PR TITLE
Get Live Unit Testing working with current Roslyn targets...

### DIFF
--- a/Roslyn.runsettings
+++ b/Roslyn.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<!-- This file can be removed once https://github.com/dotnet/roslyn/pull/20333 is merged. --> 
+<RunSettings>  
+  <RunConfiguration>  
+    <TestAdaptersPaths>%userprofile%\.nuget\packages\xunit.runner.visualstudio\2.2.0-beta4-build1194</TestAdaptersPaths>  
+  </RunConfiguration>   
+</RunSettings>  

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -72,7 +72,8 @@
     <RoslynNetSdkRootPath>$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\</RoslynNetSdkRootPath> 
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <!-- Live Unit Testing does not currently support PackageReference style restore unless the Sdk="Microsoft.NET.Sdk" attribute is used on projects. -->
+    <!-- Live Unit Testing does not currently support PackageReference style restore unless the Sdk="Microsoft.NET.Sdk" attribute is used on projects.
+         Removal of this work-around tracked by:  https://github.com/dotnet/roslyn/issues/20427 -->
     <ProjectAssetsFile Condition="'$(BuildingForLiveUnitTesting)' == 'true'">$(LiveUnitTestingOriginalBaseIntermediateOutputPath)project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -71,6 +71,9 @@
 
     <RoslynNetSdkRootPath>$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\</RoslynNetSdkRootPath> 
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+
+    <!-- Live Unit Testing does not currently support PackageReference style restore unless the Sdk="Microsoft.NET.Sdk" attribute is used on projects. -->
+    <ProjectAssetsFile Condition="'$(BuildingForLiveUnitTesting)' == 'true'">$(LiveUnitTestingOriginalBaseIntermediateOutputPath)project.assets.json</ProjectAssetsFile>
   </PropertyGroup>
 
   <!-- Windows specific settings -->


### PR DESCRIPTION
**Customer scenario**

Live Unit Testing cannot build current Roslyn projects, because the (somewhat fragile) logic we have for overriding the BaseIntermediateOutputPath doesn't work the same for project.assets.json resolution as it does with "default" .NET Core SDK projects.

**Bugs this fixes:**

N/A

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

**Root cause analysis:**

**How was the bug found?**
