### PR TITLE
Analyzer to offer simplification for inferred member names

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -375,6 +375,7 @@
     <Compile Include="UseCollectionInitializer\UseCollectionInitializerTests.cs" />
     <Compile Include="UseCoalesceExpression\UseCoalesceExpressionForNullableTests.cs" />
     <Compile Include="UseCoalesceExpression\UseCoalesceExpressionTests.cs" />
+    <Compile Include="UseInferredMemberName\UseInferredMemberNameTests.cs" />
     <Compile Include="UseDefaultLiteral\UseDefaultLiteralTests.cs" />
     <Compile Include="UseExplicitTupleName\UseExplicitTupleNameTests.cs" />
     <Compile Include="UseExpressionBody\Refactoring\UseExpressionBodyForConstructorsRefactoringTests.cs" />

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -4073,11 +4073,11 @@ class Program
     {
         int a = 1;
         int {|Rename:y1|} = C.y;
-        var t = (a: a, x: y1);
+        var t = (a, x: y1);
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, ignoreTrivia: false);
+            await TestAsync(code, expected, ignoreTrivia: false, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -4102,11 +4102,11 @@ class Program
     {
         int x = 1;
         int {|Rename:y1|} = C.y;
-        var t = (x: x, y: y1);
+        var t = (x, y: y1);
     }
 }";
 
-            await TestInRegularAndScriptAsync(code, expected, ignoreTrivia: false);
+            await TestAsync(code, expected, ignoreTrivia: false, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -4132,11 +4132,11 @@ class Program
     {
         int x = 1;
         int {|Rename:y1|} = C.y;
-        var t = (x: x, y: y1);
-        var t2 = (y: y1, x:x);
+        var t = (x, y: y1);
+        var t2 = (y: y1, x);
     }
 }";
-            await TestInRegularAndScriptAsync(code, expected, index: 1, ignoreTrivia: false);
+            await TestAsync(code, expected, index: 1, ignoreTrivia: false, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -4133,7 +4133,7 @@ class Program
         int x = 1;
         int {|Rename:y1|} = C.y;
         var t = (x: x, y: y1);
-        var t2 = (y: y1, x);
+        var t2 = (y: y1, x:x);
     }
 }";
             await TestInRegularAndScriptAsync(code, expected, index: 1, ignoreTrivia: false);

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -4073,7 +4073,7 @@ class Program
     {
         int a = 1;
         int {|Rename:y1|} = C.y;
-        var t = (a, x: y1);
+        var t = (a: a, x: y1);
     }
 }";
 
@@ -4102,7 +4102,7 @@ class Program
     {
         int x = 1;
         int {|Rename:y1|} = C.y;
-        var t = (x, y: y1);
+        var t = (x: x, y: y1);
     }
 }";
 
@@ -4132,7 +4132,7 @@ class Program
     {
         int x = 1;
         int {|Rename:y1|} = C.y;
-        var t = (x, y: y1);
+        var t = (x: x, y: y1);
         var t2 = (y: y1, x);
     }
 }";

--- a/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InferredMemberName
             => (new CSharpUseInferredMemberNameDiagnosticAnalyzer(), new CSharpUseInferredMemberNameCodeFixProvider());
 
         private static readonly CSharpParseOptions s_parseOptions =
-            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7_1);
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
 
         [Fact]
         public async Task TestInferredTupleName()

--- a/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.UseInferredMemberName;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InferredMemberName
+{
+    [Trait(Traits.Feature, Traits.Features.CodeActionsUseInferredMemberName)]
+    public class UseInferredMemberNameTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
+            => (new CSharpUseInferredMemberNameDiagnosticAnalyzer(), new CSharpUseInferredMemberNameCodeFixProvider());
+
+        private static readonly CSharpParseOptions s_parseOptions =
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp7);
+
+        [Fact]
+        public async Task TestInferredTupleName()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M()
+    {
+        int a = 1;
+        var t = ([||]a: a, 2);
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int a = 1;
+        var t = (a, 2);
+    }
+}", parseOptions: s_parseOptions);
+        }
+
+        [Fact]
+        public async Task TestInferredTupleName2()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M()
+    {
+        int a = 2;
+        var t = (1, [||]a: a);
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int a = 2;
+        var t = (1, a);
+    }
+}", parseOptions: s_parseOptions);
+        }
+
+        [Fact]
+        public async Task TestNoFixAllInferredTupleName()
+        {
+            await TestActionCountAsync(
+@"
+class C
+{
+    void M()
+    {
+        int a = 1;
+        int b = 2;
+        var t = ([||]a: a, b: b);
+    }
+}",
+count: 1);
+        }
+
+        [Fact]
+        public async Task TestInferredAnonymousTypeMemberName()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M()
+    {
+        int a = 1;
+        var t = new { [||]a=a, 2 };
+    }
+}",
+@"
+class C
+{
+    void M()
+    {
+        int a = 1;
+        var t = new { a, 2 };
+    }
+}", parseOptions: s_parseOptions);
+        }
+
+        [Fact]
+        public async Task TestNoFixAllInferredAnonymousTypeMemberName()
+        {
+            await TestActionCountAsync(
+@"
+class C
+{
+    void M()
+    {
+        int a = 1;
+        int b = 2;
+        var t = new { [||]a=a, b=b };
+    }
+}",
+count: 1);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseInferredMemberName/UseInferredMemberNameTests.cs
@@ -124,7 +124,6 @@ class C
 }", parseOptions: s_parseOptions);
         }
 
-
         [Fact]
         public async Task TestFixAllInferredAnonymousTypeMemberNameWithTrivia()
         {

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -99,6 +99,7 @@ namespace Roslyn.Test.Utilities
             public const string CodeActionsUseCoalesceExpression = "CodeActions.UseCoalesceExpression";
             public const string CodeActionsUseCollectionInitializer = "CodeActions.UseCollectionInitializer";
             public const string CodeActionsUseDefaultLiteral = "CodeActions.UseDefaultLiteral";
+            public const string CodeActionsUseInferredMemberName = "CodeActions.UseInferredMemberName";
             public const string CodeActionsUseExpressionBody = "CodeActions.UseExpressionBody";
             public const string CodeActionsUseImplicitType = "CodeActions.UseImplicitType";
             public const string CodeActionsUseExplicitType = "CodeActions.UseExplicitType";

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -588,6 +588,7 @@
     <Compile Include="TypeInferrer\TypeInferrerTests.vb" />
     <Compile Include="UseCollectionInitializer\UseCollectionInitializerTests.vb" />
     <Compile Include="UseCoalesceExpression\UseCoalesceExpressionForNullableTests.vb" />
+    <Compile Include="UseInferredMemberName\UseInferredMemberNameTests.vb" />
     <Compile Include="UseExplicitTupleName\UseExplicitTupleNameTests.vb" />
     <Compile Include="UseObjectInitializer\UseObjectInitializerTests.vb" />
     <Compile Include="Utilities\CodeSnippets.vb" />

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/AbstractVisualBasicCodeActionTest.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/AbstractVisualBasicCodeActionTest.vb
@@ -9,8 +9,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
     Public MustInherit Class AbstractVisualBasicCodeActionTest
         Inherits AbstractCodeActionTest
 
-        Private ReadOnly _compilationOptions As CompilationOptions =
-            New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionInfer(True)
+        Private ReadOnly _compilationOptions As VisualBasicCompilationOptions =
+            New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionInfer(True).WithParseOptions(New VisualBasicParseOptions(LanguageVersion.Latest))
 
         Protected Overrides Function GetScriptOptions() As ParseOptions
             Return TestOptions.Script
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
             Dim initialMarkupStr = initialMarkup.ConvertTestSourceTag()
             Dim expectedStr = expected.ConvertTestSourceTag()
 
-            Await MyBase.TestAsync(initialMarkupStr, expectedStr, parseOptions:=Nothing, compilationOptions:=_compilationOptions, index:=index, ignoreTrivia:=ignoreTrivia)
+            Await MyBase.TestAsync(initialMarkupStr, expectedStr, parseOptions:=_compilationOptions.ParseOptions, compilationOptions:=_compilationOptions, index:=index, ignoreTrivia:=ignoreTrivia)
         End Function
 
         Protected Overloads Async Function TestMissingAsync(initialMarkup As XElement) As Threading.Tasks.Task

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -2747,7 +2747,7 @@ end class")
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Async Function TupleWithInferredName_LeaveExplicitName() As Task
-            Dim code = <File>
+            Dim code = "
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2755,8 +2755,8 @@ Class C
         Dim t = (a, x:=[|C.y|])
     End Sub
 End Class
-</File>
-            Dim expected = <File>
+"
+            Dim expected = "
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2765,13 +2765,13 @@ Class C
         Dim t = (a, x:=y1)
     End Sub
 End Class
-</File>
-            Await TestAsync(code, expected, ignoreTrivia:=False)
+"
+            Await TestAsync(code, expected, ignoreTrivia:=False, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Async Function TupleWithInferredName_InferredNameBecomesExplicit() As Task
-            Dim code = <File>
+            Dim code = "
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2779,8 +2779,8 @@ Class C
         Dim t = (a, [|C.y|])
     End Sub
 End Class
-</File>
-            Dim expected = <File>
+"
+            Dim expected = "
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2789,13 +2789,13 @@ Class C
         Dim t = (a, y:=y1)
     End Sub
 End Class
-</File>
-            Await TestAsync(code, expected, ignoreTrivia:=False)
+"
+            Await TestAsync(code, expected, ignoreTrivia:=False, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Async Function TupleWithInferredName_AllOccurrences() As Task
-            Dim code = <File>
+            Dim code = "
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2804,8 +2804,8 @@ Class C
         Dim t2 = (C.y, a)
     End Sub
 End Class
-</File>
-            Dim expected = <File>
+"
+            Dim expected = "
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2815,8 +2815,9 @@ Class C
         Dim t2 = (y:=y1, a)
     End Sub
 End Class
-</File>
-            Await TestAsync(code, expected, index:=1, ignoreTrivia:=False)
+"
+            Await TestAsync(code, expected, index:=1, ignoreTrivia:=False,
+                parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
@@ -2843,7 +2844,7 @@ End Class
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Async Function TupleWithInferredName_NoReservedNames() As Task
-            Dim code = <File>
+            Dim code = "
 Class C
     Shared Dim rest As Integer = 2
     Sub M()
@@ -2851,8 +2852,8 @@ Class C
         Dim t = (a, [|C.rest|])
     End Sub
 End Class
-</File>
-            Dim expected = <File>
+"
+            Dim expected = "
 Class C
     Shared Dim rest As Integer = 2
     Sub M()
@@ -2861,8 +2862,8 @@ Class C
         Dim t = (a, rest1)
     End Sub
 End Class
-</File>
-            Await TestAsync(code, expected, ignoreTrivia:=False)
+"
+            Await TestAsync(code, expected, ignoreTrivia:=False, parseOptions:=TestOptions.Regular.WithLanguageVersion(LanguageVersion.Latest))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/IntroduceVariable/IntroduceVariableTests.vb
@@ -2747,7 +2747,7 @@ end class")
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Async Function TupleWithInferredName_LeaveExplicitName() As Task
-            Dim code = "
+            Dim code = <File>
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2755,8 +2755,8 @@ Class C
         Dim t = (a, x:=[|C.y|])
     End Sub
 End Class
-"
-            Dim expected = "
+</File>
+            Dim expected = <File>
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2765,13 +2765,13 @@ Class C
         Dim t = (a, x:=y1)
     End Sub
 End Class
-"
-            Await TestInRegularAndScriptAsync(code, expected, ignoreTrivia:=False)
+</File>
+            Await TestAsync(code, expected, ignoreTrivia:=False)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Async Function TupleWithInferredName_InferredNameBecomesExplicit() As Task
-            Dim code = "
+            Dim code = <File>
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2779,8 +2779,8 @@ Class C
         Dim t = (a, [|C.y|])
     End Sub
 End Class
-"
-            Dim expected = "
+</File>
+            Dim expected = <File>
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2789,13 +2789,13 @@ Class C
         Dim t = (a, y:=y1)
     End Sub
 End Class
-"
-            Await TestInRegularAndScriptAsync(code, expected, ignoreTrivia:=False)
+</File>
+            Await TestAsync(code, expected, ignoreTrivia:=False)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Async Function TupleWithInferredName_AllOccurrences() As Task
-            Dim code = "
+            Dim code = <File>
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2804,8 +2804,8 @@ Class C
         Dim t2 = (C.y, a)
     End Sub
 End Class
-"
-            Dim expected = "
+</File>
+            Dim expected = <File>
 Class C
     Shared Dim y As Integer = 2
     Sub M()
@@ -2815,8 +2815,8 @@ Class C
         Dim t2 = (y:=y1, a)
     End Sub
 End Class
-"
-            Await TestInRegularAndScriptAsync(code, expected, index:=1, ignoreTrivia:=False)
+</File>
+            Await TestAsync(code, expected, index:=1, ignoreTrivia:=False)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
@@ -2843,7 +2843,7 @@ End Class
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>
         Public Async Function TupleWithInferredName_NoReservedNames() As Task
-            Dim code = "
+            Dim code = <File>
 Class C
     Shared Dim rest As Integer = 2
     Sub M()
@@ -2851,8 +2851,8 @@ Class C
         Dim t = (a, [|C.rest|])
     End Sub
 End Class
-"
-            Dim expected = "
+</File>
+            Dim expected = <File>
 Class C
     Shared Dim rest As Integer = 2
     Sub M()
@@ -2861,8 +2861,8 @@ Class C
         Dim t = (a, rest1)
     End Sub
 End Class
-"
-            Await TestInRegularAndScriptAsync(code, expected, ignoreTrivia:=False)
+</File>
+            Await TestAsync(code, expected, ignoreTrivia:=False)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)>

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest.vb
@@ -10,8 +10,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
     Public MustInherit Class AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
         Inherits AbstractDiagnosticProviderBasedUserDiagnosticTest
 
-        Private ReadOnly _compilationOptions As CompilationOptions =
-            New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionInfer(True)
+        Private ReadOnly _compilationOptions As VisualBasicCompilationOptions =
+            New VisualBasicCompilationOptions(OutputKind.ConsoleApplication).WithOptionInfer(True).WithParseOptions(New VisualBasicParseOptions(LanguageVersion.Latest))
 
         Protected Overrides Function GetScriptOptions() As ParseOptions
             Return TestOptions.Script
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
             Dim expectedStr = expected.ConvertTestSourceTag()
 
             Await MyBase.TestAsync(initialMarkupStr, expectedStr,
-                                   parseOptions:=Nothing, compilationOptions:=_compilationOptions,
+                                   parseOptions:=_compilationOptions.ParseOptions, compilationOptions:=_compilationOptions,
                                    index:=index, ignoreTrivia:=ignoreTrivia,
                                    priority:=priority)
         End Function

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -15,52 +15,55 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseInferredMemberN
                     New VisualBasicUseInferredMemberNameCodeFixProvider())
         End Function
 
+        Private Shared ReadOnly s_parseOptions As VisualBasicParseOptions =
+            VisualBasicParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest)
+
         <Fact>
         Public Async Function TestInferredTupleName() As Task
             Await TestAsync(
-<File>
+"
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim t = ([||]a:=a, 2)
     End Sub
 End Class
-</File>,
-<File>
+",
+"
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim t = (a, 2)
     End Sub
 End Class
-</File>)
+", parseOptions:=s_parseOptions)
         End Function
 
         <Fact>
         Public Async Function TestInferredTupleName2() As Task
             Await TestAsync(
-<File>
+"
 Class C
     Sub M()
         Dim a As Integer = 2
         Dim t = (1, [||]a:=a)
     End Sub
 End Class
-</File>,
-<File>
+",
+"
 Class C
     Sub M()
         Dim a As Integer = 2
         Dim t = (1, a)
     End Sub
 End Class
-</File>)
+", parseOptions:=s_parseOptions)
         End Function
 
         <Fact>
         Public Async Function TestFixAllInferredTupleName() As Task
             Await TestAsync(
-<File>
+"
 Class C
     Sub M()
         Dim a As Integer = 1
@@ -68,8 +71,8 @@ Class C
         Dim t = ({|FixAllInDocument:a:=|}a, b:=b)
     End Sub
 End Class
-</File>,
-<File>
+",
+"
 Class C
     Sub M()
         Dim a As Integer = 1
@@ -77,34 +80,34 @@ Class C
         Dim t = (a, b)
     End Sub
 End Class
-</File>)
+", parseOptions:=s_parseOptions)
         End Function
 
         <Fact>
         Public Async Function TestInferredAnonymousTypeMemberName() As Task
             Await TestAsync(
-<File>
+"
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim t = New With {[|.a =|] a, .b = 2}
     End Sub
 End Class
-</File>,
-<File>
+",
+"
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim t = New With {a, .b = 2}
     End Sub
 End Class
-</File>)
+", parseOptions:=s_parseOptions)
         End Function
 
         <Fact>
         Public Async Function TestFixAllInferredAnonymousTypeMemberName() As Task
             Await TestAsync(
-<File>
+"
 Class C
     Sub M()
         Dim a As Integer = 1
@@ -112,8 +115,8 @@ Class C
         Dim t = New With {{|FixAllInDocument:.a =|} a, .b = b}
     End Sub
 End Class
-</File>,
-<File>
+",
+"
 Class C
     Sub M()
         Dim a As Integer = 1
@@ -121,7 +124,7 @@ Class C
         Dim t = New With { a, b }
     End Sub
 End Class
-</File>)
+", parseOptions:=s_parseOptions)
         End Function
 
     End Class

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -17,101 +17,111 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseInferredMemberN
 
         <Fact>
         Public Async Function TestInferredTupleName() As Task
-            Await TestInRegularAndScriptAsync(
-"
+            Await TestAsync(
+<File>
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim t = ([||]a:=a, 2)
     End Sub
-End Class",
-"
+End Class
+</File>,
+<File>
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim t = (a, 2)
     End Sub
-End Class")
+End Class
+</File>)
         End Function
 
         <Fact>
         Public Async Function TestInferredTupleName2() As Task
-            Await TestInRegularAndScriptAsync(
-"
+            Await TestAsync(
+<File>
 Class C
     Sub M()
         Dim a As Integer = 2
         Dim t = (1, [||]a:=a)
     End Sub
-End Class",
-"
+End Class
+</File>,
+<File>
 Class C
     Sub M()
         Dim a As Integer = 2
         Dim t = (1, a)
     End Sub
-End Class")
+End Class
+</File>)
         End Function
 
         <Fact>
         Public Async Function TestFixAllInferredTupleName() As Task
-            Await TestInRegularAndScriptAsync(
-"
+            Await TestAsync(
+<File>
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim b As Integer = 2
         Dim t = ({|FixAllInDocument:a:=|}a, b:=b)
     End Sub
-End Class",
-"
+End Class
+</File>,
+<File>
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim b As Integer = 2
         Dim t = (a, b)
     End Sub
-End Class")
+End Class
+</File>)
         End Function
 
         <Fact>
         Public Async Function TestInferredAnonymousTypeMemberName() As Task
-            Await TestInRegularAndScriptAsync(
-"
+            Await TestAsync(
+<File>
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim t = New With {[|.a =|] a, .b = 2}
     End Sub
-End Class",
-"
+End Class
+</File>,
+<File>
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim t = New With {a, .b = 2}
     End Sub
-End Class")
+End Class
+</File>)
         End Function
 
         <Fact>
         Public Async Function TestFixAllInferredAnonymousTypeMemberName() As Task
-            Await TestInRegularAndScriptAsync(
-"
+            Await TestAsync(
+<File>
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim b As Integer = 2
         Dim t = New With {{|FixAllInDocument:.a =|} a, .b = b}
     End Sub
-End Class",
-"
+End Class
+</File>,
+<File>
 Class C
     Sub M()
         Dim a As Integer = 1
         Dim b As Integer = 2
         Dim t = New With { a, b }
     End Sub
-End Class")
+End Class
+</File>)
         End Function
 
     End Class

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -81,7 +81,7 @@ End Class")
 Class C
     Sub M()
         Dim a As Integer = 1
-        Dim t = New With {[||].a = a, .b = 2}
+        Dim t = New With {[|.a =|] a, .b = 2}
     End Sub
 End Class",
 "

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -54,16 +54,24 @@ End Class")
         End Function
 
         <Fact>
-        Public Async Function TestNoFixAllInferredTupleName() As Task
-            Await TestActionCountAsync(
+        Public Async Function TestFixAllInferredTupleName() As Task
+            Await TestInRegularAndScriptAsync(
 "
 Class C
     Sub M()
-        Dim a As Integer = 2
-        Dim t = (1, [||]a:=a)
+        Dim a As Integer = 1
+        Dim b As Integer = 2
+        Dim t = ({|FixAllInDocument:a:=|}a, b:=b)
     End Sub
 End Class",
-count:=1)
+"
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim b As Integer = 2
+        Dim t = (a, b)
+    End Sub
+End Class")
         End Function
 
         <Fact>
@@ -86,16 +94,25 @@ End Class")
         End Function
 
         <Fact>
-        Public Async Function TestNoFixAllInferredAnonymousTypeMemberName() As Task
-            Await TestActionCountAsync(
+        Public Async Function TestFixAllInferredAnonymousTypeMemberName() As Task
+            Await TestInRegularAndScriptAsync(
 "
 Class C
     Sub M()
         Dim a As Integer = 1
-        Dim t = New With {[||].a = a, .b = 2}
+        Dim b As Integer = 2
+        Dim t = New With {{|FixAllInDocument:.a =|} a, .b = b}
     End Sub
 End Class",
-count:=1)
+"
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim b As Integer = 2
+        Dim t = New With { a, b }
+    End Sub
+End Class")
         End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/UseInferredMemberName/UseInferredMemberNameTests.vb
@@ -1,0 +1,101 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics
+Imports Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.UseInferredMemberName
+    <Trait(Traits.Feature, Traits.Features.CodeActionsUseInferredMemberName)>
+    Public Class UseInferredMemberNameTests
+        Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
+
+        Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As (DiagnosticAnalyzer, CodeFixProvider)
+            Return (New VisualBasicUseInferredMemberNameDiagnosticAnalyzer(),
+                    New VisualBasicUseInferredMemberNameCodeFixProvider())
+        End Function
+
+        <Fact>
+        Public Async Function TestInferredTupleName() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim t = ([||]a:=a, 2)
+    End Sub
+End Class",
+"
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim t = (a, 2)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestInferredTupleName2() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Class C
+    Sub M()
+        Dim a As Integer = 2
+        Dim t = (1, [||]a:=a)
+    End Sub
+End Class",
+"
+Class C
+    Sub M()
+        Dim a As Integer = 2
+        Dim t = (1, a)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestNoFixAllInferredTupleName() As Task
+            Await TestActionCountAsync(
+"
+Class C
+    Sub M()
+        Dim a As Integer = 2
+        Dim t = (1, [||]a:=a)
+    End Sub
+End Class",
+count:=1)
+        End Function
+
+        <Fact>
+        Public Async Function TestInferredAnonymousTypeMemberName() As Task
+            Await TestInRegularAndScriptAsync(
+"
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim t = New With {[||].a = a, .b = 2}
+    End Sub
+End Class",
+"
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim t = New With {a, .b = 2}
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestNoFixAllInferredAnonymousTypeMemberName() As Task
+            Await TestActionCountAsync(
+"
+Class C
+    Sub M()
+        Dim a As Integer = 1
+        Dim t = New With {[||].a = a, .b = 2}
+    End Sub
+End Class",
+count:=1)
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -103,6 +103,8 @@
     <Compile Include="UpgradeProject\CSharpUpgradeProjectCodeFixProvider.cs" />
     <Compile Include="UseCoalesceExpression\CSharpUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs" />
     <Compile Include="UseCoalesceExpression\CSharpUseCoalesceExpressionDiagnosticAnalyzer.cs" />
+    <Compile Include="UseInferredMemberName\CSharpUseInferredMemberNameCodeFixProvider.cs" />
+    <Compile Include="UseInferredMemberName\CSharpUseInferredMemberNameDiagnosticAnalyzer.cs" />
     <Compile Include="UseDefaultLiteral\CSharpUseDefaultLiteralCodeFixProvider.cs" />
     <Compile Include="UseExpressionBody\Helpers\UseExpressionBodyHelper.cs" />
     <Compile Include="UseExpressionBody\UseExpressionBodyCodeRefactoringProvider.cs" />

--- a/src/Features/CSharp/Portable/UseDefaultLiteral/CSharpUseDefaultLiteralCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseDefaultLiteral/CSharpUseDefaultLiteralCodeFixProvider.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDefaultLiteral
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
             public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
-                : base(FeaturesResources.Simplify_default_expression, createChangedDocument)
+                : base(FeaturesResources.Simplify_default_expression, createChangedDocument, FeaturesResources.Simplify_default_expression)
             {
             }
         }

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
@@ -33,13 +33,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
             Document document, ImmutableArray<Diagnostic> diagnostics,
             SyntaxEditor editor, CancellationToken cancellationToken)
         {
-            var generator = editor.Generator;
             var root = editor.OriginalRoot;
 
             foreach (var diagnostic in diagnostics)
             {
-                var nameColon = root.FindNode(diagnostic.Location.SourceSpan);
-                editor.RemoveNode(nameColon, SyntaxRemoveOptions.KeepExteriorTrivia);
+                var node = root.FindNode(diagnostic.Location.SourceSpan);
+                editor.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia);
             }
 
             return SpecializedTasks.EmptyTask;

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+    internal sealed class CSharpUseInferredMemberNameCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds { get; }
+            = ImmutableArray.Create(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId);
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            context.RegisterCodeFix(new MyCodeAction(
+                c => FixAsync(context.Document, context.Diagnostics.First(), c)),
+                context.Diagnostics);
+
+            return SpecializedTasks.EmptyTask;
+        }
+
+        protected override Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics,
+            SyntaxEditor editor, CancellationToken cancellationToken)
+        {
+            var generator = editor.Generator;
+            var root = editor.OriginalRoot;
+
+            foreach (var diagnostic in diagnostics)
+            {
+                var nameColon = root.FindNode(diagnostic.Location.SourceSpan);
+                editor.RemoveNode(nameColon);
+            }
+
+            return SpecializedTasks.EmptyTask;
+        }
+
+        private class MyCodeAction : CodeAction.DocumentChangeAction
+        {
+            public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
+                : base(FeaturesResources.Use_inferred_member_name, createChangedDocument)
+            {
+            }
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameCodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
             foreach (var diagnostic in diagnostics)
             {
                 var nameColon = root.FindNode(diagnostic.Location.SourceSpan);
-                editor.RemoveNode(nameColon);
+                editor.RemoveNode(nameColon, SyntaxRemoveOptions.KeepExteriorTrivia);
             }
 
             return SpecializedTasks.EmptyTask;
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
         private class MyCodeAction : CodeAction.DocumentChangeAction
         {
             public MyCodeAction(Func<CancellationToken, Task<Document>> createChangedDocument)
-                : base(FeaturesResources.Use_inferred_member_name, createChangedDocument)
+                : base(FeaturesResources.Use_inferred_member_name, createChangedDocument, FeaturesResources.Use_inferred_member_name)
             {
             }
         }

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
         }
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            => DiagnosticAnalyzerCategory.SyntaxAnalysis;
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
         public override bool OpenFileOnly(Workspace workspace)
             => false;

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
         }
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+            => DiagnosticAnalyzerCategory.SyntaxAnalysis;
 
         public override bool OpenFileOnly(Workspace workspace)
             => false;
@@ -62,7 +62,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
 
             var argument = (ArgumentSyntax)nameColon.Parent;
             var parseOptions = (CSharpParseOptions)syntaxTree.Options;
-            if (!CSharpInferredMemberNameReducer.CanSimplifyTupleElementName(argument, parseOptions, optionSet))
+            if (!optionSet.GetOption(CSharpCodeStyleOptions.PreferInferredTupleNames).Value ||
+                !CSharpInferredMemberNameReducer.CanSimplifyTupleElementName(argument, parseOptions))
             {
                 return;
             }
@@ -89,7 +90,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
             }
 
             var anonCtor = (AnonymousObjectMemberDeclaratorSyntax)nameEquals.Parent;
-            if (!CSharpInferredMemberNameReducer.CanSimplifyAnonymousTypeMemberName(anonCtor, optionSet))
+            if (!optionSet.GetOption(CSharpCodeStyleOptions.PreferInferredAnonymousTypeMemberNames).Value ||
+                !CSharpInferredMemberNameReducer.CanSimplifyAnonymousTypeMemberName(anonCtor))
             {
                 return;
             }

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
         }
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
-            => DiagnosticAnalyzerCategory.SyntaxAnalysis;
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 
         public override bool OpenFileOnly(Workspace workspace)
             => false;

--- a/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseInferredMemberName/CSharpUseInferredMemberNameDiagnosticAnalyzer.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Simplification;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.UseInferredMemberName
+{
+    // REVIEW Ignoring VB for now. Can I factor the logic with IOperation?
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal sealed class CSharpUseInferredMemberNameDiagnosticAnalyzer : AbstractCodeStyleDiagnosticAnalyzer
+    {
+        public CSharpUseInferredMemberNameDiagnosticAnalyzer()
+            : base(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId,
+                   new LocalizableResourceString(nameof(FeaturesResources.Use_inferred_member_name), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
+                   new LocalizableResourceString(nameof(FeaturesResources.Member_name_can_be_simplified), FeaturesResources.ResourceManager, typeof(FeaturesResources)))
+        {
+        }
+
+        public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
+            => DiagnosticAnalyzerCategory.SyntaxAnalysis;
+
+        public override bool OpenFileOnly(Workspace workspace)
+            => false;
+
+        protected override void InitializeWorker(AnalysisContext context)
+            => context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.NameColon, SyntaxKind.NameEquals);
+
+        private void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+        {
+            var cancellationToken = context.CancellationToken;
+
+            var syntaxTree = context.Node.SyntaxTree;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
+            var parseOptions = (CSharpParseOptions)syntaxTree.Options;
+            switch (context.Node.Kind())
+            {
+                case SyntaxKind.NameColon:
+                    ReportDiagnosticsIfNeeded((NameColonSyntax)context.Node, context, optionSet, syntaxTree);
+                    break;
+                case SyntaxKind.NameEquals:
+                    ReportDiagnosticsIfNeeded((NameEqualsSyntax)context.Node, context, optionSet, syntaxTree);
+                    break;
+            }
+        }
+
+        private bool ReportDiagnosticsIfNeeded(NameColonSyntax nameColon, SyntaxNodeAnalysisContext context, OptionSet optionSet, SyntaxTree syntaxTree)
+        {
+            if (!nameColon.IsParentKind(SyntaxKind.Argument))
+            {
+                return false;
+            }
+
+            var argument = (ArgumentSyntax)nameColon.Parent;
+            if (!CSharpInferredMemberNameReducer.CanSimplifyTupleElementName(argument))
+            {
+                return false;
+            }
+
+            // Create a normal diagnostic
+            context.ReportDiagnostic(
+                Diagnostic.Create(GetDescriptorWithSeverity(
+                    optionSet.GetOption(CSharpCodeStyleOptions.PreferInferredTupleNames).Notification.Value),
+                    nameColon.GetLocation()));
+
+            // Also fade out the part of the name-colon syntax
+            var fadeSpan = TextSpan.FromBounds(nameColon.Name.SpanStart, nameColon.ColonToken.Span.End);
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    UnnecessaryWithoutSuggestionDescriptor,
+                    syntaxTree.GetLocation(fadeSpan)));
+
+            return true;
+        }
+
+        private bool ReportDiagnosticsIfNeeded(NameEqualsSyntax nameEquals, SyntaxNodeAnalysisContext context, OptionSet optionSet, SyntaxTree syntaxTree)
+        {
+            if (!nameEquals.IsParentKind(SyntaxKind.AnonymousObjectMemberDeclarator))
+            {
+                return false;
+            }
+
+            var anonCtor = (AnonymousObjectMemberDeclaratorSyntax)nameEquals.Parent;
+            if (!CSharpInferredMemberNameReducer.CanSimplifyAnonymousTypeMemberName(anonCtor))
+            {
+                return false;
+            }
+
+            // Create a normal diagnostic
+            context.ReportDiagnostic(
+                Diagnostic.Create(GetDescriptorWithSeverity(
+                    optionSet.GetOption(CSharpCodeStyleOptions.PreferInferredAnonymousTypeMemberNames).Notification.Value),
+                    nameEquals.GetLocation()));
+
+            // Also fade out the part of the name-equals syntax
+            var fadeSpan = TextSpan.FromBounds(nameEquals.Name.SpanStart, nameEquals.EqualsToken.Span.End);
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    UnnecessaryWithoutSuggestionDescriptor,
+                    syntaxTree.GetLocation(fadeSpan)));
+
+            return true;
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -50,6 +50,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public const string OrderModifiers = "IDE0036";
 
+        public const string UseInferredMemberNameDiagnosticId = "IDE0037";
+
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";
         public const string AnalyzerDependencyConflictId = "IDE1002";

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -1900,6 +1900,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Member name can be simplified.
+        /// </summary>
+        internal static string Member_name_can_be_simplified {
+            get {
+                return ResourceManager.GetString("Member_name_can_be_simplified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to method.
         /// </summary>
         internal static string method {
@@ -3423,6 +3432,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string Use_framework_type {
             get {
                 return ResourceManager.GetString("Use_framework_type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use inferred member name.
+        /// </summary>
+        internal static string Use_inferred_member_name {
+            get {
+                return ResourceManager.GetString("Use_inferred_member_name", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1247,6 +1247,12 @@ This version used in: {2}</value>
   <data name="default_expression_can_be_simplified" xml:space="preserve">
     <value>'default' expression can be simplified</value>
   </data>
+    <data name="Use_inferred_member_name" xml:space="preserve">
+    <value>Use inferred member name</value>
+  </data>
+  <data name="Member_name_can_be_simplified" xml:space="preserve">
+    <value>Member name can be simplified</value>
+  </data>
   <data name="Reported_diagnostic_0_has_a_source_location_in_file_1_which_is_not_part_of_the_compilation_being_analyzed" xml:space="preserve">
     <value>Reported diagnostic '{0}' has a source location in file '{1}', which is not part of the compilation being analyzed.</value>
   </data>

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -434,6 +434,8 @@
     <Compile Include="UseCollectionInitializer\VisualBasicUseCollectionInitializerDiagnosticAnalyzer.vb" />
     <Compile Include="UseCoalesceExpression\VisualBasicUseCoalesceExpressionForNullableDiagnosticAnalyzer.vb" />
     <Compile Include="UseCoalesceExpression\VisualBasicUseCoalesceExpressionDiagnosticAnalyzer.vb" />
+    <Compile Include="UseInferredMemberName\VisualBasicUseInferredMemberNameCodeFixProvider.vb" />
+    <Compile Include="UseInferredMemberName\VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb" />
     <Compile Include="UseNullPropagation\VisualBasicUseNullPropagationCodeFixProvider.vb" />
     <Compile Include="UseNullPropagation\VisualBasicUseNullPropagationDiagnosticAnalyzer.vb" />
     <Compile Include="UseObjectInitializer\UseInitializerHelpers.vb" />

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameCodeFixProvider.vb
@@ -27,7 +27,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
 
         Protected Overrides Function FixAllAsync(document As Document, diagnostics As ImmutableArray(Of Diagnostic),
                                                  editor As SyntaxEditor, cancellationToken As CancellationToken) As Task
-            Dim generator = editor.Generator
             Dim root = editor.OriginalRoot
 
             For Each diagnostic In diagnostics

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameCodeFixProvider.vb
@@ -14,11 +14,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
     Friend Class VisualBasicUseInferredMemberNameCodeFixProvider
         Inherits SyntaxEditorBasedCodeFixProvider
 
-        Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
-            Get
-                Return ImmutableArray.Create(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId)
-            End Get
-        End Property
+        Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String) =
+            ImmutableArray.Create(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId)
 
         Public Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
             context.RegisterCodeFix(New MyCodeAction(
@@ -37,12 +34,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
                 Dim node = root.FindNode(diagnostic.Location.SourceSpan)
                 Select Case node.Kind
                     Case SyntaxKind.NameColonEquals
-                        editor.RemoveNode(node)
+                        editor.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia)
                         Exit Select
 
                     Case SyntaxKind.NamedFieldInitializer
                         Dim namedFieldInitializer = DirectCast(node, NamedFieldInitializerSyntax)
-                        Dim inferredFieldInitializer = SyntaxFactory.InferredFieldInitializer(namedFieldInitializer.Expression).WithTriviaFrom(namedFieldInitializer)
+                        Dim inferredFieldInitializer = SyntaxFactory.InferredFieldInitializer(namedFieldInitializer.Expression).
+                            WithTriviaFrom(namedFieldInitializer)
                         editor.ReplaceNode(namedFieldInitializer, inferredFieldInitializer)
                         Exit Select
                 End Select
@@ -54,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
         Private Class MyCodeAction
             Inherits CodeAction.DocumentChangeAction
             Public Sub New(createChangedDocument As Func(Of CancellationToken, Task(Of Document)))
-                MyBase.New(FeaturesResources.Use_inferred_member_name, createChangedDocument)
+                MyBase.New(FeaturesResources.Use_inferred_member_name, createChangedDocument, FeaturesResources.Use_inferred_member_name)
 
             End Sub
         End Class

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameCodeFixProvider.vb
@@ -1,0 +1,62 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports System.Composition
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeActions
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Editing
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
+    Friend Class VisualBasicUseInferredMemberNameCodeFixProvider
+        Inherits SyntaxEditorBasedCodeFixProvider
+
+        Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
+            Get
+                Return ImmutableArray.Create(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId)
+            End Get
+        End Property
+
+        Public Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
+            context.RegisterCodeFix(New MyCodeAction(
+                Function(c) FixAsync(context.Document, context.Diagnostics.First(), c)),
+                context.Diagnostics)
+
+            Return SpecializedTasks.EmptyTask
+        End Function
+
+        Protected Overrides Function FixAllAsync(document As Document, diagnostics As ImmutableArray(Of Diagnostic),
+                                                 editor As SyntaxEditor, cancellationToken As CancellationToken) As Task
+            Dim generator = editor.Generator
+            Dim root = editor.OriginalRoot
+
+            For Each diagnostic In diagnostics
+                Dim node = root.FindNode(diagnostic.Location.SourceSpan)
+                Select Case node.Kind
+                    Case SyntaxKind.NameColonEquals
+                        editor.RemoveNode(node)
+                        Exit Select
+
+                    Case SyntaxKind.NamedFieldInitializer
+                        Dim namedFieldInitializer = DirectCast(node, NamedFieldInitializerSyntax)
+                        Dim inferredFieldInitializer = SyntaxFactory.InferredFieldInitializer(namedFieldInitializer.Expression).WithTriviaFrom(namedFieldInitializer)
+                        editor.ReplaceNode(namedFieldInitializer, inferredFieldInitializer)
+                        Exit Select
+                End Select
+            Next
+
+            Return SpecializedTasks.EmptyTask
+        End Function
+
+        Private Class MyCodeAction
+            Inherits CodeAction.DocumentChangeAction
+            Public Sub New(createChangedDocument As Func(Of CancellationToken, Task(Of Document)))
+                MyBase.New(FeaturesResources.Use_inferred_member_name, createChangedDocument)
+
+            End Sub
+        End Class
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
         End Sub
 
         Private Sub ReportDiagnosticsIfNeeded(nameColonEquals As NameColonEqualsSyntax, context As SyntaxNodeAnalysisContext,
-            optionSet As OptionSet, syntaxTree As SyntaxTree, parseOptions As VisualBasicParseOptions)
+                                              optionSet As OptionSet, syntaxTree As SyntaxTree, parseOptions As VisualBasicParseOptions)
 
             If Not nameColonEquals.IsParentKind(SyntaxKind.SimpleArgument) Then
                 Return
@@ -83,8 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
         End Sub
 
         Private Sub ReportDiagnosticsIfNeeded(fieldInitializer As NamedFieldInitializerSyntax, context As SyntaxNodeAnalysisContext,
-            optionSet As OptionSet, syntaxTree As SyntaxTree)
-
+                                              optionSet As OptionSet, syntaxTree As SyntaxTree)
 
             If Not optionSet.GetOption(VisualBasicCodeStyleOptions.PreferInferredAnonymousTypeMemberNames).Value OrElse
                 Not VisualBasicInferredMemberNameReducer.CanSimplifyNamedFieldInitializer(fieldInitializer) Then

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
         End Sub
 
         Public Overrides Function GetAnalyzerCategory() As DiagnosticAnalyzerCategory
-            Return DiagnosticAnalyzerCategory.SemanticSpanAnalysis
+            Return DiagnosticAnalyzerCategory.SyntaxAnalysis
         End Function
 
         Public Overrides Function OpenFileOnly(workspace As Workspace) As Boolean
@@ -63,7 +63,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
             End If
 
             Dim argument = DirectCast(nameColonEquals.Parent, SimpleArgumentSyntax)
-            If Not VisualBasicInferredMemberNameReducer.CanSimplifyTupleName(argument, parseOptions, optionSet) Then
+            If Not optionSet.GetOption(VisualBasicCodeStyleOptions.PreferInferredTupleNames).Value OrElse
+                Not VisualBasicInferredMemberNameReducer.CanSimplifyTupleName(argument, parseOptions) Then
                 Return
             End If
 
@@ -82,9 +83,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
         End Sub
 
         Private Sub ReportDiagnosticsIfNeeded(fieldInitializer As NamedFieldInitializerSyntax, context As SyntaxNodeAnalysisContext,
-                                                   optionSet As OptionSet, syntaxTree As SyntaxTree)
+            optionSet As OptionSet, syntaxTree As SyntaxTree)
 
-            If Not VisualBasicInferredMemberNameReducer.CanSimplifyNamedFieldInitializer(fieldInitializer, optionSet) Then
+
+            If Not optionSet.GetOption(VisualBasicCodeStyleOptions.PreferInferredAnonymousTypeMemberNames).Value OrElse
+                Not VisualBasicInferredMemberNameReducer.CanSimplifyNamedFieldInitializer(fieldInitializer) Then
+
                 Return
             End If
 

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
         End Sub
 
         Public Overrides Function GetAnalyzerCategory() As DiagnosticAnalyzerCategory
-            Return DiagnosticAnalyzerCategory.SyntaxAnalysis
+            Return DiagnosticAnalyzerCategory.SemanticSpanAnalysis
         End Function
 
         Public Overrides Function OpenFileOnly(workspace As Workspace) As Boolean

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
             Dim parseOptions = DirectCast(syntaxTree.Options, VisualBasicParseOptions)
             Select Case context.Node.Kind()
                 Case SyntaxKind.NameColonEquals
-                    ReportDiagnosticsIfNeeded(DirectCast(context.Node, NameColonEqualsSyntax), context, optionSet, syntaxTree)
+                    ReportDiagnosticsIfNeeded(DirectCast(context.Node, NameColonEqualsSyntax), context, optionSet, syntaxTree, parseOptions)
                     Exit Select
                 Case SyntaxKind.NamedFieldInitializer
                     ReportDiagnosticsIfNeeded(DirectCast(context.Node, NamedFieldInitializerSyntax), context, optionSet, syntaxTree)
@@ -55,16 +55,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
             End Select
         End Sub
 
-        Private Function ReportDiagnosticsIfNeeded(nameColonEquals As NameColonEqualsSyntax, context As SyntaxNodeAnalysisContext,
-                                                   optionSet As OptionSet, syntaxTree As SyntaxTree) As Boolean
+        Private Sub ReportDiagnosticsIfNeeded(nameColonEquals As NameColonEqualsSyntax, context As SyntaxNodeAnalysisContext,
+            optionSet As OptionSet, syntaxTree As SyntaxTree, parseOptions As VisualBasicParseOptions)
 
             If Not nameColonEquals.IsParentKind(SyntaxKind.SimpleArgument) Then
-                Return False
+                Return
             End If
 
             Dim argument = DirectCast(nameColonEquals.Parent, SimpleArgumentSyntax)
-            If Not VisualBasicInferredMemberNameReducer.CanSimplifyTupleName(argument) Then
-                Return False
+            If Not VisualBasicInferredMemberNameReducer.CanSimplifyTupleName(argument, parseOptions, optionSet) Then
+                Return
             End If
 
             ' Create a normal diagnostic
@@ -79,15 +79,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
                 Diagnostic.Create(
                     UnnecessaryWithoutSuggestionDescriptor,
                     syntaxTree.GetLocation(fadeSpan)))
+        End Sub
 
-            Return True
-        End Function
+        Private Sub ReportDiagnosticsIfNeeded(fieldInitializer As NamedFieldInitializerSyntax, context As SyntaxNodeAnalysisContext,
+                                                   optionSet As OptionSet, syntaxTree As SyntaxTree)
 
-        Private Function ReportDiagnosticsIfNeeded(fieldInitializer As NamedFieldInitializerSyntax, context As SyntaxNodeAnalysisContext,
-                                                   optionSet As OptionSet, syntaxTree As SyntaxTree) As Boolean
-
-            If Not VisualBasicInferredMemberNameReducer.CanSimplifyNamedFieldInitializer(fieldInitializer) Then
-                Return False
+            If Not VisualBasicInferredMemberNameReducer.CanSimplifyNamedFieldInitializer(fieldInitializer, optionSet) Then
+                Return
             End If
 
             ' Create a normal diagnostic
@@ -102,8 +100,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
                 Diagnostic.Create(
                     UnnecessaryWithoutSuggestionDescriptor,
                     syntaxTree.GetLocation(fadeSpan)))
-
-            Return True
-        End Function
+        End Sub
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -88,14 +88,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
                 Return
             End If
 
+            Dim fadeSpan = TextSpan.FromBounds(fieldInitializer.Name.SpanStart, fieldInitializer.EqualsToken.Span.End)
+
             ' Create a normal diagnostic
             context.ReportDiagnostic(
                 Diagnostic.Create(GetDescriptorWithSeverity(
                     optionSet.GetOption(VisualBasicCodeStyleOptions.PreferInferredAnonymousTypeMemberNames).Notification.Value),
-                    fieldInitializer.GetLocation()))
+                    syntaxTree.GetLocation(fadeSpan)))
 
             ' Also fade out the part of the name-equals syntax
-            Dim fadeSpan = TextSpan.FromBounds(fieldInitializer.Name.SpanStart, fieldInitializer.EqualsToken.Span.End)
             context.ReportDiagnostic(
                 Diagnostic.Create(
                     UnnecessaryWithoutSuggestionDescriptor,

--- a/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/UseInferredMemberName/VisualBasicUseInferredMemberNameDiagnosticAnalyzer.vb
@@ -1,0 +1,109 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.CodeStyle
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
+Imports Microsoft.CodeAnalysis.VisualBasic.Simplification
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UseInferredMemberName
+    ''' <summary>
+    ''' Offers to simplify tuple expressions and anonymous types with redundant names, such as `(a:=a, b:=b)` or `New With {.a = a, .b = b}`
+    ''' </summary>
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Friend Class VisualBasicUseInferredMemberNameDiagnosticAnalyzer
+        Inherits AbstractCodeStyleDiagnosticAnalyzer
+
+        Public Sub New()
+            MyBase.New(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId,
+                  New LocalizableResourceString(NameOf(FeaturesResources.Use_inferred_member_name), FeaturesResources.ResourceManager, GetType(FeaturesResources)),
+                  New LocalizableResourceString(NameOf(FeaturesResources.Member_name_can_be_simplified), FeaturesResources.ResourceManager, GetType(FeaturesResources)))
+        End Sub
+
+        Public Overrides Function GetAnalyzerCategory() As DiagnosticAnalyzerCategory
+            Return DiagnosticAnalyzerCategory.SemanticSpanAnalysis
+        End Function
+
+        Public Overrides Function OpenFileOnly(workspace As Workspace) As Boolean
+            Return False
+        End Function
+
+        Protected Overrides Sub InitializeWorker(context As AnalysisContext)
+            context.RegisterSyntaxNodeAction(Sub(c As SyntaxNodeAnalysisContext) AnalyzeSyntax(c),
+                SyntaxKind.NameColonEquals, SyntaxKind.NamedFieldInitializer)
+        End Sub
+
+        Private Sub AnalyzeSyntax(context As SyntaxNodeAnalysisContext)
+            Dim cancellationToken = context.CancellationToken
+
+            Dim syntaxTree = context.Node.SyntaxTree
+            Dim optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult()
+            If optionSet Is Nothing Then
+                Return
+            End If
+
+            Dim parseOptions = DirectCast(syntaxTree.Options, VisualBasicParseOptions)
+            Select Case context.Node.Kind()
+                Case SyntaxKind.NameColonEquals
+                    ReportDiagnosticsIfNeeded(DirectCast(context.Node, NameColonEqualsSyntax), context, optionSet, syntaxTree)
+                    Exit Select
+                Case SyntaxKind.NamedFieldInitializer
+                    ReportDiagnosticsIfNeeded(DirectCast(context.Node, NamedFieldInitializerSyntax), context, optionSet, syntaxTree)
+                    Exit Select
+            End Select
+        End Sub
+
+        Private Function ReportDiagnosticsIfNeeded(nameColonEquals As NameColonEqualsSyntax, context As SyntaxNodeAnalysisContext,
+                                                   optionSet As OptionSet, syntaxTree As SyntaxTree) As Boolean
+
+            If Not nameColonEquals.IsParentKind(SyntaxKind.SimpleArgument) Then
+                Return False
+            End If
+
+            Dim argument = DirectCast(nameColonEquals.Parent, SimpleArgumentSyntax)
+            If Not VisualBasicInferredMemberNameReducer.CanSimplifyTupleName(argument) Then
+                Return False
+            End If
+
+            ' Create a normal diagnostic
+            context.ReportDiagnostic(
+                Diagnostic.Create(GetDescriptorWithSeverity(
+                    optionSet.GetOption(VisualBasicCodeStyleOptions.PreferInferredTupleNames).Notification.Value),
+                    nameColonEquals.GetLocation()))
+
+            ' Also fade out the part of the name-colon-equals syntax
+            Dim fadeSpan = TextSpan.FromBounds(nameColonEquals.Name.SpanStart, nameColonEquals.ColonEqualsToken.Span.End)
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    UnnecessaryWithoutSuggestionDescriptor,
+                    syntaxTree.GetLocation(fadeSpan)))
+
+            Return True
+        End Function
+
+        Private Function ReportDiagnosticsIfNeeded(fieldInitializer As NamedFieldInitializerSyntax, context As SyntaxNodeAnalysisContext,
+                                                   optionSet As OptionSet, syntaxTree As SyntaxTree) As Boolean
+
+            If Not VisualBasicInferredMemberNameReducer.CanSimplifyNamedFieldInitializer(fieldInitializer) Then
+                Return False
+            End If
+
+            ' Create a normal diagnostic
+            context.ReportDiagnostic(
+                Diagnostic.Create(GetDescriptorWithSeverity(
+                    optionSet.GetOption(VisualBasicCodeStyleOptions.PreferInferredAnonymousTypeMemberNames).Notification.Value),
+                    fieldInitializer.GetLocation()))
+
+            ' Also fade out the part of the name-equals syntax
+            Dim fadeSpan = TextSpan.FromBounds(fieldInitializer.Name.SpanStart, fieldInitializer.EqualsToken.Span.End)
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    UnnecessaryWithoutSuggestionDescriptor,
+                    syntaxTree.GetLocation(fadeSpan)))
+
+            Return True
+        End Function
+    End Class
+End Namespace

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -451,10 +451,10 @@ class Customer
     {{
 //[
         // {ServicesVSResources.Prefer_colon}
-        var tuple = (age, name); 
+        var tuple = (age, name);
 
         // {ServicesVSResources.Over_colon}
-        var tuple = (age: age, name: name); 
+        var tuple = (age: age, name: name);
 //]
     }}
 }}
@@ -469,10 +469,10 @@ class Customer
     {{
 //[
         // {ServicesVSResources.Prefer_colon}
-        var anon = new {{ age, name }}; 
+        var anon = new {{ age, name }};
 
         // {ServicesVSResources.Over_colon}
-        var anon = new {{ age=age, name=name }}; 
+        var anon = new {{ age = age, name = name }};
 //]
     }}
 }}

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -442,6 +442,42 @@ class Customer
 }}
 ";
 
+        private static readonly string s_preferInferredTupleName = $@"
+using System.Threading;
+
+class Customer
+{{
+    public Customer(int age, string name)
+    {{
+//[
+        // {ServicesVSResources.Prefer_colon}
+        var tuple = (age, name); 
+
+        // {ServicesVSResources.Over_colon}
+        var tuple = (age: age, name: name); 
+//]
+    }}
+}}
+";
+
+        private static readonly string s_preferInferredAnonymousTypeMemberName = $@"
+using System.Threading;
+
+class Customer
+{{
+    public Customer(int age, string name)
+    {{
+//[
+        // {ServicesVSResources.Prefer_colon}
+        var anon = new {{ age, name }}; 
+
+        // {ServicesVSResources.Over_colon}
+        var anon = new {{ age=age, name=name }}; 
+//]
+    }}
+}}
+";
+
         private static readonly string s_preferInlinedVariableDeclaration = $@"
 using System;
 
@@ -709,6 +745,8 @@ class List<T>
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck, CSharpVSResources.Prefer_pattern_matching_over_as_with_null_check, s_preferPatternMatchingOverAsWithNullCheck, s_preferPatternMatchingOverAsWithNullCheck, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferExplicitTupleNames, ServicesVSResources.Prefer_explicit_tuple_name, s_preferExplicitTupleName, s_preferExplicitTupleName, this, optionSet, expressionPreferencesGroupTitle));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferSimpleDefaultExpression, ServicesVSResources.Prefer_simple_default_expression, s_preferSimpleDefaultExpression, s_preferSimpleDefaultExpression, this, optionSet, expressionPreferencesGroupTitle));
+            CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferInferredTupleNames, ServicesVSResources.Prefer_inferred_tuple_names, s_preferInferredTupleName, s_preferInferredTupleName, this, optionSet, expressionPreferencesGroupTitle));
+            CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(CSharpCodeStyleOptions.PreferInferredAnonymousTypeMemberNames, ServicesVSResources.Prefer_inferred_anonymous_type_member_names, s_preferInferredAnonymousTypeMemberName, s_preferInferredAnonymousTypeMemberName, this, optionSet, expressionPreferencesGroupTitle));
 
             AddExpressionBodyOptions(optionSet, expressionPreferencesGroupTitle);
 

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1575,6 +1575,24 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Prefer inferred anonymous type member names.
+        /// </summary>
+        internal static string Prefer_inferred_anonymous_type_member_names {
+            get {
+                return ResourceManager.GetString("Prefer_inferred_anonymous_type_member_names", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prefer inferred tuple element names.
+        /// </summary>
+        internal static string Prefer_inferred_tuple_names {
+            get {
+                return ResourceManager.GetString("Prefer_inferred_tuple_names", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Prefer inlined variable declaration.
         /// </summary>
         internal static string Prefer_inlined_variable_declaration {

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -921,6 +921,12 @@ Additional information: {1}</value>
   <data name="Prefer_simple_default_expression" xml:space="preserve">
     <value>Prefer simple 'default' expression</value>
   </data>
+  <data name="Prefer_inferred_tuple_names" xml:space="preserve">
+    <value>Prefer inferred tuple element names</value>
+  </data>
+  <data name="Prefer_inferred_anonymous_type_member_names" xml:space="preserve">
+    <value>Prefer inferred anonymous type member names</value>
+  </data>
   <data name="Preview_pane" xml:space="preserve">
     <value>Preview pane</value>
   </data>

--- a/src/VisualStudio/VisualBasic/Impl/Options/StyleViewModel.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/StyleViewModel.vb
@@ -5,6 +5,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeStyle
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Simplification
+Imports Microsoft.CodeAnalysis.VisualBasic.CodeStyle
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
@@ -206,6 +207,34 @@ Class Customer
 end class
 "
 
+        Private Shared ReadOnly s_preferInferredTupleName As String = $"
+Class Customer
+    Public Sub New(name as String, age As Integer)
+//[
+        ' {ServicesVSResources.Prefer_colon}
+        Dim tuple = (name, age)
+
+        ' {ServicesVSResources.Over_colon}
+        Dim tuple = (name:=name, age:=age)
+//]
+    End Sub
+end class
+"
+
+        Private Shared ReadOnly s_preferInferredAnonymousTypeMemberName As String = $"
+Class Customer
+    Public Sub New(name as String, age As Integer)
+//[
+        ' {ServicesVSResources.Prefer_colon}
+        Dim anon = New With {{ name, age }}
+
+        ' {ServicesVSResources.Over_colon}
+        Dim anon = New With {{ .name = name, .age = age }}
+//]
+    End Sub
+end class
+"
+
         Private Shared ReadOnly s_preferCoalesceExpression As String = $"
 Imports System
 
@@ -281,6 +310,8 @@ End Class"
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferObjectInitializer, ServicesVSResources.Prefer_object_initializer, s_preferObjectInitializer, s_preferObjectInitializer, Me, optionSet, expressionPreferencesGroupTitle))
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferCollectionInitializer, ServicesVSResources.Prefer_collection_initializer, s_preferCollectionInitializer, s_preferCollectionInitializer, Me, optionSet, expressionPreferencesGroupTitle))
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferExplicitTupleNames, ServicesVSResources.Prefer_explicit_tuple_name, s_preferExplicitTupleName, s_preferExplicitTupleName, Me, optionSet, expressionPreferencesGroupTitle))
+            Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(VisualBasicCodeStyleOptions.PreferInferredTupleNames, ServicesVSResources.Prefer_inferred_tuple_names, s_preferInferredTupleName, s_preferInferredTupleName, Me, optionSet, expressionPreferencesGroupTitle))
+            Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(VisualBasicCodeStyleOptions.PreferInferredAnonymousTypeMemberNames, ServicesVSResources.Prefer_inferred_anonymous_type_member_names, s_preferInferredAnonymousTypeMemberName, s_preferInferredAnonymousTypeMemberName, Me, optionSet, expressionPreferencesGroupTitle))
 
             ' nothing preferences
             Me.CodeStyleItems.Add(New BooleanCodeStyleOptionViewModel(CodeStyleOptions.PreferCoalesceExpression, ServicesVSResources.Prefer_coalesce_expression, s_preferCoalesceExpression, s_preferCoalesceExpression, Me, optionSet, nothingPreferencesGroupTitle))

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -142,6 +142,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
                 EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_prefer_simple_default_expression"),
                 new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferSimpleDefaultExpression)}")});
 
+        public static readonly Option<CodeStyleOption<bool>> PreferInferredTupleNames = new Option<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions), nameof(PreferInferredTupleNames), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
+            storageLocations: new OptionStorageLocation[] {
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_prefer_inferred_tuple_names"),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferInferredTupleNames)}")});
+
+        public static readonly Option<CodeStyleOption<bool>> PreferInferredAnonymousTypeMemberNames = new Option<CodeStyleOption<bool>>(
+            nameof(CodeStyleOptions), nameof(PreferInferredAnonymousTypeMemberNames), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
+            storageLocations: new OptionStorageLocation[] {
+                EditorConfigStorageLocation.ForBoolCodeStyleOption("csharp_prefer_inferred_anonymous_type_member_names"),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferInferredAnonymousTypeMemberNames)}")});
+
         private static readonly SyntaxKind[] s_preferredModifierOrderDefault =
             {
                 SyntaxKind.PublicKeyword, SyntaxKind.PrivateKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.InternalKeyword,

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -184,6 +184,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
             yield return PreferPatternMatchingOverIsWithCastCheck;
             yield return PreferBraces;
             yield return PreferSimpleDefaultExpression;
+            yield return PreferInferredTupleNames;
+            yield return PreferInferredAnonymousTypeMemberNames;
         }
 
         public static IEnumerable<Option<CodeStyleOption<ExpressionBodyPreference>>> GetExpressionBodyOptions()

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpInferredMemberNameReducer.Rewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpInferredMemberNameReducer.Rewriter.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Simplification
 {
@@ -23,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
 
             private ArgumentSyntax SimplifyTupleName(ArgumentSyntax node, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
             {
-                if (CanSimplifyTupleElementName(node, this.ParseOptions, optionSet))
+                if (CanSimplifyTupleElementName(node, this.ParseOptions))
                 {
                     return node.WithNameColon(null).WithTriviaFrom(node);
                 }
@@ -35,7 +34,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
 
             private static SyntaxNode SimplifyAnonymousTypeMemberName(AnonymousObjectMemberDeclaratorSyntax node, SemanticModel semanticModel, OptionSet optionSet, CancellationToken canellationToken)
             {
-                if (CanSimplifyAnonymousTypeMemberName(node, optionSet))
+
+                if (CanSimplifyAnonymousTypeMemberName(node))
                 {
                     return node.WithNameEquals(null).WithTriviaFrom(node);
                 }

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpInferredMemberNameReducer.Rewriter.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpInferredMemberNameReducer.Rewriter.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -13,6 +16,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             public Rewriter(ObjectPool<IReductionRewriter> pool)
                 : base(pool)
             {
+                s_simplifyTupleName = SimplifyTupleName;
+            }
+
+            private readonly Func<ArgumentSyntax, SemanticModel, OptionSet, CancellationToken, ArgumentSyntax> s_simplifyTupleName;
+
+            private ArgumentSyntax SimplifyTupleName(ArgumentSyntax node, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
+            {
+                if (CanSimplifyTupleElementName(node, this.ParseOptions, optionSet))
+                {
+                    return node.WithNameColon(null).WithTriviaFrom(node);
+                }
+
+                return node;
+            }
+
+            private static readonly Func<AnonymousObjectMemberDeclaratorSyntax, SemanticModel, OptionSet, CancellationToken, SyntaxNode> s_simplifyAnonymousTypeMemberName = SimplifyAnonymousTypeMemberName;
+
+            private static SyntaxNode SimplifyAnonymousTypeMemberName(AnonymousObjectMemberDeclaratorSyntax node, SemanticModel semanticModel, OptionSet optionSet, CancellationToken canellationToken)
+            {
+                if (CanSimplifyAnonymousTypeMemberName(node, optionSet))
+                {
+                    return node.WithNameEquals(null).WithTriviaFrom(node);
+                }
+
+                return node;
             }
 
             public override SyntaxNode VisitArgument(ArgumentSyntax node)

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpInferredMemberNameReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpInferredMemberNameReducer.cs
@@ -1,13 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Simplification
 {
@@ -25,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
         {
         }
 
-        internal static bool CanSimplifyTupleElementName(ArgumentSyntax node, CSharpParseOptions parseOptions, OptionSet optionSet)
+        internal static bool CanSimplifyTupleElementName(ArgumentSyntax node, CSharpParseOptions parseOptions)
         {
             // Tuple elements are arguments in a tuple expression
             if (node.NameColon == null || !node.IsParentKind(SyntaxKind.TupleExpression))
@@ -33,8 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 return false;
             }
 
-            if (parseOptions.LanguageVersion < LanguageVersion.CSharp7_1 ||
-                !optionSet.GetOption(CSharpCodeStyleOptions.PreferInferredTupleNames).Value)
+            if (parseOptions.LanguageVersion < LanguageVersion.CSharp7_1)
             {
                 return false;
             }
@@ -48,14 +42,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
             return true;
         }
 
-        internal static bool CanSimplifyAnonymousTypeMemberName(AnonymousObjectMemberDeclaratorSyntax node, OptionSet optionSet)
+        internal static bool CanSimplifyAnonymousTypeMemberName(AnonymousObjectMemberDeclaratorSyntax node)
         {
             if (node.NameEquals == null)
-            {
-                return false;
-            }
-
-            if (!optionSet.GetOption(CSharpCodeStyleOptions.PreferInferredAnonymousTypeMemberNames).Value)
             {
                 return false;
             }

--- a/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpInferredMemberNameReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Reducers/CSharpInferredMemberNameReducer.cs
@@ -28,39 +28,58 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
 
         private static ArgumentSyntax SimplifyTupleName(ArgumentSyntax node, SemanticModel semanticModel, OptionSet optionSet, CancellationToken cancellationToken)
         {
+            if (CanSimplifyTupleElementName(node))
+            {
+                return node.WithNameColon(null).WithTriviaFrom(node);
+            }
+            return node;
+        }
+
+        internal static bool CanSimplifyTupleElementName(ArgumentSyntax node)
+        {
             // Tuple elements are arguments in a tuple expression
             if (node.NameColon == null || !node.IsParentKind(SyntaxKind.TupleExpression))
             {
-                return node;
+                return false;
             }
 
             var inferredName = node.Expression.TryGetInferredMemberName();
 
             if (inferredName == null || inferredName != node.NameColon.Name.Identifier.ValueText)
             {
-                return node;
+                return false;
             }
 
-            return node.WithNameColon(null).WithTriviaFrom(node);
+            return true;
         }
 
         private static readonly Func<AnonymousObjectMemberDeclaratorSyntax, SemanticModel, OptionSet, CancellationToken, SyntaxNode> s_simplifyAnonymousTypeMemberName = SimplifyAnonymousTypeMemberName;
 
         private static SyntaxNode SimplifyAnonymousTypeMemberName(AnonymousObjectMemberDeclaratorSyntax node, SemanticModel semanticModel, OptionSet optionSet, CancellationToken canellationToken)
         {
+            if (CanSimplifyAnonymousTypeMemberName(node))
+            {
+                return node.WithNameEquals(null).WithTriviaFrom(node);
+            }
+
+            return node;
+        }
+
+        internal static bool CanSimplifyAnonymousTypeMemberName(AnonymousObjectMemberDeclaratorSyntax node)
+        {
             if (node.NameEquals == null)
             {
-                return node;
+                return false;
             }
 
             var inferredName = node.Expression.TryGetInferredMemberName();
 
             if (inferredName == null || inferredName != node.NameEquals.Name.Identifier.ValueText)
             {
-                return node;
+                return false;
             }
 
-            return node.WithNameEquals(null).WithTriviaFrom(node);
+            return true;
         }
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/CodeStyle/VisualBasicCodeStyleOptions.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeStyle/VisualBasicCodeStyleOptions.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 imports System.Collections.Generic
 imports System.Collections.Immutable
@@ -23,5 +23,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeStyle
             New CodeStyleOption(Of String)(String.Join(",", PreferredModifierOrderDefault.Select(AddressOf SyntaxFacts.GetText)), NotificationOption.None),
             EditorConfigStorageLocation.ForStringCodeStyleOption("visual_basic_preferred_modifier_order"),
             New RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{NameOf(PreferredModifierOrder)}"))
+
+        Public ReadOnly PreferInferredTupleNames As [Option](Of CodeStyleOption(Of Boolean)) = New [Option](Of CodeStyleOption(Of Boolean))(
+            NameOf(CodeStyleOptions), NameOf(PreferInferredTupleNames),
+            CodeStyleOptions.TrueWithSuggestionEnforcement,
+            EditorConfigStorageLocation.ForStringCodeStyleOption("visual_basic_prefer_inferred_tuple_names"),
+            New RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{NameOf(PreferInferredTupleNames)}"))
+
+        Public ReadOnly PreferInferredAnonymousTypeMemberNames As [Option](Of CodeStyleOption(Of Boolean)) = New [Option](Of CodeStyleOption(Of Boolean))(
+            NameOf(CodeStyleOptions), NameOf(PreferInferredAnonymousTypeMemberNames),
+            CodeStyleOptions.TrueWithSuggestionEnforcement,
+            EditorConfigStorageLocation.ForStringCodeStyleOption("visual_basic_prefer_inferred_anonymous_type_member_names"),
+            New RoamingProfileStorageLocation($"TextEditor.%LANGUAGE%.Specific.{NameOf(PreferInferredAnonymousTypeMemberNames)}"))
+
     End Module
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
@@ -51,6 +51,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
         Public Overrides Sub WriteTo(options As OptionSet, writer As ObjectWriter, cancellationToken As CancellationToken)
             WriteOptionSetTo(options, LanguageNames.VisualBasic, writer, cancellationToken)
             WriteOptionTo(options, VisualBasicCodeStyleOptions.PreferredModifierOrder, writer, cancellationToken)
+            WriteOptionTo(options, VisualBasicCodeStyleOptions.PreferInferredTupleNames, writer, cancellationToken)
+            WriteOptionTo(options, VisualBasicCodeStyleOptions.PreferInferredAnonymousTypeMemberNames, writer, cancellationToken)
         End Sub
 
         Public Overrides Function ReadCompilationOptionsFrom(reader As ObjectReader, cancellationToken As CancellationToken) As CompilationOptions
@@ -129,6 +131,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
 
             options = ReadOptionSetFrom(options, LanguageNames.VisualBasic, reader, cancellationToken)
             options = ReadOptionFrom(options, VisualBasicCodeStyleOptions.PreferredModifierOrder, reader, cancellationToken)
+            options = ReadOptionFrom(options, VisualBasicCodeStyleOptions.PreferInferredTupleNames, reader, cancellationToken)
+            options = ReadOptionFrom(options, VisualBasicCodeStyleOptions.PreferInferredAnonymousTypeMemberNames, reader, cancellationToken)
 
             Return options
         End Function

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.AbstractReductionRewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/AbstractVisualBasicReducer.AbstractReductionRewriter.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             Private ReadOnly _pool As ObjectPool(Of IReductionRewriter)
 
             Protected CancellationToken As CancellationToken
-            Private _parseOptions As ParseOptions
+            Protected Property ParseOptions As VisualBasicParseOptions
             Private _simplificationOptions As OptionSet
 
             Private ReadOnly _processedParentNodes As HashSet(Of SyntaxNode) = New HashSet(Of SyntaxNode)()
@@ -29,13 +29,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             End Sub
 
             Public Sub Initialize(parseOptions As ParseOptions, optionSet As OptionSet, cancellationToken As CancellationToken) Implements IReductionRewriter.Initialize
-                _parseOptions = parseOptions
+                Me.ParseOptions = DirectCast(parseOptions, VisualBasicParseOptions)
                 _simplificationOptions = optionSet
                 cancellationToken = cancellationToken
             End Sub
 
             Public Sub Dispose() Implements IDisposable.Dispose
-                _parseOptions = Nothing
+                ParseOptions = Nothing
                 _simplificationOptions = Nothing
                 CancellationToken = CancellationToken.None
                 _processedParentNodes.Clear()

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicInferredMemberNameReducer.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicInferredMemberNameReducer.Rewriter.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
                 cancellationToken As CancellationToken
                 ) As SimpleArgumentSyntax
 
-                If CanSimplifyTupleName(node, ParseOptions, optionSet) Then
+                If CanSimplifyTupleName(node, ParseOptions) Then
                     Return node.WithNameColonEquals(Nothing).WithTriviaFrom(node)
                 End If
 

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicInferredMemberNameReducer.Rewriter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicInferredMemberNameReducer.Rewriter.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -13,6 +14,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             Public Sub New(pool As ObjectPool(Of IReductionRewriter))
                 MyBase.New(pool)
             End Sub
+
+            Private ReadOnly s_simplifyTupleName As Func(Of SimpleArgumentSyntax, SemanticModel, OptionSet, CancellationToken, SimpleArgumentSyntax) = AddressOf SimplifyTupleName
+
+            Private Function SimplifyTupleName(
+                node As SimpleArgumentSyntax,
+                semanticModel As SemanticModel,
+                optionSet As OptionSet,
+                cancellationToken As CancellationToken
+                ) As SimpleArgumentSyntax
+
+                If CanSimplifyTupleName(node, ParseOptions, optionSet) Then
+                    Return node.WithNameColonEquals(Nothing).WithTriviaFrom(node)
+                End If
+
+                Return node
+            End Function
 
             Public Overrides Function VisitSimpleArgument(node As SimpleArgumentSyntax) As SyntaxNode
                 CancellationToken.ThrowIfCancellationRequested()

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicInferredMemberNameReducer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicInferredMemberNameReducer.vb
@@ -23,15 +23,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             MyBase.New(s_pool)
         End Sub
 
-        Friend Shared Function CanSimplifyTupleName(node As SimpleArgumentSyntax, parseOptions As VisualBasicParseOptions, optionSet As OptionSet) As Boolean
+        Friend Shared Function CanSimplifyTupleName(node As SimpleArgumentSyntax, parseOptions As VisualBasicParseOptions) As Boolean
             ' Tuple elements are arguments in a tuple expression
             If node.NameColonEquals Is Nothing OrElse Not node.IsParentKind(SyntaxKind.TupleExpression) Then
                 Return False
             End If
 
-            If parseOptions.LanguageVersion < LanguageVersion.VisualBasic15_3 AndAlso
-                Not optionSet.GetOption(VisualBasicCodeStyleOptions.PreferInferredTupleNames).Value Then
-
+            If parseOptions.LanguageVersion < LanguageVersion.VisualBasic15_3 Then
                 Return False
             End If
 
@@ -48,20 +46,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
         Private Shared ReadOnly s_simplifyNamedFieldInitializer As Func(Of NamedFieldInitializerSyntax, SemanticModel, OptionSet, CancellationToken, SyntaxNode) = AddressOf SimplifyNamedFieldInitializer
 
         Private Shared Function SimplifyNamedFieldInitializer(node As NamedFieldInitializerSyntax, arg2 As SemanticModel, optionSet As OptionSet, arg4 As CancellationToken) As SyntaxNode
-            If CanSimplifyNamedFieldInitializer(node, optionSet) Then
+            If CanSimplifyNamedFieldInitializer(node) Then
                 Return SyntaxFactory.InferredFieldInitializer(node.Expression).WithTriviaFrom(node)
             End If
 
             Return node
         End Function
 
-        Friend Shared Function CanSimplifyNamedFieldInitializer(node As NamedFieldInitializerSyntax, optionSet As OptionSet) As Boolean
+        Friend Shared Function CanSimplifyNamedFieldInitializer(node As NamedFieldInitializerSyntax) As Boolean
             Dim inferredName = node.Expression.TryGetInferredMemberName()
-
-            If Not optionSet.GetOption(VisualBasicCodeStyleOptions.PreferInferredAnonymousTypeMemberNames).Value Then
-                Return False
-            End If
-
             If inferredName Is Nothing OrElse
                     Not CaseInsensitiveComparison.Equals(inferredName, node.Name.Identifier.ValueText) Then
                 Return False

--- a/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicInferredMemberNameReducer.vb
+++ b/src/Workspaces/VisualBasic/Portable/Simplification/Reducers/VisualBasicInferredMemberNameReducer.vb
@@ -31,9 +31,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             cancellationToken As CancellationToken
         ) As SimpleArgumentSyntax
 
+            If CanSimplifyTupleName(node) Then
+                Return node.WithNameColonEquals(Nothing).WithTriviaFrom(node)
+            End If
+
+            Return node
+        End Function
+
+        Friend Shared Function CanSimplifyTupleName(node As SimpleArgumentSyntax) As Boolean
             ' Tuple elements are arguments in a tuple expression
             If node.NameColonEquals Is Nothing OrElse Not node.IsParentKind(SyntaxKind.TupleExpression) Then
-                Return node
+                Return False
             End If
 
             Dim inferredName = node.Expression.TryGetInferredMemberName()
@@ -41,23 +49,31 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Simplification
             If inferredName Is Nothing OrElse
                 Not CaseInsensitiveComparison.Equals(inferredName, node.NameColonEquals.Name.Identifier.ValueText) Then
 
-                Return node
+                Return False
             End If
 
-            Return node.WithNameColonEquals(Nothing).WithTriviaFrom(node)
+            Return True
         End Function
 
         Private Shared ReadOnly s_simplifyNamedFieldInitializer As Func(Of NamedFieldInitializerSyntax, SemanticModel, OptionSet, CancellationToken, SyntaxNode) = AddressOf SimplifyNamedFieldInitializer
 
         Private Shared Function SimplifyNamedFieldInitializer(node As NamedFieldInitializerSyntax, arg2 As SemanticModel, arg3 As OptionSet, arg4 As CancellationToken) As SyntaxNode
+            If CanSimplifyNamedFieldInitializer(node) Then
+                Return SyntaxFactory.InferredFieldInitializer(node.Expression).WithTriviaFrom(node)
+            End If
+
+            Return node
+        End Function
+
+        Friend Shared Function CanSimplifyNamedFieldInitializer(node As NamedFieldInitializerSyntax) As Boolean
             Dim inferredName = node.Expression.TryGetInferredMemberName()
 
             If inferredName Is Nothing OrElse
                     Not CaseInsensitiveComparison.Equals(inferredName, node.Name.Identifier.ValueText) Then
-                Return node
+                Return False
             End If
 
-            Return SyntaxFactory.InferredFieldInitializer(node.Expression).WithTriviaFrom(node)
+            Return True
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
**Customer scenario**
Type `int a = 1; var t = (a: a, 2);` or `int a = 1; var anon = new { a=a, b=2 };`. The analyzer will offer to remove the explicit tuple element name and anonymous type member names.

I will do the same for VB.

**Bugs this fixes:**

https://github.com/dotnet/roslyn/issues/19485

I'm not sure whether it's desirable, but the current behavior uses the same diagnostic for tuples and anonymous types (but we do use separate code style preferences). So if you choose to "Fix all in document", both kinds will be fixed together:

![image](https://user-images.githubusercontent.com/12466233/27888467-f914effe-619a-11e7-9108-d67df43b3e49.png)

As a side-note, I wasn't sure how to unittest that scenario.