### PR TITLE
Don't force editor composition during ASL

### DIFF
--- a/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
+++ b/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices
     /// </summary>
     [Export(typeof(IWpfTextViewConnectionListener))]
     [ContentType(ContentTypeNames.RoslynContentType)]
-    [TextViewRole(PredefinedTextViewRoles.Interactive)]
+    [TextViewRole(PredefinedTextViewRoles.Analyzable)]
     internal sealed class HACK_ThemeColorFixer : IWpfTextViewConnectionListener
     {
         private readonly IClassificationTypeRegistryService _classificationTypeRegistryService;

--- a/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
+++ b/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
@@ -127,18 +127,12 @@ namespace Microsoft.VisualStudio.LanguageServices
         {
             // DevDiv https://devdiv.visualstudio.com/DevDiv/_workitems/edit/130129:
             //
-            // We used to schedule the RefreshThemeColors task when the Roslyn Package loaded
-            // during async solution load. Even though we scheduled the task for UI thread idle,
-            // it was possible for it to run before any files had been opened.This meant
-            // that our requests for colors and editor services would cause the composition of
-            // the editor, thus leading to a UI delay during ASL.
-            // To avoid this, we now wait until a text editor has been opened to schedule the
-            // color synchronization.
-
+            // This needs to be scheduled after editor has been composed. Otherwise
+            // it may cause UI delays by composing the editor before it is needed
+            // by the rest of VS.
             if (!_done)
             {
                 _done = true;
-                // Run on the UI thread when VS is idle 
                 VsTaskLibraryHelper.CreateAndStartTask(VsTaskLibraryHelper.ServiceInstance, VsTaskRunContext.UIThreadIdlePriority, RefreshThemeColors);
             }
         }

--- a/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
+++ b/src/VisualStudio/Core/Def/HACK_ThemeColorFixer.cs
@@ -141,8 +141,6 @@ namespace Microsoft.VisualStudio.LanguageServices
                 // Run on the UI thread when VS is idle 
                 VsTaskLibraryHelper.CreateAndStartTask(VsTaskLibraryHelper.ServiceInstance, VsTaskRunContext.UIThreadIdlePriority, RefreshThemeColors);
             }
-
-           
         }
 
         public void SubjectBuffersDisconnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -104,7 +104,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             this.ComponentModel.GetService<VisualStudioTodoListTable>();
             this.ComponentModel.GetService<VisualStudioDiagnosticListTableCommandHandler>().Initialize(this);
 
-            this.ComponentModel.GetService<HACK_ThemeColorFixer>();
             this.ComponentModel.GetExtensions<IDefinitionsAndReferencesPresenter>();
             this.ComponentModel.GetExtensions<INavigableItemsPresenter>();
             this.ComponentModel.GetService<VisualStudioMetadataAsSourceFileSupportService>();

--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
@@ -44,8 +44,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
 
             _componentModel = (IComponentModel)GetService(typeof(SComponentModel));
             _interactiveWindowProvider = _componentModel.DefaultExportProvider.GetExportedValue<TVsInteractiveWindowProvider>();
-            KnownUIContexts.ShellInitializedContext.WhenActivated(() =>
-                _componentModel.GetService<HACK_ThemeColorFixer>());
 
             var menuCommandService = (OleMenuCommandService)GetService(typeof(IMenuCommandService));
             InitializeMenuCommands(menuCommandService);


### PR DESCRIPTION
Hack_ThemeColorFixer was running during ASL for some users and forcing the editor to compose at that time. Instead, we wait until a text editor of the appropriate content type has been opened.

Addresses devdiv bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/130129

If you take a look at the [stacks](http://perfwatson/#?q=f:microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.HACK_ThemeColorFixer.RefreshThemeColors%20v%3D15*&t&s=microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.HACK_ThemeColorFixer.RefreshThemeColors&sf=Stacks), you'll see that the "scenarios" this occurs in are almost entirely all async solution load and package load and that the delay time is MEF composition. That suggests to me that the delay is not a mid-session settings sync but simply us loading the editor extra early to start copying the settings.

Tag @dotnet/roslyn-ide 
