### PR TITLE
Fix cases where ISymbol.Name could return null

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Crefs.cs
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 callingConvention: candidateMethodIsVararg ? Microsoft.Cci.CallingConvention.ExtraArguments : Microsoft.Cci.CallingConvention.HasThis,
                                 // These are ignored by this specific MemberSignatureComparer.
                                 containingType: null,
-                                name: null,
+                                name: string.Empty,
                                 refKind: RefKind.None,
                                 returnType: null,
                                 returnTypeCustomModifiers: ImmutableArray<CustomModifier>.Empty,
@@ -753,7 +753,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 parameters: parameterSymbols,
                                 // These are ignored by this specific MemberSignatureComparer.
                                 containingType: null,
-                                name: null,
+                                name: string.Empty,
                                 refKind: RefKind.None,
                                 type: null,
                                 typeCustomModifiers: ImmutableArray<CustomModifier>.Empty,

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override string Name
         {
-            get { return null; }
+            get { return string.Empty; }
         }
 
         public override TypeSymbol Type

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/DataFlowPass.Symbols.vb
@@ -79,7 +79,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Public Overrides ReadOnly Property Name As String
                 Get
-                    Return Nothing
+                    Return String.Empty
                 End Get
             End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedLocal.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedLocal.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overrides ReadOnly Property Name As String
             Get
-                Return Nothing
+                Return String.Empty
             End Get
         End Property
 


### PR DESCRIPTION
Fixes some invalid state cases which could conceivably result in `SymbolTreeInfo.GetDerivedMetadataTypes` throwing a `NullReferenceException`.

<details><summary>Ask Mode not complete</summary><p>

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)

</p></details>