### PR TITLE
Fix the UI delay during solution load from analyzer dependency checker

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
@@ -85,8 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             // Report conflict resolution diagnostics on a background thread.
             // This is done to avoid blocking the UI thread for attribute binding to determine diagnostic suppression.
             // See https://github.com/dotnet/roslyn/issues/20476 for further details.
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            Task.Run(() =>
+            await Task.Run(() =>
             {
                 foreach (var project in projects)
                 {
@@ -129,8 +128,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                 {
                     LogMissingDependency(missingDependency);
                 }
-            });
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            }).ConfigureAwait(false);
         }
 
         private void LogConflict(AnalyzerDependencyConflict conflict)

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyCheckingService.cs
@@ -80,48 +80,57 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             var conflicts = results.Conflicts;
             var missingDependencies = results.MissingDependencies;
+            var projects = _workspace.DeferredState.ProjectTracker.ImmutableProjects;
 
-            foreach (var project in _workspace.DeferredState.ProjectTracker.ImmutableProjects)
+            // Report conflict resolution diagnostics on a background thread.
+            // This is done to avoid blocking the UI thread for attribute binding to determine diagnostic suppression.
+            // See https://github.com/dotnet/roslyn/issues/20476 for further details.
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            Task.Run(() =>
             {
-                builder.Clear();
+                foreach (var project in projects)
+                {
+                    builder.Clear();
+
+                    foreach (var conflict in conflicts)
+                    {
+                        if (project.CurrentProjectAnalyzersContains(conflict.AnalyzerFilePath1) ||
+                            project.CurrentProjectAnalyzersContains(conflict.AnalyzerFilePath2))
+                        {
+                            var messageArguments = new string[] { conflict.AnalyzerFilePath1, conflict.AnalyzerFilePath2, conflict.Identity.ToString() };
+                            if (DiagnosticData.TryCreate(_analyzerDependencyConflictRule, messageArguments, project.Id, _workspace, out var diagnostic))
+                            {
+                                builder.Add(diagnostic);
+                            }
+                        }
+                    }
+
+                    foreach (var missingDependency in missingDependencies)
+                    {
+                        if (project.CurrentProjectAnalyzersContains(missingDependency.AnalyzerPath))
+                        {
+                            var messageArguments = new string[] { missingDependency.AnalyzerPath, missingDependency.DependencyIdentity.ToString() };
+                            if (DiagnosticData.TryCreate(_missingAnalyzerReferenceRule, messageArguments, project.Id, _workspace, out var diagnostic))
+                            {
+                                builder.Add(diagnostic);
+                            }
+                        }
+                    }
+
+                    _updateSource.UpdateDiagnosticsForProject(project.Id, s_dependencyConflictErrorId, builder.ToImmutable());
+                }
 
                 foreach (var conflict in conflicts)
                 {
-                    if (project.CurrentProjectAnalyzersContains(conflict.AnalyzerFilePath1) ||
-                        project.CurrentProjectAnalyzersContains(conflict.AnalyzerFilePath2))
-                    {
-                        var messageArguments = new string[] { conflict.AnalyzerFilePath1, conflict.AnalyzerFilePath2, conflict.Identity.ToString() };
-                        if (DiagnosticData.TryCreate(_analyzerDependencyConflictRule, messageArguments, project.Id, _workspace, out var diagnostic))
-                        {
-                            builder.Add(diagnostic);
-                        }
-                    }
+                    LogConflict(conflict);
                 }
 
                 foreach (var missingDependency in missingDependencies)
                 {
-                    if (project.CurrentProjectAnalyzersContains(missingDependency.AnalyzerPath))
-                    {
-                        var messageArguments = new string[] { missingDependency.AnalyzerPath, missingDependency.DependencyIdentity.ToString() };
-                        if (DiagnosticData.TryCreate(_missingAnalyzerReferenceRule, messageArguments, project.Id, _workspace, out var diagnostic))
-                        {
-                            builder.Add(diagnostic);
-                        }
-                    }
+                    LogMissingDependency(missingDependency);
                 }
-
-                _updateSource.UpdateDiagnosticsForProject(project.Id, s_dependencyConflictErrorId, builder.ToImmutable());
-            }
-
-            foreach (var conflict in conflicts)
-            {
-                LogConflict(conflict);
-            }
-
-            foreach (var missingDependency in missingDependencies)
-            {
-                LogMissingDependency(missingDependency);
-            }
+            });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         }
 
         private void LogConflict(AnalyzerDependencyConflict conflict)

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
@@ -70,6 +70,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             Contract.ThrowIfNull(key);
             Contract.ThrowIfNull(items);
 
+            if (!_workspace.CurrentSolution.ContainsProject(projectId))
+            {
+                // Project already removed from the workspace
+                return;
+            }
+
             lock (_gate)
             {
                 _diagnosticMap.GetOrAdd(projectId, id => new HashSet<object>()).Add(key);


### PR DESCRIPTION
A customer reported a very large UI delay on solution load, whose underlying cause was attempting to report analyzer dependency conflict diagnostic IDE1002 on UI thread during analyzer reference initialization. This is done on the UI thread by both legacy and new project systems. The root cause is that diagnostic reporting involves checking if diagnostic was suppressed or not, which requires binding and decoding all the global assembly level attributes. Fix is to push the analyzer dependency conflict diagnostic reporting on background thread to avoid this UI delay. Long term, we should move the language service initialization in the new project system onto background thread to avoid such delays.

Fixes #20476