### PR TITLE
Always offer to fix an expression-bodied accessor used on an entity where it's not allowed.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForConstructorsAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForConstructorsAnalyzerTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -159,6 +160,56 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseExpressionBody
         throw new NotImplementedException(); // comment
     }
 }", ignoreTrivia: false, options: UseBlockBody);
+        }
+
+        [WorkItem(20362, "https://github.com/dotnet/roslyn/issues/20362")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferToConvertToBlockEvenIfExpressionBodyPreferredIfPriorToCSharp7()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    public C() [|=>|] throw new NotImplementedException();
+}",
+@"
+using System;
+class C
+{
+    public C()
+    {
+        throw new NotImplementedException();
+    }
+}", options: UseExpressionBody, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6));
+        }
+
+        [WorkItem(20362, "https://github.com/dotnet/roslyn/issues/20362")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferToConvertToBlockEvenIfExpressionBodyPreferredIfPriorToCSharp7_FixAll()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    public C() {|FixAllInDocument:=>|} throw new NotImplementedException();
+    public C(int i) => throw new NotImplementedException();
+}",
+@"
+using System;
+class C
+{
+    public C()
+    {
+        throw new NotImplementedException();
+    }
+
+    public C(int i)
+    {
+        throw new NotImplementedException();
+    }
+}", options: UseExpressionBody, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForMethodsAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseExpressionBody/Analyzer/UseExpressionBodyForMethodsAnalyzerTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.UseExpressionBody;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -402,6 +403,56 @@ class Program
 #endif
 
 }", options: UseExpressionBody, ignoreTrivia: false);
+        }
+
+        [WorkItem(20362, "https://github.com/dotnet/roslyn/issues/20362")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferToConvertToBlockEvenIfExpressionBodyPreferredIfPriorToCSharp6()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M() [|=>|] throw new NotImplementedException();
+}",
+@"
+using System;
+class C
+{
+    void M()
+    {
+        throw new NotImplementedException();
+    }
+}", options: UseExpressionBody, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5));
+        }
+
+        [WorkItem(20362, "https://github.com/dotnet/roslyn/issues/20362")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestOfferToConvertToBlockEvenIfExpressionBodyPreferredIfPriorToCSharp6_FixAll()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M() {|FixAllInDocument:=>|} throw new NotImplementedException();
+    void M(int i) => throw new NotImplementedException();
+}",
+@"
+using System;
+class C
+{
+    void M()
+    {
+        throw new NotImplementedException();
+    }
+
+    void M(int i)
+    {
+        throw new NotImplementedException();
+    }
+}", options: UseExpressionBody, parseOptions: CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp6));
         }
     }
 }

--- a/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         public abstract ArrowExpressionClauseSyntax GetExpressionBody(SyntaxNode declaration);
 
         public abstract bool CanOfferUseExpressionBody(OptionSet optionSet, SyntaxNode declaration, bool forAnalyzer);
-        public abstract bool CanOfferUseBlockBody(OptionSet optionSet, SyntaxNode declaration, bool forAnalyzer);
+        public abstract (bool canOffer, bool fixesError) CanOfferUseBlockBody(OptionSet optionSet, SyntaxNode declaration, bool forAnalyzer);
         public abstract SyntaxNode Update(SyntaxNode declaration, OptionSet options, ParseOptions parseOptions, bool useExpressionBody);
 
         public abstract Location GetDiagnosticLocation(SyntaxNode declaration);

--- a/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
@@ -141,6 +141,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 return (canOffer, fixesError: true);
             }
 
+            if (declaration is AccessorDeclarationSyntax &&
+                ((CSharpParseOptions)declaration.SyntaxTree.Options).LanguageVersion < LanguageVersion.CSharp7)
+            {
+                // If they're using expression bodies for accessors and it's prior to C# 7
+                // then always mark this as something that can be fixed by the analyzer.  This way
+                // we'll also get 'fix all' working to fix all these cases.
+                return (canOffer, fixesError: true);
+            }
+
             // If the user likes block bodies, then we offer block bodies from the diagnostic analyzer.
             // If the user does not like block bodies then we offer block bodies from the refactoring provider.
             return (userPrefersBlockBodies == forAnalyzer, fixesError: false);

--- a/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/Helpers/UseExpressionBodyHelper`1.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         public override bool CanOfferUseExpressionBody(OptionSet optionSet, SyntaxNode declaration, bool forAnalyzer)
             => CanOfferUseExpressionBody(optionSet, (TDeclaration)declaration, forAnalyzer);
 
-        public override bool CanOfferUseBlockBody(OptionSet optionSet, SyntaxNode declaration, bool forAnalyzer)
+        public override (bool canOffer, bool fixesError) CanOfferUseBlockBody(OptionSet optionSet, SyntaxNode declaration, bool forAnalyzer)
             => CanOfferUseBlockBody(optionSet, (TDeclaration)declaration, forAnalyzer);
 
         public override SyntaxNode Update(SyntaxNode declaration, OptionSet options, ParseOptions parseOptions, bool useExpressionBody)
@@ -118,21 +118,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 out expressionWhenOnSingleLine, out semicolonWhenOnSingleLine);
         }
 
-        public virtual bool CanOfferUseBlockBody(
+        public (bool canOffer, bool fixesError) CanOfferUseBlockBody(
             OptionSet optionSet, TDeclaration declaration, bool forAnalyzer)
         {
             var preference = optionSet.GetOption(this.Option).Value;
             var userPrefersBlockBodies = preference == ExpressionBodyPreference.Never;
 
-            // If the user likes block bodies, then we offer block bodies from the diagnostic analyzer.
-            // If the user does not like block bodies then we offer block bodies from the refactoring provider.
-            if (userPrefersBlockBodies == forAnalyzer)
-            {
-                return this.GetExpressionBody(declaration)?.TryConvertToBlock(
+            var expressionBodyOpt = this.GetExpressionBody(declaration);
+            var canOffer = expressionBodyOpt?.TryConvertToBlock(
                     SyntaxFactory.Token(SyntaxKind.SemicolonToken), false, out var block) == true;
+            if (!canOffer)
+            {
+                return (canOffer, fixesError: false);
             }
 
-            return false;
+            if (expressionBodyOpt.Expression.IsKind(SyntaxKind.ThrowExpression) &&
+                ((CSharpParseOptions)declaration.SyntaxTree.Options).LanguageVersion < LanguageVersion.CSharp7)
+            {
+                // If they're using a throw expression in a declaration and it's prior to C# 7
+                // then always mark this as something that can be fixed by the analyzer.  This way
+                // we'll also get 'fix all' working to fix all these cases.
+                return (canOffer, fixesError: true);
+            }
+
+            // If the user likes block bodies, then we offer block bodies from the diagnostic analyzer.
+            // If the user does not like block bodies then we offer block bodies from the refactoring provider.
+            return (userPrefersBlockBodies == forAnalyzer, fixesError: false);
         }
 
         public TDeclaration Update(

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeFixProvider.cs
@@ -31,7 +31,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         }
 
         protected override bool IncludeDiagnosticDuringFixAll(Diagnostic diagnostic)
-            => diagnostic.Severity != DiagnosticSeverity.Hidden;
+            => diagnostic.Severity != DiagnosticSeverity.Hidden ||
+               diagnostic.Properties.ContainsKey(UseExpressionBodyDiagnosticAnalyzer.FixesError);
 
         public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -88,7 +88,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 succeeded = true;
             }
 
-            if (helper.CanOfferUseBlockBody(optionSet, declaration, forAnalyzer: false))
+            var (canOffer, _) = helper.CanOfferUseBlockBody(optionSet, declaration, forAnalyzer: false);
+            if (canOffer)
             {
                 context.RegisterRefactoring(new MyCodeAction(
                     helper.UseBlockBodyTitle.ToString(),


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/20801

Fixes https://github.com/dotnet/roslyn/issues/20361