### PR TITLE
Enable GitHub code owner feature for Compilers folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Automatically request reviews when a pull request changes any owned files
 # More information: https://github.com/blog/2392-introducing-code-owners 
 
-build/* @roslyn-infrastructure
+build/* @dotnet/roslyn-infrastructure
 src/Compilers/* @dotnet/roslyn-compiler
-src/NuGet/* @roslyn-infrastructure
-src/Setup/* @roslyn-infrastructure
+src/NuGet/* @dotnet/roslyn-infrastructure
+src/Setup/* @dotnet/roslyn-infrastructure
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Automatically request reviews when a pull request changes any owned files
+# More information: https://github.com/blog/2392-introducing-code-owners 
+
+src/Compilers/* @dotnet/roslyn-compiler
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 # Automatically request reviews when a pull request changes any owned files
 # More information: https://github.com/blog/2392-introducing-code-owners 
 
+build/* @roslyn-infrastructure
 src/Compilers/* @dotnet/roslyn-compiler
+src/NuGet/* @roslyn-infrastructure
+src/Setup/* @roslyn-infrastructure
 


### PR DESCRIPTION
@jaredpar @jasonmalinowski @dotnet/roslyn-infrastructure  for review.
I could add other folders, let me know.