### PR TITLE
Perform the initial tagging for a file as fast as possible so that that the file appears 'complete' immediately after opening.

### DIFF
--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -123,17 +123,15 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 // in.  That way we can get the initial set of results for the buffer as quickly as 
                 // possible, without kicking the work  down the road.
                 var initialTagsCancellationToken = _initialComputationCancellationTokenSource.Token;
-                if (_workQueue.IsForeground())
-                {
-                    RecomputeTagsForeground(cancellationTokenOpt: initialTagsCancellationToken);
-                }
-                else
-                {
-                    RegisterNotification(
-                        () => RecomputeTagsForeground(cancellationTokenOpt: initialTagsCancellationToken),
-                        delay: 0,
-                        cancellationToken: initialTagsCancellationToken);
-                }
+
+                // Note: we always kick this off to the new UI pump instead of computing tags right
+                // on this thread.  The reason for that is that we may be getting created at a time
+                // when the view itself is initializing.  As such the view is not in a state where
+                // we want code touching it.
+                RegisterNotification(
+                    () => RecomputeTagsForeground(cancellationTokenOpt: initialTagsCancellationToken),
+                    delay: 0,
+                    cancellationToken: initialTagsCancellationToken);
             }
 
             private ITaggerEventSource CreateEventSource()

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource.cs
@@ -80,6 +80,13 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             public event EventHandler Paused;
             public event EventHandler Resumed;
 
+            /// <summary>
+            /// A cancellation source we use for the initial tagging computation.  We only cancel
+            /// if our ref count actually reaches 0.  Otherwise, we always try to compute the initial
+            /// set of tags for our view/buffer.
+            /// </summary>
+            private readonly CancellationTokenSource _initialComputationCancellationTokenSource = new CancellationTokenSource();
+
             public TaggerDelay AddedTagNotificationDelay => _dataSource.AddedTagNotificationDelay;
             public TaggerDelay RemovedTagNotificationDelay => _dataSource.RemovedTagNotificationDelay;
 
@@ -111,8 +118,22 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
 
                 Connect();
 
-                // Kick off a task to compute the initial set of tags.
-                RecalculateTagsOnChanged(new TaggerEventArgs(TaggerDelay.Short));
+                // Kick off a task to immediately compute the initial set of tags. This work should 
+                // not be cancellable (except if we get completely released), even if more events come 
+                // in.  That way we can get the initial set of results for the buffer as quickly as 
+                // possible, without kicking the work  down the road.
+                var initialTagsCancellationToken = _initialComputationCancellationTokenSource.Token;
+                if (_workQueue.IsForeground())
+                {
+                    RecomputeTagsForeground(cancellationTokenOpt: initialTagsCancellationToken);
+                }
+                else
+                {
+                    RegisterNotification(
+                        () => RecomputeTagsForeground(cancellationTokenOpt: initialTagsCancellationToken),
+                        delay: 0,
+                        cancellationToken: initialTagsCancellationToken);
+                }
             }
 
             private ITaggerEventSource CreateEventSource()
@@ -198,17 +219,13 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             public void RegisterNotification(Action action, int delay, CancellationToken cancellationToken)
                 => _notificationService.RegisterNotification(action, delay, _asyncListener.BeginAsyncOperation("TagSource"), cancellationToken);
 
-            /// <summary>
-            /// Called by derived types to enqueue tags re-calculation request
-            /// </summary>
             private void RecalculateTagsOnChanged(TaggerEventArgs e)
             {
                 // First, cancel any previous requests (either still queued, or started).  We no longer
                 // want to continue it if new changes have come in.
                 _workQueue.CancelCurrentWork();
-
                 RegisterNotification(
-                    RecomputeTagsForeground,
+                    () => RecomputeTagsForeground(cancellationTokenOpt: null),
                     (int)e.Delay.ComputeTimeDelay(_subjectBuffer).TotalMilliseconds,
                     _workQueue.CancellationToken);
             }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ReferenceCounting.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.TagSource_ReferenceCounting.cs
@@ -42,6 +42,8 @@ StackTrace:
                     return;
                 }
 
+                // Stop computing any initial tags if we've been asked for them.
+                _initialComputationCancellationTokenSource.Cancel();
                 _disposed = true;
                 this.Disposed(this, EventArgs.Empty);
                 GC.SuppressFinalize(this);

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.Tagger.cs
@@ -63,6 +63,37 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
                 _tagSource.TagsChangedForBuffer += OnTagsChangedForBuffer;
                 _tagSource.Paused += OnPaused;
                 _tagSource.Resumed += OnResumed;
+
+                // There is a many-to-one relationship between Taggers and TagSources.  i.e. one
+                // tag-source can be used by many Taggers.  As such, we may be a tagger that is 
+                // wrapping a tag-source that has already produced tags and had sent out the 
+                // notifications about those tags.
+                //
+                // However, we still want to notify the code consuming us that we have tags to
+                // display.  That way, tags can display as soon as possible when someone creates
+                // a new tagger for a view/buffer.
+                //
+                // Note: we have to do this in the future instead of right now because we haven't
+                // even been returned to the caller for them to hook up to change notifications
+                // from us.
+                notificationService.RegisterNotification(
+                    () =>
+                    {
+                        if (this.TagsChanged == null)
+                        {
+                            // don't bother reporting tags if no one is listening.
+                            return;
+                        }
+
+                        var tags = _tagSource.TryGetTagIntervalTreeForBuffer(_subjectBuffer);
+                        if (tags != null)
+                        {
+                            var collection = new NormalizedSnapshotSpanCollection(
+                                tags.GetSpans(_subjectBuffer.CurrentSnapshot).Select(ts => ts.Span));
+                            this.NotifyEditorNow(collection);
+                        }
+                    },
+                    listener.BeginAsyncOperation(GetType().FullName + ".ctor-ReportInitialTags"));
             }
 
             public void Dispose()


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/18383
Fixes https://github.com/dotnet/roslyn/issues/20358

Original PR introduced crash in TypeScript due to calling into them when the view had not been fully initialized.  I've the code to always delay ourselves until the next UI pump to avoid that issue.

Mitigates: #18376

Note: no matter what, there may be some delay on some tags. This is because computing tags actually does take time. And either we block the editor on computing the tags (i.e. synchronous tag computation, which could def slow down file open), or we're async, but that means you can observe a period of time without the tags.

This also only affects initial tag reporting when a tagger is created. It does not by design change any of our delays and whatnot reporting tags after edits or caret moving.