### PR TITLE
Provide diagnostics when using ref extension methods with lang version before 7.2

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -923,6 +923,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // If this was a ref extension method, receiverArgument must be checked for L-value constraints.
                     // This helper method will also replace it with a BoundBadExpression if it was invalid.
                     receiverArgument = CheckValue(receiverArgument, BindValueKind.RefOrOut, diagnostics);
+
+                    CheckFeatureAvailability(receiverArgument.Syntax, MessageID.IDS_FeatureRefExtensionMethods, diagnostics);
+                }
+                else if (receiverParameter.RefKind == RefKind.RefReadOnly)
+                {
+                    CheckFeatureAvailability(receiverArgument.Syntax, MessageID.IDS_FeatureRefExtensionMethods, diagnostics);
                 }
 
                 ArrayBuilder<BoundExpression> builder = ArrayBuilder<BoundExpression>.GetInstance(analyzedArguments.Arguments.Count);

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -10521,7 +10521,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to reference extension methods.
+        ///   Looks up a localized string similar to ref or in extension methods.
         /// </summary>
         internal static string IDS_FeatureRefExtensionMethods {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -10521,6 +10521,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to reference extension methods.
+        /// </summary>
+        internal static string IDS_FeatureRefExtensionMethods {
+            get {
+                return ResourceManager.GetString("IDS_FeatureRefExtensionMethods", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to byref locals and returns.
         /// </summary>
         internal static string IDS_FeatureRefLocalsReturns {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1967,7 +1967,7 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_StaticClassInterfaceImpl" xml:space="preserve">
     <value>'{0}': static classes cannot implement interfaces</value>
   </data>
-    <data name="ERR_RefStructInterfaceImpl" xml:space="preserve">
+  <data name="ERR_RefStructInterfaceImpl" xml:space="preserve">
     <value>'{0}': ref structs cannot implement interfaces</value>
   </data>
   <data name="ERR_OperatorInStaticClass" xml:space="preserve">
@@ -5167,5 +5167,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_FieldlikeEventsInRoStruct" xml:space="preserve">
     <value>Field-like events are not allowed in readonly structs.</value>
+  </data>
+  <data name="IDS_FeatureRefExtensionMethods" xml:space="preserve">
+    <value>reference extension methods</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -5169,6 +5169,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Field-like events are not allowed in readonly structs.</value>
   </data>
   <data name="IDS_FeatureRefExtensionMethods" xml:space="preserve">
-    <value>reference extension methods</value>
+    <value>ref or in extension methods</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -140,6 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureReadonlyReferences = MessageBase + 12818,
         IDS_FeatureRefStructs = MessageBase + 12819,
         IDS_FeatureReadOnlyStructs = MessageBase + 12820,
+        IDS_FeatureRefExtensionMethods = MessageBase + 12821,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -200,6 +201,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureReadonlyReferences:
                 case MessageID.IDS_FeatureRefStructs:
                 case MessageID.IDS_FeatureReadOnlyStructs:
+                case MessageID.IDS_FeatureRefExtensionMethods:
                     return LanguageVersion.CSharp7_2;
 
                 // C# 7.1 features.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4027,6 +4027,8 @@ tryAgain:
 
         private void ParseParameterModifiers(SyntaxListBuilder modifiers)
         {
+            var seenRefModifier = false;
+
             while (IsParameterModifier(this.CurrentToken.Kind))
             {
                 var modifier = this.EatToken();
@@ -4035,10 +4037,18 @@ tryAgain:
                 {
                     case SyntaxKind.ThisKeyword:
                         modifier = CheckFeatureAvailability(modifier, MessageID.IDS_FeatureExtensionMethod);
+                        if (seenRefModifier)
+                        {
+                            modifier = CheckFeatureAvailability(modifier, MessageID.IDS_FeatureRefExtensionMethods);
+                        }
                         break;
                     case SyntaxKind.InKeyword:
                     case SyntaxKind.ReadOnlyKeyword:
                         modifier = CheckFeatureAvailability(modifier, MessageID.IDS_FeatureReadonlyReferences);
+                        seenRefModifier = true;
+                        break;
+                    case SyntaxKind.RefKeyword:
+                        seenRefModifier = true;
                         break;
                 }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
@@ -1981,12 +1981,13 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
-                // (4,34): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (4,30): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 34),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("reference extension methods", "7.2").WithLocation(4, 30),
                 // (14,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9)
+            );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }
@@ -2054,15 +2055,16 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
-                // (4,34): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref readonly this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(4, 34),
-                // (4,43): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("readonly references", "7.2").WithLocation(4, 30),
+                // (4,30): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref readonly this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 43),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("reference extension methods", "7.2").WithLocation(4, 30),
                 // (14,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9)
+            );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }
@@ -2130,15 +2132,16 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+                // (4,30): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                //     public static void Print(in this int p)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("reference extension methods", "7.2").WithLocation(4, 30),
                 // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(in this int p)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("readonly references", "7.2").WithLocation(4, 30),
-                // (4,33): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
-                //     public static void Print(in this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 33),
                 // (14,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9)
+            );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefExtensionMethodsTests.cs
@@ -1981,12 +1981,12 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
-                // (4,30): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (4,30): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("reference extension methods", "7.2").WithLocation(4, 30),
-                // (14,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 30),
+                // (14,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(14, 9)
             );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
@@ -2018,17 +2018,17 @@ public static class Program
                 text: code,
                 parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1),
                 references: new[] { reference.ToMetadataReference() }).VerifyDiagnostics(
-                // (7,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (7,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(7, 9));
 
             CreateCompilationWithMscorlibAndSystemCore(
                 text: code,
                 parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1),
                 references: new[] { reference.EmitToImageReference() }).VerifyDiagnostics(
-                // (7,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (7,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(7, 9));
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef, reference.ToMetadataReference() }, expectedOutput: "5");
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef, reference.EmitToImageReference() }, expectedOutput: "5");
@@ -2058,12 +2058,12 @@ public static class Program
                 // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref readonly this int p)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("readonly references", "7.2").WithLocation(4, 30),
-                // (4,30): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (4,30): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref readonly this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("reference extension methods", "7.2").WithLocation(4, 30),
-                // (14,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 30),
+                // (14,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(14, 9)
             );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
@@ -2095,17 +2095,17 @@ public static class Program
                 text: code,
                 parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1),
                 references: new[] { reference.ToMetadataReference() }).VerifyDiagnostics(
-                // (7,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (7,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(7, 9));
 
             CreateCompilationWithMscorlibAndSystemCore(
                 text: code,
                 parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1),
                 references: new[] { reference.EmitToImageReference() }).VerifyDiagnostics(
-                // (7,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (7,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(7, 9));
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef, reference.ToMetadataReference() }, expectedOutput: "5");
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef, reference.EmitToImageReference() }, expectedOutput: "5");
@@ -2132,15 +2132,15 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
-                // (4,30): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (4,30): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(in this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("reference extension methods", "7.2").WithLocation(4, 30),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 30),
                 // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(in this int p)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("readonly references", "7.2").WithLocation(4, 30),
-                // (14,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (14,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(14, 9)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(14, 9)
             );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
@@ -2172,17 +2172,17 @@ public static class Program
                 text: code,
                 parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1),
                 references: new[] { reference.ToMetadataReference() }).VerifyDiagnostics(
-                // (7,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (7,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(7, 9));
 
             CreateCompilationWithMscorlibAndSystemCore(
                 text: code,
                 parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1),
                 references: new[] { reference.EmitToImageReference() }).VerifyDiagnostics(
-                // (7,9): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (7,9): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //         p.Print();
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("reference extension methods", "7.2").WithLocation(7, 9));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "p").WithArguments("ref or in extension methods", "7.2").WithLocation(7, 9));
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef, reference.ToMetadataReference() }, expectedOutput: "5");
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef, reference.EmitToImageReference() }, expectedOutput: "5");

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2927,10 +2927,10 @@ public class Test
 }";
 
             ParseAndValidate(code, new CSharpParseOptions(LanguageVersion.CSharp7),
-                // (4,29): error CS8107: Feature 'ref or in extension methods' is not available in C# 7. Please use language version 7.2 or greater.
-                //     public void DoSomething(in int x) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "in").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 29)
-                );
+                // (4,29): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
+                // public void DoSomething(in int x) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "in").WithArguments("readonly references", "7.2").WithLocation(4, 29)
+            );
         }
 
         [WorkItem(906072, "DevDiv/Personal")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -5614,7 +5614,7 @@ public static class Program
     }
 }";
 
-            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
                 // (4,34): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref readonly this int p)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(4, 34),
@@ -5645,7 +5645,7 @@ public static class Program
     }
 }";
 
-            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
                 // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(in this int p)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("readonly references", "7.2").WithLocation(4, 30),
@@ -5676,7 +5676,7 @@ public static class Program
     }
 }";
 
-            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
                       // (4,34): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                       //     public static void Print(ref this int p)
                       Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 34));

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2927,9 +2927,9 @@ public class Test
 }";
 
             ParseAndValidate(code, new CSharpParseOptions(LanguageVersion.CSharp7),
-                // (4,29): error CS8107: Feature 'readonly references' is not available in C# 7. Please use language version 7.2 or greater.
+                // (4,29): error CS8107: Feature 'ref or in extension methods' is not available in C# 7. Please use language version 7.2 or greater.
                 //     public void DoSomething(in int x) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "in").WithArguments("readonly references", "7.2").WithLocation(4, 29)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7, "in").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 29)
                 );
         }
 
@@ -5615,12 +5615,13 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
-                // (4,34): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
-                //     public static void Print(ref readonly this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(4, 34),
-                // (4,43): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
-                //     public static void Print(ref readonly this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 43));
+               // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
+               //     public static void Print(ref readonly this int p)
+               Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("readonly references", "7.2").WithLocation(4, 30),
+               // (4,30): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+               //     public static void Print(ref readonly this int p)
+               Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 30)
+            );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }
@@ -5646,12 +5647,14 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
-                // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
-                //     public static void Print(in this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("readonly references", "7.2").WithLocation(4, 30),
-                // (4,33): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
-                //     public static void Print(in this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 33));
+               // (4,30): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+               //     public static void Print(in this int p)
+               Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 30),
+
+               // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
+               //     public static void Print(in this int p)
+               Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("readonly references", "7.2").WithLocation(4, 30)
+            );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }
@@ -5677,9 +5680,10 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
-                      // (4,34): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
-                      //     public static void Print(ref this int p)
-                      Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 34));
+               // (4,30): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+               //     public static void Print(ref this int p)
+               Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "ref").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 30)
+            );
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -5618,9 +5618,9 @@ public static class Program
                 // (4,34): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref readonly this int p)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(4, 34),
-                // (4,43): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (4,43): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(ref readonly this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 43));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 43));
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }
@@ -5649,9 +5649,9 @@ public static class Program
                 // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(in this int p)
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("readonly references", "7.2").WithLocation(4, 30),
-                // (4,33): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                // (4,33): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                 //     public static void Print(in this int p)
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 33));
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 33));
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }
@@ -5677,9 +5677,9 @@ public static class Program
 }";
 
             CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).GetParseDiagnostics().Verify(
-                      // (4,34): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                      // (4,34): error CS8302: Feature 'ref or in extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
                       //     public static void Print(ref this int p)
-                      Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 34));
+                      Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("ref or in extension methods", "7.2").WithLocation(4, 34));
 
             CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -5594,6 +5594,96 @@ class TestClass { }";
             N(SyntaxKind.EndOfFileToken);
         }
 
+        [Fact]
+        public void RefExtensionMethodsNotSupportedBefore7_2_RefReadOnlySyntax()
+        {
+            var code = @"
+public static class Extensions
+{
+    public static void Print(ref readonly this int p)
+    {
+        System.Console.WriteLine(p);
+    }
+}
+public static class Program
+{
+    public static void Main()
+    {
+        int p = 5;
+        p.Print();
+    }
+}";
+
+            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+                // (4,34): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
+                //     public static void Print(ref readonly this int p)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "readonly").WithArguments("readonly references", "7.2").WithLocation(4, 34),
+                // (4,43): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                //     public static void Print(ref readonly this int p)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 43));
+
+            CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
+        }
+
+        [Fact]
+        public void RefExtensionMethodsNotSupportedBefore7_2_InSyntax()
+        {
+            var code = @"
+public static class Extensions
+{
+    public static void Print(in this int p)
+    {
+        System.Console.WriteLine(p);
+    }
+}
+public static class Program
+{
+    public static void Main()
+    {
+        int p = 5;
+        p.Print();
+    }
+}";
+
+            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+                // (4,30): error CS8302: Feature 'readonly references' is not available in C# 7.1. Please use language version 7.2 or greater.
+                //     public static void Print(in this int p)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "in").WithArguments("readonly references", "7.2").WithLocation(4, 30),
+                // (4,33): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                //     public static void Print(in this int p)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 33));
+
+            CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
+        }
+
+        [Fact]
+        public void RefExtensionMethodsNotSupportedBefore7_2_RefSyntax()
+        {
+            var code = @"
+public static class Extensions
+{
+    public static void Print(ref this int p)
+    {
+        System.Console.WriteLine(p);
+    }
+}
+public static class Program
+{
+    public static void Main()
+    {
+        int p = 5;
+        p.Print();
+    }
+}";
+
+            CreateCompilationWithMscorlibAndSystemCore(code, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1)).VerifyDiagnostics(
+                      // (4,34): error CS8302: Feature 'reference extension methods' is not available in C# 7.1. Please use language version 7.2 or greater.
+                      //     public static void Print(ref this int p)
+                      Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_1, "this").WithArguments("reference extension methods", "7.2").WithLocation(4, 34));
+
+            CompileAndVerify(code, additionalRefs: new[] { SystemCoreRef }, expectedOutput: "5");
+        }
+
         #endregion
 
         #region "Targeted Warning Tests - please arrange tests in the order of error code"


### PR DESCRIPTION
Fixes #20395
cc @VSadov @dotnet/roslyn-compiler 