### PR TITLE
Improve Extract Method exception message

### DIFF
--- a/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
+++ b/src/Features/Core/Portable/ExtractMethod/ExtractMethodMatrix.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 }
             }
 
-            Contract.ThrowIfFalse(s_matrix.ContainsKey(key));
+            Contract.ThrowIfFalse(s_matrix.ContainsKey(key), $"Matrix does not contain Key '{key}'.");
 
             return s_matrix[key];
         }
@@ -231,6 +231,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
                 return hashCode;
             }
+
+            public override string ToString() => GetHashCode().ToString("X");
         }
     }
 }


### PR DESCRIPTION
Related to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/459425.

Extract Method maintains a table mapping various properties of a
variable (e.g. if it is captured, declared, assigned, etc.) to a "style"
controlling how that variable will look in the generated code. There
are 256 (2^8) possible combinations of these various properties, but the
table currently only maps 69 of them to a particular style. Presumably
we believe the unmapped combinations shouldn't/can't occur; however, we
have error data indicating otherwise.

This change updates the exception thrown when the table does not contain
a particular combination to include the properties. Since `Key.GetHashCode()`
already encodes the values into the hash code in a lossless way, we simply
reuse that.