### PR TITLE
Fixed issue with missing suggestion to import namespace if class contains a property with same name as the extension method.

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_ExtensionMethods.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_ExtensionMethods.cs
@@ -1108,5 +1108,68 @@ namespace N
 }",
 parseOptions: null);
         }
+
+        [WorkItem(16547, "https://github.com/dotnet/roslyn/issues/16547")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
+        public async Task TestAddUsingForAddExtentionMethodWithSameNameAsProperty()
+        {
+            await TestAsync(
+@"
+namespace A
+{
+    public class Foo
+    {
+        public void Bar()
+        {
+            var self = this.[|Self()|];
+        }
+
+        public Foo Self
+        {
+            get { return this; }
+        }
+    }
+}
+
+namespace A.Extensions
+{
+    public static class FooExtensions
+    {
+        public static Foo Self(this Foo foo)
+        {
+            return foo;
+        }
+    }
+}",
+@"
+using A.Extensions;
+
+namespace A
+{
+    public class Foo
+    {
+        public void Bar()
+        {
+            var self = this.Self();
+        }
+
+        public Foo Self
+        {
+            get { return this; }
+        }
+    }
+}
+
+namespace A.Extensions
+{
+    public static class FooExtensions
+    {
+        public static Foo Self(this Foo foo)
+        {
+            return foo;
+        }
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -92,6 +92,11 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         public const string CS1929 = nameof(CS1929);
 
         /// <summary>
+        /// Property cannot be used like a method
+        /// </summary>
+        public const string CS1955 = nameof(CS1955);
+
+        /// <summary>
         /// Cannot convert method group 'X' to non-delegate type 'Y'. Did you intend to invoke the method?
         /// </summary>
         public const string CS0428 = nameof(CS0428);
@@ -128,6 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
                     CS1574,
                     CS1584,
                     CS1929,
+                    CS1955,
                     CS0428,
                     CS7036));
     }

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -95,6 +95,8 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
                     }
 
                     break;
+                case CS1955:
+                    break;
 
                 default:
                     return false;
@@ -158,6 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
                 case CS0616:
                 case CS1580:
                 case CS1581:
+                case CS1955:
                     break;
 
                 case CS1574:


### PR DESCRIPTION
**Customer scenario**
Missing suggestion to import namespace if class contains a property with same name as the extension method.

**Bugs this fixes:**

Fixes #16547

**Workarounds, if any**
None

**Risk**
Minimal

**Performance impact**

**Is this a regression from a previous update?**

**Root cause analysis:**
If class has a property with same name as the extension method we will have a error CS1955, which isn't handled by CSharpAddImportFeatureService.

**How was the bug found?**
Customer reported
