### PR TITLE
Added explicit conversion expression tests for C#.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConversionExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConversionExpression.cs
@@ -2619,7 +2619,7 @@ IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclaratio
             VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics,
                 AdditionalOperationTreeVerifier: new ExpectedSymbolVerifier()
                 {
-                    ConversionChildSelector = (conversion) => ((IConversionExpression)conversion.Operand).Operand
+                    ConversionChildSelector = ExpectedSymbolVerifier.NestedConversionChildSelector
                 }.Verify);
         }
 
@@ -3129,6 +3129,1749 @@ IReturnStatement (OperationKind.ReturnStatement) (Syntax: 'return f;')
 
         #endregion
 
+        #region Explicit Conversion
+
+        [Fact]
+        public void ConversionExpression_Explicit_ExplicitIdentityConversionCreatesIConversionExpression()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        int /*<bind>*/i = (int)1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'int /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'int /*<bind ... *</bind>*/;')
+    Variables: Local_1: System.Int32 i
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: System.Int32, Constant: 1) (Syntax: '(int)1')
+        ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0219: The variable 'i' is assigned but its value is never used
+                //         int /*<bind>*/i = (int)1/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 23)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics,
+                AdditionalOperationTreeVerifier: new ExpectedSymbolVerifier().Verify);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ImplicitAndExplicitConversion()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        long /*<bind>*/i = (int)1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'long /*<bin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'long /*<bin ... *</bind>*/;')
+    Variables: Local_1: System.Int64 i
+    Initializer: IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.Int64, Constant: 1) (Syntax: '(int)1')
+        IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: System.Int32, Constant: 1) (Syntax: '(int)1')
+          ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0219: The variable 'i' is assigned but its value is never used
+                //         long /*<bind>*/i = (int)1/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 24)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics,
+                AdditionalOperationTreeVerifier: new ExpectedSymbolVerifier().Verify);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_SimpleNumericCast()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        int i = /*<bind>*/(int)1.0/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.Int32, Constant: 1) (Syntax: '(int)1.0')
+  ILiteralExpression (OperationKind.LiteralExpression, Type: System.Double, Constant: 1) (Syntax: '1.0')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0219: The variable 'i' is assigned but its value is never used
+                //         int i = /*<bind>*/(int)1.0/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 13)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<CastExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_SimpleNumericConversion_InvalidNoImplicitConversion()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        int /*<bind>*/i = (float)1.0/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'int /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'int /*<bind ... *</bind>*/;')
+    Variables: Local_1: System.Int32 i
+    Initializer: IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid) (Syntax: '(float)1.0')
+        IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.Single, Constant: 1) (Syntax: '(float)1.0')
+          ILiteralExpression (OperationKind.LiteralExpression, Type: System.Double, Constant: 1) (Syntax: '1.0')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0266: Cannot implicitly convert type 'float' to 'int'. An explicit conversion exists (are you missing a cast?)
+                //         int /*<bind>*/i = (float)1.0/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "(float)1.0").WithArguments("float", "int").WithLocation(6, 27)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_SimpleNumericConversion_InvalidSyntax()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        long /*<bind>*/i = (int)/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'long /*<bin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'long /*<bin ... *</bind>*/;')
+    Variables: Local_1: System.Int64 i
+    Initializer: IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.Int64, IsInvalid) (Syntax: '(int)/*</bind>*/')
+        IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: System.Int32, IsInvalid) (Syntax: '(int)/*</bind>*/')
+          IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid) (Syntax: '')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS1525: Invalid expression term ';'
+                //         long /*<bind>*/i = (int)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ";").WithArguments(";").WithLocation(6, 44)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_EnumFromNumericLiteralConversion()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        E1 /*<bind>*/e1 = (E1)1/*</bind>*/;
+    }
+}
+
+enum E1
+{
+    One, Two
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'E1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'E1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: E1 e1
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: E1, Constant: 1) (Syntax: '(E1)1')
+        ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0219: The variable 'e1' is assigned but its value is never used
+                //         E1 /*<bind>*/e1 = (E1)1/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "e1").WithArguments("e1").WithLocation(6, 22)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_EnumToNumericTypeConversion()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        int /*<bind>*/i = (int)E1.One/*</bind>*/;
+    }
+}
+
+enum E1
+{
+    One, Two
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'int /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'int /*<bind ... *</bind>*/;')
+    Variables: Local_1: System.Int32 i
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.Int32, Constant: 0) (Syntax: '(int)E1.One')
+        IFieldReferenceExpression: E1.One (Static) (OperationKind.FieldReferenceExpression, Type: E1, Constant: 0) (Syntax: 'E1.One')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0219: The variable 'i' is assigned but its value is never used
+                //         int /*<bind>*/i = (int)E1.One/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 23)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_EnumToEnumConversion()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        E2 /*<bind>*/e2 = (E2)E1.One/*</bind>*/;
+    }
+}
+
+enum E1
+{
+    One, Two
+}
+
+enum E2
+{
+    Three, Four
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'E2 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'E2 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: E2 e2
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: E2, Constant: 0) (Syntax: '(E2)E1.One')
+        IFieldReferenceExpression: E1.One (Static) (OperationKind.FieldReferenceExpression, Type: E1, Constant: 0) (Syntax: 'E1.One')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0219: The variable 'e2' is assigned but its value is never used
+                //         E2 /*<bind>*/e2 = (E2)E1.One/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "e2").WithArguments("e2").WithLocation(6, 22)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_EnumToEnumConversion_InvalidOutOfRange()
+        {
+            string source = @"
+class C1
+{
+    public void M1()
+    {
+        E2 /*<bind>*/e2 = (E2)E1.One/*</bind>*/;
+    }
+}
+
+enum E1
+{
+    One = 1000
+}
+
+enum E2 : byte
+{
+    Two
+}
+";
+
+            // Note: The lack of a constant value for the conversion is expected here, it matches the semantic model.
+            // Because the enum value is larger than the destination enum, the conversion is bad
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'E2 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'E2 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: E2 e2
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: E2, Constant: null) (Syntax: '(E2)E1.One')
+        IFieldReferenceExpression: E1.One (Static) (OperationKind.FieldReferenceExpression, Type: E1, Constant: 1000) (Syntax: 'E1.One')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0221: Constant value '1000' cannot be converted to a 'E2' (use 'unchecked' syntax to override)
+                //         E2 /*<bind>*/e2 = (E2)E1.One/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_ConstOutOfRangeChecked, "(E2)E1.One").WithArguments("1000", "E2").WithLocation(6, 27),
+                // CS0219: The variable 'e2' is assigned but its value is never used
+                //         E2 /*<bind>*/e2 = (E2)E1.One/*</bind>*/;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "e2").WithArguments("e2").WithLocation(6, 22)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_NullableToNullableConversion()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        long? l = null;
+        int? /*<bind>*/i = (int?)l/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'int? /*<bin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'int? /*<bin ... *</bind>*/;')
+    Variables: Local_1: System.Int32? i
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.Int32?) (Syntax: '(int?)l')
+        ILocalReferenceExpression: l (OperationKind.LocalReferenceExpression, Type: System.Int64?) (Syntax: 'l')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_NullableToNonNullableConversion()
+        {
+            string source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        long? l = null;
+        int /*<bind>*/i = (int)l/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'int /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'int /*<bind ... *</bind>*/;')
+    Variables: Local_1: System.Int32 i
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.Int32) (Syntax: '(int)l')
+        ILocalReferenceExpression: l (OperationKind.LocalReferenceExpression, Type: System.Int64?) (Syntax: 'l')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceFromObjectConversion()
+        {
+            string source = @"
+class C1
+{
+    static void M1()
+    {
+        object o = string.Empty;
+        string /*<bind>*/s = (string)o/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'string /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'string /*<b ... *</bind>*/;')
+    Variables: Local_1: System.String s
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: System.String) (Syntax: '(string)o')
+        ILocalReferenceExpression: o (OperationKind.LocalReferenceExpression, Type: System.Object) (Syntax: 'o')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceFromDynamicConversion()
+        {
+            string source = @"
+class C1
+{
+    static void M1()
+    {
+        dynamic d = string.Empty;
+        string /*<bind>*/s = (string)d/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'string /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'string /*<b ... *</bind>*/;')
+    Variables: Local_1: System.String s
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.String) (Syntax: '(string)d')
+        ILocalReferenceExpression: d (OperationKind.LocalReferenceExpression, Type: dynamic) (Syntax: 'd')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceFromSuperclassConversion()
+        {
+            string source = @"
+class C1
+{
+    static void M1()
+    {
+        C1 c1 = new C2();
+        C2 /*<bind>*/c2 = (C2)c1/*</bind>*/;
+    }
+}
+
+class C2 : C1
+{
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C2 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C2 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: C2 c2
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: C2) (Syntax: '(C2)c1')
+        ILocalReferenceExpression: c1 (OperationKind.LocalReferenceExpression, Type: C1) (Syntax: 'c1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceFromSuperclassConversion_InvalidNoConversion()
+        {
+            string source = @"
+class C1
+{
+    static void M1()
+    {
+        C1 c1 = new C1();
+        C2 /*<bind>*/c2 = (C2)c1/*</bind>*/;
+    }
+}
+
+class C2
+{
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'C2 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'C2 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: C2 c2
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: C2, IsInvalid) (Syntax: '(C2)c1')
+        ILocalReferenceExpression: c1 (OperationKind.LocalReferenceExpression, Type: C1) (Syntax: 'c1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'C1' to 'C2'
+                //         C2 /*<bind>*/c2 = (C2)c1/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(C2)c1").WithArguments("C1", "C2").WithLocation(7, 27)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceFromImplementedInterfaceConversion()
+        {
+            string source = @"
+interface I1 { }
+
+class C1 : I1
+{
+    static void M1()
+    {
+        I1 i1 = new C1();
+        C1 /*<bind>*/c1 = (C1)i1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: C1 c1
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: C1) (Syntax: '(C1)i1')
+        ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: I1) (Syntax: 'i1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceFromUnimplementedInterfaceConversion()
+        {
+            string source = @"
+interface I1 { }
+
+class C1
+{
+    static void M1()
+    {
+        I1 i1 = null;
+        C1 /*<bind>*/c1 = (C1)i1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: C1 c1
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: C1) (Syntax: '(C1)i1')
+        ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: I1) (Syntax: 'i1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceFromUnimplementedInterfaceConversion_InvalidSealedClass()
+        {
+            string source = @"
+interface I1 { }
+
+sealed class C1
+{
+    static void M1()
+    {
+        I1 i1 = null;
+        C1 /*<bind>*/c1 = (C1)i1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'C1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'C1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: C1 c1
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: C1, IsInvalid) (Syntax: '(C1)i1')
+        ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: I1) (Syntax: 'i1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'I1' to 'C1'
+                //         C1 /*<bind>*/c1 = (C1)i1/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(C1)i1").WithArguments("I1", "C1").WithLocation(9, 27)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceFromInterfaceToInterfaceConversion()
+        {
+            string source = @"
+interface I1 { }
+
+interface I2 { }
+
+sealed class C1
+{
+    static void M1()
+    {
+        I1 i1 = null;
+        I2 /*<bind>*/i2 = (I2)i1/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'I2 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'I2 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: I2 i2
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: I2) (Syntax: '(I2)i1')
+        ILocalReferenceExpression: i1 (OperationKind.LocalReferenceExpression, Type: I1) (Syntax: 'i1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceConversion_InvalidSyntax()
+        {
+            string source = @"
+interface I2 { }
+
+sealed class C1
+{
+    static void M1()
+    {
+        I2 /*<bind>*/i2 = /*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'I2 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'I2 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: I2 i2
+    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: I2, IsInvalid) (Syntax: '')
+        IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid) (Syntax: '')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS1525: Invalid expression term ';'
+                //         I2 /*<bind>*/i2 = /*</bind>*/;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ";").WithArguments(";").WithLocation(8, 38),
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceArrayTypeToArrayTypeConversion()
+        {
+            string source = @"
+class C1
+{
+    static void M1()
+    {
+        C1[] c1arr = new C2[1];
+        C2[] /*<bind>*/c2arr = (C2[])c1arr/*</bind>*/;
+    }
+}
+
+class C2 : C1 { }
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C2[] /*<bin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C2[] /*<bin ... *</bind>*/;')
+    Variables: Local_1: C2[] c2arr
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: C2[]) (Syntax: '(C2[])c1arr')
+        ILocalReferenceExpression: c1arr (OperationKind.LocalReferenceExpression, Type: C1[]) (Syntax: 'c1arr')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceArrayTypeToArrayTypeConversion_InvalidNoElementTypeConversion()
+        {
+            string source = @"
+class C1
+{
+    static void M1()
+    {
+        C1[] c1arr = new C1[1];
+        C2[] /*<bind>*/c2arr = (C2[])c1arr/*</bind>*/;
+    }
+}
+
+class C2 { }
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'C2[] /*<bin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'C2[] /*<bin ... *</bind>*/;')
+    Variables: Local_1: C2[] c2arr
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: C2[], IsInvalid) (Syntax: '(C2[])c1arr')
+        ILocalReferenceExpression: c1arr (OperationKind.LocalReferenceExpression, Type: C1[]) (Syntax: 'c1arr')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'C1[]' to 'C2[]'
+                //         C2[] /*<bind>*/c2arr = (C2[])c1arr/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(C2[])c1arr").WithArguments("C1[]", "C2[]").WithLocation(7, 32)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceArrayTypeToArrayTypeConversion_InvalidMismatchedSized()
+        {
+            string source = @"
+class C1
+{
+    static void M1()
+    {
+        C1[] c1arr = new C1[1];
+        C1[][] /*<bind>*/c2arr = (C1[][])c1arr/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'C1[][] /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'C1[][] /*<b ... *</bind>*/;')
+    Variables: Local_1: C1[][] c2arr
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: C1[][], IsInvalid) (Syntax: '(C1[][])c1arr')
+        ILocalReferenceExpression: c1arr (OperationKind.LocalReferenceExpression, Type: C1[]) (Syntax: 'c1arr')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'C1[]' to 'C1[][]'
+                //         C1[][] /*<bind>*/c2arr = (C1[][])c1arr/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(C1[][])c1arr").WithArguments("C1[]", "C1[][]").WithLocation(7, 34)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceSystemArrayToArrayTypeConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    static void M1()
+    {
+        Array c1arr = new C1[1];
+        C1[] /*<bind>*/c2arr = (C1[])c1arr/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C1[] /*<bin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C1[] /*<bin ... *</bind>*/;')
+    Variables: Local_1: C1[] c2arr
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: C1[]) (Syntax: '(C1[])c1arr')
+        ILocalReferenceExpression: c1arr (OperationKind.LocalReferenceExpression, Type: System.Array) (Syntax: 'c1arr')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceArrayToIListConversion()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+
+class C1
+{
+    static void M1()
+    {
+        C1[] c1arr = new C1[1];
+        IList<C1> /*<bind>*/c1list = (IList<C1>)c1arr/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'IList<C1> / ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'IList<C1> / ... *</bind>*/;')
+    Variables: Local_1: System.Collections.Generic.IList<C1> c1list
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: System.Collections.Generic.IList<C1>) (Syntax: '(IList<C1>)c1arr')
+        ILocalReferenceExpression: c1arr (OperationKind.LocalReferenceExpression, Type: C1[]) (Syntax: 'c1arr')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceArrayToIListConversion_InvalidMismatchedDimensions()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+
+class C1
+{
+    static void M1()
+    {
+        C1[][] c1arr = new C1[1][];
+        IList<C1> /*<bind>*/c1list = (IList<C1>)c1arr/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'IList<C1> / ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'IList<C1> / ... *</bind>*/;')
+    Variables: Local_1: System.Collections.Generic.IList<C1> c1list
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: System.Collections.Generic.IList<C1>, IsInvalid) (Syntax: '(IList<C1>)c1arr')
+        ILocalReferenceExpression: c1arr (OperationKind.LocalReferenceExpression, Type: C1[][]) (Syntax: 'c1arr')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'C1[][]' to 'System.Collections.Generic.IList<C1>'
+                //         IList<C1> /*<bind>*/c1list = (IList<C1>)c1arr/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(IList<C1>)c1arr").WithArguments("C1[][]", "System.Collections.Generic.IList<C1>").WithLocation(10, 38)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceIListToArrayTypeConversion()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+
+class C1
+{
+    static void M1()
+    {
+        IList<C1> c1List = new List<C1>();
+        C1[] /*<bind>*/c1arr = (C1[])c1List/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C1[] /*<bin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C1[] /*<bin ... *</bind>*/;')
+    Variables: Local_1: C1[] c1arr
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: C1[]) (Syntax: '(C1[])c1List')
+        ILocalReferenceExpression: c1List (OperationKind.LocalReferenceExpression, Type: System.Collections.Generic.IList<C1>) (Syntax: 'c1List')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceIListToArrayTypeConversion_InvalidMismatchedDimensions()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+
+class C1
+{
+    static void M1()
+    {
+        IList<C1> c1List = new List<C1>();
+        C1[][] /*<bind>*/c1arr = (C1[][])c1List/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'C1[][] /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'C1[][] /*<b ... *</bind>*/;')
+    Variables: Local_1: C1[][] c1arr
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: C1[][], IsInvalid) (Syntax: '(C1[][])c1List')
+        ILocalReferenceExpression: c1List (OperationKind.LocalReferenceExpression, Type: System.Collections.Generic.IList<C1>) (Syntax: 'c1List')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'System.Collections.Generic.IList<C1>' to 'C1[][]'
+                //         C1[][] /*<bind>*/c1arr = (C1[][])c1List/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(C1[][])c1List").WithArguments("System.Collections.Generic.IList<C1>", "C1[][]").WithLocation(10, 34)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceDelegateToDelegateTypeConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    static void M1()
+    {
+        Delegate d = (Action)(() => { });
+        Action /*<bind>*/a = (Action)d/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'Action /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'Action /*<b ... *</bind>*/;')
+    Variables: Local_1: System.Action a
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: System.Action) (Syntax: '(Action)d')
+        ILocalReferenceExpression: d (OperationKind.LocalReferenceExpression, Type: System.Delegate) (Syntax: 'd')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ReferenceContravarianceConversion()
+        {
+            string source = @"
+interface I1<out T>
+{
+}
+
+class C1<T> : I1<T>
+{
+    void M1()
+    {
+        C2<C3> c2 = new C2<C3>();
+        I1<C4> /*<bind>*/c1 = (I1<C4>)c2/*</bind>*/;
+    }
+}
+
+class C2<T> : C1<T>
+{
+}
+
+class C3
+{
+}
+
+class C4 : C3
+{
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'I1<C4> /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'I1<C4> /*<b ... *</bind>*/;')
+    Variables: Local_1: I1<C4> c1
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: I1<C4>) (Syntax: '(I1<C4>)c2')
+        ILocalReferenceExpression: c2 (OperationKind.LocalReferenceExpression, Type: C2<C3>) (Syntax: 'c2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingObjectToValueTypeConversion()
+        {
+            string source = @"
+class C1
+{
+    void M1()
+    {
+        object o = 1;
+        int /*<bind>*/i = (int)o/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'int /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'int /*<bind ... *</bind>*/;')
+    Variables: Local_1: System.Int32 i
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: System.Int32) (Syntax: '(int)o')
+        ILocalReferenceExpression: o (OperationKind.LocalReferenceExpression, Type: System.Object) (Syntax: 'o')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingDynamicToValueTypeConversion()
+        {
+            string source = @"
+class C1
+{
+    void M1()
+    {
+        dynamic d = 1;
+        int /*<bind>*/i = (int)d/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'int /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'int /*<bind ... *</bind>*/;')
+    Variables: Local_1: System.Int32 i
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.Int32) (Syntax: '(int)d')
+        ILocalReferenceExpression: d (OperationKind.LocalReferenceExpression, Type: dynamic) (Syntax: 'd')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingSystemValueTypeToValueTypeConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        ValueType v = 1;
+        int /*<bind>*/i = (int)v/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'int /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'int /*<bind ... *</bind>*/;')
+    Variables: Local_1: System.Int32 i
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: System.Int32) (Syntax: '(int)v')
+        ILocalReferenceExpression: v (OperationKind.LocalReferenceExpression, Type: System.ValueType) (Syntax: 'v')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingSystemEnumToEnumConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Enum e = E1.One;
+        E1 /*<bind>*/e1 = (E1)e/*</bind>*/;
+    }
+}
+
+enum E1
+{
+    One = 1
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'E1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'E1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: E1 e1
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: E1) (Syntax: '(E1)e')
+        ILocalReferenceExpression: e (OperationKind.LocalReferenceExpression, Type: System.Enum) (Syntax: 'e')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingReferenceToNullableTypeConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Enum e = null;
+        E1? /*<bind>*/e1 = (E1?)e/*</bind>*/;
+    }
+}
+
+enum E1
+{
+    One = 1
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'E1? /*<bind ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'E1? /*<bind ... *</bind>*/;')
+    Variables: Local_1: E1? e1
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: E1?) (Syntax: '(E1?)e')
+        ILocalReferenceExpression: e (OperationKind.LocalReferenceExpression, Type: System.Enum) (Syntax: 'e')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingReferenceToNullableTypeConversion_InvalidNoConversionToNonNullableType()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Enum e = null;
+        int? /*<bind>*/e1 = (E1?)e/*</bind>*/;
+    }
+}
+
+enum E1
+{
+    One = 1
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'int? /*<bin ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'int? /*<bin ... *</bind>*/;')
+    Variables: Local_1: System.Int32? e1
+    Initializer: IConversionExpression (ConversionKind.CSharp, Implicit) (OperationKind.ConversionExpression, Type: System.Int32?, IsInvalid) (Syntax: '(E1?)e')
+        IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: E1?) (Syntax: '(E1?)e')
+          ILocalReferenceExpression: e (OperationKind.LocalReferenceExpression, Type: System.Enum) (Syntax: 'e')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0266: Cannot implicitly convert type 'E1?' to 'int?'. An explicit conversion exists (are you missing a cast?)
+                //         int? /*<bind>*/e1 = (E1?)e/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "(E1?)e").WithArguments("E1?", "int?").WithLocation(9, 29)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingValueTypeFromInterfaceConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        I1 i = null;
+        S1 /*<bind>*/s1 = (S1)i/*</bind>*/;
+    }
+}
+
+interface I1 { }
+
+struct S1 : I1 { }
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'S1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'S1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: S1 s1
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: S1) (Syntax: '(S1)i')
+        ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: I1) (Syntax: 'i')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingValueTypeFromInterfaceConversion_InvalidNoConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        I1 i = null;
+        S1 /*<bind>*/s1 = (S1)i/*</bind>*/;
+    }
+}
+
+interface I1 { }
+
+struct S1 { }
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'S1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'S1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: S1 s1
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: S1, IsInvalid) (Syntax: '(S1)i')
+        ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: I1) (Syntax: 'i')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'I1' to 'S1'
+                //         S1 /*<bind>*/s1 = (S1)i/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(S1)i").WithArguments("I1", "S1").WithLocation(9, 27)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_UnboxingVarianceConversion()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+
+class C1
+{
+    void M1()
+    {
+        IList<I1> i1List = new List<I1>();
+        IList<S1> /*<bind>*/s1List = (IList<S1>)i1List/*</bind>*/;
+    }
+}
+
+interface I1 { }
+
+struct S1 : I1 { }
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'IList<S1> / ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'IList<S1> / ... *</bind>*/;')
+    Variables: Local_1: System.Collections.Generic.IList<S1> s1List
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: System.Collections.Generic.IList<S1>) (Syntax: '(IList<S1>)i1List')
+        ILocalReferenceExpression: i1List (OperationKind.LocalReferenceExpression, Type: System.Collections.Generic.IList<I1>) (Syntax: 'i1List')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_TypeParameterSubclassConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1<T, U>(U u) where T : U
+    {
+        T /*<bind>*/t = (T)u/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'T /*<bind>* ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'T /*<bind>* ... *</bind>*/;')
+    Variables: Local_1: T t
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: T) (Syntax: '(T)u')
+        IParameterReferenceExpression: u (OperationKind.ParameterReferenceExpression, Type: U) (Syntax: 'u')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_TypeParameterSubclassConversion_InvalidNoConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1<T, U>(U u)
+    {
+        T /*<bind>*/t = (T)u/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'T /*<bind>* ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'T /*<bind>* ... *</bind>*/;')
+    Variables: Local_1: T t
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: T, IsInvalid) (Syntax: '(T)u')
+        IParameterReferenceExpression: u (OperationKind.ParameterReferenceExpression, Type: U) (Syntax: 'u')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'U' to 'T'
+                //         T /*<bind>*/t = (T)u/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(T)u").WithArguments("U", "T").WithLocation(8, 25)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_TypeParameterToInterfaceConversion()
+        {
+            string source = @"
+interface I1 { }
+
+class C1
+{
+    void M1<T>(I1 i)
+    {
+        T /*<bind>*/t = (T)i/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'T /*<bind>* ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'T /*<bind>* ... *</bind>*/;')
+    Variables: Local_1: T t
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: T) (Syntax: '(T)i')
+        IParameterReferenceExpression: i (OperationKind.ParameterReferenceExpression, Type: I1) (Syntax: 'i')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_TypeParameterFromInterfaceConversion()
+        {
+            string source = @"
+interface I1 { }
+
+class C1
+{
+    void M1<T>(T t)
+    {
+        I1 /*<bind>*/i = (I1)t/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'I1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'I1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: I1 i
+    Initializer: IConversionExpression (ConversionKind.Cast, Explicit) (OperationKind.ConversionExpression, Type: I1) (Syntax: '(I1)t')
+        IParameterReferenceExpression: t (OperationKind.ParameterReferenceExpression, Type: T) (Syntax: 't')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ImplicitUserDefinedConversionAsExplicitConversion()
+        {
+            string source = @"
+class C1
+{
+    void M1()
+    {
+        C1 c1 = new C1();
+        C2 /*<bind>*/c2 = (C2)c1/*</bind>*/;
+    }
+
+    public static implicit operator C2(C1 c1) => new C2();
+}
+
+class C2 { }
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C2 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C2 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: C2 c2
+    Initializer: IConversionExpression (ConversionKind.OperatorMethod, Explicit) (OperatorMethod: C2 C1.op_Implicit(C1 c1)) (OperationKind.ConversionExpression, Type: C2) (Syntax: '(C2)c1')
+        ILocalReferenceExpression: c1 (OperationKind.LocalReferenceExpression, Type: C1) (Syntax: 'c1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ExplicitUserDefinedConversion()
+        {
+            string source = @"
+class C1
+{
+    void M1()
+    {
+        C1 c1 = new C1();
+        C2 /*<bind>*/c2 = (C2)c1/*</bind>*/;
+    }
+
+    public static explicit operator C2(C1 c1) => new C2();
+}
+
+class C2 { }
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'C2 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'C2 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: C2 c2
+    Initializer: IConversionExpression (ConversionKind.OperatorMethod, Explicit) (OperatorMethod: C2 C1.op_Explicit(C1 c1)) (OperationKind.ConversionExpression, Type: C2) (Syntax: '(C2)c1')
+        ILocalReferenceExpression: c1 (OperationKind.LocalReferenceExpression, Type: C1) (Syntax: 'c1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_ExplicitUserDefinedConversion_WithImplicitConversionAfter()
+        {
+            string source = @"
+interface I1 { }
+
+class C1
+{
+    void M1()
+    {
+        C1 c1 = new C1();
+        I1 /*<bind>*/i1 = (C2)c1/*</bind>*/;
+    }
+
+    public static explicit operator C2(C1 c1) => new C2();
+}
+
+class C2 : I1 { }
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'I1 /*<bind> ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'I1 /*<bind> ... *</bind>*/;')
+    Variables: Local_1: I1 i1
+    Initializer: IConversionExpression (ConversionKind.Cast, Implicit) (OperationKind.ConversionExpression, Type: I1) (Syntax: '(C2)c1')
+        IConversionExpression (ConversionKind.OperatorMethod, Explicit) (OperatorMethod: C2 C1.op_Explicit(C1 c1)) (OperationKind.ConversionExpression, Type: C2) (Syntax: '(C2)c1')
+          ILocalReferenceExpression: c1 (OperationKind.LocalReferenceExpression, Type: C1) (Syntax: 'c1')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateFromLambdaExplicitCastConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action /*<bind>*/a = (Action)(() => { })/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'Action /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'Action /*<b ... *</bind>*/;')
+    Variables: Local_1: System.Action a
+    Initializer: IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.Action) (Syntax: '(Action)(() => { })')
+        ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: null) (Syntax: '() => { }')
+          IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: '{ }')
+            IReturnStatement (OperationKind.ReturnStatement) (Syntax: '{ }')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateFromLambdaExplicitCastConversion_InvalidIncorrectReturnType()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action /*<bind>*/a = (Action)(() => 1)/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'Action /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'Action /*<b ... *</bind>*/;')
+    Variables: Local_1: System.Action a
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: System.Action, IsInvalid) (Syntax: '(Action)(() => 1)')
+        ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: null, IsInvalid) (Syntax: '() => 1')
+          IBlockStatement (2 statements) (OperationKind.BlockStatement, IsInvalid) (Syntax: '1')
+            IExpressionStatement (OperationKind.ExpressionStatement, IsInvalid) (Syntax: '1')
+              ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+            IReturnStatement (OperationKind.ReturnStatement) (Syntax: '1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
+                //         Action /*<bind>*/a = (Action)(() => 1)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_IllegalStatement, "1").WithLocation(8, 45)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateFromLambdaExplicitCastConversion_InvalidParameters()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action /*<bind>*/a = (Action)((string s) => { })/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'Action /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'Action /*<b ... *</bind>*/;')
+    Variables: Local_1: System.Action a
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: System.Action, IsInvalid) (Syntax: '(Action)((s ...  s) => { })')
+        ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: null) (Syntax: '(string s) => { }')
+          IBlockStatement (0 statements) (OperationKind.BlockStatement) (Syntax: '{ }')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS1593: Delegate 'Action' does not take 1 arguments
+                //         Action /*<bind>*/a = (Action)((string s) => { })/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadDelArgCount, "(string s) => { }").WithArguments("System.Action", "1").WithLocation(8, 39)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateCreationFromLambdaExplicitCastConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action a = /*<bind>*/new Action((Action)(() => { }))/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IOperation:  (OperationKind.None) (Syntax: 'new Action( ... () => { }))')
+  Children(1): IConversionExpression (ConversionKind.CSharp, Explicit) (OperationKind.ConversionExpression, Type: System.Action) (Syntax: '(Action)(() => { })')
+      ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: null) (Syntax: '() => { }')
+        IBlockStatement (1 statements) (OperationKind.BlockStatement) (Syntax: '{ }')
+          IReturnStatement (OperationKind.ReturnStatement) (Syntax: '{ }')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateCreationFromLambdaExplicitCastConversion_InvalidReturnType()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action a = /*<bind>*/new Action((Action)(() => 1))/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IInvalidExpression (OperationKind.InvalidExpression, Type: System.Action, IsInvalid) (Syntax: 'new Action( ... )(() => 1))')
+  Children(1): IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: System.Action, IsInvalid) (Syntax: '(Action)(() => 1)')
+      ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: null, IsInvalid) (Syntax: '() => 1')
+        IBlockStatement (2 statements) (OperationKind.BlockStatement, IsInvalid) (Syntax: '1')
+          IExpressionStatement (OperationKind.ExpressionStatement, IsInvalid) (Syntax: '1')
+            ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')
+          IReturnStatement (OperationKind.ReturnStatement) (Syntax: '1')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
+                //         Action a = /*<bind>*/new Action((Action)(() => 1))/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_IllegalStatement, "1").WithLocation(8, 56)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateCreationFromLambdaExplicitCastConversion_InvalidMismatchedParameters()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action a = /*<bind>*/new Action((Action)((string s) => { }))/*</bind>*/;
+    }
+}
+";
+            string expectedOperationTree = @"
+IInvalidExpression (OperationKind.InvalidExpression, Type: System.Action, IsInvalid) (Syntax: 'new Action( ... s) => { }))')
+  Children(1): IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: System.Action, IsInvalid) (Syntax: '(Action)((s ...  s) => { })')
+      ILambdaExpression (Signature: lambda expression) (OperationKind.LambdaExpression, Type: null) (Syntax: '(string s) => { }')
+        IBlockStatement (0 statements) (OperationKind.BlockStatement) (Syntax: '{ }')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS1593: Delegate 'Action' does not take 1 arguments
+                //         Action a = /*<bind>*/new Action((Action)((string s) => { }))/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadDelArgCount, "(string s) => { }").WithArguments("System.Action", "1").WithLocation(8, 50)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateFromMethodReferenceExplicitCastConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action /*<bind>*/a = (Action)M2/*</bind>*/;
+    }
+
+    void M2() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'Action /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'Action /*<b ... *</bind>*/;')
+    Variables: Local_1: System.Action a
+    Initializer: IMethodBindingExpression: void C1.M2() (OperationKind.MethodBindingExpression, Type: System.Action) (Syntax: '(Action)M2')
+        Instance Receiver: IInstanceReferenceExpression (InstanceReferenceKind.Implicit) (OperationKind.InstanceReferenceExpression, Type: C1) (Syntax: 'M2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateFromMethodReferenceExplicitCastConversion_InvalidMismatchedParameter()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action /*<bind>*/a = (Action)M2/*</bind>*/;
+    }
+
+    void M2(int i) { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'Action /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'Action /*<b ... *</bind>*/;')
+    Variables: Local_1: System.Action a
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: System.Action, IsInvalid) (Syntax: '(Action)M2')
+        IOperation:  (OperationKind.None) (Syntax: 'M2')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'method' to 'Action'
+                //         Action /*<bind>*/a = (Action)M2/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(Action)M2").WithArguments("method", "System.Action").WithLocation(8, 30)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateFromMethodReferenceExplicitCastConversion_InvalidReturnType()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action /*<bind>*/a = (Action)M2/*</bind>*/;
+    }
+
+    int M2() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'Action /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'Action /*<b ... *</bind>*/;')
+    Variables: Local_1: System.Action a
+    Initializer: IMethodBindingExpression: System.Int32 C1.M2() (OperationKind.MethodBindingExpression, Type: System.Action, IsInvalid) (Syntax: '(Action)M2')
+        Instance Receiver: IInstanceReferenceExpression (InstanceReferenceKind.Implicit) (OperationKind.InstanceReferenceExpression, Type: C1) (Syntax: 'M2')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0407: 'int C1.M2()' has the wrong return type
+                //         Action /*<bind>*/a = (Action)M2/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadRetType, "(Action)M2").WithArguments("C1.M2()", "int").WithLocation(8, 30),
+                // CS0161: 'C1.M2()': not all code paths return a value
+                //     int M2() { }
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "M2").WithArguments("C1.M2()").WithLocation(11, 9)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateCreationFromMethodReferenceExplicitCastConversion()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action /*<bind>*/a = new Action((Action)M2)/*</bind>*/;
+    }
+
+    void M2() { }
+}
+";
+            string expectedOperationTree = @"
+IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'Action /*<b ... *</bind>*/;')
+  IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'Action /*<b ... *</bind>*/;')
+    Variables: Local_1: System.Action a
+    Initializer: IOperation:  (OperationKind.None) (Syntax: 'new Action((Action)M2)')
+        Children(1): IMethodBindingExpression: void C1.M2() (OperationKind.MethodBindingExpression, Type: System.Action) (Syntax: '(Action)M2')
+            Instance Receiver: IInstanceReferenceExpression (InstanceReferenceKind.Implicit) (OperationKind.InstanceReferenceExpression, Type: C1) (Syntax: 'M2')
+";
+            var expectedDiagnostics = DiagnosticDescription.None;
+
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateCreationFromMethodBindingConversion_InvalidMismatchedParameters()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action a = /*<bind>*/new Action((Action)M2)/*</bind>*/;
+    }
+
+    void M2(int i) { }
+}
+";
+            string expectedOperationTree = @"
+IInvalidExpression (OperationKind.InvalidExpression, Type: System.Action, IsInvalid) (Syntax: 'new Action((Action)M2)')
+  Children(1): IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: System.Action, IsInvalid) (Syntax: '(Action)M2')
+      IOperation:  (OperationKind.None) (Syntax: 'M2')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0030: Cannot convert type 'method' to 'Action'
+                //         Action a = /*<bind>*/new Action((Action)M2)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "(Action)M2").WithArguments("method", "System.Action").WithLocation(8, 41)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        [Fact]
+        public void ConversionExpression_Explicit_DelegateCreationFromMethodBindingConversion_InvalidReturnType()
+        {
+            string source = @"
+using System;
+
+class C1
+{
+    void M1()
+    {
+        Action a = /*<bind>*/new Action((Action)M2)/*</bind>*/;
+    }
+
+    int M2() { }
+}
+";
+            string expectedOperationTree = @"
+IInvalidExpression (OperationKind.InvalidExpression, Type: System.Action, IsInvalid) (Syntax: 'new Action((Action)M2)')
+  Children(1): IMethodBindingExpression: System.Int32 C1.M2() (OperationKind.MethodBindingExpression, Type: System.Action, IsInvalid) (Syntax: '(Action)M2')
+      Instance Receiver: IInstanceReferenceExpression (InstanceReferenceKind.Implicit) (OperationKind.InstanceReferenceExpression, Type: C1) (Syntax: 'M2')
+";
+            var expectedDiagnostics = new DiagnosticDescription[] {
+                // CS0407: 'int C1.M2()' has the wrong return type
+                //         Action a = /*<bind>*/new Action((Action)M2)/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_BadRetType, "(Action)M2").WithArguments("C1.M2()", "int").WithLocation(8, 41),
+                // CS0161: 'C1.M2()': not all code paths return a value
+                //     int M2() { }
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "M2").WithArguments("C1.M2()").WithLocation(11, 9)
+            };
+
+            VerifyOperationTreeAndDiagnosticsForTest<ObjectCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+        }
+
+        #endregion
+
         private class ExpectedSymbolVerifier
         {
             public static SyntaxNode VariableDeclaratorSelector(SyntaxNode syntaxNode) =>
@@ -3143,6 +4886,9 @@ IReturnStatement (OperationKind.ReturnStatement) (Syntax: 'return f;')
 
             public static IConversionExpression IReturnDeclarationStatementSelector(IOperation operation) =>
                 (IConversionExpression)((IReturnStatement)operation).ReturnedValue;
+
+            public static IOperation NestedConversionChildSelector(IConversionExpression conversion) =>
+                ((IConversionExpression)conversion.Operand).Operand;
 
             public Func<IOperation, IConversionExpression> OperationSelector { get; set; }
 
@@ -3187,6 +4933,8 @@ IReturnStatement (OperationKind.ReturnStatement) (Syntax: 'return f;')
                             return VariableDeclaratorSelector(syntax);
                         case ReturnStatementSyntax _:
                             return ReturnStatementSelector(syntax);
+                        case CastExpressionSyntax cast:
+                            return cast.Expression;
                         default:
                             throw new ArgumentException($"Cannot handle syntax of type {syntax.GetType()}");
                     }
@@ -3200,12 +4948,14 @@ IReturnStatement (OperationKind.ReturnStatement) (Syntax: 'return f;')
                     return OperationSelector(operation);
                 }
 
-                switch(operation)
+                switch (operation)
                 {
                     case IVariableDeclarationStatement _:
                         return IVariableDeclarationStatementSelector(operation);
                     case IReturnStatement _:
                         return IReturnDeclarationStatementSelector(operation);
+                    case IConversionExpression conv:
+                        return conv;
                     default:
                         throw new ArgumentException($"Cannot handle arguments of type {operation.GetType()}");
                 }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConversionExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConversionExpression.cs
@@ -3707,7 +3707,7 @@ sealed class C1
 {
     static void M1()
     {
-        I2 /*<bind>*/i2 = /*</bind>*/;
+        I2 /*<bind>*/i2 = (I2)()/*</bind>*/;
     }
 }
 ";
@@ -3715,13 +3715,13 @@ sealed class C1
 IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement, IsInvalid) (Syntax: 'I2 /*<bind> ... *</bind>*/;')
   IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration, IsInvalid) (Syntax: 'I2 /*<bind> ... *</bind>*/;')
     Variables: Local_1: I2 i2
-    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: I2, IsInvalid) (Syntax: '')
+    Initializer: IConversionExpression (ConversionKind.Invalid, Explicit) (OperationKind.ConversionExpression, Type: I2, IsInvalid) (Syntax: '(I2)()')
         IInvalidExpression (OperationKind.InvalidExpression, Type: ?, IsInvalid) (Syntax: '')
 ";
             var expectedDiagnostics = new DiagnosticDescription[] {
-                // CS1525: Invalid expression term ';'
-                //         I2 /*<bind>*/i2 = /*</bind>*/;
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ";").WithArguments(";").WithLocation(8, 38),
+                // CS1525: Invalid expression term ')'
+                //         I2 /*<bind>*/i2 = (I2)()/*</bind>*/;
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(8, 32)
             };
 
             VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
@@ -4306,7 +4306,7 @@ IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclaratio
         }
 
         [Fact]
-        public void ConversionExpression_Explicit_TypeParameterSubclassConversion()
+        public void ConversionExpression_Explicit_TypeParameterConstraintConversion()
         {
             string source = @"
 using System;
@@ -4332,7 +4332,7 @@ IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclaratio
         }
 
         [Fact]
-        public void ConversionExpression_Explicit_TypeParameterSubclassConversion_InvalidNoConversion()
+        public void ConversionExpression_Explicit_TypeParameterConversion_InvalidNoConversion()
         {
             string source = @"
 using System;
@@ -4895,7 +4895,7 @@ IReturnStatement (OperationKind.ReturnStatement) (Syntax: 'return (int)1.0;')
         }
 
         [Fact]
-        public void XConversionExpression_Explicit_ReturnConversion_InvalidConversion()
+        public void ConversionExpression_Explicit_ReturnConversion_InvalidConversion()
         {
             string source = @"
 using System;


### PR DESCRIPTION
Tagging @dotnet/analyzer-ioperation for review. Adds tests for explicit C# casts. I didn't do verification of the semantic model in comparison here, as the semantic model doesn't change the converted type in the presence of an explicit cast. For example:
```C#
class C1
{
    void M1()
    {
        int i = (int)1.0;
    }
}
```
The `Type` and `ConvertedType` of the number literal in the semantic model are both `System.Double` here, so there's nothing for us to match against.