### PR TITLE
Initial tree data structure for closure conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -37,8 +37,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 /// <summary>
                 /// A list of all locals or parameters that were declared in this scope and captured
-                /// in nested scopes. "Declared" refers to the start of the variable lifetime (which,
-                /// at this point in lowering, should be equivalent to lexical scope).
+                /// in this scope or nested scopes. "Declared" refers to the start of the variable
+                /// lifetime (which, at this point in lowering, should be equivalent to lexical scope).
                 /// </summary>
                 public ArrayBuilder<Symbol> DeclaredVariables { get; } = ArrayBuilder<Symbol>.GetInstance();
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -58,7 +58,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 public Scope(Scope parent, BoundNode boundNode, Closure containingClosure)
                 {
-                    Debug.Assert(parent != null);
                     Debug.Assert(boundNode != null);
 
                     Parent = parent;

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -215,6 +215,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 private ScopeTreeBuilder(Scope rootScope, Analysis analysis)
                 {
+                    Debug.Assert(rootScope != null);
+                    Debug.Assert(analysis != null);
+
                     _currentScope = rootScope;
                     _analysis = analysis;
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -1,0 +1,566 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class LambdaRewriter
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        internal sealed partial class Analysis : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+        {
+            private sealed class Scope
+            {
+                public Scope Parent { get; }
+
+                public ArrayBuilder<Scope> NestedScopes { get; } = ArrayBuilder<Scope>.GetInstance();
+
+                public ArrayBuilder<Closure> Closures { get; } = ArrayBuilder<Closure>.GetInstance();
+
+                public ArrayBuilder<Symbol> DeclaredCapturedVariables { get; } = ArrayBuilder<Symbol>.GetInstance();
+
+                public BoundNode BoundNode { get; }
+
+                public ArrayBuilder<LambdaFrame> Environments { get; } = ArrayBuilder<LambdaFrame>.GetInstance();
+
+                public Closure ContainingClosure { get; }
+
+                public Scope(Scope parent, BoundNode boundNode, Closure containingClosure)
+                {
+                    Parent = parent;
+                    BoundNode = boundNode;
+                    ContainingClosure = containingClosure;
+                }
+
+                public void Free()
+                {
+                    foreach (var scope in NestedScopes)
+                    {
+                        scope.Free();
+                    }
+                    NestedScopes.Free();
+
+                    foreach (var closure in Closures)
+                    {
+                        closure.Free();
+                    }
+                    Closures.Free();
+                    DeclaredCapturedVariables.Free();
+                    Environments.Free();
+                }
+            }
+
+            private sealed class Closure
+            {
+                public MethodSymbol Symbol { get; }
+
+                public PooledHashSet<Symbol> CapturedVariables { get; } = PooledHashSet<Symbol>.GetInstance();
+
+                public ArrayBuilder<LambdaFrame> CapturedEnvironments { get; } = ArrayBuilder<LambdaFrame>.GetInstance();
+
+                public NamedTypeSymbol ContainingType { get; set; }
+
+                public Closure(MethodSymbol symbol)
+                {
+                    Symbol = symbol;
+                }
+
+                public void Free()
+                {
+                    CapturedVariables.Free();
+                    CapturedEnvironments.Free();
+                }
+            }
+
+            private void RemoveUnneededReferences2()
+            {
+                var methodGraph = new MultiDictionary<MethodSymbol, MethodSymbol>();
+                var capturesThis = new HashSet<MethodSymbol>();
+                var capturesVariable = new HashSet<MethodSymbol>();
+                var visitStack = new Stack<MethodSymbol>();
+                VisitClosures(_scopeTree, (scope, closure) =>
+                {
+                    foreach (var capture in closure.CapturedVariables)
+                    {
+                        if (capture is MethodSymbol localFunc)
+                        {
+                            methodGraph.Add(localFunc, closure.Symbol);
+                        }
+                        else if (capture == _topLevelMethod.ThisParameter)
+                        {
+                            if (capturesThis.Add(closure.Symbol))
+                            {
+                                visitStack.Push(closure.Symbol);
+                            }
+                        }
+                        else if (capturesVariable.Add(closure.Symbol) && !capturesThis.Contains(closure.Symbol))
+                        {
+                            visitStack.Push(closure.Symbol);
+                        }
+                    }
+                });
+
+                while (visitStack.Count > 0)
+                {
+                    var current = visitStack.Pop();
+                    var setToAddTo = capturesVariable.Contains(current) ? capturesVariable : capturesThis;
+                    foreach (var capturesCurrent in methodGraph[current])
+                    {
+                        if (setToAddTo.Add(capturesCurrent))
+                        {
+                            visitStack.Push(capturesCurrent);
+                        }
+                    }
+                }
+
+                VisitClosures(_scopeTree, (scope, closure) =>
+                {
+                    if (!capturesVariable.Contains(closure.Symbol))
+                    {
+                        closure.CapturedVariables.Clear();
+                    }
+                    if (capturesThis.Contains(closure.Symbol))
+                    {
+                        closure.CapturedVariables.Add(_topLevelMethod.ThisParameter);
+                    }
+                });
+            }
+
+            /// <summary>
+            /// Visit all closures in all nested scopes and run the <paramref name="action"/>.
+            /// </summary>
+            private static void VisitClosures(Scope scope, Action<Scope, Closure> action)
+            {
+                foreach (var closure in scope.Closures)
+                {
+                    action(scope, closure);
+                }
+                foreach (var nested in scope.NestedScopes)
+                {
+                    VisitClosures(nested, action);
+                }
+            }
+
+            private void ComputeLambdaScopesAndFrameCaptures2()
+            {
+                LambdaScopes = new Dictionary<MethodSymbol, BoundNode>(ReferenceEqualityComparer.Instance);
+                NeedsParentFrame = new HashSet<BoundNode>();
+
+                VisitClosures(_scopeTree, (scope, closure) =>
+                {
+                    if (closure.CapturedVariables.Count > 0)
+                    {
+                        (Scope innermost, Scope outermost) = FindLambdaScopeRange(closure, scope);
+                        RecordClosureScope(innermost, outermost, closure);
+                    }
+                });
+
+                (Scope innermost, Scope outermost) FindLambdaScopeRange(Closure closure, Scope closureScope)
+                {
+                    Scope innermost = null;
+                    Scope outermost = null;
+
+                    var capturedVars = PooledHashSet<Symbol>.GetInstance();
+                    capturedVars.AddAll(closure.CapturedVariables);
+
+                    // If any of the captured variables are local functions we'll need
+                    // to add the captured variables of that local function to the current
+                    // set. This has the effect of ensuring that if the local function
+                    // captures anything "above" the current scope then parent frame
+                    // is itself captured (so that the current lambda can call that
+                    // local function).
+                    foreach (var captured in closure.CapturedVariables)
+                    {
+                        if (captured is LocalFunctionSymbol localFunc)
+                        {
+                            capturedVars.AddAll(FindClosureInScope(closureScope, localFunc).CapturedVariables);
+                        }
+                    }
+
+                    for (var curScope = closureScope;
+                         curScope != null && capturedVars.Count > 0;
+                         curScope = curScope.Parent)
+                    {
+                        if (!(capturedVars.Overlaps(curScope.DeclaredCapturedVariables) ||
+                              capturedVars.Overlaps(curScope.Closures.Select(c => c.Symbol))))
+                        {
+                            continue;
+                        }
+
+                        outermost = curScope;
+                        if (innermost == null)
+                        {
+                            innermost = curScope;
+                        }
+
+                        capturedVars.RemoveAll(curScope.DeclaredCapturedVariables);
+                        capturedVars.RemoveAll(curScope.Closures.Select(c => c.Symbol));
+                    }
+
+                    // If any captured variables are left, they're captured above method scope
+                    if (capturedVars.Count > 0)
+                    {
+                        outermost = null;
+                    }
+
+                    capturedVars.Free();
+
+                    return (innermost, outermost);
+                }
+
+                // Walk up the scope tree looking for a closure
+                Closure FindClosureInScope(Scope startingScope, MethodSymbol closureSymbol)
+                {
+                    var currentScope = startingScope;
+                    while (currentScope != null)
+                    {
+                        var found = currentScope.Closures.SingleOrDefault(c => c.Symbol == closureSymbol);
+                        if (found != null)
+                        {
+                            return found;
+                        }
+                        currentScope = currentScope.Parent;
+                    }
+                    return null;
+                }
+
+                void RecordClosureScope(Scope innermost, Scope outermost, Closure closure)
+                {
+                    // 1) if there is innermost scope, lambda goes there as we cannot go any higher.
+                    // 2) scopes in [innermostScope, outermostScope) chain need to have access to the parent scope.
+                    //
+                    // Example: 
+                    //   if a lambda captures a method's parameter and `this`, 
+                    //   its innermost scope depth is 0 (method locals and parameters) 
+                    //   and outermost scope is -1
+                    //   Such lambda will be placed in a closure frame that corresponds to the method's outer block
+                    //   and this frame will also lift original `this` as a field when created by its parent.
+                    //   Note that it is completely irrelevant how deeply the lexical scope of the lambda was originally nested.
+                    if (innermost != null)
+                    {
+                        LambdaScopes.Add(closure.Symbol, innermost.BoundNode);
+
+                        // Disable struct closures on methods converted to delegates, as well as on async and iterator methods.
+                        var markAsNoStruct = !CanTakeRefParameters(closure.Symbol);
+                        if (markAsNoStruct)
+                        {
+                            ScopesThatCantBeStructs.Add(innermost.BoundNode);
+                        }
+
+                        while (innermost != outermost)
+                        {
+                            NeedsParentFrame.Add(innermost.BoundNode);
+                            innermost = innermost.Parent;
+                            if (markAsNoStruct && innermost != null)
+                            {
+                                ScopesThatCantBeStructs.Add(innermost.BoundNode);
+                            }
+                        }
+                    }
+
+                }
+            }
+
+            private class ScopeTreeBuilder : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+            {
+                private Scope _currentScope;
+                // Null if we're not inside a closure scope, otherwise the nearest closure scope
+                private Closure _currentClosure;
+                private bool _inExpressionTree = false;
+
+                // A mapping from all captured vars to the scope they were declared in. This
+                // is used when recording captured variables as we must know what the lifetime
+                // of a captured variable is to determine the lifetime of its capture environment.
+                private readonly SmallDictionary<Symbol, Scope> _localToScope = new SmallDictionary<Symbol, Scope>();
+
+                private readonly Analysis _analysis;
+
+                private ScopeTreeBuilder(Scope rootScope, Analysis analysis)
+                {
+                    _currentScope = rootScope;
+                    _analysis = analysis;
+                    _currentClosure = null;
+                }
+
+                public static Scope Build(BoundNode node, Analysis analysis)
+                {
+                    // This should be the top-level node
+                    Debug.Assert(node == FindNodeToAnalyze(node));
+
+                    var rootScope = new Scope(parent: null, boundNode: node, containingClosure: null);
+                    var builder = new ScopeTreeBuilder(rootScope, analysis);
+                    builder.Build();
+                    return rootScope;
+                }
+
+                private void Build()
+                {
+                    // Set up the current method locals
+                    DeclareLocals(_currentScope, _analysis._topLevelMethod.Parameters);
+                    Visit(_currentScope.BoundNode);
+                }
+
+                public override BoundNode VisitMethodGroup(BoundMethodGroup node)
+                    => throw ExceptionUtilities.Unreachable;
+
+                public override BoundNode VisitBlock(BoundBlock node)
+                {
+                    if (node.Locals.IsDefaultOrEmpty)
+                    {
+                        // Skip introducing a new scope if there are no new locals
+                        return base.VisitBlock(node);
+                    }
+
+                    var oldScope = _currentScope;
+                    _currentScope = NewNestedScope(node);
+                    DeclareLocals(_currentScope, node.Locals);
+                    var result = base.VisitBlock(node);
+                    _currentScope = oldScope;
+                    return result; 
+                }
+
+                public override BoundNode VisitCatchBlock(BoundCatchBlock node)
+                {
+                    var oldScope = _currentScope;
+                    _currentScope = NewNestedScope(node);
+                    DeclareLocals(_currentScope, node.Locals);
+                    var result = base.VisitCatchBlock(node);
+                    _currentScope = oldScope;
+                    return result;
+                }
+
+                public override BoundNode VisitSequence(BoundSequence node)
+                {
+                    var oldScope = _currentScope;
+                    _currentScope = NewNestedScope(node);
+                    DeclareLocals(_currentScope, node.Locals);
+                    var result = base.VisitSequence(node);
+                    _currentScope = oldScope;
+                    return result;
+                }
+
+                public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
+                {
+                    if (node.InnerLocals.IsDefaultOrEmpty)
+                    {
+                        // Skip introducing a new scope if there are no new locals
+                        return base.VisitSwitchStatement(node);
+                    }
+
+                    var oldScope = _currentScope;
+                    _currentScope = NewNestedScope(node);
+                    DeclareLocals(_currentScope, node.InnerLocals);
+                    var result = base.VisitSwitchStatement(node);
+                    _currentScope = oldScope;
+                    return result;
+                }
+
+                public override BoundNode VisitLambda(BoundLambda node)
+                {
+                    var oldInExpressionTree = _inExpressionTree;
+                    _inExpressionTree |= node.Type.IsExpressionTree();
+
+                    _analysis.MethodsConvertedToDelegates.Add(node.Symbol.OriginalDefinition);
+                    var result = VisitClosure(node.Symbol, node.Body);
+
+                    _inExpressionTree = oldInExpressionTree;
+                    return result;
+                }
+
+                public override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
+                    => VisitClosure(node.Symbol.OriginalDefinition, node.Body);
+
+                public override BoundNode VisitCall(BoundCall node)
+                {
+                    if (node.Method.MethodKind == MethodKind.LocalFunction)
+                    {
+                        // Use OriginalDefinition to strip generic type parameters
+                        AddIfCaptured(node.Method.OriginalDefinition);
+                    }
+                    return base.VisitCall(node);
+                }
+
+                public override BoundNode VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
+                {
+                    if (node.MethodOpt?.MethodKind == MethodKind.LocalFunction)
+                    {
+                        // Use OriginalDefinition to strip generic type parameters
+                        var method = node.MethodOpt.OriginalDefinition;
+                        AddIfCaptured(method);
+                        _analysis.MethodsConvertedToDelegates.Add(method);
+                    }
+                    return base.VisitDelegateCreationExpression(node);
+                }
+
+                public override BoundNode VisitParameter(BoundParameter node)
+                {
+                    AddIfCaptured(node.ParameterSymbol);
+                    return base.VisitParameter(node);
+                }
+
+                public override BoundNode VisitLocal(BoundLocal node)
+                {
+                    AddIfCaptured(node.LocalSymbol);
+                    return base.VisitLocal(node);
+                }
+
+                public override BoundNode VisitBaseReference(BoundBaseReference node)
+                {
+                    AddIfCaptured(_analysis._topLevelMethod.ThisParameter);
+                    return base.VisitBaseReference(node);
+                }
+
+                public override BoundNode VisitThisReference(BoundThisReference node)
+                {
+                    var thisParam = _analysis._topLevelMethod.ThisParameter;
+                    if (thisParam != null)
+                    {
+                        AddIfCaptured(thisParam);
+                    }
+                    else
+                    {
+                        // This can occur in a delegate creation expression because the method group
+                        // in the argument can have a "this" receiver even when "this"
+                        // is not captured because a static method is selected.  But we do preserve
+                        // the method group and its receiver in the bound tree.
+                        // No need to capture "this" in such case.
+
+                        // TODO: Why don't we drop "this" while lowering if method is static? 
+                        //       Actually, considering that method group expression does not evaluate to a particular value 
+                        //       why do we have it in the lowered tree at all?
+                    }
+
+                    return base.VisitThisReference(node);
+                }
+
+                private BoundNode VisitClosure(MethodSymbol closureSymbol, BoundBlock body)
+                {
+                    Debug.Assert((object)closureSymbol != null);
+
+                    // Closure is declared (lives) in the parent scope, but its
+                    // variables are in a nested scope
+                    var closure = new Closure(closureSymbol);
+                    _currentScope.Closures.Add(closure);
+
+                    var oldClosure = _currentClosure;
+                    _currentClosure = closure;
+
+                    var oldScope = _currentScope;
+                    _currentScope = NewNestedScope(body);
+
+                    BoundNode result;
+                    if (!_inExpressionTree)
+                    {
+                        // For the purposes of scoping, parameters live in the same scope as the
+                        // closure block
+                        DeclareLocals(_currentScope, closureSymbol.Parameters);
+                        result = VisitBlock(body);
+                    }
+                    else
+                    {
+                        result = base.VisitBlock(body);
+                    }
+
+                    _currentScope = oldScope;
+                    _currentClosure = oldClosure;
+                    return result;
+                }
+
+                private void AddIfCaptured(Symbol symbol)
+                {
+                    if (_currentClosure == null)
+                    {
+                        // Can't be captured if we're not in a closure
+                        return;
+                    }
+
+                    if (symbol is LocalSymbol local && local.IsConst)
+                    {
+                        // consts aren't captured since they're inlined
+                        return;
+                    }
+
+                    if (symbol.ContainingSymbol != _currentClosure.Symbol)
+                    {
+                        // Record the captured variable where it's captured
+                        var scope = _currentScope;
+                        var closure = _currentClosure;
+                        while (closure != null && symbol.ContainingSymbol != closure.Symbol)
+                        {
+                            closure.CapturedVariables.Add(symbol);
+
+                            // Also mark captured in enclosing scopes
+                            while (scope.ContainingClosure == closure)
+                            {
+                                scope = scope.Parent;
+                            }
+                            closure = scope.ContainingClosure;
+                        }
+
+                        // Also record where the captured variable lives
+
+                        // No need to record where local functions live: that was recorded
+                        // in the Closures list in each scope
+                        if (symbol.Kind == SymbolKind.Method)
+                        {
+                            return;
+                        }
+
+                        // The 'this' parameter isn't declared in method scope
+                        if (symbol is ParameterSymbol param && param.IsThis)
+                        {
+                            return;
+                        }
+
+                        if (_localToScope.TryGetValue(symbol, out var declScope))
+                        {
+                            declScope.DeclaredCapturedVariables.Add(symbol);
+                        }
+                        else
+                        {
+                            // Parameters and locals from expression tree lambdas
+                            // don't get recorded
+                            Debug.Assert(_inExpressionTree);
+                        }
+                    }
+                }
+
+                private Scope NewNestedScope(BoundNode node)
+                {
+                    // We should never create a new scope with the same bound
+                    // node. We can get into this situation for methods and
+                    // closures where a new scope is created to add parameters
+                    // and a new scope would be created for the method block,
+                    // despite the fact that they should be the same scope.
+                    if (_currentScope.BoundNode == node)
+                    {
+                        return _currentScope;
+                    }
+
+                    var newScope = new Scope(_currentScope, node, _currentClosure);
+                    _currentScope.NestedScopes.Add(newScope);
+                    return newScope;
+                }
+
+                private void DeclareLocals<TSymbol>(Scope scope, ImmutableArray<TSymbol> locals)
+                    where TSymbol : Symbol
+                {
+                    foreach (var local in locals)
+                    {
+                        Debug.Assert(!_localToScope.ContainsKey(local));
+                        _localToScope[local] = scope;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -58,6 +58,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 public Scope(Scope parent, BoundNode boundNode, Closure containingClosure)
                 {
+                    Debug.Assert(parent != null);
+                    Debug.Assert(boundNode != null);
+
                     Parent = parent;
                     BoundNode = boundNode;
                     ContainingClosure = containingClosure;

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -115,7 +115,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             /// <summary>
-            /// Optimizes local functions such that if a local function only references other local functions without closures, it itself doesn't need a closure.
+            /// Optimizes local functions such that if a local function only references other local functions
+            /// that capture no variables, we don't need to create capture environments for any of them.
             /// </summary>
             private void RemoveUnneededReferences()
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 /// in nested scopes. "Declared" refers to the start of the variable lifetime (which,
                 /// at this point in lowering, should be equivalent to lexical scope).
                 /// </summary>
-                public ArrayBuilder<Symbol> DeclaredCapturedVariables { get; } = ArrayBuilder<Symbol>.GetInstance();
+                public ArrayBuilder<Symbol> DeclaredVariables { get; } = ArrayBuilder<Symbol>.GetInstance();
 
                 /// <summary>
                 /// The bound node representing this scope. This roughly corresponds to the bound
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         closure.Free();
                     }
                     Closures.Free();
-                    DeclaredCapturedVariables.Free();
+                    DeclaredVariables.Free();
                 }
 
                 public override string ToString() => BoundNode.Syntax.GetText().ToString();
@@ -450,7 +450,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (_localToScope.TryGetValue(symbol, out var declScope))
                         {
-                            declScope.DeclaredCapturedVariables.Add(symbol);
+                            declScope.DeclaredVariables.Add(symbol);
                         }
                         else
                         {

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// because it modifies <see cref="CapturedVariablesByLambda"/>, which is still used
             /// in other areas of the code. Once those uses are gone, this method should be removed.
             /// </summary>
-            private void Old_RemoveUnneededReferences()
+            private void OldRemoveUnneededReferences()
             {
                 // Note: methodGraph is the inverse of the dependency graph
                 var methodGraph = new MultiDictionary<MethodSymbol, MethodSymbol>();
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal void ComputeLambdaScopesAndFrameCaptures()
             {
                 // We need to keep this around
-                Old_RemoveUnneededReferences();
+                OldRemoveUnneededReferences();
                 RemoveUnneededReferences();
 
                 LambdaScopes = new Dictionary<MethodSymbol, BoundNode>(ReferenceEqualityComparer.Instance);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private void Analyze(BoundNode node)
             {
-                this._scopeTree = ScopeTreeBuilder.Build(node, this);
+                _scopeTree = ScopeTreeBuilder.Build(node, this);
                 _currentScope = FindNodeToAnalyze(node);
 
                 Debug.Assert(!_inExpressionLambda);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                          curScope = curScope.Parent)
                     {
                         if (!(capturedVars.Overlaps(curScope.DeclaredCapturedVariables) ||
-                              capturedVars.Overlaps(curScope.Closures.Select(c => c.Symbol))))
+                              capturedVars.Overlaps(curScope.Closures.Select(c => c.OriginalMethodSymbol))))
                         {
                             continue;
                         }
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
 
                         capturedVars.RemoveAll(curScope.DeclaredCapturedVariables);
-                        capturedVars.RemoveAll(curScope.Closures.Select(c => c.Symbol));
+                        capturedVars.RemoveAll(curScope.Closures.Select(c => c.OriginalMethodSymbol));
                     }
 
                     // If any captured variables are left, they're captured above method scope
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var currentScope = startingScope;
                     while (currentScope != null)
                     {
-                        var found = currentScope.Closures.SingleOrDefault(c => c.Symbol == closureSymbol);
+                        var found = currentScope.Closures.SingleOrDefault(c => c.OriginalMethodSymbol == closureSymbol);
                         if (found != null)
                         {
                             return found;
@@ -350,10 +350,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     //   Note that it is completely irrelevant how deeply the lexical scope of the lambda was originally nested.
                     if (innermost != null)
                     {
-                        LambdaScopes.Add(closure.Symbol, innermost.BoundNode);
+                        LambdaScopes.Add(closure.OriginalMethodSymbol, innermost.BoundNode);
 
                         // Disable struct closures on methods converted to delegates, as well as on async and iterator methods.
-                        var markAsNoStruct = !CanTakeRefParameters(closure.Symbol);
+                        var markAsNoStruct = !CanTakeRefParameters(closure.OriginalMethodSymbol);
                         if (markAsNoStruct)
                         {
                             ScopesThatCantBeStructs.Add(innermost.BoundNode);

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                          curScope != null && capturedVars.Count > 0;
                          curScope = curScope.Parent)
                     {
-                        if (!(capturedVars.Overlaps(curScope.DeclaredCapturedVariables) ||
+                        if (!(capturedVars.Overlaps(curScope.DeclaredVariables) ||
                               capturedVars.Overlaps(curScope.Closures.Select(c => c.OriginalMethodSymbol))))
                         {
                             continue;
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             innermost = curScope;
                         }
 
-                        capturedVars.RemoveAll(curScope.DeclaredCapturedVariables);
+                        capturedVars.RemoveAll(curScope.DeclaredVariables);
                         capturedVars.RemoveAll(curScope.Closures.Select(c => c.OriginalMethodSymbol));
                     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -9,7 +9,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal sealed class LambdaSymbol : MethodSymbol
+    internal sealed class LambdaSymbol : SourceMethodSymbol
     {
         private readonly Symbol _containingSymbol;
         private readonly MessageID _messageID;
@@ -404,6 +404,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get { return true; }
         }
+
+        public override ImmutableArray<TypeParameterConstraintClause> TypeParameterConstraintClauses => ImmutableArray<TypeParameterConstraintClause>.Empty;
 
         internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
         {

--- a/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis
                 V value;
                 if (!TryGetValue(key, out value))
                 {
-                    throw new InvalidOperationException("key not found");
+                    throw new KeyNotFoundException($"Could not find key {key}");
                 }
 
                 return value;


### PR DESCRIPTION
This PR adds the initial work for a new closure conversion design based around a tree instead of a series of dictionaries. The tree should

1. Make it easier to assert invariants as we perform rewriting.
2. Make debugging simpler.
3. Allow us to move to a series of cheap, simple passes over the simplified tree, rather than one, very complicated pass over the bound tree.
4. Make it easier to move almost all logic into the analysis phase and make rewriting a simple mechanical transformation.

The heart of the new design is the `Scope` tree, which consists of a series of nested `Scope`s, each of which hold relevant information about what variables and closures are declared in that scope. The `Closure`, meanwhile, holds information for each closure, including a list of captured variables. By carefully visiting the bound node once we should be able to encode all relevant information into the `Scope` tree, and then iterate over a series of quick, simple passes to create the fully converted form.

This PR is split into two commits. The first adds the new `Scope` tree work and duplicates the functionality of `ComputeLambdaScopesAndFrameCaptures` and `RemoveUnneededReferences` entirely using the new tree. In this PR, both analyses are run and then consistency is asserted between the resulting data structures. The second commit actually removes the old implementation of `ComputeLambdaScopesAndFrameCaptures` entirely. Unfortunately, both forms of `RemoveUnneededReferences` are still needed for now because `CapturedVariablesByLambda`, which is modified by the old method, is still used in other places in closure conversion.