### PR TITLE
Increment stream version so we invalidate all existing streams.

### DIFF
--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -31,7 +31,7 @@ namespace Roslyn.Utilities
         /// this version, just change VersionByte2.
         /// </summary>
         internal const byte VersionByte1 = 0b10101010;
-        internal const byte VersionByte2 = 0b00001000;
+        internal const byte VersionByte2 = 0b00001001;
 
         private readonly BinaryReader _reader;
         private readonly CancellationToken _cancellationToken;


### PR DESCRIPTION
Change https://github.com/dotnet/roslyn/pull/20267 changed the format checksums use when serializing/deserializing from streams.  The old format was whatever the serializer writes out when writing a byte[].  Teh new format is the direct write of the the 20 bytes of the sha1 instead the stream.

The issue here is that this then affects any cached data that stores checksums within it.  Anything previously written out with the old form will be unreadable with teh new form.  We can either change each piece of persisted data that may contain a checksum to change their version, or we can make the single change here to invalidate all existing persisted streams.