### PR TITLE
Use IVsSolution to get the correct IVsProject for an IVsHierarchy

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _needsSave = needsSave;
 
             var invisibleEditorManager = (IIntPtrReturningVsInvisibleEditorManager)serviceProvider.GetService(typeof(SVsInvisibleEditorManager));
-            var vsProject = projectOpt?.Hierarchy as IVsProject;
+            var vsProject = TryGetProjectOfHierarchy(projectOpt?.Hierarchy);
             var invisibleEditorPtr = IntPtr.Zero;
             Marshal.ThrowExceptionForHR(invisibleEditorManager.RegisterInvisibleEditor(filePath, vsProject, 0, null, out invisibleEditorPtr));
 
@@ -82,6 +82,34 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // We need to clean up the extra reference we have, now that we have an RCW holding onto the object.
                 Marshal.Release(invisibleEditorPtr);
             }
+        }
+
+        private IVsProject TryGetProjectOfHierarchy(IVsHierarchy hierarchyOpt)
+        {
+            // The invisible editor manager will fail in cases where the IVsProject passed to it is not consistent with
+            // the IVsProject known to IVsSolution (e.g. if the object is a wrapper like AbstractHostObject created by
+            // the CPS-based project system). This method returns an IVsProject instance known to the solution, or null
+            // if the project could not be determined.
+            if (hierarchyOpt == null)
+            {
+                return null;
+            }
+
+            if (!ErrorHandler.Succeeded(hierarchyOpt.GetGuidProperty(
+                (uint)VSConstants.VSITEMID.Root,
+                (int)__VSHPROPID.VSHPROPID_ProjectIDGuid,
+                out var projectId)))
+            {
+                return null;
+            }
+
+            var solution = (IVsSolution)_serviceProvider.GetService(typeof(SVsSolution));
+            if (!ErrorHandler.Succeeded(solution.GetProjectOfGuid(projectId, out var projectHierarchy)))
+            {
+                return null;
+            }
+
+            return projectHierarchy as IVsProject;
         }
 
         public IVsTextLines VsTextLines


### PR DESCRIPTION
Fixes crashes associated with InvisibleEditor.

**Customer scenario**

* Use the Inline Rename functionality to rename an element (rare, never reproduced outside of crash reports)
* Use the following steps:
  1. Open dotnet/vs-threading
  2. Open **AsyncAutoResetEvent.cs**
  3. Use Inline Rename to rename `AsyncAutoResetEvent` to `AsyncAutoResetEvent2`
  4. Use CodeLens to drop down the references to the type
  5. Double click the reference in **AsyncAutoResetEventTests.cs** from the `evt` field

**Bugs this fixes:**

Fixes [DevDiv 458062](https://devdiv.visualstudio.com/DevDiv/_workitems?id=458062).

**Workarounds, if any**

None.

**Risk**

Low. The solution to the problem was implemented using techniques which all project systems should support without trouble.

**Performance impact**

Negligible. The solution was analyzed specifically to ensure the performance benefits of #19919 are retained.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

Edge case / race condition introduced by #19919. The root cause is documented in a comment in code:

> The invisible editor manager will fail in cases where the `IVsProject` passed to it is not consistent with the `IVsProject` known to `IVsSolution` (e.g. if the object is a wrapper like `AbstractHostObject` created by the CPS-based project system). This method returns an `IVsProject` instance known to the solution, or null if the project could not be determined.

**How was the bug found?**

Watson and manual testing.
