### PR TITLE
Added SharedCompilationId switch to ManagedCompiler and DesktopBuildClient

### DIFF
--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -473,8 +473,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         buildPaths,
                         keepAlive: null,
                         libEnvVariable: LibDirectoryToUse(),
-                        cancellationToken: _sharedCompileCts.Token,
-                        sharedCompilationId: SharedCompilationId);
+                        sharedCompilationId: SharedCompilationId,
+                        cancellationToken: _sharedCompileCts.Token);
 
                     responseTask.Wait(_sharedCompileCts.Token);
 

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -288,6 +288,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (ITaskItem[])_store[nameof(ResponseFiles)]; }
         }
 
+        public string SharedCompilationId
+        {
+            set { _store[nameof(SharedCompilationId)] = value; }
+            get { return (string)_store[nameof(SharedCompilationId)]; }
+        }
+
         public bool SkipCompilerExecution
         {
             set { _store[nameof(SkipCompilerExecution)] = value; }
@@ -467,7 +473,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         buildPaths,
                         keepAlive: null,
                         libEnvVariable: LibDirectoryToUse(),
-                        cancellationToken: _sharedCompileCts.Token);
+                        cancellationToken: _sharedCompileCts.Token,
+                        sharedCompilationId: SharedCompilationId);
 
                     responseTask.Wait(_sharedCompileCts.Token);
 

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -134,6 +134,7 @@
          Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
          ResponseFiles="$(CompilerResponseFile)"
          RuntimeMetadataVersion="$(RuntimeMetadataVersion)"
+         SharedCompilationId="$(SharedCompilationId)"
          SkipCompilerExecution="$(SkipCompilerExecution)"
          Sources="@(Compile)"
          SubsystemVersion="$(SubsystemVersion)"

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -129,6 +129,7 @@
          RootNamespace="$(RootNamespace)"
          RuntimeMetadataVersion="$(RuntimeMetadataVersion)"
          SdkPath="$(FrameworkPathOverride)"
+         SharedCompilationId="$(SharedCompilationId)"
          SkipCompilerExecution="$(SkipCompilerExecution)"
          Sources="@(Compile)"
          SubsystemVersion="$(SubsystemVersion)"

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineParser.cs
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis
         /// Only defined if errors were encountered.
         /// The error message for the encountered error.
         /// </param>
-        /// <param name="sessionKey">
+        /// <param name="sharedCompilationId">
         /// Only specified if <paramref name="containsShared"/> is true and the session key
         /// was provided.  Can be null
         /// </param>
@@ -414,14 +414,14 @@ namespace Microsoft.CodeAnalysis
             out List<string> parsedArgs,
             out bool containsShared,
             out string keepAliveValue,
-            out string sessionKey,
+            out string sharedCompilationId,
             out string errorMessage)
         {
             containsShared = false;
             keepAliveValue = null;
             errorMessage = null;
             parsedArgs = null;
-            sessionKey = null;
+            sharedCompilationId = null;
             var newArgs = new List<string>();
             foreach (var arg in args)
             {
@@ -463,7 +463,7 @@ namespace Microsoft.CodeAnalysis
                             return false;
                         }
 
-                        sessionKey = value;
+                        sharedCompilationId = value;
                     }
 
                     containsShared = true;

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -140,19 +140,19 @@ End Module")
             bool hasShared;
             string keepAlive;
             string errorMessage;
-            string pipeName;
+            string sharedCompilationId;
             List<string> parsedArgs;
             if (CommandLineParser.TryParseClientArgs(
                     arguments.Split(' '),
                     out parsedArgs,
                     out hasShared,
                     out keepAlive,
-                    out pipeName,
+                    out sharedCompilationId,
                     out errorMessage))
             {
-                if (hasShared && string.IsNullOrEmpty(pipeName))
+                if (hasShared && string.IsNullOrEmpty(sharedCompilationId))
                 {
-                    throw new InvalidOperationException("Must specify a pipe name in these suites to ensure we're not running out of proc servers");
+                    throw new InvalidOperationException("Must specify a shared compilation id in these suites to ensure we're not running out of proc servers");
                 }
             }
         }
@@ -228,7 +228,7 @@ End Module")
             // Verify csc will fall back to command line when server fails to process
             using (var serverData = ServerUtil.CreateServerFailsConnection())
             {
-                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
                 await serverData.Verify(connections: 1, completed: 0).ConfigureAwait(true);
             }
@@ -242,7 +242,7 @@ End Module")
             {
                 var files = new Dictionary<string, string> { { "hello.cs", "♕" } };
 
-                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo hello.cs", _tempDirectory, files);
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /nologo hello.cs", _tempDirectory, files);
                 Assert.Equal(result.ExitCode, 1);
                 Assert.True(result.ContainsErrors);
                 Assert.Equal("hello.cs(1,1): error CS1056: Unexpected character '?'", result.Output.Trim());
@@ -263,7 +263,7 @@ End Module")
                     CSharpCompilerClientExecutable,
                     srcFile,
                     tempOut.Path,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal("test.cs(1,1): error CS1056: Unexpected character '♕'".Trim(),
@@ -282,7 +282,7 @@ End Module")
             {
                 var result = ProcessUtilities.Run(
                     BasicCompilerClientExecutable,
-                    $"/shared:{serverData.PipeName} /nologo test.vb",
+                    $"/shared:{serverData.SharedCompilationId} /nologo test.vb",
                     _tempDirectory.Path);
 
                 Assert.Equal(result.ExitCode, 1);
@@ -308,7 +308,7 @@ End Module")
                     BasicCompilerClientExecutable,
                     srcFile,
                     tempOut.Path,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal(@"test.vb(1) : error BC30037: Character is not valid.
@@ -325,7 +325,7 @@ End Module")
         {
             using (var serverData = ServerUtil.CreateServerFailsConnection())
             {
-                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo hello.vb", _tempDirectory, s_helloWorldSrcVb);
+                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /nologo hello.vb", _tempDirectory, s_helloWorldSrcVb);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
                 await serverData.Verify(connections: 1, completed: 0).ConfigureAwait(true);
             }
@@ -337,7 +337,7 @@ End Module")
         {
             using (var serverData = ServerUtil.CreateServer())
             {
-                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /nologo hello.cs", _tempDirectory, s_helloWorldSrcCs);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
                 await serverData.Verify(connections: 1, completed: 1).ConfigureAwait(true);
             }
@@ -366,7 +366,7 @@ End Module")
             {
                 var files = new Dictionary<string, string> { { "c.cs", "class C {}" } };
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
-                                                    $"/shared:{serverData.PipeName} /nologo /t:library /platform:x86 c.cs",
+                                                    $"/shared:{serverData.SharedCompilationId} /nologo /t:library /platform:x86 c.cs",
                                                     _tempDirectory,
                                                     files);
                 VerifyResult(result);
@@ -382,7 +382,7 @@ End Module")
             {
                 var files = new Dictionary<string, string> { { "c.vb", "Class C\nEnd Class" } };
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable,
-                                                    $"/shared:{serverData.PipeName} /nologo /t:library /platform:x86 c.vb",
+                                                    $"/shared:{serverData.SharedCompilationId} /nologo /t:library /platform:x86 c.vb",
                                                     _tempDirectory,
                                                     files);
                 VerifyResult(result);
@@ -397,7 +397,7 @@ End Module")
             using (var serverData = ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
-                                                    $"/shared:{serverData.PipeName} /nologo /r:mscorlib.dll hello.cs",
+                                                    $"/shared:{serverData.SharedCompilationId} /nologo /r:mscorlib.dll hello.cs",
                                                     _tempDirectory,
                                                     s_helloWorldSrcCs);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello, world.\r\n");
@@ -412,7 +412,7 @@ End Module")
             using (var serverData = ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable,
-                                                    $"/shared:{serverData.PipeName} /nologo /r:Microsoft.VisualBasic.dll hello.vb",
+                                                    $"/shared:{serverData.SharedCompilationId} /nologo /r:Microsoft.VisualBasic.dll hello.vb",
                                                     _tempDirectory,
                                                     s_helloWorldSrcVb);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
@@ -427,7 +427,7 @@ End Module")
             using (var serverData = ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable,
-                    $"/shared:{serverData.PipeName} /nologo /r:mscorlib.dll /r:Microsoft.VisualBasic.dll hello.vb",
+                    $"/shared:{serverData.SharedCompilationId} /nologo /r:mscorlib.dll /r:Microsoft.VisualBasic.dll hello.vb",
                     _tempDirectory,
                     s_helloWorldSrcVb);
                 VerifyResultAndOutput(result, _tempDirectory, "Hello from VB\r\n");
@@ -451,7 +451,7 @@ class Hello
     { Console.WriteLine(""Hello, world."") }
 }"}};
 
-                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} hello.cs", _tempDirectory, files);
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} hello.cs", _tempDirectory, files);
 
                 // Should output errors, but not create output file.
                 Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
@@ -480,7 +480,7 @@ Module Module1
     End Sub
 End Class"}};
 
-                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.PipeName} /r:Microsoft.VisualBasic.dll hellovb.vb", _tempDirectory, files);
+                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /r:Microsoft.VisualBasic.dll hellovb.vb", _tempDirectory, files);
 
                 // Should output errors, but not create output file.
                 Assert.Contains("Copyright (C) Microsoft Corporation. All rights reserved.", result.Output, StringComparison.Ordinal);
@@ -499,7 +499,7 @@ End Class"}};
         {
             using (var serverData = ServerUtil.CreateServer())
             {
-                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} missingfile.cs", _tempDirectory, new Dictionary<string, string>());
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} missingfile.cs", _tempDirectory, new Dictionary<string, string>());
 
                 // Should output errors, but not create output file.
                 Assert.Equal("", result.Errors);
@@ -517,7 +517,7 @@ End Class"}};
         {
             using (var serverData = ServerUtil.CreateServer())
             {
-                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /r:missing.dll hello.cs", _tempDirectory, s_helloWorldSrcCs);
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /r:missing.dll hello.cs", _tempDirectory, s_helloWorldSrcCs);
 
                 // Should output errors, but not create output file.
                 Assert.Equal("", result.Errors);
@@ -542,7 +542,7 @@ End Class"}};
                                                { "app.cs", "class Test { static void Main() {} }"},
                                                };
 
-                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.PipeName} /r:Lib.cs app.cs", _tempDirectory, files);
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /r:Lib.cs app.cs", _tempDirectory, files);
 
                 // Should output errors, but not create output file.
                 Assert.Equal("", result.Errors);
@@ -560,7 +560,7 @@ End Class"}};
         {
             using (var serverData = ServerUtil.CreateServer())
             {
-                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.PipeName} missingfile.vb", _tempDirectory, new Dictionary<string, string>());
+                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} missingfile.vb", _tempDirectory, new Dictionary<string, string>());
 
                 // Should output errors, but not create output file.
                 Assert.Equal("", result.Errors);
@@ -590,7 +590,7 @@ Module Module1
     End Sub
 End Module"}};
 
-                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.PipeName} /nologo /r:Microsoft.VisualBasic.dll /r:missing.dll hellovb.vb", _tempDirectory, files);
+                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /nologo /r:Microsoft.VisualBasic.dll /r:missing.dll hellovb.vb", _tempDirectory, files);
 
                 // Should output errors, but not create output file.
                 Assert.Equal("", result.Errors);
@@ -619,7 +619,7 @@ End Class" },
     End Sub
 End Module"}};
 
-                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.PipeName} /r:Lib.vb app.vb", _tempDirectory, files);
+                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"/shared:{serverData.SharedCompilationId} /r:Lib.vb app.vb", _tempDirectory, files);
 
                 // Should output errors, but not create output file.
                 Assert.Equal("", result.Errors);
@@ -653,7 +653,7 @@ End Class
             using (var serverData = ServerUtil.CreateServer())
             using (var tmpFile = GetResultFile(rootDirectory, "lib.dll"))
             {
-                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"src1.vb /shared:{serverData.PipeName} /nologo /t:library /out:lib.dll", rootDirectory, files);
+                var result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"src1.vb /shared:{serverData.SharedCompilationId} /nologo /t:library /out:lib.dll", rootDirectory, files);
                 Assert.Equal("", result.Output);
                 Assert.Equal("", result.Errors);
                 Assert.Equal(0, result.ExitCode);
@@ -670,7 +670,7 @@ Module Module1
     End Sub
 End Module
 "}};
-                    result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"hello1.vb /shared:{serverData.PipeName} /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello1.exe", rootDirectory, files);
+                    result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"hello1.vb /shared:{serverData.SharedCompilationId} /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello1.exe", rootDirectory, files);
                     Assert.Equal("", result.Output);
                     Assert.Equal("", result.Errors);
                     Assert.Equal(0, result.ExitCode);
@@ -691,7 +691,7 @@ Public Sub Main()
 End Sub
 End Module
 "}};
-                        result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"hello2.vb /shared:{serverData.PipeName} /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello2.exe", rootDirectory, files);
+                        result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"hello2.vb /shared:{serverData.SharedCompilationId} /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello2.exe", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -715,7 +715,7 @@ Public Class Library
 End Class
 "}};
 
-                        result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"src2.vb /shared:{serverData.PipeName} /nologo /t:library /out:lib.dll", rootDirectory, files);
+                        result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"src2.vb /shared:{serverData.SharedCompilationId} /nologo /t:library /out:lib.dll", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -732,7 +732,7 @@ Module Module1
     End Sub
 End Module
 "}};
-                            result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"hello3.vb /shared:{serverData.PipeName} /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello3.exe", rootDirectory, files);
+                            result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"hello3.vb /shared:{serverData.SharedCompilationId} /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello3.exe", rootDirectory, files);
                             Assert.Equal("", result.Output);
                             Assert.Equal("", result.Errors);
                             Assert.Equal(0, result.ExitCode);
@@ -775,7 +775,7 @@ public class Library
     { return ""library1""; }
 }"}};
 
-                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"src1.cs /shared:{serverData.PipeName} /nologo /t:library /out:lib.dll", rootDirectory, files);
+                var result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"src1.cs /shared:{serverData.SharedCompilationId} /nologo /t:library /out:lib.dll", rootDirectory, files);
                 Assert.Equal("", result.Output);
                 Assert.Equal("", result.Errors);
                 Assert.Equal(0, result.ExitCode);
@@ -791,7 +791,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello1 from {0}"", Library.GetString()); }
 }"}};
-                    result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"hello1.cs /shared:{serverData.PipeName} /nologo /r:lib.dll /out:hello1.exe", rootDirectory, files);
+                    result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"hello1.cs /shared:{serverData.SharedCompilationId} /nologo /r:lib.dll /out:hello1.exe", rootDirectory, files);
                     Assert.Equal("", result.Output);
                     Assert.Equal("", result.Errors);
                     Assert.Equal(0, result.ExitCode);
@@ -813,7 +813,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello2 from {0}"", Library.GetString()); }
 }"}};
-                        result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"hello2.cs /shared:{serverData.PipeName} /nologo /r:lib.dll /out:hello2.exe", rootDirectory, files);
+                        result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"hello2.cs /shared:{serverData.SharedCompilationId} /nologo /r:lib.dll /out:hello2.exe", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -836,7 +836,7 @@ public class Library
     { return ""library3""; }
 }"}};
 
-                        result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"src2.cs /shared:{serverData.PipeName} /nologo /t:library /out:lib.dll", rootDirectory, files);
+                        result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"src2.cs /shared:{serverData.SharedCompilationId} /nologo /t:library /out:lib.dll", rootDirectory, files);
                         Assert.Equal("", result.Output);
                         Assert.Equal("", result.Errors);
                         Assert.Equal(0, result.ExitCode);
@@ -852,7 +852,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello3 from {0}"", Library.GetString2()); }
 }"}};
-                            result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"hello3.cs /shared:{serverData.PipeName} /nologo /r:lib.dll /out:hello3.exe", rootDirectory, files);
+                            result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"hello3.cs /shared:{serverData.SharedCompilationId} /nologo /r:lib.dll /out:hello3.exe", rootDirectory, files);
                             Assert.Equal("", result.Output);
                             Assert.Equal("", result.Errors);
                             Assert.Equal(0, result.ExitCode);
@@ -874,7 +874,7 @@ class Hello
             GC.KeepAlive(rootDirectory);
         }
 
-        private async static Task<DisposableFile> RunCompilationAsync(RequestLanguage language, string pipeName, int i, TempDirectory compilationDir, TempDirectory tempDir)
+        private async static Task<DisposableFile> RunCompilationAsync(RequestLanguage language, string sharedCompilationId, int i, TempDirectory compilationDir, TempDirectory tempDir)
         {
             TempFile sourceFile;
             string exeFileName;
@@ -923,7 +923,7 @@ End Module";
                 workingDir: compilationDir.Path,
                 sdkDir: RuntimeEnvironment.GetRuntimeDirectory(),
                 tempDir: tempDir.Path);
-            var result = await client.RunCompilationAsync(new[] { $"/shared:{pipeName}", "/nologo", Path.GetFileName(sourceFile.Path), $"/out:{exeFileName}" }, buildPaths);
+            var result = await client.RunCompilationAsync(new[] { $"/shared:{sharedCompilationId}", "/nologo", Path.GetFileName(sourceFile.Path), $"/out:{exeFileName}" }, buildPaths);
             Assert.Equal(0, result.ExitCode);
             Assert.True(result.RanOnServer);
 
@@ -951,7 +951,7 @@ End Module";
                     var language = i % 2 == 0 ? RequestLanguage.CSharpCompile : RequestLanguage.VisualBasicCompile;
                     var compilationDir = Temp.CreateDirectory();
                     var tempDir = Temp.CreateDirectory();
-                    tasks[i] = RunCompilationAsync(language, serverData.PipeName, i, compilationDir, tempDir);
+                    tasks[i] = RunCompilationAsync(language, serverData.SharedCompilationId, i, compilationDir, tempDir);
                 }
 
                 await Task.WhenAll(tasks);
@@ -985,7 +985,7 @@ public class Library
             using (var serverData = ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
-                                                    $"src1.cs /shared:{serverData.PipeName} /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
+                                                    $"src1.cs /shared:{serverData.SharedCompilationId} /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
                                                     _tempDirectory, files);
 
                 Assert.Equal("", result.Output);
@@ -1003,7 +1003,7 @@ class Hello
     public static void Main()
     { Console.WriteLine(""Hello1 from {0}"", Library.GetString()); }
 }"}};
-                result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"hello1.cs /shared:{serverData.PipeName} /nologo /r:lib.dll /out:hello1.exe", _tempDirectory, files,
+                result = RunCommandLineCompiler(CSharpCompilerClientExecutable, $"hello1.cs /shared:{serverData.SharedCompilationId} /nologo /r:lib.dll /out:hello1.exe", _tempDirectory, files,
                                                 additionalEnvironmentVars: new Dictionary<string, string>() { { "LIB", libDirectory.Path } });
 
                 Assert.Equal("", result.Output);
@@ -1037,7 +1037,7 @@ End Class
             using (var serverData = ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(BasicCompilerClientExecutable,
-                                                    $"src1.vb /shared:{serverData.PipeName} /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
+                                                    $"src1.vb /shared:{serverData.SharedCompilationId} /nologo /t:library /out:" + libDirectory.Path + "\\lib.dll",
                                                     _tempDirectory, files);
 
                 Assert.Equal("", result.Output);
@@ -1056,7 +1056,7 @@ Module Module1
     End Sub
 End Module
 "}};
-                result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"hello1.vb /shared:{serverData.PipeName} /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello1.exe", _tempDirectory, files,
+                result = RunCommandLineCompiler(BasicCompilerClientExecutable, $"hello1.vb /shared:{serverData.SharedCompilationId} /nologo /r:Microsoft.VisualBasic.dll /r:lib.dll /out:hello1.exe", _tempDirectory, files,
                                                 additionalEnvironmentVars: new Dictionary<string, string>() { { "LIB", libDirectory.Path } });
 
                 Assert.Equal("", result.Output);
@@ -1083,7 +1083,7 @@ End Module
                     CSharpCompilerClientExecutable,
                     srcFile,
                     tempOut.Path,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal("SRC.CS(1,1): error CS1056: Unexpected character '?'".Trim(),
@@ -1107,7 +1107,7 @@ End Module
                     BasicCompilerClientExecutable,
                     srcFile,
                     tempOut.Path,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal(@"SRC.VB(1) : error BC30037: Character is not valid.
@@ -1135,7 +1135,7 @@ End Module
                     CSharpCompilerClientExecutable,
                     srcFile,
                     tempOut.Path,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal("SRC.CS(1,1): error CS1056: Unexpected character '♕'".Trim(),
@@ -1159,7 +1159,7 @@ End Module
                     BasicCompilerClientExecutable,
                     srcFile,
                     tempOut.Path,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal(@"SRC.VB(1) : error BC30037: Character is not valid.
@@ -1197,7 +1197,7 @@ End Module
             using (var serverData = ServerUtil.CreateServer())
             {
                 var result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
-                                                    $"ref_mscorlib2.cs /shared:{serverData.PipeName} /nologo /nostdlib /noconfig /t:library /r:mscorlib20.dll",
+                                                    $"ref_mscorlib2.cs /shared:{serverData.SharedCompilationId} /nologo /nostdlib /noconfig /t:library /r:mscorlib20.dll",
                                                     _tempDirectory, files);
 
                 Assert.Equal("", result.Output);
@@ -1221,7 +1221,7 @@ class Program
 }
 "}};
                 result = RunCommandLineCompiler(CSharpCompilerClientExecutable,
-                                                $"main.cs /shared:{serverData.PipeName} /nologo /nostdlib /noconfig /r:mscorlib40.dll /r:ref_mscorlib2.dll",
+                                                $"main.cs /shared:{serverData.SharedCompilationId} /nologo /nostdlib /noconfig /r:mscorlib40.dll /r:ref_mscorlib2.dll",
                                                 _tempDirectory, files);
 
                 Assert.Equal("", result.Output);
@@ -1248,7 +1248,7 @@ class Program
                         CSharpCompilerClientExecutable,
                         rspFile,
                         tempOut,
-                        serverData.PipeName));
+                        serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal("src.cs(1,1): error CS1056: Unexpected character '♕'",
@@ -1275,7 +1275,7 @@ class Program
                         BasicCompilerClientExecutable,
                         rspFile,
                         tempOut,
-                        serverData.PipeName));
+                        serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal(@"src.vb(1) : error BC30037: Character is not valid.
@@ -1284,6 +1284,47 @@ class Program
 ~", tempOut.ReadAllText().Trim().Replace(srcFile, "src.vb"));
                 Assert.Equal(1, result.ExitCode);
                 await serverData.Verify(connections: 1, completed: 1).ConfigureAwait(true);
+            }
+        }
+
+        [Fact]
+        public void TestSharedCompilationIdMultiServer()
+        {
+            using (ServerData serverData1 = ServerUtil.CreateServer())
+            using (ServerData serverData2 = ServerUtil.CreateServer())
+            {
+                var testFile1 = _tempDirectory.CreateFile("test1.cs").WriteAllText(
+@"using System;
+public class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(""Hello world"");
+    }
+}")
+                .Path;
+                var testFile2 = _tempDirectory.CreateFile("test2.cs").WriteAllText(
+@"using System;
+public class Program
+{
+    static void Main()
+    {
+        Console.WriteLine(""Hello world"");
+    }
+}")
+                .Path;
+
+                var result1 = ProcessUtilities.Run(CSharpCompilerClientExecutable, $"test1.cs /nologo /shared:{serverData1.SharedCompilationId} /out:app1.exe", _tempDirectory.Path);
+                var result2 = ProcessUtilities.Run(CSharpCompilerClientExecutable, $"test1.cs /nologo /shared:{serverData1.SharedCompilationId} /out:app1.exe", _tempDirectory.Path);
+
+                Assert.Equal(0, result1.ExitCode);
+                Assert.Equal("", result1.Output);
+                Assert.Equal("", result1.Errors);
+                Assert.Equal(0, result2.ExitCode);
+                Assert.Equal("", result2.Output);
+                Assert.Equal("", result2.Errors);
+                serverData1.Verify(connections: 1, completed: 1).ConfigureAwait(true);
+                serverData2.Verify(connections: 1, completed: 1).ConfigureAwait(true);
             }
         }
 
@@ -1347,7 +1388,7 @@ class Program
                     CSharpCompilerClientExecutable,
                     srcFile,
                     tmp,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal(0, result.ExitCode);
 
@@ -1380,7 +1421,7 @@ class Program
                     BasicCompilerClientExecutable,
                     srcFile,
                     tmp,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal(0, result.ExitCode);
 
@@ -1390,7 +1431,7 @@ class Program
                     string.Format("/C {0} /shared:{2} /nologo /t:library {1}",
                     BasicCompilerClientExecutable,
                     srcFile,
-                    serverData.PipeName));
+                    serverData.SharedCompilationId));
 
                 Assert.Equal("", result.Output.Trim());
                 Assert.Equal(0, result.ExitCode);

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -32,9 +32,15 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         internal CancellationTokenSource CancellationTokenSource { get; }
         internal Task<ServerStats> ServerTask { get; }
         internal Task ListenTask { get; }
-        // fully constructed server pipe name
+
+        /// <summary>
+        /// Fully constructed server pipe name
+        /// </summary>
         internal string PipeName { get; }
-        // "uniqueifying" component for pipe name, unhashed
+
+        /// <summary>
+        /// "Uniqueifying" component for pipe name, unhashed
+        /// </summary>
         internal string SharedCompilationId { get; }
 
         internal ServerData(CancellationTokenSource cancellationTokenSource, string clientDirectory, string sharedCompilationId, Task<ServerStats> serverTask, Task listenTask)
@@ -87,14 +93,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         /// <summary>
         /// Gets the client directory from a host if it has one, or a default otherwise
         /// </summary>
-        private static string GetClientDirectory(ICompilerServerHost compilerServerHost)
+        private static string GetClientDirectoryOrDefault(ICompilerServerHost compilerServerHost)
         {
             var compilerHostImpl = compilerServerHost as CompilerServerHost;
             return compilerHostImpl?.ClientDirectory ?? DefaultClientDirectory;
         }
 
         internal static ServerData CreateServer(
-            // This is the "uniquefied" token ingredient for pipe name.
             string sharedCompilationId = null,
             TimeSpan? timeout = null,
             ICompilerServerHost compilerServerHost = null,
@@ -103,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
             sharedCompilationId = sharedCompilationId ?? Guid.NewGuid().ToString();
             compilerServerHost = compilerServerHost ?? new DesktopCompilerServerHost(DefaultClientDirectory, DefaultSdkDirectory);
 
-            string clientDirectory = GetClientDirectory(compilerServerHost);
+            string clientDirectory = GetClientDirectoryOrDefault(compilerServerHost);
             // Get the fully constructed, hashed pipe name.
             string pipeName = BuildServerConnection.GetPipeNameForPathOpt(clientDirectory, sharedCompilationId);
 

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -32,12 +32,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         internal CancellationTokenSource CancellationTokenSource { get; }
         internal Task<ServerStats> ServerTask { get; }
         internal Task ListenTask { get; }
+        // fully constructed server pipe name
         internal string PipeName { get; }
+        // "uniqueifying" component for pipe name, unhashed
+        internal string SharedCompilationId { get; }
 
-        internal ServerData(CancellationTokenSource cancellationTokenSource, string pipeName, Task<ServerStats> serverTask, Task listenTask)
+        internal ServerData(CancellationTokenSource cancellationTokenSource, string clientDirectory, string sharedCompilationId, Task<ServerStats> serverTask, Task listenTask)
         {
             CancellationTokenSource = cancellationTokenSource;
-            PipeName = pipeName;
+            PipeName = BuildServerConnection.GetPipeNameForPathOpt(clientDirectory, sharedCompilationId);
+            SharedCompilationId = sharedCompilationId;
             ServerTask = serverTask;
             ListenTask = listenTask;
         }
@@ -80,14 +84,28 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 tempDir: tempDir);
         }
 
+        /// <summary>
+        /// Gets the client directory from a host if it has one, or a default otherwise
+        /// </summary>
+        private static string GetClientDirectory(ICompilerServerHost compilerServerHost)
+        {
+            var compilerHostImpl = compilerServerHost as CompilerServerHost;
+            return compilerHostImpl?.ClientDirectory ?? DefaultClientDirectory;
+        }
+
         internal static ServerData CreateServer(
-            string pipeName = null,
+            // This is the "uniquefied" token ingredient for pipe name.
+            string sharedCompilationId = null,
             TimeSpan? timeout = null,
             ICompilerServerHost compilerServerHost = null,
             IClientConnectionHost clientConnectionHost = null)
         {
-            pipeName = pipeName ?? Guid.NewGuid().ToString();
+            sharedCompilationId = sharedCompilationId ?? Guid.NewGuid().ToString();
             compilerServerHost = compilerServerHost ?? new DesktopCompilerServerHost(DefaultClientDirectory, DefaultSdkDirectory);
+
+            string clientDirectory = GetClientDirectory(compilerServerHost);
+            // Get the fully constructed, hashed pipe name.
+            string pipeName = BuildServerConnection.GetPipeNameForPathOpt(clientDirectory, sharedCompilationId);
 
             var serverStatsSource = new TaskCompletionSource<ServerStats>();
             var serverListenSource = new TaskCompletionSource<bool>();
@@ -124,15 +142,18 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 Thread.Yield();
             }
 
-            return new ServerData(cts, pipeName, serverStatsSource.Task, serverListenSource.Task);
+            return new ServerData(cts, clientDirectory, sharedCompilationId, serverStatsSource.Task, serverListenSource.Task);
         }
 
         /// <summary>
         /// Create a compiler server that fails all connections.
         /// </summary>
-        internal static ServerData CreateServerFailsConnection(string pipeName = null)
+        internal static ServerData CreateServerFailsConnection(string sharedCompilationId = null)
         {
-            pipeName = pipeName ?? Guid.NewGuid().ToString();
+            // This is the "uniqueifying" component of the pipe name.
+            sharedCompilationId = sharedCompilationId ?? Guid.NewGuid().ToString();
+            // Get the fully constructed, hashed pipe name.
+            string pipeName = BuildServerConnection.GetPipeNameForPathOpt(DefaultClientDirectory, sharedCompilationId);
 
             var taskSource = new TaskCompletionSource<ServerStats>();
             var cts = new CancellationTokenSource();
@@ -164,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 mre.WaitOne();
             }
 
-            return new ServerData(cts, pipeName, taskSource.Task, Task.FromException(new Exception()));
+            return new ServerData(cts, DefaultClientDirectory, sharedCompilationId, taskSource.Task, Task.FromException(new Exception()));
         }
 
         internal static async Task<BuildResponse> Send(string pipeName, BuildRequest request)

--- a/src/Compilers/Shared/CoreClrBuildClient.cs
+++ b/src/Compilers/Shared/CoreClrBuildClient.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             return _compileFunc(arguments, buildPaths, textWriter, new CoreClrAnalyzerAssemblyLoader());
         }
 
-        protected override string GetSessionKey(BuildPaths buildPaths)
+        protected override string ConstructPipeName(BuildPaths buildPaths, string sharedCompilationId = null)
         {
             return string.Empty;
         }

--- a/src/Compilers/Shared/DesktopBuildClient.cs
+++ b/src/Compilers/Shared/DesktopBuildClient.cs
@@ -60,12 +60,12 @@ namespace Microsoft.CodeAnalysis.CommandLine
         protected override Task<BuildResponse> RunServerCompilation(
             List<string> arguments,
             BuildPaths buildPaths,
-            string sessionKey,
+            string pipeName,
             string keepAlive,
             string libDirectory,
             CancellationToken cancellationToken)
         {
-            return RunServerCompilationCore(_language, arguments, buildPaths, sessionKey, keepAlive, libDirectory, TimeoutOverride, TryCreateServer, cancellationToken);
+            return RunServerCompilationCore(_language, arguments, buildPaths, pipeName, keepAlive, libDirectory, TimeoutOverride, TryCreateServer, cancellationToken);
         }
 
         public static Task<BuildResponse> RunServerCompilation(
@@ -129,13 +129,13 @@ namespace Microsoft.CodeAnalysis.CommandLine
         }
 
         /// <summary>
-        /// Given the full path to the directory containing the compiler exes,
+        /// Given the full path to the directory containing the compiler exes and an optional session moniker,
         /// retrieves the name of the pipe for client/server communication on
         /// that instance of the compiler.
         /// </summary>
-        protected override string GetSessionKey(BuildPaths buildPaths)
+        protected override string ConstructPipeName(BuildPaths buildPaths, string sharedCompilationId = null)
         {
-            return BuildServerConnection.GetPipeNameForPathOpt(buildPaths.ClientDirectory);
+            return BuildServerConnection.GetPipeNameForPathOpt(buildPaths.ClientDirectory, sharedCompilationId);
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

This is a feature update requested by VSTS team to allow analyzers to run in "enforcement mode" in simultaneous parallel lab builds. Prior, MSBuild only launched one instance of VBCSCompiler.exe; multiple builds using different versions of a code analyzer would not be possible. This change unifies the behavior for specifying a "SharedCompilationId" in ManagedCompiler build tasks and csc.exe/vbc.exe. In both cases, the VBCSCompiler server base pipe name is constructed from the client directory and an optional user specified token: the SharedCompilationId. Thus, a build running with a particular SharedCompilationId will send data to one specific instance of the server, and a build using a different Id will launch its own server instance.

**Bugs this fixes:**

https://mseng.visualstudio.com/VSOnline/_workitems?id=1011824

**Workarounds, if any**

At present, the VSTS team has two code analyzers that are attached to projects which only run in "local" builds, or in Visual Studio itself. This allows them to be used as an "optional" feature of a sort, but their rules cannot be enforced as part of the automated build process.

**Risk**

The changes are applied to the ManagedCompiler build task, BuildClient/DesktopBuildClient and BuildServerConnection. It was necessary to change the process of constructing a VBCSCompiler pipe name by plumbing the SharedCompilationId parameter through either path to the GetBasePipeName method. Further changes were required to decouple the concept of a "pipeName" parameter passed through the csc/vbc path - as prior to these changes, that value (/shared:sessionKey argument) was used as the pipe name in its entirety if it was present. The sharedCompilationId parameter is specified as optional with a default value of null wherever it is added. Behavior of pipe name construction remains entirely unchanged if a SharedCompilationId value is not provided for both MSBuild and csc/vbc.

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

There is minimal performance impact as there are no complexity changes. There is a single additional allocation for the SharedCompilationId property in the ManagedCompiler class.