### PR TITLE
Fixed completion list for explicit interface implementation

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
@@ -100,6 +100,7 @@ class Bar : IFoo
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(19947, "https://github.com/dotnet/roslyn/issues/19947")]
         public async Task ExplicitInterfaceMemberCompletionContainsOnlyValidValues()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProviderTests.cs
@@ -98,5 +98,35 @@ class Bar : IFoo
 
             await VerifyProviderCommitAsync(markup, "Foo()", expected, '(', "");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task ExplicitInterfaceMemberCompletionContainsOnlyValidValues()
+        {
+            var markup = @"
+interface I1
+{
+    void Foo();
+}
+
+interface I2 : I1
+{
+    void Foo2();
+    int Prop { get; }
+}
+
+class Bar : I2
+{
+     void I2.$$
+}";
+
+            await VerifyItemIsAbsentAsync(markup, "Equals(object obj)");
+            await VerifyItemIsAbsentAsync(markup, "Foo()");
+            await VerifyItemIsAbsentAsync(markup, "GetHashCode()");
+            await VerifyItemIsAbsentAsync(markup, "GetType()");
+            await VerifyItemIsAbsentAsync(markup, "ToString()");
+
+            await VerifyItemExistsAsync(markup, "Foo2()");
+            await VerifyItemExistsAsync(markup, "Prop");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceMemberCompletionProvider.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             var members = semanticModel.LookupSymbols(
                 position: name.SpanStart,
                 container: symbol)
-                    .WhereAsArray(s => !s.IsStatic)
+                    .WhereAsArray(s => !s.IsStatic && s.ContainingType.Equals(symbol))
                     .FilterToVisibleAndBrowsableSymbols(options.GetOption(CompletionOptions.HideAdvancedMembers, semanticModel.Language), semanticModel.Compilation);
 
             // We're going to create a entry for each one, including the signature


### PR DESCRIPTION
Fixes #15988
Fixes #19947

**Customer scenario**
Completion list for explicit interface implementations includes invalid members.

**Bugs this fixes:**
#19947, #15988

**Workarounds, if any**
None

**Risk**
Low, affected only ```ExplicitInterfaceMemberCompletionProvider``` class.

**Performance impact**

**Is this a regression from a previous update?**

**Root cause analysis:**
Completion members aren't filtered by interface type. Tests doesn't check that invalid members are not presented in code completion.

**How was the bug found?**

customer reported
