### PR TITLE
Add tuple declarations to AllInOneCSharpCode

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.AllInOne.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.AllInOne.cs
@@ -25,20 +25,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             symbolKindsWithNoCodeBlocks.Add(SymbolKind.Property);
             symbolKindsWithNoCodeBlocks.Add(SymbolKind.NamedType);
 
-            var syntaxKindsMissing = new HashSet<SyntaxKind>();
-
-            // AllInOneCSharpCode has no deconstruction or declaration expression
-            syntaxKindsMissing.Add(SyntaxKind.SingleVariableDesignation);
-            syntaxKindsMissing.Add(SyntaxKind.ParenthesizedVariableDesignation);
-            syntaxKindsMissing.Add(SyntaxKind.ForEachVariableStatement);
-            syntaxKindsMissing.Add(SyntaxKind.DeclarationExpression);
-            syntaxKindsMissing.Add(SyntaxKind.DiscardDesignation);
-
             var analyzer = new CSharpTrackingDiagnosticAnalyzer();
             CreateCompilationWithMscorlib45(source).VerifyAnalyzerDiagnostics(new[] { analyzer });
             analyzer.VerifyAllAnalyzerMembersWereCalled();
             analyzer.VerifyAnalyzeSymbolCalledForAllSymbolKinds();
-            analyzer.VerifyAnalyzeNodeCalledForAllSyntaxKinds(syntaxKindsMissing);
+            analyzer.VerifyAnalyzeNodeCalledForAllSyntaxKinds(new HashSet<SyntaxKind>());
             analyzer.VerifyOnCodeBlockCalledForAllSymbolAndMethodKinds(symbolKindsWithNoCodeBlocks);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -30,14 +30,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UserDiagnos
             symbolKindsWithNoCodeBlocks.Add(SymbolKind.Property);
             symbolKindsWithNoCodeBlocks.Add(SymbolKind.NamedType);
 
-            var syntaxKindsMissing = new HashSet<SyntaxKind>();
-
-            // AllInOneCSharpCode has no deconstruction or declaration expression
-            syntaxKindsMissing.Add(SyntaxKind.SingleVariableDesignation);
-            syntaxKindsMissing.Add(SyntaxKind.ParenthesizedVariableDesignation);
-            syntaxKindsMissing.Add(SyntaxKind.ForEachVariableStatement);
-            syntaxKindsMissing.Add(SyntaxKind.DeclarationExpression);
-            syntaxKindsMissing.Add(SyntaxKind.DiscardDesignation);
 
             var analyzer = new CSharpTrackingDiagnosticAnalyzer();
             using (var workspace = TestWorkspace.CreateCSharp(source, TestOptions.Regular))
@@ -47,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UserDiagnos
                 await DiagnosticProviderTestUtilities.GetAllDiagnosticsAsync(analyzer, document, new Text.TextSpan(0, document.GetTextAsync().Result.Length));
                 analyzer.VerifyAllAnalyzerMembersWereCalled();
                 analyzer.VerifyAnalyzeSymbolCalledForAllSymbolKinds();
-                analyzer.VerifyAnalyzeNodeCalledForAllSyntaxKinds(syntaxKindsMissing);
+                analyzer.VerifyAnalyzeNodeCalledForAllSyntaxKinds(new HashSet<SyntaxKind>());
                 analyzer.VerifyOnCodeBlockCalledForAllSymbolAndMethodKinds(symbolKindsWithNoCodeBlocks, true);
             }
         }

--- a/src/Test/Utilities/Portable/Diagnostics/TrackingDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/TrackingDiagnosticAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         #region Analysis
 
         private static readonly Regex s_omittedSyntaxKindRegex =
-            new Regex(@"None|Trivia|Token|Keyword|List|Xml|Cref|Compilation|Namespace|Class|Struct|Enum|Interface|Delegate|Field|Property|Indexer|Event|Operator|Constructor|Access|Incomplete|Attribute|Filter|InterpolatedString|TupleType|TupleElement|TupleExpression.*");
+            new Regex(@"None|Trivia|Token|Keyword|List|Xml|Cref|Compilation|Namespace|Class|Struct|Enum|Interface|Delegate|Field|Property|Indexer|Event|Operator|Constructor|Access|Incomplete|Attribute|Filter|InterpolatedString");
 
         private bool FilterByAbstractName(Entry entry, string abstractMemberName)
         {
@@ -89,13 +89,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return !s_omittedSyntaxKindRegex.IsMatch(syntaxKind.ToString());
         }
 
-        public void VerifyAnalyzeNodeCalledForAllSyntaxKinds(HashSet<TLanguageKindEnum> syntaxKindsPatterns)
+        public void VerifyAnalyzeNodeCalledForAllSyntaxKinds(HashSet<TLanguageKindEnum> expectedMissingSyntaxKinds)
         {
             var expectedSyntaxKinds = AllSyntaxKinds.Where(IsAnalyzeNodeSupported);
             var actualSyntaxKinds = new HashSet<TLanguageKindEnum>(_callLog.Where(a => FilterByAbstractName(a, "SyntaxNode")).Select(e => e.SyntaxKind));
-            var savedSyntaxKindsPatterns = new HashSet<TLanguageKindEnum>(syntaxKindsPatterns);
-            syntaxKindsPatterns.IntersectWith(actualSyntaxKinds);
-            Assert.True(syntaxKindsPatterns.Count == 0, "AllInOne test contains ignored SyntaxKinds: " + string.Join(", ", syntaxKindsPatterns));
+            var savedSyntaxKindsPatterns = new HashSet<TLanguageKindEnum>(expectedMissingSyntaxKinds);
+            expectedMissingSyntaxKinds.IntersectWith(actualSyntaxKinds);
+            Assert.True(expectedMissingSyntaxKinds.Count == 0, "AllInOne test contains ignored SyntaxKinds: " + string.Join(", ", expectedMissingSyntaxKinds));
             actualSyntaxKinds.UnionWith(savedSyntaxKindsPatterns);
             AssertIsSuperset(expectedSyntaxKinds, actualSyntaxKinds);
         }

--- a/src/Test/Utilities/Portable/Diagnostics/TrackingDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/TrackingDiagnosticAnalyzer.cs
@@ -92,7 +92,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public void VerifyAnalyzeNodeCalledForAllSyntaxKinds(HashSet<TLanguageKindEnum> syntaxKindsPatterns)
         {
             var expectedSyntaxKinds = AllSyntaxKinds.Where(IsAnalyzeNodeSupported);
-            var actualSyntaxKinds = _callLog.Where(a => FilterByAbstractName(a, "SyntaxNode")).Select(e => e.SyntaxKind).Concat(syntaxKindsPatterns).Distinct();
+            var actualSyntaxKinds = new HashSet<TLanguageKindEnum>(_callLog.Where(a => FilterByAbstractName(a, "SyntaxNode")).Select(e => e.SyntaxKind));
+            var savedSyntaxKindsPatterns = new HashSet<TLanguageKindEnum>(syntaxKindsPatterns);
+            syntaxKindsPatterns.IntersectWith(actualSyntaxKinds);
+            Assert.True(syntaxKindsPatterns.Count == 0, "AllInOne test contains ignored SyntaxKinds: " + string.Join(", ", syntaxKindsPatterns));
+            actualSyntaxKinds.UnionWith(savedSyntaxKindsPatterns);
             AssertIsSuperset(expectedSyntaxKinds, actualSyntaxKinds);
         }
 

--- a/src/Test/Utilities/Portable/TestResource.resx
+++ b/src/Test/Utilities/Portable/TestResource.resx
@@ -961,7 +961,7 @@ L:
             Dim o4 = New MyObject(dynamic) With {.A = 0, .B = 0, .C = 0}
             Dim o5 = New With {Key .A = 0}
             Dim a() As Integer = {0, 1, 2, 3, 4, 5}
-            Dim a As (named As Integer, Integer) = (named:=1, 2)
+            Dim a As(named As Integer, Integer) =(named:=1, 2)
             Select Case i
                 Case 1
                     GoTo CaseLabel1
@@ -1992,7 +1992,7 @@ L:
             Dim o4 = New MyObject(dynamic) With {.A = 0, .B = 0, .C = 0}
             Dim o5 = New With {Key .A = 0}
             Dim a() As Integer = {0, 1, 2, 3, 4, 5}
-            Dim a As (named As Integer, Integer) = (named:=1, 2)
+            Dim a As(named As Integer, Integer) =(named:=1, 2)
             Select Case i
                 Case 1
                     GoTo CaseLabel1

--- a/src/Test/Utilities/Portable/TestResource.resx
+++ b/src/Test/Utilities/Portable/TestResource.resx
@@ -300,6 +300,7 @@ namespace My
                 0f,
                 1.1f
             };
+            var (tuple, _) = (named: 1, 2);
             int[, ,] cube = { { { 111, 112, }, { 121, 122 } }, { { 211, 212 }, { 221, 222 } } };
             int[][] jagged = { { 111 }, { 121, 122 } };
             int[][,] arr = new int[5][,]; // as opposed to new int[][5,5]
@@ -360,6 +361,9 @@ namespace My
                     return;
                 else
                     continue;
+            }
+            foreach (var (_, _) in new (int, int)[]{ (1, 2) })
+            {
             }
             checked
             {

--- a/src/Test/Utilities/Portable/TestResource.resx
+++ b/src/Test/Utilities/Portable/TestResource.resx
@@ -961,6 +961,7 @@ L:
             Dim o4 = New MyObject(dynamic) With {.A = 0, .B = 0, .C = 0}
             Dim o5 = New With {Key .A = 0}
             Dim a() As Integer = {0, 1, 2, 3, 4, 5}
+            Dim a As (named As Integer, Integer) = (named:=1, 2)
             Select Case i
                 Case 1
                     GoTo CaseLabel1
@@ -1991,6 +1992,7 @@ L:
             Dim o4 = New MyObject(dynamic) With {.A = 0, .B = 0, .C = 0}
             Dim o5 = New With {Key .A = 0}
             Dim a() As Integer = {0, 1, 2, 3, 4, 5}
+            Dim a As (named As Integer, Integer) = (named:=1, 2)
             Select Case i
                 Case 1
                     GoTo CaseLabel1


### PR DESCRIPTION
Also modify the test that checks for all SyntaxKinds to be present to
fail if an "expected to be missing" SyntaxKind is actually present.

Fixes #12446

Test-only change.