### PR TITLE
Don't fetch every PR ref for every PR job

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -29,11 +29,12 @@ static void addRoslynJob(def myJob, String jobName, String branchName, Boolean i
 
   // Create the standard job.  This will setup parameter, SCM, timeout, etc ...
   def projectName = 'dotnet/roslyn'
-  def defaultBranch = "*/${branchName}"
-  Utilities.standardJobSetup(myJob, projectName, isPr, defaultBranch)
 
   // Need to setup the triggers for the job
   if (isPr) {
+    // Note the use of ' vs " for the 4th argument. We don't want groovy to interpolate this string (the ${ghprbPullId}
+    // is resolved when the job is run based on an environment variable set by the Jenkins Pull Request Builder plugin.
+    Utilities.standardJobSetupPR(myJob, projectName, null, '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*');
     def triggerCore = "open|all|${jobName}"
     if (triggerPhraseExtra) {
       triggerCore = "${triggerCore}|${triggerPhraseExtra}"
@@ -42,6 +43,7 @@ static void addRoslynJob(def myJob, String jobName, String branchName, Boolean i
     def contextName = jobName
     Utilities.addGithubPRTriggerForBranch(myJob, branchName, contextName, triggerPhrase, triggerPhraseOnly)
   } else {
+    Utilities.standardJobSetupPush(myJob, projectName, "*/${branchName}");
     Utilities.addGithubPushTrigger(myJob)
     // TODO: Add once external email sending is available again
     // addEmailPublisher(myJob)


### PR DESCRIPTION
Newer versions of git (I've seen this behavior on 2.13.1.windows.1 and
have not seen it on 2.11.1.windows.1) are much slower at writing out local
copies of refs after a fetch. Given that we fetch about 10K refs when
running each PR job this can lead to a massive slowdown in fetch times (on
the roslyn integration job, which has a newer version of git on the
workers compared to the other machines, we see fetch taking ~20 mins).

This changes all the Roslyn jobs to fetch just the PR they are going to
test, which speeds up the fetch significantly.
