### PR TITLE
Don't lower a second time when converting method group

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -13,6 +13,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return RewriteConditionalAccess(node, used: true);
         }
 
+        public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
+        {
+            return node;
+        }
+
         // null when currently enclosing conditional access node
         // is not supposed to be lowered.
         private BoundExpression _currentConditionalAccessTarget;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
         {
+            Debug.Assert(false);
             return node;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalAccess.cs
@@ -15,8 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
         {
-            Debug.Assert(false);
-            return node;
+            throw ExceptionUtilities.Unreachable;
         }
 
         // null when currently enclosing conditional access node

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert((object)method != null);
                         var oldSyntax = _factory.Syntax;
                         _factory.Syntax = (mg.ReceiverOpt ?? mg).Syntax;
-                        var receiver = (method.IsStatic && !oldNode.IsExtensionMethod) ? _factory.Type(method.ContainingType) : VisitExpression(mg.ReceiverOpt);
+                        var receiver = (method.IsStatic && !oldNode.IsExtensionMethod) ? _factory.Type(method.ContainingType) : mg.ReceiverOpt;
                         _factory.Syntax = oldSyntax;
                         return new BoundDelegateCreationExpression(syntax, argument: receiver, methodOpt: method, isExtensionMethod: oldNode.IsExtensionMethod, type: rewrittenType);
                     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
@@ -103,6 +103,31 @@ class C : I
 ");
         }
 
+        [Fact, WorkItem(20266, "https://github.com/dotnet/roslyn/issues/20266")]
+        public void ConditionalAccessInMethodGroupConversion()
+        {
+            var source = @"
+class C
+{
+    void M(object o)
+    {
+        System.Func<int, string> filter = new C(o?.ToString()).Method;
+        filter(0);
+    }
+    string Method(int x)
+    {
+        throw null;
+    }
+    C(string x)
+    {
+    }
+}
+";
+            var comp = CreateStandardCompilation(source);
+            comp.VerifyDiagnostics();
+            CompileAndVerify(comp);
+        }
+
         [Fact, WorkItem(638289, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638289")]
         public void ConditionalDelegateInterfaceUnification2()
         {


### PR DESCRIPTION
From discussion with the customer, this is not blocking his team. Although this is a crash, there is a workaround, so this probably won't meet the 15.3 bar at this point. The PR will be moved to 15.4 once such a branch exists.

**Customer scenario**
The problem occurs when there is a conditional access (`o?.ToString()`) inside a method group conversion `System.Func<int, string> filter = new C(o?.ToString()).Method;`.

**Bugs this fixes:**
Fixes https://github.com/dotnet/roslyn/issues/20266

**Workarounds, if any**
The conditional access can be extracted to a local variable.

**Risk**
**Performance impact**
Low. The change is very localized (lowering method group conversions) and actually saves un-necessary processing.

**Is this a regression from a previous update?**
Yes, this bug was introduced in 15.3.

**Root cause analysis:**
When we lower a conditional access, we end up with a `BoundLoweredConditionalAccess` node.
The conversion logic for method group tries to lower the bound tree a second time, but the local rewriter is not set up to properly handle this node type.

This conversion logic for method group was introduced by https://github.com/dotnet/roslyn/pull/17227, which tries to lower a bound tree that had already been lowered.

**How was the bug found?**
Reported by internal team.

@gafter @dotnet/roslyn-compiler for review.