### PR TITLE
Use proper lowering for language version

### DIFF
--- a/src/Compilers/CSharp/Portable/LanguageVersion.cs
+++ b/src/Compilers/CSharp/Portable/LanguageVersion.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
-            switch (version.ToLowerInvariant())
+            switch (CaseInsensitiveComparison.ToLower(version))
             {
                 case "default":
                     result = LanguageVersion.Default;

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -1412,6 +1412,16 @@ d.cs
         }
 
         [Fact]
+        public void LanguageVersion_TryParseTurkishDisplayString()
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
+            Assert.True("ISO-1".TryParse(out var version));
+            Assert.Equal(LanguageVersion.CSharp1, version);
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+
+        [Fact]
         public void LangVersion_ListLangVersions()
         {
             var dir = Temp.CreateDirectory();

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBConstantTests.cs
@@ -12,8 +12,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.PDB
 {
     public class PDBConstantTests : CSharpTestBase
     {
-        private CultureInfo _testCulture = new CultureInfo("en-US");
-
         [Fact]
         public void StringsWithSurrogateChar()
         {


### PR DESCRIPTION
**Customer scenario**

Invoke the compiler with "ISO-1" on a machine with Turkish culture.
`csc.exe /langversion:ISO-1 b.cs`
`csc.exe /langversion:"ISO-1" b.cs`

You get "CSC : error CS1617: Invalid option '"ISO-1"' for /langversion; must be ISO-1, ISO-2, Default or an integer in range 1 to 6"

**Bugs this fixes:**

https://devdiv.visualstudio.com/DevDiv/_workitems?id=194594

**Workarounds, if any**

Use lowercase format "iso-1"
