### PR TITLE
Don't show a count for FAR definitions with zero references to them.

### DIFF
--- a/src/VisualStudio/Core/Next/FindReferences/Entries/SimpleMessageEntry.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Entries/SimpleMessageEntry.cs
@@ -18,6 +18,11 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                 string message)
                 : base(definitionBucket)
             {
+                // We only create 'message entries' when we found no references to this definition.
+                // In that case, suppress showing the count next to the definition as it will just
+                // be strange.  i.e. the count will show '(1)' (i.e. us) even though we're indicating
+                // that there really were zero references.
+                DefinitionBucket.ShowCount = false;
                 _message = message;
             }
 


### PR DESCRIPTION
Improvement, but not total fix, for https://github.com/dotnet/roslyn/issues/20259