### PR TITLE
Only recompute SymbolTreeInfo for a project when syntax changes in a document

### DIFF
--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
@@ -160,6 +160,8 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
             /// <remarks>
             /// SymbolTreeInfo is an index of source symbols in a project.  As such, we only need
             /// to recompute the index for a project when the syntax for a document within it changes.
+            /// i.e. the change to syntax in one project P could not affect the SymbolTree index for
+            /// *any* other project.
             /// 
             /// Note that AnalyzeSyntaxAsync will be called if anything changes that could affect
             /// syntax (for example, if project preprocessor-definitions chnages), not just direct

--- a/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
+++ b/src/Features/Core/Portable/IncrementalCaches/SymbolTreeInfoIncrementalAnalyzerProvider.cs
@@ -157,52 +157,33 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                 _metadataPathToInfo = metadataPathToInfo;
             }
 
-            public override Task AnalyzeDocumentAsync(Document document, SyntaxNode bodyOpt, InvocationReasons reasons, CancellationToken cancellationToken)
+            /// <remarks>
+            /// SymbolTreeInfo is an index of source symbols in a project.  As such, we only need
+            /// to recompute the index for a project when the syntax for a document within it changes.
+            /// 
+            /// Note that AnalyzeSyntaxAsync will be called if anything changes that could affect
+            /// syntax (for example, if project preprocessor-definitions chnages), not just direct
+            /// edits of that file.
+            /// </remarks>
+            public override async Task AnalyzeSyntaxAsync(Document document, InvocationReasons reasons, CancellationToken cancellationToken)
             {
                 if (!document.SupportsSyntaxTree)
                 {
                     // Not a language we can produce indices for (i.e. TypeScript).  Bail immediately.
-                    return SpecializedTasks.EmptyTask;
-                }
-
-                if (bodyOpt != null)
-                {
-                    // This was a method level edit.  This can't change the symbol tree info
-                    // for this project.  Bail immediately.
-                    return SpecializedTasks.EmptyTask;
-                }
-
-                return UpdateSymbolTreeInfoAsync(document.Project, cancellationToken);
-            }
-
-            public override Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
-            {
-                return UpdateSymbolTreeInfoAsync(project, cancellationToken);
-            }
-
-            private async Task UpdateSymbolTreeInfoAsync(Project project, CancellationToken cancellationToken)
-            {
-                if (!project.SupportsCompilation)
-                {
-                    // Not a language we can produce indices for (i.e. TypeScript).  Bail immediately.
                     return;
                 }
 
-                if (!RemoteFeatureOptions.ShouldComputeIndex(project.Solution.Workspace))
+                if (!RemoteFeatureOptions.ShouldComputeIndex(document.Project.Solution.Workspace))
                 {
                     return;
                 }
 
-                // Produce the indices for the source and metadata symbols in parallel.
-                var projectTask = UpdateSourceSymbolTreeInfoAsync(project, cancellationToken);
-                var referencesTask = UpdateReferencesAync(project, cancellationToken);
-
-                await Task.WhenAll(projectTask, referencesTask).ConfigureAwait(false);
-            }
-
-            private async Task UpdateSourceSymbolTreeInfoAsync(Project project, CancellationToken cancellationToken)
-            {
+                // Cache data at the project level.  That way if we get a N AnalyzeSyntaxAsync calls
+                // for all the documents in a project, we'll only compute the index for the first call
+                // and we'll bail out immediately for all subsequent calls.
+                var project = document.Project;
                 var checksum = await SymbolTreeInfo.GetSourceSymbolsChecksumAsync(project, cancellationToken).ConfigureAwait(false);
+
                 if (!_projectToInfo.TryGetValue(project.Id, out var projectInfo) ||
                     projectInfo.Checksum != checksum)
                 {
@@ -218,14 +199,34 @@ namespace Microsoft.CodeAnalysis.IncrementalCaches
                 }
             }
 
-            private Task UpdateReferencesAync(Project project, CancellationToken cancellationToken)
+            public override async Task AnalyzeProjectAsync(Project project, bool semanticsChanged, InvocationReasons reasons, CancellationToken cancellationToken)
             {
-                // Process all metadata references in parallel.
-                var tasks = project.MetadataReferences.OfType<PortableExecutableReference>()
-                                   .Select(r => UpdateReferenceAsync(project, r, cancellationToken))
-                                   .ToArray();
+                if (!project.SupportsCompilation)
+                {
+                    // Not a language we can produce indices for (i.e. TypeScript).  Bail immediately.
+                    return;
+                }
 
-                return Task.WhenAll(tasks);
+                if (!RemoteFeatureOptions.ShouldComputeIndex(project.Solution.Workspace))
+                {
+                    return;
+                }
+
+                // If a project changes, see if it was because any metadata references changed.  If so,
+                // attempt to recompute the indices for those metadata references.
+                //
+                // If this is the remote workspace, do it in parallel.
+                var isRemoteWorkspace = project.Solution.Workspace.Kind == WorkspaceKind.RemoteWorkspace ||
+                                        project.Solution.Workspace.Kind == WorkspaceKind.RemoteTemporaryWorkspace;
+                var tasks = new List<Task>();
+                foreach (var reference in project.MetadataReferences.OfType<PortableExecutableReference>())
+                {
+                    tasks.Add(isRemoteWorkspace
+                        ? Task.Run(() => UpdateReferenceAsync(project, reference, cancellationToken), cancellationToken)
+                        : UpdateReferenceAsync(project, reference, cancellationToken));
+                }
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
             }
 
             private async Task UpdateReferenceAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -149,11 +149,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public static Checksum GetMetadataChecksum(
             Solution solution, PortableExecutableReference reference, CancellationToken cancellationToken)
         {
-            // We can reuse the index for any given reference as long as it hasn't changed.
-            // So our checksum is just the checksum for the PEReference itself.
-            var serializer = new Serializer(solution.Workspace);
-            var checksum = serializer.CreateChecksum(reference, cancellationToken);
-            return checksum;
+            return ChecksumCache.GetOrCreate(reference, _ =>
+            {
+
+                // We can reuse the index for any given reference as long as it hasn't changed.
+                // So our checksum is just the checksum for the PEReference itself.
+                var serializer = new Serializer(solution.Workspace);
+                var checksum = serializer.CreateChecksum(reference, cancellationToken);
+                return checksum;
+            });
         }
 
         private static Task<SymbolTreeInfo> TryLoadOrCreateMetadataSymbolTreeInfoAsync(

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -92,11 +92,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static readonly Func<ISymbol, bool> s_useSymbolNoPrivate =
             s => s.CanBeReferencedByName && s.DeclaredAccessibility != Accessibility.Private;
 
-        private static readonly Func<ISymbol, bool> s_useSymbolNoPrivateOrInternal =
-            s => s.CanBeReferencedByName &&
-            s.DeclaredAccessibility != Accessibility.Private &&
-            s.DeclaredAccessibility != Accessibility.Internal;
-
         // generate nodes for symbols that share the same name, and all their descendants
         private static void GenerateSourceNodes(
             string name,

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.FindSymbols

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -49,6 +49,11 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             Project project, Checksum checksum, CancellationToken cancellationToken)
         {
             var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+            // Note: we build our index from the source assembly for a compilation.  As such,
+            // the index only contains information about the source symbols defined in this 
+            // compilation.  If that ever changes then we need to change how we cache and recompute
+            // data in SymbolTreeInfoIncrementalAnalyzerProvider.
             var assembly = compilation.Assembly;
             if (assembly == null)
             {


### PR DESCRIPTION
This prevents us from having to do *any* downstream work for other projects when syntax changes in another project.  