### PR TITLE
Support adding PackageReferences to CPS projects

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -89,6 +89,7 @@
     <MicrosoftVisualStudioProgressionCodeSchemaVersion>15.0.26507-alpha</MicrosoftVisualStudioProgressionCodeSchemaVersion>
     <MicrosoftVisualStudioProgressionCommonVersion>15.0.26507-alpha</MicrosoftVisualStudioProgressionCommonVersion>
     <MicrosoftVisualStudioProgressionInterfacesVersion>15.0.26507-alpha</MicrosoftVisualStudioProgressionInterfacesVersion>
+    <MicrosoftVisualStudioProjectSystemVersion>15.0.751</MicrosoftVisualStudioProjectSystemVersion>
     <MicrosoftVisualStudioQualityToolsUnitTestFrameworkVersion>10.0.0.0-alpha</MicrosoftVisualStudioQualityToolsUnitTestFrameworkVersion>
     <MicrosoftVisualStudioRemoteControlVersion>14.0.249-master2E2DC10C</MicrosoftVisualStudioRemoteControlVersion>
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.3.269-rc</MicrosoftVisualStudioSetupConfigurationInteropVersion>

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -89,7 +89,7 @@
     <MicrosoftVisualStudioProgressionCodeSchemaVersion>15.0.26507-alpha</MicrosoftVisualStudioProgressionCodeSchemaVersion>
     <MicrosoftVisualStudioProgressionCommonVersion>15.0.26507-alpha</MicrosoftVisualStudioProgressionCommonVersion>
     <MicrosoftVisualStudioProgressionInterfacesVersion>15.0.26507-alpha</MicrosoftVisualStudioProgressionInterfacesVersion>
-    <MicrosoftVisualStudioProjectSystemVersion>15.0.751</MicrosoftVisualStudioProjectSystemVersion>
+    <MicrosoftVisualStudioProjectSystemVersion>15.3.178-pre-g209fb07c2e</MicrosoftVisualStudioProjectSystemVersion>
     <MicrosoftVisualStudioQualityToolsUnitTestFrameworkVersion>10.0.0.0-alpha</MicrosoftVisualStudioQualityToolsUnitTestFrameworkVersion>
     <MicrosoftVisualStudioRemoteControlVersion>14.0.249-master2E2DC10C</MicrosoftVisualStudioRemoteControlVersion>
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.3.269-rc</MicrosoftVisualStudioSetupConfigurationInteropVersion>

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/ProjectUtilities.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/ProjectUtilities.cs
@@ -30,4 +30,15 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils
             Name = name;
         }
     }
+
+    public class PackageReference : Identity
+    {
+        public string Version { get; }
+
+        public PackageReference(string name, string version)
+        {
+            Name = name;
+            Version = version;
+        }
+    }
 }

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -229,6 +229,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                     return await packageService.AddAsync(packageName, version);
                 });
             }
+            else
+            {
+                throw new InvalidOperationException($"'{nameof(AddPackageReference)}' is not supported in project '{projectName}'.");
+            }
         }
 
         public void RemovePackageReference(string projectName, string packageName)
@@ -244,6 +248,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
                 {
                     return await packageService.RemoveAsync(packageName);
                 });
+            }
+            else
+            {
+                throw new InvalidOperationException($"'{nameof(RemovePackageReference)}' is not supported in project '{projectName}'.");
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Xml.Linq;
 using EnvDTE80;
 using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -212,6 +213,38 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         {
             var project = GetProject(projectName);
             ((VSProject)project.Object).References.Add(fullyQualifiedAssemblyName);
+        }
+
+        public void AddPackageReference(string projectName, string packageName, string version)
+        {
+            var project = GetProject(projectName);
+
+            if (project.Object is IVsBrowseObjectContext browseObjectContext)
+            {
+                var threadingService = browseObjectContext.UnconfiguredProject.ProjectService.Services.ThreadingPolicy;
+                var packageService = browseObjectContext.ConfiguredProject.Services.PackageReferences;
+
+                var result = threadingService.ExecuteSynchronously(async () =>
+                {
+                    return await packageService.AddAsync(packageName, version);
+                });
+            }
+        }
+
+        public void RemovePackageReference(string projectName, string packageName)
+        {
+            var project = GetProject(projectName);
+
+            if (project.Object is IVsBrowseObjectContext browseObjectContext)
+            {
+                var threadingService = browseObjectContext.UnconfiguredProject.ProjectService.Services.ThreadingPolicy;
+                var packageService = browseObjectContext.ConfiguredProject.Services.PackageReferences;
+
+                var result = threadingService.ExecuteSynchronously(async () =>
+                {
+                    return await packageService.RemoveAsync(packageName);
+                });
+            }
         }
 
         public void RemoveProjectReference(string projectName, string projectReferenceName)

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -221,13 +221,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
             if (project.Object is IVsBrowseObjectContext browseObjectContext)
             {
-                var threadingService = browseObjectContext.UnconfiguredProject.ProjectService.Services.ThreadingPolicy;
                 var packageService = browseObjectContext.ConfiguredProject.Services.PackageReferences;
 
-                var result = threadingService.ExecuteSynchronously(async () =>
-                {
-                    return await packageService.AddAsync(packageName, version);
-                });
+                var result = packageService.AddAsync(packageName, version).GetAwaiter().GetResult();
             }
             else
             {
@@ -241,13 +237,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
 
             if (project.Object is IVsBrowseObjectContext browseObjectContext)
             {
-                var threadingService = browseObjectContext.UnconfiguredProject.ProjectService.Services.ThreadingPolicy;
                 var packageService = browseObjectContext.ConfiguredProject.Services.PackageReferences;
 
-                var result = threadingService.ExecuteSynchronously(async () =>
-                {
-                    return await packageService.RemoveAsync(packageName);
-                });
+                packageService.RemoveAsync(packageName).GetAwaiter().GetResult();
             }
             else
             {

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -69,6 +69,20 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
             _instance.Workspace.WaitForAsyncOperations(FeatureAttribute.Workspace);
         }
 
+        /// <summary>
+        /// Add a PackageReference to the specified project. Generally this should be followed up by
+        /// a call to <see cref="RestoreNuGetPackages"/>.
+        /// </summary>
+        public void AddPackageReference(ProjectUtils.Project project, ProjectUtils.PackageReference package)
+            => _inProc.AddPackageReference(project.Name, package.Name, package.Version);
+
+        /// <summary>
+        /// Remove a PackageReference from the specified project. Generally this should be followed up by
+        /// a call to <see cref="RestoreNuGetPackages"/>.
+        /// </summary>
+        public void RemovePackageReference(ProjectUtils.Project project, ProjectUtils.PackageReference package)
+            => _inProc.RemovePackageReference(project.Name, package.Name);
+
         public void CleanUpOpenSolution()
             => _inProc.CleanUpOpenSolution();
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioIntegrationTestUtilities.csproj
@@ -129,6 +129,9 @@
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop">
       <Version>$(MicrosoftVisualStudioOLEInteropVersion)</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
+      <Version>$(MicrosoftVisualStudioProjectSystemVersion)</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop">
       <Version>$(MicrosoftVisualStudioSetupConfigurationInteropVersion)</Version>
     </PackageReference>


### PR DESCRIPTION
Add APIs to allow integration tests to add PackageReferences to CPS projects.

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
