### PR TITLE
Fix signed build

### DIFF
--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -3,6 +3,7 @@ param (
     # Configuration
     [switch]$restore = $false,
     [switch]$release = $false,
+    [switch]$official = $false,
     [switch]$cibuild = $false,
     [switch]$build = $false,
     [switch]$bootstrap = $false,
@@ -29,6 +30,7 @@ function Print-Usage() {
     Write-Host "  -release                  Perform release build (default is debug)"
     Write-Host "  -restore                  Restore packages"
     Write-Host "  -build                    Build the Roslyn source"
+    Write-Host "  -official                 Perform an official build"
     Write-Host "  -bootstrap                Build using a bootstrap Roslyn"
     Write-Host "  -msbuildDir               MSBuild to use for operations"
     Write-Host "" 
@@ -85,6 +87,10 @@ function Run-MSBuild([string]$buildArgs = "", [string]$logFile = "") {
 
     if ($cibuild) { 
         $args += " /p:PathMap=`"$($repoDir)=q:\roslyn`" /p:Feature=pdb-path-determinism" 
+    }
+
+    if ($official) {
+        $args += " /p:OfficialBuild=true"
     }
 
     $args += " $buildArgs"

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <ConfigurationArg Condition="'$(Configuration)' == 'Release'">-release</ConfigurationArg>
+    <OfficialArg Condition="'$(OfficialBuild)' == 'true'">-official</OfficialArg>
     <RepoRoot>$(MSBuildThisFileDirectory)..\..\..\</RepoRoot>
     <BranchName Condition="'$(BranchName)' == ''">$(BUILD_SOURCEBRANCH)</BranchName>
     <BinariesPath>$(RepoRoot)Binaries\$(Configuration)</BinariesPath>
@@ -25,7 +26,7 @@
 
   <Target Name="Build">
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(RepoRoot)build\scripts\build.ps1 -restore -msbuildDir &quot;$(MSBuildBinPath)&quot;" Condition="'$(SkipRestore)' != 'true'" />
-    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(RepoRoot)build\scripts\build.ps1 -build $(ConfigurationArg) -msbuildDir &quot;$(MSBuildBinPath)&quot;" />
+    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(RepoRoot)build\scripts\build.ps1 -build $(ConfigurationArg) $(OfficialArg) -msbuildDir &quot;$(MSBuildBinPath)&quot;" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)..\..\..\build\scripts\create-perftests.ps1 -buildDir &quot;$(BinariesPath)&quot;" />
 


### PR DESCRIPTION
A recent change to src\Tools\MicroBuild\Build.proj replaced invocation of <MSBuild Roslyn.sln> with <Exec powershell build.ps1>. However, value of the OfficialBuild msbuild property was not being propagated to build.ps1. Consequently, signed build was producing binaries and VSIXes with version 42.42 leading to build breaks when these assets were inserted into VS build.