### PR TITLE
Support Source and Additional files having the same path

### DIFF
--- a/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
         {
             if (this.CurrentSolution.ContainsAdditionalDocument(documentId))
             {
-                OpenAdditionalDocument(documentId, activate);
+                OpenAdditionalDocument(documentId);
                 return;
             }
 
@@ -60,6 +60,11 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
             this.OnDocumentOpened(documentId, text.Container);
         }
 
+        /// <summary>
+        /// Puts the specified additional document into the open state.
+        /// </summary>
+        /// <param name="documentId">The <see cref="DocumentId"/> to open.</param>
+        /// <param name="activate">Ignored - not necessary for additional documents.</param>
         public override void OpenAdditionalDocument(DocumentId documentId, bool activate = true)
         {
             var document = this.CurrentSolution.GetAdditionalDocument(documentId);

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private readonly List<ProjectReference> _projectReferences = new List<ProjectReference>();
         private readonly List<VisualStudioMetadataReference> _metadataReferences = new List<VisualStudioMetadataReference>();
         private readonly Dictionary<DocumentId, IVisualStudioHostDocument> _documents = new Dictionary<DocumentId, IVisualStudioHostDocument>();
-        private readonly Dictionary<string, IVisualStudioHostDocument> _documentMonikers = new Dictionary<string, IVisualStudioHostDocument>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, (IVisualStudioHostDocument document, int refCount)> _documentMonikers = new Dictionary<string, (IVisualStudioHostDocument, int)>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, VisualStudioAnalyzer> _analyzers = new Dictionary<string, VisualStudioAnalyzer>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<DocumentId, IVisualStudioHostDocument> _additionalDocuments = new Dictionary<DocumentId, IVisualStudioHostDocument>();
 
@@ -410,8 +410,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             lock (_gate)
             {
-                _documentMonikers.TryGetValue(filePath, out var document);
-                return document;
+                return _documentMonikers.TryGetValue(filePath, out var value)
+                    ? value.document
+                    : null;
             }
         }
 
@@ -903,7 +904,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        private static void OnAdditionalDocumentOpened(object sender, bool isCurrentContext)
+        private static void OnAdditionalDocumentOpened(object sender, bool isCurrentContextIgnored)
         {
             IVisualStudioHostDocument document = (IVisualStudioHostDocument)sender;
             AbstractProject project = (AbstractProject)document.Project;
@@ -912,7 +913,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             if (project._pushingChangesToWorkspaceHosts)
             {
-                project.ProjectTracker.NotifyWorkspaceHosts(host => host.OnAdditionalDocumentOpened(document.Id, document.GetOpenTextBuffer(), isCurrentContext));
+                project.ProjectTracker.NotifyWorkspaceHosts(host => host.OnAdditionalDocumentOpened(document.Id, document.GetOpenTextBuffer()));
             }
             else
             {
@@ -962,6 +963,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 filePath: filename,
                 sourceCodeKind: sourceCodeKind,
                 getFolderNames: getFolderNames,
+                isAdditionalFile: false,
                 canUseTextBuffer: CanUseTextBuffer,
                 updatedOnDiskHandler: s_documentUpdatedOnDiskEventHandler,
                 openedHandler: s_documentOpenedEventHandler,
@@ -1025,7 +1027,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 lock (_gate)
                 {
                     _documents.Add(document.Id, document);
-                    _documentMonikers.Add(document.Key.Moniker, document);
+                    AddMoniker(document);
                 }
 
                 if (_pushingChangesToWorkspaceHosts)
@@ -1064,7 +1066,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 lock (_gate)
                 {
                     _documents.Remove(document.Id);
-                    _documentMonikers.Remove(document.Key.Moniker);
+                    RemoveMoniker(document);
                 }
 
                 UninitializeDocument(document);
@@ -1072,14 +1074,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        internal void AddAdditionalDocument(IVisualStudioHostDocument document, bool isCurrentContext)
+        internal void AddAdditionalDocument(IVisualStudioHostDocument document)
         {
             AssertIsForeground();
 
             lock (_gate)
             {
                 _additionalDocuments.Add(document.Id, document);
-                _documentMonikers.Add(document.Key.Moniker, document);
+                AddMoniker(document);
             }
 
             if (_pushingChangesToWorkspaceHosts)
@@ -1088,7 +1090,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 if (document.IsOpen)
                 {
-                    this.ProjectTracker.NotifyWorkspaceHosts(host => host.OnAdditionalDocumentOpened(document.Id, document.GetOpenTextBuffer(), isCurrentContext));
+                    this.ProjectTracker.NotifyWorkspaceHosts(host => host.OnAdditionalDocumentOpened(document.Id, document.GetOpenTextBuffer()));
                 }
             }
 
@@ -1107,10 +1109,46 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             lock (_gate)
             {
                 _additionalDocuments.Remove(document.Id);
-                _documentMonikers.Remove(document.Key.Moniker);
+                RemoveMoniker(document);
             }
 
             UninitializeAdditionalDocument(document);
+        }
+
+        private void AddMoniker(IVisualStudioHostDocument document)
+        {
+            var moniker = document.Key.Moniker;
+            if (_documentMonikers.TryGetValue(moniker, out var value))
+            {
+                value.refCount++;
+                _documentMonikers[moniker] = (value.document, value.refCount);
+            }
+            else
+            {
+                _documentMonikers.Add(moniker, (document, 1));
+            }
+        }
+
+        private void RemoveMoniker(IVisualStudioHostDocument document)
+        {
+            var moniker = document.Key.Moniker;
+            if (_documentMonikers.TryGetValue(moniker, out var value))
+            {
+                Debug.Assert(value.document.Equals(document));
+                value.refCount--;
+                if (value.refCount == 0)
+                {
+                    _documentMonikers.Remove(moniker);
+                }
+                else
+                {
+                    _documentMonikers[moniker] = (value.document, value.refCount);
+                }
+            }
+            else
+            {
+                Debug.Fail($"Couldn't find '{moniker}' in {nameof(_documentMonikers)} to remove it.");
+            }
         }
 
         public virtual void Disconnect()

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
@@ -137,6 +137,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 sourceCodeKind: SourceCodeKind.Regular,
                 getFolderNames: _ => SpecializedCollections.EmptyReadOnlyList<string>(),
                 canUseTextBuffer: _ => true,
+                isAdditionalFile: true,
                 updatedOnDiskHandler: s_additionalDocumentUpdatedOnDiskEventHandler,
                 openedHandler: s_additionalDocumentOpenedEventHandler,
                 closingHandler: s_additionalDocumentClosingEventHandler);
@@ -146,7 +147,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return;
             }
 
-            AddAdditionalDocument(document, isCurrentContext: getIsInCurrentContext(document));
+            AddAdditionalDocument(document);
         }
 
         public void RemoveAdditionalFile(string additionalFilePath)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject_Analyzers.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public void RemoveAdditionalFile(string additionalFilePath)
         {
-            IVisualStudioHostDocument document = this.GetCurrentDocumentFromPath(additionalFilePath);
+            IVisualStudioHostDocument document = this.GetCurrentDocumentFromPath(additionalFilePath, additionalFile: true);
             if (document == null)
             {
                 throw new InvalidOperationException("The document is not a part of the finalProject.");

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentKey.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentKey.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     /// 
     /// Immutable, since this object is used as a key into some dictionaries.
     /// </summary>
-    [DebuggerDisplay("{GetDebuggerDisplay(),nq")]
+    [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     internal class DocumentKey : IEquatable<DocumentKey>
     {
         public IVisualStudioHostProject HostProject { get; }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.cs
@@ -85,6 +85,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             Marshal.ThrowExceptionForHR(runningDocumentTableForEvents.AdviseRunningDocTableEvents(new RunningDocTableEventsSink(this), out _runningDocumentTableEventCookie));
         }
 
+        [Obsolete("Use the overload with 'isAdditionalFile' instead", error: true)]
+        public IVisualStudioHostDocument TryGetDocumentForFile(
+            IVisualStudioHostProject hostProject,
+            string filePath,
+            SourceCodeKind sourceCodeKind,
+            Func<ITextBuffer, bool> canUseTextBuffer,
+            Func<uint, IReadOnlyList<string>> getFolderNames,
+            EventHandler updatedOnDiskHandler = null,
+            EventHandler<bool> openedHandler = null,
+            EventHandler<bool> closingHandler = null)
+        {
+            return TryGetDocumentForFile(
+                hostProject, filePath, sourceCodeKind, canUseTextBuffer, getFolderNames, isAdditionalFile: false,
+                updatedOnDiskHandler: updatedOnDiskHandler, openedHandler: openedHandler, closingHandler: closingHandler);
+        }
+
         /// <summary>
         /// Gets the <see cref="IVisualStudioHostDocument"/> for the file at the given filePath.
         /// If we are on the foreground thread and this document is already open in the editor,

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioWorkspaceHost.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/IVisualStudioWorkspaceHost.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         void OnAnalyzerReferenceRemoved(ProjectId projectId, AnalyzerReference analyzerReference);
         void OnAdditionalDocumentAdded(DocumentInfo documentInfo);
         void OnAdditionalDocumentRemoved(DocumentId documentInfo);
-        void OnAdditionalDocumentOpened(DocumentId documentId, ITextBuffer textBuffer, bool isCurrentContext);
+        void OnAdditionalDocumentOpened(DocumentId documentId, ITextBuffer textBuffer);
         void OnAdditionalDocumentClosed(DocumentId documentId, ITextBuffer textBuffer, TextLoader loader);
         void OnAdditionalDocumentTextUpdatedOnDisk(DocumentId id);
     }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -369,6 +369,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 hostProject,
                 moniker,
                 parseOptionsOpt?.Kind ?? SourceCodeKind.Regular,
+                isAdditionalFile: false,
                 getFolderNames: _ => SpecializedCollections.EmptyReadOnlyList<string>(),
                 canUseTextBuffer: _ => true);
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
@@ -166,6 +166,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                                 isCurrentContext: LinkedFileUtilities.IsCurrentContextHierarchy(document, _tracker._runningDocumentTable));
                         }
                     }
+
+                    foreach (var additionalDocument in project.GetCurrentAdditionalDocuments())
+                    {
+                        if (additionalDocument.IsOpen)
+                        {
+                            this.Host.OnAdditionalDocumentOpened(
+                                additionalDocument.Id,
+                                additionalDocument.GetOpenTextBuffer());
+                        }
+                    }
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -753,9 +753,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             OpenDocumentCore(documentId, activate);
         }
 
+        /// <summary>
+        /// Puts the specified additional document into the open state.
+        /// </summary>
+        /// <param name="documentId">The <see cref="DocumentId"/> to open.</param>
+        /// <param name="activate">Ignored - not necessary for additional documents.</param>
         public override void OpenAdditionalDocument(DocumentId documentId, bool activate = true)
         {
-            OpenDocumentCore(documentId, activate);
+            OpenDocumentCore(documentId);
         }
 
         public override void CloseDocument(DocumentId documentId)
@@ -1441,9 +1446,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _workspace.OnAdditionalDocumentRemoved(documentInfo);
             }
 
-            void IVisualStudioWorkspaceHost.OnAdditionalDocumentOpened(DocumentId documentId, ITextBuffer textBuffer, bool isCurrentContext)
+            void IVisualStudioWorkspaceHost.OnAdditionalDocumentOpened(DocumentId documentId, ITextBuffer textBuffer)
             {
-                _workspace.OnAdditionalDocumentOpened(documentId, textBuffer.AsTextContainer(), isCurrentContext);
+                _workspace.OnAdditionalDocumentOpened(documentId, textBuffer.AsTextContainer());
             }
 
             void IVisualStudioWorkspaceHost.OnAdditionalDocumentClosed(DocumentId documentId, ITextBuffer textBuffer, TextLoader loader)

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 _itemMoniker = moniker;
             }
 
-            this.Key = new DocumentKey(Project, filePath);
+            this.Key = new DocumentKey(Project, filePath, isAdditionalFile: false);
             this.Id = DocumentId.CreateNewId(Project.Id, filePath);
             this.Folders = containedLanguage.Project.GetFolderNamesFromHierarchy(itemId);
             this.Loader = TextLoader.From(containedLanguage.SubjectBuffer.AsTextContainer(), VersionStamp.Create(), filePath);

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
 
             // Check that we know about this file!
-            var hostDocument = _project.GetCurrentDocumentFromPath(filePath);
+            var hostDocument = _project.GetCurrentDocumentFromPath(filePath, additionalFile: false);
             if (hostDocument == null)
             {
                 // Matches behavior of native (C#) implementation

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 return false;
             }
 
-            var hostDocument = project.GetCurrentDocumentFromPath(_incomingFilePath);
+            var hostDocument = project.GetCurrentDocumentFromPath(_incomingFilePath, additionalFile: false);
             if (hostDocument == null)
             {
                 return false;

--- a/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
+++ b/src/VisualStudio/Core/Next/Remote/ServiceHubRemoteHostClient.WorkspaceHost.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             public void ClearSolution() { }
             public void OnAdditionalDocumentAdded(DocumentInfo documentInfo) { }
             public void OnAdditionalDocumentClosed(DocumentId documentId, ITextBuffer textBuffer, TextLoader loader) { }
-            public void OnAdditionalDocumentOpened(DocumentId documentId, ITextBuffer textBuffer, bool isCurrentContext) { }
+            public void OnAdditionalDocumentOpened(DocumentId documentId, ITextBuffer textBuffer) { }
             public void OnAdditionalDocumentRemoved(DocumentId documentInfo) { }
             public void OnAdditionalDocumentTextUpdatedOnDisk(DocumentId id) { }
             public void OnAnalyzerReferenceAdded(ProjectId projectId, AnalyzerReference analyzerReference) { }

--- a/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/TestUtilities2/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -216,8 +216,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
                 _workspace.OnAdditionalDocumentClosed(documentId, loader)
             End Sub
 
-            Public Sub OnAdditionalDocumentOpened(documentId As DocumentId, textBuffer As ITextBuffer, isCurrentContext As Boolean) Implements IVisualStudioWorkspaceHost.OnAdditionalDocumentOpened
-                _workspace.OnAdditionalDocumentOpened(documentId, textBuffer.AsTextContainer(), isCurrentContext)
+            Public Sub OnAdditionalDocumentOpened(documentId As DocumentId, textBuffer As ITextBuffer) Implements IVisualStudioWorkspaceHost.OnAdditionalDocumentOpened
+                _workspace.OnAdditionalDocumentOpened(documentId, textBuffer.AsTextContainer())
             End Sub
 
             Public Sub OnAdditionalDocumentRemoved(additionalDocument As DocumentId) Implements IVisualStudioWorkspaceHost.OnAdditionalDocumentRemoved

--- a/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicProjectCodeModel.vb
+++ b/src/VisualStudio/VisualBasic/Impl/CodeModel/VisualBasicProjectCodeModel.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         End Sub
 
         Friend Overrides Function CanCreateFileCodeModelThroughProject(filePath As String) As Boolean
-            Return _project.GetCurrentDocumentFromPath(filePath) IsNot Nothing
+            Return _project.GetCurrentDocumentFromPath(filePath, additionalFile:=False) IsNot Nothing
         End Function
 
         Friend Overrides Function CreateFileCodeModelThroughProject(filePath As String) As Object
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
             ' with the correct "parent" object.
             '
             ' Because the VB project system lacks these hooks, we simulate the same operations that those hooks perform.
-            Dim document = _project.GetCurrentDocumentFromPath(filePath)
+            Dim document = _project.GetCurrentDocumentFromPath(filePath, additionalFile:=False)
             If document Is Nothing Then
                 Throw New ArgumentException(NameOf(filePath))
             End If

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                     _vsWorkspace);
             }
 
-            IVisualStudioHostDocument vsDocument = project.GetCurrentDocumentFromPath(filePath);
+            IVisualStudioHostDocument vsDocument = project.GetCurrentDocumentFromPath(filePath, additionalFile: false);
             if (vsDocument == null)
             {
                 if (!TryCreateXamlDocument(project, filePath, out vsDocument))
@@ -182,13 +182,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
 
             // Managed languages rely on the msbuild host object to add and remove documents during rename.
             // For XAML we have to do that ourselves.
-            IVisualStudioHostDocument oldDocument = project.GetCurrentDocumentFromPath(oldMoniker);
+            IVisualStudioHostDocument oldDocument = project.GetCurrentDocumentFromPath(oldMoniker, additionalFile: false);
             if (oldDocument != null)
             {
                 project.RemoveDocument(oldDocument);
             }
 
-            IVisualStudioHostDocument newDocument = project.GetCurrentDocumentFromPath(newMoniker);
+            IVisualStudioHostDocument newDocument = project.GetCurrentDocumentFromPath(newMoniker, additionalFile: false);
             Debug.Assert(newDocument == null, "Why does the renamed document already exist in the project?");
             if (newDocument == null)
             {
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 return;
             }
 
-            IVisualStudioHostDocument document = project.GetCurrentDocumentFromPath(info.Moniker);
+            IVisualStudioHostDocument document = project.GetCurrentDocumentFromPath(info.Moniker, additionalFile: false);
             if (document == null)
             {
                 return;

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             vsDocument = _vsWorkspace.DeferredState.ProjectTracker.DocumentProvider.TryGetDocumentForFile(
                 project, filePath, SourceCodeKind.Regular,
                 tb => tb.ContentType.IsOfType(ContentTypeNames.XamlContentType),
-                _ => SpecializedCollections.EmptyReadOnlyList<string>());
+                _ => SpecializedCollections.EmptyReadOnlyList<string>(), isAdditionalFile: false);
 
             return vsDocument != null;
         }

--- a/src/Workspaces/Core/Portable/Workspace/AdhocWorkspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/AdhocWorkspace.cs
@@ -177,13 +177,15 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Puts the specified additional document into the open state.
         /// </summary>
+        /// <param name="documentId">The <see cref="DocumentId"/> to open.</param>
+        /// <param name="activate">Ignored - not necessary for additional documents.</param>
         public override void OpenAdditionalDocument(DocumentId documentId, bool activate = true)
         {
             var doc = this.CurrentSolution.GetAdditionalDocument(documentId);
             if (doc != null)
             {
                 var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
-                this.OnAdditionalDocumentOpened(documentId, text.Container, activate);
+                this.OnAdditionalDocumentOpened(documentId, text.Container);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -543,6 +543,8 @@ namespace Microsoft.CodeAnalysis
                 var oldDocument = oldSolution.GetAdditionalDocument(documentId);
                 var oldText = oldDocument.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
 
+                AddToOpenDocumentMap(documentId);
+
                 // keep open document text alive by using PreserveIdentity
                 var newText = textContainer.CurrentText;
                 Solution currentSolution;

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -152,6 +152,8 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Open the specified additional document in the host environment.
         /// </summary>
+        /// <param name="documentId">The <see cref="DocumentId"/> to open.</param>
+        /// <param name="activate">Ignored - not necessary for additional documents.</param>
         public virtual void OpenAdditionalDocument(DocumentId documentId, bool activate = true)
         {
             this.CheckCanOpenDocuments();
@@ -497,11 +499,14 @@ namespace Microsoft.CodeAnalysis
                 : TextAndVersion.Create(newText, version.GetNewerVersion(), filePath);
         }
 
-        private void SignupForTextChanges(DocumentId documentId, SourceTextContainer textContainer, bool isCurrentContext, Action<Workspace, DocumentId, SourceText, PreservationMode> onChangedHandler)
+        private void SignupForTextChanges(DocumentId documentId, SourceTextContainer textContainer, bool? isCurrentContext, Action<Workspace, DocumentId, SourceText, PreservationMode> onChangedHandler)
         {
             var tracker = new TextTracker(this, documentId, textContainer, onChangedHandler);
             _textTrackers.Add(documentId, tracker);
-            this.UpdateCurrentContextMapping_NoLock(textContainer, documentId, isCurrentContext);
+            if (isCurrentContext != null)
+            {
+                this.UpdateCurrentContextMapping_NoLock(textContainer, documentId, isCurrentContext.Value);
+            }
             tracker.Connect();
         }
 
@@ -521,6 +526,12 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <summary>
+        /// To be called by the host when an ="AdditionalDocument" is opened in the editor.
+        /// </summary>
+        /// <param name="documentId">The <see cref="DocumentId"/>.</param>
+        /// <param name="textContainer">The <see cref="SourceTextContainer"/> for the open file additional document.</param>
+        /// <param name="isCurrentContext">Ignored - not necessary for Additional Files.</param>
         protected internal void OnAdditionalDocumentOpened(DocumentId documentId, SourceTextContainer textContainer, bool isCurrentContext = true)
         {
             CheckAdditionalDocumentIsInCurrentSolution(documentId);
@@ -550,7 +561,7 @@ namespace Microsoft.CodeAnalysis
 
                 var newSolution = this.SetCurrentSolution(currentSolution);
 
-                SignupForTextChanges(documentId, textContainer, isCurrentContext, (w, id, text, mode) => w.OnAdditionalDocumentTextChanged(id, text, mode));
+                SignupForTextChanges(documentId, textContainer, isCurrentContext: null, onChangedHandler: (w, id, text, mode) => w.OnAdditionalDocumentTextChanged(id, text, mode));
 
                 // Fire and forget.
                 this.RaiseWorkspaceChangedEventAsync(WorkspaceChangeKind.AdditionalDocumentChanged, oldSolution, newSolution, documentId: documentId);

--- a/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/Core/Services/RemoteWorkspace.cs
@@ -138,6 +138,8 @@ namespace Microsoft.CodeAnalysis.Remote
         /// <summary>
         /// Puts the specified additional document into the open state.
         /// </summary>
+        /// <param name="documentId">The <see cref="DocumentId"/> to open.</param>
+        /// <param name="activate">Ignored - not necessary for additional documents.</param>
         public override void OpenAdditionalDocument(DocumentId documentId, bool activate = true)
         {
             lock (_gate)
@@ -146,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (doc != null)
                 {
                     var text = doc.GetTextAsync(CancellationToken.None).WaitAndGetResult_CanCallOnBackground(CancellationToken.None);
-                    this.OnAdditionalDocumentOpened(documentId, text.Container, activate);
+                    this.OnAdditionalDocumentOpened(documentId, text.Container);
                 }
             }
         }


### PR DESCRIPTION
## Ask Mode
**Customer scenario**
If a single filepath is included in both the `Compile` and the `AdditionalFiles` item groups, the project system would fail to add the second of those two, and throw, leaving things in a bad state.  In the legacy project system, that seemed to be caught and ignored, and likely you just didn't have the AdditionalFile in your compilations.  In CPS a dialog would be displayed, and the file would end up in Miscellaneous files (however, this can happen during a transient state in CPS due to it's async nature).  In Lightweight solution load, VS would crash.

**Bugs this fixes:** Fixes #19968 / https://devdiv.visualstudio.com/DevDiv/_workitems/edit/463124
**Workarounds, if any**: Not have the item in both `Compile` and `AdditionalFiles`.  Hard, because they may not realize they do, or it may be a transient case in CPS.
**Risk**: Medium - plumbs through new ids for additional items, etc.
**Performance impact**: Low - most significant change is ref counting instead of mere entry in a dictionary.
**Is this a regression from a previous update?**: No, this behavior has been since additional files were added.
**Root cause analysis**: We never expected an item to be in both groups.
**How was the bug found?**: Customers reported files ending up in "Miscellaneous files" in CPS after changing the build action.