### PR TITLE
Changes to ensure Roslyn compiles with .NET Native

### DIFF
--- a/src/Compilers/Core/Portable/Interop/IClrStrongName.cs
+++ b/src/Compilers/Core/Portable/Interop/IClrStrongName.cs
@@ -14,14 +14,14 @@ namespace Microsoft.CodeAnalysis.Interop
         void GetHashFromAssemblyFile(
             [In, MarshalAs(UnmanagedType.LPStr)] string pszFilePath,
             [In, Out, MarshalAs(UnmanagedType.U4)] ref int piHashAlg,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] pbHash,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] byte[] pbHash,
             [In, MarshalAs(UnmanagedType.U4)] int cchHash,
             [MarshalAs(UnmanagedType.U4)] out int pchHash);
 
         void GetHashFromAssemblyFileW(
             [In, MarshalAs(UnmanagedType.LPWStr)] string pwzFilePath,
             [In, Out, MarshalAs(UnmanagedType.U4)] ref int piHashAlg,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] pbHash,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] byte[] pbHash,
             [In, MarshalAs(UnmanagedType.U4)] int cchHash,
             [MarshalAs(UnmanagedType.U4)] out int pchHash);
 
@@ -29,28 +29,28 @@ namespace Microsoft.CodeAnalysis.Interop
             [In] IntPtr pbBlob,
             [In, MarshalAs(UnmanagedType.U4)] int cchBlob,
             [In, Out, MarshalAs(UnmanagedType.U4)] ref int piHashAlg,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] pbHash,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)] byte[] pbHash,
             [In, MarshalAs(UnmanagedType.U4)] int cchHash,
             [MarshalAs(UnmanagedType.U4)] out int pchHash);
 
         void GetHashFromFile(
             [In, MarshalAs(UnmanagedType.LPStr)] string pszFilePath,
             [In, Out, MarshalAs(UnmanagedType.U4)] ref int piHashAlg,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] pbHash,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] byte[] pbHash,
             [In, MarshalAs(UnmanagedType.U4)] int cchHash,
             [MarshalAs(UnmanagedType.U4)] out int pchHash);
 
         void GetHashFromFileW(
             [In, MarshalAs(UnmanagedType.LPWStr)] string pwzFilePath,
             [In, Out, MarshalAs(UnmanagedType.U4)] ref int piHashAlg,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] pbHash,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] byte[] pbHash,
             [In, MarshalAs(UnmanagedType.U4)] int cchHash,
             [MarshalAs(UnmanagedType.U4)] out int pchHash);
 
         void GetHashFromHandle(
             [In] IntPtr hFile,
             [In, Out, MarshalAs(UnmanagedType.U4)] ref int piHashAlg,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] pbHash,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] byte[] pbHash,
             [In, MarshalAs(UnmanagedType.U4)] int cchHash,
             [MarshalAs(UnmanagedType.U4)] out int pchHash);
 
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Interop
         void StrongNameGetBlobFromImage(
             [In] IntPtr pbBase,
             [In, MarshalAs(UnmanagedType.U4)] int dwLength,
-            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] pbBlob,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] byte[] pbBlob,
             [In, Out, MarshalAs(UnmanagedType.U4)] ref int pcbBlob);
 
         void StrongNameGetPublicKey(
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Interop
             [In, MarshalAs(UnmanagedType.LPWStr)] string pwzKeyContainer,
             [In] IntPtr pbKeyBlob,
             [In, MarshalAs(UnmanagedType.U4)] int cbKeyBlob,
-            byte[] ppbSignatureBlob,
+            [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5)]byte[] ppbSignatureBlob,
             [MarshalAs(UnmanagedType.U4)] out int pcbSignatureBlob);
 
         void StrongNameSignatureGenerationEx(

--- a/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/ISymUnmanagedWriter.cs
@@ -147,48 +147,35 @@ namespace Microsoft.Cci
     [StructLayout(LayoutKind.Explicit)]
     internal struct VariantStructure
     {
-        public VariantStructure(DateTime date) : this() // Need this to avoid errors about the uninteresting union fields.
+        public unsafe VariantStructure(DateTime date) : this() // Need this to avoid errors about the uninteresting union fields.
         {
-            _longValue = date.Ticks;
+            fixed (VariantStructure* thisPtr = &this)
+            {
+                *((long*)((byte*)thisPtr + 8)) = date.Ticks;
+            }
+
             _type = (short)VarEnum.VT_DATE;
         }
 
         [FieldOffset(0)]
         private readonly short _type;
 
-        [FieldOffset(8)]
-        private readonly long _longValue;
-
         /// <summary>
         /// This field determines the size of the struct 
         /// (16 bytes on 32-bit platforms, 24 bytes on 64-bit platforms).
         /// </summary>
         [FieldOffset(8)]
-        private readonly VariantPadding _padding;
-
-        // Fields below this point are only used to make inspecting this struct in the debugger easier.
-
-        [FieldOffset(0)] // NB: 0, not 8
-        private readonly decimal _decimalValue;
-
-        [FieldOffset(8)]
-        private readonly bool _boolValue;
-
-        [FieldOffset(8)]
-        private readonly long _intValue;
-
-        [FieldOffset(8)]
-        private readonly double _doubleValue;
+        private readonly VariantData _data;
     }
 
     /// <summary>
     /// This type is 8 bytes on a 32-bit platforms and 16 bytes on 64-bit platforms.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    internal struct VariantPadding
+    internal struct VariantData
     {
-        public readonly IntPtr Data2;
-        public readonly IntPtr Data3;
+        public readonly IntPtr Data0;
+        public readonly IntPtr Data1;
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]


### PR DESCRIPTION
In particular, this change contains the following:
* Fix SizeParamIndex in a number of P/Invoke signature
* Initialize AssemblyLoadContext in lazy fashion
* Modified VariantStructure fields to ensure there are no overlapping
fields as .NET Native doesn't support P/Invokes with such structs.