### PR TITLE
Serialize a guid without an intermediary array allocation.

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -1033,6 +1033,21 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void TestRoundTripGuid()
+        {
+            TestRoundTripGuid(Guid.Empty);
+            for (int i = 0; i < 10; i++)
+            {
+                TestRoundTripGuid(Guid.NewGuid());
+            }
+        }
+
+        private void TestRoundTripGuid(Guid guid)
+        {
+            TestRoundTrip(guid, (w, v) => w.WriteGuid(v), r => r.ReadGuid());
+        }
+
+        [Fact]
         public void TestRoundTripStringCharacters()
         {
             // round trip all possible characters as a string

--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -1036,6 +1036,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void TestRoundTripGuid()
         {
             TestRoundTripGuid(Guid.Empty);
+            TestRoundTripGuid(new Guid(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1));
+            TestRoundTripGuid(new Guid(0b10000000000000000000000000000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1));
+            TestRoundTripGuid(new Guid(0b10000000000000000000000000000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
             for (int i = 0; i < 10; i++)
             {
                 TestRoundTripGuid(Guid.NewGuid());

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -124,7 +124,7 @@ namespace Roslyn.Utilities
         public ushort ReadUInt16() => _reader.ReadUInt16();
         public string ReadString() => ReadStringValue();
 
-        public unsafe Guid ReadGuid()
+        public Guid ReadGuid()
         {
             var accessor = new ObjectWriter.GuidAccessor
             {

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -126,15 +126,13 @@ namespace Roslyn.Utilities
 
         public unsafe Guid ReadGuid()
         {
-            Debug.Assert(sizeof(Guid) == 16);
-            Debug.Assert(sizeof(long) == 8);
+            var accessor = new ObjectWriter.GuidAccessor
+            {
+                Low64 = ReadInt64(),
+                High64 = ReadInt64()
+            };
 
-            Guid guid;
-            long* pGuid = (long*)&guid;
-            pGuid[0] = ReadInt64();
-            pGuid[1] = ReadInt64();
-
-            return guid;
+            return accessor.Guid;
         }
 
         public object ReadValue()

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -124,6 +124,19 @@ namespace Roslyn.Utilities
         public ushort ReadUInt16() => _reader.ReadUInt16();
         public string ReadString() => ReadStringValue();
 
+        public unsafe Guid ReadGuid()
+        {
+            Debug.Assert(sizeof(Guid) == 16);
+            Debug.Assert(sizeof(long) == 8);
+
+            Guid guid;
+            long* pGuid = (long*)&guid;
+            pGuid[0] = ReadInt64();
+            pGuid[1] = ReadInt64();
+
+            return guid;
+        }
+
         public object ReadValue()
         {
             var oldDepth = _recursionDepth;

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -119,6 +119,15 @@ namespace Roslyn.Utilities
         public void WriteUInt16(ushort value) => _writer.Write(value);
         public void WriteString(string value) => WriteStringValue(value);
 
+        public unsafe void WriteGuid(Guid guid)
+        {
+            Debug.Assert(sizeof(Guid) == 16);
+            Debug.Assert(sizeof(long) == 8);
+            long* pGuid = (long*)&guid;
+            WriteInt64(pGuid[0]);
+            WriteInt64(pGuid[1]);
+        }
+
         public void WriteValue(object value)
         {
             Debug.Assert(value == null || !value.GetType().GetTypeInfo().IsEnum, "Enum should not be written with WriteValue.  Write them as ints instead.");

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -125,12 +125,6 @@ namespace Roslyn.Utilities
         [StructLayout(LayoutKind.Explicit)]
         internal struct GuidAccessor
         {
-            unsafe static GuidAccessor()
-            {
-                Debug.Assert(sizeof(Guid) == 16);
-                Debug.Assert(sizeof(long) == 8);
-            }
-
             [FieldOffset(0)]
             public Guid Guid;
 

--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Execution
                     var mvidHandle = metadataReader.GetModuleDefinition().Mvid;
                     var guid = metadataReader.GetGuid(mvidHandle);
 
-                    writer.WriteValue(guid.ToByteArray());
+                    writer.WriteGuid(guid);
                 }
             }
             catch
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Execution
             var mvidHandle = metadataReader.GetModuleDefinition().Mvid;
             var guid = metadataReader.GetGuid(mvidHandle);
 
-            writer.WriteValue(guid.ToByteArray());
+            writer.WriteGuid(guid);
         }
 
         private void WritePortableExecutableReferenceTo(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis
         {
             ProjectId.WriteTo(writer);
 
-            writer.WriteValue(Id.ToByteArray());
+            writer.WriteGuid(Id);
             writer.WriteString(DebugName);
         }
 
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis
         {
             var projectId = ProjectId.ReadFrom(reader);
 
-            var guid = new Guid((byte[])reader.ReadValue());
+            var guid = reader.ReadGuid();
             var debugName = reader.ReadString();
 
             return CreateFromSerialized(projectId, guid, debugName);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -86,13 +86,13 @@ namespace Microsoft.CodeAnalysis
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
-            writer.WriteValue(Id.ToByteArray());
+            writer.WriteGuid(Id);
             writer.WriteString(DebugName);
         }
 
         internal static ProjectId ReadFrom(ObjectReader reader)
         {
-            var guid = new Guid((byte[])reader.ReadValue());
+            var guid = reader.ReadGuid();
             var debugName = reader.ReadString();
 
             return CreateFromSerialized(guid, debugName);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
@@ -83,13 +83,13 @@ namespace Microsoft.CodeAnalysis
 
         void IObjectWritable.WriteTo(ObjectWriter writer)
         {
-            writer.WriteValue(Id.ToByteArray());
+            writer.WriteGuid(Id);
             writer.WriteString(DebugName);
         }
 
         internal static SolutionId ReadFrom(ObjectReader reader)
         {
-            var guid = new Guid((byte[])reader.ReadValue());
+            var guid = reader.ReadGuid();
             var debugName = reader.ReadString();
 
             return CreateFromSerialized(guid, debugName);


### PR DESCRIPTION
Addresses issue reported by @davkean where he was seeing an excessive amount of byte[]s created while creating the checksum for a metadata reference.