### PR TITLE
Always create a block-accessor when converting a property to have a block body.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForAccessorsAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForAccessorsAnalyzerTests.cs
@@ -297,5 +297,52 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     }
 }", ignoreTrivia: false, options: UseBlockBodyIncludingPropertiesAndIndexers);
         }
+
+        [WorkItem(20350, "https://github.com/dotnet/roslyn/issues/20350")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestAccessorListFormatting()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    int Foo { get [|=>|] Bar(); }
+}",
+@"class C
+{
+    int Foo
+    {
+        get
+        {
+            return Bar();
+        }
+    }
+}", options: UseBlockBodyIncludingPropertiesAndIndexers, ignoreTrivia: false);
+        }
+
+        [WorkItem(20350, "https://github.com/dotnet/roslyn/issues/20350")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestAccessorListFormatting_FixAll()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    int Foo { get {|FixAllInDocument:=>|} Bar(); set => Bar(); }
+}",
+@"class C
+{
+    int Foo
+    {
+        get
+        {
+            return Bar();
+        }
+
+        set
+        {
+            Bar();
+        }
+    }
+}", options: UseBlockBodyIncludingPropertiesAndIndexers, ignoreTrivia: false);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForIndexersAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForIndexersAnalyzerTests.cs
@@ -150,8 +150,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }", options: UseBlockBody);
         }
 
+        [WorkItem(20363, "https://github.com/dotnet/roslyn/issues/20363")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
-        public async Task TestUseBlockBodyIfAccessorWantExpression1()
+        public async Task TestUseBlockBodyForAccessorEventWhenAccessorWantExpression1()
         {
             await TestInRegularAndScriptAsync(
 @"class C
@@ -162,9 +163,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     int this[int i]
     {
-        get => Bar();
-        }
-    }", options: UseBlockBodyExceptAccessor);
+        get { return Bar(); }
+    }
+}", options: UseBlockBodyExceptAccessor);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForPropertiesAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForPropertiesAnalyzerTests.cs
@@ -167,8 +167,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }", options: UseBlockBody);
         }
 
+        [WorkItem(20363, "https://github.com/dotnet/roslyn/issues/20363")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
-        public async Task TestUseBlockBodyIfAccessorWantExpression1()
+        public async Task TestUseBlockBodyForAccessorEventWhenAccessorWantExpression1()
         {
             await TestInRegularAndScriptAsync(
 @"class C
@@ -179,9 +180,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 {
     int Foo
     {
-        get => Bar();
-        }
-    }", options: UseBlockBodyExceptAccessor);
+        get { return Bar(); }
+    }
+}", options: UseBlockBodyExceptAccessor);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForAccessorsRefactoringTests.cs
@@ -151,5 +151,26 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
     int Foo => Bar();
 }", parameters: new TestParameters(options: UseExpressionBodyForAccessors_BlockBodyForProperties));
         }
+
+        [WorkItem(20350, "https://github.com/dotnet/roslyn/issues/20350")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestAccessorListFormatting()
+        {
+            await TestInRegularAndScript1Async(
+@"class C
+{
+    int Foo { get => [||]Bar(); }
+}",
+@"class C
+{
+    int Foo
+    {
+        get
+        {
+            return Bar();
+        }
+    }
+}", ignoreTrivia: false, parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForIndexersRefactoringTests.cs
@@ -85,6 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }", parameters: new TestParameters(options: UseBlockBody));
         }
 
+        [WorkItem(20363, "https://github.com/dotnet/roslyn/issues/20363")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
         {
@@ -95,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    int this[int i] { get => Bar(); }
+    int this[int i] { get { return Bar(); } }
 }", parameters: new TestParameters(options: UseExpressionBody));
         }
     }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Refactoring/UseExpressionBodyForPropertiesRefactoringTests.cs
@@ -153,6 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }", parameters: new TestParameters(options: UseBlockBodyForAccessors_BlockBodyForProperties));
         }
 
+        [WorkItem(20363, "https://github.com/dotnet/roslyn/issues/20363")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
         public async Task TestOfferedIfUserPrefersExpressionBodiesAndInExpressionBody()
         {
@@ -163,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
 }",
 @"class C
 {
-    int Foo { get => Bar(); }
+    int Foo { get { return Bar(); } }
 }", parameters: new TestParameters(options: UseExpressionBodyForAccessors_ExpressionBodyForProperties));
         }
 

--- a/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
@@ -210,17 +210,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 
             expressionBody.TryConvertToBlock(GetSemicolonToken(declaration), CreateReturnStatementForExpression(declaration), out var block);
 
-            AccessorDeclarationSyntax accessor;
-            if (block == null)
-            {
-                accessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                                        .WithExpressionBody(expressionBody)
-                                        .WithSemicolonToken(semicolonToken);
-            }
-            else
-            {
-                accessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, block);
-            }
+            var accessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration);
+            accessor = block != null
+                ? accessor.WithBody(block)
+                : accessor.WithExpressionBody(expressionBody)
+                          .WithSemicolonToken(semicolonToken);
 
             return WithAccessorList(declaration, SyntaxFactory.AccessorList(
                 SyntaxFactory.SingletonList(accessor)));

--- a/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
@@ -200,16 +200,18 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
             var expressionBody = GetExpressionBody(declaration);
             var semicolonToken = GetSemicolonToken(declaration);
 
-            var expressionBodyPreference = options.GetOption(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors).Value;
+            // When converting an expression-bodied property to a block body, always attempt to 
+            // create an accessor with a block body (even if the user likes expression bodied
+            // accessors.  While this technically doesn't match their preferences, it fits with
+            // the far more likely scenario that the user wants to convert this property into
+            // a full property so that they can flesh out the body contents.  If we keep around
+            // an expression bodied accessor they'll just have to convert that to a block as well
+            // and that means two steps to take instead of one.
+
             expressionBody.TryConvertToBlock(GetSemicolonToken(declaration), CreateReturnStatementForExpression(declaration), out var block);
 
-            var useExpressionBodyIfAvailable =
-                expressionBodyPreference != ExpressionBodyPreference.Never &&
-                ((CSharpParseOptions)parseOptions).LanguageVersion >= LanguageVersion.CSharp7;
-
             AccessorDeclarationSyntax accessor;
-            if (block == null ||
-                useExpressionBodyIfAvailable)
+            if (block == null)
             {
                 accessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
                                         .WithExpressionBody(expressionBody)

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -8,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
@@ -51,16 +53,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         {
             var options = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
 
+            var accessorLists = new HashSet<AccessorListSyntax>();
             foreach (var diagnostic in diagnostics)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                AddEdits(editor, diagnostic, options, cancellationToken);
+                AddEdits(editor, diagnostic, options, accessorLists, cancellationToken);
+            }
+
+            // Ensure that if we changed any accessors that the accessor lists they're contained
+            // in are formatted properly as well.  Do this as a last pass so that we see all 
+            // individual changes made to the child accessors if we're doing a fix-all.
+            foreach (var accessorList in accessorLists)
+            {
+                editor.ReplaceNode(accessorList, (current, _) => current.WithAdditionalAnnotations(Formatter.Annotation));
             }
         }
 
         private void AddEdits(
-            SyntaxEditor editor, Diagnostic diagnostic, 
-            OptionSet options, CancellationToken cancellationToken)
+            SyntaxEditor editor, Diagnostic diagnostic,
+            OptionSet options, HashSet<AccessorListSyntax> accessorLists,
+            CancellationToken cancellationToken)
         {
             var declarationLocation = diagnostic.AdditionalLocations[0];
             var helper = _helpers.Single(h => h.DiagnosticId == diagnostic.Id);
@@ -72,6 +84,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                                            .WithAdditionalAnnotations(Formatter.Annotation);
 
             editor.ReplaceNode(declaration, updatedDeclaration);
+
+            if (declaration.Parent is AccessorListSyntax accessorList)
+            {
+                accessorLists.Add(accessorList);
+            }
         }
 
         private class MyCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -120,10 +120,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
             CancellationToken cancellationToken)
         {
             var parseOptions = root.SyntaxTree.Options;
-            var updatedDeclaration = helper.Update(declaration, options, parseOptions, useExpressionBody)
-                                           .WithAdditionalAnnotations(Formatter.Annotation);
-            var newRoot = root.ReplaceNode(declaration, updatedDeclaration);
+            var updatedDeclaration = helper.Update(declaration, options, parseOptions, useExpressionBody);
 
+            var parent = declaration is AccessorDeclarationSyntax
+                ? declaration.Parent
+                : declaration;
+            var updatedParent = parent.ReplaceNode(declaration, updatedDeclaration)
+                                      .WithAdditionalAnnotations(Formatter.Annotation);
+
+            var newRoot = root.ReplaceNode(parent, updatedParent);
             return Task.FromResult(document.WithSyntaxRoot(newRoot));
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/20363

Followup to https://github.com/dotnet/roslyn/pull/20690