### PR TITLE
Don't crash in OOP with TS projects/documents

### DIFF
--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -67,6 +67,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             using (session)
             {
+                // This service is only defined for C# and VB, but we'll be a bit paranoid.
                 if (session == null || !RemoteSupportedLanguages.IsSupported(document.Project.Language))
                 {
                     return await GetFixesInCurrentProcessAsync(

--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             using (session)
             {
-                if (session == null)
+                if (session == null || !RemoteSupportedLanguages.IsSupported(document.Project.Language))
                 {
                     return await GetFixesInCurrentProcessAsync(
                         document, span, diagnosticId, placeSystemNamespaceFirst,

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
@@ -31,6 +31,11 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
         private static Task<RemoteHostClient.Session> GetRemoteHostSessionAsync(Project project, CancellationToken cancellationToken)
         {
+            if (!RemoteSupportedLanguages.IsSupported(project.Language))
+            {
+                return null;
+            }
+
             return project.Solution.TryCreateCodeAnalysisServiceSessionAsync(
                 RemoteFeatureOptions.NavigateToEnabled, cancellationToken);
         }

--- a/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
+++ b/src/Features/Core/Portable/NavigateTo/AbstractNavigateToSearchService.Remote.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
 
         private static Task<RemoteHostClient.Session> GetRemoteHostSessionAsync(Project project, CancellationToken cancellationToken)
         {
+            // This service is only defined for C# and VB, but we'll be a bit paranoid.
             if (!RemoteSupportedLanguages.IsSupported(project.Language))
             {
                 return null;

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_DocumentHighlights.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             var solution = await GetSolutionAsync().ConfigureAwait(false);
             var document = solution.GetDocument(documentId);
-            var documentsToSearch = ImmutableHashSet.CreateRange(documentIdsToSearch.Select(solution.GetDocument));
+            var documentsToSearch = ImmutableHashSet.CreateRange(
+                documentIdsToSearch.Select(solution.GetDocument).Where(d => d != null));
 
             var service = document.GetLanguageService<IDocumentHighlightsService>();
             var result = await service.GetDocumentHighlightsAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 }
 
                 var documents = documentArgs?.Select(solution.GetDocument)
+                                             .Where(d => d != null)
                                              .ToImmutableHashSet();
 
                 await SymbolFinder.FindReferencesInCurrentProcessAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/CodeAnalysisService_SymbolFinder.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -30,8 +31,12 @@ namespace Microsoft.CodeAnalysis.Remote
                     return;
                 }
 
+                // NOTE: In projection scenarios, we might get a set of documents to search
+                // that are not all the same language and might not exist in the OOP process
+                // (like the JS parts of a .cshtml file). Filter them out here.  This will
+                // need to be revisited if we someday support FAR between these languages.
                 var documents = documentArgs?.Select(solution.GetDocument)
-                                             .Where(d => d != null)
+                                             .WhereNotNull()
                                              .ToImmutableHashSet();
 
                 await SymbolFinder.FindReferencesInCurrentProcessAsync(


### PR DESCRIPTION
## Ask Mode
**Customer scenario**

Enable the option to perform analysis in an external process, and then either:
1. search in solution explorer with a JS or TS file open in the editor.
2. Put the caret on a C# identifier in a cshtml file that also contains a JS script block.

**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/454792 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/455588
**Workarounds, if any:** Disable the option to run these features out of process, but we'd really like to get feedback on the option to enable it by default later.
**Risk:** Low - just some checks specifically to prevent these cases, in the OOP specific codepaths.
**Performance impact:** Low - just some if checks.
**Is this a regression from a previous update?** Yes, if the OOP option is enabled.
**Root cause analysis:** Once again, we need to do more testing with JS/TS and razor scenarios.
**How was the bug found?** Divisional automated tests immediately after enabling the option for internal users, and internal dogfooders.