### PR TITLE
Change for `fixed` statement to emit more optimal code.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2069,7 +2069,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             TypeSymbol operandType = operand.Type;
-            Debug.Assert((object)operandType != null || hasErrors, "BindValue should have caught a null operand type");
+            Debug.Assert((object)operandType != null, "BindValue should have caught a null operand type");
 
             bool isManagedType = operandType.IsManagedType;
             bool allowManagedAddressOf = Flags.Includes(BinderFlags.AllowManagedAddressOf);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2064,7 +2064,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.UnboundLambda:
                     {
                         Debug.Assert(hasErrors);
-                        return new BoundAddressOfOperator(node, operand, isFixedStatementAddressOfExpression, CreateErrorType(), hasErrors: true);
+                        return new BoundAddressOfOperator(node, operand, CreateErrorType(), hasErrors: true);
                     }
             }
 
@@ -2095,7 +2095,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol pointerType = new PointerTypeSymbol(isManagedType && allowManagedAddressOf
                 ? GetSpecialType(SpecialType.System_IntPtr, diagnostics, node)
                 : operandType ?? CreateErrorType());
-            return new BoundAddressOfOperator(node, operand, isFixedStatementAddressOfExpression, pointerType, hasErrors);
+
+            return new BoundAddressOfOperator(node, operand, pointerType, hasErrors);
         }
 
         // Basically a port of ExpressionBinder::isFixedExpression, which basically implements spec section 18.3.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1085,7 +1085,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (!fa.FieldSymbol.IsFixed)
                             {
                                 Error(diagnostics, ErrorCode.ERR_FixedNotNeeded, initializerSyntax);
-                                hasErrors = true;
+                                return true;
                             }
                             else
                             {
@@ -1098,11 +1098,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             // NOTE: Dev10 specifically doesn't report this error for the array or string cases.
                             Error(diagnostics, ErrorCode.ERR_BadCastInFixed, initializerSyntax);
-                            return true; ;
+                            return true;
                         default:
                             // CONSIDER: this is a very confusing error message, but it's what Dev10 reports.
                             Error(diagnostics, ErrorCode.ERR_FixedNotNeeded, initializerSyntax);
-                            return true; ;
+                            return true;
                     }
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1050,44 +1050,47 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Error(diagnostics, ErrorCode.ERR_FixedNotNeeded, initializerSyntax);
                 }
             }
-            else if (initializerType.SpecialType == SpecialType.System_String)
-            {
-                // See ExpressionBinder::bindPtrToString
-
-                TypeSymbol elementType = this.GetSpecialType(SpecialType.System_Char, diagnostics, initializerSyntax);
-                Debug.Assert(!elementType.IsManagedType);
-
-                initializerOpt = GetFixedLocalCollectionInitializer(initializerOpt, elementType, declType, false, diagnostics);
-
-                // The string case is special - we'll pin a synthesized string temp, rather than the pointer local.
-                localSymbol.SetSpecificallyNotPinned();
-
-                // UNDONE: ExpressionBinder::CheckFieldUse (something about MarshalByRef)
-            }
-            else if (initializerType.IsArray())
-            {
-                // See ExpressionBinder::BindPtrToArray (though most of that functionality is now in LocalRewriter).
-
-                var arrayType = (ArrayTypeSymbol)initializerType;
-                TypeSymbol elementType = arrayType.ElementType;
-
-                bool hasErrors = false;
-                if (elementType.IsManagedType)
-                {
-                    Error(diagnostics, ErrorCode.ERR_ManagedAddr, initializerSyntax, elementType);
-                    hasErrors = true;
-                }
-
-                initializerOpt = GetFixedLocalCollectionInitializer(initializerOpt, elementType, declType, hasErrors, diagnostics);
-            }
             else
             {
-                if (!initializerOpt.HasAnyErrors)
+                TypeSymbol elementType;
+                bool hasErrors = false;
+
+                if (initializerType.SpecialType == SpecialType.System_String)
                 {
+                    elementType = this.GetSpecialType(SpecialType.System_Char, diagnostics, initializerSyntax);
+                    Debug.Assert(!elementType.IsManagedType);
+                }
+                else if (initializerType.IsArray())
+                {
+                    // See ExpressionBinder::BindPtrToArray (though most of that functionality is now in LocalRewriter).
+                    var arrayType = (ArrayTypeSymbol)initializerType;
+                    elementType = arrayType.ElementType;
+
+                    if (elementType.IsManagedType)
+                    {
+                        Error(diagnostics, ErrorCode.ERR_ManagedAddr, initializerSyntax, elementType);
+                        hasErrors = true;
+                    }
+                }
+                else if (!initializerOpt.HasAnyErrors)
+                {
+                    elementType = initializerOpt.Type;
                     switch (initializerOpt.Kind)
                     {
                         case BoundKind.AddressOfOperator:
-                            // OK
+                            elementType = ((BoundAddressOfOperator)initializerOpt).Operand.Type;
+                            break;
+                        case BoundKind.FieldAccess:
+                            var fa = (BoundFieldAccess)initializerOpt;
+                            if (!fa.FieldSymbol.IsFixed)
+                            {
+                                Error(diagnostics, ErrorCode.ERR_FixedNotNeeded, initializerSyntax);
+                                hasErrors = true;
+                            }
+                            else
+                            {
+                                elementType = ((PointerTypeSymbol)fa.Type).PointedAtType;
+                            }
                             break;
                         case BoundKind.Conversion:
                             // The following assertion would not be correct because there might be an implicit conversion after (above) the explicit one.
@@ -1095,22 +1098,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             // NOTE: Dev10 specifically doesn't report this error for the array or string cases.
                             Error(diagnostics, ErrorCode.ERR_BadCastInFixed, initializerSyntax);
-                            break;
-                        case BoundKind.FieldAccess:
-                            var fa = (BoundFieldAccess)initializerOpt;
-                            if (!fa.FieldSymbol.IsFixed)
-                            {
-                                Error(diagnostics, ErrorCode.ERR_FixedNotNeeded, initializerSyntax);
-                            }
-                            break;
+                            return true; ;
                         default:
                             // CONSIDER: this is a very confusing error message, but it's what Dev10 reports.
                             Error(diagnostics, ErrorCode.ERR_FixedNotNeeded, initializerSyntax);
-                            break;
+                            return true; ;
                     }
                 }
+                else
+                {
+                    // convert to generate any additional conversion errors
+                    initializerOpt = GenerateConversionForAssignment(declType, initializerOpt, diagnostics);
+                    return true;
+                }
 
-                initializerOpt = GenerateConversionForAssignment(declType, initializerOpt, diagnostics);
+                initializerOpt = GetFixedLocalCollectionInitializer(initializerOpt, elementType, declType, hasErrors, diagnostics);
             }
 
             return true;
@@ -1142,7 +1144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 pointerType,
                 elementConversion,
                 initializer,
-                initializer.Type,
+                declType,
                 hasErrors);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Conversion InterpolatedString => new Conversion(ConversionKind.InterpolatedString);
         internal static Conversion Deconstruction => new Conversion(ConversionKind.Deconstruction);
         internal static Conversion IdentityValue => new Conversion(ConversionKind.IdentityValue);
-        internal static Conversion ObjectToPointer => new Conversion(ConversionKind.ObjectToPointer);
+        internal static Conversion PinnedObjectToPointer => new Conversion(ConversionKind.PinnedObjectToPointer);
 
         // trivial conversions that could be underlying in nullable conversion
         // NOTE: tuple conversions can be underlying as well, but they are not trivial 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -236,6 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static Conversion InterpolatedString => new Conversion(ConversionKind.InterpolatedString);
         internal static Conversion Deconstruction => new Conversion(ConversionKind.Deconstruction);
         internal static Conversion IdentityValue => new Conversion(ConversionKind.IdentityValue);
+        internal static Conversion ObjectToPointer => new Conversion(ConversionKind.ObjectToPointer);
 
         // trivial conversions that could be underlying in nullable conversion
         // NOTE: tuple conversions can be underlying as well, but they are not trivial 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -48,5 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // It is used by lowering to ensure that trivially reduced expressions 
         // do not become exposed to mutations if used as receivers of struct methods.
         IdentityValue,  
+
+        ObjectToPointer,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -49,9 +49,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // do not become exposed to mutations if used as receivers of struct methods.
         IdentityValue,
 
-        // ObjectToPointer is not directly a part of the language
+        // PinnedObjectToPointer is not directly a part of the language
         // It is used by lowering of "fixed" statements to represent conversion of an object reference (O) to an unmanaged pointer (*)
         // The conversion is unsafe and makes sense only if (O) is pinned.
-        ObjectToPointer,
+        PinnedObjectToPointer,
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionKind.cs
@@ -47,8 +47,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         // IdentityValue is not a part of the language. 
         // It is used by lowering to ensure that trivially reduced expressions 
         // do not become exposed to mutations if used as receivers of struct methods.
-        IdentityValue,  
+        IdentityValue,
 
+        // ObjectToPointer is not directly a part of the language
+        // It is used by lowering of "fixed" statements to represent conversion of an object reference (O) to an unmanaged pointer (*)
+        // The conversion is unsafe and makes sense only if (O) is pinned.
         ObjectToPointer,
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -257,15 +257,6 @@
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Operand" Type="BoundExpression"/>
-    
-    <!-- 
-      Normal address-of operators can only operate on non-moveable variables. 
-      Fixed statement address-of operators (note: only applies to the top-level
-      expression in the initializer, not nested expressions) can only operate
-      on moveable variables.  This flag indicates which sort of address-of
-      operator we're dealing with.
-      -->
-    <Field Name="IsFixedStatementAddressOf" Type="bool"/>
   </Node>
   <Node Name="BoundPointerIndirectionOperator" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -111,6 +111,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                     _builder.EmitNumericConversion(fromPredefTypeKind, toPredefTypeKind, conversion.Checked);
                     break;
+                case ConversionKind.ObjectToPointer:
+                    // same representation, but stop GC tracking
+                    _builder.EmitOpCode(ILOpCode.Conv_u);
+                    break;
                 case ConversionKind.NullToPointer:
                     throw ExceptionUtilities.UnexpectedValue(conversion.ConversionKind); // Should be handled by caller.
                 case ConversionKind.ImplicitNullable:

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -112,7 +112,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     _builder.EmitNumericConversion(fromPredefTypeKind, toPredefTypeKind, conversion.Checked);
                     break;
                 case ConversionKind.PinnedObjectToPointer:
-                    // same representation, but stop GC tracking
+                    // CLR allows unsafe conversion from(O) to native int/uint.
+                    // The conversion does not change the representation of the value, 
+                    // but the value will not be reported to subsequent GC operations (and therefore will not be updated by such operations)
                     _builder.EmitOpCode(ILOpCode.Conv_u);
                     break;
                 case ConversionKind.NullToPointer:

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                     _builder.EmitNumericConversion(fromPredefTypeKind, toPredefTypeKind, conversion.Checked);
                     break;
-                case ConversionKind.ObjectToPointer:
+                case ConversionKind.PinnedObjectToPointer:
                     // same representation, but stop GC tracking
                     _builder.EmitOpCode(ILOpCode.Conv_u);
                     break;

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -590,7 +590,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             var temp = EmitAddress(expression.Operand, AddressKind.Writeable);
             Debug.Assert(temp == null, "If the operand is addressable, then a temp shouldn't be required.");
-            if (used && !expression.IsFixedStatementAddressOf)
+            if (used)
             {
                 // When computing an address to be used to initialize a fixed-statement variable, we have to be careful
                 // not to convert the managed reference to an unmanaged pointer before storing it.  Otherwise the GC might

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -1610,7 +1610,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         public override BoundNode VisitAddressOfOperator(BoundAddressOfOperator node)
         {
             BoundExpression visitedOperand = this.VisitExpression(node.Operand, ExprContext.Address);
-            return node.Update(visitedOperand, node.IsFixedStatementAddressOf, node.Type);
+            return node.Update(visitedOperand, node.Type);
         }
 
         public override BoundNode VisitReturnStatement(BoundReturnStatement node)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1922,7 +1922,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                if (highestBoundExpr?.Kind == BoundKind.Lambda) // the enclosing conversion is explicit
+                // we match highestBoundExpr.Kind to various kind frequently, so cache it here.
+                // use NoOp kind for the case when highestBoundExpr == null - NoOp will not match anything below.
+                var highestBoundExprKind = highestBoundExpr?.Kind ?? BoundKind.NoOpStatement;
+
+                if (highestBoundExprKind == BoundKind.Lambda) // the enclosing conversion is explicit
                 {
                     var lambda = (BoundLambda)highestBoundExpr;
                     convertedType = lambda.Type;
@@ -1948,7 +1952,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     convertedType = tupleLiteralConversion.Type;
                     conversion = tupleLiteralConversion.Conversion;
                 }
-                else if (highestBoundExpr?.Kind == BoundKind.FixedLocalCollectionInitializer)
+                else if (highestBoundExprKind == BoundKind.FixedLocalCollectionInitializer)
                 {
                     var initializer = (BoundFixedLocalCollectionInitializer)highestBoundExpr;
                     convertedType = initializer.Type;
@@ -1960,7 +1964,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (highestBoundExpr != null && highestBoundExpr != boundExpr && highestBoundExpr.HasExpressionType())
                 {
                     convertedType = highestBoundExpr.Type;
-                    if (highestBoundExpr.Kind != BoundKind.Conversion)
+                    if (highestBoundExprKind != BoundKind.Conversion)
                     {
                         conversion = Conversion.Identity;
                     }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1948,7 +1948,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     convertedType = tupleLiteralConversion.Type;
                     conversion = tupleLiteralConversion.Conversion;
                 }
-                else if(highestBoundExpr?.Kind == BoundKind.FixedLocalCollectionInitializer)
+                else if (highestBoundExpr?.Kind == BoundKind.FixedLocalCollectionInitializer)
                 {
                     var initializer = (BoundFixedLocalCollectionInitializer)highestBoundExpr;
                     convertedType = initializer.Type;
@@ -4096,7 +4096,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // argument could be an argument of a tuple expression
             // var x = (Identifier: 1, AnotherIdentifier: 2);
-            var parent3 = identifierNameSyntax.Parent.Parent.Parent;        
+            var parent3 = identifierNameSyntax.Parent.Parent.Parent;
             if (parent3.IsKind(SyntaxKind.TupleExpression))
             {
                 var tupleArgument = (ArgumentSyntax)identifierNameSyntax.Parent.Parent;

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -1948,6 +1948,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     convertedType = tupleLiteralConversion.Type;
                     conversion = tupleLiteralConversion.Conversion;
                 }
+                else if(highestBoundExpr?.Kind == BoundKind.FixedLocalCollectionInitializer)
+                {
+                    var initializer = (BoundFixedLocalCollectionInitializer)highestBoundExpr;
+                    convertedType = initializer.Type;
+                    type = initializer.Expression.Type;
+
+                    // the most pertinent conversion is the pointer conversion 
+                    conversion = initializer.ElementPointerTypeConversion;
+                }
                 else if (highestBoundExpr != null && highestBoundExpr != boundExpr && highestBoundExpr.HasExpressionType())
                 {
                     convertedType = highestBoundExpr.Type;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1880,39 +1880,49 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public override BoundNode VisitAddressOfOperator(BoundAddressOfOperator node)
+        public override BoundNode VisitFixedLocalCollectionInitializer(BoundFixedLocalCollectionInitializer node)
         {
-            BoundExpression operand = node.Operand;
-            bool shouldReadOperand = false;
+            var initializer = node.Expression;
+
+            if (initializer.Kind == BoundKind.AddressOfOperator)
+            {
+                initializer = ((BoundAddressOfOperator)initializer).Operand;
+            }
 
             // If the node is a fixed statement address-of operator (e.g. fixed(int *p = &...)),
             // then we don't need to consider it for membership in unsafeAddressTakenVariables,
             // because it is either not a local/parameter/range variable (if the variable is
             // non-moveable) or it is and it has a RefKind other than None, in which case it can't
             // be referred to in a lambda (i.e. can't be captured).
-            if (!node.IsFixedStatementAddressOf)
-            {
-                Symbol variable = UseNonFieldSymbolUnsafely(operand);
-                if ((object)variable != null)
-                {
-                    // The goal here is to treat address-of as a read in cases where
-                    // we (a) care about a read happening (e.g. for DataFlowsIn) and
-                    // (b) have information indicating that this will not result in
-                    // a read to an unassigned variable (i.e. the operand is definitely
-                    // assigned).
-                    if (_unassignedVariableAddressOfSyntaxes?.Contains(node.Syntax as PrefixUnaryExpressionSyntax) == false)
-                    {
-                        shouldReadOperand = true;
-                    }
+            VisitAddressOfOperand(initializer, shouldReadOperand: false);
+            return null;
+        }
 
-                    if (!_unsafeAddressTakenVariables.ContainsKey(variable))
-                    {
-                        _unsafeAddressTakenVariables.Add(variable, node.Syntax.Location);
-                    }
+        public override BoundNode VisitAddressOfOperator(BoundAddressOfOperator node)
+        {
+            BoundExpression operand = node.Operand;
+            bool shouldReadOperand = false;
+
+            Symbol variable = UseNonFieldSymbolUnsafely(operand);
+            if ((object)variable != null)
+            {
+                // The goal here is to treat address-of as a read in cases where
+                // we (a) care about a read happening (e.g. for DataFlowsIn) and
+                // (b) have information indicating that this will not result in
+                // a read to an unassigned variable (i.e. the operand is definitely
+                // assigned).
+                if (_unassignedVariableAddressOfSyntaxes?.Contains(node.Syntax as PrefixUnaryExpressionSyntax) == false)
+                {
+                    shouldReadOperand = true;
+                }
+
+                if (!_unsafeAddressTakenVariables.ContainsKey(variable))
+                {
+                    _unsafeAddressTakenVariables.Add(variable, node.Syntax.Location);
                 }
             }
 
-            VisitAddressOfOperator(node, shouldReadOperand);
+            VisitAddressOfOperand(node.Operand, shouldReadOperand);
 
             return null;
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2515,7 +2515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitAddressOfOperator(BoundAddressOfOperator node)
         {
-            VisitAddressOfOperator(node, shouldReadOperand: false);
+            VisitAddressOfOperand(node.Operand, shouldReadOperand: false);
             return null;
         }
 
@@ -2523,10 +2523,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// If the operand is definitely assigned, we may want to perform a read (in addition to
         /// a write) so that the operand can show up as ReadInside/DataFlowsIn.
         /// </summary>
-        protected void VisitAddressOfOperator(BoundAddressOfOperator node, bool shouldReadOperand)
+        protected void VisitAddressOfOperand(BoundExpression operand, bool shouldReadOperand)
         {
-            BoundExpression operand = node.Operand;
-
             if (shouldReadOperand)
             {
                 this.VisitRvalue(operand);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -765,7 +765,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundAddressOfOperator : BoundExpression
     {
-        public BoundAddressOfOperator(SyntaxNode syntax, BoundExpression operand, bool isFixedStatementAddressOf, TypeSymbol type, bool hasErrors = false)
+        public BoundAddressOfOperator(SyntaxNode syntax, BoundExpression operand, TypeSymbol type, bool hasErrors = false)
             : base(BoundKind.AddressOfOperator, syntax, type, hasErrors || operand.HasErrors())
         {
 
@@ -773,24 +773,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
             this.Operand = operand;
-            this.IsFixedStatementAddressOf = isFixedStatementAddressOf;
         }
 
 
         public BoundExpression Operand { get; }
-
-        public bool IsFixedStatementAddressOf { get; }
 
         public override BoundNode Accept(BoundTreeVisitor visitor)
         {
             return visitor.VisitAddressOfOperator(this);
         }
 
-        public BoundAddressOfOperator Update(BoundExpression operand, bool isFixedStatementAddressOf, TypeSymbol type)
+        public BoundAddressOfOperator Update(BoundExpression operand, TypeSymbol type)
         {
-            if (operand != this.Operand || isFixedStatementAddressOf != this.IsFixedStatementAddressOf || type != this.Type)
+            if (operand != this.Operand || type != this.Type)
             {
-                var result = new BoundAddressOfOperator(this.Syntax, operand, isFixedStatementAddressOf, type, this.HasErrors);
+                var result = new BoundAddressOfOperator(this.Syntax, operand, type, this.HasErrors);
                 result.WasCompilerGenerated = this.WasCompilerGenerated;
                 return result;
             }
@@ -8443,7 +8440,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression operand = (BoundExpression)this.Visit(node.Operand);
             TypeSymbol type = this.VisitType(node.Type);
-            return node.Update(operand, node.IsFixedStatementAddressOf, type);
+            return node.Update(operand, type);
         }
         public override BoundNode VisitPointerIndirectionOperator(BoundPointerIndirectionOperator node)
         {
@@ -9390,7 +9387,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new TreeDumperNode("addressOfOperator", null, new TreeDumperNode[]
             {
                 new TreeDumperNode("operand", null, new TreeDumperNode[] { Visit(node.Operand, null) }),
-                new TreeDumperNode("isFixedStatementAddressOf", node.IsFixedStatementAddressOf, null),
                 new TreeDumperNode("type", node.Type, null)
             }
             );

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -591,7 +591,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundSpillSequenceBuilder builder = null;
             var expr = VisitExpression(ref builder, node.Operand);
-            return UpdateExpression(builder, node.Update(expr, node.IsFixedStatementAddressOf, node.Type));
+            return UpdateExpression(builder, node.Update(expr, node.Type));
         }
 
         public override BoundNode VisitArgListOperator(BoundArgListOperator node)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
@@ -35,9 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (fieldSymbol.IsFixed)
             {
                 // a reference to a fixed buffer is translated into its address
-                result = new BoundConversion(syntax,
-                    new BoundAddressOfOperator(syntax, result, syntax != null && SyntaxFacts.IsFixedStatementExpression(syntax), type, false),
-                    Conversion.PointerToPointer, false, false, default(ConstantValue), type, false);
+                result = new BoundAddressOfOperator(syntax, result, type, false);
             }
 
             return result;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var addr = factory.Convert(
                  fixedInitializer.ElementPointerType,
                  factory.Local(pinnedTemp),
-                 Conversion.ObjectToPointer);
+                 Conversion.PinnedObjectToPointer);
 
             var convertedStringTemp = factory.Convert(
                 localType,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -28,17 +28,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0; i < numFixedLocals; i++)
             {
                 BoundLocalDeclaration localDecl = localDecls[i];
-                LocalSymbol temp;
-                LocalSymbol localToClear;
-                statementBuilder.Add(InitializeFixedStatementLocal(localDecl, _factory, out temp, out localToClear));
-
-                if (!ReferenceEquals(temp, null))
-                {
-                    localBuilder.Add(temp);
-                }
+                LocalSymbol pinnedTemp;
+                statementBuilder.Add(InitializeFixedStatementLocal(localDecl, _factory, out pinnedTemp));
+                localBuilder.Add(pinnedTemp);
 
                 // NOTE: Dev10 nulls out the locals in declaration order (as opposed to "popping" them in reverse order).
-                cleanup[i] = _factory.Assignment(_factory.Local(localToClear), _factory.Null(localToClear.Type));
+                if (pinnedTemp.RefKind == RefKind.None)
+                {
+                    // temp = null;
+                    cleanup[i] = _factory.Assignment(_factory.Local(pinnedTemp), _factory.Null(pinnedTemp.Type));
+                }
+                else
+                {
+                    Debug.Assert(!pinnedTemp.Type.IsManagedType);
+
+                    // temp = ref *default(T*);
+                    cleanup[i] = _factory.Assignment(_factory.Local(pinnedTemp), new BoundPointerIndirectionOperator(
+                        _factory.Syntax,
+                        _factory.Default(new PointerTypeSymbol(pinnedTemp.Type)),
+                        pinnedTemp.Type),
+                        refKind: RefKind.Ref);
+                }
             }
 
             BoundStatement rewrittenBody = VisitStatement(node.Body);
@@ -187,45 +197,104 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundStatement InitializeFixedStatementLocal(
             BoundLocalDeclaration localDecl,
             SyntheticBoundNodeFactory factory,
-            out LocalSymbol temp,
-            out LocalSymbol localToClear)
+            out LocalSymbol pinnedTemp)
         {
             BoundExpression initializer = localDecl.InitializerOpt;
             Debug.Assert(!ReferenceEquals(initializer, null));
 
             LocalSymbol localSymbol = localDecl.LocalSymbol;
+            var fixedCollectionInitializer = (BoundFixedLocalCollectionInitializer)initializer;
 
-            if (initializer.Kind == BoundKind.FixedLocalCollectionInitializer)
+            if (fixedCollectionInitializer.Expression.Type.SpecialType == SpecialType.System_String)
             {
-                var fixedInitializer = (BoundFixedLocalCollectionInitializer)initializer;
-
-                if (fixedInitializer.Expression.Type.SpecialType == SpecialType.System_String)
-                {
-                    return InitializeFixedStatementStringLocal(localDecl, localSymbol, fixedInitializer, factory, out temp, out localToClear);
-                }
-                else
-                {
-                    Debug.Assert(fixedInitializer.Expression.Type.IsArray());
-
-                    localToClear = localSymbol;
-                    return InitializeFixedStatementArrayLocal(localDecl, localSymbol, fixedInitializer, factory, out temp);
-                }
+                return InitializeFixedStatementStringLocal(localDecl, localSymbol, fixedCollectionInitializer, factory, out pinnedTemp);
+            }
+            else if (fixedCollectionInitializer.Expression.Type.IsArray())
+            {
+                return InitializeFixedStatementArrayLocal(localDecl, localSymbol, fixedCollectionInitializer, factory, out pinnedTemp);
             }
             else
             {
-                temp = null;
-                localToClear = localSymbol;
-                return RewriteLocalDeclaration(localDecl, localDecl.Syntax, localSymbol, VisitExpression(initializer));
-            }
+                return InitializeFixedStatementRegularLocal(localDecl, localSymbol, fixedCollectionInitializer, factory, out pinnedTemp);
+            } 
         }
 
+
+        // fixed(int* ptr = &v){ ... }    == becomes ===>
+        // 
+        // pinned ref int pinnedTemp = ref v;    // pinning managed ref
+        // int* ptr = (int*)&pinnedTemp;         // unsafe cast to unmanaged ptr
+        //   . . . 
+        private BoundStatement InitializeFixedStatementRegularLocal(
+            BoundLocalDeclaration localDecl,
+            LocalSymbol localSymbol,
+            BoundFixedLocalCollectionInitializer fixedInitializer,
+            SyntheticBoundNodeFactory factory,
+            out LocalSymbol pinnedTemp)
+        {
+            TypeSymbol localType = localSymbol.Type;
+            BoundExpression initializerExpr = VisitExpression(fixedInitializer.Expression);
+
+            // initializer expr should be either an address(&) of something or a fixed field access.
+            // either should lower into addressof
+            Debug.Assert(initializerExpr.Kind == BoundKind.AddressOfOperator);
+
+            // initializer expressions are bound/lowered right into addressof operators here
+            // that is a bit too far
+            // we need to pin the underlying field, and only then take the address.
+            initializerExpr = ((BoundAddressOfOperator)initializerExpr).Operand;
+ 
+            TypeSymbol initializerType = initializerExpr.Type;
+
+            // intervening parens may have been skipped by the binder; find the declarator
+            VariableDeclaratorSyntax declarator = fixedInitializer.Syntax.FirstAncestorOrSelf<VariableDeclaratorSyntax>();
+            Debug.Assert(declarator != null);
+
+            pinnedTemp = factory.SynthesizedLocal(
+                initializerType, 
+                syntax: declarator, 
+                isPinned: true, 
+                refKind: RefKind.Ref,  // different from the array and string cases
+                kind: SynthesizedLocalKind.FixedReference);
+
+            // NOTE: we pin the reference, not the pointer.
+            Debug.Assert(pinnedTemp.IsPinned);
+            Debug.Assert(!localSymbol.IsPinned);
+
+            // pinnedTemp = ref v;
+            BoundStatement pinnedTempInit = factory.Assignment(factory.Local(pinnedTemp), initializerExpr, refKind: RefKind.Ref);
+
+            // &pinnedTemp;
+            var addr = new BoundAddressOfOperator(
+                factory.Syntax,
+                 factory.Local(pinnedTemp),
+                 type: fixedInitializer.ElementPointerType);
+
+            // (int*)&pinnedTemp
+            var pointerValue = factory.Convert(
+                localType,
+                addr,
+                fixedInitializer.ElementPointerTypeConversion);
+
+            // ptr = (int*)&pinnedTemp;
+            BoundStatement localInit = InstrumentLocalDeclarationIfNecessary(localDecl, localSymbol,
+                factory.Assignment(factory.Local(localSymbol), pointerValue));
+
+            return factory.Block(pinnedTempInit, localInit);
+        }
+
+        // fixed(char* ptr = stringVar){ ... }    == becomes ===>
+        // 
+        // pinned string pinnedTemp = stringVar;    // pinning managed ref
+        // char* ptr = (char*)pinnedTemp;           // unsafe cast to unmanaged ptr
+        // if (pinnedTemp != null) ptr += OffsetToStringData();
+        //   . . . 
         private BoundStatement InitializeFixedStatementStringLocal(
             BoundLocalDeclaration localDecl,
             LocalSymbol localSymbol,
             BoundFixedLocalCollectionInitializer fixedInitializer,
             SyntheticBoundNodeFactory factory,
-            out LocalSymbol stringTemp,
-            out LocalSymbol localToClear)
+            out LocalSymbol pinnedTemp)
         {
             TypeSymbol localType = localSymbol.Type;
             BoundExpression initializerExpr = VisitExpression(fixedInitializer.Expression);
@@ -235,17 +304,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             VariableDeclaratorSyntax declarator = fixedInitializer.Syntax.FirstAncestorOrSelf<VariableDeclaratorSyntax>();
             Debug.Assert(declarator != null);
 
-            stringTemp = factory.SynthesizedLocal(initializerType, syntax: declarator, isPinned: true, kind: SynthesizedLocalKind.FixedString);
+            pinnedTemp = factory.SynthesizedLocal(
+                initializerType, 
+                syntax: declarator, 
+                isPinned: true, 
+                kind: SynthesizedLocalKind.FixedReference);
 
             // NOTE: we pin the string, not the pointer.
-            Debug.Assert(stringTemp.IsPinned);
+            Debug.Assert(pinnedTemp.IsPinned);
             Debug.Assert(!localSymbol.IsPinned);
 
-            BoundStatement stringTempInit = factory.Assignment(factory.Local(stringTemp), initializerExpr);
+            BoundStatement stringTempInit = factory.Assignment(factory.Local(pinnedTemp), initializerExpr);
+
+            // (char*)pinnedTemp;
+            var addr = factory.Convert(
+                 fixedInitializer.ElementPointerType,
+                 factory.Local(pinnedTemp),
+                 Conversion.ObjectToPointer);
 
             var convertedStringTemp = factory.Convert(
                 localType,
-                factory.Local(stringTemp),
+                addr,
                 fixedInitializer.ElementPointerTypeConversion);
 
             BoundStatement localInit = InstrumentLocalDeclarationIfNecessary(localDecl, localSymbol,
@@ -267,59 +346,57 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression addition = factory.Binary(BinaryOperatorKind.PointerAndIntAddition, localType, factory.Local(localSymbol), helperCall);
             BoundStatement conditionalAdd = factory.If(notNullCheck, factory.Assignment(factory.Local(localSymbol), addition));
 
-            localToClear = stringTemp;
             return factory.Block(stringTempInit, localInit, conditionalAdd);
         }
 
+        // fixed(int* ptr = arr){ ... }    == becomes ===>
+        // 
+        // pinned int[] pinnedTemp = arr;         // pinning managed ref
+        // int* ptr = pinnedTemp != null && pinnedTemp.Length != 0
+        //                (int*)&pinnedTemp[0]:   // unsafe cast to unmanaged ptr
+        //                0;
+        //   . . . 
         private BoundStatement InitializeFixedStatementArrayLocal(
             BoundLocalDeclaration localDecl,
             LocalSymbol localSymbol,
             BoundFixedLocalCollectionInitializer fixedInitializer,
             SyntheticBoundNodeFactory factory,
-            out LocalSymbol arrayTemp)
+            out LocalSymbol pinnedTemp)
         {
-            // From ExpressionBinder::BindPtrToArray:
-            // (((temp = array) != null && temp.Length > 0) ? loc = &temp[0] : loc = null)
-            // NOTE: The assignment needs to be inside the EK_QUESTIONMARK. See Whidbey bug #397859.
-            // We can't do loc = (... ? ... : ...) since the CLR type of &temp[0] is a managed
-            // pointer and null is a UIntPtr - which confuses the JIT. We can't just convert
-            // &temp[0] to UIntPtr with a conv.u instruction because then if a GC occurs between
-            // the time of the cast and the assignment to the local, we're toast.
-
             TypeSymbol localType = localSymbol.Type;
             BoundExpression initializerExpr = VisitExpression(fixedInitializer.Expression);
             TypeSymbol initializerType = initializerExpr.Type;
 
-            arrayTemp = factory.SynthesizedLocal(initializerType);
-            ArrayTypeSymbol arrayType = (ArrayTypeSymbol)arrayTemp.Type;
+            pinnedTemp = factory.SynthesizedLocal(initializerType, isPinned: true);
+            ArrayTypeSymbol arrayType = (ArrayTypeSymbol)pinnedTemp.Type;
             TypeSymbol arrayElementType = arrayType.ElementType;
 
-            // NOTE: we pin the pointer, not the array.
-            Debug.Assert(!arrayTemp.IsPinned);
-            Debug.Assert(localSymbol.IsPinned);
+            // NOTE: we pin the array, not the pointer.
+            Debug.Assert(pinnedTemp.IsPinned);
+            Debug.Assert(!localSymbol.IsPinned);
 
-            //(temp = array)
-            BoundExpression arrayTempInit = factory.AssignmentExpression(factory.Local(arrayTemp), initializerExpr);
+            //(pinnedTemp = array)
+            BoundExpression arrayTempInit = factory.AssignmentExpression(factory.Local(pinnedTemp), initializerExpr);
 
-            //(temp = array) != null
+            //(pinnedTemp = array) != null
             BoundExpression notNullCheck = MakeNullCheck(factory.Syntax, arrayTempInit, BinaryOperatorKind.NotEqual);
 
             BoundExpression lengthCall;
 
             if (arrayType.IsSZArray)
             {
-                lengthCall = factory.ArrayLength(factory.Local(arrayTemp));
+                lengthCall = factory.ArrayLength(factory.Local(pinnedTemp));
             }
             else
             {
                 MethodSymbol lengthMethod;
                 if (TryGetWellKnownTypeMember(fixedInitializer.Syntax, WellKnownMember.System_Array__get_Length, out lengthMethod))
                 {
-                    lengthCall = factory.Call(factory.Local(arrayTemp), lengthMethod);
+                    lengthCall = factory.Call(factory.Local(pinnedTemp), lengthMethod);
                 }
                 else
                 {
-                    lengthCall = new BoundBadExpression(fixedInitializer.Syntax, LookupResultKind.NotInvocable, ImmutableArray<Symbol>.Empty, ImmutableArray.Create<BoundExpression>(factory.Local(arrayTemp)), ErrorTypeSymbol.UnknownResultType);
+                    lengthCall = new BoundBadExpression(fixedInitializer.Syntax, LookupResultKind.NotInvocable, ImmutableArray<Symbol>.Empty, ImmutableArray.Create<BoundExpression>(factory.Local(pinnedTemp)), ErrorTypeSymbol.UnknownResultType);
                 }
             }
 
@@ -331,11 +408,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression condition = factory.Binary(BinaryOperatorKind.LogicalBoolAnd, factory.SpecialType(SpecialType.System_Boolean), notNullCheck, lengthCheck);
 
             //temp[0]
-            BoundExpression firstElement = factory.ArrayAccessFirstElement(factory.Local(arrayTemp));
+            BoundExpression firstElement = factory.ArrayAccessFirstElement(factory.Local(pinnedTemp));
 
-            // NOTE: this is a fixed statement address-of in that it's the initial value of pinned local.
+            // NOTE: this is a fixed statement address-of in that it's the initial value of the pointer.
             //&temp[0]
-            BoundExpression firstElementAddress = new BoundAddressOfOperator(factory.Syntax, firstElement, isFixedStatementAddressOf: true, type: new PointerTypeSymbol(arrayElementType));
+            BoundExpression firstElementAddress = new BoundAddressOfOperator(factory.Syntax, firstElement, type: new PointerTypeSymbol(arrayElementType));
             BoundExpression convertedFirstElementAddress = factory.Convert(
                 localType,
                 firstElementAddress,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -220,10 +220,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// fixed(int* ptr = &v){ ... }    == becomes ===>
+        /// fixed(int* ptr = &amp;v){ ... }    == becomes ===>
         /// 
         /// pinned ref int pinnedTemp = ref v;    // pinning managed ref
-        /// int* ptr = (int*)&pinnedTemp;         // unsafe cast to unmanaged ptr
+        /// int* ptr = (int*)&amp;pinnedTemp;         // unsafe cast to unmanaged ptr
         ///   . . . 
         /// </summary>
         private BoundStatement InitializeFixedStatementRegularLocal(
@@ -356,8 +356,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// fixed(int* ptr = arr){ ... }    == becomes ===>
         /// 
         /// pinned int[] pinnedTemp = arr;         // pinning managed ref
-        /// int* ptr = pinnedTemp != null && pinnedTemp.Length != 0
-        ///                (int*)&pinnedTemp[0]:   // unsafe cast to unmanaged ptr
+        /// int* ptr = pinnedTemp != null &amp;&amp; pinnedTemp.Length != 0
+        ///                (int*)&amp;pinnedTemp[0]:   // unsafe cast to unmanaged ptr
         ///                0;
         ///   . . . 
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -219,12 +219,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             } 
         }
 
-
-        // fixed(int* ptr = &v){ ... }    == becomes ===>
-        // 
-        // pinned ref int pinnedTemp = ref v;    // pinning managed ref
-        // int* ptr = (int*)&pinnedTemp;         // unsafe cast to unmanaged ptr
-        //   . . . 
+        /// <summary>
+        /// fixed(int* ptr = &v){ ... }    == becomes ===>
+        /// 
+        /// pinned ref int pinnedTemp = ref v;    // pinning managed ref
+        /// int* ptr = (int*)&pinnedTemp;         // unsafe cast to unmanaged ptr
+        ///   . . . 
+        /// </summary>
         private BoundStatement InitializeFixedStatementRegularLocal(
             BoundLocalDeclaration localDecl,
             LocalSymbol localSymbol,
@@ -283,12 +284,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return factory.Block(pinnedTempInit, localInit);
         }
 
-        // fixed(char* ptr = stringVar){ ... }    == becomes ===>
-        // 
-        // pinned string pinnedTemp = stringVar;    // pinning managed ref
-        // char* ptr = (char*)pinnedTemp;           // unsafe cast to unmanaged ptr
-        // if (pinnedTemp != null) ptr += OffsetToStringData();
-        //   . . . 
+        /// <summary>
+        /// fixed(char* ptr = stringVar){ ... }    == becomes ===>
+        /// 
+        /// pinned string pinnedTemp = stringVar;    // pinning managed ref
+        /// char* ptr = (char*)pinnedTemp;           // unsafe cast to unmanaged ptr
+        /// if (pinnedTemp != null) ptr += OffsetToStringData();
+        ///   . . . 
+        /// </summary>
         private BoundStatement InitializeFixedStatementStringLocal(
             BoundLocalDeclaration localDecl,
             LocalSymbol localSymbol,
@@ -349,13 +352,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return factory.Block(stringTempInit, localInit, conditionalAdd);
         }
 
-        // fixed(int* ptr = arr){ ... }    == becomes ===>
-        // 
-        // pinned int[] pinnedTemp = arr;         // pinning managed ref
-        // int* ptr = pinnedTemp != null && pinnedTemp.Length != 0
-        //                (int*)&pinnedTemp[0]:   // unsafe cast to unmanaged ptr
-        //                0;
-        //   . . . 
+        /// <summary>
+        /// fixed(int* ptr = arr){ ... }    == becomes ===>
+        /// 
+        /// pinned int[] pinnedTemp = arr;         // pinning managed ref
+        /// int* ptr = pinnedTemp != null && pinnedTemp.Length != 0
+        ///                (int*)&pinnedTemp[0]:   // unsafe cast to unmanaged ptr
+        ///                0;
+        ///   . . . 
+        /// </summary>
         private BoundStatement InitializeFixedStatementArrayLocal(
             BoundLocalDeclaration localDecl,
             LocalSymbol localSymbol,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -1294,12 +1294,12 @@ class C
             verifier.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
 @"
 {
-  // Code size      199 (0xc7)
+  // Code size      198 (0xc6)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
-                pinned byte& V_2, //p
-                byte[] V_3,
+                byte* V_2, //p
+                pinned byte[] V_3,
                 System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_4,
                 System.Runtime.CompilerServices.YieldAwaitable V_5,
                 System.Exception V_6)
@@ -1309,7 +1309,7 @@ class C
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_006c
+    IL_0008:  brfalse.s  IL_006b
     IL_000a:  ldarg.0
     IL_000b:  ldfld      ""byte[] C.<F>d__0.b""
     IL_0010:  dup
@@ -1322,94 +1322,92 @@ class C
     IL_0019:  ldc.i4.0
     IL_001a:  conv.u
     IL_001b:  stloc.2
-    IL_001c:  br.s       IL_0026
+    IL_001c:  br.s       IL_0027
     IL_001e:  ldloc.3
     IL_001f:  ldc.i4.0
     IL_0020:  ldelema    ""byte""
-    IL_0025:  stloc.2
-    IL_0026:  ldarg.0
-    IL_0027:  ldloc.2
-    IL_0028:  conv.i
+    IL_0025:  conv.u
+    IL_0026:  stloc.2
+    IL_0027:  ldarg.0
+    IL_0028:  ldloc.2
     IL_0029:  ldind.u1
     IL_002a:  stfld      ""int C.<F>d__0.<i>5__1""
-    IL_002f:  ldc.i4.0
-    IL_0030:  conv.u
-    IL_0031:  stloc.2
-    IL_0032:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_0037:  stloc.s    V_5
-    IL_0039:  ldloca.s   V_5
-    IL_003b:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0040:  stloc.s    V_4
-    IL_0042:  ldloca.s   V_4
-    IL_0044:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_0049:  brtrue.s   IL_0089
-    IL_004b:  ldarg.0
-    IL_004c:  ldc.i4.0
-    IL_004d:  dup
-    IL_004e:  stloc.0
-    IL_004f:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0054:  ldarg.0
-    IL_0055:  ldloc.s    V_4
-    IL_0057:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_005c:  ldarg.0
-    IL_005d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_0062:  ldloca.s   V_4
-    IL_0064:  ldarg.0
-    IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__0)""
-    IL_006a:  leave.s    IL_00c6
-    IL_006c:  ldarg.0
-    IL_006d:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_0072:  stloc.s    V_4
-    IL_0074:  ldarg.0
-    IL_0075:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_007a:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_0080:  ldarg.0
-    IL_0081:  ldc.i4.m1
-    IL_0082:  dup
-    IL_0083:  stloc.0
-    IL_0084:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0089:  ldloca.s   V_4
-    IL_008b:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_0090:  ldarg.0
-    IL_0091:  ldfld      ""int C.<F>d__0.<i>5__1""
-    IL_0096:  stloc.1
-    IL_0097:  leave.s    IL_00b2
+    IL_002f:  ldnull
+    IL_0030:  stloc.3
+    IL_0031:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_0036:  stloc.s    V_5
+    IL_0038:  ldloca.s   V_5
+    IL_003a:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_003f:  stloc.s    V_4
+    IL_0041:  ldloca.s   V_4
+    IL_0043:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_0048:  brtrue.s   IL_0088
+    IL_004a:  ldarg.0
+    IL_004b:  ldc.i4.0
+    IL_004c:  dup
+    IL_004d:  stloc.0
+    IL_004e:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0053:  ldarg.0
+    IL_0054:  ldloc.s    V_4
+    IL_0056:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_005b:  ldarg.0
+    IL_005c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_0061:  ldloca.s   V_4
+    IL_0063:  ldarg.0
+    IL_0064:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__0)""
+    IL_0069:  leave.s    IL_00c5
+    IL_006b:  ldarg.0
+    IL_006c:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_0071:  stloc.s    V_4
+    IL_0073:  ldarg.0
+    IL_0074:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_0079:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_007f:  ldarg.0
+    IL_0080:  ldc.i4.m1
+    IL_0081:  dup
+    IL_0082:  stloc.0
+    IL_0083:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_0088:  ldloca.s   V_4
+    IL_008a:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_008f:  ldarg.0
+    IL_0090:  ldfld      ""int C.<F>d__0.<i>5__1""
+    IL_0095:  stloc.1
+    IL_0096:  leave.s    IL_00b1
   }
   catch System.Exception
   {
-    IL_0099:  stloc.s    V_6
-    IL_009b:  ldarg.0
-    IL_009c:  ldc.i4.s   -2
-    IL_009e:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00a3:  ldarg.0
-    IL_00a4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_00a9:  ldloc.s    V_6
-    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00b0:  leave.s    IL_00c6
+    IL_0098:  stloc.s    V_6
+    IL_009a:  ldarg.0
+    IL_009b:  ldc.i4.s   -2
+    IL_009d:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00a2:  ldarg.0
+    IL_00a3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_00a8:  ldloc.s    V_6
+    IL_00aa:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00af:  leave.s    IL_00c5
   }
-  IL_00b2:  ldarg.0
-  IL_00b3:  ldc.i4.s   -2
-  IL_00b5:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00ba:  ldarg.0
-  IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00c0:  ldloc.1
-  IL_00c1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00c6:  ret
+  IL_00b1:  ldarg.0
+  IL_00b2:  ldc.i4.s   -2
+  IL_00b4:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_00b9:  ldarg.0
+  IL_00ba:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00bf:  ldloc.1
+  IL_00c0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00c5:  ret
 }");
             verifier = CompileAndVerify(text, options: TestOptions.UnsafeDebugExe, expectedOutput: @"1");
             verifier.VerifyIL("C.<F>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
 @"
 {
-  // Code size      216 (0xd8)
+  // Code size      227 (0xe3)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
-                pinned byte& V_2, //p
-                byte[] V_3,
-                System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_4,
-                System.Runtime.CompilerServices.YieldAwaitable V_5,
-                C.<F>d__0 V_6,
-                System.Exception V_7)
+                pinned byte[] V_2,
+                System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_3,
+                System.Runtime.CompilerServices.YieldAwaitable V_4,
+                C.<F>d__0 V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<F>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -1418,103 +1416,105 @@ class C
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_000c
     IL_000a:  br.s       IL_000e
-    IL_000c:  br.s       IL_007a
+    IL_000c:  br.s       IL_0086
     IL_000e:  nop
     IL_000f:  nop
     IL_0010:  ldarg.0
     IL_0011:  ldfld      ""byte[] C.<F>d__0.b""
     IL_0016:  dup
-    IL_0017:  stloc.3
+    IL_0017:  stloc.2
     IL_0018:  brfalse.s  IL_001f
-    IL_001a:  ldloc.3
+    IL_001a:  ldloc.2
     IL_001b:  ldlen
     IL_001c:  conv.i4
-    IL_001d:  brtrue.s   IL_0024
-    IL_001f:  ldc.i4.0
-    IL_0020:  conv.u
-    IL_0021:  stloc.2
-    IL_0022:  br.s       IL_002c
-    IL_0024:  ldloc.3
-    IL_0025:  ldc.i4.0
-    IL_0026:  ldelema    ""byte""
-    IL_002b:  stloc.2
-    IL_002c:  nop
-    IL_002d:  ldarg.0
-    IL_002e:  ldloc.2
-    IL_002f:  conv.i
-    IL_0030:  ldind.u1
-    IL_0031:  stfld      ""int C.<F>d__0.<i>5__1""
-    IL_0036:  nop
-    IL_0037:  ldc.i4.0
-    IL_0038:  conv.u
-    IL_0039:  stloc.2
-    IL_003a:  nop
-    IL_003b:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-    IL_0040:  stloc.s    V_5
-    IL_0042:  ldloca.s   V_5
-    IL_0044:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-    IL_0049:  stloc.s    V_4
-    IL_004b:  ldloca.s   V_4
-    IL_004d:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-    IL_0052:  brtrue.s   IL_0097
-    IL_0054:  ldarg.0
-    IL_0055:  ldc.i4.0
-    IL_0056:  dup
-    IL_0057:  stloc.0
-    IL_0058:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_005d:  ldarg.0
-    IL_005e:  ldloc.s    V_4
-    IL_0060:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_0065:  ldarg.0
-    IL_0066:  stloc.s    V_6
-    IL_0068:  ldarg.0
-    IL_0069:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_006e:  ldloca.s   V_4
-    IL_0070:  ldloca.s   V_6
-    IL_0072:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__0)""
-    IL_0077:  nop
-    IL_0078:  leave.s    IL_00d7
-    IL_007a:  ldarg.0
-    IL_007b:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_0080:  stloc.s    V_4
-    IL_0082:  ldarg.0
-    IL_0083:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
-    IL_0088:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-    IL_008e:  ldarg.0
-    IL_008f:  ldc.i4.m1
-    IL_0090:  dup
-    IL_0091:  stloc.0
-    IL_0092:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_0097:  ldloca.s   V_4
-    IL_0099:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_009e:  nop
-    IL_009f:  ldarg.0
-    IL_00a0:  ldfld      ""int C.<F>d__0.<i>5__1""
-    IL_00a5:  stloc.1
-    IL_00a6:  leave.s    IL_00c2
+    IL_001d:  brtrue.s   IL_0029
+    IL_001f:  ldarg.0
+    IL_0020:  ldc.i4.0
+    IL_0021:  conv.u
+    IL_0022:  stfld      ""byte* C.<F>d__0.<p>5__2""
+    IL_0027:  br.s       IL_0037
+    IL_0029:  ldarg.0
+    IL_002a:  ldloc.2
+    IL_002b:  ldc.i4.0
+    IL_002c:  ldelema    ""byte""
+    IL_0031:  conv.u
+    IL_0032:  stfld      ""byte* C.<F>d__0.<p>5__2""
+    IL_0037:  nop
+    IL_0038:  ldarg.0
+    IL_0039:  ldarg.0
+    IL_003a:  ldfld      ""byte* C.<F>d__0.<p>5__2""
+    IL_003f:  ldind.u1
+    IL_0040:  stfld      ""int C.<F>d__0.<i>5__1""
+    IL_0045:  nop
+    IL_0046:  ldnull
+    IL_0047:  stloc.2
+    IL_0048:  nop
+    IL_0049:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_004e:  stloc.s    V_4
+    IL_0050:  ldloca.s   V_4
+    IL_0052:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_0057:  stloc.3
+    IL_0058:  ldloca.s   V_3
+    IL_005a:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_005f:  brtrue.s   IL_00a2
+    IL_0061:  ldarg.0
+    IL_0062:  ldc.i4.0
+    IL_0063:  dup
+    IL_0064:  stloc.0
+    IL_0065:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_006a:  ldarg.0
+    IL_006b:  ldloc.3
+    IL_006c:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_0071:  ldarg.0
+    IL_0072:  stloc.s    V_5
+    IL_0074:  ldarg.0
+    IL_0075:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_007a:  ldloca.s   V_3
+    IL_007c:  ldloca.s   V_5
+    IL_007e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__0>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__0)""
+    IL_0083:  nop
+    IL_0084:  leave.s    IL_00e2
+    IL_0086:  ldarg.0
+    IL_0087:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_008c:  stloc.3
+    IL_008d:  ldarg.0
+    IL_008e:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__0.<>u__1""
+    IL_0093:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0099:  ldarg.0
+    IL_009a:  ldc.i4.m1
+    IL_009b:  dup
+    IL_009c:  stloc.0
+    IL_009d:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00a2:  ldloca.s   V_3
+    IL_00a4:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_00a9:  nop
+    IL_00aa:  ldarg.0
+    IL_00ab:  ldfld      ""int C.<F>d__0.<i>5__1""
+    IL_00b0:  stloc.1
+    IL_00b1:  leave.s    IL_00cd
   }
   catch System.Exception
   {
-    IL_00a8:  stloc.s    V_7
-    IL_00aa:  ldarg.0
-    IL_00ab:  ldc.i4.s   -2
-    IL_00ad:  stfld      ""int C.<F>d__0.<>1__state""
-    IL_00b2:  ldarg.0
-    IL_00b3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-    IL_00b8:  ldloc.s    V_7
-    IL_00ba:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
-    IL_00bf:  nop
-    IL_00c0:  leave.s    IL_00d7
+    IL_00b3:  stloc.s    V_6
+    IL_00b5:  ldarg.0
+    IL_00b6:  ldc.i4.s   -2
+    IL_00b8:  stfld      ""int C.<F>d__0.<>1__state""
+    IL_00bd:  ldarg.0
+    IL_00be:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+    IL_00c3:  ldloc.s    V_6
+    IL_00c5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00ca:  nop
+    IL_00cb:  leave.s    IL_00e2
   }
-  IL_00c2:  ldarg.0
-  IL_00c3:  ldc.i4.s   -2
-  IL_00c5:  stfld      ""int C.<F>d__0.<>1__state""
-  IL_00ca:  ldarg.0
-  IL_00cb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
-  IL_00d0:  ldloc.1
-  IL_00d1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
-  IL_00d6:  nop
-  IL_00d7:  ret
+  IL_00cd:  ldarg.0
+  IL_00ce:  ldc.i4.s   -2
+  IL_00d0:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_00d5:  ldarg.0
+  IL_00d6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__0.<>t__builder""
+  IL_00db:  ldloc.1
+  IL_00dc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00e1:  nop
+  IL_00e2:  ret
 }");
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -1471,11 +1471,12 @@ class Program
 
             CompileAndVerify(text, options: TestOptions.UnsafeDebugDll).VerifyIL("Program.Main()", @"
 {
-  // Code size       51 (0x33)
+  // Code size       54 (0x36)
   .maxstack  3
   .locals init (int& V_0, //rl
                 System.TypedReference V_1, //tr
-                pinned int& V_2) //i
+                int* V_2, //i
+                pinned int& V_3)
   IL_0000:  nop
   IL_0001:  ldsflda    ""int Program.field""
   IL_0006:  stloc.0
@@ -1501,16 +1502,19 @@ class Program
   IL_001e:  call       ""void Program.N(out int)""
   IL_0023:  nop
   IL_0024:  ldloc.0
-  IL_0025:  stloc.2
-  IL_0026:  nop
-  IL_0027:  nop
-  IL_0028:  ldc.i4.0
-  IL_0029:  conv.u
-  IL_002a:  stloc.2
-  IL_002b:  ldloc.0
-  IL_002c:  mkrefany   ""int""
-  IL_0031:  stloc.1
-  IL_0032:  ret
+  IL_0025:  stloc.3
+  IL_0026:  ldloc.3
+  IL_0027:  conv.u
+  IL_0028:  stloc.2
+  IL_0029:  nop
+  IL_002a:  nop
+  IL_002b:  ldc.i4.0
+  IL_002c:  conv.u
+  IL_002d:  stloc.3
+  IL_002e:  ldloc.0
+  IL_002f:  mkrefany   ""int""
+  IL_0034:  stloc.1
+  IL_0035:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -1263,11 +1263,9 @@ class Program
 
             CompileAndVerifyRef(text, options: TestOptions.UnsafeReleaseDll).VerifyIL("Program.Main()", @"
 {
-  // Code size      285 (0x11d)
+  // Code size      291 (0x123)
   .maxstack  4
-  .locals init (pinned int& V_0, //i
-                pinned int& V_1, //i
-                pinned int& V_2) //i
+  .locals init (pinned int& V_0)
   IL_0000:  newobj     ""Program..ctor()""
   IL_0005:  dup
   IL_0006:  callvirt   ""ref int Program.P.get""
@@ -1299,108 +1297,114 @@ class Program
   IL_003c:  dup
   IL_003d:  callvirt   ""ref int Program.P.get""
   IL_0042:  stloc.0
-  IL_0043:  ldc.i4.0
-  IL_0044:  conv.u
-  IL_0045:  stloc.0
-  IL_0046:  dup
-  IL_0047:  callvirt   ""ref int Program.P.get""
-  IL_004c:  mkrefany   ""int""
-  IL_0051:  pop
-  IL_0052:  dup
-  IL_0053:  ldc.i4.0
-  IL_0054:  callvirt   ""ref int Program.this[int].get""
-  IL_0059:  ldc.i4.0
-  IL_005a:  stind.i4
-  IL_005b:  dup
-  IL_005c:  ldc.i4.0
-  IL_005d:  callvirt   ""ref int Program.this[int].get""
-  IL_0062:  dup
-  IL_0063:  ldind.i4
-  IL_0064:  ldc.i4.1
-  IL_0065:  add
-  IL_0066:  stind.i4
-  IL_0067:  dup
-  IL_0068:  ldc.i4.0
-  IL_0069:  callvirt   ""ref int Program.this[int].get""
-  IL_006e:  dup
-  IL_006f:  ldind.i4
-  IL_0070:  ldc.i4.1
-  IL_0071:  add
-  IL_0072:  stind.i4
-  IL_0073:  dup
-  IL_0074:  dup
-  IL_0075:  ldc.i4.0
-  IL_0076:  callvirt   ""ref int Program.this[int].get""
-  IL_007b:  callvirt   ""ref int Program.M(ref int)""
-  IL_0080:  pop
-  IL_0081:  dup
-  IL_0082:  dup
-  IL_0083:  ldc.i4.0
-  IL_0084:  callvirt   ""ref int Program.this[int].get""
-  IL_0089:  callvirt   ""void Program.N(out int)""
-  IL_008e:  dup
-  IL_008f:  ldc.i4.0
-  IL_0090:  callvirt   ""ref int Program.this[int].get""
-  IL_0095:  stloc.1
-  IL_0096:  ldc.i4.0
-  IL_0097:  conv.u
-  IL_0098:  stloc.1
-  IL_0099:  dup
+  IL_0043:  ldloc.0
+  IL_0044:  pop
+  IL_0045:  ldc.i4.0
+  IL_0046:  conv.u
+  IL_0047:  stloc.0
+  IL_0048:  dup
+  IL_0049:  callvirt   ""ref int Program.P.get""
+  IL_004e:  mkrefany   ""int""
+  IL_0053:  pop
+  IL_0054:  dup
+  IL_0055:  ldc.i4.0
+  IL_0056:  callvirt   ""ref int Program.this[int].get""
+  IL_005b:  ldc.i4.0
+  IL_005c:  stind.i4
+  IL_005d:  dup
+  IL_005e:  ldc.i4.0
+  IL_005f:  callvirt   ""ref int Program.this[int].get""
+  IL_0064:  dup
+  IL_0065:  ldind.i4
+  IL_0066:  ldc.i4.1
+  IL_0067:  add
+  IL_0068:  stind.i4
+  IL_0069:  dup
+  IL_006a:  ldc.i4.0
+  IL_006b:  callvirt   ""ref int Program.this[int].get""
+  IL_0070:  dup
+  IL_0071:  ldind.i4
+  IL_0072:  ldc.i4.1
+  IL_0073:  add
+  IL_0074:  stind.i4
+  IL_0075:  dup
+  IL_0076:  dup
+  IL_0077:  ldc.i4.0
+  IL_0078:  callvirt   ""ref int Program.this[int].get""
+  IL_007d:  callvirt   ""ref int Program.M(ref int)""
+  IL_0082:  pop
+  IL_0083:  dup
+  IL_0084:  dup
+  IL_0085:  ldc.i4.0
+  IL_0086:  callvirt   ""ref int Program.this[int].get""
+  IL_008b:  callvirt   ""void Program.N(out int)""
+  IL_0090:  dup
+  IL_0091:  ldc.i4.0
+  IL_0092:  callvirt   ""ref int Program.this[int].get""
+  IL_0097:  stloc.0
+  IL_0098:  ldloc.0
+  IL_0099:  pop
   IL_009a:  ldc.i4.0
-  IL_009b:  callvirt   ""ref int Program.this[int].get""
-  IL_00a0:  mkrefany   ""int""
-  IL_00a5:  pop
-  IL_00a6:  dup
-  IL_00a7:  dup
-  IL_00a8:  ldflda     ""int Program.field""
-  IL_00ad:  callvirt   ""ref int Program.M(ref int)""
-  IL_00b2:  ldc.i4.0
-  IL_00b3:  stind.i4
-  IL_00b4:  dup
-  IL_00b5:  dup
-  IL_00b6:  ldflda     ""int Program.field""
-  IL_00bb:  callvirt   ""ref int Program.M(ref int)""
-  IL_00c0:  dup
-  IL_00c1:  ldind.i4
-  IL_00c2:  ldc.i4.1
-  IL_00c3:  add
-  IL_00c4:  stind.i4
-  IL_00c5:  dup
-  IL_00c6:  dup
-  IL_00c7:  ldflda     ""int Program.field""
-  IL_00cc:  callvirt   ""ref int Program.M(ref int)""
-  IL_00d1:  dup
-  IL_00d2:  ldind.i4
-  IL_00d3:  ldc.i4.1
-  IL_00d4:  add
-  IL_00d5:  stind.i4
-  IL_00d6:  dup
-  IL_00d7:  dup
-  IL_00d8:  dup
-  IL_00d9:  ldflda     ""int Program.field""
-  IL_00de:  callvirt   ""ref int Program.M(ref int)""
-  IL_00e3:  callvirt   ""ref int Program.M(ref int)""
-  IL_00e8:  pop
-  IL_00e9:  dup
-  IL_00ea:  dup
-  IL_00eb:  dup
-  IL_00ec:  ldflda     ""int Program.field""
-  IL_00f1:  callvirt   ""ref int Program.M(ref int)""
-  IL_00f6:  callvirt   ""void Program.N(out int)""
-  IL_00fb:  dup
-  IL_00fc:  dup
-  IL_00fd:  ldflda     ""int Program.field""
-  IL_0102:  callvirt   ""ref int Program.M(ref int)""
-  IL_0107:  stloc.2
-  IL_0108:  ldc.i4.0
-  IL_0109:  conv.u
-  IL_010a:  stloc.2
-  IL_010b:  dup
-  IL_010c:  ldflda     ""int Program.field""
-  IL_0111:  callvirt   ""ref int Program.M(ref int)""
-  IL_0116:  mkrefany   ""int""
-  IL_011b:  pop
-  IL_011c:  ret
+  IL_009b:  conv.u
+  IL_009c:  stloc.0
+  IL_009d:  dup
+  IL_009e:  ldc.i4.0
+  IL_009f:  callvirt   ""ref int Program.this[int].get""
+  IL_00a4:  mkrefany   ""int""
+  IL_00a9:  pop
+  IL_00aa:  dup
+  IL_00ab:  dup
+  IL_00ac:  ldflda     ""int Program.field""
+  IL_00b1:  callvirt   ""ref int Program.M(ref int)""
+  IL_00b6:  ldc.i4.0
+  IL_00b7:  stind.i4
+  IL_00b8:  dup
+  IL_00b9:  dup
+  IL_00ba:  ldflda     ""int Program.field""
+  IL_00bf:  callvirt   ""ref int Program.M(ref int)""
+  IL_00c4:  dup
+  IL_00c5:  ldind.i4
+  IL_00c6:  ldc.i4.1
+  IL_00c7:  add
+  IL_00c8:  stind.i4
+  IL_00c9:  dup
+  IL_00ca:  dup
+  IL_00cb:  ldflda     ""int Program.field""
+  IL_00d0:  callvirt   ""ref int Program.M(ref int)""
+  IL_00d5:  dup
+  IL_00d6:  ldind.i4
+  IL_00d7:  ldc.i4.1
+  IL_00d8:  add
+  IL_00d9:  stind.i4
+  IL_00da:  dup
+  IL_00db:  dup
+  IL_00dc:  dup
+  IL_00dd:  ldflda     ""int Program.field""
+  IL_00e2:  callvirt   ""ref int Program.M(ref int)""
+  IL_00e7:  callvirt   ""ref int Program.M(ref int)""
+  IL_00ec:  pop
+  IL_00ed:  dup
+  IL_00ee:  dup
+  IL_00ef:  dup
+  IL_00f0:  ldflda     ""int Program.field""
+  IL_00f5:  callvirt   ""ref int Program.M(ref int)""
+  IL_00fa:  callvirt   ""void Program.N(out int)""
+  IL_00ff:  dup
+  IL_0100:  dup
+  IL_0101:  ldflda     ""int Program.field""
+  IL_0106:  callvirt   ""ref int Program.M(ref int)""
+  IL_010b:  stloc.0
+  IL_010c:  ldloc.0
+  IL_010d:  pop
+  IL_010e:  ldc.i4.0
+  IL_010f:  conv.u
+  IL_0110:  stloc.0
+  IL_0111:  dup
+  IL_0112:  ldflda     ""int Program.field""
+  IL_0117:  callvirt   ""ref int Program.M(ref int)""
+  IL_011c:  mkrefany   ""int""
+  IL_0121:  pop
+  IL_0122:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/FixedSizeBufferTests.cs
@@ -104,38 +104,40 @@ class Program
 }";
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput: "12")
                 .VerifyIL("Program.Main",
-@"{
-  // Code size       48 (0x30)
+@"
+{
+  // Code size       47 (0x2f)
   .maxstack  2
-  .locals init (pinned int& V_0) //p
+  .locals init (int* V_0, //p
+                pinned int*& V_1)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  ldflda     ""S C.s""
   IL_000a:  ldflda     ""int* S.x""
-  IL_000f:  ldflda     ""int S.<x>e__FixedBuffer.FixedElementField""" /* Note the absence of conv.u here */ + @"
-  IL_0014:  stloc.0
-  IL_0015:  ldloc.0
-  IL_0016:  conv.i
-  IL_0017:  ldc.i4.s   12
-  IL_0019:  stind.i4
-  IL_001a:  ldloc.0
-  IL_001b:  conv.i
-  IL_001c:  ldc.i4.4
-  IL_001d:  add
-  IL_001e:  ldloc.0
-  IL_001f:  conv.i
+  IL_000f:  ldflda     ""int S.<x>e__FixedBuffer.FixedElementField""
+  IL_0014:  stloc.1
+  IL_0015:  ldloc.1
+  IL_0016:  conv.u
+  IL_0017:  stloc.0
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.s   12
+  IL_001b:  stind.i4
+  IL_001c:  ldloc.0
+  IL_001d:  ldc.i4.4
+  IL_001e:  add
+  IL_001f:  ldloc.0
   IL_0020:  ldind.i4
   IL_0021:  stind.i4
   IL_0022:  ldloc.0
-  IL_0023:  conv.i
-  IL_0024:  ldc.i4.4
-  IL_0025:  add
-  IL_0026:  ldind.i4
-  IL_0027:  call       ""void System.Console.WriteLine(int)""
-  IL_002c:  ldc.i4.0
-  IL_002d:  conv.u
-  IL_002e:  stloc.0
-  IL_002f:  ret
-}");
+  IL_0023:  ldc.i4.4
+  IL_0024:  add
+  IL_0025:  ldind.i4
+  IL_0026:  call       ""void System.Console.WriteLine(int)""
+  IL_002b:  ldc.i4.0
+  IL_002c:  conv.u
+  IL_002d:  stloc.1
+  IL_002e:  ret
+}
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -1207,13 +1207,13 @@ unsafe class C
 {
   // Code size       30 (0x1e)
   .maxstack  3
-  .locals init (pinned int& V_0) //p
+  .locals init (pinned int& V_0)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  dup
   IL_0006:  ldflda     ""int C.x""
   IL_000b:  stloc.0
   IL_000c:  ldloc.0
-  IL_000d:  conv.i
+  IL_000d:  conv.u
   IL_000e:  ldc.i4.1
   IL_000f:  stind.i4
   IL_0010:  ldc.i4.0
@@ -1254,37 +1254,40 @@ unsafe class C
 
             compVerifier.VerifyIL("C.Main", @"
 {
-  // Code size       55 (0x37)
-  .maxstack  3
-  .locals init (pinned int& V_0, //p
-                pinned int& V_1) //q
+  // Code size       57 (0x39)
+  .maxstack  4
+  .locals init (int* V_0, //p
+                pinned int& V_1,
+                pinned int& V_2)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  dup
   IL_0006:  ldflda     ""int C.x""
-  IL_000b:  stloc.0
-  IL_000c:  dup
-  IL_000d:  ldflda     ""int C.y""
-  IL_0012:  stloc.1
-  IL_0013:  ldloc.0
-  IL_0014:  conv.i
-  IL_0015:  ldc.i4.1
-  IL_0016:  stind.i4
-  IL_0017:  ldloc.1
-  IL_0018:  conv.i
-  IL_0019:  ldc.i4.2
+  IL_000b:  stloc.1
+  IL_000c:  ldloc.1
+  IL_000d:  conv.u
+  IL_000e:  stloc.0
+  IL_000f:  dup
+  IL_0010:  ldflda     ""int C.y""
+  IL_0015:  stloc.2
+  IL_0016:  ldloc.2
+  IL_0017:  conv.u
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.1
   IL_001a:  stind.i4
-  IL_001b:  ldc.i4.0
-  IL_001c:  conv.u
-  IL_001d:  stloc.0
-  IL_001e:  ldc.i4.0
-  IL_001f:  conv.u
-  IL_0020:  stloc.1
-  IL_0021:  dup
-  IL_0022:  ldfld      ""int C.x""
-  IL_0027:  call       ""void System.Console.Write(int)""
-  IL_002c:  ldfld      ""int C.y""
-  IL_0031:  call       ""void System.Console.Write(int)""
-  IL_0036:  ret
+  IL_001b:  ldc.i4.2
+  IL_001c:  stind.i4
+  IL_001d:  ldc.i4.0
+  IL_001e:  conv.u
+  IL_001f:  stloc.1
+  IL_0020:  ldc.i4.0
+  IL_0021:  conv.u
+  IL_0022:  stloc.2
+  IL_0023:  dup
+  IL_0024:  ldfld      ""int C.x""
+  IL_0029:  call       ""void System.Console.Write(int)""
+  IL_002e:  ldfld      ""int C.y""
+  IL_0033:  call       ""void System.Console.Write(int)""
+  IL_0038:  ret
 }
 ");
         }
@@ -1316,13 +1319,13 @@ unsafe class C
   .maxstack  2
   .locals init (char* V_0, //o
                 pinned string V_1,
-                pinned char& V_2, //o
-                char[] V_3)
+                char* V_2, //o
+                pinned char[] V_3)
   IL_0000:  ldarg.0
   IL_0001:  callvirt   ""string C.P.get""
   IL_0006:  stloc.1
   IL_0007:  ldloc.1
-  IL_0008:  conv.i
+  IL_0008:  conv.u
   IL_0009:  stloc.0
   IL_000a:  ldloc.0
   IL_000b:  brfalse.s  IL_0015
@@ -1344,16 +1347,17 @@ unsafe class C
   IL_0026:  ldc.i4.0
   IL_0027:  conv.u
   IL_0028:  stloc.2
-  IL_0029:  br.s       IL_0033
+  IL_0029:  br.s       IL_0034
   IL_002b:  ldloc.3
   IL_002c:  ldc.i4.0
   IL_002d:  ldelema    ""char""
-  IL_0032:  stloc.2
-  IL_0033:  ldc.i4.0
-  IL_0034:  conv.u
-  IL_0035:  stloc.2
+  IL_0032:  conv.u
+  IL_0033:  stloc.2
+  IL_0034:  ldnull
+  IL_0035:  stloc.3
   IL_0036:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -1384,37 +1388,40 @@ unsafe class C
 
             compVerifier.VerifyIL("C.Main", @"
 {
-  // Code size       55 (0x37)
-  .maxstack  3
-  .locals init (pinned int& V_0, //p
-      pinned int& V_1) //q
+  // Code size       57 (0x39)
+  .maxstack  4
+  .locals init (int* V_0, //p
+                pinned int& V_1,
+                pinned int& V_2)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  dup
   IL_0006:  ldflda     ""int C.x""
-  IL_000b:  stloc.0
-  IL_000c:  dup
-  IL_000d:  ldflda     ""int C.y""
-  IL_0012:  stloc.1
-  IL_0013:  ldloc.0
-  IL_0014:  conv.i
-  IL_0015:  ldc.i4.1
-  IL_0016:  stind.i4
-  IL_0017:  ldloc.1
-  IL_0018:  conv.i
-  IL_0019:  ldc.i4.2
+  IL_000b:  stloc.1
+  IL_000c:  ldloc.1
+  IL_000d:  conv.u
+  IL_000e:  stloc.0
+  IL_000f:  dup
+  IL_0010:  ldflda     ""int C.y""
+  IL_0015:  stloc.2
+  IL_0016:  ldloc.2
+  IL_0017:  conv.u
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.1
   IL_001a:  stind.i4
-  IL_001b:  ldc.i4.0
-  IL_001c:  conv.u
-  IL_001d:  stloc.0
-  IL_001e:  ldc.i4.0
-  IL_001f:  conv.u
-  IL_0020:  stloc.1
-  IL_0021:  dup
-  IL_0022:  ldfld      ""int C.x""
-  IL_0027:  call       ""void System.Console.Write(int)""
-  IL_002c:  ldfld      ""int C.y""
-  IL_0031:  call       ""void System.Console.Write(int)""
-  IL_0036:  ret
+  IL_001b:  ldc.i4.2
+  IL_001c:  stind.i4
+  IL_001d:  ldc.i4.0
+  IL_001e:  conv.u
+  IL_001f:  stloc.1
+  IL_0020:  ldc.i4.0
+  IL_0021:  conv.u
+  IL_0022:  stloc.2
+  IL_0023:  dup
+  IL_0024:  ldfld      ""int C.x""
+  IL_0029:  call       ""void System.Console.Write(int)""
+  IL_002e:  ldfld      ""int C.y""
+  IL_0033:  call       ""void System.Console.Write(int)""
+  IL_0038:  ret
 }
 ");
         }
@@ -1449,17 +1456,68 @@ class C
 {
   // Code size       11 (0xb)
   .maxstack  2
-  .locals init (pinned char& V_0) //p
+  .locals init (pinned char& V_0)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  conv.i
+  IL_0003:  conv.u
   IL_0004:  ldc.i4.s   97
   IL_0006:  stind.i2
   IL_0007:  ldc.i4.0
   IL_0008:  conv.u
   IL_0009:  stloc.0
   IL_000a:  ret
+}
+");
+        }
+
+        [Fact]
+        public void FixedStatementReferenceParameterDebug()
+        {
+            var text = @"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        char ch;
+        M(out ch);
+        Console.WriteLine(ch);
+    }
+
+    unsafe static void M(out char ch)
+    {
+        fixed (char* p = &ch)
+        {
+            *p = 'a';
+        }
+    }
+}
+";
+            var compVerifier = CompileAndVerify(text, options: TestOptions.UnsafeDebugExe, expectedOutput: @"a");
+
+            compVerifier.VerifyIL("C.M", @"
+{
+  // Code size       16 (0x10)
+  .maxstack  2
+  .locals init (char* V_0, //p
+                pinned char& V_1)
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  stloc.1
+  IL_0003:  ldloc.1
+  IL_0004:  conv.u
+  IL_0005:  stloc.0
+  IL_0006:  nop
+  IL_0007:  ldloc.0
+  IL_0008:  ldc.i4.s   97
+  IL_000a:  stind.i2
+  IL_000b:  nop
+  IL_000c:  ldc.i4.0
+  IL_000d:  conv.u
+  IL_000e:  stloc.1
+  IL_000f:  ret
 }
 ");
         }
@@ -1493,7 +1551,7 @@ unsafe class C
   IL_0001:  ldstr      ""hello""
   IL_0006:  stloc.1
  -IL_0007:  ldloc.1
-  IL_0008:  conv.i
+  IL_0008:  conv.u
   IL_0009:  stloc.0
   IL_000a:  ldloc.0
   IL_000b:  brfalse.s  IL_0015
@@ -1555,7 +1613,7 @@ unsafe class C
   IL_0007:  ldloc.0
   IL_0008:  stloc.2
  -IL_0009:  ldloc.2
-  IL_000a:  conv.i
+  IL_000a:  conv.u
   IL_000b:  stloc.1
   IL_000c:  ldloc.1
   IL_000d:  brfalse.s  IL_0017
@@ -1576,7 +1634,7 @@ unsafe class C
   IL_0025:  ldloc.0
   IL_0026:  stloc.s    V_4
  -IL_0028:  ldloc.s    V_4
-  IL_002a:  conv.i
+  IL_002a:  conv.u
   IL_002b:  stloc.3
   IL_002c:  ldloc.3
   IL_002d:  brfalse.s  IL_0037
@@ -1636,7 +1694,7 @@ unsafe class C
   IL_0000:  ldstr      ""hello""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -1652,7 +1710,7 @@ unsafe class C
   IL_001d:  ldnull
   IL_001e:  stloc.1
   IL_001f:  ldloc.1
-  IL_0020:  conv.i
+  IL_0020:  conv.u
   IL_0021:  stloc.2
   IL_0022:  ldloc.2
   IL_0023:  brfalse.s  IL_002d
@@ -1698,10 +1756,10 @@ unsafe class C
 
             compVerifier.VerifyIL("C.Main", @"
 {
-  // Code size       66 (0x42)
+  // Code size       65 (0x41)
   .maxstack  3
-  .locals init (pinned int& V_0, //p
-                int[] V_1)
+  .locals init (int* V_0, //p
+                pinned int[] V_1)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  dup
   IL_0006:  ldfld      ""int[] C.a""
@@ -1720,23 +1778,22 @@ unsafe class C
   IL_0021:  ldc.i4.0
   IL_0022:  conv.u
   IL_0023:  stloc.0
-  IL_0024:  br.s       IL_002e
+  IL_0024:  br.s       IL_002f
   IL_0026:  ldloc.1
   IL_0027:  ldc.i4.0
   IL_0028:  ldelema    ""int""
-  IL_002d:  stloc.0
-  IL_002e:  ldloc.0
-  IL_002f:  conv.i
+  IL_002d:  conv.u
+  IL_002e:  stloc.0
+  IL_002f:  ldloc.0
   IL_0030:  ldc.i4.1
   IL_0031:  stind.i4
-  IL_0032:  ldc.i4.0
-  IL_0033:  conv.u
-  IL_0034:  stloc.0
-  IL_0035:  ldfld      ""int[] C.a""
-  IL_003a:  ldc.i4.0
-  IL_003b:  ldelem.i4
-  IL_003c:  call       ""void System.Console.Write(int)""
-  IL_0041:  ret
+  IL_0032:  ldnull
+  IL_0033:  stloc.1
+  IL_0034:  ldfld      ""int[] C.a""
+  IL_0039:  ldc.i4.0
+  IL_003a:  ldelem.i4
+  IL_003b:  call       ""void System.Console.Write(int)""
+  IL_0040:  ret
 }
 ");
         }
@@ -1767,10 +1824,10 @@ unsafe class C
 
             compVerifier.VerifyIL("C.Main", @"
 {
-  // Code size       66 (0x42)
+  // Code size       65 (0x41)
   .maxstack  3
-  .locals init (pinned int& V_0, //p
-  int[] V_1)
+  .locals init (int* V_0, //p
+                pinned int[] V_1)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  dup
   IL_0006:  ldfld      ""int[] C.a""
@@ -1789,23 +1846,22 @@ unsafe class C
   IL_0021:  ldc.i4.0
   IL_0022:  conv.u
   IL_0023:  stloc.0
-  IL_0024:  br.s       IL_002e
+  IL_0024:  br.s       IL_002f
   IL_0026:  ldloc.1
   IL_0027:  ldc.i4.0
   IL_0028:  ldelema    ""int""
-  IL_002d:  stloc.0
-  IL_002e:  ldloc.0
-  IL_002f:  conv.i
+  IL_002d:  conv.u
+  IL_002e:  stloc.0
+  IL_002f:  ldloc.0
   IL_0030:  ldc.i4.1
   IL_0031:  stind.i4
-  IL_0032:  ldc.i4.0
-  IL_0033:  conv.u
-  IL_0034:  stloc.0
-  IL_0035:  ldfld      ""int[] C.a""
-  IL_003a:  ldc.i4.0
-  IL_003b:  ldelem.i4
-  IL_003c:  call       ""void System.Console.Write(int)""
-  IL_0041:  ret
+  IL_0032:  ldnull
+  IL_0033:  stloc.1
+  IL_0034:  ldfld      ""int[] C.a""
+  IL_0039:  ldc.i4.0
+  IL_003a:  ldelem.i4
+  IL_003b:  call       ""void System.Console.Write(int)""
+  IL_0040:  ret
 }
 ");
         }
@@ -1836,10 +1892,10 @@ unsafe class C
 
             compVerifier.VerifyIL("C.Main", @"
 {
-  // Code size       80 (0x50)
+  // Code size       79 (0x4f)
   .maxstack  4
-  .locals init (pinned int& V_0, //p
-      int[,] V_1)
+  .locals init (int* V_0, //p
+                pinned int[,] V_1)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  dup
   IL_0006:  ldfld      ""int[,] C.a""
@@ -1858,25 +1914,24 @@ unsafe class C
   IL_0029:  ldc.i4.0
   IL_002a:  conv.u
   IL_002b:  stloc.0
-  IL_002c:  br.s       IL_0037
+  IL_002c:  br.s       IL_0038
   IL_002e:  ldloc.1
   IL_002f:  ldc.i4.0
   IL_0030:  ldc.i4.0
   IL_0031:  call       ""int[*,*].Address""
-  IL_0036:  stloc.0
-  IL_0037:  ldloc.0
-  IL_0038:  conv.i
+  IL_0036:  conv.u
+  IL_0037:  stloc.0
+  IL_0038:  ldloc.0
   IL_0039:  ldc.i4.1
   IL_003a:  stind.i4
-  IL_003b:  ldc.i4.0
-  IL_003c:  conv.u
-  IL_003d:  stloc.0
-  IL_003e:  ldfld      ""int[,] C.a""
+  IL_003b:  ldnull
+  IL_003c:  stloc.1
+  IL_003d:  ldfld      ""int[,] C.a""
+  IL_0042:  ldc.i4.0
   IL_0043:  ldc.i4.0
-  IL_0044:  ldc.i4.0
-  IL_0045:  call       ""int[*,*].Get""
-  IL_004a:  call       ""void System.Console.Write(int)""
-  IL_004f:  ret
+  IL_0044:  call       ""int[*,*].Get""
+  IL_0049:  call       ""void System.Console.Write(int)""
+  IL_004e:  ret
 }
 ");
         }
@@ -1908,64 +1963,66 @@ unsafe class C
 
             compVerifier.VerifyIL("C.Main", @"
 {
-  // Code size       94 (0x5e)
+  // Code size       99 (0x63)
   .maxstack  2
-  .locals init (pinned char& V_0, //p
-                pinned char& V_1, //q
+  .locals init (char* V_0, //p
+                char* V_1, //q
                 char* V_2, //r
-                char[] V_3,
-                pinned string V_4)
+                pinned char& V_3,
+                pinned char[] V_4,
+                pinned string V_5)
   IL_0000:  newobj     ""C..ctor()""
   IL_0005:  dup
   IL_0006:  ldflda     ""char C.c""
-  IL_000b:  stloc.0
-  IL_000c:  ldfld      ""char[] C.a""
-  IL_0011:  dup
-  IL_0012:  stloc.3
-  IL_0013:  brfalse.s  IL_001a
-  IL_0015:  ldloc.3
-  IL_0016:  ldlen
-  IL_0017:  conv.i4
-  IL_0018:  brtrue.s   IL_001f
-  IL_001a:  ldc.i4.0
-  IL_001b:  conv.u
-  IL_001c:  stloc.1
-  IL_001d:  br.s       IL_0027
-  IL_001f:  ldloc.3
-  IL_0020:  ldc.i4.0
-  IL_0021:  ldelema    ""char""
-  IL_0026:  stloc.1
-  IL_0027:  ldstr      ""hello""
-  IL_002c:  stloc.s    V_4
-  IL_002e:  ldloc.s    V_4
-  IL_0030:  conv.i
-  IL_0031:  stloc.2
-  IL_0032:  ldloc.2
-  IL_0033:  brfalse.s  IL_003d
-  IL_0035:  ldloc.2
-  IL_0036:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
-  IL_003b:  add
-  IL_003c:  stloc.2
-  IL_003d:  ldloc.0
-  IL_003e:  conv.i
-  IL_003f:  ldind.u2
-  IL_0040:  call       ""void System.Console.Write(int)""
-  IL_0045:  ldloc.1
-  IL_0046:  conv.i
-  IL_0047:  ldind.u2
-  IL_0048:  call       ""void System.Console.Write(int)""
-  IL_004d:  ldloc.2
-  IL_004e:  ldind.u2
-  IL_004f:  call       ""void System.Console.Write(int)""
-  IL_0054:  ldc.i4.0
-  IL_0055:  conv.u
-  IL_0056:  stloc.0
-  IL_0057:  ldc.i4.0
-  IL_0058:  conv.u
-  IL_0059:  stloc.1
-  IL_005a:  ldnull
-  IL_005b:  stloc.s    V_4
-  IL_005d:  ret
+  IL_000b:  stloc.3
+  IL_000c:  ldloc.3
+  IL_000d:  conv.u
+  IL_000e:  stloc.0
+  IL_000f:  ldfld      ""char[] C.a""
+  IL_0014:  dup
+  IL_0015:  stloc.s    V_4
+  IL_0017:  brfalse.s  IL_001f
+  IL_0019:  ldloc.s    V_4
+  IL_001b:  ldlen
+  IL_001c:  conv.i4
+  IL_001d:  brtrue.s   IL_0024
+  IL_001f:  ldc.i4.0
+  IL_0020:  conv.u
+  IL_0021:  stloc.1
+  IL_0022:  br.s       IL_002e
+  IL_0024:  ldloc.s    V_4
+  IL_0026:  ldc.i4.0
+  IL_0027:  ldelema    ""char""
+  IL_002c:  conv.u
+  IL_002d:  stloc.1
+  IL_002e:  ldstr      ""hello""
+  IL_0033:  stloc.s    V_5
+  IL_0035:  ldloc.s    V_5
+  IL_0037:  conv.u
+  IL_0038:  stloc.2
+  IL_0039:  ldloc.2
+  IL_003a:  brfalse.s  IL_0044
+  IL_003c:  ldloc.2
+  IL_003d:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
+  IL_0042:  add
+  IL_0043:  stloc.2
+  IL_0044:  ldloc.0
+  IL_0045:  ldind.u2
+  IL_0046:  call       ""void System.Console.Write(int)""
+  IL_004b:  ldloc.1
+  IL_004c:  ldind.u2
+  IL_004d:  call       ""void System.Console.Write(int)""
+  IL_0052:  ldloc.2
+  IL_0053:  ldind.u2
+  IL_0054:  call       ""void System.Console.Write(int)""
+  IL_0059:  ldc.i4.0
+  IL_005a:  conv.u
+  IL_005b:  stloc.3
+  IL_005c:  ldnull
+  IL_005d:  stloc.s    V_4
+  IL_005f:  ldnull
+  IL_0060:  stloc.s    V_5
+  IL_0062:  ret
 }
 ");
         }
@@ -2007,7 +2064,7 @@ unsafe class C
       IL_0000:  ldstr      ""hello""
       IL_0005:  stloc.1
       IL_0006:  ldloc.1
-      IL_0007:  conv.i
+      IL_0007:  conv.u
       IL_0008:  stloc.0
       IL_0009:  ldloc.0
       IL_000a:  brfalse.s  IL_0014
@@ -2069,7 +2126,7 @@ unsafe class C
       IL_0000:  ldstr      ""hello""
       IL_0005:  stloc.1
       IL_0006:  ldloc.1
-      IL_0007:  conv.i
+      IL_0007:  conv.u
       IL_0008:  stloc.0
       IL_0009:  ldloc.0
       IL_000a:  brfalse.s  IL_0014
@@ -2134,7 +2191,7 @@ unsafe class C
     IL_0002:  ldstr      ""hello""
     IL_0007:  stloc.1
     IL_0008:  ldloc.1
-    IL_0009:  conv.i
+    IL_0009:  conv.u
     IL_000a:  stloc.0
     IL_000b:  ldloc.0
     IL_000c:  brfalse.s  IL_0016
@@ -2193,7 +2250,7 @@ unsafe class C
     IL_0009:  ldstr      ""hello""
     IL_000e:  stloc.1
     IL_000f:  ldloc.1
-    IL_0010:  conv.i
+    IL_0010:  conv.u
     IL_0011:  stloc.0
     IL_0012:  ldloc.0
     IL_0013:  brfalse.s  IL_001d
@@ -2255,7 +2312,7 @@ unsafe class C
       IL_0008:  ldstr      ""hello""
       IL_000d:  stloc.1
       IL_000e:  ldloc.1
-      IL_000f:  conv.i
+      IL_000f:  conv.u
       IL_0010:  stloc.0
       IL_0011:  ldloc.0
       IL_0012:  brfalse.s  IL_001c
@@ -2308,7 +2365,7 @@ unsafe class C
   IL_0000:  ldstr      ""goodbye""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -2319,7 +2376,7 @@ unsafe class C
   IL_0014:  ldstr      ""hello""
   IL_0019:  stloc.3
   IL_001a:  ldloc.3
-  IL_001b:  conv.i
+  IL_001b:  conv.u
   IL_001c:  stloc.2
   IL_001d:  ldloc.2
   IL_001e:  brfalse.s  IL_0028
@@ -2370,7 +2427,7 @@ unsafe class C
     IL_0000:  ldstr      ""goodbye""
     IL_0005:  stloc.1
     IL_0006:  ldloc.1
-    IL_0007:  conv.i
+    IL_0007:  conv.u
     IL_0008:  stloc.0
     IL_0009:  ldloc.0
     IL_000a:  brfalse.s  IL_0014
@@ -2384,7 +2441,7 @@ unsafe class C
       IL_0015:  ldstr      ""hello""
       IL_001a:  stloc.3
       IL_001b:  ldloc.3
-      IL_001c:  conv.i
+      IL_001c:  conv.u
       IL_001d:  stloc.2
       IL_001e:  ldloc.2
       IL_001f:  brfalse.s  IL_0029
@@ -2446,7 +2503,7 @@ unsafe class C
     IL_0000:  ldstr      ""goodbye""
     IL_0005:  stloc.1
     IL_0006:  ldloc.1
-    IL_0007:  conv.i
+    IL_0007:  conv.u
     IL_0008:  stloc.0
     IL_0009:  ldloc.0
     IL_000a:  brfalse.s  IL_0014
@@ -2457,7 +2514,7 @@ unsafe class C
     IL_0014:  ldstr      ""hello""
     IL_0019:  stloc.3
     IL_001a:  ldloc.3
-    IL_001b:  conv.i
+    IL_001b:  conv.u
     IL_001c:  stloc.2
     IL_001d:  ldloc.2
     IL_001e:  brfalse.s  IL_0028
@@ -2534,7 +2591,7 @@ unsafe class C
   IL_0000:  ldstr      ""A""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -2545,7 +2602,7 @@ unsafe class C
   IL_0014:  ldstr      ""B""
   IL_0019:  stloc.3
   IL_001a:  ldloc.3
-  IL_001b:  conv.i
+  IL_001b:  conv.u
   IL_001c:  stloc.2
   IL_001d:  ldloc.2
   IL_001e:  brfalse.s  IL_0028
@@ -2556,7 +2613,7 @@ unsafe class C
   IL_0028:  ldstr      ""C""
   IL_002d:  stloc.s    V_5
   IL_002f:  ldloc.s    V_5
-  IL_0031:  conv.i
+  IL_0031:  conv.u
   IL_0032:  stloc.s    V_4
   IL_0034:  ldloc.s    V_4
   IL_0036:  brfalse.s  IL_0042
@@ -2569,7 +2626,7 @@ unsafe class C
   IL_0045:  ldstr      ""D""
   IL_004a:  stloc.s    V_5
   IL_004c:  ldloc.s    V_5
-  IL_004e:  conv.i
+  IL_004e:  conv.u
   IL_004f:  stloc.s    V_6
   IL_0051:  ldloc.s    V_6
   IL_0053:  brfalse.s  IL_005f
@@ -2584,7 +2641,7 @@ unsafe class C
   IL_0064:  ldstr      ""E""
   IL_0069:  stloc.3
   IL_006a:  ldloc.3
-  IL_006b:  conv.i
+  IL_006b:  conv.u
   IL_006c:  stloc.s    V_7
   IL_006e:  ldloc.s    V_7
   IL_0070:  brfalse.s  IL_007c
@@ -2595,7 +2652,7 @@ unsafe class C
   IL_007c:  ldstr      ""F""
   IL_0081:  stloc.s    V_5
   IL_0083:  ldloc.s    V_5
-  IL_0085:  conv.i
+  IL_0085:  conv.u
   IL_0086:  stloc.s    V_8
   IL_0088:  ldloc.s    V_8
   IL_008a:  brfalse.s  IL_0096
@@ -2608,7 +2665,7 @@ unsafe class C
   IL_0099:  ldstr      ""G""
   IL_009e:  stloc.s    V_5
   IL_00a0:  ldloc.s    V_5
-  IL_00a2:  conv.i
+  IL_00a2:  conv.u
   IL_00a3:  stloc.s    V_9
   IL_00a5:  ldloc.s    V_9
   IL_00a7:  brfalse.s  IL_00b3
@@ -2658,7 +2715,7 @@ unsafe class C
     IL_0000:  ldstr      ""hello""
     IL_0005:  stloc.1
     IL_0006:  ldloc.1
-    IL_0007:  conv.i
+    IL_0007:  conv.u
     IL_0008:  stloc.0
     IL_0009:  ldloc.0
     IL_000a:  brfalse.s  IL_0014
@@ -2718,7 +2775,7 @@ unsafe class C
     IL_000c:  ldstr      ""hello""
     IL_0011:  stloc.3
     IL_0012:  ldloc.3
-    IL_0013:  conv.i
+    IL_0013:  conv.u
     IL_0014:  stloc.2
     IL_0015:  ldloc.2
     IL_0016:  brfalse.s  IL_0020
@@ -2785,7 +2842,7 @@ unsafe class C
     IL_000a:  ldstr      ""hello""
     IL_000f:  stloc.3
     IL_0010:  ldloc.3
-    IL_0011:  conv.i
+    IL_0011:  conv.u
     IL_0012:  stloc.2
     IL_0013:  ldloc.2
     IL_0014:  brfalse.s  IL_001e
@@ -2868,7 +2925,7 @@ class Enumerator : System.IDisposable
       IL_0010:  ldstr      ""hello""
       IL_0015:  stloc.2
       IL_0016:  ldloc.2
-      IL_0017:  conv.i
+      IL_0017:  conv.u
       IL_0018:  stloc.1
       IL_0019:  ldloc.1
       IL_001a:  brfalse.s  IL_0024
@@ -2938,7 +2995,7 @@ unsafe class C
     IL_0000:  ldstr      ""hello""
     IL_0005:  stloc.1
     IL_0006:  ldloc.1
-    IL_0007:  conv.i
+    IL_0007:  conv.u
     IL_0008:  stloc.0
     IL_0009:  ldloc.0
     IL_000a:  brfalse.s  IL_0014
@@ -2992,7 +3049,7 @@ unsafe class C
   IL_0000:  ldstr      ""hello""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -3039,7 +3096,7 @@ unsafe class C
     IL_0000:  ldstr      ""hello""
     IL_0005:  stloc.1
     IL_0006:  ldloc.1
-    IL_0007:  conv.i
+    IL_0007:  conv.u
     IL_0008:  stloc.0
     IL_0009:  ldloc.0
     IL_000a:  brfalse.s  IL_0014
@@ -3093,7 +3150,7 @@ unsafe class C
     IL_0000:  ldstr      ""hello""
     IL_0005:  stloc.1
     IL_0006:  ldloc.1
-    IL_0007:  conv.i
+    IL_0007:  conv.u
     IL_0008:  stloc.0
     IL_0009:  ldloc.0
     IL_000a:  brfalse.s  IL_0014
@@ -3110,7 +3167,8 @@ unsafe class C
     IL_0018:  endfinally
   }
   IL_0019:  ret
-}");
+}
+");
         }
 
         [Fact]
@@ -3142,7 +3200,7 @@ unsafe class C
     IL_0000:  ldstr      ""hello""
     IL_0005:  stloc.1
     IL_0006:  ldloc.1
-    IL_0007:  conv.i
+    IL_0007:  conv.u
     IL_0008:  stloc.0
     IL_0009:  ldloc.0
     IL_000a:  brfalse.s  IL_0014
@@ -3195,7 +3253,7 @@ unsafe class C
     IL_0001:  ldstr      ""hello""
     IL_0006:  stloc.1
     IL_0007:  ldloc.1
-    IL_0008:  conv.i
+    IL_0008:  conv.u
     IL_0009:  stloc.0
     IL_000a:  ldloc.0
     IL_000b:  brfalse.s  IL_0015
@@ -3249,7 +3307,7 @@ unsafe class C
     IL_0001:  ldstr      ""hello""
     IL_0006:  stloc.1
     IL_0007:  ldloc.1
-    IL_0008:  conv.i
+    IL_0008:  conv.u
     IL_0009:  stloc.0
     IL_000a:  ldloc.0
     IL_000b:  brfalse.s  IL_0015
@@ -3302,7 +3360,7 @@ unsafe class C
     IL_0001:  ldstr      ""hello""
     IL_0006:  stloc.1
     IL_0007:  ldloc.1
-    IL_0008:  conv.i
+    IL_0008:  conv.u
     IL_0009:  stloc.0
     IL_000a:  ldloc.0
     IL_000b:  brfalse.s  IL_0015
@@ -3356,7 +3414,7 @@ unsafe class C
     IL_0001:  ldstr      ""hello""
     IL_0006:  stloc.1
     IL_0007:  ldloc.1
-    IL_0008:  conv.i
+    IL_0008:  conv.u
     IL_0009:  stloc.0
     IL_000a:  ldloc.0
     IL_000b:  brfalse.s  IL_0015
@@ -3406,7 +3464,7 @@ unsafe class C
     IL_0001:  ldstr      ""hello""
     IL_0006:  stloc.1
     IL_0007:  ldloc.1
-    IL_0008:  conv.i
+    IL_0008:  conv.u
     IL_0009:  stloc.0
     IL_000a:  ldloc.0
     IL_000b:  brfalse.s  IL_0015
@@ -3455,7 +3513,7 @@ unsafe class C
     IL_0000:  ldstr      ""hello""
     IL_0005:  stloc.1
     IL_0006:  ldloc.1
-    IL_0007:  conv.i
+    IL_0007:  conv.u
     IL_0008:  stloc.0
     IL_0009:  ldloc.0
     IL_000a:  brfalse.s  IL_0014
@@ -3502,7 +3560,7 @@ unsafe class C
   IL_0000:  ldstr      ""hello""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -3542,7 +3600,7 @@ unsafe class C
   IL_0000:  ldstr      ""hello""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -3584,7 +3642,7 @@ unsafe class C
   IL_0000:  ldstr      ""hello""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -3641,7 +3699,7 @@ unsafe class C
   IL_0000:  ldstr      ""hello""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -3706,7 +3764,7 @@ unsafe class C
   IL_0000:  ldstr      ""hello""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -3772,7 +3830,7 @@ unsafe class C
   IL_0000:  ldstr      ""hello""
   IL_0005:  stloc.1
   IL_0006:  ldloc.1
-  IL_0007:  conv.i
+  IL_0007:  conv.u
   IL_0008:  stloc.0
   IL_0009:  ldloc.0
   IL_000a:  brfalse.s  IL_0014
@@ -4439,75 +4497,77 @@ unsafe class C
             // NB: "pinned System.IntPtr&" (which ildasm displays as "pinned native int&"), not void.
             var expectedIL = @"
 {
-  // Code size      107 (0x6b)
+  // Code size      112 (0x70)
   .maxstack  2
   .locals init (C V_0, //c
-                pinned System.IntPtr& V_1, //p
-                pinned System.IntPtr& V_2, //q
+                void* V_1, //p
+                void* V_2, //q
                 void* V_3, //r
-                char[] V_4,
-                pinned string V_5)
+                pinned char& V_4,
+                pinned char[] V_5,
+                pinned string V_6)
  -IL_0000:  nop
  -IL_0001:  nop
  -IL_0002:  newobj     ""C..ctor()""
   IL_0007:  stloc.0
- -IL_0008:  ldloc.0
+  IL_0008:  ldloc.0
   IL_0009:  ldflda     ""char C.c""
-  IL_000e:  stloc.1
- -IL_000f:  ldloc.0
-  IL_0010:  ldfld      ""char[] C.a""
-  IL_0015:  dup
-  IL_0016:  stloc.s    V_4
-  IL_0018:  brfalse.s  IL_0020
-  IL_001a:  ldloc.s    V_4
-  IL_001c:  ldlen
-  IL_001d:  conv.i4
-  IL_001e:  brtrue.s   IL_0025
-  IL_0020:  ldc.i4.0
-  IL_0021:  conv.u
-  IL_0022:  stloc.2
-  IL_0023:  br.s       IL_002e
-  IL_0025:  ldloc.s    V_4
-  IL_0027:  ldc.i4.0
-  IL_0028:  ldelema    ""char""
-  IL_002d:  stloc.2
-  IL_002e:  ldstr      ""hello""
-  IL_0033:  stloc.s    V_5
- -IL_0035:  ldloc.s    V_5
-  IL_0037:  conv.i
-  IL_0038:  stloc.3
-  IL_0039:  ldloc.3
-  IL_003a:  brfalse.s  IL_0044
-  IL_003c:  ldloc.3
-  IL_003d:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
-  IL_0042:  add
-  IL_0043:  stloc.3
- -IL_0044:  nop
- -IL_0045:  ldloc.1
-  IL_0046:  conv.i
-  IL_0047:  ldind.u2
-  IL_0048:  call       ""void System.Console.Write(int)""
-  IL_004d:  nop
- -IL_004e:  ldloc.2
-  IL_004f:  conv.i
-  IL_0050:  ldind.u2
-  IL_0051:  call       ""void System.Console.Write(int)""
-  IL_0056:  nop
- -IL_0057:  ldloc.3
-  IL_0058:  ldind.u2
-  IL_0059:  call       ""void System.Console.Write(int)""
-  IL_005e:  nop
- -IL_005f:  nop
- ~IL_0060:  ldc.i4.0
-  IL_0061:  conv.u
-  IL_0062:  stloc.1
-  IL_0063:  ldc.i4.0
-  IL_0064:  conv.u
-  IL_0065:  stloc.2
-  IL_0066:  ldnull
-  IL_0067:  stloc.s    V_5
- -IL_0069:  nop
- -IL_006a:  ret
+  IL_000e:  stloc.s    V_4
+ -IL_0010:  ldloc.s    V_4
+  IL_0012:  conv.u
+  IL_0013:  stloc.1
+ -IL_0014:  ldloc.0
+  IL_0015:  ldfld      ""char[] C.a""
+  IL_001a:  dup
+  IL_001b:  stloc.s    V_5
+  IL_001d:  brfalse.s  IL_0025
+  IL_001f:  ldloc.s    V_5
+  IL_0021:  ldlen
+  IL_0022:  conv.i4
+  IL_0023:  brtrue.s   IL_002a
+  IL_0025:  ldc.i4.0
+  IL_0026:  conv.u
+  IL_0027:  stloc.2
+  IL_0028:  br.s       IL_0034
+  IL_002a:  ldloc.s    V_5
+  IL_002c:  ldc.i4.0
+  IL_002d:  ldelema    ""char""
+  IL_0032:  conv.u
+  IL_0033:  stloc.2
+  IL_0034:  ldstr      ""hello""
+  IL_0039:  stloc.s    V_6
+ -IL_003b:  ldloc.s    V_6
+  IL_003d:  conv.u
+  IL_003e:  stloc.3
+  IL_003f:  ldloc.3
+  IL_0040:  brfalse.s  IL_004a
+  IL_0042:  ldloc.3
+  IL_0043:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
+  IL_0048:  add
+  IL_0049:  stloc.3
+ -IL_004a:  nop
+ -IL_004b:  ldloc.1
+  IL_004c:  ldind.u2
+  IL_004d:  call       ""void System.Console.Write(int)""
+  IL_0052:  nop
+ -IL_0053:  ldloc.2
+  IL_0054:  ldind.u2
+  IL_0055:  call       ""void System.Console.Write(int)""
+  IL_005a:  nop
+ -IL_005b:  ldloc.3
+  IL_005c:  ldind.u2
+  IL_005d:  call       ""void System.Console.Write(int)""
+  IL_0062:  nop
+ -IL_0063:  nop
+ ~IL_0064:  ldc.i4.0
+  IL_0065:  conv.u
+  IL_0066:  stloc.s    V_4
+  IL_0068:  ldnull
+  IL_0069:  stloc.s    V_5
+  IL_006b:  ldnull
+  IL_006c:  stloc.s    V_6
+ -IL_006e:  nop
+ -IL_006f:  ret
 }
 ";
             var expectedOutput = @"970104";
@@ -4546,7 +4606,7 @@ unsafe class C
   // Code size       36 (0x24)
   .maxstack  3
   .locals init (char V_0, //ch
-  pinned void*& V_1) //p
+                pinned void*& V_1)
   IL_0000:  ldc.i4.s   97
   IL_0002:  stloc.0
   IL_0003:  newobj     ""C..ctor()""
@@ -4557,7 +4617,7 @@ unsafe class C
   IL_0011:  ldflda     ""void* C.v""
   IL_0016:  stloc.1
   IL_0017:  ldloc.1
-  IL_0018:  conv.i
+  IL_0018:  conv.u
   IL_0019:  ldind.i
   IL_001a:  ldind.u2
   IL_001b:  call       ""void System.Console.Write(char)""
@@ -4739,7 +4799,7 @@ unsafe class C
   // Code size       41 (0x29)
   .maxstack  4
   .locals init (int*[] V_0,
-  int V_1)
+                int V_1)
   IL_0000:  ldc.i4.2
   IL_0001:  newarr     ""int*""
   IL_0006:  dup
@@ -4802,10 +4862,10 @@ unsafe class C
   // Code size      120 (0x78)
   .maxstack  5
   .locals init (int*[,] V_0,
-  int V_1,
-  int V_2,
-  int V_3,
-  int V_4)
+                int V_1,
+                int V_2,
+                int V_3,
+                int V_4)
   IL_0000:  ldc.i4.2
   IL_0001:  ldc.i4.2
   IL_0002:  newobj     ""int*[*,*]..ctor""
@@ -5129,7 +5189,7 @@ unsafe struct S
 }
 ";
 
-            // Dev10 has conv.i after IL_000d and conv.i8 in place of conv.u8 at IL_0017.
+            // Dev10 has conv.u after IL_000d and conv.i8 in place of conv.u8 at IL_0017.
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).VerifyIL("S.Main", @"
 {
   // Code size       59 (0x3b)
@@ -5194,7 +5254,7 @@ unsafe struct S
 }
 ";
 
-            // Dev10 has conv.i after IL_000d and conv.i8 in place of conv.u8 at IL_0017.
+            // Dev10 has conv.u after IL_000d and conv.i8 in place of conv.u8 at IL_0017.
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).VerifyIL("S.Main", @"
 {
   // Code size       59 (0x3b)
@@ -5259,7 +5319,7 @@ unsafe struct S
 }
 ";
 
-            // Dev10 has conv.i after IL_000d and conv.i8 in place of conv.u8 at IL_0017.
+            // Dev10 has conv.u after IL_000d and conv.i8 in place of conv.u8 at IL_0017.
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).VerifyIL("S.Main", @"
 {
   // Code size       59 (0x3b)
@@ -5324,7 +5384,7 @@ unsafe struct S
 }
 ";
 
-            // Dev10 has conv.i after IL_000d and conv.i8 in place of conv.u8 at IL_0017.
+            // Dev10 has conv.u after IL_000d and conv.i8 in place of conv.u8 at IL_0017.
             CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll).VerifyIL("S.Main", @"
 {
   // Code size       59 (0x3b)
@@ -5400,7 +5460,7 @@ unsafe class C
   // Code size       50 (0x32)
   .maxstack  2
   .locals init (byte V_0, //b
-  byte* V_1) //p
+                byte* V_1) //p
   IL_0000:  nop
   IL_0001:  nop
   IL_0002:  ldc.i4.3
@@ -5449,7 +5509,8 @@ unsafe class C
   IL_002f:  stloc.1
   IL_0030:  nop
   IL_0031:  ret
-}");
+}
+");
         }
 
         [WorkItem(546750, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546750")]
@@ -5487,7 +5548,7 @@ unsafe class C
   // Code size       50 (0x32)
   .maxstack  2
   .locals init (byte V_0, //b
-  byte* V_1) //p
+                byte* V_1) //p
   IL_0000:  nop
   IL_0001:  nop
   IL_0002:  ldc.i4.3
@@ -5874,8 +5935,8 @@ unsafe struct S
   // Code size       78 (0x4e)
   .maxstack  5
   .locals init (S V_0, //s
-  S& V_1,
-  int V_2)
+                S& V_1,
+                int V_2)
   IL_0000:  ldloca.s   V_0
   IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
@@ -5941,7 +6002,7 @@ unsafe struct S
   // Code size       39 (0x27)
   .maxstack  2
   .locals init (S* V_0, //p
-  S* V_1) //q
+                S* V_1) //q
   IL_0000:  ldc.i4.8
   IL_0001:  conv.i
   IL_0002:  stloc.0
@@ -5999,7 +6060,7 @@ unsafe struct S
   // Code size       39 (0x27)
   .maxstack  2
   .locals init (S* V_0, //p
-      S* V_1) //q
+                S* V_1) //q
   IL_0000:  ldc.i4.8
   IL_0001:  conv.i
   IL_0002:  stloc.0
@@ -6055,7 +6116,7 @@ unsafe struct S
   // Code size       29 (0x1d)
   .maxstack  2
   .locals init (int* V_0, //p
-      int* V_1) //q
+                int* V_1) //q
   IL_0000:  ldc.i4.8
   IL_0001:  conv.i
   IL_0002:  stloc.0
@@ -6114,8 +6175,8 @@ unsafe struct S
   // Code size       43 (0x2b)
   .maxstack  2
   .locals init (S* V_0, //p1
-      S* V_1, //p2
-      S* V_2) //q
+                S* V_1, //p2
+                S* V_2) //q
   IL_0000:  ldc.i4.7
   IL_0001:  conv.i
   IL_0002:  stloc.0
@@ -7579,7 +7640,7 @@ unsafe struct S
   // Code size      133 (0x85)
   .maxstack  2
   .locals init (S* V_0, //p
-      S* V_1) //q
+                S* V_1) //q
   IL_0000:  ldc.i4.0
   IL_0001:  conv.i
   IL_0002:  stloc.0
@@ -8185,7 +8246,7 @@ unsafe class C
   IL_001b:  ldstr      ""pinned""
   IL_0020:  stloc.2
   IL_0021:  ldloc.2
-  IL_0022:  conv.i
+  IL_0022:  conv.u
   IL_0023:  stloc.1
   IL_0024:  ldloc.1
   IL_0025:  brfalse.s  IL_002f
@@ -8209,7 +8270,7 @@ unsafe class C
   IL_004c:  ldstr      ""pinned""
   IL_0051:  stloc.2
   IL_0052:  ldloc.2
-  IL_0053:  conv.i
+  IL_0053:  conv.u
   IL_0054:  stloc.3
   IL_0055:  ldloc.3
   IL_0056:  brfalse.s  IL_0060
@@ -8413,7 +8474,88 @@ unsafe public struct FixedStruct
     }
 }
 ";
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: false).VerifyDiagnostics();
+            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: false).VerifyDiagnostics();
+
+            comp.VerifyIL("FixedStruct.ToString", @"
+{
+  // Code size       20 (0x14)
+  .maxstack  1
+  .locals init (pinned char*& V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldflda     ""char* FixedStruct.c""
+  IL_0006:  ldflda     ""char FixedStruct.<c>e__FixedBuffer.FixedElementField""
+  IL_000b:  stloc.0
+  IL_000c:  ldloc.0
+  IL_000d:  conv.u
+  IL_000e:  call       ""string char.ToString()""
+  IL_0013:  ret
+}
+");
+        }
+
+        public void FixedBufferAndStatementWithFixedArrayElementAsInitializerExe()
+        {
+            var text = @"
+    class Program
+    {
+        unsafe static void Main(string[] args)
+        {
+            FixedStruct s = new FixedStruct();
+
+            s.c[0] = 'A';
+            s.c[1] = 'B';
+            s.c[2] = 'C';
+
+            FixedStruct[] arr = { s };
+
+            System.Console.Write(arr[0].ToString());
+        }
+    }
+
+    unsafe public struct FixedStruct
+    {
+        public fixed char c[10];
+
+        override public string ToString()
+        {
+            fixed (char* pc = this.c)
+            {
+                System.Console.Write(pc[0]);
+                System.Console.Write(pc[1].ToString());
+                return pc[2].ToString();
+            }
+        }
+    }";
+            var comp = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, expectedOutput:"ABC", verify: false).VerifyDiagnostics();
+
+            comp.VerifyIL("FixedStruct.ToString", @"
+{
+  // Code size       45 (0x2d)
+  .maxstack  3
+  .locals init (pinned char*& V_0)
+  IL_0000:  ldarg.0
+  IL_0001:  ldflda     ""char* FixedStruct.c""
+  IL_0006:  ldflda     ""char FixedStruct.<c>e__FixedBuffer.FixedElementField""
+  IL_000b:  stloc.0
+  IL_000c:  ldloc.0
+  IL_000d:  conv.u
+  IL_000e:  dup
+  IL_000f:  ldind.u2
+  IL_0010:  call       ""void System.Console.Write(char)""
+  IL_0015:  dup
+  IL_0016:  ldc.i4.2
+  IL_0017:  add
+  IL_0018:  call       ""string char.ToString()""
+  IL_001d:  call       ""void System.Console.Write(string)""
+  IL_0022:  ldc.i4.2
+  IL_0023:  conv.i
+  IL_0024:  ldc.i4.2
+  IL_0025:  mul
+  IL_0026:  add
+  IL_0027:  call       ""string char.ToString()""
+  IL_002c:  ret
+}
+");
         }
 
         [Fact, WorkItem(545299, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545299")]
@@ -8766,8 +8908,8 @@ unsafe class C
   // Code size       36 (0x24)
   .maxstack  2
   .locals init (byte* V_0, //data
-  uint V_1, //offset
-  byte* V_2) //wrong
+                uint V_1, //offset
+                byte* V_2) //wrong
   IL_0000:  ldc.i4     0x76543210
   IL_0005:  conv.i
   IL_0006:  stloc.0
@@ -8812,8 +8954,8 @@ unsafe class C
   // Code size       40 (0x28)
   .maxstack  3
   .locals init (short* V_0, //data
-  uint V_1, //offset
-  short* V_2) //wrong
+                uint V_1, //offset
+                short* V_2) //wrong
   IL_0000:  ldc.i4     0x76543210
   IL_0005:  conv.i
   IL_0006:  stloc.0
@@ -8861,7 +9003,7 @@ unsafe class C
   // Code size       34 (0x22)
   .maxstack  2
   .locals init (byte* V_0, //data
-  byte* V_1) //wrong
+                byte* V_1) //wrong
   IL_0000:  ldc.i4     0x76543210
   IL_0005:  conv.i
   IL_0006:  stloc.0
@@ -8903,7 +9045,7 @@ unsafe class C
   // Code size       33 (0x21)
   .maxstack  2
   .locals init (byte* V_0, //data
-  byte* V_1) //wrong
+                byte* V_1) //wrong
   IL_0000:  ldc.i4     0x76543210
   IL_0005:  conv.i
   IL_0006:  stloc.0
@@ -8999,8 +9141,8 @@ public unsafe class C
 {
   // Code size       42 (0x2a)
   .maxstack  3
-  .locals init (pinned byte& V_0, //pBytes
-  byte[] V_1)
+  .locals init (byte* V_0, //pBytes
+                pinned byte[] V_1)
   IL_0000:  ldarg.0
   IL_0001:  brtrue.s   IL_0009
   IL_0003:  ldsfld     ""byte[] C._emptyArray""
@@ -9018,14 +9160,14 @@ public unsafe class C
   IL_0019:  ldc.i4.0
   IL_001a:  conv.u
   IL_001b:  stloc.0
-  IL_001c:  br.s       IL_0026
+  IL_001c:  br.s       IL_0027
   IL_001e:  ldloc.1
   IL_001f:  ldc.i4.0
   IL_0020:  ldelema    ""byte""
-  IL_0025:  stloc.0
-  IL_0026:  ldc.i4.0
-  IL_0027:  conv.u
-  IL_0028:  stloc.0
+  IL_0025:  conv.u
+  IL_0026:  stloc.0
+  IL_0027:  ldnull
+  IL_0028:  stloc.1
   IL_0029:  ret
 }
 ");
@@ -9070,13 +9212,13 @@ public unsafe class C
             var v = CompileAndVerify(text, options: TestOptions.UnsafeDebugExe, expectedOutput: "System.Byte[]");
             v.VerifyIL("C.ToManagedByteArray", @"
 {
-  // Code size       63 (0x3f)
+  // Code size       64 (0x40)
   .maxstack  2
   .locals init (bool V_0,
                 byte[] V_1,
                 byte[] V_2, //bytes
-                pinned byte& V_3, //pBytes
-                byte[] V_4)
+                byte* V_3, //pBytes
+                pinned byte[] V_4)
  -IL_0000:  nop
  -IL_0001:  ldarg.0
   IL_0002:  ldc.i4.0
@@ -9087,7 +9229,7 @@ public unsafe class C
  -IL_0009:  nop
  -IL_000a:  ldsfld     ""byte[] C._emptyArray""
   IL_000f:  stloc.1
-  IL_0010:  br.s       IL_003d
+  IL_0010:  br.s       IL_003e
  -IL_0012:  nop
  -IL_0013:  ldarg.0
   IL_0014:  newarr     ""byte""
@@ -9103,21 +9245,21 @@ public unsafe class C
   IL_0026:  ldc.i4.0
   IL_0027:  conv.u
   IL_0028:  stloc.3
-  IL_0029:  br.s       IL_0034
+  IL_0029:  br.s       IL_0035
   IL_002b:  ldloc.s    V_4
   IL_002d:  ldc.i4.0
   IL_002e:  ldelema    ""byte""
-  IL_0033:  stloc.3
- -IL_0034:  nop
+  IL_0033:  conv.u
+  IL_0034:  stloc.3
  -IL_0035:  nop
- ~IL_0036:  ldc.i4.0
-  IL_0037:  conv.u
-  IL_0038:  stloc.3
- -IL_0039:  ldloc.2
-  IL_003a:  stloc.1
-  IL_003b:  br.s       IL_003d
- -IL_003d:  ldloc.1
-  IL_003e:  ret
+ -IL_0036:  nop
+ ~IL_0037:  ldnull
+  IL_0038:  stloc.s    V_4
+ -IL_003a:  ldloc.2
+  IL_003b:  stloc.1
+  IL_003c:  br.s       IL_003e
+ -IL_003e:  ldloc.1
+  IL_003f:  ret
 }
 ", sequencePoints: "C.ToManagedByteArray");
         }
@@ -9170,7 +9312,7 @@ public unsafe class C
 .class public AddressHelper{
     .method public hidebysig static native int AddressOf<T>(!!0& t){
         ldc.i4.5
-	    conv.i
+	    conv.u
 	    ret
     }    
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -683,20 +683,20 @@ public class C
             diff1.VerifyIL("C.M",
 @"
 {
-  // Code size       80 (0x50)
+  // Code size       81 (0x51)
   .maxstack  2
   .locals init (char* V_0, //p
                 pinned string V_1,
-                pinned int& V_2, //q
+                int* V_2, //q
                 [unchanged] V_3,
                 char* V_4, //r
                 pinned string V_5,
-                int[] V_6)
+                pinned int[] V_6)
   IL_0000:  nop
   IL_0001:  ldarg.0
   IL_0002:  stloc.1
   IL_0003:  ldloc.1
-  IL_0004:  conv.i
+  IL_0004:  conv.u
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  brfalse.s  IL_0011
@@ -716,35 +716,35 @@ public class C
   IL_001e:  ldc.i4.0
   IL_001f:  conv.u
   IL_0020:  stloc.2
-  IL_0021:  br.s       IL_002c
+  IL_0021:  br.s       IL_002d
   IL_0023:  ldloc.s    V_6
   IL_0025:  ldc.i4.0
   IL_0026:  ldelema    ""int""
-  IL_002b:  stloc.2
-  IL_002c:  nop
+  IL_002b:  conv.u
+  IL_002c:  stloc.2
   IL_002d:  nop
-  IL_002e:  ldc.i4.0
-  IL_002f:  conv.u
-  IL_0030:  stloc.2
-  IL_0031:  ldarg.0
-  IL_0032:  stloc.s    V_5
-  IL_0034:  ldloc.s    V_5
-  IL_0036:  conv.i
-  IL_0037:  stloc.s    V_4
-  IL_0039:  ldloc.s    V_4
-  IL_003b:  brfalse.s  IL_0047
-  IL_003d:  ldloc.s    V_4
-  IL_003f:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
-  IL_0044:  add
-  IL_0045:  stloc.s    V_4
-  IL_0047:  nop
+  IL_002e:  nop
+  IL_002f:  ldnull
+  IL_0030:  stloc.s    V_6
+  IL_0032:  ldarg.0
+  IL_0033:  stloc.s    V_5
+  IL_0035:  ldloc.s    V_5
+  IL_0037:  conv.u
+  IL_0038:  stloc.s    V_4
+  IL_003a:  ldloc.s    V_4
+  IL_003c:  brfalse.s  IL_0048
+  IL_003e:  ldloc.s    V_4
+  IL_0040:  call       ""int System.Runtime.CompilerServices.RuntimeHelpers.OffsetToStringData.get""
+  IL_0045:  add
+  IL_0046:  stloc.s    V_4
   IL_0048:  nop
-  IL_0049:  ldnull
-  IL_004a:  stloc.s    V_5
-  IL_004c:  nop
-  IL_004d:  ldnull
-  IL_004e:  stloc.1
-  IL_004f:  ret
+  IL_0049:  nop
+  IL_004a:  ldnull
+  IL_004b:  stloc.s    V_5
+  IL_004d:  nop
+  IL_004e:  ldnull
+  IL_004f:  stloc.1
+  IL_0050:  ret
 }");
         }
 
@@ -809,7 +809,7 @@ public class C
   IL_0001:  ldarg.0
   IL_0002:  stloc.2
   IL_0003:  ldloc.2
-  IL_0004:  conv.i
+  IL_0004:  conv.u
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  brfalse.s  IL_0011
@@ -820,7 +820,7 @@ public class C
   IL_0011:  ldarg.1
   IL_0012:  stloc.3
   IL_0013:  ldloc.3
-  IL_0014:  conv.i
+  IL_0014:  conv.u
   IL_0015:  stloc.1
   IL_0016:  ldloc.1
   IL_0017:  brfalse.s  IL_0021
@@ -841,7 +841,7 @@ public class C
   IL_002b:  ldarg.0
   IL_002c:  stloc.s    V_7
   IL_002e:  ldloc.s    V_7
-  IL_0030:  conv.i
+  IL_0030:  conv.u
   IL_0031:  stloc.s    V_4
   IL_0033:  ldloc.s    V_4
   IL_0035:  brfalse.s  IL_0041
@@ -852,7 +852,7 @@ public class C
   IL_0041:  ldarg.2
   IL_0042:  stloc.s    V_8
   IL_0044:  ldloc.s    V_8
-  IL_0046:  conv.i
+  IL_0046:  conv.u
   IL_0047:  stloc.s    V_5
   IL_0049:  ldloc.s    V_5
   IL_004b:  brfalse.s  IL_0057
@@ -863,7 +863,7 @@ public class C
   IL_0057:  ldarg.3
   IL_0058:  stloc.s    V_9
   IL_005a:  ldloc.s    V_9
-  IL_005c:  conv.i
+  IL_005c:  conv.u
   IL_005d:  stloc.s    V_6
   IL_005f:  ldloc.s    V_6
   IL_0061:  brfalse.s  IL_006d
@@ -883,7 +883,7 @@ public class C
   IL_007a:  ldarg.1
   IL_007b:  stloc.s    V_11
   IL_007d:  ldloc.s    V_11
-  IL_007f:  conv.i
+  IL_007f:  conv.u
   IL_0080:  stloc.s    V_10
   IL_0082:  ldloc.s    V_10
   IL_0084:  brfalse.s  IL_0090

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -5443,8 +5443,7 @@ unsafe class C
 }
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugExe);
-            c.VerifyPdb(@"
-<symbols>
+            c.VerifyPdb(@"<symbols>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -5455,24 +5454,25 @@ unsafe class C
         <encLocalSlotMap>
           <slot kind=""0"" offset=""13"" />
           <slot kind=""0"" offset=""47"" />
+          <slot kind=""9"" offset=""47"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""9"" startColumn=""5"" endLine=""9"" endColumn=""6"" />
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""23"" />
-        <entry offset=""0x7"" startLine=""11"" startColumn=""16"" endLine=""11"" endColumn=""29"" />
-        <entry offset=""0xe"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
-        <entry offset=""0xf"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""20"" />
-        <entry offset=""0x13"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
-        <entry offset=""0x14"" hidden=""true"" />
-        <entry offset=""0x17"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""32"" />
-        <entry offset=""0x23"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
+        <entry offset=""0xe"" startLine=""11"" startColumn=""16"" endLine=""11"" endColumn=""29"" />
+        <entry offset=""0x11"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""10"" />
+        <entry offset=""0x12"" startLine=""13"" startColumn=""13"" endLine=""13"" endColumn=""20"" />
+        <entry offset=""0x15"" startLine=""14"" startColumn=""9"" endLine=""14"" endColumn=""10"" />
+        <entry offset=""0x16"" hidden=""true"" />
+        <entry offset=""0x19"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""32"" />
+        <entry offset=""0x25"" startLine=""16"" startColumn=""5"" endLine=""16"" endColumn=""6"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x24"">
+      <scope startOffset=""0x0"" endOffset=""0x26"">
         <namespace name=""System"" />
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x24"" attributes=""0"" />
-        <scope startOffset=""0x7"" endOffset=""0x17"">
-          <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x17"" attributes=""0"" />
+        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x26"" attributes=""0"" />
+        <scope startOffset=""0x7"" endOffset=""0x19"">
+          <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x19"" attributes=""0"" />
         </scope>
       </scope>
     </method>
@@ -5573,18 +5573,18 @@ unsafe class C
         <entry offset=""0x1"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""23"" />
         <entry offset=""0x7"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""31"" />
         <entry offset=""0x15"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""28"" />
-        <entry offset=""0x31"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x32"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""20"" />
+        <entry offset=""0x32"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
+        <entry offset=""0x33"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""20"" />
         <entry offset=""0x39"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
         <entry offset=""0x3a"" hidden=""true"" />
-        <entry offset=""0x3d"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" />
-        <entry offset=""0x4b"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
+        <entry offset=""0x3c"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""31"" />
+        <entry offset=""0x4a"" startLine=""17"" startColumn=""5"" endLine=""17"" endColumn=""6"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x4c"">
+      <scope startOffset=""0x0"" endOffset=""0x4b"">
         <namespace name=""System"" />
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x4c"" attributes=""0"" />
-        <scope startOffset=""0x15"" endOffset=""0x3d"">
-          <local name=""p"" il_index=""1"" il_start=""0x15"" il_end=""0x3d"" attributes=""0"" />
+        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x4b"" attributes=""0"" />
+        <scope startOffset=""0x15"" endOffset=""0x3c"">
+          <local name=""p"" il_index=""1"" il_start=""0x15"" il_end=""0x3c"" attributes=""0"" />
         </scope>
       </scope>
     </method>
@@ -5625,8 +5625,7 @@ unsafe class C
 ";
             // NOTE: stop on each declarator.
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugExe);
-            c.VerifyPdb(@"
-<symbols>
+            c.VerifyPdb(@"<symbols>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -5638,27 +5637,29 @@ unsafe class C
           <slot kind=""0"" offset=""13"" />
           <slot kind=""0"" offset=""47"" />
           <slot kind=""0"" offset=""57"" />
+          <slot kind=""9"" offset=""47"" />
+          <slot kind=""9"" offset=""57"" />
         </encLocalSlotMap>
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
         <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""23"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""29"" />
-        <entry offset=""0xe"" startLine=""12"" startColumn=""31"" endLine=""12"" endColumn=""39"" />
-        <entry offset=""0x15"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x16"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""20"" />
-        <entry offset=""0x1a"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""20"" />
-        <entry offset=""0x1e"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
-        <entry offset=""0x1f"" hidden=""true"" />
-        <entry offset=""0x25"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""38"" />
-        <entry offset=""0x38"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
+        <entry offset=""0xe"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""29"" />
+        <entry offset=""0x19"" startLine=""12"" startColumn=""31"" endLine=""12"" endColumn=""39"" />
+        <entry offset=""0x1d"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
+        <entry offset=""0x1e"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""20"" />
+        <entry offset=""0x21"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""20"" />
+        <entry offset=""0x24"" startLine=""16"" startColumn=""9"" endLine=""16"" endColumn=""10"" />
+        <entry offset=""0x25"" hidden=""true"" />
+        <entry offset=""0x2c"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""38"" />
+        <entry offset=""0x3f"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x39"">
+      <scope startOffset=""0x0"" endOffset=""0x40"">
         <namespace name=""System"" />
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x39"" attributes=""0"" />
-        <scope startOffset=""0x7"" endOffset=""0x25"">
-          <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x25"" attributes=""0"" />
-          <local name=""q"" il_index=""2"" il_start=""0x7"" il_end=""0x25"" attributes=""0"" />
+        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x40"" attributes=""0"" />
+        <scope startOffset=""0x7"" endOffset=""0x2c"">
+          <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x2c"" attributes=""0"" />
+          <local name=""q"" il_index=""2"" il_start=""0x7"" il_end=""0x2c"" attributes=""0"" />
         </scope>
       </scope>
     </method>
@@ -5751,8 +5752,7 @@ unsafe class C
 }
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugExe);
-            c.VerifyPdb(@"
-<symbols>
+            c.VerifyPdb(@"<symbols>
   <entryPoint declaringType=""C"" methodName=""Main"" />
   <methods>
     <method containingType=""C"" name=""Main"">
@@ -5774,22 +5774,22 @@ unsafe class C
         <entry offset=""0x7"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""31"" />
         <entry offset=""0x15"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""31"" />
         <entry offset=""0x23"" startLine=""14"" startColumn=""16"" endLine=""14"" endColumn=""28"" />
-        <entry offset=""0x3f"" startLine=""14"" startColumn=""30"" endLine=""14"" endColumn=""37"" />
-        <entry offset=""0x5e"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
-        <entry offset=""0x5f"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""20"" />
-        <entry offset=""0x63"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""20"" />
+        <entry offset=""0x40"" startLine=""14"" startColumn=""30"" endLine=""14"" endColumn=""37"" />
+        <entry offset=""0x60"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""10"" />
+        <entry offset=""0x61"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""20"" />
+        <entry offset=""0x64"" startLine=""17"" startColumn=""13"" endLine=""17"" endColumn=""20"" />
         <entry offset=""0x67"" startLine=""18"" startColumn=""9"" endLine=""18"" endColumn=""10"" />
         <entry offset=""0x68"" hidden=""true"" />
-        <entry offset=""0x6e"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""31"" />
-        <entry offset=""0x7c"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""31"" />
-        <entry offset=""0x8a"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
+        <entry offset=""0x6d"" startLine=""19"" startColumn=""9"" endLine=""19"" endColumn=""31"" />
+        <entry offset=""0x7b"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""31"" />
+        <entry offset=""0x89"" startLine=""21"" startColumn=""5"" endLine=""21"" endColumn=""6"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x8b"">
+      <scope startOffset=""0x0"" endOffset=""0x8a"">
         <namespace name=""System"" />
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x8b"" attributes=""0"" />
-        <scope startOffset=""0x23"" endOffset=""0x6e"">
-          <local name=""p"" il_index=""1"" il_start=""0x23"" il_end=""0x6e"" attributes=""0"" />
-          <local name=""q"" il_index=""2"" il_start=""0x23"" il_end=""0x6e"" attributes=""0"" />
+        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x8a"" attributes=""0"" />
+        <scope startOffset=""0x23"" endOffset=""0x6d"">
+          <local name=""p"" il_index=""1"" il_start=""0x23"" il_end=""0x6d"" attributes=""0"" />
+          <local name=""q"" il_index=""2"" il_start=""0x23"" il_end=""0x6d"" attributes=""0"" />
         </scope>
       </scope>
     </method>
@@ -5830,8 +5830,7 @@ unsafe class C
 }
 ";
             var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.UnsafeDebugDll);
-            c.VerifyPdb(@"
-<symbols>
+            c.VerifyPdb(@"<symbols>
   <methods>
     <method containingType=""C"" name=""Main"">
       <customDebugInfo>
@@ -5843,6 +5842,7 @@ unsafe class C
           <slot kind=""0"" offset=""48"" />
           <slot kind=""0"" offset=""58"" />
           <slot kind=""0"" offset=""67"" />
+          <slot kind=""9"" offset=""48"" />
           <slot kind=""temp"" />
           <slot kind=""9"" offset=""67"" />
         </encLocalSlotMap>
@@ -5850,24 +5850,24 @@ unsafe class C
       <sequencePoints>
         <entry offset=""0x0"" startLine=""10"" startColumn=""5"" endLine=""10"" endColumn=""6"" />
         <entry offset=""0x1"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""23"" />
-        <entry offset=""0x7"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""30"" />
-        <entry offset=""0xe"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""39"" />
-        <entry offset=""0x34"" startLine=""12"" startColumn=""41"" endLine=""12"" endColumn=""52"" />
-        <entry offset=""0x43"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
-        <entry offset=""0x44"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""36"" />
-        <entry offset=""0x4d"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""36"" />
-        <entry offset=""0x56"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""36"" />
-        <entry offset=""0x5e"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
-        <entry offset=""0x5f"" hidden=""true"" />
-        <entry offset=""0x68"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
+        <entry offset=""0xf"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""30"" />
+        <entry offset=""0x13"" startLine=""12"" startColumn=""32"" endLine=""12"" endColumn=""39"" />
+        <entry offset=""0x3a"" startLine=""12"" startColumn=""41"" endLine=""12"" endColumn=""52"" />
+        <entry offset=""0x49"" startLine=""13"" startColumn=""9"" endLine=""13"" endColumn=""10"" />
+        <entry offset=""0x4a"" startLine=""14"" startColumn=""13"" endLine=""14"" endColumn=""36"" />
+        <entry offset=""0x52"" startLine=""15"" startColumn=""13"" endLine=""15"" endColumn=""36"" />
+        <entry offset=""0x5a"" startLine=""16"" startColumn=""13"" endLine=""16"" endColumn=""36"" />
+        <entry offset=""0x62"" startLine=""17"" startColumn=""9"" endLine=""17"" endColumn=""10"" />
+        <entry offset=""0x63"" hidden=""true"" />
+        <entry offset=""0x6d"" startLine=""18"" startColumn=""5"" endLine=""18"" endColumn=""6"" />
       </sequencePoints>
-      <scope startOffset=""0x0"" endOffset=""0x69"">
+      <scope startOffset=""0x0"" endOffset=""0x6e"">
         <namespace name=""System"" />
-        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x69"" attributes=""0"" />
-        <scope startOffset=""0x7"" endOffset=""0x68"">
-          <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x68"" attributes=""0"" />
-          <local name=""q"" il_index=""2"" il_start=""0x7"" il_end=""0x68"" attributes=""0"" />
-          <local name=""r"" il_index=""3"" il_start=""0x7"" il_end=""0x68"" attributes=""0"" />
+        <local name=""c"" il_index=""0"" il_start=""0x0"" il_end=""0x6e"" attributes=""0"" />
+        <scope startOffset=""0x7"" endOffset=""0x6d"">
+          <local name=""p"" il_index=""1"" il_start=""0x7"" il_end=""0x6d"" attributes=""0"" />
+          <local name=""q"" il_index=""2"" il_start=""0x7"" il_end=""0x6d"" attributes=""0"" />
+          <local name=""r"" il_index=""3"" il_start=""0x7"" il_end=""0x6d"" attributes=""0"" />
         </scope>
       </scope>
     </method>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -6155,16 +6155,17 @@ class NotPointer
             CreateStandardCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (9,26): error CS0254: The right hand side of a fixed statement assignment may not be a cast expression
                 //         fixed (byte* p = (byte*)&x)
-                Diagnostic(ErrorCode.ERR_BadCastInFixed, "(byte*)&x"),
+                Diagnostic(ErrorCode.ERR_BadCastInFixed, "(byte*)&x").WithLocation(9, 26),
                 // (13,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
                 //         fixed (int* p = n) //CS0213 (confusing, but matches dev10)
-                Diagnostic(ErrorCode.ERR_FixedNotNeeded, "n"),
+                Diagnostic(ErrorCode.ERR_FixedNotNeeded, "n").WithLocation(13, 25),
+                // (13,25): error CS0266: Cannot implicitly convert type 'NotPointer*' to 'int*'. An explicit conversion exists (are you missing a cast?)
+                //         fixed (int* p = n) //CS0213 (confusing, but matches dev10)
+                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "n").WithArguments("NotPointer*", "int*").WithLocation(13, 25),
                 // (17,25): error CS0254: The right hand side of a fixed statement assignment may not be a cast expression
                 //         fixed (int* p = (int*)n)
-                Diagnostic(ErrorCode.ERR_BadCastInFixed, "(int*)n"),
-                // (5,16): warning CS0649: Field 'C.n' is never assigned to, and will always have its default value null
-                //     NotPointer n;
-                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "n").WithArguments("C.n", "null"));
+                Diagnostic(ErrorCode.ERR_BadCastInFixed, "(int*)n").WithLocation(17, 25)
+                );
         }
 
         [Fact]
@@ -6567,7 +6568,7 @@ unsafe class C
                 var summary = initializerSummaries[i];
                 Assert.Equal(0, summary.CandidateSymbols.Length);
                 Assert.Equal(CandidateReason.None, summary.CandidateReason);
-                Assert.Equal(summary.Type, summary.ConvertedType);
+                Assert.Equal(charPointerSymbol, summary.ConvertedType);
                 Assert.Equal(Conversion.Identity, summary.ImplicitConversion);
                 Assert.Equal(0, summary.MethodGroup.Length);
                 Assert.Null(summary.Alias);
@@ -6650,14 +6651,14 @@ unsafe class C
             var arraySymbol = compilation.GlobalNamespace.GetMember<TypeSymbol>("C").GetMember<FieldSymbol>("a");
             Assert.Equal(arraySymbol, summary1.Symbol);
             Assert.Equal(arraySymbol.Type, summary1.Type);
-            Assert.Equal(summary1.Type, summary1.ConvertedType);
-            Assert.Equal(Conversion.Identity, summary1.ImplicitConversion);
+            Assert.Equal(voidPointerSymbol, summary1.ConvertedType);
+            Assert.Equal(Conversion.PointerToVoid, summary1.ImplicitConversion);
 
             var summary2 = initializerSummaries[2];
             Assert.Null(summary2.Symbol);
             Assert.Equal(stringSymbol, summary2.Type);
-            Assert.Equal(summary2.Type, summary2.ConvertedType);
-            Assert.Equal(Conversion.Identity, summary2.ImplicitConversion);
+            Assert.Equal(voidPointerSymbol, summary2.ConvertedType);
+            Assert.Equal(Conversion.PointerToVoid, summary2.ImplicitConversion);
         }
 
         #endregion Fixed statement semantic model tests
@@ -8155,65 +8156,62 @@ class Program
 ";
             var compilation = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe);
 
-            compilation.VerifyIL("Program.Store", @"{
-  // Code size       36 (0x24)
-  .maxstack  2
-  .locals init (pinned bool& V_0) //buffer
+            compilation.VerifyIL("Program.Store", @"
+{
+  // Code size       34 (0x22)
+  .maxstack  3
+  .locals init (pinned bool*& V_0)
   IL_0000:  ldsflda    ""s Program._fixedBufferExample""
   IL_0005:  ldflda     ""bool* s._buffer""
   IL_000a:  ldflda     ""bool s.<_buffer>e__FixedBuffer.FixedElementField""
   IL_000f:  stloc.0
   IL_0010:  ldloc.0
-  IL_0011:  conv.i
-  IL_0012:  ldc.i4.1
-  IL_0013:  stind.i1
-  IL_0014:  ldloc.0
-  IL_0015:  conv.i
+  IL_0011:  conv.u
+  IL_0012:  dup
+  IL_0013:  ldc.i4.1
+  IL_0014:  stind.i1
+  IL_0015:  dup
   IL_0016:  ldc.i4.1
   IL_0017:  add
   IL_0018:  ldc.i4.0
   IL_0019:  stind.i1
-  IL_001a:  ldloc.0
-  IL_001b:  conv.i
-  IL_001c:  ldc.i4.2
-  IL_001d:  add
-  IL_001e:  ldc.i4.1
-  IL_001f:  stind.i1
-  IL_0020:  ldc.i4.0
-  IL_0021:  conv.u
-  IL_0022:  stloc.0
-  IL_0023:  ret
+  IL_001a:  ldc.i4.2
+  IL_001b:  add
+  IL_001c:  ldc.i4.1
+  IL_001d:  stind.i1
+  IL_001e:  ldc.i4.0
+  IL_001f:  conv.u
+  IL_0020:  stloc.0
+  IL_0021:  ret
 }
 ");
             compilation.VerifyIL("Program.Load", @"
 {
-  // Code size       48 (0x30)
-  .maxstack  2
-  .locals init (pinned bool& V_0) //buffer
+  // Code size       46 (0x2e)
+  .maxstack  3
+  .locals init (pinned bool*& V_0)
   IL_0000:  ldsflda    ""s Program._fixedBufferExample""
   IL_0005:  ldflda     ""bool* s._buffer""
   IL_000a:  ldflda     ""bool s.<_buffer>e__FixedBuffer.FixedElementField""
   IL_000f:  stloc.0
   IL_0010:  ldloc.0
-  IL_0011:  conv.i
-  IL_0012:  ldind.u1
-  IL_0013:  call       ""void System.Console.Write(bool)""
-  IL_0018:  ldloc.0
-  IL_0019:  conv.i
+  IL_0011:  conv.u
+  IL_0012:  dup
+  IL_0013:  ldind.u1
+  IL_0014:  call       ""void System.Console.Write(bool)""
+  IL_0019:  dup
   IL_001a:  ldc.i4.1
   IL_001b:  add
   IL_001c:  ldind.u1
   IL_001d:  call       ""void System.Console.Write(bool)""
-  IL_0022:  ldloc.0
-  IL_0023:  conv.i
-  IL_0024:  ldc.i4.2
-  IL_0025:  add
-  IL_0026:  ldind.u1
-  IL_0027:  call       ""void System.Console.Write(bool)""
-  IL_002c:  ldc.i4.0
-  IL_002d:  conv.u
-  IL_002e:  stloc.0
-  IL_002f:  ret
+  IL_0022:  ldc.i4.2
+  IL_0023:  add
+  IL_0024:  ldind.u1
+  IL_0025:  call       ""void System.Console.Write(bool)""
+  IL_002a:  ldc.i4.0
+  IL_002b:  conv.u
+  IL_002c:  stloc.0
+  IL_002d:  ret
 }
 ");
         }
@@ -8276,63 +8274,60 @@ class Program
             var compilation = CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe);
             compilation.VerifyIL("Program.Load", @"
 {
-  // Code size       49 (0x31)
-  .maxstack  2
-  .locals init (pinned bool& V_0) //buffer
+  // Code size       47 (0x2f)
+  .maxstack  3
+  .locals init (pinned bool*& V_0)
   IL_0000:  ldsflda    ""s Program._fixedBufferExample""
   IL_0005:  ldflda     ""bool* s._buffer""
   IL_000a:  ldflda     ""bool s.<_buffer>e__FixedBuffer.FixedElementField""
   IL_000f:  stloc.0
   IL_0010:  ldloc.0
-  IL_0011:  conv.i
-  IL_0012:  ldind.u1
-  IL_0013:  call       ""void System.Console.Write(bool)""
-  IL_0018:  ldloc.0
-  IL_0019:  conv.i
+  IL_0011:  conv.u
+  IL_0012:  dup
+  IL_0013:  ldind.u1
+  IL_0014:  call       ""void System.Console.Write(bool)""
+  IL_0019:  dup
   IL_001a:  ldc.i4.8
   IL_001b:  add
   IL_001c:  ldind.u1
   IL_001d:  call       ""void System.Console.Write(bool)""
-  IL_0022:  ldloc.0
-  IL_0023:  conv.i
-  IL_0024:  ldc.i4.s   10
-  IL_0026:  add
-  IL_0027:  ldind.u1
-  IL_0028:  call       ""void System.Console.Write(bool)""
-  IL_002d:  ldc.i4.0
-  IL_002e:  conv.u
-  IL_002f:  stloc.0
-  IL_0030:  ret
+  IL_0022:  ldc.i4.s   10
+  IL_0024:  add
+  IL_0025:  ldind.u1
+  IL_0026:  call       ""void System.Console.Write(bool)""
+  IL_002b:  ldc.i4.0
+  IL_002c:  conv.u
+  IL_002d:  stloc.0
+  IL_002e:  ret
 }");
 
-            compilation.VerifyIL("Program.Store", @"{
-  // Code size       37 (0x25)
-  .maxstack  2
-  .locals init (pinned bool& V_0) //buffer
+            compilation.VerifyIL("Program.Store", @"
+{
+  // Code size       35 (0x23)
+  .maxstack  3
+  .locals init (pinned bool*& V_0)
   IL_0000:  ldsflda    ""s Program._fixedBufferExample""
   IL_0005:  ldflda     ""bool* s._buffer""
   IL_000a:  ldflda     ""bool s.<_buffer>e__FixedBuffer.FixedElementField""
   IL_000f:  stloc.0
   IL_0010:  ldloc.0
-  IL_0011:  conv.i
-  IL_0012:  ldc.i4.1
-  IL_0013:  stind.i1
-  IL_0014:  ldloc.0
-  IL_0015:  conv.i
+  IL_0011:  conv.u
+  IL_0012:  dup
+  IL_0013:  ldc.i4.1
+  IL_0014:  stind.i1
+  IL_0015:  dup
   IL_0016:  ldc.i4.8
   IL_0017:  add
   IL_0018:  ldc.i4.0
   IL_0019:  stind.i1
-  IL_001a:  ldloc.0
-  IL_001b:  conv.i
-  IL_001c:  ldc.i4.s   10
-  IL_001e:  add
-  IL_001f:  ldc.i4.1
-  IL_0020:  stind.i1
-  IL_0021:  ldc.i4.0
-  IL_0022:  conv.u
-  IL_0023:  stloc.0
-  IL_0024:  ret
+  IL_001a:  ldc.i4.s   10
+  IL_001c:  add
+  IL_001d:  ldc.i4.1
+  IL_001e:  stind.i1
+  IL_001f:  ldc.i4.0
+  IL_0020:  conv.u
+  IL_0021:  stloc.0
+  IL_0022:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -6298,6 +6298,26 @@ class Program
         fixed (int* p = null)
         {
         }
+
+        fixed (int* p = &null)
+        {
+        }
+
+        fixed (int* p = _)
+        {
+        }
+
+        fixed (int* p = &_)
+        {
+        }
+
+        fixed (int* p = ()=>throw null)
+        {
+        }
+
+        fixed (int* p = &(()=>throw null))
+        {
+        }
     }
 }
 ";
@@ -6305,7 +6325,23 @@ class Program
             CreateStandardCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (6,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
                 //         fixed (int* p = null)
-                Diagnostic(ErrorCode.ERR_FixedNotNeeded, "null"));
+                Diagnostic(ErrorCode.ERR_FixedNotNeeded, "null").WithLocation(6, 25),
+                // (10,26): error CS0211: Cannot take the address of the given expression
+                //         fixed (int* p = &null)
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "null").WithLocation(10, 26),
+                // (14,25): error CS0103: The name '_' does not exist in the current context
+                //         fixed (int* p = _)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(14, 25),
+                // (18,26): error CS0103: The name '_' does not exist in the current context
+                //         fixed (int* p = &_)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "_").WithArguments("_").WithLocation(18, 26),
+                // (22,25): error CS1660: Cannot convert lambda expression to type 'int*' because it is not a delegate type
+                //         fixed (int* p = ()=>throw null)
+                Diagnostic(ErrorCode.ERR_AnonMethToNonDel, "()=>throw null").WithArguments("lambda expression", "int*").WithLocation(22, 25),
+                // (26,27): error CS0211: Cannot take the address of the given expression
+                //         fixed (int* p = &(()=>throw null))
+                Diagnostic(ErrorCode.ERR_InvalidAddrOp, "()=>throw null").WithLocation(26, 27)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -6159,13 +6159,13 @@ class NotPointer
                 // (13,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
                 //         fixed (int* p = n) //CS0213 (confusing, but matches dev10)
                 Diagnostic(ErrorCode.ERR_FixedNotNeeded, "n").WithLocation(13, 25),
-                // (13,25): error CS0266: Cannot implicitly convert type 'NotPointer*' to 'int*'. An explicit conversion exists (are you missing a cast?)
-                //         fixed (int* p = n) //CS0213 (confusing, but matches dev10)
-                Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "n").WithArguments("NotPointer*", "int*").WithLocation(13, 25),
                 // (17,25): error CS0254: The right hand side of a fixed statement assignment may not be a cast expression
                 //         fixed (int* p = (int*)n)
-                Diagnostic(ErrorCode.ERR_BadCastInFixed, "(int*)n").WithLocation(17, 25)
-                );
+                Diagnostic(ErrorCode.ERR_BadCastInFixed, "(int*)n").WithLocation(17, 25),
+                // (5,23): warning CS0649: Field 'C.n' is never assigned to, and will always have its default value null
+                //     public NotPointer n;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "n").WithArguments("C.n", "null").WithLocation(5, 23)
+            );
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilderEmit.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilderEmit.cs
@@ -425,18 +425,6 @@ namespace Microsoft.CodeAnalysis.CodeGen
                     }
                     break;
             }
-
-            // As in ILGENREC::dumpLocal
-            // CONSIDER: this is somewhat C# specific - it might be better to incorporate this
-            // into the bound tree as a conversion to int.
-            // VSADOV: pinned locals are used in C# to represent pointers in "fixed" statements.
-            // in the user's code they are used as pointers (*), however in their implementation
-            // they hold pinned references (O or &) to the fixed data so they need to be converted 
-            // them to unmanaged pointer type when loaded.
-            if (local.IsPinned)
-            {
-                EmitOpCode(ILOpCode.Conv_i);
-            }
         }
 
         // Generate a "store local" opcode with the given slot number.

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -98,9 +98,9 @@ namespace Microsoft.CodeAnalysis
         ForEachArrayIndex = 8,
 
         /// <summary>
-        /// Local variable that holds a pinned handle of a string passed to a fixed statement (C#).
+        /// Local variable that holds a pinned handle of a managed reference passed to a fixed statement (C#).
         /// </summary>
-        FixedString = 9,
+        FixedReference = 9,
 
         /// <summary>
         /// Local variable that holds the object passed to With statement (VB). 

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -1157,15 +1157,15 @@ class B : A
             var testData = new CompilationTestData();
             context.CompileExpression("s", out error, testData);
             testData.GetMethodData("<>x.<>m0").VerifyIL(
-@"{
-  // Code size        3 (0x3)
+@"
+{
+  // Code size        2 (0x2)
   .maxstack  1
   .locals init (pinned string V_0, //s
                 pinned int& V_1, //f
                 int& V_2) //i
   IL_0000:  ldloc.0
-  IL_0001:  conv.i
-  IL_0002:  ret
+  IL_0001:  ret
 }");
             testData = new CompilationTestData();
             context.CompileAssignment("s", "\"hello\"", out error, testData);
@@ -1183,15 +1183,15 @@ class B : A
             testData = new CompilationTestData();
             context.CompileExpression("f", out error, testData);
             testData.GetMethodData("<>x.<>m0").VerifyIL(
-@"{
-  // Code size        3 (0x3)
+@"
+{
+  // Code size        2 (0x2)
   .maxstack  1
   .locals init (pinned string V_0, //s
                 pinned int& V_1, //f
                 int& V_2) //i
   IL_0000:  ldloc.1
-  IL_0001:  conv.i
-  IL_0002:  ret
+  IL_0001:  ret
 }");
             testData = new CompilationTestData();
             context.CompileAssignment("f", "1", out error, testData);
@@ -1260,25 +1260,24 @@ class B : A
 
                 testData.GetMethodData("<>x.<>m0").VerifyIL(
 @"{
-  // Code size       11 (0xb)
+  // Code size       10 (0xa)
   .maxstack  2
   .locals init (char* V_0, //p1
                 pinned string V_1,
-                pinned int& V_2, //p2
-                pinned System.IntPtr& V_3, //p3
-                int[] V_4,
-                int V_5) //y
+                int* V_2, //p2
+                pinned int& V_3,
+                void* V_4, //p3
+                pinned int[] V_5,
+                int V_6) //y
   IL_0000:  ldloc.0
   IL_0001:  ldind.u2
   IL_0002:  ldloc.2
-  IL_0003:  conv.i
-  IL_0004:  ldind.i4
-  IL_0005:  add
-  IL_0006:  ldloc.3
-  IL_0007:  conv.i
-  IL_0008:  ldind.i4
-  IL_0009:  add
-  IL_000a:  ret
+  IL_0003:  ldind.i4
+  IL_0004:  add
+  IL_0005:  ldloc.s    V_4
+  IL_0007:  ldind.i4
+  IL_0008:  add
+  IL_0009:  ret
 }");
             });
         }

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTests.vb
@@ -1201,14 +1201,13 @@ End Class
             Assert.Null(errorMessage)
             testData.GetMethodData("<>x.<>m0").VerifyIL(
 "{
-  // Code size        3 (0x3)
+  // Code size        2 (0x2)
   .maxstack  1
   .locals init (pinned String V_0, //s
-  pinned Integer& V_1, //f
-  Integer& V_2) //i
+                pinned Integer& V_1, //f
+                Integer& V_2) //i
   IL_0000:  ldloc.0
-  IL_0001:  conv.i
-  IL_0002:  ret
+  IL_0001:  ret
 }")
 
             testData = New CompilationTestData()
@@ -1230,33 +1229,33 @@ End Class
             context.CompileExpression("f", errorMessage, testData)
             Assert.Null(errorMessage)
             testData.GetMethodData("<>x.<>m0").VerifyIL(
-"{
-  // Code size        4 (0x4)
+"
+{
+  // Code size        3 (0x3)
   .maxstack  1
   .locals init (pinned String V_0, //s
-  pinned Integer& V_1, //f
-  Integer& V_2) //i
+                pinned Integer& V_1, //f
+                Integer& V_2) //i
   IL_0000:  ldloc.1
-  IL_0001:  conv.i
-  IL_0002:  ldind.i4
-  IL_0003:  ret
+  IL_0001:  ldind.i4
+  IL_0002:  ret
 }")
 
             testData = New CompilationTestData()
             context.CompileAssignment("f", "1", errorMessage, testData)
             Assert.Null(errorMessage)
             testData.GetMethodData("<>x.<>m0").VerifyIL(
-"{
-  // Code size        5 (0x5)
+"
+{
+  // Code size        4 (0x4)
   .maxstack  2
   .locals init (pinned String V_0, //s
-  pinned Integer& V_1, //f
-  Integer& V_2) //i
+                pinned Integer& V_1, //f
+                Integer& V_2) //i
   IL_0000:  ldloc.1
-  IL_0001:  conv.i
-  IL_0002:  ldc.i4.1
-  IL_0003:  stind.i4
-  IL_0004:  ret
+  IL_0001:  ldc.i4.1
+  IL_0002:  stind.i4
+  IL_0003:  ret
 }")
 
             testData = New CompilationTestData()


### PR DESCRIPTION
Fixes: #18615

Also related to:
   - Jit intrinsics for Span<T>.get_Item and ReadOnlySpan<T>.get_Item: https://github.com/dotnet/coreclr/pull/10910
   - Investigate perf diff between the Span ctor that takes array vs pointer: https://github.com/dotnet/corefxlab/issues/1479

In some cases `fixed`  statement uses a peculiar codegen strategy -
Instead of mapping the pointer variable to a pointer, it maps it to the managed pinned reference (which does not even have the same type).
Then the difference is compensated for in all the places where the pointer is used, by converting the reference to a pointer on demand, repeatedly.

I.E.
```C#
fixed(int * p = &v)
{
    Use(p);
    Use(p);
    Use(p);
}
```
is emitted as

```C#
try
{
     pinned ref int refTemp = ref v;

    Use((int*)refTemp);      // unsafely cast pinned ref
    Use((int*)refTemp);      // unsafely cast pinned ref
    Use((int*)refTemp);      // unsafely cast pinned ref
}
finally
{
      // zero-out refTemp
}
```
instead of what logically follows from the semantics:
```C#
try
{
     pinned ref int refTemp = ref v;
     int * p = (int*)refTemp;  // unsafely cast pinned ref

    Use(p);
    Use(p);
    Use(p);
}
finally
{
      // zero-out refTemp
}
```

The reason for the strange emit was never truly understood. In fact, in other cases, like fixed string, the more obvious variant is used.
One theory is that this codegen was just a result of the lack of internal expressiveness in the old compiler around byref locals and it was simply carried forward.

The inconsistency requires special casing of such `fixed` statements - in binding, lowering, codegen and in the semantical model, which must expose the "logical" shape of the statement.

Another guess was that this kind of emit was better for JIT.
That turned out not to be true. To the contrary - while a pointer temp would be very optimizable, repeated accesses to a pinned ref can result in noticeable worse JITted code, forcing users to use workarounds like:

```C#
fixed(int * p = &v)
{
    // PERF: accessing p has additional expenses, so use it via another temp;
    int * cheapP = p;
    Use(cheapP);
    Use(cheapP);
    Use(cheapP);
}
```

Compiler should do that not the users.
