### PR TITLE
Exec-Command should re-use console

### DIFF
--- a/build/scripts/build-utils.ps1
+++ b/build/scripts/build-utils.ps1
@@ -27,41 +27,36 @@ function Exec-Block([scriptblock]$cmd) {
     } 
 }
 
-# Handy function for executing a windows command which needs to go through 
-# windows command line parsing.  
-#
-# Use this when the command arguments are stored in a variable.  Particularly 
-# when the variable needs reparsing by the windows command line. Example:
-#
-#   $args = "/p:ManualBuild=true Test.proj"
-#   Exec-Command $msbuild $args
-# 
-function Exec-Command([string]$command, [string]$commandArgs) {
+function Exec-CommandCore([string]$command, [string]$commandArgs, [switch]$useConsole = $true) {
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
     $startInfo.FileName = $command
     $startInfo.Arguments = $commandArgs
 
-    $startInfo.RedirectStandardOutput = $true
     $startInfo.UseShellExecute = $false
-    $startInfo.CreateNoWindow = $true
     $startInfo.WorkingDirectory = Get-Location
+
+    if (-not $useConsole) {
+       $startInfo.RedirectStandardOutput = $true
+       $startInfo.CreateNoWindow = $true
+    }
 
     $process = New-Object System.Diagnostics.Process
     $process.StartInfo = $startInfo
-    $process.StartInfo.RedirectStandardOutput = $true;
     $process.Start() | Out-Null
 
     $finished = $false
     try {
-        # The OutputDataReceived event doesn't fire as events are sent by the 
-        # process in powershell.  Possibly due to subtlties of how Powershell
-        # manages the thread pool that I'm not aware of.  Using blocking
-        # reading here as an alternative which is fine since this blocks 
-        # on completion already.
-        $out = $process.StandardOutput
-        while (-not $out.EndOfStream) {
-            $line = $out.ReadLine()
-            Write-Output $line
+        if (-not $useConsole) { 
+            # The OutputDataReceived event doesn't fire as events are sent by the 
+            # process in powershell.  Possibly due to subtlties of how Powershell
+            # manages the thread pool that I'm not aware of.  Using blocking
+            # reading here as an alternative which is fine since this blocks 
+            # on completion already.
+            $out = $process.StandardOutput
+            while (-not $out.EndOfStream) {
+                $line = $out.ReadLine()
+                Write-Output $line
+            }
         }
 
         while (-not $process.WaitForExit(100)) { 
@@ -80,6 +75,29 @@ function Exec-Command([string]$command, [string]$commandArgs) {
             $process.Kill()
         }
     }
+}
+
+# Handy function for executing a windows command which needs to go through 
+# windows command line parsing.  
+#
+# Use this when the command arguments are stored in a variable.  Particularly 
+# when the variable needs reparsing by the windows command line. Example:
+#
+#   $args = "/p:ManualBuild=true Test.proj"
+#   Exec-Command $msbuild $args
+# 
+function Exec-Command([string]$command, [string]$commandArgs) {
+    Exec-CommandCore -command $command -commandArgs $commandargs -useConsole:$false
+}
+
+# Functions exactly like Exec-Command but lets the process re-use the current 
+# console. This means items like colored output will function correctly.
+#
+# In general this command should be used in place of
+#   Exec-Command $msbuild $args | Out-Host
+#
+function Exec-Console([string]$command, [string]$commandArgs) {
+    Exec-CommandCore -command $command -commandArgs $commandargs -useConsole:$true
 }
 
 # Handy function for executing a powershell script in a clean environment with 

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -106,14 +106,14 @@ function Make-BootstrapBuild() {
 
     $bootstrapLog = Join-Path $binariesDir "Bootstrap.log"
     Write-Host "Building Bootstrap compiler"
-    Run-MSBuild "/p:UseShippingAssemblyVersion=true /p:InitialDefineConstants=BOOTSTRAP build\Toolset\Toolset.csproj /p:Configuration=$buildConfiguration" -logFile $bootstrapLog | Out-Host
+    Run-MSBuild "/p:UseShippingAssemblyVersion=true /p:InitialDefineConstants=BOOTSTRAP build\Toolset\Toolset.csproj /p:Configuration=$buildConfiguration" -logFile $bootstrapLog 
     $dir = Join-Path $binariesDir "Bootstrap"
     Remove-Item -re $dir -ErrorAction SilentlyContinue
     Create-Directory $dir
     Move-Item "$configDir\Exes\Toolset\*" $dir
 
     Write-Host "Cleaning Bootstrap compiler artifacts"
-    Run-MSBuild "/t:Clean build\Toolset\Toolset.csproj /p:Configuration=$buildConfiguration" | Out-Host 
+    Run-MSBuild "/t:Clean build\Toolset\Toolset.csproj /p:Configuration=$buildConfiguration"
     Stop-BuildProcesses
     return $dir
 }
@@ -162,7 +162,7 @@ function Test-XUnitCoreClr() {
     Create-Directory $logDir 
 
     Write-Host "Publishing CoreClr tests"
-    Run-MSBuild "src\Test\DeployCoreClrTestRuntime\DeployCoreClrTestRuntime.csproj /m /v:m /t:Publish /p:RuntimeIdentifier=win7-x64 /p:PublishDir=$unitDir" | Out-Host
+    Run-MSBuild "src\Test\DeployCoreClrTestRuntime\DeployCoreClrTestRuntime.csproj /m /v:m /t:Publish /p:RuntimeIdentifier=win7-x64 /p:PublishDir=$unitDir"
 
     $corerun = Join-Path $unitDir "CoreRun.exe"
     $args = Join-Path $unitDir "xunit.console.netcore.exe"

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -94,7 +94,7 @@ function Run-MSBuild([string]$buildArgs = "", [string]$logFile = "") {
     }
 
     $args += " $buildArgs"
-    Exec-Command $msbuild $args
+    Exec-Console $msbuild $args
 }
 
 # Create a bootstrap build of the compiler.  Returns the directory where the bootstrap buil 
@@ -174,7 +174,7 @@ function Test-XUnitCoreClr() {
     $args += " -xml $logFile"
 
     Write-Host "Running CoreClr tests"
-    Exec-Command $corerun $args | Out-Host
+    Exec-Console $corerun $args
 }
 
 # Core function for running our unit / integration tests tests
@@ -247,7 +247,7 @@ function Test-XUnit() {
     }
     
     try {
-        Exec-Command $runTests $args | Out-Host 
+        Exec-Console $runTests $args
     }
     finally {
         Get-Process "xunit*" -ErrorAction SilentlyContinue | Stop-Process    
@@ -293,7 +293,7 @@ function Deploy-VsixViaTool() {
         $filePath = Join-Path $configDir $e
         $fullArg = "$baseArgs $filePath"
         Write-Host "`tInstalling $name"
-        Exec-Command $vsixExe $fullArg | Out-Host
+        Exec-Console $vsixExe $fullArg
     }
 }
 

--- a/build/scripts/generate-compiler-code.ps1
+++ b/build/scripts/generate-compiler-code.ps1
@@ -10,7 +10,7 @@ $ErrorActionPreference="Stop"
 function Run-Tool($tool, $toolArgs) {
     $toolName = Split-Path -leaf $tool
     Write-Host "Running $toolName"
-    Exec-Command $tool $toolArgs | Out-Host
+    Exec-Console $tool $toolArgs
 }
 
 function Run-LanguageCore($language, $languageSuffix, $languageDir, $syntaxTool, $errorFactsTool, $generatedDir, $generatedTestDir) {

--- a/build/scripts/test-build-correctness.ps1
+++ b/build/scripts/test-build-correctness.ps1
@@ -33,13 +33,13 @@ try {
     }
 
     Write-Host "Building Roslyn.sln with logging support"
-    Exec-Command $msbuild "/noconlog /v:m /m /p:Configuration=$config /logger:StructuredLogger,$structuredLoggerPath;$logPath /nodeReuse:false /p:DeployExtension=false $solution"
+    Exec-Console $msbuild "/noconlog /v:m /m /p:Configuration=$config /logger:StructuredLogger,$structuredLoggerPath;$logPath /nodeReuse:false /p:DeployExtension=false $solution"
     Write-Host ""
 
     # Verify the state of our various build artifacts
     Write-Host "Running BuildBoss"
     $buildBossPath = Join-Path $configDir "Exes\BuildBoss\BuildBoss.exe"
-    Exec-Command $buildBossPath "Roslyn.sln Compilers.sln src\Samples\Samples.sln CrossPlatform.sln build\Targets $logPath"
+    Exec-Console $buildBossPath "Roslyn.sln Compilers.sln src\Samples\Samples.sln CrossPlatform.sln build\Targets $logPath"
     Write-Host ""
 
     # Verify the state of our generated syntax files

--- a/build/scripts/test-determinism.ps1
+++ b/build/scripts/test-determinism.ps1
@@ -22,7 +22,7 @@ function Run-Build([string]$rootDir, [string]$pathMapBuildOption, [switch]$resto
 
         # Clean out the previous run
         Write-Host "Cleaning the Binaries"
-        Exec-Command $msbuild "/nologo /v:m /nodeReuse:false /t:clean Roslyn.sln" 
+        Exec-Console $msbuild "/nologo /v:m /nodeReuse:false /t:clean Roslyn.sln" 
 
         if ($restore) {
             Write-Host "Restoring the packages"
@@ -30,7 +30,7 @@ function Run-Build([string]$rootDir, [string]$pathMapBuildOption, [switch]$resto
         }
 
         Write-Host "Building the Solution"
-        Exec-Command $msbuild "/nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:bootstrapDir /p:Features=`"debug-determinism`" /p:UseRoslynAnalyzers=false $pathMapBuildOption Roslyn.sln"
+        Exec-Console $msbuild "/nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:bootstrapDir /p:Features=`"debug-determinism`" /p:UseRoslynAnalyzers=false $pathMapBuildOption Roslyn.sln"
     }
     finally {
         Pop-Location


### PR DESCRIPTION
Change the Exec-Command to re-use the current console vs. redirecting all
of the output. This lets items like color, and cancel work more naturally for
spawned processes.
