### PR TITLE
Fixed syntax visualizer build to properly include project dlls.

### DIFF
--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerExtension.csproj
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/SyntaxVisualizerExtension.csproj
@@ -142,10 +142,14 @@
     <ProjectReference Include="..\SyntaxVisualizerControl\SyntaxVisualizerControl.csproj">
       <Project>{afe45e23-e7ee-48c5-8143-ebe2ff67070f}</Project>
       <Name>SyntaxVisualizerControl</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\SyntaxVisualizerDgmlHelper\SyntaxVisualizerDgmlHelper.vbproj">
       <Project>{da4f74af-2694-4ac9-a8cc-18382de8215e}</Project>
       <Name>SyntaxVisualizerDgmlHelper</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The other projects in the syntax visualizer solution weren't having their outputs included in the final VSIX. This PR adds them back so the syntax visualizer actually works.