### PR TITLE
Fix PIA embedding for Nuget.VisualStudio.

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -31,8 +31,7 @@
     <ItemGroup>
       <_NuGetVisualStudioPackageReference Include="@(Reference)" Condition="'%(Filename)' == 'NuGet.VisualStudio'" />
     </ItemGroup>
-    <Error Condition="'@(_NuGetVisualStudioPackageReference)' == ''" Text="Could not find NuGet.VisualStudio package to add EmbedInteropTypes to." />
-    <ItemGroup>
+    <ItemGroup Condition="'@(_NuGetVisualStudioPackageReference)' != ''">
       <Reference Remove="@(_NuGetVisualStudioPackageReference)" />
       <Reference Include="@(_NuGetVisualStudioPackageReference)">
         <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -27,9 +27,9 @@
        To deal with that, we write this target which finds that added package, removes it from
        the references list, then adds it back in again with the 'EmbedInteropTypes' flag properly
        set. -->
-  <Target Name="MarkNuGetVisualStudioPackageWithEmbedInteropType" AfterTargets="ResolveNuGetPackageAssets">
+  <Target Name="MarkNuGetVisualStudioPackageWithEmbedInteropType" AfterTargets="ResolvePackageDependenciesForBuild">
     <ItemGroup>
-      <_NuGetVisualStudioPackageReference Include="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'NuGet.VisualStudio'" />
+      <_NuGetVisualStudioPackageReference Include="@(Reference)" Condition="'%(Filename)' == 'NuGet.VisualStudio'" />
     </ItemGroup>
     <Error Condition="'@(_NuGetVisualStudioPackageReference)' == ''" Text="Could not find NuGet.VisualStudio package to add EmbedInteropTypes to." />
     <ItemGroup>


### PR DESCRIPTION
The MarkNuGetVisualStudioPackageWithEmbedInteropType target was depending on a ResolveNuGetPackageAssets target that no longer runs as part of Roslyn builds since Roslyn has been switched over to use the new SDK. Consequently, the Nuget.VisualStudio PIA was not getting embedded in MicroSoft.VisualStudio.LanguageServices.dll. Switching the dependency to the ResolvePackageDependenciesForBuild target should fix this issue.