### PR TITLE
Suspend solution crawler during line commit

### DIFF
--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -114,8 +114,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     End If
 
                     Using _notificationService.Start("LineCommit")
-
-
                         Dim dirtyRegion = _dirtyState.DirtyRegion.GetSpan(_buffer.CurrentSnapshot)
                         Dim info As FormattingInfo
                         If Not TryComputeExpandedSpanToFormat(dirtyRegion, info, cancellationToken) Then

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManager.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
         Private ReadOnly _buffer As ITextBuffer
         Private ReadOnly _commitFormatter As ICommitFormatter
         Private ReadOnly _inlineRenameService As IInlineRenameService
-        Private ReadOnly _notificationService As IGlobalOperationNotificationService
         Private _referencingViews As Integer
 
         ''' <summary>
@@ -32,18 +31,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
         Public Sub New(
             buffer As ITextBuffer,
             commitFormatter As ICommitFormatter,
-            inlineRenameService As IInlineRenameService,
-            notificationService As IGlobalOperationNotificationService)
+            inlineRenameService As IInlineRenameService)
 
             Contract.ThrowIfNull(buffer)
             Contract.ThrowIfNull(commitFormatter)
             Contract.ThrowIfNull(inlineRenameService)
-            Contract.ThrowIfNull(notificationService)
 
             _buffer = buffer
             _commitFormatter = commitFormatter
             _inlineRenameService = inlineRenameService
-            _notificationService = notificationService
         End Sub
 
         Private Sub Connect()
@@ -113,7 +109,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                         Return
                     End If
 
-                    Using _notificationService.Start("LineCommit")
+                    Dim notificationService = _dirtyState.BaseDocument.Project.Solution.Workspace.Services _
+                        .GetService(Of IGlobalOperationNotificationService)()
+                    Using notificationService.Start("LineCommit")
                         Dim dirtyRegion = _dirtyState.DirtyRegion.GetSpan(_buffer.CurrentSnapshot)
                         Dim info As FormattingInfo
                         If Not TryComputeExpandedSpanToFormat(dirtyRegion, info, cancellationToken) Then

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManagerFactory.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManagerFactory.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Composition
+Imports Microsoft.CodeAnalysis.Notification
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Operations
 
@@ -9,15 +10,17 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
     Friend Class CommitBufferManagerFactory
         Private ReadOnly _commitFormatter As ICommitFormatter
         Private ReadOnly _inlineRenameService As IInlineRenameService
+        Private ReadOnly _notificationService As IGlobalOperationNotificationService
 
         <ImportingConstructor()>
-        Public Sub New(commitFormatter As ICommitFormatter, inlineRenameService As IInlineRenameService)
+        Public Sub New(commitFormatter As ICommitFormatter, inlineRenameService As IInlineRenameService, notificationService As IGlobalOperationNotificationService)
             _commitFormatter = commitFormatter
             _inlineRenameService = inlineRenameService
+            _notificationService = notificationService
         End Sub
 
         Public Function CreateForBuffer(buffer As ITextBuffer) As CommitBufferManager
-            Return buffer.Properties.GetOrCreateSingletonProperty(Function() New CommitBufferManager(buffer, _commitFormatter, _inlineRenameService))
+            Return buffer.Properties.GetOrCreateSingletonProperty(Function() New CommitBufferManager(buffer, _commitFormatter, _inlineRenameService, _notificationService))
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManagerFactory.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitBufferManagerFactory.vb
@@ -10,17 +10,15 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
     Friend Class CommitBufferManagerFactory
         Private ReadOnly _commitFormatter As ICommitFormatter
         Private ReadOnly _inlineRenameService As IInlineRenameService
-        Private ReadOnly _notificationService As IGlobalOperationNotificationService
 
         <ImportingConstructor()>
-        Public Sub New(commitFormatter As ICommitFormatter, inlineRenameService As IInlineRenameService, notificationService As IGlobalOperationNotificationService)
+        Public Sub New(commitFormatter As ICommitFormatter, inlineRenameService As IInlineRenameService)
             _commitFormatter = commitFormatter
             _inlineRenameService = inlineRenameService
-            _notificationService = notificationService
         End Sub
 
         Public Function CreateForBuffer(buffer As ITextBuffer) As CommitBufferManager
-            Return buffer.Properties.GetOrCreateSingletonProperty(Function() New CommitBufferManager(buffer, _commitFormatter, _inlineRenameService, _notificationService))
+            Return buffer.Properties.GetOrCreateSingletonProperty(Function() New CommitBufferManager(buffer, _commitFormatter, _inlineRenameService))
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -32,9 +32,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
         Private ReadOnly _inlineRenameService As InlineRenameServiceMock
 
         Public Shared Async Function CreateAsync(test As XElement) As Task(Of CommitTestData)
-            Dim catalog = TestExportProvider.EntireAssemblyCatalogWithCSharpAndVisualBasic.WithParts(GetType(MockGlobalOperationNotificationServiceFactory))
-            Dim exportProvider = MinimalTestExportProvider.CreateExportProvider(catalog)
-            Dim workspace = Await TestWorkspace.CreateAsync(test, exportProvider:=exportProvider)
+            Dim workspace = Await TestWorkspace.CreateAsync(test)
             Return New CommitTestData(workspace)
         End Function
 
@@ -61,8 +59,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
             _formatter = New FormatterMock(workspace)
             _inlineRenameService = New InlineRenameServiceMock()
             Dim commitManagerFactory As New CommitBufferManagerFactory(_formatter,
-                                                                       _inlineRenameService,
-                                                                       New MockGlobalOperationNotificationServiceFactory())
+                                                                       _inlineRenameService)
 
             ' Make sure the manager exists for the buffer
             Dim commitManager = commitManagerFactory.CreateForBuffer(Buffer)
@@ -118,24 +115,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
                     Throw New NotImplementedException()
                 End Sub
             End Class
-        End Class
-
-        <Export(GetType(IGlobalOperationNotificationService))>
-        <ExportWorkspaceServiceFactory(GetType(IGlobalOperationNotificationService)), [Shared]>
-        Friend Class MockGlobalOperationNotificationServiceFactory
-            Implements IWorkspaceServiceFactory, IGlobalOperationNotificationService
-
-
-            Public Function CreateService(workspaceServices As HostWorkspaceServices) As IWorkspaceService Implements IWorkspaceServiceFactory.CreateService
-                Return Me
-            End Function
-
-            Public Event Started As EventHandler Implements IGlobalOperationNotificationService.Started
-            Public Event Stopped As EventHandler(Of GlobalOperationEventArgs) Implements IGlobalOperationNotificationService.Stopped
-
-            Public Function Start(operation As String) As GlobalOperationRegistration Implements IGlobalOperationNotificationService.Start
-                Return Nothing
-            End Function
         End Class
 
         Private Class FormatterMock

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitTestData.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
+Imports Microsoft.CodeAnalysis.Notification
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.VisualStudio.Text
@@ -53,7 +54,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.LineCommit
 
             _formatter = New FormatterMock(workspace)
             _inlineRenameService = New InlineRenameServiceMock()
-            Dim commitManagerFactory As New CommitBufferManagerFactory(_formatter, _inlineRenameService)
+            Dim commitManagerFactory As New CommitBufferManagerFactory(_formatter,
+                                                                       _inlineRenameService,
+                                                                       workspace.GetService(Of IGlobalOperationNotificationService))
 
             ' Make sure the manager exists for the buffer
             Dim commitManager = commitManagerFactory.CreateForBuffer(Buffer)


### PR DESCRIPTION
Line commit on enter goes from ~40 seconds in a 3000 line file to instantaneous.

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
