### PR TITLE
changed OOP to use JsonRpc's CancellationToken support

### DIFF
--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngine.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngine.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     /// </summary>
     internal partial class SymbolSearchUpdateEngine : ISymbolSearchUpdateEngine
     {
-        private ConcurrentDictionary<string, IAddReferenceDatabaseWrapper> _sourceToDatabase = 
+        private ConcurrentDictionary<string, IAddReferenceDatabaseWrapper> _sourceToDatabase =
             new ConcurrentDictionary<string, IAddReferenceDatabaseWrapper>();
 
         public SymbolSearchUpdateEngine(ISymbolSearchLogService logService)
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         }
 
         public SymbolSearchUpdateEngine(
-            ISymbolSearchLogService logService, 
+            ISymbolSearchLogService logService,
             CancellationToken updateCancellationToken)
             : this(logService,
                    new RemoteControlService(),
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         }
 
         public Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
-            string source, string name, int arity)
+            string source, string name, int arity, CancellationToken cancellationToken)
         {
             if (!_sourceToDatabase.TryGetValue(source, out var databaseWrapper))
             {
@@ -98,6 +98,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
                 foreach (var type in types)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     // Ignore any reference assembly results.
                     if (type.PackageName.ToString() != MicrosoftAssemblyReferencesName)
                     {
@@ -110,7 +112,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         }
 
         public Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
-            string source, string assemblyName)
+            string source, string assemblyName, CancellationToken cancellationToken)
         {
             if (!_sourceToDatabase.TryGetValue(source, out var databaseWrapper))
             {
@@ -128,6 +130,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             {
                 for (var i = startIndex; i < (startIndex + count); i++)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     var symbol = new Symbol(database, matches[i]);
                     if (symbol.Type == SymbolType.Assembly)
                     {
@@ -147,7 +151,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         }
 
         public Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-            string name, int arity)
+            string name, int arity, CancellationToken cancellationToken)
         {
             // Our reference assembly data is stored in the nuget.org DB.
             if (!_sourceToDatabase.TryGetValue(NugetOrgSource, out var databaseWrapper))
@@ -173,13 +177,15 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
                 foreach (var type in types)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     // Only look at reference assembly results.
                     if (type.PackageName.ToString() == MicrosoftAssemblyReferencesName)
                     {
                         var nameParts = ArrayBuilder<string>.GetInstance();
                         GetFullName(nameParts, type.FullName.Parent);
                         var result = new ReferenceAssemblyWithTypeResult(
-                            type.AssemblyName.ToString(), type.Name.ToString(), 
+                            type.AssemblyName.ToString(), type.Name.ToString(),
                             containingNamespaceNames: nameParts.ToImmutableAndFree());
                         results.Add(result);
                     }
@@ -210,8 +216,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             var version = database.GetPackageVersion(type.Index).ToString();
 
             return new PackageWithTypeResult(
-                packageName: packageName, 
-                typeName: type.Name.ToString(), 
+                packageName: packageName,
+                typeName: type.Name.ToString(),
                 version: version,
                 rank: GetRank(type),
                 containingNamespaceNames: nameParts.ToImmutableAndFree());

--- a/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
+++ b/src/EditorFeatures/Core/SymbolSearch/SymbolSearchUpdateEngineFactory.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Experiments;
 using Microsoft.CodeAnalysis.Remote;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
@@ -48,31 +46,31 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             }
 
             public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
-                string source, string name, int arity)
+                string source, string name, int arity, CancellationToken cancellationToken)
             {
                 var results = await _session.TryInvokeAsync<ImmutableArray<PackageWithTypeResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindPackagesWithTypeAsync),
-                    source, name, arity).ConfigureAwait(false);
+                    new object[] { source, name, arity }, cancellationToken).ConfigureAwait(false);
 
                 return results.NullToEmpty();
             }
 
             public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
-                string source, string assemblyName)
+                string source, string assemblyName, CancellationToken cancellationToken)
             {
                 var results = await _session.TryInvokeAsync<ImmutableArray<PackageWithAssemblyResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindPackagesWithAssemblyAsync),
-                    source, assemblyName).ConfigureAwait(false);
+                    new object[] { source, assemblyName }, cancellationToken).ConfigureAwait(false);
 
                 return results.NullToEmpty();
             }
 
             public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-                string name, int arity)
+                string name, int arity, CancellationToken cancellationToken)
             {
                 var results = await _session.TryInvokeAsync<ImmutableArray<ReferenceAssemblyWithTypeResult>>(
                     nameof(IRemoteSymbolSearchUpdateEngine.FindReferenceAssembliesWithTypeAsync),
-                    name, arity).ConfigureAwait(false);
+                    new object[] { name, arity }, cancellationToken).ConfigureAwait(false);
 
                 return results.NullToEmpty();
             }
@@ -82,7 +80,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             {
                 await _session.TryInvokeAsync(
                     nameof(IRemoteSymbolSearchUpdateEngine.UpdateContinuouslyAsync),
-                    sourceName, localSettingsDirectory).ConfigureAwait(false);
+                    new object[] { sourceName, localSettingsDirectory }, CancellationToken.None).ConfigureAwait(false);
             }
         }
     }

--- a/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/InProcRemostHostClient.cs
@@ -74,7 +74,7 @@ namespace Roslyn.Test.Utilities.Remote
             // this is what consumer actually use to communicate information
             var serviceStream = await _inprocServices.RequestServiceAsync(serviceName, cancellationToken).ConfigureAwait(false);
 
-            return new JsonRpcConnection(callbackTarget, serviceStream, _remotableDataRpc.TryAddReference(), cancellationToken);
+            return new JsonRpcConnection(callbackTarget, serviceStream, _remotableDataRpc.TryAddReference());
         }
 
         protected override void OnStarted()

--- a/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/AbstractAddImportFeatureService_Remote.cs
@@ -23,14 +23,14 @@ namespace Microsoft.CodeAnalysis.AddImport
         private class RemoteSymbolSearchService : IRemoteSymbolSearchUpdateEngine
         {
             private readonly ISymbolSearchService _symbolSearchService;
-            private readonly CancellationToken _cancellationToken;
+            private readonly CancellationToken _shutdownCancellation;
 
             public RemoteSymbolSearchService(
                 ISymbolSearchService symbolSearchService,
-                CancellationToken cancellationToken)
+                CancellationToken shutdownCancellationToken)
             {
                 _symbolSearchService = symbolSearchService;
-                _cancellationToken = cancellationToken;
+                _shutdownCancellation = shutdownCancellationToken;
             }
 
             public Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory)
@@ -40,24 +40,24 @@ namespace Microsoft.CodeAnalysis.AddImport
             }
 
             public Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
-                string source, string name, int arity)
+                string source, string name, int arity, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindPackagesWithTypeAsync(
-                    source, name, arity, _cancellationToken);
+                    source, name, arity, cancellationToken);
             }
 
             public Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
-                string source, string name)
+                string source, string name, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindPackagesWithAssemblyAsync(
-                    source, name, _cancellationToken);
+                    source, name, cancellationToken);
             }
 
             public Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-                string name, int arity)
+                string name, int arity, CancellationToken cancellationToken)
             {
                 return _symbolSearchService.FindReferenceAssembliesWithTypeAsync(
-                    name, arity, _cancellationToken);
+                    name, arity, cancellationToken);
             }
         }
     }

--- a/src/Features/Core/Portable/AddImport/Remote/IRemoteAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/Remote/IRemoteAddImportFeatureService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Packaging;
 using Microsoft.CodeAnalysis.Text;
@@ -11,6 +12,6 @@ namespace Microsoft.CodeAnalysis.AddImport
     {
         Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
-            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources);
+            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/IRemoteDesignerAttributeService.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.DesignerAttributes
 {
     internal interface IRemoteDesignerAttributeService
     {
-        Task<ImmutableArray<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId);
+        Task<ImmutableArray<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticAnalyzerExecutor.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var result = await session.InvokeAsync(
                         WellKnownServiceHubServices.CodeAnalysisService_CalculateDiagnosticsAsync,
                         new object[] { argument },
-                        (s, c) => GetCompilerAnalysisResultAsync(s, analyzerMap, project, c)).ConfigureAwait(false);
+                        (s, c) => GetCompilerAnalysisResultAsync(s, analyzerMap, project, c), cancellationToken).ConfigureAwait(false);
 
                     ReportAnalyzerExceptions(project, result.Exceptions);
 

--- a/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlights.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/IRemoteDocumentHighlights.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.DocumentHighlighting
@@ -9,7 +10,7 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
     internal interface IRemoteDocumentHighlights
     {
         Task<ImmutableArray<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
-            DocumentId documentId, int position, DocumentId[] documentIdsToSearch);
+            DocumentId documentId, int position, DocumentId[] documentIdsToSearch, CancellationToken cancellationToken);
     }
 
     internal struct SerializableDocumentHighlights

--- a/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
+++ b/src/Features/Core/Portable/NavigateTo/IRemoteNavigateToSearchService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
 
@@ -8,7 +9,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 {
     internal interface IRemoteNavigateToSearchService
     {
-        Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern);
-        Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern);
+        Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(DocumentId documentId, string searchPattern, CancellationToken cancellationToken);
+        Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(ProjectId projectId, string searchPattern, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/AbstractTodoCommentService.cs
@@ -66,20 +66,18 @@ namespace Microsoft.CodeAnalysis.TodoComments
             var result = await keepAliveSession.TryInvokeAsync<IList<TodoComment>>(
                 nameof(IRemoteTodoCommentService.GetTodoCommentsAsync),
                 document.Project.Solution,
-                new object[] { document.Id, commentDescriptors }).ConfigureAwait(false);
+                new object[] { document.Id, commentDescriptors }, cancellationToken).ConfigureAwait(false);
 
             return result ?? SpecializedCollections.EmptyList<TodoComment>();
         }
 
-        private async Task<KeepAliveSession> TryGetKeepAliveSessionAsync(RemoteHostClient client, CancellationToken cancellation)
+        private async Task<KeepAliveSession> TryGetKeepAliveSessionAsync(RemoteHostClient client, CancellationToken cancellationToken)
         {
-            using (await _gate.DisposableWaitAsync(cancellation).ConfigureAwait(false))
+            using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
                 if (_sessionDoNotAccessDirectly == null)
                 {
-                    // we give cancellation none here since the cancellation will cause KeepAlive session to be shutdown
-                    // when raised
-                    _sessionDoNotAccessDirectly = await client.TryCreateCodeAnalysisKeepAliveSessionAsync(CancellationToken.None).ConfigureAwait(false);
+                    _sessionDoNotAccessDirectly = await client.TryCreateCodeAnalysisKeepAliveSessionAsync(cancellationToken).ConfigureAwait(false);
                 }
 
                 return _sessionDoNotAccessDirectly;

--- a/src/Features/Core/Portable/TodoComments/IRemoteTodoCommentService.cs
+++ b/src/Features/Core/Portable/TodoComments/IRemoteTodoCommentService.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.TodoComments
@@ -11,6 +12,6 @@ namespace Microsoft.CodeAnalysis.TodoComments
     /// </summary>
     internal interface IRemoteTodoCommentService
     {
-        Task<IList<TodoComment>> GetTodoCommentsAsync(DocumentId documentId, ImmutableArray<TodoCommentDescriptor> commentDescriptors);
+        Task<IList<TodoComment>> GetTodoCommentsAsync(DocumentId documentId, ImmutableArray<TodoCommentDescriptor> commentDescriptors, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 }
 
                 var serializedResults = await session.InvokeAsync<ImmutableArray<DesignerAttributeDocumentData>>(
-                    nameof(IRemoteDesignerAttributeService.ScanDesignerAttributesAsync), project.Id).ConfigureAwait(false);
+                    nameof(IRemoteDesignerAttributeService.ScanDesignerAttributesAsync), new object[] { project.Id }, cancellationToken).ConfigureAwait(false);
 
                 var data = serializedResults.ToImmutableDictionary(kvp => kvp.FilePath);
                 return data;
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             return _dotNotAccessDirectlyDesigner;
         }
 
-#region unused
+        #region unused
 
         public Task NewSolutionSnapshotAsync(Solution solution, CancellationToken cancellationToken)
             => SpecializedTasks.EmptyTask;
@@ -279,6 +279,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         {
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/VisualStudioSymbolSearchService.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
             var allPackagesWithType = await engine.FindPackagesWithTypeAsync(
-                source, name, arity).ConfigureAwait(false);
+                source, name, arity, cancellationToken).ConfigureAwait(false);
 
             return FilterAndOrderPackages(allPackagesWithType);
         }
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
             var allPackagesWithAssembly = await engine.FindPackagesWithAssemblyAsync(
-                source, assemblyName).ConfigureAwait(false);
+                source, assemblyName, cancellationToken).ConfigureAwait(false);
 
             return FilterAndOrderPackages(allPackagesWithAssembly);
         }
@@ -172,7 +172,7 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
         {
             var engine = await GetEngine(cancellationToken).ConfigureAwait(false);
             return await engine.FindReferenceAssembliesWithTypeAsync(
-                name, arity).ConfigureAwait(false);
+                name, arity, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
@@ -18,15 +18,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     internal abstract class JsonRpcEx : IDisposable
     {
         private readonly JsonRpc _rpc;
-        private readonly CancellationToken _cancellationToken;
 
-        public JsonRpcEx(
-            Stream stream, object callbackTarget, bool useThisAsCallback, CancellationToken cancellationToken)
+        public JsonRpcEx(Stream stream, object callbackTarget, bool useThisAsCallback)
         {
             Contract.Requires(stream != null);
 
             var target = useThisAsCallback ? this : callbackTarget;
-            _cancellationToken = cancellationToken;
 
             _rpc = new JsonRpc(new JsonRpcMessageHandler(stream, stream), target);
             _rpc.JsonSerializer.Converters.Add(AggregateJsonConverter.Instance);
@@ -36,13 +33,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
         protected abstract void Dispose(bool disposing);
 
-        public async Task InvokeAsync(string targetName, params object[] arguments)
+        public async Task InvokeAsync(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
-            _cancellationToken.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                await _rpc.InvokeAsync(targetName, arguments).ConfigureAwait(false);
+
+                await _rpc.InvokeWithCancellationAsync(targetName, arguments, cancellationToken).ConfigureAwait(false);
             }
             catch
             {
@@ -50,18 +48,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 // until we move to newly added cancellation support in JsonRpc, we will catch exception and translate to
                 // cancellation exception here. if any exception is thrown unrelated to cancellation, then we will rethrow
                 // the exception
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 throw;
             }
         }
 
-        public async Task<T> InvokeAsync<T>(string targetName, params object[] arguments)
+        public async Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
-            _cancellationToken.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                return await _rpc.InvokeAsync<T>(targetName, arguments).ConfigureAwait(false);
+                return await _rpc.InvokeWithCancellationAsync<T>(targetName, arguments, cancellationToken).ConfigureAwait(false);
             }
             catch
             {
@@ -69,19 +67,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 // until we move to newly added cancellation support in JsonRpc, we will catch exception and translate to
                 // cancellation exception here. if any exception is thrown unrelated to cancellation, then we will rethrow
                 // the exception
-                _cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 throw;
             }
         }
 
-        public Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync)
+        public Task InvokeAsync(
+            string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync, CancellationToken cancellationToken)
         {
-            return Extensions.InvokeAsync(_rpc, targetName, arguments, funcWithDirectStreamAsync, _cancellationToken);
+            return Extensions.InvokeAsync(_rpc, targetName, arguments, funcWithDirectStreamAsync, cancellationToken);
         }
 
-        public Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync)
+        public Task<T> InvokeAsync<T>(
+            string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync, CancellationToken cancellationToken)
         {
-            return Extensions.InvokeAsync(_rpc, targetName, arguments, funcWithDirectStreamAsync, _cancellationToken);
+            return Extensions.InvokeAsync(_rpc, targetName, arguments, funcWithDirectStreamAsync, cancellationToken);
         }
 
         protected void Disconnect()

--- a/src/VisualStudio/Core/Next/Remote/RemotableDataJsonRpcEx.cs
+++ b/src/VisualStudio/Core/Next/Remote/RemotableDataJsonRpcEx.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         private readonly CancellationTokenSource _source;
 
         public RemotableDataJsonRpc(Microsoft.CodeAnalysis.Workspace workspace, Stream stream)
-            : base(stream, callbackTarget: null, useThisAsCallback: true, cancellationToken: CancellationToken.None)
+            : base(stream, callbackTarget: null, useThisAsCallback: true)
         {
             _remotableDataService = workspace.Services.GetService<IRemotableDataService>();
 

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -59,11 +59,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     }
 
                     await connection.InvokeAsync(
-                        nameof(IRemoteHostService.RegisterPrimarySolutionId), solutionId).ConfigureAwait(false);
+                        nameof(IRemoteHostService.RegisterPrimarySolutionId), new object[] { solutionId }, CancellationToken.None).ConfigureAwait(false);
 
                     await connection.InvokeAsync(
-                        nameof(IRemoteHostService.UpdateSolutionIdStorageLocation), solutionId,
-                        _workspace.DeferredState?.ProjectTracker.GetWorkingFolderPath(_workspace.CurrentSolution)).ConfigureAwait(false);
+                        nameof(IRemoteHostService.UpdateSolutionIdStorageLocation),
+                        new object[] { solutionId, _workspace.DeferredState?.ProjectTracker.GetWorkingFolderPath(_workspace.CurrentSolution) },
+                        CancellationToken.None).ConfigureAwait(false);
                 }
             }
 

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             // this is what consumer actually use to communicate information
             var serviceStream = await RequestServiceAsync(_hubClient, serviceName, _hostGroup, _timeout, cancellationToken).ConfigureAwait(false);
 
-            return new JsonRpcConnection(callbackTarget, serviceStream, _remotableDataRpc.TryAddReference(), cancellationToken);
+            return new JsonRpcConnection(callbackTarget, serviceStream, _remotableDataRpc.TryAddReference());
         }
 
         protected override void OnStarted()

--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -137,11 +137,11 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var client = await service.TryGetRemoteHostClientAsync(CancellationToken.None);
 
             var session = await client.TryCreateKeepAliveSessionAsync(WellKnownServiceHubServices.RemoteSymbolSearchUpdateEngine, mock, CancellationToken.None);
-            var result = await session.TryInvokeAsync(nameof(IRemoteSymbolSearchUpdateEngine.UpdateContinuouslyAsync), "emptySource", Path.GetTempPath());
+            var result = await session.TryInvokeAsync(nameof(IRemoteSymbolSearchUpdateEngine.UpdateContinuouslyAsync), new object[] { "emptySource", Path.GetTempPath() }, CancellationToken.None);
 
             Assert.True(result);
 
-            session.Shutdown();
+            session.Shutdown(CancellationToken.None);
 
             service.Disable();
         }

--- a/src/VisualStudio/Razor/RazorLangaugeServiceClient.cs
+++ b/src/VisualStudio/Razor/RazorLangaugeServiceClient.cs
@@ -47,24 +47,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor
                 _inner = inner;
             }
 
-            public Task InvokeAsync(string targetName, params object[] arguments)
+            public Task InvokeAsync(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
             {
-                return _inner.InvokeAsync(targetName, arguments);
+                return _inner.InvokeAsync(targetName, arguments, cancellationToken);
             }
 
-            public Task<T> InvokeAsync<T>(string targetName, params object[] arguments)
+            public Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
             {
-                return _inner.InvokeAsync<T>(targetName, arguments);
+                return _inner.InvokeAsync<T>(targetName, arguments, cancellationToken);
             }
 
-            public Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync)
+            public Task InvokeAsync(string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync, CancellationToken cancellationToken)
             {
-                return _inner.InvokeAsync(targetName, arguments, funcWithDirectStreamAsync);
+                return _inner.InvokeAsync(targetName, arguments, funcWithDirectStreamAsync, cancellationToken);
             }
 
-            public Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync)
+            public Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync, CancellationToken cancellationToken)
             {
-                return _inner.InvokeAsync<T>(targetName, arguments, funcWithDirectStreamAsync);
+                return _inner.InvokeAsync<T>(targetName, arguments, funcWithDirectStreamAsync, cancellationToken);
             }
 
             public void Dispose()

--- a/src/Workspaces/Core/Portable/AddImports/AddImportHelpers.cs
+++ b/src/Workspaces/Core/Portable/AddImports/AddImportHelpers.cs
@@ -49,7 +49,8 @@ namespace Microsoft.CodeAnalysis.AddImports
 
                     newImports[0] = newImports[0].WithLeadingTrivia(originalFirstUsing.GetLeadingTrivia());
 
-                    if (!syntaxFacts.IsEndOfLineTrivia(newImports[0].GetTrailingTrivia().LastOrDefault()))
+                    var trailingTrivia = newImports[0].GetTrailingTrivia();
+                    if (!syntaxFacts.IsEndOfLineTrivia(trailingTrivia.Count == 0 ? default(SyntaxTrivia) : trailingTrivia[trailingTrivia.Count - 1]))
                     {
                         newImports[0] = newImports[0].WithAppendedTrailingTrivia(syntaxFacts.ElasticCarriageReturnLineFeed);
                     }

--- a/src/Workspaces/Core/Portable/Execution/AssetStorages.Storage.cs
+++ b/src/Workspaces/Core/Portable/Execution/AssetStorages.Storage.cs
@@ -37,10 +37,8 @@ namespace Microsoft.CodeAnalysis.Execution
 
             public SolutionState SolutionState { get; }
 
-            public void AddAdditionalAsset(CustomAsset asset, CancellationToken cancellationToken)
+            public void AddAdditionalAsset(CustomAsset asset)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
                 LazyInitialization.EnsureInitialized(ref _additionalAssets, s_additionalAssetsCreator);
 
                 _additionalAssets.TryAdd(asset.Checksum, asset);

--- a/src/Workspaces/Core/Portable/Execution/PinnedRemotableDataScope.cs
+++ b/src/Workspaces/Core/Portable/Execution/PinnedRemotableDataScope.cs
@@ -78,9 +78,9 @@ namespace Microsoft.CodeAnalysis.Execution
         /// TODO: currently, this asset must be something <see cref="Serializer"/> can understand
         ///       this should be changed so that custom serializer can be discoverable by <see cref="RemotableData.Kind"/> 
         /// </summary>
-        public void AddAdditionalAsset(CustomAsset asset, CancellationToken cancellationToken)
+        public void AddAdditionalAsset(CustomAsset asset)
         {
-            _storage.AddAdditionalAsset(asset, cancellationToken);
+            _storage.AddAdditionalAsset(asset);
         }
 
         public RemotableData GetRemotableData(Checksum checksum, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/IRemoteSymbolFinder.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote;
 
@@ -9,19 +10,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 {
     internal interface IRemoteSymbolFinder
     {
-        Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs);
-        Task FindLiteralReferencesAsync(object value, TypeCode typeCode);
+        Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, CancellationToken cancellationToken);
+        Task FindLiteralReferencesAsync(object value, TypeCode typeCode, CancellationToken cancellationToken);
 
         Task<ImmutableArray<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
-            ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria);
+            ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria, CancellationToken cancellationToken);
 
         Task<ImmutableArray<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
-            string name, bool ignoreCase, SymbolFilter criteria);
+            string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken);
 
         Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
-            ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria);
+            ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken);
 
         Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
-            ProjectId projectId, string pattern, SymbolFilter criteria);
+            ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
+++ b/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Remote
@@ -7,12 +8,12 @@ namespace Microsoft.CodeAnalysis.Remote
     internal interface IRemoteHostService
     {
         string Connect(string host, string serializedSession);
-        Task SynchronizePrimaryWorkspaceAsync(Checksum checksum);
-        Task SynchronizeGlobalAssetsAsync(Checksum[] checksums);
+        Task SynchronizePrimaryWorkspaceAsync(Checksum checksum, CancellationToken cancellationToken);
+        Task SynchronizeGlobalAssetsAsync(Checksum[] checksums, CancellationToken cancellationToken);
 
-        void RegisterPrimarySolutionId(SolutionId solutionId);
-        void UnregisterPrimarySolutionId(SolutionId solutionId, bool synchronousShutdown);
+        void RegisterPrimarySolutionId(SolutionId solutionId, CancellationToken cancellationToken);
+        void UnregisterPrimarySolutionId(SolutionId solutionId, bool synchronousShutdown, CancellationToken cancellationToken);
 
-        void UpdateSolutionIdStorageLocation(SolutionId solutionId, string storageLocation);
+        void UpdateSolutionIdStorageLocation(SolutionId solutionId, string storageLocation, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -101,47 +101,19 @@ namespace Microsoft.CodeAnalysis.Remote
             // this will be removed soon.
             protected readonly CancellationToken CancellationToken;
 
-            // scope will be also removed from the connection
-            private readonly object _gate;
-            private PinnedRemotableDataScope _scopeDoNotAccessDirectly;
-
             private bool _disposed;
 
             protected Connection(CancellationToken cancellationToken)
             {
-                _gate = new object();
-
                 _disposed = false;
-                _scopeDoNotAccessDirectly = null;
 
                 CancellationToken = cancellationToken;
             }
 
             protected abstract Task OnRegisterPinnedRemotableDataScopeAsync(PinnedRemotableDataScope scope);
 
-            public PinnedRemotableDataScope PinnedRemotableDataScope
-            {
-                get
-                {
-                    lock (_gate)
-                    {
-                        return _scopeDoNotAccessDirectly;
-                    }
-                }
-                set
-                {
-                    lock (_gate)
-                    {
-                        _scopeDoNotAccessDirectly = value;
-                    }
-                }
-            }
-
             public virtual Task RegisterPinnedRemotableDataScopeAsync(PinnedRemotableDataScope scope)
             {
-                // make sure all thread can read the info
-                PinnedRemotableDataScope = scope;
-
                 return OnRegisterPinnedRemotableDataScopeAsync(scope);
             }
 

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClient.cs
@@ -98,16 +98,11 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         public abstract class Connection : IDisposable
         {
-            // this will be removed soon.
-            protected readonly CancellationToken CancellationToken;
-
             private bool _disposed;
 
-            protected Connection(CancellationToken cancellationToken)
+            protected Connection()
             {
                 _disposed = false;
-
-                CancellationToken = cancellationToken;
             }
 
             protected abstract Task OnRegisterPinnedRemotableDataScopeAsync(PinnedRemotableDataScope scope);
@@ -117,10 +112,10 @@ namespace Microsoft.CodeAnalysis.Remote
                 return OnRegisterPinnedRemotableDataScopeAsync(scope);
             }
 
-            public abstract Task InvokeAsync(string targetName, params object[] arguments);
-            public abstract Task<T> InvokeAsync<T>(string targetName, params object[] arguments);
-            public abstract Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync);
-            public abstract Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync);
+            public abstract Task InvokeAsync(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken);
+            public abstract Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken);
+            public abstract Task InvokeAsync(string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync, CancellationToken cancellationToken);
+            public abstract Task<T> InvokeAsync<T>(string targetName, IReadOnlyList<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync, CancellationToken cancellationToken);
 
             protected virtual void OnDisposed()
             {

--- a/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
+++ b/src/Workspaces/Core/Portable/Remote/RemoteHostClientExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Execution;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -75,13 +76,13 @@ namespace Microsoft.CodeAnalysis.Remote
         public static async Task<KeepAliveSession> TryCreateKeepAliveSessionAsync(
             this RemoteHostClient client, string serviceName, object callbackTarget, CancellationToken cancellationToken)
         {
-            var session = await client.TryCreateConnectionAsync(serviceName, callbackTarget, cancellationToken).ConfigureAwait(false);
-            if (session == null)
+            var connection = await client.TryCreateConnectionAsync(serviceName, callbackTarget, cancellationToken).ConfigureAwait(false);
+            if (connection == null)
             {
                 return null;
             }
 
-            return new KeepAliveSession(client, session, serviceName, callbackTarget, cancellationToken);
+            return new KeepAliveSession(client, connection, serviceName, callbackTarget);
         }
 
         public static Task<SessionWithSolution> TryCreateCodeAnalysisSessionAsync(
@@ -153,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public static async Task<bool> TryRunRemoteAsync(
             this RemoteHostClient client, string serviceName, Solution solution, object callbackTarget,
-            string targetName, object[] arguments, CancellationToken cancellationToken)
+            string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
             using (var session = await client.TryCreateSessionAsync(serviceName, solution, callbackTarget, cancellationToken).ConfigureAwait(false))
             {
@@ -163,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     return false;
                 }
 
-                await session.InvokeAsync(targetName, arguments).ConfigureAwait(false);
+                await session.InvokeAsync(targetName, arguments, cancellationToken).ConfigureAwait(false);
                 return true;
             }
         }
@@ -172,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// Run given service on remote host. if it fails to run on remote host, it will return default(T)
         /// </summary>
         public static async Task<T> TryRunRemoteAsync<T>(
-            this RemoteHostClient client, string serviceName, Solution solution, string targetName, object[] arguments, CancellationToken cancellationToken)
+            this RemoteHostClient client, string serviceName, Solution solution, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
             using (var session = await client.TryCreateSessionAsync(serviceName, solution, cancellationToken).ConfigureAwait(false))
             {
@@ -182,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     return default;
                 }
 
-                return await session.InvokeAsync<T>(targetName, arguments).ConfigureAwait(false);
+                return await session.InvokeAsync<T>(targetName, arguments, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -264,7 +265,7 @@ namespace Microsoft.CodeAnalysis.Remote
             => TryRunCodeAnalysisRemoteAsync(solution, option, callbackTarget, targetName, new object[] { argument }, cancellationToken);
 
         public static async Task<bool> TryRunCodeAnalysisRemoteAsync(
-            this Solution solution, Option<bool> option, object callbackTarget, string targetName, object[] arguments, CancellationToken cancellationToken)
+            this Solution solution, Option<bool> option, object callbackTarget, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
             using (var session = await TryCreateCodeAnalysisSessionAsync(solution, option, callbackTarget, cancellationToken).ConfigureAwait(false))
             {
@@ -273,7 +274,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     return false;
                 }
 
-                await session.InvokeAsync(targetName, arguments).ConfigureAwait(false);
+                await session.InvokeAsync(targetName, arguments, cancellationToken).ConfigureAwait(false);
                 return true;
             }
         }
@@ -292,7 +293,7 @@ namespace Microsoft.CodeAnalysis.Remote
         /// Run given service on remote host. if it fails to run on remote host, it will return default(T)
         /// </summary>
         public static async Task<T> TryRunCodeAnalysisRemoteAsync<T>(
-            this Solution solution, Option<bool> option, object callbackTarget, string targetName, object[] arguments, CancellationToken cancellationToken)
+            this Solution solution, Option<bool> option, object callbackTarget, string targetName, IReadOnlyList<object> arguments, CancellationToken cancellationToken)
         {
             using (var session = await TryCreateCodeAnalysisSessionAsync(solution, option, callbackTarget, cancellationToken).ConfigureAwait(false))
             {
@@ -301,7 +302,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     return default;
                 }
 
-                return await session.InvokeAsync<T>(targetName, arguments).ConfigureAwait(false);
+                return await session.InvokeAsync<T>(targetName, arguments, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/IRemoteSymbolSearchUpdateEngine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
@@ -9,8 +10,8 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
     {
         Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory);
 
-        Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity);
-        Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name);
-        Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity);
+        Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken);
+        Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string name, CancellationToken cancellationToken);
+        Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/ISymbolSearchUpdateEngine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.SymbolSearch
@@ -14,10 +15,10 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
         Task UpdateContinuouslyAsync(string sourceName, string localSettingsDirectory);
 
         Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(
-            string source, string name, int arity);
+            string source, string name, int arity, CancellationToken cancellationToken);
         Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(
-            string source, string assemblyName);
+            string source, string assemblyName, CancellationToken cancellationToken);
         Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(
-            string name, int arity);
+            string name, int arity, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/Core/Services/AssetSource.cs
+++ b/src/Workspaces/Remote/Core/Services/AssetSource.cs
@@ -21,6 +21,6 @@ namespace Microsoft.CodeAnalysis.Remote
             _assetStorage.SetAssetSource(this);
         }
 
-        public abstract Task<IList<ValueTuple<Checksum, object>>> RequestAssetsAsync(int scopeId, ISet<Checksum> checksums, CancellationToken cancellationToken);
+        public abstract Task<IList<(Checksum, object)>> RequestAssetsAsync(int scopeId, ISet<Checksum> checksums, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_AddImport.cs
@@ -15,11 +15,11 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         public async Task<ImmutableArray<AddImportFixData>> GetFixesAsync(
             DocumentId documentId, TextSpan span, string diagnosticId, bool placeSystemNamespaceFirst,
-            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources)
+            bool searchReferenceAssemblies, ImmutableArray<PackageSource> packageSources, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                 var document = solution.GetDocument(documentId);
 
                 var service = document.GetLanguageService<IAddImportFeatureService>();
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 var result = await service.GetFixesAsync(
                     document, span, diagnosticId, placeSystemNamespaceFirst,
                     symbolSearchService, searchReferenceAssemblies,
-                    packageSources, CancellationToken).ConfigureAwait(false);
+                    packageSources, cancellationToken).ConfigureAwait(false);
 
                 return result;
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_CodeLens.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_CodeLens.cs
@@ -6,24 +6,24 @@ using System.IO;
 using Microsoft.CodeAnalysis.CodeLens;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Remote.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
     internal partial class CodeAnalysisService
     {
-        public async Task<ReferenceCount> GetReferenceCountAsync(DocumentId documentId, TextSpan textSpan, int maxResultCount)
+        public async Task<ReferenceCount> GetReferenceCountAsync(DocumentId documentId, TextSpan textSpan, int maxResultCount, CancellationToken cancellationToken)
         {
             try
             {
-                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_GetReferenceCountAsync, documentId.ProjectId.DebugName, CancellationToken))
+                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_GetReferenceCountAsync, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync().ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                     var syntaxNode = (await solution.GetDocument(documentId).GetSyntaxRootAsync().ConfigureAwait(false)).FindNode(textSpan);
 
                     return await CodeLensReferencesServiceFactory.Instance.GetReferenceCountAsync(solution, documentId,
-                        syntaxNode, maxResultCount, CancellationToken).ConfigureAwait(false);
+                        syntaxNode, maxResultCount, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (IOException)
@@ -41,17 +41,17 @@ namespace Microsoft.CodeAnalysis.Remote
             return null;
         }
 
-        public async Task<IEnumerable<ReferenceLocationDescriptor>> FindReferenceLocationsAsync(DocumentId documentId, TextSpan textSpan)
+        public async Task<IEnumerable<ReferenceLocationDescriptor>> FindReferenceLocationsAsync(DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
             try
             {
-                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceLocationsAsync, documentId.ProjectId.DebugName, CancellationToken))
+                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceLocationsAsync, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync().ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                     var syntaxNode = (await solution.GetDocument(documentId).GetSyntaxRootAsync().ConfigureAwait(false)).FindNode(textSpan);
 
                     return await CodeLensReferencesServiceFactory.Instance.FindReferenceLocationsAsync(solution, documentId,
-                        syntaxNode, CancellationToken).ConfigureAwait(false);
+                        syntaxNode, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (IOException)
@@ -69,17 +69,17 @@ namespace Microsoft.CodeAnalysis.Remote
             return null;
         }
 
-        public async Task<IEnumerable<ReferenceMethodDescriptor>> FindReferenceMethodsAsync(DocumentId documentId, TextSpan textSpan)
+        public async Task<IEnumerable<ReferenceMethodDescriptor>> FindReferenceMethodsAsync(DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
             try
             {
-                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceMethodsAsync, documentId.ProjectId.DebugName, CancellationToken))
+                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_FindReferenceMethodsAsync, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync().ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                     var syntaxNode = (await solution.GetDocument(documentId).GetSyntaxRootAsync().ConfigureAwait(false)).FindNode(textSpan);
 
                     return await CodeLensReferencesServiceFactory.Instance.FindReferenceMethodsAsync(solution, documentId,
-                        syntaxNode, CancellationToken).ConfigureAwait(false);
+                        syntaxNode, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (IOException)
@@ -97,17 +97,17 @@ namespace Microsoft.CodeAnalysis.Remote
             return null;
         }
 
-        public async Task<string> GetFullyQualifiedName(DocumentId documentId, TextSpan textSpan)
+        public async Task<string> GetFullyQualifiedName(DocumentId documentId, TextSpan textSpan, CancellationToken cancellationToken)
         {
             try
             {
-                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_GetFullyQualifiedName, documentId.ProjectId.DebugName, CancellationToken))
+                using (Internal.Log.Logger.LogBlock(FunctionId.CodeAnalysisService_GetFullyQualifiedName, documentId.ProjectId.DebugName, cancellationToken))
                 {
-                    var solution = await GetSolutionAsync().ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                     var syntaxNode = (await solution.GetDocument(documentId).GetSyntaxRootAsync().ConfigureAwait(false)).FindNode(textSpan);
 
                     return await CodeLensReferencesServiceFactory.Instance.GetFullyQualifiedName(solution, documentId,
-                        syntaxNode, CancellationToken).ConfigureAwait(false);
+                        syntaxNode, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (IOException)

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DesignerAttributes.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DesignerAttributes;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -17,14 +17,14 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<ImmutableArray<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId)
+        public async Task<ImmutableArray<DesignerAttributeDocumentData>> ScanDesignerAttributesAsync(ProjectId projectId, CancellationToken cancellationToken)
         {
-            using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetDesignerAttributesAsync, projectId.DebugName, CancellationToken))
+            using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetDesignerAttributesAsync, projectId.DebugName, cancellationToken))
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(projectId);
                 var data = await AbstractDesignerAttributeService.TryAnalyzeProjectInCurrentProcessAsync(
-                    project, CancellationToken).ConfigureAwait(false);
+                    project, cancellationToken).ConfigureAwait(false);
 
                 return data.Values.ToImmutableArray();
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_Diagnostics.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
@@ -21,51 +21,45 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task CalculateDiagnosticsAsync(DiagnosticArguments arguments, string streamName)
+        public async Task CalculateDiagnosticsAsync(DiagnosticArguments arguments, string streamName, CancellationToken cancellationToken)
         {
             // if this analysis is explicitly asked by user, boost priority of this request
-            using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_CalculateDiagnosticsAsync, arguments.ProjectId.DebugName, CancellationToken))
+            using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_CalculateDiagnosticsAsync, arguments.ProjectId.DebugName, cancellationToken))
             using (arguments.ForcedAnalysis ? UserOperationBooster.Boost() : default)
             {
                 try
                 {
                     // entry point for diagnostic service
-                    var solution = await GetSolutionAsync().ConfigureAwait(false);
+                    var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
 
-                    var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.OptionSetChecksum, CancellationToken).ConfigureAwait(false);
+                    var optionSet = await RoslynServices.AssetService.GetAssetAsync<OptionSet>(arguments.OptionSetChecksum, cancellationToken).ConfigureAwait(false);
                     var projectId = arguments.ProjectId;
-                    var analyzers = RoslynServices.AssetService.GetGlobalAssetsOfType<AnalyzerReference>(CancellationToken);
+                    var analyzers = RoslynServices.AssetService.GetGlobalAssetsOfType<AnalyzerReference>(cancellationToken);
 
                     var result = await (new DiagnosticComputer(solution.GetProject(projectId))).GetDiagnosticsAsync(
-                        analyzers, optionSet, arguments.AnalyzerIds, arguments.ReportSuppressedDiagnostics, arguments.LogAnalyzerExecutionTime, CancellationToken).ConfigureAwait(false);
+                        analyzers, optionSet, arguments.AnalyzerIds, arguments.ReportSuppressedDiagnostics, arguments.LogAnalyzerExecutionTime, cancellationToken).ConfigureAwait(false);
 
-                    await SerializeDiagnosticResultAsync(streamName, result).ConfigureAwait(false);
+                    await SerializeDiagnosticResultAsync(streamName, result, cancellationToken).ConfigureAwait(false);
                 }
                 catch (IOException)
                 {
-                    // stream to send over result has closed before we
+                    // direct stream to send over result has closed before we
                     // had chance to check cancellation
-                }
-                catch (OperationCanceledException)
-                {
-                    // rpc connection has closed.
-                    // this can happen if client side cancelled the
-                    // operation
                 }
             }
         }
 
-        private async Task SerializeDiagnosticResultAsync(string streamName, DiagnosticAnalysisResultMap<string, DiagnosticAnalysisResultBuilder> result)
+        private async Task SerializeDiagnosticResultAsync(string streamName, DiagnosticAnalysisResultMap<string, DiagnosticAnalysisResultBuilder> result, CancellationToken cancellationToken)
         {
-            using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_SerializeDiagnosticResultAsync, GetResultLogInfo, result, CancellationToken))
-            using (var stream = await DirectStream.GetAsync(streamName, CancellationToken).ConfigureAwait(false))
+            using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_SerializeDiagnosticResultAsync, GetResultLogInfo, result, cancellationToken))
+            using (var stream = await DirectStream.GetAsync(streamName, cancellationToken).ConfigureAwait(false))
             {
                 using (var writer = new ObjectWriter(stream))
                 {
-                    DiagnosticResultSerializer.Serialize(writer, result, CancellationToken);
+                    DiagnosticResultSerializer.Serialize(writer, result, cancellationToken);
                 }
 
-                await stream.FlushAsync(CancellationToken).ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -12,15 +13,15 @@ namespace Microsoft.CodeAnalysis.Remote
     internal partial class CodeAnalysisService : IRemoteDocumentHighlights
     {
         public async Task<ImmutableArray<SerializableDocumentHighlights>> GetDocumentHighlightsAsync(
-            DocumentId documentId, int position, DocumentId[] documentIdsToSearch)
+            DocumentId documentId, int position, DocumentId[] documentIdsToSearch, CancellationToken cancellationToken)
         {
-            var solution = await GetSolutionAsync().ConfigureAwait(false);
+            var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
             var document = solution.GetDocument(documentId);
             var documentsToSearch = ImmutableHashSet.CreateRange(documentIdsToSearch.Select(solution.GetDocument));
 
             var service = document.GetLanguageService<IDocumentHighlightsService>();
             var result = await service.GetDocumentHighlightsAsync(
-                document, position, documentsToSearch, CancellationToken).ConfigureAwait(false);
+                document, position, documentsToSearch, cancellationToken).ConfigureAwait(false);
 
             return result.SelectAsArray(SerializableDocumentHighlights.Dehydrate);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_NavigateTo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.NavigateTo;
 
@@ -10,30 +10,30 @@ namespace Microsoft.CodeAnalysis.Remote
     internal partial class CodeAnalysisService : IRemoteNavigateToSearchService
     {
         public async Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchDocumentAsync(
-            DocumentId documentId, string searchPattern)
+            DocumentId documentId, string searchPattern, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
 
                 var project = solution.GetDocument(documentId);
                 var result = await AbstractNavigateToSearchService.SearchDocumentInCurrentProcessAsync(
-                    project, searchPattern, CancellationToken).ConfigureAwait(false);
+                    project, searchPattern, cancellationToken).ConfigureAwait(false);
 
                 return Convert(result);
             }
         }
 
         public async Task<ImmutableArray<SerializableNavigateToSearchResult>> SearchProjectAsync(
-            ProjectId projectId, string searchPattern)
+            ProjectId projectId, string searchPattern, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
 
                 var project = solution.GetProject(projectId);
                 var result = await AbstractNavigateToSearchService.SearchProjectInCurrentProcessAsync(
-                    project, searchPattern, CancellationToken).ConfigureAwait(false);
+                    project, searchPattern, cancellationToken).ConfigureAwait(false);
 
                 return Convert(result);
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
@@ -12,14 +13,14 @@ namespace Microsoft.CodeAnalysis.Remote
     // root level service for all Roslyn services
     internal partial class CodeAnalysisService : IRemoteSymbolFinder
     {
-        public async Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs)
+        public async Task FindReferencesAsync(SerializableSymbolAndProjectId symbolAndProjectIdArg, DocumentId[] documentArgs, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
 
                 var symbolAndProjectId = await symbolAndProjectIdArg.TryRehydrateAsync(
-                    solution, CancellationToken).ConfigureAwait(false);
+                    solution, cancellationToken).ConfigureAwait(false);
 
                 var progressCallback = new FindReferencesProgressCallback(this);
 
@@ -35,35 +36,35 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 await SymbolFinder.FindReferencesInCurrentProcessAsync(
                     symbolAndProjectId.Value, solution,
-                    progressCallback, documents, CancellationToken).ConfigureAwait(false);
+                    progressCallback, documents, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public async Task FindLiteralReferencesAsync(object value, TypeCode typeCode)
+        public async Task FindLiteralReferencesAsync(object value, TypeCode typeCode, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
                 var convertedType = System.Convert.ChangeType(value, typeCode);
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
 
                 var progressCallback = new FindLiteralReferencesProgressCallback(this);
                 await SymbolFinder.FindLiteralReferencesInCurrentProcessAsync(
-                    convertedType, solution, progressCallback, CancellationToken).ConfigureAwait(false);
+                    convertedType, solution, progressCallback, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindAllDeclarationsWithNormalQueryAsync(
-            ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria)
+            ProjectId projectId, string name, SearchKind searchKind, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(projectId);
 
                 using (var query = SearchQuery.Create(name, searchKind))
                 {
                     var result = await DeclarationFinder.FindAllDeclarationsWithNormalQueryInCurrentProcessAsync(
-                        project, query, criteria, this.CancellationToken).ConfigureAwait(false);
+                        project, query, criteria, cancellationToken).ConfigureAwait(false);
 
                     return result.SelectAsArray(SerializableSymbolAndProjectId.Dehydrate);
                 }
@@ -71,43 +72,43 @@ namespace Microsoft.CodeAnalysis.Remote
         }
 
         public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindSolutionSourceDeclarationsWithNormalQueryAsync(
-            string name, bool ignoreCase, SymbolFilter criteria)
+            string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                 var result = await DeclarationFinder.FindSourceDeclarationsWithNormalQueryInCurrentProcessAsync(
-                    solution, name, ignoreCase, criteria, CancellationToken).ConfigureAwait(false);
+                    solution, name, ignoreCase, criteria, cancellationToken).ConfigureAwait(false);
 
                 return result.SelectAsArray(SerializableSymbolAndProjectId.Dehydrate);
             }
         }
 
         public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithNormalQueryAsync(
-            ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria)
+            ProjectId projectId, string name, bool ignoreCase, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(projectId);
 
                 var result = await DeclarationFinder.FindSourceDeclarationsWithNormalQueryInCurrentProcessAsync(
-                    project, name, ignoreCase, criteria, CancellationToken).ConfigureAwait(false);
+                    project, name, ignoreCase, criteria, cancellationToken).ConfigureAwait(false);
 
                 return result.SelectAsArray(SerializableSymbolAndProjectId.Dehydrate);
             }
         }
 
         public async Task<ImmutableArray<SerializableSymbolAndProjectId>> FindProjectSourceDeclarationsWithPatternAsync(
-            ProjectId projectId, string pattern, SymbolFilter criteria)
+            ProjectId projectId, string pattern, SymbolFilter criteria, CancellationToken cancellationToken)
         {
             using (UserOperationBooster.Boost())
             {
-                var solution = await GetSolutionAsync().ConfigureAwait(false);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
                 var project = solution.GetProject(projectId);
 
                 var result = await DeclarationFinder.FindSourceDeclarationsWithPatternInCurrentProcessAsync(
-                    project, pattern, criteria, CancellationToken).ConfigureAwait(false);
+                    project, pattern, criteria, cancellationToken).ConfigureAwait(false);
 
                 return result.SelectAsArray(SerializableSymbolAndProjectId.Dehydrate);
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_TodoComments.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -21,32 +22,18 @@ namespace Microsoft.CodeAnalysis.Remote
         /// 
         /// This will be called by ServiceHub/JsonRpc framework
         /// </summary>
-        public async Task<IList<TodoComment>> GetTodoCommentsAsync(DocumentId documentId, ImmutableArray<TodoCommentDescriptor> tokens)
+        public async Task<IList<TodoComment>> GetTodoCommentsAsync(DocumentId documentId, ImmutableArray<TodoCommentDescriptor> tokens, CancellationToken cancellationToken)
         {
-            using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetTodoCommentsAsync, documentId.ProjectId.DebugName, CancellationToken))
+            using (RoslynLogger.LogBlock(FunctionId.CodeAnalysisService_GetTodoCommentsAsync, documentId.ProjectId.DebugName, cancellationToken))
             {
-                try
-                {
-                    var solution = await GetSolutionAsync().ConfigureAwait(false);
-                    var document = solution.GetDocument(documentId);
+                var solution = await GetSolutionAsync(cancellationToken).ConfigureAwait(false);
+                var document = solution.GetDocument(documentId);
 
-                    var service = document.GetLanguageService<ITodoCommentService>();
-                    if (service != null)
-                    {
-                        // todo comment service supported
-                        return await service.GetTodoCommentsAsync(document, tokens, CancellationToken).ConfigureAwait(false);
-                    }
-                }
-                catch (IOException)
+                var service = document.GetLanguageService<ITodoCommentService>();
+                if (service != null)
                 {
-                    // stream to send over result has closed before we
-                    // had chance to check cancellation
-                }
-                catch (OperationCanceledException)
-                {
-                    // rpc connection has closed.
-                    // this can happen if client side cancelled the
-                    // operation
+                    // todo comment service supported
+                    return await service.GetTodoCommentsAsync(document, tokens, cancellationToken).ConfigureAwait(false);
                 }
 
                 return SpecializedCollections.EmptyList<TodoComment>();

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteSymbolSearchUpdateEngine.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.SymbolSearch;
 
@@ -16,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Remote
             : base(serviceProvider, stream)
         {
             _updateEngine = new SymbolSearchUpdateEngine(
-                new LogService(this), updateCancellationToken: this.CancellationToken);
+                new LogService(this), updateCancellationToken: ShutdownCancellationToken);
 
             Rpc.StartListening();
         }
@@ -26,26 +27,26 @@ namespace Microsoft.CodeAnalysis.Remote
             return _updateEngine.UpdateContinuouslyAsync(sourceName, localSettingsDirectory);
         }
 
-        public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity)
+        public async Task<ImmutableArray<PackageWithTypeResult>> FindPackagesWithTypeAsync(string source, string name, int arity, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindPackagesWithTypeAsync(
-                source, name, arity).ConfigureAwait(false);
+                source, name, arity, cancellationToken).ConfigureAwait(false);
 
             return results;
         }
 
-        public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName)
+        public async Task<ImmutableArray<PackageWithAssemblyResult>> FindPackagesWithAssemblyAsync(string source, string assemblyName, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindPackagesWithAssemblyAsync(
-                source, assemblyName).ConfigureAwait(false);
+                source, assemblyName, cancellationToken).ConfigureAwait(false);
 
             return results;
         }
 
-        public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity)
+        public async Task<ImmutableArray<ReferenceAssemblyWithTypeResult>> FindReferenceAssembliesWithTypeAsync(string name, int arity, CancellationToken cancellationToken)
         {
             var results = await _updateEngine.FindReferenceAssembliesWithTypeAsync(
-                name, arity).ConfigureAwait(false);
+                name, arity, cancellationToken).ConfigureAwait(false);
 
             return results;
         }

--- a/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/ServiceHubServiceBase.cs
@@ -18,14 +18,14 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         private static int s_instanceId;
 
-        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly CancellationTokenSource _shutdownCancellationSource;
 
         protected readonly int InstanceId;
 
         protected readonly JsonRpc Rpc;
         protected readonly TraceSource Logger;
         protected readonly AssetStorage AssetStorage;
-        protected readonly CancellationToken CancellationToken;
+        protected readonly CancellationToken ShutdownCancellationToken;
 
         /// <summary>
         /// PinnedSolutionInfo.ScopeId. scope id of the solution. caller and callee share this id which one
@@ -53,8 +53,8 @@ namespace Microsoft.CodeAnalysis.Remote
             Logger = (TraceSource)serviceProvider.GetService(typeof(TraceSource));
             Logger.TraceInformation($"{DebugInstanceString} Service instance created");
 
-            _cancellationTokenSource = new CancellationTokenSource();
-            CancellationToken = _cancellationTokenSource.Token;
+            _shutdownCancellationSource = new CancellationTokenSource();
+            ShutdownCancellationToken = _shutdownCancellationSource.Token;
 
             Rpc = JsonRpc.Attach(stream, this);
             Rpc.JsonSerializer.Converters.Add(AggregateJsonConverter.Instance);
@@ -72,8 +72,8 @@ namespace Microsoft.CodeAnalysis.Remote
             Logger = (TraceSource)serviceProvider.GetService(typeof(TraceSource));
             Logger.TraceInformation($"{DebugInstanceString} Service instance created");
 
-            _cancellationTokenSource = new CancellationTokenSource();
-            CancellationToken = _cancellationTokenSource.Token;
+            _shutdownCancellationSource = new CancellationTokenSource();
+            ShutdownCancellationToken = _shutdownCancellationSource.Token;
 
             // due to this issue - https://github.com/dotnet/roslyn/issues/16900#issuecomment-277378950
             // all sub type must explicitly start JsonRpc once everything is
@@ -98,12 +98,12 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        protected Task<Solution> GetSolutionAsync()
+        protected Task<Solution> GetSolutionAsync(CancellationToken cancellationToken)
         {
             Contract.ThrowIfNull(_solutionInfo);
 
             var solutionController = (ISolutionController)RoslynServices.SolutionService;
-            return solutionController.GetSolutionAsync(_solutionInfo.SolutionChecksum, _solutionInfo.FromPrimaryBranch, CancellationToken);
+            return solutionController.GetSolutionAsync(_solutionInfo.SolutionChecksum, _solutionInfo.FromPrimaryBranch, cancellationToken);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -126,6 +126,8 @@ namespace Microsoft.CodeAnalysis.Remote
         public void Dispose()
         {
             Rpc.Dispose();
+            _shutdownCancellationSource.Dispose();
+
             Dispose(false);
 
             Logger.TraceInformation($"{DebugInstanceString} Service instance disposed");
@@ -144,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Remote
         private void OnRpcDisconnected(object sender, JsonRpcDisconnectedEventArgs e)
         {
             // raise cancellation
-            _cancellationTokenSource.Cancel();
+            _shutdownCancellationSource.Cancel();
 
             OnDisconnected(e);
 


### PR DESCRIPTION
now rather than disconnecting connection between VS and remote host for cancellation, it uses native support from JsonRpc for cancellation.

this should reduce us from having various exceptions due to disruptive disconnection for service hub stream due to cancellation.