### PR TITLE
Fix bootstrap build for unit tests

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -25,6 +25,7 @@
     <add key="dotnet.myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="dotnet.myget.org devcore" value="https://www.myget.org/F/vs-devcore/api/v3/index.json" />
     <add key="dotnet.myget.org roslyn-tools" value = "https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="dotnet.myget.org roslyn-analyzers" value = "https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
     <add key="dotnet.myget.org roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="myget.org vs-editor" value="https://myget.org/F/vs-editor/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -45,8 +45,8 @@
     <MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>14.3.25407-alpha</MicrosoftInternalVisualStudioShellInterop140DesignTimeVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-61531-03</MicrosoftMetadataVisualizerVersion>
     <MicrosoftMSXMLVersion>8.0.0.0-alpha</MicrosoftMSXMLVersion>
-    <MicrosoftNetCompilersVersion>2.3.0-beta3-61821-14</MicrosoftNetCompilersVersion>
-    <MicrosoftNetRoslynDiagnosticsVersion>2.3.0-beta1</MicrosoftNetRoslynDiagnosticsVersion>
+    <MicrosoftNetCompilersVersion>2.6.0-beta1-61906-08</MicrosoftNetCompilersVersion>
+    <MicrosoftNetRoslynDiagnosticsVersion>2.5.0-beta1-61906-01</MicrosoftNetRoslynDiagnosticsVersion>
     <MicrosoftNetCoreILAsmVersion>1.1.0</MicrosoftNetCoreILAsmVersion>
     <MicrosoftNETCoreCompilersVersion>2.3.0-beta3-61821-14</MicrosoftNETCoreCompilersVersion>
     <MicrosoftNETCoreVersion>5.0.0</MicrosoftNETCoreVersion>

--- a/build/scripts/build.ps1
+++ b/build/scripts/build.ps1
@@ -93,6 +93,10 @@ function Run-MSBuild([string]$buildArgs = "", [string]$logFile = "") {
         $args += " /p:OfficialBuild=true"
     }
 
+    if ($bootstrapDir -ne "") {
+        $args += " /p:BootstrapBuildPath=$bootstrapDir"
+    }
+
     $args += " $buildArgs"
     Exec-Console $msbuild $args
 }


### PR DESCRIPTION
Reviewing some code today I realized the bootstrap build was only
running for our deterimnism suites, not for unit tests.

Fixing that required that I also update the analyzers + base toolset
package being used. The analyzers package is tied to major + minor versions
of the compiler presently. This means in order to function our base
toolset and bootstrap build must have same major + minor version.

