### PR TITLE
Cast the correct object to IVsBrowseObjectContext

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         {
             var project = GetProject(projectName);
 
-            if (project.Object is IVsBrowseObjectContext browseObjectContext)
+            if (project is IVsBrowseObjectContext browseObjectContext)
             {
                 var packageService = browseObjectContext.ConfiguredProject.Services.PackageReferences;
 
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         {
             var project = GetProject(projectName);
 
-            if (project.Object is IVsBrowseObjectContext browseObjectContext)
+            if (project is IVsBrowseObjectContext browseObjectContext)
             {
                 var packageService = browseObjectContext.ConfiguredProject.Services.PackageReferences;
 


### PR DESCRIPTION
According to [Finding CPS in a VS project](https://github.com/Microsoft/VSProjectSystem/blob/master/doc/automation/finding_CPS_in_a_VS_project.md) we should cast an `EnvDTE.Project` instance directly to `IVsBrowseObjectContext`. Currently we take the object returned by `EnvDTE.Project.Object` and cast that, but this seems to only be valid for VC projects.