### PR TITLE
Override object.ToString in Optional<T>

### DIFF
--- a/src/Compilers/Core/Portable/Optional.cs
+++ b/src/Compilers/Core/Portable/Optional.cs
@@ -5,16 +5,17 @@ using System;
 namespace Microsoft.CodeAnalysis
 {
     /// <summary>
-    /// Represents a value type that can be assigned null.
+    /// Combines a value, <see cref="Value"/>, and a flag, <see cref="HasValue"/>, 
+    /// indicating whether or not that value is meaningful.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of the value.</typeparam>
     public struct Optional<T>
     {
         private readonly bool _hasValue;
         private readonly T _value;
 
         /// <summary>
-        /// Initializes a new instance to the specified value.
+        /// Constructs an <see cref="Optional{T}"/> with a meaningful value.
         /// </summary>
         /// <param name="value"></param>
         public Optional(T value)
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Gets a value indicating whether the current object has a value.
+        /// Returns <see langword="true"/> if the <see cref="Value"/> will return a meaningful value.
         /// </summary>
         /// <returns></returns>
         public bool HasValue
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Gets the value of the current object.
+        /// Gets the value of the current object.  Not meaningful unless <see cref="HasValue"/> returns <see langword="true"/>.
         /// </summary>
         /// <remarks>
         /// <para>Unlike <see cref="Nullable{T}.Value"/>, this property does not throw an exception when
@@ -49,7 +50,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Creates a new object initialized to a specified value. 
+        /// Creates a new object initialized to a meaningful value. 
         /// </summary>
         /// <param name="value"></param>
         public static implicit operator Optional<T>(T value)
@@ -58,7 +59,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Returns a string representation of the optional value.
+        /// Returns a string representation of this object.
         /// </summary>
         public override string ToString()
         {

--- a/src/Compilers/Core/Portable/Optional.cs
+++ b/src/Compilers/Core/Portable/Optional.cs
@@ -56,5 +56,15 @@ namespace Microsoft.CodeAnalysis
         {
             return new Optional<T>(value);
         }
+
+        /// <summary>
+        /// Returns a string representation of the optional value.
+        /// </summary>
+        public override string ToString()
+        {
+            return _hasValue
+                ? _value.ToString()
+                : "null";
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Optional.cs
+++ b/src/Compilers/Core/Portable/Optional.cs
@@ -63,9 +63,10 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public override string ToString()
         {
+            // Note: For nullable types, it's possible to have _hasValue true and _value null.
             return _hasValue
-                ? _value.ToString()
-                : "null";
+                ? _value?.ToString() ?? "null"
+                : "unspecified";
         }
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -666,6 +666,7 @@ abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.R
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationBlockEndAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationBlockAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.SemanticModel.GetOperationCore(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.IOperation
 const Microsoft.CodeAnalysis.LanguageNames.FSharp = "F#" -> string
+override Microsoft.CodeAnalysis.Optional<T>.ToString() -> string
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.Visit(Microsoft.CodeAnalysis.IOperation operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitAddressOfExpression(Microsoft.CodeAnalysis.Semantics.IAddressOfExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitArgument(Microsoft.CodeAnalysis.Semantics.IArgument operation) -> void


### PR DESCRIPTION
**How was the bug found?**

Printed an unhelpful value in a TypeScript server log.