### PR TITLE
Fix caret placement when undo'ing an automatically split string.

### DIFF
--- a/src/EditorFeatures/CSharp/CSharpEditorResources.Designer.cs
+++ b/src/EditorFeatures/CSharp/CSharpEditorResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CSharpEditorResources {
@@ -75,6 +75,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp {
         internal static string Smart_Indenting {
             get {
                 return ResourceManager.GetString("Smart_Indenting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Split string.
+        /// </summary>
+        internal static string Split_string {
+            get {
+                return ResourceManager.GetString("Split_string", resourceCulture);
             }
         }
     }

--- a/src/EditorFeatures/CSharp/CSharpEditorResources.resx
+++ b/src/EditorFeatures/CSharp/CSharpEditorResources.resx
@@ -123,4 +123,7 @@
   <data name="Smart_Indenting" xml:space="preserve">
     <value>Smart Indenting</value>
   </data>
+  <data name="Split_string" xml:space="preserve">
+    <value>Split string</value>
+  </data>
 </root>

--- a/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/SplitStringLiteral/SplitStringLiteralCommandHandlerTests.cs
@@ -1,16 +1,15 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 {
@@ -24,10 +23,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
                 var document = workspace.Documents.Single();
                 var view = document.GetTextView();
 
-                var snapshot = view.TextBuffer.CurrentSnapshot;
-                view.SetSelection(document.SelectedSpans.Single().ToSnapshotSpan(snapshot));
+                var originalSnapshot = view.TextBuffer.CurrentSnapshot;
+                var originalSelection = document.SelectedSpans.Single();
+                view.SetSelection(originalSelection.ToSnapshotSpan(originalSnapshot));
 
-                var commandHandler = new SplitStringLiteralCommandHandler();
+                var undoHistoryRegistry = workspace.GetService<ITextUndoHistoryRegistry>();
+                var commandHandler = new SplitStringLiteralCommandHandler(
+                    undoHistoryRegistry,
+                    workspace.GetService<IEditorOperationsFactoryService>());
                 commandHandler.ExecuteCommand(new ReturnKeyCommandArgs(view, view.TextBuffer), callback);
 
                 if (expectedOutputMarkup != null)
@@ -37,6 +40,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
 
                     Assert.Equal(expectedOutput, view.TextBuffer.CurrentSnapshot.AsText().ToString());
                     Assert.Equal(expectedSpans.Single().Start, view.Caret.Position.BufferPosition.Position);
+
+                    // Ensure that after undo we go back to where we were to begin with.
+                    var history = undoHistoryRegistry.GetHistory(document.TextBuffer);
+                    history.Undo(count: 1);
+
+                    var currentSnapshot = document.TextBuffer.CurrentSnapshot;
+                    Assert.Equal(originalSnapshot.GetText(), currentSnapshot.GetText());
+                    Assert.Equal(originalSelection.Start, view.Caret.Position.BufferPosition.Position);
                 }
             }
         }
@@ -381,6 +392,210 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SplitStringLiteral
     void M()
     {
         var v = ""now is [|the|] time"";
+    }
+}");
+        }
+
+        [WorkItem(20258, "https://github.com/dotnet/roslyn/issues/20258")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestBeforeEndQuote1()
+        {
+            TestHandled(
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}[||]"" +
+            $""{args[1]}"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""string3"";
+    }
+}",
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""[||]"" +
+            $""{args[1]}"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""string3"";
+    }
+}");
+        }
+
+        [WorkItem(20258, "https://github.com/dotnet/roslyn/issues/20258")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestBeforeEndQuote2()
+        {
+            TestHandled(
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}[||]"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""string3"";
+    }
+}",
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""[||]"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""string3"";
+    }
+}");
+        }
+
+        [WorkItem(20258, "https://github.com/dotnet/roslyn/issues/20258")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestBeforeEndQuote3()
+        {
+            TestHandled(
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""{args[2]}[||]"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""string3"";
+    }
+}",
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""{args[2]}"" +
+            $""[||]"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""string3"";
+    }
+}");
+        }
+
+        [WorkItem(20258, "https://github.com/dotnet/roslyn/issues/20258")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestBeforeEndQuote4()
+        {
+            TestHandled(
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1[||]"" +
+            ""string2"" +
+            ""string3"";
+    }
+}",
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""[||]"" +
+            ""string2"" +
+            ""string3"";
+    }
+}");
+        }
+
+        [WorkItem(20258, "https://github.com/dotnet/roslyn/issues/20258")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestBeforeEndQuote5()
+        {
+            TestHandled(
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""string2[||]"" +
+            ""string3"";
+    }
+}",
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""[||]"" +
+            ""string3"";
+    }
+}");
+        }
+
+        [WorkItem(20258, "https://github.com/dotnet/roslyn/issues/20258")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SplitStringLiteral)]
+        public void TestBeforeEndQuote6()
+        {
+            TestHandled(
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""string3[||]"";
+    }
+}",
+@"class Program
+{
+    static void Main(string[] args)
+    {
+        var str = $""somestring { args[0]}"" +
+            $""{args[1]}"" +
+            $""{args[2]}"";
+
+        var str2 = ""string1"" +
+            ""string2"" +
+            ""string3"" +
+            ""[||]"";
     }
 }");
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/20258