### PR TITLE
Properly disable the CPS dependencies node

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -249,16 +249,6 @@
     </SuggestedBindingRedirects>
   </ItemGroup>
 
-  <!-- 
-       Work around some UI delays in the new project system
-
-       https://github.com/dotnet/project-system/issues/2297
-
-  --> 
-  <ItemGroup>
-    <ProjectCapability Remove="DependenciesTree"/>
-  </ItemGroup>
-
   <Import Project="$(MSBuildTargetsFilePath)" Condition="'$(RoslynSdkProject)' != 'true'" />
   <Import Project="$(RoslynNetSdkRootPath)Sdk.targets" Condition="'$(RoslynSdkProject)' == 'true'" />
 

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!-- 
+    Work around some UI delays in the new project system
+    https://github.com/dotnet/project-system/issues/2297
+  --> 
+  <ItemGroup>
+    <ProjectCapability Remove="DependenciesTree"/>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The previous implementation did not actually disable this CPS feature.

This seemed to be a culprit when investigating #20553, though I was not able to produce results as consistent as I like to state this with confidence. However, we should *either* take this PR or an alternate PR that simply removes the line from **Imports.targets**.

See dotnet/project-system#2297
