### PR TITLE
Don't crash when an interface is not implemented by the HostObject

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
             else if (HostObject != null)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format(ErrorString.General_IncorrectHostObject, "Csc", "ICscHostObject"));
             }
             if (!designTime)
             {

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -206,6 +206,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 designTime = csHost.IsDesignTime();
             }
+            else if (HostObject != null)
+            {
+                throw new InvalidOperationException();
+            }
             if (!designTime)
             {
                 if (!string.IsNullOrWhiteSpace(VsSessionGuid))

--- a/src/Compilers/Core/MSBuildTask/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Csc.cs
@@ -202,9 +202,8 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
             // If not design time build and the globalSessionGuid property was set then add a -globalsessionguid:<guid>
             bool designTime = false;
-            if (HostObject != null)
+            if (HostObject is ICscHostObject csHost)
             {
-                var csHost = HostObject as ICscHostObject;
                 designTime = csHost.IsDesignTime();
             }
             if (!designTime)
@@ -642,12 +641,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
 
                 // NOTE: For compat reasons this must remain ICscHostObject
                 // we can dynamically test for smarter interfaces later..
-                using (RCWForCurrentContext<ICscHostObject> hostObject = new RCWForCurrentContext<ICscHostObject>(HostObject as ICscHostObject))
+                if (HostObject is ICscHostObject hostObjectCOM)
                 {
-                    ICscHostObject cscHostObject = hostObject.RCW;
-
-                    if (cscHostObject != null)
+                    using (RCWForCurrentContext<ICscHostObject> hostObject = new RCWForCurrentContext<ICscHostObject>(hostObjectCOM))
                     {
+                        ICscHostObject cscHostObject = hostObject.RCW;
+
                         bool hostObjectSuccessfullyInitialized = InitializeHostCompiler(cscHostObject);
 
                         // If we're currently only in design-time (as opposed to build-time),
@@ -699,10 +698,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                             return HostObjectInitializationStatus.NoActionReturnFailure;
                         }
                     }
-                    else
-                    {
-                        Log.LogErrorWithCodeFromResources("General_IncorrectHostObject", "Csc", "ICscHostObject");
-                    }
+                }
+                else
+                {
+                    Log.LogErrorWithCodeFromResources("General_IncorrectHostObject", "Csc", "ICscHostObject");
                 }
             }
 

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -512,7 +512,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             }
             else if (this.HostObject != null)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(string.Format(ErrorString.General_IncorrectHostObject, "Vbc", "IVbcHostObject"));
             }
             if (!designTime)
             {

--- a/src/Compilers/Core/MSBuildTask/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Vbc.cs
@@ -510,6 +510,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             {
                 designTime = vbHost.IsDesignTime();
             }
+            else if (this.HostObject != null)
+            {
+                throw new InvalidOperationException();
+            }
             if (!designTime)
             {
                 if (!string.IsNullOrWhiteSpace(this.VsSessionGuid))


### PR DESCRIPTION
Partially resolves #18633, in that instead of crashing when the host object doesn't implement the `I{Vbc,Csc}HostObject` interface, we silently continue. This also fixes another error in the same file, but that fix is more concrete in that there was already logic for handling the error, it just wasn't getting hit (RCWForCurrentContext should throw a NullArgException in its constructor if passed null).

The decision of if we should silently eat the error or explicitly error out (for the first case) is up for debate. The only behavior from something correctly implementing from the interface is to suppress "/sqmsessionguid" during design time builds (if the HostObject does not implement the interface, it will not suppress the flag, which seemed to be the original intent of the code).

The issue still remains of how we got into this state in the first place (with HostObject not implementing `ICscHostObject` - possibly issues with assembly version mismatches), but this at least resolves the NRE.

Ping @agocke as they helped me work through this.