### PR TITLE
[StringTable] Fix bug in Add(string, int, int)

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/StringTableTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/StringTableTests.cs
@@ -118,5 +118,21 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.False(TestTextEqualsASCII("\ud800", "xx"));
             Assert.False(TestTextEqualsASCII("\uffff", ""));
         }
+
+        [Fact]
+        public void TestAddEqualSubstringsFromDifferentStringsWorks()
+        {
+            // Make neither of the strings equal to the result of the substring call
+            // to test an issue that was surfaced by pooling the wrong string.
+            var str1 = "abcd1";
+            var str2 = "abcd2";
+            var st = new StringTable();
+
+            var s1 = st.Add(str1, 0, 4);
+            var s2 = st.Add(str2, 0, 4);
+
+            Assert.Same(s1, s2);
+            Assert.Equal("abcd", s1);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/StringTable.cs
@@ -499,7 +499,7 @@ namespace Roslyn.Utilities
         private string AddItem(string chars, int start, int len, int hashCode)
         {
             var text = chars.Substring(start, len);
-            AddCore(chars, hashCode);
+            AddCore(text, hashCode);
             return text;
         }
 


### PR DESCRIPTION
Most likely a typo, as all the surrounding code uses `text` not chars`

<details>
**Customer scenario**

Copied over the code to MonoDevelop and found this bug while toying with it.

**Bugs this fixes:**

N/A

**Workarounds, if any**

N/A

**Risk**

Low risk, the method is only referenced in unit tests, still a nice to have API.

**Performance impact**

N/A

**Is this a regression from a previous update?**

No

**Root cause analysis:**

I added a test to verify the bug.

**How was the bug found?**

Testing the usage of this class in MonoDevelop
</details>