### PR TITLE
Fixed #13158 (IntelliSense does not display get-only abstract collection properties in object initializers).

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -701,6 +701,58 @@ class Program
             await VerifyItemIsAbsentAsync(markup, "D");
         }
 
+        [WorkItem(13158, "https://github.com/dotnet/roslyn/issues/13158")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CollectionInitializerForInterfaceType1()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public class Foo
+{
+    public IList<int> Items { get; } = new List<int>();
+    public int Bar;
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var y = new Foo { $$ };
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "Items");
+            await VerifyItemExistsAsync(markup, "Bar");
+        }
+
+        [WorkItem(13158, "https://github.com/dotnet/roslyn/issues/13158")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CollectionInitializerForInterfaceType2()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+public interface ICustomCollection<T> : ICollection<T> { }
+
+public class Foo
+{
+    public ICustomCollection<int> Items { get; } = new List<int>();
+    public int Bar;
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var y = new Foo { $$ };
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "Items");
+            await VerifyItemExistsAsync(markup, "Bar");
+        }
+
         [WorkItem(4754, "https://github.com/dotnet/roslyn/issues/4754")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CollectionInitializerPatternFromBaseTypeAccessible()

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -641,8 +641,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 typeSymbol.AllInterfaces.Any(i => i.SpecialType == SpecialType.System_Collections_IEnumerable) &&
                 typeSymbol.GetBaseTypesAndThis()
                     .Union(typeSymbol.GetOriginalInterfacesAndTheirBaseInterfaces())
-                    .SelectAccessibleMembers<IMethodSymbol>(within ?? typeSymbol)
-                    .Where(s => s.Name == WellKnownMemberNames.CollectionInitializerAddMethodName)
+                    .SelectAccessibleMembers<IMethodSymbol>(WellKnownMemberNames.CollectionInitializerAddMethodName, within ?? typeSymbol)
                     .OfType<IMethodSymbol>()
                     .Any(m => m.Parameters.Any());
         }
@@ -731,6 +730,16 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             }
 
             return types.SelectMany(x => x.GetMembers().OfType<T>().Where(m => m.IsAccessibleWithin(within)));
+        }
+
+        private static IEnumerable<T> SelectAccessibleMembers<T>(this IEnumerable<ITypeSymbol> types, string memberName, ISymbol within) where T : class, ISymbol
+        {
+            if (types == null)
+            {
+                return ImmutableArray<T>.Empty;
+            }
+
+            return types.SelectMany(x => x.GetMembers(memberName).OfType<T>().Where(m => m.IsAccessibleWithin(within)));
         }
 
         private static bool? IsMoreSpecificThan(this ITypeSymbol t1, ITypeSymbol t2)


### PR DESCRIPTION
**Customer scenario**
IntelliSense does not display get-only abstract collection properties in object initializers

**Bugs this fixes:**
#13158

**Risk**
Low

**Performance impact**

**Is this a regression from a previous update?**
No

**Root cause analysis:**

Missed check for interface members for abstract collection properties 

**How was the bug found?**

customer reported