### PR TITLE
Fixing a race in PEMethodSymbol

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -196,12 +196,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             //
             // Do not set _lazyUseSiteDiagnostic !!!!
             //
-            // "null" Indicates "no errors" or "unknown state".
+            // "null" Indicates "no errors" or "unknown state",
             // and we know which one of the states we have from IsUseSiteDiagnosticPopulated
             //
-            // setting _lazyUseSiteDiagnostic to a sentinel value here would introduce
-            // a number of states with various permutations between IsUseSiteDiagnosticPopulated, UncommonFields and _lazyUseSiteDiagnostic
-            // some of them, in tight races, may lead to returning the sentinel as the diagnostics.
+            // Setting _lazyUseSiteDiagnostic to a sentinel value here would introduce
+            // a number of extra states for various permutations of IsUseSiteDiagnosticPopulated, UncommonFields and _lazyUseSiteDiagnostic
+            // Some of them, in tight races, may lead to returning the sentinel as the diagnostics.
             //
 
             if (_packedFlags.IsCustomAttributesPopulated)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
@@ -182,6 +182,7 @@ class Program
         }
 
         // Overriding base System.Object methods on struct
+        [WorkItem(20496, "https://github.com/dotnet/roslyn/issues/20496")]
         [WorkItem(540990, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540990")]
         [ClrOnlyFact(ClrOnlyReason.MemberOrder)]
         public void TestOverridingBaseConstructorStruct()


### PR DESCRIPTION
Fixes:#20496

The race seems to have more effect when running on CoreClr/Linux and in particular affects CoreFxLab repo where it causes build breaks.

There is a test that this race causes to fail - TestOverridingBaseConstructorStruct, but it happens very rarily.

The issue seems to be in computation of the use site diagnostics in PEMethodSymbol
One of possible race scenarios:

thread #1 sees that IsUseSiteDiagnosticPopulated is not set, goes to compute and publish diagnostics
thread #2 sees that IsUseSiteDiagnosticPopulated is not set, goes to compute and publish diagnostics
thread #1 finds no issues and sets IsUseSiteDiagnosticPopulated
thread #3 does something else and indirectly creates UncommonFields with a sentinel value for the use site diagnostics
thread #2 checks again IsUseSiteDiagnosticPopulated and since it is set (by thread #1) happily returns the sentinel as the actual value!!!

While we must fix the race ASAP in the readonly-ref branch, the rest of the PEMethodSymbol must be reviewed/simplified.
It seems to reuse this same pattern that mixes sentinel/null/flag as indication of the current state thus introducing a lot of states and it is hard to prove that incoherent states are unreachable.