### PR TITLE
Updating VisualStudioInstanceFactory to not take the trailing slash into account when comparing directories.

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/VisualStudioInstanceFactory.cs
@@ -247,6 +247,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
             if (haveVsInstallDir)
             {
                 vsInstallDir = Path.GetFullPath(vsInstallDir);
+                vsInstallDir = vsInstallDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                 Debug.WriteLine($"An environment variable named 'VSInstallDir' was found, adding this to the specified requirements. (VSInstallDir: {vsInstallDir})");
             }
 
@@ -258,6 +259,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
                     if (haveVsInstallDir)
                     {
                         var installationPath = instance.GetInstallationPath();
+                        installationPath = Path.GetFullPath(installationPath);
+                        installationPath = installationPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                         isMatch &= installationPath.Equals(vsInstallDir, StringComparison.OrdinalIgnoreCase);
                     }
                 }


### PR DESCRIPTION
The `VSInstallDir` environment variable (set by the developer command prompt) contains a trailing slash by default.

The `InstallationPath` returned by the managed query APIs does not.

This breaks the comparison.