### PR TITLE
IDE fixes for non-trailing named arguments

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -194,6 +194,23 @@ class Program
         }
 
         [Fact]
+        public async Task UpgradeProjectWithNonTrailingNamedArgumentToCSharp7_2()
+        {
+            await TestLanguageVersionUpgradedAsync(
+@"
+class Program
+{
+    void M()
+    {
+        [|M2(a: 1, 2);|]
+    }
+}",
+                LanguageVersion.CSharp7_2,
+                new CSharpParseOptions(LanguageVersion.CSharp7_1),
+                index: 1);
+        }
+
+        [Fact]
         public async Task UpgradeProjectFromCSharp7ToCSharp7_1_B()
         {
             await TestLanguageVersionUpgradedAsync(

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -574,6 +574,28 @@ class C
             End Using
         End Function
 
+        <WpfFact>
+        Public Async Function TestNonTrailingNamedArgument() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void M(int a, int bar, int c)
+    {
+        int better = 2;
+        M(a: 1, $$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("b")
+                Await state.AssertSelectedCompletionItem(displayText:="bar", isHardSelected:=True)
+                state.SendTypeChars("e")
+                Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
+                state.SendTypeChars(", ")
+                Assert.Contains("M(a: 1, better,", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestSymbolInTupleLiteral() As Task

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -575,21 +575,55 @@ class C
         End Function
 
         <WpfFact>
-        Public Async Function TestNonTrailingNamedArgument() As Task
-            Using state = TestState.CreateCSharpTestState(
-                  <Document><![CDATA[
+        Public Async Function TestNonTrailingNamedArgumentInCSharp7_1() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                 <Workspace>
+                     <Project Language="C#" LanguageVersion="7.1" CommonReferences="true" AssemblyName="CSProj">
+                         <Document FilePath="C.cs">
 class C
 {
-    public void M(int a, int bar, int c)
+    public void M()
     {
         int better = 2;
         M(a: 1, $$)
     }
-}]]></Document>)
+    public void M(int a, int bar, int c) { }
+}
+                         </Document>
+                     </Project>
+                 </Workspace>)
 
                 state.SendTypeChars("b")
-                Await state.AssertSelectedCompletionItem(displayText:="bar", isHardSelected:=True)
+                Await state.AssertSelectedCompletionItem(displayText:="bar:", isHardSelected:=True)
                 state.SendTypeChars("e")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:", isSoftSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function TestNonTrailingNamedArgumentInCSharp7_2() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                 <Workspace>
+                     <Project Language="C#" LanguageVersion="7.2" CommonReferences="true" AssemblyName="CSProj">
+                         <Document FilePath="C.cs">
+class C
+{
+    public void M()
+    {
+        int better = 2;
+        M(a: 1, $$)
+    }
+    public void M(int a, int bar, int c) { }
+}
+                         </Document>
+                     </Project>
+                 </Workspace>)
+
+                state.SendTypeChars("b")
+                Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:", isHardSelected:=True)
+                state.SendBackspace()
                 Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
                 state.SendTypeChars(", ")
                 Assert.Contains("M(a: 1, better,", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -578,7 +578,7 @@ class C
         Public Async Function TestNonTrailingNamedArgumentInCSharp7_1() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                  <Workspace>
-                     <Project Language="C#" LanguageVersion="7.1" CommonReferences="true" AssemblyName="CSProj">
+                     <Project Language="C#" LanguageVersion="CSharp7_1" CommonReferences="true" AssemblyName="CSProj">
                          <Document FilePath="C.cs">
 class C
 {
@@ -604,7 +604,7 @@ class C
         Public Async Function TestNonTrailingNamedArgumentInCSharp7_2() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                  <Workspace>
-                     <Project Language="C#" LanguageVersion="7.2" CommonReferences="true" AssemblyName="CSProj">
+                     <Project Language="C#" LanguageVersion="CSharp7_2" CommonReferences="true" AssemblyName="CSProj">
                          <Document FilePath="C.cs">
 class C
 {

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2528,7 +2528,7 @@ Anonymous Types:
         Public Async Function TestNonTrailingNamedArgumentInVB15_3() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                  <Workspace>
-                     <Project Language="Visual Basic" LanguageVersion="15.3" CommonReferences="true" AssemblyName="VBProj">
+                     <Project Language="Visual Basic" LanguageVersion="VisualBasic15_3" CommonReferences="true" AssemblyName="VBProj">
                          <Document FilePath="C.vb">
 Class C
     Sub M()
@@ -2553,7 +2553,7 @@ End Class
         Public Async Function TestNonTrailingNamedArgumentInVB15_5() As Task
             Using state = TestState.CreateTestStateFromWorkspace(
                  <Workspace>
-                     <Project Language="Visual Basic" LanguageVersion="15.5" CommonReferences="true" AssemblyName="VBProj">
+                     <Project Language="Visual Basic" LanguageVersion="VisualBasic15_5" CommonReferences="true" AssemblyName="VBProj">
                          <Document FilePath="C.vb">
 Class C
     Sub M()

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2545,7 +2545,7 @@ End Class
                 state.SendTypeChars("b")
                 Await state.AssertSelectedCompletionItem(displayText:="bar:=", isHardSelected:=True)
                 state.SendTypeChars("e")
-                Await state.AssertSelectedCompletionItem(displayText:="bar:=", isSoftSelected:=True)
+                Await state.AssertNoCompletionSession()
             End Using
         End Function
 
@@ -2560,21 +2560,21 @@ Class C
         Dim better As Integer = 2
         M(a:=1, $$)
     End Sub
-    Sub M(int a, int bar, int c)
+    Sub M(a As Integer, bar As Integer, c As Integer)
     End Sub
 End Class
                          </Document>
                      </Project>
                  </Workspace>)
 
-                state.SendTypeChars("b")
-                Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
-                state.SendTypeChars("a")
-                Await state.AssertSelectedCompletionItem(displayText:="bar:", isHardSelected:=True)
+                state.SendTypeChars("bar")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:=", isHardSelected:=True)
                 state.SendBackspace()
+                state.SendBackspace()
+                state.SendTypeChars("et")
                 Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
                 state.SendTypeChars(", ")
-                Assert.Contains("M(a: 1, better,", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+                Assert.Contains("M(a:=1, better,", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2524,6 +2524,60 @@ Anonymous Types:
             End Using
         End Function
 
+        <WpfFact>
+        Public Async Function TestNonTrailingNamedArgumentInVB15_3() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                 <Workspace>
+                     <Project Language="Visual Basic" LanguageVersion="15.3" CommonReferences="true" AssemblyName="VBProj">
+                         <Document FilePath="C.vb">
+Class C
+    Sub M()
+        Dim better As Integer = 2
+        M(a:=1, $$)
+    End Sub
+    Sub M(a As Integer, bar As Integer, c As Integer)
+    End Sub
+End Class
+                         </Document>
+                     </Project>
+                 </Workspace>)
+
+                state.SendTypeChars("b")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:=", isHardSelected:=True)
+                state.SendTypeChars("e")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:=", isSoftSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function TestNonTrailingNamedArgumentInVB15_5() As Task
+            Using state = TestState.CreateTestStateFromWorkspace(
+                 <Workspace>
+                     <Project Language="Visual Basic" LanguageVersion="15.5" CommonReferences="true" AssemblyName="VBProj">
+                         <Document FilePath="C.vb">
+Class C
+    Sub M()
+        Dim better As Integer = 2
+        M(a:=1, $$)
+    End Sub
+    Sub M(int a, int bar, int c)
+    End Sub
+End Class
+                         </Document>
+                     </Project>
+                 </Workspace>)
+
+                state.SendTypeChars("b")
+                Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
+                state.SendTypeChars("a")
+                Await state.AssertSelectedCompletionItem(displayText:="bar:", isHardSelected:=True)
+                state.SendBackspace()
+                Await state.AssertSelectedCompletionItem(displayText:="better", isHardSelected:=True)
+                state.SendTypeChars(", ")
+                Assert.Contains("M(a: 1, better,", state.GetLineTextFromCaretPosition(), StringComparison.Ordinal)
+            End Using
+        End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestSymbolInTupleLiteral() As Task
             Using state = TestState.CreateVisualBasicTestState(

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -390,15 +390,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             if (language == LanguageNames.CSharp)
             {
-                var found = CodeAnalysis.CSharp.LanguageVersionFacts.TryParse(languageVersionAttribute.Value, out var languageVersion);
-                Assert.True(found, $"'{languageVersionAttribute.Value}' is not a valid C# language version");
+                var languageVersion = (CodeAnalysis.CSharp.LanguageVersion)Enum.Parse(typeof(CodeAnalysis.CSharp.LanguageVersion), languageVersionAttribute.Value);
                 parseOptions = ((CSharpParseOptions)parseOptions).WithLanguageVersion(languageVersion);
             }
             else if (language == LanguageNames.VisualBasic)
             {
-                var languageVersion = CodeAnalysis.VisualBasic.LanguageVersion.Default;
-                var found = CodeAnalysis.VisualBasic.LanguageVersionFacts.TryParse(languageVersionAttribute.Value, ref languageVersion);
-                Assert.True(found, $"'{languageVersionAttribute.Value}' is not a valid VB language version");
+                var languageVersion = (CodeAnalysis.VisualBasic.LanguageVersion)Enum.Parse(typeof(CodeAnalysis.VisualBasic.LanguageVersion), languageVersionAttribute.Value);
                 parseOptions = ((VisualBasicParseOptions)parseOptions).WithLanguageVersion(languageVersion);
             }
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -390,12 +390,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             if (language == LanguageNames.CSharp)
             {
-                var languageVersion = (CodeAnalysis.CSharp.LanguageVersion)Enum.Parse(typeof(CodeAnalysis.CSharp.LanguageVersion), languageVersionAttribute.Value);
+                var found = CodeAnalysis.CSharp.LanguageVersionFacts.TryParse(languageVersionAttribute.Value, out var languageVersion);
+                Assert.True(found, $"'{languageVersionAttribute.Value}' is not a valid C# language version");
                 parseOptions = ((CSharpParseOptions)parseOptions).WithLanguageVersion(languageVersion);
             }
             else if (language == LanguageNames.VisualBasic)
             {
-                var languageVersion = (CodeAnalysis.VisualBasic.LanguageVersion)Enum.Parse(typeof(CodeAnalysis.VisualBasic.LanguageVersion), languageVersionAttribute.Value);
+                var languageVersion = CodeAnalysis.VisualBasic.LanguageVersion.Default;
+                var found = CodeAnalysis.VisualBasic.LanguageVersionFacts.TryParse(languageVersionAttribute.Value, ref languageVersion);
+                Assert.True(found, $"'{languageVersionAttribute.Value}' is not a valid VB language version");
                 parseOptions = ((VisualBasicParseOptions)parseOptions).WithLanguageVersion(languageVersion);
             }
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -79,11 +79,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return;
             }
 
-            if (token.IsMandatoryNamedParameterPosition())
-            {
-                context.IsExclusive = true;
-            }
-
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             var workspace = document.Project.Solution.Workspace;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -79,6 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return;
             }
 
+            // Consider refining this logic to mandate completion with an argument name, if preceded by an out-of-position name
+            // See https://github.com/dotnet/roslyn/issues/20657
             var languageVersion = ((CSharpParseOptions)document.Project.ParseOptions).LanguageVersion;
             if (languageVersion < LanguageVersion.CSharp7_2 && token.IsMandatoryNamedParameterPosition())
             {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -79,6 +79,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return;
             }
 
+            var languageVersion = ((CSharpParseOptions)document.Project.ParseOptions).LanguageVersion;
+            if (languageVersion < LanguageVersion.CSharp7_2 && token.IsMandatoryNamedParameterPosition())
+            {
+                context.IsExclusive = true;
+            }
+
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             var workspace = document.Project.Solution.Workspace;

--- a/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UpgradeProject/CSharpUpgradeProjectCodeFixProvider.cs
@@ -28,9 +28,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UpgradeProject
         private const string CS8306 = nameof(CS8306); // error CS8306: ... Please use language version 7.1 or greater to access a un-named element by its inferred name.
         private const string CS8314 = nameof(CS8314); // error CS9003: An expression of type '{0}' cannot be handled by a pattern of type '{1}' in C# {2}. Please use language version {3} or greater.
         private const string CS8320 = nameof(CS8320); // error CS8320: Feature is not available in C# 7.2. Please use language version X or greater.
+        private const string CS1738 = nameof(CS1738); // error CS1738: Named argument specifications must appear after all fixed arguments have been specified. Please use language version 7.2 or greater to allow non-trailing named arguments.
 
         public override ImmutableArray<string> FixableDiagnosticIds { get; } =
-            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302, CS8306, CS8314, CS8320);
+            ImmutableArray.Create(CS8022, CS8023, CS8024, CS8025, CS8026, CS8059, CS8107, CS8302, CS8306, CS8314, CS8320, CS1738);
 
         public override string UpgradeThisProjectResource => CSharpFeaturesResources.Upgrade_this_project_to_csharp_language_version_0;
         public override string UpgradeAllProjectsResource => CSharpFeaturesResources.Upgrade_all_csharp_projects_to_language_version_0;

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
@@ -43,14 +43,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             End If
 
             If token.Kind = SyntaxKind.CommaToken Then
+                ' Consider refining this logic to mandate completion with an argument name, if preceded by an out-of-position name
+                ' See https://github.com/dotnet/roslyn/issues/20657
                 Dim languageVersion = DirectCast(document.Project.ParseOptions, VisualBasicParseOptions).LanguageVersion
-                If languageVersion < LanguageVersion.VisualBasic15_5 Then
-                    For Each n In argumentList.Arguments.GetWithSeparators()
-                        If n.IsNode AndAlso DirectCast(n.AsNode(), ArgumentSyntax).IsNamed Then
-                            context.IsExclusive = True
-                            Exit For
-                        End If
-                    Next
+                If languageVersion < LanguageVersion.VisualBasic15_5 AndAlso token.IsMandatoryNamedParameterPosition() Then
+                    context.IsExclusive = True
                 End If
             End If
 

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.vb
@@ -43,12 +43,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             End If
 
             If token.Kind = SyntaxKind.CommaToken Then
-                For Each n In argumentList.Arguments.GetWithSeparators()
-                    If n.IsNode AndAlso DirectCast(n.AsNode(), ArgumentSyntax).IsNamed Then
-                        context.IsExclusive = True
-                        Exit For
-                    End If
-                Next
+                Dim languageVersion = DirectCast(document.Project.ParseOptions, VisualBasicParseOptions).LanguageVersion
+                If languageVersion < LanguageVersion.VisualBasic15_5 Then
+                    For Each n In argumentList.Arguments.GetWithSeparators()
+                        If n.IsNode AndAlso DirectCast(n.AsNode(), ArgumentSyntax).IsNamed Then
+                            context.IsExclusive = True
+                            Exit For
+                        End If
+                    Next
+                End If
             End If
 
             Dim semanticModel = Await document.GetSemanticModelForNodeAsync(argumentList, cancellationToken).ConfigureAwait(False)

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.vb
@@ -120,6 +120,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                    token.HasNonContinuableEndOfLineBeforePosition(position, checkForSecondEol:=True)
         End Function
 
+        <Extension>
+        Friend Function IsMandatoryNamedParameterPosition(token As SyntaxToken) As Boolean
+            If token.Kind() = SyntaxKind.CommaToken Then
+                Dim argumentList = TryCast(token.Parent, ArgumentListSyntax)
+                If argumentList Is Nothing Then
+                    Return False
+                End If
+
+                For Each n In argumentList.Arguments.GetWithSeparators()
+                    If n.IsToken AndAlso n.AsToken() = token Then
+                        Return False
+                    End If
+
+                    If n.IsNode AndAlso DirectCast(n.AsNode(), ArgumentSyntax).IsNamed Then
+                        Return True
+                    End If
+                Next
+            End If
+
+            Return False
+        End Function
+
         <Extension()>
         Friend Function IsModifier(token As SyntaxToken) As Boolean
             Select Case token.Kind


### PR DESCRIPTION
Two fixes:
- if you use non-trailing named arguments in C# 7.1 or older, the UpgradeProject code fixer should trigger and offer to upgrade your project to C# 7.2.
- when you type arguments in an invocation, parameter names are no longer the exclusive completion that is offered.

Two subtleties that I did not try to implement (let me know if I should):
~~- the completion scenario does not check what language version you're using.~~
- it also does not check whether the previous named arguments in your invocation had any out-of-position names (technically, names are mandated after any out-of-position argument name).

@CyrusNajmabadi @DustinCampbell @dotnet/roslyn-ide for review. Thanks