### PR TITLE
Don't assume a document has SyntaxFactsService

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionHelperServiceFactory.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelperServiceFactory.cs
@@ -43,7 +43,9 @@ namespace Microsoft.CodeAnalysis.Completion
                     }
 
                     var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
-                    return syntaxFacts.IsCaseSensitive
+                    var caseSensitive = syntaxFacts?.IsCaseSensitive ?? true;
+
+                    return caseSensitive
                         ? this._caseSensitiveInstance
                         : this._caseInsensitiveInstance;
                 }


### PR DESCRIPTION
If it doesn't, just use case sensitive matching

Tag @dotnet/roslyn-ide, @tannergooding 
Tag @MattGertz for approval

**Customer scenario**

Customer types in a TypeScript file, completion crashes.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/20518

**Workarounds, if any**

None

**Risk**

Low, this only affects statement completion.

**Performance impact**

Minimal, adds a null check (that was present before it was removed in https://github.com/dotnet/roslyn/commit/e6f090e991841d8ffb56a2be4856e41f07965ab5

**Is this a regression from a previous update?**

It was regressed by https://github.com/dotnet/roslyn/commit/e6f090e991841d8ffb56a2be4856e41f07965ab5 and detected by the typescript ddrit.

**Root cause analysis:**

This was regressed by the above change and detected by the typescript ddrit. The null check was accidentally removed and missed in code review. This was caught by the TypeScript DDRIT run in VSO. The type script integration test currently being worked on should help us detect this in the future.

**How was the bug found?**

DDRIT


