### PR TITLE
Improve performance of inline rename with multi-targeting

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxDiffer.cs
@@ -531,6 +531,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (oldNodeCount == 1 && newNodeCount == 1)
             {
+                // Avoid creating a Queue<T> which we immediately discard in the most common case for old/new counts
                 var removedNode = _oldNodes.Pop();
                 var oldSpan = removedNode.FullSpan;
 
@@ -637,10 +638,10 @@ namespace Microsoft.CodeAnalysis
             return TextSpan.FromBounds(start, end);
         }
 
-        private static TextSpan GetSpan(Queue<SyntaxNodeOrToken> stack, int first, int length)
+        private static TextSpan GetSpan(Queue<SyntaxNodeOrToken> queue, int first, int length)
         {
             int start = -1, end = -1, i = 0;
-            foreach (var n in stack)
+            foreach (var n in queue)
             {
                 if (i == first)
                 {
@@ -824,30 +825,30 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private static string GetText(Queue<SyntaxNodeOrToken> stack)
+        private static string GetText(Queue<SyntaxNodeOrToken> queue)
         {
-            if (stack == null || stack.Count == 0)
+            if (queue == null || queue.Count == 0)
             {
                 return string.Empty;
             }
 
-            var span = GetSpan(stack, 0, stack.Count);
+            var span = GetSpan(queue, 0, queue.Count);
             var builder = new StringBuilder(span.Length);
 
-            CopyText(stack, builder);
+            CopyText(queue, builder);
 
             return builder.ToString();
         }
 
-        private static void CopyText(Queue<SyntaxNodeOrToken> stack, StringBuilder builder)
+        private static void CopyText(Queue<SyntaxNodeOrToken> queue, StringBuilder builder)
         {
             builder.Length = 0;
 
-            if (stack != null && stack.Count > 0)
+            if (queue != null && queue.Count > 0)
             {
                 var writer = new System.IO.StringWriter(builder);
 
-                foreach (var n in stack)
+                foreach (var n in queue)
                 {
                     n.WriteTo(writer);
                 }

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -472,14 +472,29 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
 
             var asyncToken = _asyncListener.BeginAsyncOperation(nameof(QueueApplyReplacements));
-            _conflictResolutionTask.SafeContinueWith(
-                t => ApplyReplacements(t.Result, _conflictResolutionTaskCancellationSource.Token),
-                _conflictResolutionTaskCancellationSource.Token,
-                TaskContinuationOptions.OnlyOnRanToCompletion,
-                ForegroundTaskScheduler).CompletesAsyncOperation(asyncToken);
+            _conflictResolutionTask
+                .SafeContinueWith(
+                    t => ComputeMergeResultAsync(t.Result, _conflictResolutionTaskCancellationSource.Token),
+                    _conflictResolutionTaskCancellationSource.Token,
+                    TaskContinuationOptions.OnlyOnRanToCompletion,
+                    TaskScheduler.Default)
+                .Unwrap()
+                .SafeContinueWith(
+                    t => ApplyReplacements(t.Result.replacementInfo, t.Result.mergeResult, _conflictResolutionTaskCancellationSource.Token),
+                    _conflictResolutionTaskCancellationSource.Token,
+                    TaskContinuationOptions.OnlyOnRanToCompletion,
+                    ForegroundTaskScheduler)
+                .CompletesAsyncOperation(asyncToken);
         }
 
-        private void ApplyReplacements(IInlineRenameReplacementInfo replacementInfo, CancellationToken cancellationToken)
+        private async Task<(IInlineRenameReplacementInfo replacementInfo, LinkedFileMergeSessionResult mergeResult)> ComputeMergeResultAsync(IInlineRenameReplacementInfo replacementInfo, CancellationToken cancellationToken)
+        {
+            var diffMergingSession = new LinkedFileDiffMergingSession(_baseSolution, replacementInfo.NewSolution, replacementInfo.NewSolution.GetChanges(_baseSolution), logSessionInfo: true);
+            var mergeResult = await diffMergingSession.MergeDiffsAsync(mergeConflictHandler: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return (replacementInfo, mergeResult);
+        }
+
+        private void ApplyReplacements(IInlineRenameReplacementInfo replacementInfo, LinkedFileMergeSessionResult mergeResult, CancellationToken cancellationToken)
         {
             AssertIsForeground();
             cancellationToken.ThrowIfCancellationRequested();
@@ -493,7 +508,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 if (documents.Any())
                 {
                     var textBufferManager = _openTextBuffers[textBuffer];
-                    textBufferManager.ApplyConflictResolutionEdits(replacementInfo, documents, cancellationToken);
+                    textBufferManager.ApplyConflictResolutionEdits(replacementInfo, mergeResult, documents, cancellationToken);
                 }
             }
 


### PR DESCRIPTION
* 75% user-observed improvement to typing speed while referenced documents are open in multi-targeting scenarios (closed documents were not a problem)
* 99+% improvement to applying changes at the end of a rename scenario
* GC allocation rates during inline rename reduced by up to 10GiB/minute, sometimes more
* Filed internal bug 454915 to further improve performance in other edge cases which can still be hit but are now much less likely

@dotnet/roslyn-ide for review

Fixes #20384

## Ask Mode

**Customer scenario**

Use inline rename on a project with multi-targeting, on an identifier referenced many times in many files.

* If the other files are open, typing performance is "pretty bad" but committing the rename in the end works with reasonable reliability
* If the other files are not open, typing performance is "pretty good" but committing the rename at the end causes Visual Studio to hang (long enough that a user might close the IDE rather than wait for it to complete)

**Bugs this fixes:**

Fixes #20384

**Workarounds, if any**

Wait longer, or avoid multi-targeting.

**Risk**

Moderate. There this change involves three independent changes which each carry some risk:

1. (Low-Moderate) Moving an operation from a foreground thread to a background thread
2. (Low) Modification of the `SyntaxDiffer` algorithm to use `Queue<T>` instead of `Stack<T>` for one of its internal data structures
3. (Moderate) Introduction of a heuristic to avoid complicated analysis of changes to linked documents for a common case

**Performance impact**

This change results in a dramatic improvement to numerous parts of the overall "Inline Rename" workflow.

**Is this a regression from a previous update?**

Unknown, but not likely.

**Root cause analysis:**

Failure to test workflows at scale.

**How was the bug found?**

Internal customer report.
