### PR TITLE
Change nuget moniker for dev15.3.x to beta4

### DIFF
--- a/build/Targets/Versions.props
+++ b/build/Targets/Versions.props
@@ -15,7 +15,7 @@
     <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
          moniker listed below -->
     <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
-    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta3</RoslynNuGetMoniker>
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">beta4</RoslynNuGetMoniker>
     <!-- This is the base of the NuGet versioning for prerelease packages -->
     <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>
 


### PR DESCRIPTION
since this branch is now targeting Preview 4.

**Customer scenario**
None - this just makes sure that nuget packages for Preview 4 are distinguishable from Preview 3.

**Bugs this fixes:**
None.

**Workarounds, if any**
None.

**Risk**
None.

**Performance impact**
None.

**Is this a regression from a previous update?**
N/A

**Root cause analysis:**
N/A

**How was the bug found?**
N/A