### PR TITLE
CSharpLanguageInstructionDecoder implementation of IDkmLanguageInstructionDecoder is slow

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpExpressionCompiler.cs
@@ -108,5 +108,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             appDomain.RemoveMetadataContext<CSharpMetadataContext>();
         }
+
+        internal override ImmutableArray<MetadataBlock> GetMetadataBlocks(DkmClrAppDomain appDomain, DkmClrRuntimeInstance runtimeInstance)
+        {
+            var previous = appDomain.GetMetadataContext<CSharpMetadataContext>();
+            return runtimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks);
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpInstructionDecoder.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             var appDomain = moduleInstance.AppDomain;
             var previous = appDomain.GetMetadataContext<CSharpMetadataContext>();
-            var metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain);
+            var metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks);
 
             CSharpCompilation compilation;
             if (previous.Matches(metadataBlocks))

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(
             this DkmClrRuntimeInstance runtime, 
             DkmClrAppDomain appDomain, 
-            ImmutableArray<MetadataBlock> previousMetadataBlocks = default(ImmutableArray<MetadataBlock>))
+            ImmutableArray<MetadataBlock> previousMetadataBlocks)
         {
             var builder = ArrayBuilder<MetadataBlock>.GetInstance();
             IntPtr ptr;

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -43,12 +43,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 });
         }
 
-        internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain)
-        {
-            return runtime.GetMetadataBlocks(appDomain, ImmutableArray<MetadataBlock>.Empty);
-        }
-
-        internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain, ImmutableArray<MetadataBlock> previousMetadataBlocks)
+        internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(
+            this DkmClrRuntimeInstance runtime, 
+            DkmClrAppDomain appDomain, 
+            ImmutableArray<MetadataBlock> previousMetadataBlocks = default(ImmutableArray<MetadataBlock>))
         {
             var builder = ArrayBuilder<MetadataBlock>.GetInstance();
             IntPtr ptr;
@@ -80,20 +78,6 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             ptr = runtime.GetIntrinsicAssemblyMetaDataBytesPtr(out size);
             builder.Add(GetMetadataBlock(previousMetadataBlocks, index, ptr, size));
             return builder.ToImmutableAndFree();
-        }
-
-        private static MetadataBlock GetMetadataBlock(ImmutableArray<MetadataBlock> previousMetadataBlocks, int index, IntPtr ptr, uint size)
-        {
-            if (!previousMetadataBlocks.IsDefault && index < previousMetadataBlocks.Length)
-            {
-                var previousBlock = previousMetadataBlocks[index];
-                if (previousBlock.Pointer == ptr && previousBlock.Size == size)
-                {
-                    return previousBlock;
-                }
-            }
-
-            return GetMetadataBlock(ptr, size);
         }
 
         internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(GetMetadataBytesPtrFunction getMetaDataBytesPtrFunction, ImmutableArray<AssemblyIdentity> missingAssemblyIdentities)
@@ -161,6 +145,20 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             var moduleVersionId = reader.GetGuid(moduleDef.Mvid);
             var generationId = reader.GetGuid(moduleDef.GenerationId);
             return new MetadataBlock(moduleVersionId, generationId, ptr, (int)size);
+        }
+
+        private static MetadataBlock GetMetadataBlock(ImmutableArray<MetadataBlock> previousMetadataBlocks, int index, IntPtr ptr, uint size)
+        {
+            if (!previousMetadataBlocks.IsDefault && index < previousMetadataBlocks.Length)
+            {
+                var previousBlock = previousMetadataBlocks[index];
+                if (previousBlock.Pointer == ptr && previousBlock.Size == size)
+                {
+                    return previousBlock;
+                }
+            }
+
+            return GetMetadataBlock(ptr, size);
         }
 
         internal static object GetSymReader(this DkmClrModuleInstance clrModule)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -43,12 +43,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 });
         }
 
-        internal unsafe static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain)
+        internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain)
         {
             return runtime.GetMetadataBlocks(appDomain, ImmutableArray<MetadataBlock>.Empty);
         }
 
-        internal unsafe static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain, ImmutableArray<MetadataBlock> previousMetadataBlocks)
+        internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain, ImmutableArray<MetadataBlock> previousMetadataBlocks)
         {
             var builder = ArrayBuilder<MetadataBlock>.GetInstance();
             IntPtr ptr;
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         private static MetadataBlock GetMetadataBlock(ImmutableArray<MetadataBlock> previousMetadataBlocks, int index, IntPtr ptr, uint size)
         {
-            if (previousMetadataBlocks != null && !previousMetadataBlocks.IsDefault && previousMetadataBlocks.Length > index)
+            if (!previousMetadataBlocks.IsDefault && index < previousMetadataBlocks.Length)
             {
                 var previousBlock = previousMetadataBlocks[index];
                 if (previousBlock.Pointer == ptr && previousBlock.Size == size)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/DkmUtilities.cs
@@ -45,9 +45,15 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal unsafe static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain)
         {
+            return runtime.GetMetadataBlocks(appDomain, ImmutableArray<MetadataBlock>.Empty);
+        }
+
+        internal unsafe static ImmutableArray<MetadataBlock> GetMetadataBlocks(this DkmClrRuntimeInstance runtime, DkmClrAppDomain appDomain, ImmutableArray<MetadataBlock> previousMetadataBlocks)
+        {
             var builder = ArrayBuilder<MetadataBlock>.GetInstance();
             IntPtr ptr;
             uint size;
+            int index = 0;
             foreach (DkmClrModuleInstance module in runtime.GetModulesInAppDomain(appDomain))
             {
                 MetadataBlock block;
@@ -55,7 +61,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 {
                     ptr = module.GetMetaDataBytesPtr(out size);
                     Debug.Assert(size > 0);
-                    block = GetMetadataBlock(ptr, size);
+                    block = GetMetadataBlock(previousMetadataBlocks, index, ptr, size);
                 }
                 catch (NotImplementedException e) when (module is DkmClrNcModuleInstance)
                 {
@@ -68,11 +74,26 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 }
                 Debug.Assert(block.ModuleVersionId == module.Mvid);
                 builder.Add(block);
+                index++;
             }
             // Include "intrinsic method" assembly.
             ptr = runtime.GetIntrinsicAssemblyMetaDataBytesPtr(out size);
-            builder.Add(GetMetadataBlock(ptr, size));
+            builder.Add(GetMetadataBlock(previousMetadataBlocks, index, ptr, size));
             return builder.ToImmutableAndFree();
+        }
+
+        private static MetadataBlock GetMetadataBlock(ImmutableArray<MetadataBlock> previousMetadataBlocks, int index, IntPtr ptr, uint size)
+        {
+            if (previousMetadataBlocks != null && !previousMetadataBlocks.IsDefault && previousMetadataBlocks.Length > index)
+            {
+                var previousBlock = previousMetadataBlocks[index];
+                if (previousBlock.Pointer == ptr && previousBlock.Size == size)
+                {
+                    return previousBlock;
+                }
+            }
+
+            return GetMetadataBlock(ptr, size);
         }
 
         internal static ImmutableArray<MetadataBlock> GetMetadataBlocks(GetMetadataBytesPtrFunction getMetaDataBytesPtrFunction, ImmutableArray<AssemblyIdentity> missingAssemblyIdentities)

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/ExpressionCompiler.cs
@@ -42,8 +42,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     : GetAliases(runtimeInstance, inspectionContext); // NB: Not affected by retrying.
                 string error;
                 var r = this.CompileWithRetry(
-                    moduleInstance,
-                    runtimeInstance.GetMetadataBlocks(moduleInstance.AppDomain),
+                    moduleInstance.AppDomain,
+                    runtimeInstance,
                     (blocks, useReferencedModulesOnly) => CreateMethodContext(instructionAddress, blocks, useReferencedModulesOnly),
                     (context, diagnostics) =>
                     {
@@ -105,8 +105,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 var runtimeInstance = instructionAddress.RuntimeInstance;
                 var aliases = GetAliases(runtimeInstance, inspectionContext); // NB: Not affected by retrying.
                 var r = this.CompileWithRetry(
-                    moduleInstance,
-                    runtimeInstance.GetMetadataBlocks(moduleInstance.AppDomain),
+                    moduleInstance.AppDomain,
+                    runtimeInstance,
                     (blocks, useReferencedModulesOnly) => CreateMethodContext(instructionAddress, blocks, useReferencedModulesOnly),
                     (context, diagnostics) =>
                     {
@@ -142,8 +142,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 var runtimeInstance = instructionAddress.RuntimeInstance;
                 var aliases = GetAliases(runtimeInstance, lValue.InspectionContext); // NB: Not affected by retrying.
                 var r = this.CompileWithRetry(
-                    moduleInstance,
-                    runtimeInstance.GetMetadataBlocks(moduleInstance.AppDomain),
+                    moduleInstance.AppDomain,
+                    runtimeInstance,
                     (blocks, useReferencedModulesOnly) => CreateMethodContext(instructionAddress, blocks, useReferencedModulesOnly),
                     (context, diagnostics) =>
                     {
@@ -180,8 +180,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 var runtimeInstance = moduleInstance.RuntimeInstance;
                 var appDomain = moduleInstance.AppDomain;
                 var compileResult = this.CompileWithRetry(
-                    moduleInstance,
-                    runtimeInstance.GetMetadataBlocks(appDomain),
+                    appDomain,
+                    runtimeInstance,
                     (blocks, useReferencedModulesOnly) => CreateTypeContext(appDomain, blocks, moduleInstance.Mvid, token, useReferencedModulesOnly),
                     (context, diagnostics) =>
                     {
@@ -266,6 +266,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         internal abstract void RemoveDataItem(DkmClrAppDomain appDomain);
 
+        internal abstract ImmutableArray<MetadataBlock> GetMetadataBlocks(
+            DkmClrAppDomain appDomain,
+            DkmClrRuntimeInstance runtimeInstance);
+
         private EvaluationContextBase CreateMethodContext(
             DkmClrInstructionAddress instructionAddress,
             ImmutableArray<MetadataBlock> metadataBlocks,
@@ -305,18 +309,19 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal delegate TResult CompileDelegate<TResult>(EvaluationContextBase context, DiagnosticBag diagnostics);
 
         private TResult CompileWithRetry<TResult>(
-            DkmClrModuleInstance moduleInstance,
-            ImmutableArray<MetadataBlock> metadataBlocks,
+            DkmClrAppDomain appDomain,
+            DkmClrRuntimeInstance runtimeInstance,
             CreateContextDelegate createContext,
             CompileDelegate<TResult> compile,
             out string errorMessage)
         {
+            var metadataBlocks = GetMetadataBlocks(appDomain, runtimeInstance);
             return CompileWithRetry(
                 metadataBlocks,
                 this.DiagnosticFormatter,
                 createContext,
                 compile,
-                (AssemblyIdentity assemblyIdentity, out uint size) => moduleInstance.AppDomain.GetMetaDataBytesPtr(assemblyIdentity.GetDisplayName(), out size),
+                (AssemblyIdentity assemblyIdentity, out uint size) => appDomain.GetMetaDataBytesPtr(assemblyIdentity.GetDisplayName(), out size),
                 out errorMessage);
         }
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicExpressionCompiler.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicExpressionCompiler.vb
@@ -109,6 +109,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             appDomain.RemoveMetadataContext(Of VisualBasicMetadataContext)()
         End Sub
 
+        Friend Overrides Function GetMetadataBlocks(appDomain As DkmClrAppDomain, runtimeInstance As DkmClrRuntimeInstance) As ImmutableArray(Of MetadataBlock)
+            Dim previous = appDomain.GetMetadataContext(Of VisualBasicMetadataContext)()
+            Return runtimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks)
+        End Function
+
     End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicInstructionDecoder.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overrides Function GetCompilation(moduleInstance As DkmClrModuleInstance) As VisualBasicCompilation
             Dim appDomain = moduleInstance.AppDomain
             Dim previous = appDomain.GetMetadataContext(Of VisualBasicMetadataContext)()
-            Dim metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain)
+            Dim metadataBlocks = moduleInstance.RuntimeInstance.GetMetadataBlocks(appDomain, previous.MetadataBlocks)
 
             Dim compilation As VisualBasicCompilation
             If previous.Matches(metadataBlocks) Then


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/20017

