### PR TITLE
[SlidingTextWindow] Add another common case for GetText optimization

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
@@ -668,6 +668,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     {
                         return " ";
                     }
+                    if (_characterWindow[offset] == '\n')
+                    {
+                        return "\n";
+                    }
                     break;
 
                 case 2:


### PR DESCRIPTION
For files that use \n as EOL instead of \r\n, this would not hit the optimization path of reusing the same token text.

This was seen under a profiler looking at string duplicates. It's 200kb, but it had the highest object count.

<details>
**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
</details>