### PR TITLE
Include Roslyn.Test.Utilities.dll in NuGet package

### DIFF
--- a/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
+++ b/src/NuGet/Microsoft.VisualStudio.IntegrationTest.Utilities.nuspec
@@ -19,6 +19,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="Dlls\TestUtilities\Roslyn.Test.Utilities.dll" target="lib\net46" />
     <file src="Dlls\VisualStudioIntegrationTestUtilities\Microsoft.VisualStudio.IntegrationTest.Utilities.dll" target="lib\net46" />
     <file src="Dlls\ServicesTestUtilities\Roslyn.Services.Test.Utilities.dll" target="lib\net46" />
   </files>


### PR DESCRIPTION
The Microsoft.VisualStudio.IntegrationTest.Utilities assembly now
depends on Roslyn.Test.Utilities.dll, so we need to include in in the
related NuGet package.