### PR TITLE
Report when a `void` value is the subject of a pattern-match

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var expression = BindValue(node.Expression, diagnostics, BindValueKind.RValue);
             var hasErrors = IsOperandErrors(node, ref expression, diagnostics);
             var expressionType = expression.Type;
-            if ((object)expressionType == null)
+            if ((object)expressionType == null || expressionType.SpecialType == SpecialType.System_Void)
             {
                 expressionType = CreateErrorType();
                 if (!hasErrors)


### PR DESCRIPTION
**Customer scenario**

If the operand of a pattern-match is a void expression, and the pattern is a wildcard, the compiler produces code that crashes.

**Bugs this fixes:**

Fixes #20452

**Workarounds, if any**

Avoid that pattern of code.

**Risk**

Very low, as the fix is a simple local fix for the scenario.

**Performance impact**

None to tiny.

**Is this a regression from a previous update?**

No. The bug has been present since VS2017 when pattern-matching was introduced.

**Root cause analysis:**

We did not test this scenario.

**How was the bug found?**

Customer reported.

@dotnet/roslyn-compiler May I please have two reviews of this trivial bug fix?