### PR TITLE
Ensure we clean up RuleSetFiles when we close the solution

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _ruleSetFileMap.Remove(ruleSetFile.FilePath);
         }
 
-        public void Dispose()
+        public void ClearCachedRuleSetFiles()
         {
             foreach (var pair in _ruleSetFileMap)
             {
@@ -49,6 +49,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
 
             _ruleSetFileMap.Clear();
+        }
+
+        void IDisposable.Dispose()
+        {
+            ClearCachedRuleSetFiles();
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -24,7 +24,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    internal sealed partial class VisualStudioProjectTracker : ForegroundThreadAffinitizedObject, IDisposable, IVisualStudioHostProjectContainer
+    internal sealed partial class VisualStudioProjectTracker : ForegroundThreadAffinitizedObject, IVisualStudioHostProjectContainer
     {
         #region Readonly fields
         private static readonly ConditionalWeakTable<SolutionId, string> s_workingFolderPathMap = new ConditionalWeakTable<SolutionId, string>();
@@ -243,14 +243,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public DocumentProvider DocumentProvider { get; private set; }
         public VisualStudioMetadataReferenceManager MetadataReferenceProvider { get; private set; }
         public VisualStudioRuleSetManager RuleSetFileProvider { get; private set; }
-
-        public void Dispose()
-        {
-            if (this.RuleSetFileProvider != null)
-            {
-                this.RuleSetFileProvider.Dispose();
-            }
-        }
 
         internal AbstractProject GetProject(ProjectId id)
         {
@@ -564,6 +556,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 _projectPathToIdMap.Clear();
             }
+
+            RuleSetFileProvider.ClearCachedRuleSetFiles();
 
             foreach (var workspaceHost in _workspaceHosts)
             {

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -87,8 +87,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                 project.Disconnect()
             Next
 
+            _projectTracker.OnAfterCloseSolution()
             _workspace.Dispose()
-            _projectTracker.Dispose()
 
             For Each filePath In _projectFilePaths
                 File.Delete(filePath)


### PR DESCRIPTION
The VisualStudioRuleSetManager is a singleton that acts as a cache of RuleSetFiles and also manages the lifetime of file watching. We never cleaned that up when we shut down VS, so we leaked a bunch of
file watchers, which would throw during finalization asserting they weren't cleaned up and bring down the process with it.

**Customer scenario:** in a solution that uses rule set files, close the solution. There is a chance you might crash.
**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/217450
**Workarounds, if any:** none. A slower or faster computer might help you not hit the race. :smile:
**Risk:** low. Just fixing a cleanup path during shutdown.
**Performance impact:** none. Only change is during VS shutdown.
**Is this a regression from a previous update?** the bug would seem to be very old. If it's a regression it's neither obvious when -- it might date to Roslyn's first ship.
**Root cause analysis:** (see above.)
**How was the bug found?** Watson reports.
