### PR TITLE
changed logger to log errors from all analyzers not just first analyzer

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 await SerializeAsync(serializer, project, result.ProjectId, _owner.NonLocalStateName, result.Others).ConfigureAwait(false);
 
-                AnalyzerABTestLogger.LogProjectDiagnostics(project, result);
+                AnalyzerABTestLogger.LogProjectDiagnostics(project, _owner.StateName, result);
             }
 
             public void ResetVersion()
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var syntax = state.GetAnalysisData(AnalysisKind.Syntax);
                 var semantic = state.GetAnalysisData(AnalysisKind.Semantic);
 
-                AnalyzerABTestLogger.LogDocumentDiagnostics(document, syntax.Items, semantic.Items);
+                AnalyzerABTestLogger.LogDocumentDiagnostics(document, _owner.StateName, syntax.Items, semantic.Items);
 
                 var project = document.Project;
 

--- a/src/Features/Core/Portable/Experimentation/AnalyzerABTestLogger.cs
+++ b/src/Features/Core/Portable/Experimentation/AnalyzerABTestLogger.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Experimentation
     internal static class AnalyzerABTestLogger
     {
         private static bool s_reportErrors = false;
-        private static readonly ConcurrentDictionary<object, object> s_reported = new ConcurrentDictionary<object, object>(concurrencyLevel: 2, capacity: 10);
+        private static readonly ConcurrentDictionary<(object, string), object> s_reported = new ConcurrentDictionary<(object, string), object>(concurrencyLevel: 2, capacity: 10);
 
         private const string Name = "LiveCodeAnalysisVsix";
 
@@ -59,9 +59,9 @@ namespace Microsoft.CodeAnalysis.Experimentation
             }
         }
 
-        public static void LogProjectDiagnostics(Project project, DiagnosticAnalysisResult result)
+        public static void LogProjectDiagnostics(Project project, string analyzerName, DiagnosticAnalysisResult result)
         {
-            if (!s_reportErrors || !s_reported.TryAdd(project.Id, null))
+            if (!s_reportErrors || !s_reported.TryAdd((project.Id, analyzerName), null))
             {
                 // doesn't meet the bar to report the issue.
                 return;
@@ -82,9 +82,9 @@ namespace Microsoft.CodeAnalysis.Experimentation
             LogErrors(project, "ProjectDignostics", project.Id.Id, map);
         }
 
-        public static void LogDocumentDiagnostics(Document document, ImmutableArray<DiagnosticData> syntax, ImmutableArray<DiagnosticData> semantic)
+        public static void LogDocumentDiagnostics(Document document, string analyzerName, ImmutableArray<DiagnosticData> syntax, ImmutableArray<DiagnosticData> semantic)
         {
-            if (!s_reportErrors || !s_reported.TryAdd(document.Id, null))
+            if (!s_reportErrors || !s_reported.TryAdd((document.Id, analyzerName), null))
             {
                 // doesn't meet the bar to report the issue.
                 return;


### PR DESCRIPTION
**Customer scenario**

This is not for customer facing functionality. so this should not affect customer scenario. this instead affects our telemetry data.

**Bugs this fixes:**

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=454453&fullScreen=false&_a=edit

**Workarounds, if any**

There is no workaround

**Risk**

more telemetry data than before. but we only log it once per user that got accepted into our a/b testing flight.

**Performance impact**

more data sent to telemetry but only once per (project, analyzer) per user who got accepted into our a/b testing flight.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

existing code had a bug where it only log the very first analyzer rather than all analyzers.

**How was the bug found?**

Dogfooding.
