### PR TITLE
Add exception message to CSharpCompilation.GetSpecialType

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1253,7 +1253,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (specialType <= SpecialType.None || specialType > SpecialType.Count)
             {
-                throw new ArgumentOutOfRangeException(nameof(specialType));
+                throw new ArgumentOutOfRangeException(nameof(specialType), $"Unexpected SpecialType: '{(int)specialType}'.");
             }
 
             var result = Assembly.GetSpecialType(specialType);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -5848,5 +5848,51 @@ class C
             Assert.Null(model.GetSymbolInfo(expr).Symbol);
             Assert.Equal(SpecialType.System_Boolean, model.GetTypeInfo(expr).Type.SpecialType);
         }
+
+        [Fact]
+        public void GetSpecialType_ThrowsOnLessThanZero()
+        {
+            var source = "class C1 { }";
+            var comp = CreateStandardCompilation(source);
+
+            var specialType = (SpecialType)(-1);
+
+            var exceptionThrown = false;
+
+            try
+            {
+                comp.GetSpecialType(specialType);
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                exceptionThrown = true;
+                Assert.StartsWith(expectedStartString: $"Unexpected SpecialType: '{(int)specialType}'.", actualString: e.Message);
+            }
+
+            Assert.True(exceptionThrown, $"{nameof(comp.GetSpecialType)} did not throw when it should have.");
+        }
+
+        [Fact]
+        public void GetSpecialType_ThrowsOnGreaterThanCount()
+        {
+            var source = "class C1 { }";
+            var comp = CreateStandardCompilation(source);
+
+            var specialType = SpecialType.Count + 1;
+
+            var exceptionThrown = false;
+
+            try
+            {
+                comp.GetSpecialType(specialType);
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                exceptionThrown = true;
+                Assert.StartsWith(expectedStartString: $"Unexpected SpecialType: '{(int)specialType}'.", actualString: e.Message);
+            }
+
+            Assert.True(exceptionThrown, $"{nameof(comp.GetSpecialType)} did not throw when it should have.");
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AssemblySymbol.vb
@@ -387,7 +387,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <remarks></remarks>
         Friend Function GetSpecialType(type As SpecialType) As NamedTypeSymbol
             If type <= SpecialType.None OrElse type > SpecialType.Count Then
-                Throw New ArgumentOutOfRangeException()
+                Throw New ArgumentOutOfRangeException(NameOf(type), $"Unexpected SpecialType: '{CType(type, Integer)}'.")
             End If
 
             Return CorLibrary.GetDeclaredSpecialType(type)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetSemanticInfoTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/GetSemanticInfoTests.vb
@@ -6353,5 +6353,54 @@ BC30383: 'End Try' must be preceded by a matching 'Try'.
             Assert.Equal(SpecialType.System_Boolean, model.GetTypeInfo(expr).Type.SpecialType)
         End Sub
 
+        <Fact()>
+        Public Sub GetSpecialType_ThrowsOnLessThanZero()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            <compilation>
+                <file name="a.vb">
+Class C1
+End Class
+                </file>
+            </compilation>)
+
+            Dim type = CType(SpecialType.None - 1, SpecialType)
+
+            Dim exceptionThrown = False
+
+            Try
+                compilation.GetSpecialType(type)
+            Catch ex As ArgumentOutOfRangeException
+                exceptionThrown = True
+
+                Assert.StartsWith(expectedStartString:=$"Unexpected SpecialType: '{SpecialType.None - 1}'.", actualString:=ex.Message)
+            End Try
+
+            Assert.True(exceptionThrown, $"{NameOf(GetSpecialType)} did not throw when it should have.")
+        End Sub
+
+        <Fact()>
+        Public Sub GetSpecialType_ThrowsOnGreaterThanCount()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+            <compilation>
+                <file name="a.vb">
+Class C1
+End Class
+                </file>
+            </compilation>)
+
+            Dim type = CType(SpecialType.Count + 1, SpecialType)
+
+            Dim exceptionThrown = False
+
+            Try
+                compilation.GetSpecialType(type)
+            Catch ex As ArgumentOutOfRangeException
+                exceptionThrown = True
+
+                Assert.StartsWith(expectedStartString:=$"Unexpected SpecialType: '{SpecialType.Count + 1}'.", actualString:=ex.Message)
+            End Try
+
+            Assert.True(exceptionThrown, $"{NameOf(GetSpecialType)} did not throw when it should have.")
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Related to https://devdiv.visualstudio.com/DevDiv/_workitems/edit/459418.

Our non-fatal error reports indicate this method is often called with
an out-of-range value for the `specialType` parameter. This commit adds
a custom message to the resulting `ArgumentOutOfRangeException` so we
can see what we're being asked about.