### PR TITLE
Fixed Incorrect IDE0004 (Cast is redundant) when negating enum value

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3972,9 +3972,9 @@ class Program
 
         [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveCastOnNegatingEnumValue()
+        public async Task DontRemoveCastOnNegatingEnumValue1()
         {
-            await TestInRegularAndScriptAsync(
+            await TestMissingInRegularAndScriptAsync(
 @"
 enum Sign
     {
@@ -3987,9 +3987,16 @@ enum Sign
         void Foo()
         {
             Sign mySign = Sign.Positive;
-            Sign invertedSign = (Sign) ( |-(int) mySign| );
+            Sign invertedSign = (Sign) ( [|-(int) mySign|] );
         }
-    }",
+    }");
+        }
+
+        [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveCastOnNegatingEnumValue2()
+        {
+            await TestMissingInRegularAndScriptAsync(
 @"
 enum Sign
     {
@@ -4002,7 +4009,7 @@ enum Sign
         void Foo()
         {
             Sign mySign = Sign.Positive;
-            Sign invertedSign = (Sign) ( -(int) mySign );
+            Sign invertedSign = (Sign) ( [|+(int) mySign|] );
         }
     }");
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3969,5 +3969,42 @@ class Program
     }
 }");
         }
+
+        [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveCastOnNegatingEnumValue()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+enum Sign
+    {
+        Positive = 1,
+        Negative = -1
+    }
+
+    class T
+    {
+        void Foo()
+        {
+            Sign mySign = Sign.Positive;
+            Sign invertedSign = (Sign) ( |-(int) mySign| );
+        }
+    }",
+@"
+enum Sign
+    {
+        Positive = 1,
+        Negative = -1
+    }
+
+    class T
+    {
+        void Foo()
+        {
+            Sign mySign = Sign.Positive;
+            Sign invertedSign = (Sign) ( -(int) mySign );
+        }
+    }");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -4013,5 +4013,49 @@ enum Sign
         }
     }");
         }
+
+        [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveCastOnNegatingEnumValue3()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+enum Sign
+    {
+        Positive = 1,
+        Negative = -1
+    }
+
+    class T
+    {
+        void Foo()
+        {
+            Sign mySign = Sign.Positive;
+            Sign invertedSign = (Sign) ( [|-((int) mySign)|] );
+        }
+    }");
+        }
+
+        [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveCastOnNegatingEnumValue4()
+        {
+            await TestMissingInRegularAndScriptAsync(
+@"
+enum Sign
+    {
+        Positive = 1,
+        Negative = -1
+    }
+
+    class T
+    {
+        void Foo()
+        {
+            Sign mySign = Sign.Positive;
+            Sign invertedSign = (Sign) ( [|+((int) mySign)|] );
+        }
+    }");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3971,32 +3971,58 @@ class Program
         }
 
         [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveCastOnNegatingEnumValue1()
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [InlineData("-")]
+        [InlineData("+")]
+        public async Task DontRemoveCastOnInvalidUnaryOperatorEnumValue1(string op)
         {
             await TestMissingInRegularAndScriptAsync(
-@"
+$@"
 enum Sign
-    {
+    {{
         Positive = 1,
         Negative = -1
-    }
+    }}
 
     class T
-    {
+    {{
         void Foo()
-        {
+        {{
             Sign mySign = Sign.Positive;
-            Sign invertedSign = (Sign) ( [|-(int) mySign|] );
+            Sign invertedSign = (Sign) ( [|{op}((int) mySign)|] );
+        }}
+    }}");
         }
-    }");
+
+        [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        [InlineData("-")]
+        [InlineData("+")]
+        public async Task DontRemoveCastOnInvalidUnaryOperatorEnumValue2(string op)
+        {
+            await TestMissingInRegularAndScriptAsync(
+$@"
+enum Sign
+    {{
+        Positive = 1,
+        Negative = -1
+    }}
+
+    class T
+    {{
+        void Foo()
+        {{
+            Sign mySign = Sign.Positive;
+            Sign invertedSign = (Sign) ( [|{op}(int) mySign|] );
+        }}
+    }}");
         }
 
         [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveCastOnNegatingEnumValue2()
+        public async Task RemoveCastOnValidUnaryOperatorEnumValue()
         {
-            await TestMissingInRegularAndScriptAsync(
+            await TestInRegularAndScriptAsync(
 @"
 enum Sign
     {
@@ -4009,16 +4035,9 @@ enum Sign
         void Foo()
         {
             Sign mySign = Sign.Positive;
-            Sign invertedSign = (Sign) ( [|+(int) mySign|] );
+            Sign invertedSign = (Sign) ( [|~(int) mySign|] );
         }
-    }");
-        }
-
-        [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveCastOnNegatingEnumValue3()
-        {
-            await TestMissingInRegularAndScriptAsync(
+    }",
 @"
 enum Sign
     {
@@ -4031,29 +4050,7 @@ enum Sign
         void Foo()
         {
             Sign mySign = Sign.Positive;
-            Sign invertedSign = (Sign) ( [|-((int) mySign)|] );
-        }
-    }");
-        }
-
-        [WorkItem(18510, "https://github.com/dotnet/roslyn/issues/18510")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
-        public async Task DontRemoveCastOnNegatingEnumValue4()
-        {
-            await TestMissingInRegularAndScriptAsync(
-@"
-enum Sign
-    {
-        Positive = 1,
-        Negative = -1
-    }
-
-    class T
-    {
-        void Foo()
-        {
-            Sign mySign = Sign.Positive;
-            Sign invertedSign = (Sign) ( [|+((int) mySign)|] );
+            Sign invertedSign = (Sign) ( ~mySign );
         }
     }");
         }

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -312,10 +312,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var expressionTypeInfo = semanticModel.GetTypeInfo(cast.Expression, cancellationToken);
             var expressionType = expressionTypeInfo.Type;
 
-            if (expressionType != null &&
-                expressionType.IsEnumType() 
-                && cast?.Parent is PrefixUnaryExpressionSyntax prefixUnaryExpression 
-                && prefixUnaryExpression.Kind() == SyntaxKind.UnaryMinusE xpression)
+            if (expressionType != null 
+                && expressionType.IsEnumType() 
+                && (cast.IsParentKind(SyntaxKind.UnaryMinusExpression) || cast.IsParentKind(SyntaxKind.UnaryPlusExpression)))
             {
                 return false;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             if (expressionType != null 
                 && expressionType.IsEnumType() 
-                && (cast.IsParentKind(SyntaxKind.UnaryMinusExpression) || cast.IsParentKind(SyntaxKind.UnaryPlusExpression)))
+                && (cast.WalkUpParentheses().IsParentKind(SyntaxKind.UnaryMinusExpression) || cast.WalkUpParentheses().IsParentKind(SyntaxKind.UnaryPlusExpression)))
             {
                 return false;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -312,6 +312,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var expressionTypeInfo = semanticModel.GetTypeInfo(cast.Expression, cancellationToken);
             var expressionType = expressionTypeInfo.Type;
 
+            if (expressionType != null &&
+                expressionType.IsEnumType() 
+                && cast?.Parent is PrefixUnaryExpressionSyntax prefixUnaryExpression 
+                && prefixUnaryExpression.Kind() == SyntaxKind.UnaryMinusE xpression)
+            {
+                return false;
+            }
+
             // We do not remove any cast on 
             // 1. Dynamic Expressions
             // 2. If there is any other argument which is dynamic

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -213,6 +213,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return false;
         }
 
+        private static bool EnumCastDefinitelyCantBeRemoved(CastExpressionSyntax cast, ITypeSymbol expressionType)
+        {
+            if (expressionType != null 
+                && expressionType.IsEnumType() 
+                && cast.WalkUpParentheses().IsParentKind(SyntaxKind.UnaryMinusExpression, SyntaxKind.UnaryPlusExpression))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         private static bool HaveSameUserDefinedConversion(Conversion conversion1, Conversion conversion2)
         {
             return conversion1.IsUserDefined
@@ -312,9 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var expressionTypeInfo = semanticModel.GetTypeInfo(cast.Expression, cancellationToken);
             var expressionType = expressionTypeInfo.Type;
 
-            if (expressionType != null 
-                && expressionType.IsEnumType() 
-                && (cast.WalkUpParentheses().IsParentKind(SyntaxKind.UnaryMinusExpression) || cast.WalkUpParentheses().IsParentKind(SyntaxKind.UnaryPlusExpression)))
+            if (EnumCastDefinitelyCantBeRemoved(cast, expressionType))
             {
                 return false;
             }


### PR DESCRIPTION
**Customer scenario**
Incorrect IDE0004 (Cast is redundant) when negating enum value

**Bugs this fixes:**

Fixes #18510

**Workarounds, if any**
None

**Risk**
Low

**Performance impact**

**Is this a regression from a previous update?**
Also repro in VS2015

**Root cause analysis:**
Not implemented check for negating enum value in CSharpRemoveUnnecessaryCastDiagnosticAnalyzer

**How was the bug found?**
customer reported
