### PR TITLE
Use an ordinal comparison in GetSourceSymbolsChecksumAsync

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             // Order the documents by FilePath.  Default ordering in the RemoteWorkspace is
             // to be ordered by Guid (which is not consistent across VS sessions).
-            var textChecksumsTasks = project.Documents.OrderBy(d => d.FilePath).Select(async d =>
+            var textChecksumsTasks = project.Documents.OrderBy(d => d.FilePath, StringComparer.Ordinal).Select(async d =>
             {
                 var documentStateChecksum = await d.State.GetStateChecksumsAsync(cancellationToken).ConfigureAwait(false);
                 return documentStateChecksum.Text;


### PR DESCRIPTION
The default string comparer uses the current culture, which increases the time taken to sort this collection, even though the result is never observed by the user.

Saves 2+ seconds of CPU time on the thread pool during solution load of Roslyn.sln.
