### PR TITLE
Restrict Document acquisition to UI Thread

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 AssertIsForeground();
 
                 var caretPosition = GetCaretPointInViewBuffer();
+                var document = Controller.GetDocument();
 
                 // Use an interlocked increment so that reads by existing filter tasks will see the
                 // change.
@@ -33,10 +34,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 var localId = _filterId;
                 Computation.ChainTaskAndNotifyControllerWhenFinished(
                     model => FilterModelInBackground(
-                        model, localId, caretPosition, filterReason, filterState));
+                        document, model, localId, caretPosition, filterReason, filterState));
             }
 
             private Model FilterModelInBackground(
+                Document document,
                 Model model,
                 int id,
                 SnapshotPoint caretPosition,
@@ -46,11 +48,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 using (Logger.LogBlock(FunctionId.Completion_ModelComputation_FilterModelInBackground, CancellationToken.None))
                 {
                     return FilterModelInBackgroundWorker(
-                        model, id, caretPosition, filterReason, filterState);
+                        document, model, id, caretPosition, filterReason, filterState);
                 }
             }
 
             private Model FilterModelInBackgroundWorker(
+                Document document,
                 Model model,
                 int id,
                 SnapshotPoint caretPosition,
@@ -91,8 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 var textSnapshot = caretPosition.Snapshot;
                 var textSpanToText = new Dictionary<TextSpan, string>();
 
-                var document = this.Controller.GetDocument();
-                var helper = this.Controller.GetCompletionHelper();
+                var helper = this.Controller.GetCompletionHelper(document);
 
                 var recentItems = this.Controller.GetRecentItems();
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -258,15 +258,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
         private Document GetDocument()
         {
+            // Documents can be closed while we are computing in the background.
+            // This can only be called from the foreground.
+            AssertIsForeground();
+
             // Crash if we don't find a document, we're already in a bad state.
             var document = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             Contract.ThrowIfNull(document, nameof(document));
             return document;
         }
 
-        private CompletionHelper GetCompletionHelper()
+        private CompletionHelper GetCompletionHelper(Document document)
         {
-            var document = GetDocument();
             return CompletionHelper.GetHelper(document);
         }
 


### PR DESCRIPTION
If the user closes a textview while completion is filtering, it's possible for the filtering task to ask for a Document before it gets cancelled, resulting in a crash. To prevent this, restrict Controller.GetDocument() to the foreground thread.

Seems like the most likely cause for https://devdiv.visualstudio.com/DevDiv/_workitems?id=451521&_a=edit (verified experimentally)
