### PR TITLE
Fixed InlineTemporary into a invocation of local function 

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4499,5 +4499,43 @@ class C
 }";
             await TestInRegularAndScriptAsync(code, expected, ignoreTrivia: false);
         }
+
+        [WorkItem(19247, "https://github.com/dotnet/roslyn/issues/19247")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task InlineTemporary_LocalFunction()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+class C
+{
+    void M()
+    {
+        var [|testStr|] = ""test"";
+        expand(testStr);
+
+        void expand(string str)
+        {
+
+        }
+    }
+}",
+
+@"
+using System;
+class C
+{
+    void M()
+    {
+        expand(""test"");
+
+        void expand(string str)
+        {
+
+        }
+    }
+}",
+ignoreTrivia: false);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -1082,6 +1082,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
 
             public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax originalNode)
             {
+                if (this._semanticModel.GetSymbolInfo(originalNode).Symbol.IsLocalFunction())
+                {
+                    return originalNode;
+                }
+
                 var rewrittenNode = (InvocationExpressionSyntax)base.VisitInvocationExpression(originalNode);
                 if (originalNode.Expression.IsKind(SyntaxKind.SimpleMemberAccessExpression))
                 {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -218,6 +218,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return symbol.Kind == SymbolKind.Method && ((IMethodSymbol)symbol).IsExtensionMethod;
         }
 
+        public static bool IsLocalFunction(this ISymbol symbol)
+        {
+            return symbol != null && symbol.Kind == SymbolKind.Method && ((IMethodSymbol)symbol).MethodKind == MethodKind.LocalFunction;
+        }
+
         public static bool IsModuleMember(this ISymbol symbol)
         {
             return symbol != null && symbol.ContainingSymbol is INamedTypeSymbol && symbol.ContainingType.TypeKind == TypeKind.Module;


### PR DESCRIPTION
Fixes #19247

**Customer scenario**
InlineTemporary into a invocation of local function produces bad code

**Bugs this fixes:**
#19247

**Workarounds, if any**
Don't use refactoring for local function

**Risk**
Low

**Performance impact**


**Is this a regression from a previous update?**
No

**Root cause analysis:**

**How was the bug found?**

customer reported
