### PR TITLE
Remove outdated TODO comment

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -395,11 +395,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case IdentifierName:
                     return syntax.IsMissing;
 
-                // TODO: The native implementation also disallows delegate
-                // creation expressions with the ERR_IllegalStatement error, 
-                // so that needs to go into the semantic analysis somewhere
-                // if we intend to carry it forward.
-
                 default:
                     return false;
             }


### PR DESCRIPTION
The check in semantic analysis the comment talks about is [here](https://github.com/dotnet/roslyn/blob/6ffc947/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs#L3661), test verifying it [here](https://github.com/dotnet/roslyn/blob/5a3e9ed/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs#L597).