### PR TITLE
Use a ScaleTransform to prevent text clipping in the outlining tag hint (fixes #2128)

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/ElisionBufferDeferredContent.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/ElisionBufferDeferredContent.cs
@@ -54,11 +54,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             var view = _textEditorFactoryService.CreateTextView(
                 buffer, _roleSet);
 
-            view.SizeToFit();
+            view.SizeToContentsAndScale();
             view.Background = Brushes.Transparent;
-
-            // Zoom out a bit to shrink the text.
-            view.ZoomLevel *= 0.75;
 
             return view;
         }

--- a/src/EditorFeatures/Core/Implementation/Structure/BlockTagState.cs
+++ b/src/EditorFeatures/Core/Implementation/Structure/BlockTagState.cs
@@ -77,12 +77,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
             var roles = textEditorFactoryService.CreateTextViewRoleSet(OutliningRegionTextViewRole);
             var view = textEditorFactoryService.CreateTextView(finalBuffer, roles);
 
+            view.SizeToContentsAndScale();
             view.Background = Brushes.Transparent;
-
-            view.SizeToFit();
-
-            // Zoom out a bit to shrink the text.
-            view.ZoomLevel *= 0.75;
 
             return view;
         }

--- a/src/EditorFeatures/Core/Shared/Extensions/IWpfTextViewExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/IWpfTextViewExtensions.cs
@@ -1,16 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Windows.Media;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 {
     internal static class IWpfTextViewExtensions
     {
-        public static void SizeToFit(this IWpfTextView view)
+        public static void SizeToContentsAndScale(this IWpfTextView view, double scaleFactor = 0.75)
         {
             // Computing the height of something is easy.
             view.VisualElement.Height = view.LineHeight * view.TextBuffer.CurrentSnapshot.LineCount;
+            
+            // view.ZoomLevel can cause clipping so use a ScaleTransform instead.
+            view.VisualElement.LayoutTransform = new ScaleTransform(scaleFactor, scaleFactor);
 
             // Computing the width... less so. We need "MaxTextRightCoordinate", but we won't have
             // that until a layout occurs.  Fortunately, a layout is going to occur because we set


### PR DESCRIPTION
Fixes #2128 

💻 🖱 ⌨️ 