### PR TITLE
Add support for inspecting Solution Explorer items

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -802,6 +802,62 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             solutionExplorer.Parent.Activate();
         }
 
+        public void SelectItemAtPath(params string[] path)
+        {
+            var dte = (DTE2)GetDTE();
+            var solutionExplorer = dte.ToolWindows.SolutionExplorer;
+
+            var item = FindItemAtPath(solutionExplorer.UIHierarchyItems, path);
+            item.Select(EnvDTE.vsUISelectionType.vsUISelectionTypeSelect);
+            solutionExplorer.Parent.Activate();
+        }
+
+        public string[] GetChildrenOfItem(string itemName)
+        {
+            var dte = (DTE2)GetDTE();
+            var solutionExplorer = dte.ToolWindows.SolutionExplorer;
+
+            var item = FindFirstItemRecursively(solutionExplorer.UIHierarchyItems, itemName);
+
+            return item.UIHierarchyItems
+                .Cast<EnvDTE.UIHierarchyItem>()
+                .Select(i => i.Name)
+                .ToArray();
+        }
+
+        public string[] GetChildrenOfItemAtPath(params string[] path)
+        {
+            var dte = (DTE2)GetDTE();
+            var solutionExplorer = dte.ToolWindows.SolutionExplorer;
+
+            var item = FindItemAtPath(solutionExplorer.UIHierarchyItems, path);
+
+            return item.UIHierarchyItems
+                .Cast<EnvDTE.UIHierarchyItem>()
+                .Select(i => i.Name)
+                .ToArray();
+        }
+
+        private static EnvDTE.UIHierarchyItem FindItemAtPath(
+            EnvDTE.UIHierarchyItems currentItems,
+            string[] path)
+        {
+            EnvDTE.UIHierarchyItem item = null;
+            foreach (var name in path)
+            {
+                item = currentItems.Cast<EnvDTE.UIHierarchyItem>().FirstOrDefault(i => i.Name == name);
+
+                if (item == null)
+                {
+                    return null;
+                }
+
+                currentItems = item.UIHierarchyItems;
+            }
+
+            return item;
+        }
+
         private static EnvDTE.UIHierarchyItem FindFirstItemRecursively(
             EnvDTE.UIHierarchyItems currentItems,
             string itemName)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
 
         public void AddProjectReference(ProjectUtils.Project fromProjectName, ProjectUtils.ProjectReference toProjectName)
         {
-           _inProc.AddProjectReference(fromProjectName.Name, toProjectName.Name);
+            _inProc.AddProjectReference(fromProjectName.Name, toProjectName.Name);
             _instance.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
         }
 
@@ -123,8 +123,35 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public string[] GetAssemblyReferences(ProjectUtils.Project project)
             => _inProc.GetAssemblyReferences(project.Name);
 
+        /// <summary>
+        /// Selects an item named by the <paramref name="itemName"/> parameter.
+        /// Note that this selects the first item of the given name found. In situations where
+        /// there may be more than one item of a given name, use <see cref="SelectItemAtPath(string[])"/>
+        /// instead.
+        /// </summary>
         public void SelectItem(string itemName)
             => _inProc.SelectItem(itemName);
+
+        /// <summary>
+        /// Selects the specific item at the given "path".
+        /// </summary>
+        public void SelectItemAtPath(params string[] path)
+            => _inProc.SelectItemAtPath(path);
+
+        /// <summary>
+        /// Returns the names of the immediate children of the given item.
+        /// Note that this uses the first item of the given name found. In situations where there
+        /// may be more than one item of a given name, use <see cref="GetChildrenOfItemAtPath(string[])"/>
+        /// instead.
+        /// </summary>
+        public string[] GetChildrenOfItem(string itemName)
+            => _inProc.GetChildrenOfItem(itemName);
+
+        /// <summary>
+        /// Returns the names of the immediate children of the item at the given "path".
+        /// </summary>
+        public string[] GetChildrenOfItemAtPath(params string[] path)
+            => _inProc.GetChildrenOfItemAtPath(path);
 
         public void ClearBuildOutputWindowPane()
             => _inProc.ClearBuildOutputWindowPane();
@@ -135,7 +162,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void EditProjectFile(ProjectUtils.Project project)
             => _inProc.EditProjectFile(project.Name);
 
-		public void AddStandaloneFile(string fileName)
+        public void AddStandaloneFile(string fileName)
             => _inProc.AddStandaloneFile(fileName);
     }
 }


### PR DESCRIPTION
Add basic support for inspecting Solution Explorer items.

This is a test-only change, and will be used in new Project System integration tests around the Dependencies node.

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
