### PR TITLE
Relax rules for matching tuple names in OHI

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -418,6 +418,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return sms?.IsPartialDefinition == true;
         }
 
+        internal static bool ContainsTupleNames(this Symbol member)
+        {
+            switch (member.Kind)
+            {
+                case SymbolKind.Method:
+                    var method = (MethodSymbol)member;
+                    return method.ReturnType.ContainsTupleNames() || method.Parameters.Any(p => p.Type.ContainsTupleNames());
+                case SymbolKind.Property:
+                    return ((PropertySymbol)member).Type.ContainsTupleNames();
+                case SymbolKind.Event:
+                    return ((EventSymbol)member).Type.ContainsTupleNames();
+                default:
+                    // We currently don't need to use this method for fields or locals
+                    throw ExceptionUtilities.UnexpectedValue(member.Kind);
+            }
+        }
+
         internal static ImmutableArray<Symbol> GetExplicitInterfaceImplementations(this Symbol member)
         {
             switch (member.Kind)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -261,8 +261,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_InterfaceMemberNotFound, memberLocation, implementingMember);
             }
 
-            if (MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(implementingMember, implementedMember))
+            if (implementingMember.ContainsTupleNames() && MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(implementingMember, implementedMember))
             {
+                // it is ok to explicitly implement with no tuple names, for compatibility with C# 6, but otherwise names should match
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, memberLocation, implementingMember, implementedMember);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -668,8 +668,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_CantChangeAccessOnOverride, overridingMemberLocation, overridingMember, accessibility, overriddenMember);
                         suppressAccessors = true;
                     }
-                    else if (MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(overridingMember, overriddenMember))
+                    else if (overridingMember.ContainsTupleNames() &&
+                        MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(overridingMember, overriddenMember))
                     {
+                        // it is ok to override with no tuple names, for compatibility with C# 6, but otherwise names should match
                         diagnostics.Add(ErrorCode.ERR_CantChangeTupleNamesOnOverride, overridingMemberLocation, overridingMember, overriddenMember);
                     }
                     else

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1084,8 +1084,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(implicitImpl, interfaceMember))
+            if (implicitImpl.ContainsTupleNames() && MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(implicitImpl, interfaceMember))
             {
+                // it is ok to implement implicitly with no tuple names, for compatibility with C# 6, but otherwise names should match
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, implicitImpl.Locations[0], implicitImpl, interfaceMember);
             }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -4588,14 +4588,34 @@ class C : I
     {
         return (1, 2);
     }
+    void M(I i, C c)
+    {
+        var result1 = i.M((null, null));
+        System.Console.Write(result1.i1);
+
+        var result2 = c.M((null, null));
+        System.Console.Write(result2.i1);
+    }
 }
 ";
             var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (9,40): error CS8141: The tuple element names in the signature of method 'C.M((string, string))' must match the tuple element names of interface method 'I.M((string, string))' (including on the return type).
-                //     public System.ValueTuple<int, int> M(System.ValueTuple<string, string> a)
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("C.M((string, string))", "I.M((string, string))").WithLocation(9, 40)
+                // (19,38): error CS1061: '(int, int)' does not contain a definition for 'i1' and no extension method 'i1' accepting a first argument of type '(int, int)' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Console.Write(result2.i1);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "i1").WithArguments("(int, int)", "i1").WithLocation(19, 38)
                 );
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var invocation1 = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ElementAt(0);
+            Assert.Equal("i.M((null, null))", invocation1.ToString());
+            Assert.Equal("(System.Int32 i1, System.Int32 i2) I.M((System.String, System.String) a)",
+                model.GetSymbolInfo(invocation1.Expression).Symbol.ToTestDisplayString());
+
+            var invocation2 = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ElementAt(2);
+            Assert.Equal("c.M((null, null))", invocation2.ToString());
+            Assert.Equal("(System.Int32, System.Int32) C.M((System.String, System.String) a)",
+                model.GetSymbolInfo(invocation2.Expression).Symbol.ToTestDisplayString());
         }
 
         [Fact]
@@ -4730,6 +4750,176 @@ class D : C
                 //     public override (int e, int f) M((int g, int h) y)
                 Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("D.M((int g, int h))", "C.M((int c, int d))").WithLocation(11, 36)
                 );
+        }
+
+        [Fact]
+        public void OverrideTupleMethodWithDifferentNamesInReturnType()
+        {
+            string source = @"
+class C
+{
+    public virtual (int a, int b) M((int c, int d) x)
+    {
+        throw new System.Exception();
+    }
+}
+class D : C
+{
+    public override (int, int) M((int g, int h) y)
+    {
+        return y;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (11,32): error CS8139: 'D.M((int g, int h))': cannot change tuple element names when overriding inherited member 'C.M((int c, int d))'
+                //     public override (int, int) M((int g, int h) y)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("D.M((int g, int h))", "C.M((int c, int d))").WithLocation(11, 32)
+                );
+        }
+
+        [Fact]
+        public void OverrideTupleMethodWithDifferentNamesInParameterType()
+        {
+            string source = @"
+class C
+{
+    public virtual (int a, int b) M((int c, int d) x)
+    {
+        throw new System.Exception();
+    }
+}
+class D : C
+{
+    public override (int e, int f) M((int, int) y)
+    {
+        return y;
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (11,36): error CS8139: 'D.M((int, int))': cannot change tuple element names when overriding inherited member 'C.M((int c, int d))'
+                //     public override (int e, int f) M((int, int) y)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("D.M((int, int))", "C.M((int c, int d))").WithLocation(11, 36)
+                );
+        }
+
+        [Fact]
+        [WorkItem(20528, "https://github.com/dotnet/roslyn/issues/20528")]
+        public void OverrideTupleMethodWithNoNames()
+        {
+            string source = @"
+class C
+{
+    public virtual (int a, int b) M((int c, int d) x)
+    {
+        throw new System.Exception();
+    }
+}
+class D : C
+{
+    public override (int, int) M((int, int) y)
+    {
+        return y;
+    }
+}
+class E
+{
+    void M(D d)
+    {
+        var result = d.M((1, 2));
+        System.Console.Write(result.a);
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (21,37): error CS1061: '(int, int)' does not contain a definition for 'a' and no extension method 'a' accepting a first argument of type '(int, int)' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Console.Write(result.a);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "a").WithArguments("(int, int)", "a").WithLocation(21, 37)
+                );
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ElementAt(0);
+            Assert.Equal("d.M((1, 2))", invocation.ToString());
+            Assert.Equal("(System.Int32, System.Int32) D.M((System.Int32, System.Int32) y)",
+                model.GetSymbolInfo(invocation.Expression).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        [WorkItem(20528, "https://github.com/dotnet/roslyn/issues/20528")]
+        public void OverrideTuplePropertyWithNoNames()
+        {
+            string source = @"
+class C
+{
+    public virtual (int a, int b) P { get; set; }
+}
+class D : C
+{
+    public override (int, int) P { get; set; } 
+}
+class E
+{
+    void M(D d)
+    {
+        var result = d.P;
+        System.Console.Write(result.a);
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (15,37): error CS1061: '(int, int)' does not contain a definition for 'a' and no extension method 'a' accepting a first argument of type '(int, int)' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Console.Write(result.a);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "a").WithArguments("(int, int)", "a").WithLocation(15, 37)
+                );
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var memberAccess = tree.GetRoot().DescendantNodes().OfType<MemberAccessExpressionSyntax>().ElementAt(0);
+            Assert.Equal("d.P", memberAccess.ToString());
+            Assert.Equal("(System.Int32, System.Int32) D.P { get; set; }", model.GetSymbolInfo(memberAccess).Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        [WorkItem(20528, "https://github.com/dotnet/roslyn/issues/20528")]
+        public void OverrideTupleEventWithNoNames()
+        {
+            string source = @"
+class C
+{
+    public virtual event System.Func<((int a, int b) c, int d)> E;
+}
+class D : C
+{
+    public override event System.Func<((int, int), int)> E;
+    void M(D d)
+    {
+        var result = d.E();
+        System.Console.Write(result.c);
+    }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (12,37): error CS1061: '((int, int), int)' does not contain a definition for 'c' and no extension method 'c' accepting a first argument of type '((int, int), int)' could be found (are you missing a using directive or an assembly reference?)
+                //         System.Console.Write(result.c);
+                Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "c").WithArguments("((int, int), int)", "c").WithLocation(12, 37),
+                // (4,65): warning CS0067: The event 'C.E' is never used
+                //     public virtual event System.Func<((int a, int b) c, int d)> E;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(4, 65)
+                );
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+            var invocation = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().ElementAt(0);
+            Assert.Equal("d.E()", invocation.ToString());
+            Assert.Equal("event System.Func<((System.Int32, System.Int32), System.Int32)> D.E",
+                model.GetSymbolInfo(invocation.Expression).Symbol.ToTestDisplayString());
         }
 
         [Fact]
@@ -18412,6 +18602,28 @@ public class Derived : Base
         }
 
         [Fact]
+        [WorkItem(20528, "https://github.com/dotnet/roslyn/issues/20528")]
+        public void HiddenMethodsWithNoNames()
+        {
+            var source = @"
+public class Base
+{
+    public virtual (int a, int b) M1() { return (1, 2); }
+}
+public class Derived : Base
+{
+    public (int, int) M1() { return (1, 2); }
+}
+";
+            var comp = CreateStandardCompilation(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (8,23): warning CS0114: 'Derived.M1()' hides inherited member 'Base.M1()'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
+                //     public (int, int) M1() { return (1, 2); }
+                Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "M1").WithArguments("Derived.M1()", "Base.M1()").WithLocation(8, 23)
+                );
+        }
+
+        [Fact]
         public void DuplicateMethodDetectionWithDifferentTupleNames()
         {
             var source = @"
@@ -18518,6 +18730,31 @@ public class C : I0
                 //     void I0.M1((int notMissing, int b) z) { }
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M1").WithArguments("C.I0.M1((int notMissing, int b))", "I0.M1((int, int b))").WithLocation(11, 13)
                 );
+        }
+
+        [Fact]
+        [WorkItem(20528, "https://github.com/dotnet/roslyn/issues/20528")]
+        public void ExplicitInterfaceImplementationWithNoNames()
+        {
+            var source = @"
+public interface I0
+{
+    void M1((int, int b) x);
+    void M2((int a, int b) x);
+    (int, int b) MR1();
+    (int a, int b) MR2();
+}
+public class C : I0
+{
+    void I0.M1((int, int) z) { }
+    void I0.M2((int, int) z) { }
+    (int, int) I0.MR1() { return (1, 2); }
+    (int, int) I0.MR2() { return (1, 2); }
+}
+";
+
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]
@@ -18763,6 +19000,48 @@ public class D2 : D1, I0<(int notA, int notB)>
                 // (24,20): error CS0540: 'D2.I0<(int a, int b)>.get()': containing type does not implement interface 'I0<(int a, int b)>'
                 //     (int a, int b) I0<(int a, int b)>.get() { return (1, 2); }
                 Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I0<(int a, int b)>").WithArguments("D2.I0<(int a, int b)>.get()", "I0<(int a, int b)>").WithLocation(24, 20)
+                );
+        }
+
+        [Fact]
+        [WorkItem(20528, "https://github.com/dotnet/roslyn/issues/20528")]
+        public void ImplicitAndExplicitInterfaceImplementationWithNoNames()
+        {
+            var source = @"
+public interface I0<T>
+{
+    T get();
+    void set(T x);
+}
+public class C1 : I0<(int a, int b)>
+{
+    public (int a, int b) get() { return (1, 2); }
+    public void set((int a, int b) y) { }
+}
+public class C2 : C1, I0<(int a, int b)>
+{
+    (int, int) I0<(int, int)>.get() { return (1, 2); }
+    void I0<(int, int)>.set((int, int) y) { }
+}
+public class D1 : I0<(int, int)>
+{
+    public (int, int) get() { return (1, 2); }
+    public void set((int, int) y) { }
+}
+public class D2 : D1, I0<(int, int)>
+{
+    (int, int) I0<(int, int)>.get() { return (1, 2); }
+    void I0<(int, int)>.set((int, int) y) { }
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (15,10): error CS0540: 'C2.I0<(int, int)>.set((int, int))': containing type does not implement interface 'I0<(int, int)>'
+                //     void I0<(int, int)>.set((int, int) y) { }
+                Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I0<(int, int)>").WithArguments("C2.I0<(int, int)>.set((int, int))", "I0<(int, int)>").WithLocation(15, 10),
+                // (14,16): error CS0540: 'C2.I0<(int, int)>.get()': containing type does not implement interface 'I0<(int, int)>'
+                //     (int, int) I0<(int, int)>.get() { return (1, 2); }
+                Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I0<(int, int)>").WithArguments("C2.I0<(int, int)>.get()", "I0<(int, int)>").WithLocation(14, 16)
                 );
         }
 
@@ -19093,11 +19372,7 @@ public class C : Base2
                             references: s_valueTupleRefs,
                             options: TestOptions.DebugDll);
 
-            compDifferent2.VerifyDiagnostics(
-                // (4,32): error CS8139: 'C.M()': cannot change tuple element names when overriding inherited member 'Base2.M()'
-                //     public override (int, int) M() { return (1, 2); }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("C.M()", "Base2.M()").WithLocation(4, 32)
-                );
+            compDifferent2.VerifyDiagnostics();
         }
 
         [Fact]
@@ -22536,13 +22811,60 @@ class Derived : Base, I<(int notA, int notB)>
     // error
 }
 ";
-            // issue https://github.com/dotnet/roslyn/issues/15709 tracks whether we should allow this to succeed instead
             var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
                 // (8,27): error CS8141: The tuple element names in the signature of method 'Base.M()' must match the tuple element names of interface method 'I<(int notA, int notB)>.M()' (including on the return type).
                 //     public (int a, int b) M() { return (1, 2); }
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("Base.M()", "I<(int notA, int notB)>.M()").WithLocation(8, 27)
                 );
+        }
+
+        [Fact]
+        [WorkItem(20528, "https://github.com/dotnet/roslyn/issues/20528")]
+        public void ImplicitBaseImplementationNotConsideredImplementationForInterfaceWithNoNames()
+        {
+            var source = @"
+interface I<T>
+{
+    T M();
+}
+class Base : I<(int a, int b)>
+{
+    public (int a, int b) M() { return (1, 2); }
+}
+class Derived : Base, I<(int, int)>
+{
+    // error
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (8,27): error CS8141: The tuple element names in the signature of method 'Base.M()' must match the tuple element names of interface method 'I<(int, int)>.M()' (including on the return type).
+                //     public (int a, int b) M() { return (1, 2); }
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("Base.M()", "I<(int, int)>.M()").WithLocation(8, 27)
+                );
+        }
+
+        [Fact]
+        [WorkItem(20528, "https://github.com/dotnet/roslyn/issues/20528")]
+        public void ImplicitBaseImplementationWithNoNamesConsideredImplementationForInterface()
+        {
+            var source = @"
+interface I<T>
+{
+    T M();
+}
+class Base : I<(int, int)>
+{
+    public (int, int) M() { return (1, 2); }
+}
+class Derived : Base, I<(int a, int b)>
+{
+    // ok
+}
+";
+            var comp = CreateStandardCompilation(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
@@ -992,11 +992,7 @@ class C : I
 }
 ";
             var comp2 = CreateCompilation(source2, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
-            comp2.VerifyDiagnostics(
-                // (4,24): error CS8141: The tuple element names in the signature of method 'C.I.P' must match the tuple element names of interface method 'I.P' (including on the return type).
-                //     (object, object) I.P { get; set; }
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "P").WithArguments("C.I.P", "I.P").WithLocation(4, 24)
-                );
+            comp2.VerifyDiagnostics();
 
             var classProperty2 = comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetProperty("I.P");
 
@@ -1159,16 +1155,7 @@ class C : Base
             comp2.VerifyDiagnostics(
                 // (5,38): error CS8139: 'C.M((object c, object d))': cannot change tuple element names when overriding inherited member 'Base.M((object c, object d))'
                 //     public override (object, object) M((object c, object d) y) { return y; }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("C.M((object c, object d))", "Base.M((object c, object d))").WithLocation(5, 38),
-                // (4,38): error CS8139: 'C.P': cannot change tuple element names when overriding inherited member 'Base.P'
-                //     public override (object, object) P { get; set; }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "P").WithArguments("C.P", "Base.P").WithLocation(4, 38),
-                // (4,42): error CS8139: 'C.P.get': cannot change tuple element names when overriding inherited member 'Base.P.get'
-                //     public override (object, object) P { get; set; }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "get").WithArguments("C.P.get", "Base.P.get").WithLocation(4, 42),
-                // (4,47): error CS8139: 'C.P.set': cannot change tuple element names when overriding inherited member 'Base.P.set'
-                //     public override (object, object) P { get; set; }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "set").WithArguments("C.P.set", "Base.P.set").WithLocation(4, 47)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("C.M((object c, object d))", "Base.M((object c, object d))").WithLocation(5, 38)
                 );
 
             var classProperty2 = comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetProperty("P");


### PR DESCRIPTION
Allows round-tripping across C# 6 and C# 7.0 with APIs involving tuples, despite C# 6 not supporting tuple element names.
For instance, you can override `(int a, int b) M()` with `ValueTuple<int, int> M()` or `(int, int) M()`.

See [LDM notes](https://github.com/dotnet/csharplang/blob/master/meetings/2017/LDM-2017-06-28.md#tuple-name-round-tripping-between-c-60-and-c-70)

Fixes https://github.com/dotnet/roslyn/issues/20528 for C#. PR for VB will follow shortly.