### PR TITLE
Ensure we disconnect any projection buffers we create for views

### DIFF
--- a/src/EditorFeatures/CSharp/QuickInfo/SyntacticQuickInfoProvider.cs
+++ b/src/EditorFeatures/CSharp/QuickInfo/SyntacticQuickInfoProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.QuickInfo
             }
 
             var span = new SnapshotSpan(textSnapshot, Span.FromBounds(spanStart, spanEnd));
-            return this.CreateElisionBufferDeferredContent(span);
+            return this.CreateProjectionBufferDeferredContent(span);
         }
 
         private static bool IsScopeBlock(SyntaxNode node)

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SyntacticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SyntacticQuickInfoSourceTests.cs
@@ -293,15 +293,8 @@ if (true)
             Assert.NotNull(state);
 
             var viewHostingControl = (ViewHostingControl)((ElisionBufferDeferredContent)state.Content).Create();
-            try
-            {
-                var actualContent = viewHostingControl.ToString();
-                Assert.Equal(expectedContent, actualContent);
-            }
-            finally
-            {
-                viewHostingControl.TextView_TestOnly.Close();
-            }
+            var actualContent = viewHostingControl.GetText_TestOnly();
+            Assert.Equal(expectedContent, actualContent);
         }
 
         protected override Task TestInMethodAsync(string code, string expectedContent, string expectedDocumentationComment = null)

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SyntacticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SyntacticQuickInfoSourceTests.cs
@@ -292,7 +292,7 @@ if (true)
             var state = await provider.GetItemAsync(document, position, cancellationToken: CancellationToken.None);
             Assert.NotNull(state);
 
-            var viewHostingControl = (ViewHostingControl)((ElisionBufferDeferredContent)state.Content).Create();
+            var viewHostingControl = (ViewHostingControl)((ProjectionBufferDeferredContent)state.Content).Create();
             var actualContent = viewHostingControl.GetText_TestOnly();
             Assert.Equal(expectedContent, actualContent);
         }

--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -573,7 +573,7 @@
     <Compile Include="Implementation\Intellisense\QuickInfo\Controller_OnCaretPositionChanged.cs" />
     <Compile Include="Implementation\Intellisense\QuickInfo\Controller_OnTextViewBufferPostChanged.cs" />
     <Compile Include="Implementation\Intellisense\QuickInfo\DeferredContent\ClassifiableDeferredContent.cs" />
-    <Compile Include="Implementation\Intellisense\QuickInfo\DeferredContent\ElisionBufferDeferredContent.cs" />
+    <Compile Include="Implementation\Intellisense\QuickInfo\DeferredContent\ProjectionBufferDeferredContent.cs" />
     <Compile Include="Implementation\Intellisense\QuickInfo\DeferredContent\QuickInfoDisplayDeferredContent.cs" />
     <Compile Include="Implementation\Intellisense\QuickInfo\DeferredContent\SymbolGlyphDeferredContent.cs" />
     <Compile Include="Implementation\Intellisense\IDocumentProvider.cs" />

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/ProjectionBufferDeferredContent.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/ProjectionBufferDeferredContent.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
 {
     /// <summary>
     /// Creates quick info content out of the span of an existing snapshot.  The span will be
-    /// used to create an elision buffer out that will then be displayed in the quick info
+    /// used to create an projection buffer out that will then be displayed in the quick info
     /// window.
     /// </summary>
-    internal class ElisionBufferDeferredContent : IDeferredQuickInfoContent
+    internal class ProjectionBufferDeferredContent : IDeferredQuickInfoContent
     {
         private readonly SnapshotSpan _span;
         private readonly IProjectionBufferFactoryService _projectionBufferFactoryService;
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
         private readonly IContentType _contentType;
         private readonly ITextViewRoleSet _roleSet;
 
-        public ElisionBufferDeferredContent(
+        public ProjectionBufferDeferredContent(
             SnapshotSpan span,
             IProjectionBufferFactoryService projectionBufferFactoryService,
             IEditorOptionsFactoryService editorOptionsFactoryService,
@@ -63,9 +63,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             return view;
         }
 
-        private IElisionBuffer CreateBuffer()
+        private IProjectionBuffer CreateBuffer()
         {
-            return _projectionBufferFactoryService.CreateElisionBufferWithoutIndentation(
+            return _projectionBufferFactoryService.CreateProjectionBufferWithoutIndentation(
                 _editorOptionsFactoryService.GlobalOptions, _contentType, _span);
         }
     }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractQuickInfoProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/Providers/AbstractQuickInfoProvider.cs
@@ -151,9 +151,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             return new DocumentationCommentDeferredContent(documentationComment, _typeMap);
         }
 
-        protected IDeferredQuickInfoContent CreateElisionBufferDeferredContent(SnapshotSpan span)
+        protected IDeferredQuickInfoContent CreateProjectionBufferDeferredContent(SnapshotSpan span)
         {
-            return new ElisionBufferDeferredContent(
+            return new ProjectionBufferDeferredContent(
                 span, _projectionBufferFactoryService, _editorOptionsFactoryService, _textEditorFactoryService);
         }
     }

--- a/src/EditorFeatures/Core/Implementation/Structure/BlockTagState.cs
+++ b/src/EditorFeatures/Core/Implementation/Structure/BlockTagState.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
         private ITextBuffer CreateElisionBufferWithoutIndentation(
             ITextBuffer dataBuffer, Span shortHintSpan)
         {
-            return _projectionBufferFactoryService.CreateElisionBufferWithoutIndentation(
+            return _projectionBufferFactoryService.CreateProjectionBufferWithoutIndentation(
                 _editorOptionsFactoryService.GlobalOptions,
                 contentType: null,
                 exposedSpans: new SnapshotSpan(dataBuffer.CurrentSnapshot, shortHintSpan));

--- a/src/EditorFeatures/Core/Shared/Extensions/IProjectionBufferFactoryServiceExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/IProjectionBufferFactoryServiceExtensions.cs
@@ -30,19 +30,19 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
         [BaseDefinition("projection")]
         public static readonly ContentTypeDefinition RoslynPreviewContentTypeDefinition;
 
-        public static IElisionBuffer CreateElisionBufferWithoutIndentation(
+        public static IProjectionBuffer CreateProjectionBufferWithoutIndentation(
             this IProjectionBufferFactoryService factoryService,
             IEditorOptions editorOptions,
             IContentType contentType = null,
             params SnapshotSpan[] exposedSpans)
         {
-            return factoryService.CreateElisionBufferWithoutIndentation(
+            return factoryService.CreateProjectionBufferWithoutIndentation(
                 editorOptions,
                 contentType,
                 (IEnumerable<SnapshotSpan>)exposedSpans);
         }
 
-        public static IElisionBuffer CreateElisionBufferWithoutIndentation(
+        public static IProjectionBuffer CreateProjectionBufferWithoutIndentation(
             this IProjectionBufferFactoryService factoryService,
             IEditorOptions editorOptions,
             IContentType contentType,
@@ -61,37 +61,55 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
             }
 
             contentType = contentType ?? factoryService.ProjectionContentType;
-            var elisionBuffer = factoryService.CreateElisionBuffer(
-                null, spans, ElisionBufferOptions.None, contentType);
+            var projectionBuffer = factoryService.CreateProjectionBuffer(
+                projectionEditResolver: null,
+                sourceSpans: Array.Empty<object>(),
+                options: ProjectionBufferOptions.None,
+                contentType: contentType);
 
             if (spans.Count > 0)
             {
-                var snapshot = spans.First().Snapshot;
-                var buffer = snapshot.TextBuffer;
+                var finalSpans = new List<object>();
 
                 // We need to figure out the shorted indentation level of the exposed lines.  We'll
                 // then remove that indentation from all lines.
                 var indentationColumn = DetermineIndentationColumn(editorOptions, spans);
 
-                var spansToElide = new List<Span>();
-
                 foreach (var span in spans)
                 {
+                    var snapshot = span.Snapshot;
                     var startLineNumber = snapshot.GetLineNumberFromPosition(span.Start);
                     var endLineNumber = snapshot.GetLineNumberFromPosition(span.End);
 
                     for (var lineNumber = startLineNumber; lineNumber <= endLineNumber; lineNumber++)
                     {
+                        // Compute the span clamped to this line
                         var line = snapshot.GetLineFromLineNumber(lineNumber);
-                        var lineOffsetOfColumn = line.GetLineOffsetFromColumn(indentationColumn, editorOptions);
-                        spansToElide.Add(Span.FromBounds(line.Start, line.Start + lineOffsetOfColumn));
+                        var finalSpanStart = Math.Max(line.Start, span.Start);
+                        var finalSpanEnd = Math.Min(line.EndIncludingLineBreak, span.End);
+
+                        // We'll only offset if our span doesn't already start at the start of the line. See the similar exclusion in
+                        // DetermineIndentationColumn that this matches.
+                        if (line.Start == finalSpanStart)
+                        {
+                            finalSpanStart += line.GetLineOffsetFromColumn(indentationColumn, editorOptions);
+
+                            // Paranoia: what if the indentation reversed our ordering?
+                            if (finalSpanStart > finalSpanEnd)
+                            {
+                                finalSpanStart = finalSpanEnd;
+                            }
+                        }
+
+                        // We don't expect edits to happen while this projection buffer is active. We'll choose EdgeExclusive so
+                        // if they do we don't end up in any cases where there is overlapping source spans.
+                        finalSpans.Add(snapshot.CreateTrackingSpan(Span.FromBounds(finalSpanStart, finalSpanEnd), SpanTrackingMode.EdgeExclusive));
                     }
                 }
-
-                elisionBuffer.ElideSpans(new NormalizedSpanCollection(spansToElide));
+                projectionBuffer.InsertSpans(0, finalSpans);
             }
 
-            return elisionBuffer;
+            return projectionBuffer;
         }
 
         private static int DetermineIndentationColumn(

--- a/src/EditorFeatures/Core/Shared/Utilities/ViewHostingControl.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ViewHostingControl.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Projection;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 {
@@ -13,6 +14,9 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
     {
         private readonly Func<ITextBuffer, IWpfTextView> _createView;
         private readonly Func<ITextBuffer> _createBuffer;
+
+        private ITextBuffer _createdTextBuffer;
+        private IWpfTextView _createdView;
 
         public ViewHostingControl(
             Func<ITextBuffer, IWpfTextView> createView, 
@@ -25,18 +29,30 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             this.IsVisibleChanged += OnIsVisibleChanged;
         }
 
+        private void EnsureBufferCreated()
+        {
+            if (_createdTextBuffer == null)
+            {
+                _createdTextBuffer = _createBuffer();
+            }
+        }
+
+        private void EnsureContentCreated()
+        {
+            if (this.Content == null)
+            {
+                EnsureBufferCreated();
+                _createdView = _createView(_createdTextBuffer);
+                this.Content = _createdView.VisualElement;
+            }
+        }
+
         public ITextView TextView_TestOnly
         {
             get
             {
-                var view = (IWpfTextView)this.Content;
-                if (view == null)
-                {
-                    view = _createView(_createBuffer());
-                    this.Content = view.VisualElement;
-                }
-
-                return view;
+                EnsureContentCreated();
+                return (ITextView)this.Content;
             }
         }
 
@@ -45,26 +61,31 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             var nowVisible = (bool)e.NewValue;
             if (nowVisible)
             {
-                if (this.Content == null)
-                {
-                    this.Content = _createView(_createBuffer()).VisualElement;
-                }
+                EnsureContentCreated();
             }
             else
             {
-                ((ITextView)this.Content).Close();
                 this.Content = null;
+
+                _createdView.Close();
+                _createdView = null;
+
+                // If a projection buffer has a source span from another buffer, the projection buffer is held alive by the other buffer too.
+                // This means that a one-off projection buffer created for a tooltip would be kept alive as long as the underlying file
+                // is still open. Removing the source spans from the projection buffer ensures the projection buffer can be GC'ed.
+                if (_createdTextBuffer is IProjectionBuffer projectionBuffer)
+                {
+                    projectionBuffer.DeleteSpans(0, projectionBuffer.CurrentSnapshot.SpanCount);
+                }
+
+                _createdTextBuffer = null;
             }
         }
 
-        public override string ToString()
+        public string GetText_TestOnly()
         {
-            if (this.Content != null)
-            {
-                return ((ITextView)this.Content).TextBuffer.CurrentSnapshot.GetText();
-            }
-
-            return _createBuffer().CurrentSnapshot.GetText();
+            EnsureBufferCreated();
+            return _createdTextBuffer.CurrentSnapshot.GetText();
         }
     }
 }

--- a/src/EditorFeatures/Test/Extensions/IProjectionBufferFactoryServiceExtensionsTests.cs
+++ b/src/EditorFeatures/Test/Extensions/IProjectionBufferFactoryServiceExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
   line 2
   line 3", contentTypeRegistryService.GetContentType("text"));
 
-            var elisionBuffer = IProjectionBufferFactoryServiceExtensions.CreateElisionBufferWithoutIndentation(
+            var elisionBuffer = IProjectionBufferFactoryServiceExtensions.CreateProjectionBufferWithoutIndentation(
                 exportProvider.GetExportedValue<IProjectionBufferFactoryService>(),
                 exportProvider.GetExportedValue<IEditorOptionsFactoryService>().GlobalOptions,
                 contentType: null,

--- a/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
+++ b/src/EditorFeatures/Test/Structure/StructureTaggerTests.cs
@@ -155,7 +155,7 @@ End Module";
                 var tags = await GetTagsFromWorkspaceAsync(workspace);
 
                 var hints = tags.Select(x => x.CollapsedHintForm).Cast<ViewHostingControl>().ToArray();
-                Assert.Equal("Sub Main(args As String())\r\nEnd Sub", hints[1].ToString()); // method
+                Assert.Equal("Sub Main(args As String())\r\nEnd Sub", hints[1].GetText_TestOnly()); // method
                 hints.Do(v => v.TextView_TestOnly.Close());
             }
         }

--- a/src/VisualStudio/Core/Next/FindReferences/Entries/DocumentSpanEntry.cs
+++ b/src/VisualStudio/Core/Next/FindReferences/Entries/DocumentSpanEntry.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindUsages
                     PredefinedTextViewRoles.Document,
                     PredefinedTextViewRoles.Editable);
 
-                var content = new ElisionBufferDeferredContent(
+                var content = new ProjectionBufferDeferredContent(
                     snapshotSpan,
                     Presenter.ProjectionBufferFactoryService,
                     Presenter.EditorOptionsFactoryService,


### PR DESCRIPTION
When we create a projection buffer, that buffer is strongly held by the underlying buffer, which means we have a memory leak unless we disconnect it by unmapping all spans. This also causes problems because bugs in the editor around projections can then cause crashes when we didn't actually need the buffers anymore.

**Customer scenario:** user mouses over a closing brace, and we show quick info help. At this point, we have a buffer leaked which due to editor bugs may later cause a crash.
**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/378999
**Workarounds, if any:** don't mouse over closing braces which causes us to show tips.
**Risk:** low. We already use this pattern in other places; this one place was missed.
**Performance impact:** improved. Fixes a small memory leak. and over time enough of them might actually hurt typing performance.
**Is this a regression from a previous update?** No. The underlying editor bug has been there a long time; we've just finally began to understand the causes.
**Root cause analysis:** When you mouse over a closing brace, we create a "projection buffer" atop the main buffer that shows just the small portion of the file from the matching brace. It's not obvious in the editor API that unless you take particular steps to clean this up, your buffer will continue to live around later. Even the editor team has discovered another version of this mistake, and long term is considering changes to fix it. Not cleaning it up means it's leaked, and which then exposes other bugs where certain edits when there's a projection buffer cause the editor to crash. The editor is aware of those bugs too but is hesitant to change them given the extreme sensitivity of that code.
**How was the bug found?** Customer reports through Send Feedback, which motivated us to add additional telemetry for 15.3 Preview 3.