### PR TITLE
Fix crash in element access signature help

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ElementAccessExpressionSignatureHelpProviderTests.cs
@@ -898,6 +898,48 @@ class TestClass
 ";
                 await TestAsync(markup, new[] { new SignatureHelpTestItem("int WithIndexer[int index]") }, usePreviousCharAsTrigger: true);
             }
+
+            [WorkItem(20507, "https://github.com/dotnet/roslyn/issues/20507")]
+            [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+            public async Task InConditionalIndexingFollowedByMemberAccess()
+            {
+                var markup = @"
+class Indexable
+{
+    public Indexable this[int x] { get => null; }
+
+    Indexable Count;
+
+    static void Main(string[] args)
+    {
+        Indexable x;
+        x?[$$].Count;
+    }
+}
+";
+                await TestAsync(markup, new[] { new SignatureHelpTestItem("Indexable Indexable[int x]") }, usePreviousCharAsTrigger: false);
+            }
+
+            [WorkItem(20507, "https://github.com/dotnet/roslyn/issues/20507")]
+            [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+            public async Task InConditionalIndexingFollowedByConditionalAcesss()
+            {
+                var markup = @"
+class Indexable
+{
+    public Indexable this[int x] { get => null; }
+
+    Indexable Count;
+
+    static void Main(string[] args)
+    {
+        Indexable x;
+        x?[$$].Count?.Count;
+    }
+}
+";
+                await TestAsync(markup, new[] { new SignatureHelpTestItem("Indexable Indexable[int x]") }, usePreviousCharAsTrigger: false);
+            }
         }
     }
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -372,7 +372,18 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
             {
                 if (CommonSignatureHelpUtilities.TryGetSyntax(root, position, syntaxFacts, triggerReason, IsTriggerToken, IsArgumentListToken, cancellationToken, out ElementBindingExpressionSyntax elementBindingExpression))
                 {
-                    identifier = ((ConditionalAccessExpressionSyntax)elementBindingExpression.Parent).Expression;
+                    // Find the first conditional access expression that starts left of our open bracket
+                    var conditionalAccess = elementBindingExpression.FirstAncestorOrSelf<ConditionalAccessExpressionSyntax>(
+                        c => c.SpanStart < elementBindingExpression.SpanStart);
+
+                    if (conditionalAccess == null)
+                    {
+                        identifier = null;
+                        openBrace = default(SyntaxToken);
+                        return false;
+                    }
+
+                    identifier = conditionalAccess.Expression;
                     openBrace = elementBindingExpression.ArgumentList.OpenBracketToken;
 
                     return true;

--- a/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ElementAccessExpressionSignatureHelpProvider.cs
@@ -376,13 +376,6 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
                     var conditionalAccess = elementBindingExpression.FirstAncestorOrSelf<ConditionalAccessExpressionSyntax>(
                         c => c.SpanStart < elementBindingExpression.SpanStart);
 
-                    if (conditionalAccess == null)
-                    {
-                        identifier = null;
-                        openBrace = default(SyntaxToken);
-                        return false;
-                    }
-
                     identifier = conditionalAccess.Expression;
                     openBrace = elementBindingExpression.ArgumentList.OpenBracketToken;
 


### PR DESCRIPTION
We previously assumed that conditional element access would never be followed by a member or conditional access.

Fixes https://github.com/dotnet/roslyn/issues/20507

Tag @dotnet/roslyn-ide 
