### PR TITLE
Remove capture allocation from WriteArray

### DIFF
--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -483,7 +483,8 @@ namespace Roslyn.Utilities
                     // don't blow the stack.  'LongRunning' ensures that we get a dedicated thread
                     // to do this work.  That way we don't end up blocking the threadpool.
                     var task = Task.Factory.StartNew(
-                        () => WriteArrayValues(array),
+                        a => WriteArrayValues((Array)a), 
+                        array,
                         _cancellationToken,
                         TaskCreationOptions.LongRunning,
                         TaskScheduler.Default);


### PR DESCRIPTION
This allocation was causing 1.4% of all allocations in the trace in https://github.com/dotnet/project-system/issues/2576.

![image](https://user-images.githubusercontent.com/1103906/28048979-a6f87820-6637-11e7-8588-c8c37211440b.png)
