### PR TITLE
Fix signed build break

### DIFF
--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -37,7 +37,7 @@
     <MSBuild Projects="$(RepoRoot)src\NuGet\NuGet.proj" />
     <MSBuild Projects="$(RepoRoot)src\Setup\SetupStep2.proj" Properties="$(SetupStep2Properties);DeployExtension=false" />
 
-    <MSBuild Projects="$(RepoRoot)BuildAndTest.proj" Targets="Test" Condition="'$(SkipTest)' != 'true'" Properties="Test32=true" />
+    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(RepoRoot)build\scripts\build.ps1 -testDesktop -msbuildDir &quot;$(MSBuildBinPath)&quot;" Condition="'$(SkipTest)' != 'true'" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)..\..\..\build\scripts\check-toolset-insertion.ps1 &quot;$(MSBuildThisFileDirectory)..\..\..&quot; &quot;$(BinariesPath)&quot;" />
     


### PR DESCRIPTION
Correct the reference to the deleted BuildAndTest.proj file to use the build.ps1 script.
