### PR TITLE
Fix options page

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPane.xaml.cs
@@ -7,11 +7,12 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Navigation;
-using EnvDTE;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Editor.Implementation.Preview;
+using IVsUIShell = Microsoft.VisualStudio.Shell.Interop.IVsUIShell;
+using OLECMDEXECOPT = Microsoft.VisualStudio.OLE.Interop.OLECMDEXECOPT;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 {
@@ -24,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 
         private readonly string _id;
         private readonly bool _logIdVerbatimInTelemetry;
-        private readonly DTE _dte;
+        private readonly IVsUIShell _uiShell;
 
         private bool _isExpanded;
         private double _heightForThreeLineTitle;
@@ -39,14 +40,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
             string helpLinkToolTipText,
             IReadOnlyList<object> previewContent,
             bool logIdVerbatimInTelemetry,
-            DTE dte,
+            IVsUIShell uiShell,
             Guid optionPageGuid = default(Guid))
         {
             InitializeComponent();
 
             _id = id;
             _logIdVerbatimInTelemetry = logIdVerbatimInTelemetry;
-            _dte = dte;
+            _uiShell = uiShell;
 
             // Initialize header portion.
             if ((severityIcon != null) && !string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(title))
@@ -358,7 +359,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
         {
             if (_optionPageGuid != default(Guid))
             {
-                _dte.ExecuteCommand("Tools.Options", _optionPageGuid.ToString());
+                ErrorHandler.ThrowOnFailure(_uiShell.PostExecCommand(
+                    VSConstants.GUID_VSStandardCommandSet97,
+                    (uint)VSConstants.VSStd97CmdID.ToolsOptions,
+                    (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT,
+                    _optionPageGuid.ToString()));
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/PreviewPane/PreviewPaneService.cs
@@ -18,18 +18,20 @@ using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Shell;
+using IVsUIShell = Microsoft.VisualStudio.Shell.Interop.IVsUIShell;
+using SVsUIShell = Microsoft.VisualStudio.Shell.Interop.SVsUIShell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 {
     [ExportWorkspaceServiceFactory(typeof(IPreviewPaneService), ServiceLayer.Host), Shared]
     internal class PreviewPaneService : ForegroundThreadAffinitizedObject, IPreviewPaneService, IWorkspaceServiceFactory
     {
-        private readonly EnvDTE.DTE _dte;
+        private readonly IVsUIShell _uiShell;
 
         [ImportingConstructor]
         public PreviewPaneService(SVsServiceProvider serviceProvider)
         {
-            _dte = serviceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
+            _uiShell = serviceProvider.GetService(typeof(SVsUIShell)) as IVsUIShell;
         }
 
         IWorkspaceService IWorkspaceServiceFactory.CreateService(HostWorkspaceServices workspaceServices)
@@ -107,7 +109,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
 
                 return new PreviewPane(
                     severityIcon: null, id: null, title: null, description: null, helpLink: null, helpLinkToolTipText: null,
-                    previewContent: previewContent, logIdVerbatimInTelemetry: false, dte: _dte);
+                    previewContent: previewContent, logIdVerbatimInTelemetry: false, uiShell: _uiShell);
             }
 
             var helpLinkToolTipText = string.Empty;
@@ -128,7 +130,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PreviewPane
                 helpLinkToolTipText: helpLinkToolTipText,
                 previewContent: previewContent,
                 logIdVerbatimInTelemetry: diagnostic.CustomTags.Contains(WellKnownDiagnosticTags.Telemetry),
-                dte: _dte,
+                uiShell: _uiShell,
                 optionPageGuid: optionPageGuid);
         }
 


### PR DESCRIPTION
**Customer scenario**

A customer sees a suggestion regarding a naming violation, and uses the light bulb option to Change Naming Style Options. Visual Studio crashes.

**Bugs this fixes:**

https://developercommunity.visualstudio.com/content/problem/25989/crash-when-clicking-change-style-options-on-fix-na.html
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/392353 (Microsoft-internal duplicate of the previous link)
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/395454 (Microsoft-internal link, but just the automated crash report from the public link above)

**Workarounds, if any**

Open the Tools &rarr; Options... page via the menu and manually navigate to the correct page.

**Risk**

Low. This is the pattern [NuGet uses](https://github.com/NuGet/NuGet.Client/blob/f9fa6b3ab4e485a4cac9e88215c59d0c4b0a8ba6/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/OptionsPageActivator.cs#L73-L79) for opening their options page.

**Performance impact**

Improved performance, but on a path where it doesn't make a difference.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Negative interaction with a Visual Studio extension can cause this, e.g. what was seen in laurentkempe/GitDiffMargin#104. This bug is very difficult to reproduce without seeing an instance of it before, but when it happens it's very frustrating.

**How was the bug found?**

Customer reported.
