### PR TITLE
Replace links to Visual Studio 2015 with VS2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Discussion about the transition of language design to the new repos is at https:
 
 ### Download C# and Visual Basic
 
-Want to start developing in C# and Visual Basic? Download [Visual Studio 2015](https://www.visualstudio.com/en-us/downloads/visual-studio-2015-downloads-vs.aspx), 
-which has the latest features built-in. There are also [prebuilt Azure VM images](https://azure.microsoft.com/en-us/marketplace/virtual-machines/all/?term=Visual+Studio+2015) available with VS 2015 already installed.
+Want to start developing in C# and Visual Basic? Download [Visual Studio 2017](https://www.visualstudio.com/downloads/), 
+which has the latest features built-in. There are also [prebuilt Azure VM images](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/category/compute?search=visual%20studio%202017) available with Visual Studio 2017 already installed.
 
 To install the latest release without Visual Studio, run one of the following [nuget](https://dist.nuget.org/index.html) command lines:
 


### PR DESCRIPTION
**Customer scenario**
Provides links to the latest public release of Visual Studio in Readme.md

**Bugs this fixes:**
n/a

**Workarounds, if any**
Find VS2017 directly

**Risk**
none

**Performance impact**
none

**Is this a regression from a previous update?**
n/a

**Root cause analysis:**
n/a

How did we miss it?  What tests are we adding to guard against it in the future?
n/a

**How was the bug found?**
ad hoc