### PR TITLE
Create connection on background thread to avoid stalling the UI when loading VS

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -39,7 +39,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 _workspace = workspace;
                 _client = client;
                 _currentSolutionId = workspace.CurrentSolution.Id;
-                _currentConnection = new ReferenceCountedDisposable<Connection>.WeakReference(currentConnection);
+                _currentConnection = currentConnection == null
+                    ? default
+                    : new ReferenceCountedDisposable<Connection>.WeakReference(currentConnection);
             }
 
             public void OnAfterWorkingFolderChange()

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -63,7 +63,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 if (connectionRef == null)
                 {
                     // Otherwise, try to create an actual connection to the OOP server
-                    var connection = _client.TryCreateConnectionAsync(WellKnownRemoteHostServices.RemoteHostService, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
+                    var connection = _client.TryCreateConnectionAsync(WellKnownRemoteHostServices.RemoteHostService, CancellationToken.None)
+                                            .WaitAndGetResult(CancellationToken.None);
                     if (connection == null)
                     {
                         return null;

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -80,7 +80,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             // projectTracker is sending events, the workspace host can then use that connection 
             // instead of having to expensively spin up a fresh one.
             var currentConnection = await client.TryCreateConnectionAsync(WellKnownRemoteHostServices.RemoteHostService, CancellationToken.None).ConfigureAwait(false);
-            using (var refCountedConnection = new ReferenceCountedDisposable<Connection>(currentConnection))
+            var refCountedConnection = currentConnection == null
+                ? null
+                : new ReferenceCountedDisposable<Connection>(currentConnection);
+            using (refCountedConnection)
             {
                 var host = new WorkspaceHost(vsWorkspace, client, refCountedConnection);
 

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -74,8 +74,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 return;
             }
 
-            // Create a connection to the host in the BG to avoid taking the hit of loading 
-            // service hub on the UI thread.
+            // Create a connection to the host in the BG to avoid taking the hit of loading service 
+            // hub on the UI thread.  We'll initially set its ref count to 1, and we will decrement 
+            // that ref-count at the end of the using block.  During this time though, when the 
+            // projectTracker is sending events, the workspace host can then use that connection 
+            // instead of having to expensively spin up a fresh one.
             var currentConnection = await client.TryCreateConnectionAsync(WellKnownRemoteHostServices.RemoteHostService, CancellationToken.None).ConfigureAwait(false);
             using (var refCountedConnection = new ReferenceCountedDisposable<Connection>(currentConnection))
             {

--- a/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
+++ b/src/Workspaces/Core/Portable/Remote/IRemoteHostService.cs
@@ -11,9 +11,7 @@ namespace Microsoft.CodeAnalysis.Remote
         Task SynchronizePrimaryWorkspaceAsync(Checksum checksum, CancellationToken cancellationToken);
         Task SynchronizeGlobalAssetsAsync(Checksum[] checksums, CancellationToken cancellationToken);
 
-        void RegisterPrimarySolutionId(SolutionId solutionId, CancellationToken cancellationToken);
+        void RegisterPrimarySolutionId(SolutionId solutionId, string storageLocation, CancellationToken cancellationToken);
         void UnregisterPrimarySolutionId(SolutionId solutionId, bool synchronousShutdown, CancellationToken cancellationToken);
-
-        void UpdateSolutionIdStorageLocation(SolutionId solutionId, string storageLocation, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/RemoteHostService.cs
@@ -97,21 +97,17 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public void RegisterPrimarySolutionId(SolutionId solutionId, CancellationToken cancellationToken)
+        public void RegisterPrimarySolutionId(SolutionId solutionId, string storageLocation, CancellationToken cancellationToken)
         {
             var persistentStorageService = GetPersistentStorageService();
             persistentStorageService?.RegisterPrimarySolution(solutionId);
+            RemotePersistentStorageLocationService.UpdateStorageLocation(solutionId, storageLocation);
         }
 
         public void UnregisterPrimarySolutionId(SolutionId solutionId, bool synchronousShutdown, CancellationToken cancellationToken)
         {
             var persistentStorageService = GetPersistentStorageService();
             persistentStorageService?.UnregisterPrimarySolution(solutionId, synchronousShutdown);
-        }
-
-        public void UpdateSolutionIdStorageLocation(SolutionId solutionId, string storageLocation, CancellationToken cancellationToken)
-        {
-            RemotePersistentStorageLocationService.UpdateStorageLocation(solutionId, storageLocation);
         }
 
         private static Func<FunctionId, bool> GetLoggingChecker()


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/454212

There are two parts to this fix:

1. We get an OOP connection ready on the BG thread before syncing over on the UI thread.  This takes the cost of spinning up servicehub and whatnot off the UI thread.
2. We move to a single sync request to the OOP server instead of two requests.  