### PR TITLE
Don't look for DesignerCategoryAttributes when the type isn't present

### DIFF
--- a/src/Features/Core/Portable/DesignerAttributes/AbstractDesignerAttributeService.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/AbstractDesignerAttributeService.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
             SemanticModel model = null;
 
             string designerAttributeArgument = null;
-            var documentHasError = false;
 
             // get type defined in current tree
             foreach (var typeNode in GetAllTopLevelTypeDefined(root))
@@ -44,7 +43,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                         {
                             // The DesignerCategoryAttribute doesn't exist. either not applicable or
                             // no idea on design attribute status, just leave things as it is.
-                            return new DesignerAttributeDocumentData(document.FilePath, designerAttributeArgument, documentHasError, notApplicable: true);
+                            return new DesignerAttributeDocumentData(document.FilePath, designerAttributeArgument);
                         }
                     }
 
@@ -64,7 +63,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                     {
                         if (type.IsErrorType())
                         {
-                            documentHasError = true;
                             continue;
                         }
 
@@ -75,7 +73,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                         if (attribute != null && attribute.ConstructorArguments.Length == 1)
                         {
                             designerAttributeArgument = GetArgumentString(attribute.ConstructorArguments[0]);
-                            return new DesignerAttributeDocumentData(document.FilePath, designerAttributeArgument, documentHasError, notApplicable: false);
+                            return new DesignerAttributeDocumentData(document.FilePath, designerAttributeArgument);
                         }
                     }
                 }
@@ -87,7 +85,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                 }
             }
 
-            return new DesignerAttributeDocumentData(document.FilePath, designerAttributeArgument, documentHasError, notApplicable: false);
+            return new DesignerAttributeDocumentData(document.FilePath, designerAttributeArgument);
         }
 
         private static string GetArgumentString(TypedConstant argument)

--- a/src/Features/Core/Portable/DesignerAttributes/DesignerAttributeDocumentData.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/DesignerAttributeDocumentData.cs
@@ -11,15 +11,11 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
     {
         public string FilePath;
         public string DesignerAttributeArgument;
-        public bool ContainsErrors;
-        public bool NotApplicable;
 
-        public DesignerAttributeDocumentData(string filePath, string designerAttributeArgument, bool containsErrors, bool notApplicable)
+        public DesignerAttributeDocumentData(string filePath, string designerAttributeArgument)
         {
             FilePath = filePath;
             DesignerAttributeArgument = designerAttributeArgument;
-            ContainsErrors = containsErrors;
-            NotApplicable = notApplicable;
         }
 
         public override bool Equals(object obj)
@@ -28,9 +24,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
         public bool Equals(DesignerAttributeDocumentData other)
         {
             return FilePath == other.FilePath &&
-                   DesignerAttributeArgument == other.DesignerAttributeArgument &&
-                   ContainsErrors == other.ContainsErrors &&
-                   NotApplicable == other.NotApplicable;
+                   DesignerAttributeArgument == other.DesignerAttributeArgument;
         }
 
         // Currently no need for GetHashCode.  If we end up using this as a key in a dictionary,

--- a/src/Features/Core/Portable/DesignerAttributes/DesignerAttributeProjectData.cs
+++ b/src/Features/Core/Portable/DesignerAttributes/DesignerAttributeProjectData.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
     internal class DesignerAttributeProjectData
     {
         private const string StreamName = "<DesignerAttribute>";
-        private const string FormatVersion = "3";
+        private const string FormatVersion = "4";
 
         public readonly VersionStamp SemanticVersion;
         public readonly ImmutableDictionary<string, DesignerAttributeDocumentData> PathToDocumentData;
@@ -51,10 +51,8 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                             {
                                 var filePath = reader.ReadString();
                                 var attribute = reader.ReadString();
-                                var containsErrors = reader.ReadBoolean();
-                                var notApplicable = reader.ReadBoolean();
 
-                                builder[filePath] = new DesignerAttributeDocumentData(filePath, attribute, containsErrors, notApplicable);
+                                builder[filePath] = new DesignerAttributeDocumentData(filePath, attribute);
                             }
 
                             return new DesignerAttributeProjectData(semanticVersion, builder.ToImmutable());
@@ -91,8 +89,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttributes
                         var result = kvp.Value;
                         writer.WriteString(result.FilePath);
                         writer.WriteString(result.DesignerAttributeArgument);
-                        writer.WriteBoolean(result.ContainsErrors);
-                        writer.WriteBoolean(result.NotApplicable);
                     }
 
                     stream.Position = 0;

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/DesignerAttributeIncrementalAnalyzer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 return;
             }
 
+            var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var designerAttribute = compilation.DesignerCategoryAttributeType();
+            if (designerAttribute == null)
+            {
+                // Project doesn't know about the System.ComponentModel.DesignerCategoryAttribute type.
+                // Don't bother running the analysis.
+                return;
+            }
+
             // Try to compute this data in the remote process.  If that fails, then compute
             // the results in the local process.
             var pathToResult = await TryAnalyzeProjectInRemoteProcessAsync(project, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Related to https://github.com/dotnet/project-system/issues/2001.

The `DesignerCategoryAttribute` type doesn't in exist in .NET Standard prior to version 2.0. If we can't find the type in the compilation we shouldn't bother running the `DesignerAttributeIncrementalAnalyzer`.

This also cleans up some unused fields.