### PR TITLE
Add a publishing manifest

### DIFF
--- a/build/config/PublishData.json
+++ b/build/config/PublishData.json
@@ -1,0 +1,36 @@
+{
+  "master": {
+    "nugetPush": [
+        {
+            "kind": "PerBuildPreRelease", 
+            "url": "https://dotnet.myget.org/F/roslyn/api/v2/package"
+        }
+    ],
+    "vsixPush": "https://dotnet.myget.org/F/roslyn/vsix/upload",
+    "channels": [
+        {
+            "name": "dev15.5",
+            "kind": "PerBuildPreRelease"
+        },
+        {
+            "name": "dev15.5p1",
+            "kind": "PerBuildPreRelease"
+        }
+    ]
+  },
+
+  "dev16": {
+    "nugetPush": [
+        {
+            "kind": "PerBuildPreRelease", 
+            "url": "https://dotnet.myget.org/F/roslyn/api/v2/package"
+        }
+    ],
+    "channels": [
+        {
+            "name": "dev16",
+            "kind": "PerBuildPreRelease"
+        }
+    ]
+  }
+}


### PR DESCRIPTION
This manifest will control how we publish our build assets going
forward across all branches. It is meant as a single source of truth
that will give us a single place to look to decide how publish is
currently working.

This approach is meant to solve a number of problems in our current
publishing story:

- No single source of truth to understand publishing.
- Creating a new branch accidentally publishes assets.
- Merging long lived branches forward ends up publishing wrong assets.
- Provides a declarative view of publishing vs. making you read
powershel code.

While this file will be checked into our repo and hence follow normal
branch flow, it only has meaning in the master branch. All of our
publish operations will consult this version before checking in, not the
copy it the local branch.

Possibly in the future we may move this file to a different location /
repo as it feels wrong to have a branching file that only has meaning in
a specific branch. Discussed this with Jason / Tanner though and we
agreed that at least in the short term we can try this approach and see
how it plays out.

Note: I'm deliberately checking this file in *before* the code that
consumes it. As stated above only the value in master has meaning. Hence
I need a version checked into master before I can commit the code that
consumes it :smile:

