### PR TITLE
Fixed #20437

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -1186,5 +1186,31 @@ options: ExplicitTypeEverywhere());
 }",
 options: ExplicitTypeEverywhere());
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(20437, "https://github.com/dotnet/roslyn/issues/20437")]
+        public async Task SuggestExplicitTypeOnDeclarationExpressionSyntax()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    static void M()
+    {
+        DateTime.TryParse(string.Empty, [|out var|] date);
+    }
+}",
+@"using System;
+
+class C
+{
+    static void M()
+    {
+        DateTime.TryParse(string.Empty, out DateTime date);
+    }
+}",
+options: ExplicitTypeEverywhere());
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1726,5 +1726,31 @@ class Program
     }
 }", options: ImplicitTypeEverywhere());
         }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        [WorkItem(20437, "https://github.com/dotnet/roslyn/issues/20437")]
+        public async Task SuggestVarOnDeclarationExpressionSyntax()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    static void M()
+    {
+        DateTime.TryParse(string.Empty, [|out DateTime|] date);
+    }
+}",
+@"using System;
+
+class C
+{
+    static void M()
+    {
+        DateTime.TryParse(string.Empty, out var date);
+    }
+}",
+options: ImplicitTypeEverywhere());
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
                 if (shouldAnalyze)
                 {
-                    state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: true, cancellationToken: cancellationToken);
+                    state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
                     shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
                 }
             }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
         protected override void InitializeWorker(AnalysisContext context)
             => context.RegisterSyntaxNodeAction(
-                HandleVariableDeclaration, SyntaxKind.VariableDeclaration, SyntaxKind.ForEachStatement);
+                HandleVariableDeclaration, SyntaxKind.VariableDeclaration, SyntaxKind.ForEachStatement, SyntaxKind.Argument);
 
         protected abstract bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken);
         protected abstract bool TryAnalyzeVariableDeclaration(TypeSyntax typeName, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken, out TextSpan issueSpan);
@@ -91,6 +92,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                     shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
                 }
             }
+            else if (declarationStatement.IsKind(SyntaxKind.Argument))
+            {
+                shouldAnalyze = false;
+                declaredType = null;
+
+                if ((declarationStatement as ArgumentSyntax)?.Expression is DeclarationExpressionSyntax declaration)
+                {
+                    declaredType = declaration.Type;
+
+                    shouldAnalyze = ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
+
+                    if (shouldAnalyze)
+                    {
+                        state = State.Generate(declarationStatement, semanticModel, optionSet, isVariableDeclarationContext: false, cancellationToken: cancellationToken);
+                        shouldAnalyze = IsStylePreferred(semanticModel, optionSet, state, cancellationToken);
+                    }
+                }
+            }
             else
             {
                 Debug.Assert(false, $"called in for unregistered node kind {declarationStatement.Kind().ToString()}");
@@ -128,6 +147,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         }
 
         protected virtual bool ShouldAnalyzeForEachStatement(ForEachStatementSyntax forEachStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
+            => true;
+
+        protected virtual bool ShouldAnalyzeDeclarationExpression(DeclarationExpressionSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
             => true;
     }
 }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
@@ -154,7 +154,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             }
 
             // The base analyzer may impose further limitations
-
             return base.ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
         }
     }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
@@ -144,5 +144,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             var initializerTypeInfo = semanticModel.GetTypeInfo(initializer, cancellationToken);
             return !initializerTypeInfo.Type.IsErrorType();
         }
+
+        protected override bool ShouldAnalyzeDeclarationExpression(DeclarationExpressionSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (!declaration.Type.IsVar)
+            {
+                // If the type is not 'var', this analyze has no work to do
+                return false;
+            }
+
+            // The base analyzer may impose further limitations
+
+            return base.ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -197,7 +197,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             }
 
             // The base analyzer may impose further limitations
-
             return base.ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
         }
     }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -124,6 +124,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
                     return true;
                 }
             }
+            else if (typeName.Parent is DeclarationExpressionSyntax declarationExpressionSyntax)
+            {
+                issueSpan = candidateIssueSpan;
+                return true;
+            }
 
             issueSpan = default(TextSpan);
             return false;
@@ -181,6 +186,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             // final check to compare type information on both sides of assignment.
             var initializerType = semanticModel.GetTypeInfo(expression, cancellationToken).Type;
             return declaredType.Equals(initializerType);
+        }
+
+        protected override bool ShouldAnalyzeDeclarationExpression(DeclarationExpressionSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            if (declaration.Type.IsVar)
+            {
+                // If the type is already 'var', this analyze has no work to do
+                return false;
+            }
+
+            // The base analyzer may impose further limitations
+
+            return base.ShouldAnalyzeDeclarationExpression(declaration, semanticModel, cancellationToken);
         }
     }
 }

--- a/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -61,6 +61,10 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
             {
                 typeSyntax = forEach.Type;
             }
+            else if (declarationContext is DeclarationExpressionSyntax declarationExpression)
+            {
+                typeSyntax = declarationExpression.Type;
+            }
             else
             {
                 Contract.Fail($"unhandled kind {declarationContext.Kind().ToString()}");


### PR DESCRIPTION
**Customer scenario**
out var ignores explicit type preference
**Note:** Also fixed ignoring implicit type preference

**Bugs this fixes:**
[#20437](https://github.com/dotnet/roslyn/issues/20437)

**Workarounds, if any**
None

**Risk**
Low

**Performance impact**

**Is this a regression from a previous update?**

**Root cause analysis:**
Analizers don't support new DeclarationExpressionSyntax

**How was the bug found?**
customer reported
