### PR TITLE
More build / SDK cleanup

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -3,17 +3,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Choose>
-    <When Condition="'$(RoslynProjectType)' == 'ExeNonDeployment'">
-      <!-- Some Exes are not designed to be directly runnable.  Typically for size savings in
-           our build output.  They are made runnable by deployment projects that reference
-           them.  -->
-      <PropertyGroup>
-        <_CopyReferences>false</_CopyReferences>
-        <_CopyProjectReferences>false</_CopyProjectReferences>
-        <CopyNuGetImplementations>false</CopyNuGetImplementations>
-        <OutputPath>$(OutputPath)Exes\$(MSBuildProjectName)\</OutputPath>
-      </PropertyGroup>
-    </When>
     <When Condition="'$(RoslynProjectType)' == 'UnitTest'">
       <PropertyGroup>
         <_IsAnyUnitTest>true</_IsAnyUnitTest>
@@ -40,13 +29,6 @@
         <_IsAnyPortableUnitTest>true</_IsAnyPortableUnitTest>
         <CopyNuGetImplementations>false</CopyNuGetImplementations>
         <OutputPath>$(OutputPath)Dlls\$(MSBuildProjectName)\</OutputPath>
-      </PropertyGroup>
-    </When>
-    <When Condition="'$(RoslynProjectType)' == 'CompilerGeneratorTool'">
-      <PropertyGroup>
-        <_CopyReferences>false</_CopyReferences>
-        <CopyNuGetImplementations>false</CopyNuGetImplementations>
-        <OutputPath>$(OutputPath)Exes\</OutputPath>
       </PropertyGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'Vsix'">

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -218,16 +218,6 @@
     </SuggestedBindingRedirects>
   </ItemGroup>
 
-  <!-- 
-       Work around some UI delays in the new project system
-
-       https://github.com/dotnet/project-system/issues/2297
-
-  --> 
-  <ItemGroup>
-    <ProjectCapability Remove="DependenciesTree"/>
-  </ItemGroup>
-
   <Import Project="$(MSBuildTargetsFilePath)" Condition="'$(RoslynSdkProject)' != 'true'" />
   <Import Project="$(RoslynNetSdkRootPath)Sdk.targets" Condition="'$(RoslynSdkProject)' == 'true'" />
 
@@ -339,6 +329,16 @@
   <Import Project="GenerateAssemblyInfo.targets" Condition="'$(ProjectLanguage)' == 'CSharp' OR '$(ProjectLanguage)' == 'VB'" />
   <Import Project="GenerateInternalsVisibleTo.targets" />
   <Import Project="DisableTransitiveReferences.targets" Condition="'$(RoslynProjectType)' == 'Vsix' AND '$(RoslynSdkProject)' == 'true'" />
+
+  <!-- 
+       Work around some UI delays in the new project system
+
+       https://github.com/dotnet/project-system/issues/2297
+
+  --> 
+  <ItemGroup>
+    <ProjectCapability Remove="DependenciesTree"/>
+  </ItemGroup>
 
   <ItemDefinitionGroup>
     <VSIXSourceItem>

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -41,11 +41,6 @@
         <CopyNuGetImplementations>false</CopyNuGetImplementations>
         <OutputPath>$(OutputPath)Dlls\$(MSBuildProjectName)\</OutputPath>
       </PropertyGroup>
-
-      <!-- Add the UnitTestContainer project capability -->
-      <ItemGroup>
-        <ProjectCapability Include="UnitTestContainer" />
-      </ItemGroup>
     </When>
     <When Condition="'$(RoslynProjectType)' == 'CompilerGeneratorTool'">
       <PropertyGroup>
@@ -206,6 +201,11 @@
 
   <ItemGroup Condition="'$(ProjectLanguage)' == 'CSharp' AND '$(TargetNetFX20)' == 'true'">
     <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
+  </ItemGroup>
+
+  <!-- Add the UnitTestContainer project capability -->
+  <ItemGroup Condition="'$(_IsAnyUnitTest)' == 'true'">
+    <ProjectCapability Include="UnitTestContainer" />
   </ItemGroup>
 
   <ItemDefinitionGroup Condition="'$(_CopyReferences)' == 'false'">

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -72,19 +72,6 @@
     </When>
   </Choose>
 
-  <Choose>
-    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable'">
-      <PropertyGroup>
-        <MSBuildTargetsFilePath>$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.$(MSBuildTargetsLanguageName).targets</MSBuildTargetsFilePath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <MSBuildTargetsFilePath>$(MSBuildToolsPath)\Microsoft.$(MSBuildTargetsLanguageName).targets</MSBuildTargetsFilePath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
   <!-- 
     DocumentationFile needs to be set before importing common targets. 
     C# common targets (unlike VB) prefix DocumentationFile path with IntermediateOutputPath.

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -108,6 +108,7 @@
     <GenerateRuntimeConfigurationFiles Condition="'$(TargetFramework)' != 'netcoreapp1.1' AND '$(TargetFramework)' != 'netcoreapp2.0'">false</GenerateRuntimeConfigurationFiles>
 
     <IbcMergePath>$(NuGetPackageRoot)\Microsoft.DotNet.IBCMerge\$(MicrosoftDotNetIBCMerge)\lib\net45\ibcmerge.exe</IbcMergePath>
+    <MSBuildTargetsFilePath>$(MSBuildToolsPath)\Microsoft.$(MSBuildTargetsLanguageName).targets</MSBuildTargetsFilePath>
   </PropertyGroup>
 
   <!-- If the project hasn't configured a ruleset, set a default ruleset. -->
@@ -220,26 +221,6 @@
 
   <Import Project="$(MSBuildTargetsFilePath)" Condition="'$(RoslynSdkProject)' != 'true'" />
   <Import Project="$(RoslynNetSdkRootPath)Sdk.targets" Condition="'$(RoslynSdkProject)' == 'true'" />
-
-  <!-- The portable v5.0 framework is delivered over NuGet, so std resolution should be disabled -->
-  <Import Project="DisableStandardFrameworkResolution.targets"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' AND '$(TargetFrameworkVersion)' == 'v5.0'" />
-
-  <Choose>
-    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' AND '$(TargetFrameworkVersion)' == 'v5.0'">
-
-      <!-- Treat portable exes as CoreClr-targeting-exes -->
-      <PropertyGroup Condition="'$(OutputType)' == 'Exe'">
-        <NuGetTargetMoniker>.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
-        <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win7</BaseNuGetRuntimeIdentifier>
-      </PropertyGroup>
-
-      <!-- Upgrade portable projects to .NETStandard 1.3 -->
-      <PropertyGroup Condition="'$(OutputType)' == 'Library'">
-        <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
-      </PropertyGroup>
-    </When>
-  </Choose>
 
   <!-- It looks like MSBuild has a bug on *nix where they aggressively
        directory separators from '\'to '/', even when the '\'

--- a/build/Targets/Roslyn.Toolsets.Xunit.targets
+++ b/build/Targets/Roslyn.Toolsets.Xunit.targets
@@ -6,12 +6,6 @@
     <XUnitPath>$(NuGetPackageRoot)\xunit.runner.console\$(xunitrunnerconsoleVersion)\tools\xunit.console.x86.exe</XUnitPath>
     <XUnitTestResultsDirectory>$(OutDir)\xUnitResults</XUnitTestResultsDirectory>
     <XUnitArguments>"$(OutDir)\$(AssemblyName).dll" -html "$(XUnitTestResultsDirectory)\$(AssemblyName).html" -noshadow</XUnitArguments>
-
-    <!-- These properties are ignored by CPS projects, which use launchSettings.json instead. -->
-    <StartAction Condition="'$(StartActions)' == ''">Program</StartAction>
-    <StartProgram Condition="'$(StartProgram)' == ''">$(XUnitPath)</StartProgram>
-    <StartArguments Condition="'$(StartArguments)' == ''">$(XUnitArguments)</StartArguments>
-
     <PrepareForBuildDependsOn>$(PrepareForBuildDependsOn);AddDefaultTestAppConfig</PrepareForBuildDependsOn>
   </PropertyGroup>
 

--- a/src/Compilers/Server/PortableServer/PortableServer.csproj
+++ b/src/Compilers/Server/PortableServer/PortableServer.csproj
@@ -18,7 +18,6 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;osx.10.10-x64</RuntimeIdentifiers>
     <NoStdLib>true</NoStdLib>
-    <RoslynProjectType>ExeNonDeployment</RoslynProjectType>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Core\Portable\CodeAnalysis.csproj">

--- a/src/Tools/BuildBoss/.gitignore
+++ b/src/Tools/BuildBoss/.gitignore
@@ -1,0 +1,1 @@
+launchSettings.json

--- a/src/Tools/BuildBoss/RoslynProjectData.cs
+++ b/src/Tools/BuildBoss/RoslynProjectData.cs
@@ -30,8 +30,6 @@ namespace BuildBoss
         {
             switch (value)
             {
-                case "ExeNonDeployment":
-                    return RoslynProjectKind.ExeNonDeployment;
                 case "UnitTestPortable":
                     return RoslynProjectKind.UnitTestPortable;
                 case "UnitTestDesktop":


### PR DESCRIPTION
Summary:

- UnitTestContainer capability
- Remove the ExeNonDeployment idea
- Remove dead MSBuild code 
- Properly disable the Dependencies node