### PR TITLE
Deploy dependencies of SyntaxVisualizer with extension

### DIFF
--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerExtension.csproj
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerExtension.csproj
@@ -143,7 +143,6 @@
       <Project>{afe45e23-e7ee-48c5-8143-ebe2ff67070f}</Project>
       <Name>SyntaxVisualizerControl</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
-      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\SyntaxVisualizerDgmlHelper\SyntaxVisualizerDgmlHelper.vbproj">
       <Project>{da4f74af-2694-4ac9-a8cc-18382de8215e}</Project>

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerExtension.csproj
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerExtension.csproj
@@ -142,10 +142,14 @@
     <ProjectReference Include="..\SyntaxVisualizerControl\SyntaxVisualizerControl.csproj">
       <Project>{afe45e23-e7ee-48c5-8143-ebe2ff67070f}</Project>
       <Name>SyntaxVisualizerControl</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
     <ProjectReference Include="..\SyntaxVisualizerDgmlHelper\SyntaxVisualizerDgmlHelper.vbproj">
       <Project>{da4f74af-2694-4ac9-a8cc-18382de8215e}</Project>
       <Name>SyntaxVisualizerDgmlHelper</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Prior to this change, installing SyntaxVisualizer and trying to open it would show an error dialog

Tag @dotnet/roslyn-ide 