### PR TITLE
[Lexer] Pool trivia comments from a file header

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2188,9 +2188,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private void LexSyntaxTrivia(bool afterFirstToken, bool isTrailing, ref SyntaxListBuilder triviaList)
         {
             bool onlyWhitespaceOnLine = !isTrailing;
-            // PERF: This pools all the comments that are at the top of the file, i.e. file copyright headers.
-            // Most of them repeat themselves and it can lead to a noticeable amount of string duplicates for huge projects.
-            bool poolTrivia = !afterFirstToken;
 
             while (true)
             {
@@ -2223,6 +2220,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         this.AddTrivia(this.ScanWhitespace(), ref triviaList);
                         break;
                     case '/':
+                        // PERF: This pools all the comments that are at the top of the file, i.e. file copyright headers.
+                        // Most of them repeat themselves and it can lead to a noticeable amount of string duplicates for huge projects.
+                        int maximumInternLength = afterFirstToken ? -1 : 256;
+
                         if ((ch = TextWindow.PeekChar(1)) == '/')
                         {
                             if (!this.SuppressDocumentationCommentParse && TextWindow.PeekChar(2) == '/' && TextWindow.PeekChar(3) != '/')
@@ -2240,7 +2241,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                             // normal single line comment
                             this.ScanToEndOfLine();
-                            var text = TextWindow.GetText(poolTrivia);
+                            var text = TextWindow.GetText(maximumInternLength);
                             this.AddTrivia(SyntaxFactory.Comment(text), ref triviaList);
                             onlyWhitespaceOnLine = false;
                             break;
@@ -2269,7 +2270,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 this.AddError(ErrorCode.ERR_OpenEndedComment);
                             }
 
-                            var text = TextWindow.GetText(poolTrivia);
+                            var text = TextWindow.GetText(maximumInternLength);
                             this.AddTrivia(SyntaxFactory.Comment(text), ref triviaList);
                             onlyWhitespaceOnLine = false;
                             break;

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2188,6 +2188,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private void LexSyntaxTrivia(bool afterFirstToken, bool isTrailing, ref SyntaxListBuilder triviaList)
         {
             bool onlyWhitespaceOnLine = !isTrailing;
+            // PERF: This pools all the comments that are at the top of the file, i.e. file copyright headers.
+            // Most of them repeat themselves and it can lead to a noticeable amount of string duplicates for huge projects.
+            bool poolTrivia = !afterFirstToken;
 
             while (true)
             {
@@ -2237,7 +2240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                             // normal single line comment
                             this.ScanToEndOfLine();
-                            var text = TextWindow.GetText(false);
+                            var text = TextWindow.GetText(poolTrivia);
                             this.AddTrivia(SyntaxFactory.Comment(text), ref triviaList);
                             onlyWhitespaceOnLine = false;
                             break;
@@ -2266,7 +2269,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 this.AddError(ErrorCode.ERR_OpenEndedComment);
                             }
 
-                            var text = TextWindow.GetText(false);
+                            var text = TextWindow.GetText(poolTrivia);
                             this.AddTrivia(SyntaxFactory.Comment(text), ref triviaList);
                             onlyWhitespaceOnLine = false;
                             break;

--- a/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SlidingTextWindow.cs
@@ -652,6 +652,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return this.GetText(this.LexemeStartPosition, this.Width, intern);
         }
 
+        public string GetText(int maximumInternLength)
+        {
+            int width = this.Width;
+
+            return this.GetText(this.LexemeStartPosition, width, width < maximumInternLength);
+        }
+
         public string GetText(int position, int length, bool intern)
         {
             int offset = position - _basis;

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -3520,5 +3520,103 @@ class C
             Assert.Equal(trivia4.Span.Start, 36);
             Assert.Equal(trivia4.Span.Length, 24);
         }
+
+        [Fact]
+        [Trait("Feature", "Comments")]
+        public void TestCommentsAtTheBeginningOfATextAreInterned()
+        {
+            var baseComment = "// aa";
+            var text = baseComment + "\r\n" + baseComment + "\r\n";
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
+            Assert.Equal(text, token.ToFullString());
+            Assert.Equal(text.Length, token.FullWidth);
+
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+
+            var trivia = token.LeadingTrivia.ToArray();
+            Assert.Equal(4, trivia.Length);
+            Assert.NotNull(trivia[0]);
+            Assert.NotNull(trivia[1]);
+            Assert.NotNull(trivia[2]);
+            Assert.NotNull(trivia[3]);
+
+            Assert.Equal(baseComment, trivia[0].ToString());
+            Assert.Equal("\r\n", trivia[1].ToString());
+            Assert.Same(trivia[0].ToString(), trivia[2].ToString());
+            Assert.Same(trivia[1].ToString(), trivia[3].ToString());
+            Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[0].Kind());
+            Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[2].Kind());
+        }
+
+        [Fact]
+        [Trait("Feature", "Comments")]
+        public void TestCommentsAtTheBeginningOfATextThatAreBigEnoughAreNotInterned()
+        {
+            var commentText = new string ('a', 256);
+            var baseComment = $"// {commentText}";
+            var text = baseComment + "\r\n" + baseComment + "\r\n";
+
+            var token = LexToken(text);
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
+            Assert.Equal(text, token.ToFullString());
+            Assert.Equal(text.Length, token.FullWidth);
+
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+
+            var trivia = token.LeadingTrivia.ToArray();
+            Assert.Equal(4, trivia.Length);
+            Assert.NotNull(trivia[0]);
+            Assert.NotNull(trivia[1]);
+            Assert.NotNull(trivia[2]);
+            Assert.NotNull(trivia[3]);
+
+            Assert.Equal(baseComment, trivia[0].ToString());
+            Assert.Equal("\r\n", trivia[1].ToString());
+            Assert.NotSame(trivia[0].ToString(), trivia[2].ToString());
+            Assert.Same(trivia[1].ToString(), trivia[3].ToString());
+            Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[0].Kind());
+            Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[2].Kind());
+        }
+
+        [Fact]
+        [Trait("Feature", "Comments")]
+        public void TestCommentsNotAtTheBeginningOfATextAreNotInterned()
+        {
+            var baseComment = "// aa";
+            var eofText = baseComment + "\r\n" + baseComment + "\r\n";
+            var text = "int x;\r\n" + eofText;
+
+            // Skip anything other than the EOF token.
+            var token = Lex(text).Last();
+
+            Assert.NotNull(token);
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
+            Assert.Equal(eofText, token.ToFullString());
+            Assert.Equal(eofText.Length, token.FullWidth);
+
+            var errors = token.Errors();
+            Assert.Equal(0, errors.Length);
+
+            var trivia = token.LeadingTrivia.ToArray();
+            Assert.Equal(4, trivia.Length);
+            Assert.NotNull(trivia[0]);
+            Assert.NotNull(trivia[1]);
+            Assert.NotNull(trivia[2]);
+            Assert.NotNull(trivia[3]);
+
+            Assert.Equal(baseComment, trivia[0].ToString());
+            Assert.Equal("\r\n", trivia[1].ToString());
+            Assert.NotSame(trivia[0].ToString(), trivia[2].ToString());
+            Assert.Same(trivia[1].ToString(), trivia[3].ToString());
+            Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[0].Kind());
+            Assert.Equal(SyntaxKind.SingleLineCommentTrivia, trivia[2].Kind());
+        }
     }
 }


### PR DESCRIPTION
The idea behind this change is that trivia that is at top of the file
usually consist of copyright headers or ~same content.

All syntax trees on MonoDevelop's main solution ended up having around
13MB of duplicate strings spread across 250000 objects.

<details>
**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address for this release.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:**

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
</details>