### PR TITLE
Enable documentation output in non-shipping projects

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -76,7 +76,7 @@
     DocumentationFile needs to be set before importing common targets. 
     C# common targets (unlike VB) prefix DocumentationFile path with IntermediateOutputPath.
   -->
-  <PropertyGroup Condition="'$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(Nonshipping)' != 'true' AND '$(AssemblyName)' != ''">
+  <PropertyGroup Condition="'$(DocumentationFile)' == '' AND '$(NoDocumentationFile)' != 'true' AND '$(AssemblyName)' != ''">
     <DocumentationFile Condition="'$(ProjectLanguage)' == 'VB'">$(AssemblyName).xml</DocumentationFile>
     <DocumentationFile Condition="'$(ProjectLanguage)' == 'CSharp'">$(IntermediateOutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -213,12 +213,15 @@
         <ErrorReport>prompt</ErrorReport>
 
         <!-- Suppress the following warnings by default for C# projects
+                1573: Suppressed in order to allow documentation for some but not all parameters.
+                      A warning will still be reported if the documentation defines/references a
+                      parameter which does not exist.
                 1591: So far we've chosen to implicitly implement interfaces and as a consequence
                       the methods are public.  We don't want to duplicate documentation for them
                       and hence suppress this warning until we get closer to release and a more
                       thorough documentation story
         -->
-        <NoWarn>$(NoWarn);1591;1701</NoWarn>
+        <NoWarn>$(NoWarn);1573;1591;1701</NoWarn>
         <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
         <MSBuildTargetsLanguageName>CSharp</MSBuildTargetsLanguageName>
       </PropertyGroup>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -5769,6 +5769,7 @@ class C
 }");
         }
 
+        /// <summary>
         /// Local names array (from PDB) may have fewer slots than method
         /// signature (from metadata) when the trailing slots are unnamed.
         /// </summary>

--- a/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EntryPointTests.cs
@@ -808,7 +808,7 @@ class B
     }
 } 
 ";
-            CompileConsoleApp(source).VerifyDiagnostics(/// (4,24): warning CS0028: 'B.Main(string[][])' has the wrong signature to be an entry point
+            CompileConsoleApp(source).VerifyDiagnostics(// (4,24): warning CS0028: 'B.Main(string[][])' has the wrong signature to be an entry point
                 //     public static void Main(string[][] args)
                 Diagnostic(ErrorCode.WRN_InvalidMainSig, "Main").WithArguments("B.Main(string[][])"),
                 // error CS5001: Program does not contain a static 'Main' method suitable for an entry point
@@ -1310,7 +1310,7 @@ class D
 }
 ";
             CreateStandardCompilation(source, options: TestOptions.ReleaseExe.WithMainTypeName("d")).VerifyDiagnostics(
-                /// error CS1555: Could not find 'd' specified for Main method
+                // error CS1555: Could not find 'd' specified for Main method
                 Diagnostic(ErrorCode.ERR_MainClassNotFound).WithArguments("d"));
         }
 
@@ -1351,7 +1351,7 @@ static class Main
 }
 ";
             CreateStandardCompilation(source, options: TestOptions.ReleaseExe.WithMainTypeName("Main")).VerifyDiagnostics(
-                /// (2,14): error CS1558: 'Main' does not have a suitable static Main method
+                // (2,14): error CS1558: 'Main' does not have a suitable static Main method
                 // static class Main
                 Diagnostic(ErrorCode.ERR_NoMainInClass, "Main").WithArguments("Main"));
         }

--- a/src/Compilers/CSharp/Test/Emit/Perf.cs
+++ b/src/Compilers/CSharp/Test/Emit/Perf.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Emit
             // So if the test fails we should fix the product bug that is causing the failure
             // as opposed to 'fixing' the test by updating the benchmark code.
 
-            ///GNAMBOO: Changing this code has implications for perf tests.
+            //GNAMBOO: Changing this code has implications for perf tests.
             CompileAndVerify(TestResources.PerfTests.CSPerfTest,
                              additionalRefs: new[] { SystemCoreRef }).
                              VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
@@ -644,12 +644,12 @@ class Test
             Assert.DoesNotContain(not_expected_in_lookup[1], actual_lookupSymbols_ignoreAcc_as_string);
         }
 
-        [WorkItem(539814, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539814")]
         /// <summary>
         /// Verify that there's a way to look up only the members of the base type that are visible
         /// from the current type.
         /// </summary>
         [Fact]
+        [WorkItem(539814, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539814")]
         public void LookupProtectedInBase()
         {
             var testSrc = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/VarianceTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/VarianceTests.cs
@@ -242,9 +242,9 @@ class Test
             }
         }
 
-        [WorkItem(539538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539538")]
         /// <remarks>Based on LambdaTests.TestLambdaErrors03</remarks>
         [Fact]
+        [WorkItem(539538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539538")]
         public void TestVarianceConversionCycle()
         {
             // To determine which overload is better, we have to try to convert D<IIn<I>> to D<I>
@@ -271,9 +271,9 @@ class C
                 Diagnostic(ErrorCode.ERR_AmbigCall, "Foo").WithArguments("C.Foo(D<IIn<I>>)", "C.Foo(D<I>)"));
         }
 
-        [WorkItem(539538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539538")]
         /// <remarks>http://blogs.msdn.com/b/ericlippert/archive/2008/05/07/covariance-and-contravariance-part-twelve-to-infinity-but-not-beyond.aspx</remarks>
         [Fact]
+        [WorkItem(539538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539538")]
         public void TestVarianceConversionInfiniteExpansion01()
         {
             // IC<double> is convertible to IN<IC<string>> if and only
@@ -296,9 +296,9 @@ class C
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "bar").WithArguments("IC<double>", "IN<IC<string>>"));
         }
 
-        [WorkItem(539538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539538")]
         /// <remarks>http://blogs.msdn.com/b/ericlippert/archive/2008/05/07/covariance-and-contravariance-part-twelve-to-infinity-but-not-beyond.aspx</remarks>
         [Fact]
+        [WorkItem(539538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539538")]
         public void TestVarianceConversionInfiniteExpansion02()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/GetSemanticInfoTests.cs
@@ -820,7 +820,7 @@ class C {
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="binding"></param>
+        /// <param name="semanticModel"></param>
         /// <param name="expr"></param>
         /// <param name="ept1">expr -> TypeInParent</param>
         /// <param name="ept2">Type(expr) -> TypeInParent</param>
@@ -1611,10 +1611,10 @@ namespace N { }
             var bindInfo = model.GetSemanticInfoSummary(exprSyntaxToBind);
         }
 
-        [WorkItem(542634, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542634")]
         /// Test that binding a local declared with var binds the same way when localSymbol.Type is called before BindVariableDeclaration.
         /// Assert occurs if the two do not compute the same type.
         [Fact]
+        [WorkItem(542634, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542634")]
         public void VarInitializedWithStaticType()
         {
             var text =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -1570,11 +1570,11 @@ S[0]");
 }");
         }
 
-        [WorkItem(542277, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542277")]
         /// <summary>
         /// Access fields on constrained generic types.
         /// </summary>
         [ClrOnlyFact]
+        [WorkItem(542277, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542277")]
         public void Fields()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/InterfaceImplementationTests.cs
@@ -1168,7 +1168,6 @@ partial class Base
             CreateStandardCompilation(text).VerifyDiagnostics();
         }
 
-        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         /// <summary>
         /// I -> M(ref int)
         /// B -> M(out int)
@@ -1177,6 +1176,7 @@ partial class Base
         /// I source, B source, D source
         /// </summary>
         [Fact]
+        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         public void TestSourceMetadataImplicitImplementation1()
         {
             var csharp = @"
@@ -1220,7 +1220,6 @@ class Program
         // I source, B source, D metadata - skip: metadata implementing source
         // public void TestSourceMetadataImplicitImplementation2()
 
-        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         /// <summary>
         /// I -> M(ref int)
         /// B -> M(out int)
@@ -1229,6 +1228,7 @@ class Program
         /// I source, B metadata, D source
         /// </summary>
         [Fact]
+        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         public void TestSourceMetadataImplicitImplementation3()
         {
             var csharp = @"
@@ -1291,7 +1291,6 @@ class Program
         // I source, B metadata, D metadata - skip: metadata implementing source
         // public void TestSourceMetadataImplicitImplementation4()
 
-        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         /// <summary>
         /// I -> M(ref int)
         /// B -> M(out int)
@@ -1300,6 +1299,7 @@ class Program
         /// I metadata, B source, D source
         /// </summary>
         [Fact]
+        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         public void TestSourceMetadataImplicitImplementation5()
         {
             var csharp = @"
@@ -1347,7 +1347,6 @@ class Program
         // I metadata, B source, D metadata - skip: metadata extending source
         // public void TestSourceMetadataImplicitImplementation6()
 
-        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         /// <summary>
         /// I -> M(ref int)
         /// B -> M(out int)
@@ -1356,6 +1355,7 @@ class Program
         /// I metadata, B metadata, D source
         /// </summary>
         [Fact]
+        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         public void TestSourceMetadataImplicitImplementation7()
         {
             var csharp = @"
@@ -1453,7 +1453,6 @@ class C : B { }
             CompileWithCustomILSource(csharp, il);
         }
 
-        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         /// <summary>
         /// I -> M(ref int)
         /// B -> M(out int)
@@ -1462,6 +1461,7 @@ class C : B { }
         /// I source, B source, D source
         /// </summary>
         [Fact]
+        [WorkItem(540451, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540451")]
         public void TestSourceMetadataImplicitImplementation8()
         {
             var csharp = @"
@@ -1595,13 +1595,13 @@ static class Program
             Assert.Equal(fooMethod, typeSymbol.FindImplementationForInterfaceMember(secondInterfaceMethod));
         }
 
-        [WorkItem(540558, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540558")]
         /// <summary>
         /// In this case, C# thinks B.M implements I.M for C, but the CLR thinks A.M does.  To make sure that we get the
         /// desired behavior, we have to insert an explicit bridge method.
         /// (See SourceNamedTypeSymbol.IsOverrideOfPossibleImplementationUnderRuntimeRules.)
         /// </summary>
         [Fact]
+        [WorkItem(540558, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540558")]
         public void TestCSharpClrDisagreement_NonOverride()
         {
             var text = @"
@@ -1655,13 +1655,13 @@ class C : B, I { }
             Assert.Equal(classBMethod, synthesizedExplicitImpl.ImplementingMethod);
         }
 
-        [WorkItem(540558, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540558")]
         /// <summary>
         /// In this case, C# thinks B.M implements I.M for C, but the CLR thinks A.M does.  However,
         /// B.M overrides A.M, so there's no problem (distinguish from TestCSharpClrDisagreement_NonOverride).
         /// (See SourceNamedTypeSymbol.IsOverrideOfPossibleImplementationUnderRuntimeRules.)
         /// </summary>
         [Fact]
+        [WorkItem(540558, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540558")]
         public void TestCSharpClrDisagreement_Override()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CompletionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CompletionTests.cs
@@ -134,7 +134,7 @@ class A {
         }
 
         /// <summary>
-        /// This test demonstrates the correctness of <see cref="Microsoft.CodeAnalysis.CSharp.Symbol.HasAtMostOneBitSet"/>.
+        /// This test demonstrates the correctness of <see cref="SymbolCompletionState.HasAtMostOneBitSet"/>.
         /// </summary>
         [Fact]
         public void TestHasAtMostOneBitSet()
@@ -147,7 +147,7 @@ class A {
         }
 
         /// <summary>
-        /// This is the simple implementation of the sbyte version of <see cref="Microsoft.CodeAnalysis.CSharp.Symbol.HasAtMostOneBitSet"/>.
+        /// This is the simple implementation of the sbyte version of <see cref="SymbolCompletionState.HasAtMostOneBitSet"/>.
         /// Hopefully, it is obviously correct.
         /// </summary>
         private static bool HasAtMostOneBitSetSafe(sbyte bits)
@@ -168,7 +168,7 @@ class A {
         }
 
         /// <summary>
-        /// This is the sbyte version of <see cref="Microsoft.CodeAnalysis.CSharp.Symbol.HasAtMostOneBitSet"/>.
+        /// This is the sbyte version of <see cref="SymbolCompletionState.HasAtMostOneBitSet"/>.
         /// It can be exhaustively tested more quickly than the full version.
         /// </summary>
         private static bool HasAtMostOneBitSetFast(sbyte bits)

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -2437,7 +2437,7 @@ End Class";
                 Diagnostic(ErrorCode.ERR_BindToBogusProp2, "_7[ref x]").WithArguments("A7.this[ref object]", "A7.get_P(ref object)", "A7.set_P(object, object)").WithLocation(13, 21),
                 // (14,9): error CS1545: Property, indexer, or event 'A8.this[ref object]' is not supported by the language; try directly calling accessor methods 'A8.get_P(ref object)' or 'A8.set_P(ref object, object)'
                 Diagnostic(ErrorCode.ERR_BindToBogusProp2, "_8[ref y]").WithArguments("A8.this[ref object]", "A8.get_P(ref object)", "A8.set_P(ref object, object)").WithLocation(14, 9),
-                /// (14,21): error CS1545: Property, indexer, or event 'A8.this[ref object]' is not supported by the language; try directly calling accessor methods 'A8.get_P(ref object)' or 'A8.set_P(ref object, object)'
+                // (14,21): error CS1545: Property, indexer, or event 'A8.this[ref object]' is not supported by the language; try directly calling accessor methods 'A8.get_P(ref object)' or 'A8.set_P(ref object, object)'
                 Diagnostic(ErrorCode.ERR_BindToBogusProp2, "_8[ref x]").WithArguments("A8.this[ref object]", "A8.get_P(ref object)", "A8.set_P(ref object, object)").WithLocation(14, 21),
                 // (15,9): error CS1545: Property, indexer, or event 'A9.this[ref object]' is not supported by the language; try directly calling accessor methods 'A9.get_P(ref object)' or 'A9.set_P(object, ref object)'
                 Diagnostic(ErrorCode.ERR_BindToBogusProp2, "_9[ref y]").WithArguments("A9.this[ref object]", "A9.get_P(ref object)", "A9.set_P(object, ref object)").WithLocation(15, 9),

--- a/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
+++ b/src/Compilers/CSharp/Test/Syntax/CSharpCompilerSyntaxTest.csproj
@@ -15,6 +15,8 @@
     <NoStdLib>true</NoStdLib>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RoslynProjectType>UnitTestPortable</RoslynProjectType>
+    <!-- The RESX resources generator produces invalid comments when the string has a line starting with '/' -->
+    <NoWarn>$(NoWarn);1570;1587</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/FusionAssemblyIdentityTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/FusionAssemblyIdentityTests.cs
@@ -11,7 +11,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.MetadataReferences
     public class FusionAssemblyIdentityTests
     {
         /// <summary>
-        /// Converts <see cref="IAssemblyName"/> to <see cref="AssemblyName"/> with possibly missing name components.
+        /// Converts <see cref="FusionAssemblyIdentity.IAssemblyName"/> to <see cref="AssemblyName"/> with possibly
+        /// missing name components.
         /// </summary>
         /// <returns>
         /// An <see cref="AssemblyName"/> whose fields are be null if not present in <paramref name="nameObject"/>.

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataNameLimitTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/MetadataNameLimitTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.UnitTests
 {
     /// <summary>
-    /// Test <see cref="PeWriter.IsTooLongInternal"/>.
+    /// Test <see cref="MetadataWriter.IsTooLongInternal"/>.
     /// </summary>
     public class MetadataNameLimitsTests
     {

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/VisualBasicCompilationOptionsTests.vb
@@ -518,7 +518,8 @@ BC2042: The options /vbruntime* and /target:module cannot be combined.
 
         ''' <summary>
         ''' If this test fails, please update the <see cref="VisualBasicCompilationOptions.GetHashCode" />
-        ''' and <see cref="VisualBasicCompilationOptions.Equals" /> methods and <see cref="VisualBasicCompilationOptions.New"/> to
+        ''' and <see cref="VisualBasicCompilationOptions.Equals" /> methods and
+        ''' <see cref="VisualBasicCompilationOptions"/> constructor(s) to
         ''' make sure they are doing the right thing with your new field And then update the baseline
         ''' here.
         ''' </summary>

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -680,7 +680,7 @@ class Derived : Base
 
         /// <summary>
         /// Instance field should be preferred to type
-        /// 7.5.4.1
+        /// §7.5.4.1
         /// </summary>
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task ColorColor4()
@@ -700,7 +700,7 @@ class Derived : Base
 
         /// <summary>
         /// Type should be preferred to a static field
-        /// 7.5.4.1
+        /// §7.5.4.1
         /// </summary>
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task ColorColor5()
@@ -985,7 +985,7 @@ class Derived : Base
         }
 
         /// <summary>
-        /// 7.5.4.2
+        /// §7.5.4.2
         /// </summary>
         [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
         public async Task GrammarAmbiguity_7_5_4_2()

--- a/src/EditorFeatures/TestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/AbstractDiagnosticProviderBasedUserDiagnosticTest.cs
@@ -99,6 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
         /// <summary>
         /// The internal method <see cref="AnalyzerExecutor.IsAnalyzerExceptionDiagnostic(Diagnostic)"/> does
         /// essentially this, but due to linked files between projects, this project cannot have internals visible
@@ -107,6 +108,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         /// starts failing on non-analyzer exception diagnostics, it can be appropriately tuned or re-evaluated.
         /// </summary>
         private void AssertNoAnalyzerExceptionDiagnostics(IEnumerable<Diagnostic> diagnostics)
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
         {
             var analyzerExceptionDiagnostics = diagnostics.Where(diag => diag.Descriptor.CustomTags.Contains(WellKnownDiagnosticTags.AnalyzerException));
             AssertEx.Empty(analyzerExceptionDiagnostics, "Found analyzer exception diagnostics");

--- a/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/WpfFactDiscoverer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/VisualBasicEditAndContinueAnalyzerTests.vb
@@ -405,7 +405,7 @@ End Class
         End Sub
 
         ''' <summary>
-        ''' Verifies that <see cref="CSharpEditAndContinueAnalyzer.GetDiagnosticSpanImpl"/> handles all <see cref="SyntaxKind"/> s.
+        ''' Verifies that <see cref="VisualBasicEditAndContinueAnalyzer.GetDiagnosticSpanImpl"/> handles all <see cref="SyntaxKind"/> s.
         ''' </summary>
         <Fact>
         Public Sub ErrorSpansAllKinds()

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/ExpansionTests.cs
@@ -665,8 +665,8 @@ class C
         /// This tests the managed address-of functionality.  When you take the address
         /// of a managed object, what you get back is an IntPtr*.  As in dev12, this
         /// exposes two pointers, the one to the IntPtr and the one to the actual data
-        /// (in the IntPtr).  For example, if you have a string "str", then "&str" yields
-        /// an IntPtr*.  The pointer is to the "string&" (typed as IntPtr, since Roslyn
+        /// (in the IntPtr).  For example, if you have a string "str", then "&amp;str" yields
+        /// an IntPtr*.  The pointer is to the "string&amp;" (typed as IntPtr, since Roslyn
         /// doesn't have a representation for reference types) and the IntPtr is a pointer
         /// to the actual string object on the heap.
         /// </summary>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/HashFunctions.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/HashFunctions.cs
@@ -4,10 +4,12 @@ using Microsoft.CodeAnalysis;
 
 namespace Roslyn.Utilities
 {
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Required by <see cref="CaseInsensitiveComparison"/>
     /// </summary>
     internal static class Hash
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         internal const int FnvOffsetBias = unchecked((int)2166136261);
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -457,7 +457,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         }
 
         /// <summary>
-        /// Get the first attribute from <see cref="DkmClrType.GetEvalAttributes"/> (including inherited attributes)
+        /// Get the first attribute from <see cref="DkmClrType.GetEvalAttributes()"/> (including inherited attributes)
         /// that is of type T, as well as the type that it targeted.
         /// </summary>
         internal static bool TryGetEvalAttribute<T>(this DkmClrType type, out DkmClrType attributeTarget, out T evalAttribute)

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -751,7 +751,7 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// This analyzer will report diagnostics only if it receives any concurrent action callbacks, which would be a
-        /// bug in the analyzer driver as this analyzer doesn't invoke <see cref="AnalysisContext.RegisterConcurrentExecution"/>.
+        /// bug in the analyzer driver as this analyzer doesn't invoke <see cref="AnalysisContext.EnableConcurrentExecution"/>.
         /// </summary>
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
         public class NonConcurrentAnalyzer : DiagnosticAnalyzer

--- a/src/Test/Utilities/Desktop/DesktopRuntimeUtil.cs
+++ b/src/Test/Utilities/Desktop/DesktopRuntimeUtil.cs
@@ -67,7 +67,7 @@ namespace Roslyn.Test.Utilities
         }
 
         /// <summary>
-        /// Loads given array of bytes as an assembly image using <see cref="System.Reflection.Assembly.Load"/> or <see cref="System.Reflection.Assembly.ReflectionOnlyLoad"/>.
+        /// Loads given array of bytes as an assembly image using <see cref="Assembly.Load(byte[])"/> or <see cref="Assembly.ReflectionOnlyLoad(byte[])"/>.
         /// </summary>
         internal static Assembly LoadAsAssembly(string moduleName, ImmutableArray<byte> rawAssembly, bool reflectionOnly = false)
         {

--- a/src/Test/Utilities/Portable/Compilation/IRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/Compilation/IRuntimeEnvironment.cs
@@ -150,7 +150,7 @@ namespace Roslyn.Test.Utilities
         /// <summary>
         /// Find all of the <see cref="Compilation"/> values reachable from this instance.
         /// </summary>
-        /// <param name="compilation"></param>
+        /// <param name="original"></param>
         /// <returns></returns>
         private static List<Compilation> FindReferencedCompilations(Compilation original)
         {

--- a/src/Test/Utilities/Portable/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Portable/Diagnostics/DiagnosticExtensions.cs
@@ -242,7 +242,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Given a set of compiler or <see cref="IDiagnosticAnalyzer"/> generated <paramref name="diagnostics"/>, returns the effective diagnostics after applying the below filters:
+        /// Given a set of compiler or <see cref="DiagnosticAnalyzer"/> generated <paramref name="diagnostics"/>, returns the effective diagnostics after applying the below filters:
         /// 1) <see cref="CompilationOptions.SpecificDiagnosticOptions"/> specified for the given <paramref name="compilation"/>.
         /// 2) <see cref="CompilationOptions.GeneralDiagnosticOption"/> specified for the given <paramref name="compilation"/>.
         /// 3) Diagnostic suppression through applied <see cref="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute"/>.
@@ -255,7 +255,6 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Returns true if all the diagnostics that can be produced by this analyzer are suppressed through options.
-        /// <paramref name="continueOnError"/> says whether the caller would like the exception thrown by the analyzers to be handled or not. If true - Handles ; False - Not handled.
         /// </summary>
         public static bool IsDiagnosticAnalyzerSuppressed(this DiagnosticAnalyzer analyzer, CompilationOptions options)
         {

--- a/src/Test/Utilities/Portable/FX/EventWaiter.cs
+++ b/src/Test/Utilities/Portable/FX/EventWaiter.cs
@@ -66,7 +66,6 @@ namespace Roslyn.Test.Utilities
         /// <summary>
         /// Use this method to block the test until the operation enclosed in the Wrap method completes
         /// </summary>
-        /// <param name="timeout"></param>
         /// <returns></returns>
         public void WaitForEventToFire()
         {

--- a/src/Test/Utilities/Portable/Metadata/ILBuilderVisualizer.cs
+++ b/src/Test/Utilities/Portable/Metadata/ILBuilderVisualizer.cs
@@ -132,7 +132,7 @@ namespace Roslyn.Test.Utilities
         }
 
         /// <remarks>
-        /// Invoked via Reflection from <see cref="ILBuilder.GetDebuggerDisplay()"/>
+        /// Invoked via Reflection from <see cref="ILBuilder"/><c>.GetDebuggerDisplay()</c>.
         /// </remarks>
         internal static string ILBuilderToString(
             ILBuilder builder,

--- a/src/VisualStudio/Core/Test/Progression/ContainsChildrenGraphQueryTests.vb
+++ b/src/VisualStudio/Core/Test/Progression/ContainsChildrenGraphQueryTests.vb
@@ -82,14 +82,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
 
                 Dim inputGraph = testState.GetGraphWithDocumentNode(filePath:="Z:\Project.cs")
 
-                ''' To simulate the situation where a solution is not yet loaded and project info is not available,
-                ''' remove a project from the solution.
+                ' To simulate the situation where a solution is not yet loaded and project info is not available,
+                ' remove a project from the solution.
 
                 Dim oldSolution = testState.GetSolution()
                 Dim newSolution = oldSolution.RemoveProject(oldSolution.ProjectIds.FirstOrDefault())
                 Dim outputContext = Await testState.GetGraphContextAfterQueryWithSolution(inputGraph, newSolution, New ContainsChildrenGraphQuery(), GraphContextDirection.Self)
 
-                ''' ContainsChildren should be set to false, so following updates will be tractable.
+                ' ContainsChildren should be set to false, so following updates will be tractable.
 
                 AssertSimplifiedGraphIs(
                     outputContext.Graph,

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/TextViewWindow_OutOfProc.cs
@@ -95,7 +95,6 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         /// Invokes the lightbulb without waiting for diagnostics
         /// Compare to <see cref="InvokeCodeActionList"/>
         /// </summary>
-        /// <param name="test"></param>
         public void InvokeCodeActionListWithoutWaiting()
         {
             ShowLightBulb();

--- a/src/VisualStudio/VisualStudioInteractiveComponents/VisualStudioInteractiveComponents.csproj
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/VisualStudioInteractiveComponents.csproj
@@ -14,7 +14,6 @@
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <NoDocumentationFile>true</NoDocumentationFile>
     <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
     <TargetFramework>net46</TargetFramework>


### PR DESCRIPTION
* Ensures comments are accurately handled, per #2773
* Fixes errors revealed in existing documentation comments