### PR TITLE
Added a new ConversionKind for Interpolated string

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -139,6 +139,9 @@ namespace Microsoft.CodeAnalysis.Semantics
                 case CSharp.ConversionKind.PointerToVoid:
                     return Semantics.ConversionKind.CSharp;
 
+                case CSharp.ConversionKind.InterpolatedString:
+                    return Semantics.ConversionKind.InterpolatedString;
+
                 default:
                     return Semantics.ConversionKind.Invalid;
             }

--- a/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConversionExpression.cs
+++ b/src/Compilers/CSharp/Test/Semantic/IOperation/IOperationTests_IConversionExpression.cs
@@ -675,7 +675,7 @@ class Program
 IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'IFormattabl ... *</bind>*/;')
   IVariableDeclaration (1 variables) (OperationKind.VariableDeclaration) (Syntax: 'IFormattabl ... *</bind>*/;')
     Variables: Local_1: System.IFormattable f1
-    Initializer: IConversionExpression (ConversionKind.Invalid, Implicit) (OperationKind.ConversionExpression, Type: System.IFormattable) (Syntax: '$""{1}""')
+    Initializer: IConversionExpression (ConversionKind.InterpolatedString, Implicit) (OperationKind.ConversionExpression, Type: System.IFormattable) (Syntax: '$""{1}""')
         IInterpolatedStringExpression (OperationKind.InterpolatedStringExpression, Type: System.String) (Syntax: '$""{1}""')
           Parts(1): IInterpolation (OperationKind.Interpolation) (Syntax: '{1}')
               Expression: ILiteralExpression (Text: 1) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1) (Syntax: '1')

--- a/src/Compilers/Core/Portable/Operations/ConversionKind.cs
+++ b/src/Compilers/Core/Portable/Operations/ConversionKind.cs
@@ -31,6 +31,11 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// </summary>
         OperatorMethod = 0x5,
         /// <summary>
+        /// Conversion is defined by the underlying type, and is created when an interoplated
+        /// string expression is being converted to an IFormattable or FormattableString.
+        /// </summary>
+        InterpolatedString = 0x6,
+        /// <summary>
         /// Conversion is invalid.
         /// </summary>
         Invalid = 0xf

--- a/src/Compilers/Core/Portable/Operations/ConversionKind.cs
+++ b/src/Compilers/Core/Portable/Operations/ConversionKind.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// </summary>
         OperatorMethod = 0x5,
         /// <summary>
-        /// Conversion is defined by the underlying type, and is created when an interoplated
+        /// Conversion is defined by the underlying type, and is created when an interpolated
         /// string expression is being converted to an IFormattable or FormattableString.
         /// </summary>
         InterpolatedString = 0x6,

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -321,6 +321,7 @@ Microsoft.CodeAnalysis.Semantics.ConversionKind.Basic = 3 -> Microsoft.CodeAnaly
 Microsoft.CodeAnalysis.Semantics.ConversionKind.CSharp = 4 -> Microsoft.CodeAnalysis.Semantics.ConversionKind
 Microsoft.CodeAnalysis.Semantics.ConversionKind.Cast = 1 -> Microsoft.CodeAnalysis.Semantics.ConversionKind
 Microsoft.CodeAnalysis.Semantics.ConversionKind.Invalid = 15 -> Microsoft.CodeAnalysis.Semantics.ConversionKind
+Microsoft.CodeAnalysis.Semantics.ConversionKind.InterpolatedString = 6 -> Microsoft.CodeAnalysis.Semantics.ConversionKind
 Microsoft.CodeAnalysis.Semantics.ConversionKind.None = 0 -> Microsoft.CodeAnalysis.Semantics.ConversionKind
 Microsoft.CodeAnalysis.Semantics.ConversionKind.OperatorMethod = 5 -> Microsoft.CodeAnalysis.Semantics.ConversionKind
 Microsoft.CodeAnalysis.Semantics.ConversionKind.TryCast = 2 -> Microsoft.CodeAnalysis.Semantics.ConversionKind


### PR DESCRIPTION
This adds support for interpolated strings to our public ConversionKind enum. I added support for C# as well. I'm going to hold off on implementing VB because of this issue: https://github.com/dotnet/roslyn/issues/20415. I'll fix that as part of a larger addition of tests for VB conversions, as part of the work for https://github.com/dotnet/roslyn/issues/17590. This PR fixes https://github.com/dotnet/roslyn/issues/20046. Tagging @dotnet/analyzer-ioperation @AlekseyTs for review.