### PR TITLE
Update Integration tests utility to support Unload/Reload project and nuget restore

### DIFF
--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/ProjectUtilities.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/ProjectUtilities.cs
@@ -9,10 +9,13 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils
 
     public class Project : Identity
     {
-        public Project(string name)
+        public Project(string name, string relativePath = null)
         {
             Name = name;
+            RelativePath = relativePath;
         }
+
+        public string RelativePath { get; }
     }
 
     public class ProjectReference : Identity

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Common/ProjectUtilities.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Common/ProjectUtilities.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.IO;
+
 namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils
 {
     public abstract class Identity
@@ -9,12 +11,23 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.Common.ProjectUtils
 
     public class Project : Identity
     {
-        public Project(string name, string relativePath = null)
+        public Project(string name, string projectExtension = ".csproj", string relativePath = null)
         {
             Name = name;
-            RelativePath = relativePath;
+
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                RelativePath = Path.Combine(name, name + projectExtension);
+            }
+            else
+            {
+                RelativePath = relativePath;
+            }
         }
 
+        /// <summary>
+        /// This path is relative to the Solution file. Default value is set to ProjectName\ProjectName.csproj
+        /// </summary>
         public string RelativePath { get; }
     }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -808,10 +808,10 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
             return Path.Combine(projectPath, relativeFilePath);
         }
 
-        public void ReloadProject(string projectName)
+        public void ReloadProject(string projectRelativePath)
         {
             var solutionPath = Path.GetDirectoryName(_solution.FullName);
-            var projectPath = Path.Combine(solutionPath, projectName);
+            var projectPath = Path.Combine(solutionPath, projectRelativePath);
             _solution.AddFromFile(projectPath);
         }
 
@@ -827,9 +827,9 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public void ShowOutputWindow()
             => ExecuteCommand(WellKnownCommandNames.View_Output);
 
-        public void UnloadProject(string projectName)
+        public void UnloadProject(int index)
         {
-            var project = _solution.Projects.Item(projectName);
+            var project = _solution.Projects.Item(index);
             _solution.Remove(project);
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/SolutionExplorer_InProc.cs
@@ -827,9 +827,19 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess
         public void ShowOutputWindow()
             => ExecuteCommand(WellKnownCommandNames.View_Output);
 
-        public void UnloadProject(int index)
+        public void UnloadProject(string projectName)
         {
-            var project = _solution.Projects.Item(index);
+            var projects = _solution.Projects;
+            EnvDTE.Project project = null;
+            for (int i = 1; i <= projects.Count; i++)
+            {
+                project = projects.Item(i);
+                if (string.Compare(project.Name, projectName, StringComparison.Ordinal) == 0)
+                {
+                    break;
+                }
+            }
+
             _solution.Remove(project);
         }
 

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -116,8 +116,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void SaveFile(ProjectUtils.Project project, string fileName)
             => _inProc.SaveFile(project.Name, fileName);
 
-        public void ReloadProject(string projectRelativePath)
-            => _inProc.ReloadProject(projectRelativePath);
+        public void ReloadProject(ProjectUtils.Project project)
+            => _inProc.ReloadProject(project.RelativePath);
 
         public void RestoreNuGetPackages()
             => _inProc.RestoreNuGetPackages();

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -116,8 +116,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void SaveFile(ProjectUtils.Project project, string fileName)
             => _inProc.SaveFile(project.Name, fileName);
 
-        public void ReloadProject(ProjectUtils.Project project)
-            => _inProc.ReloadProject(project.Name);
+        public void ReloadProject(string projectRelativePath)
+            => _inProc.ReloadProject(projectRelativePath);
 
         public void RestoreNuGetPackages()
             => _inProc.RestoreNuGetPackages();
@@ -128,8 +128,12 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void ShowOutputWindow()
             => _inProc.ShowOutputWindow();
 
-        public void UnloadProject(ProjectUtils.Project project)
-            => _inProc.UnloadProject(project.Name);
+        /// <summary>
+        /// Unloads the project. <paramref name="index"/> is 1 based.
+        /// </summary>
+        /// <param name="index"></param>
+        public void UnloadProject(int index)
+            => _inProc.UnloadProject(index);
 
         public string[] GetProjectReferences(ProjectUtils.Project project)
             => _inProc.GetProjectReferences(project.Name);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/SolutionExplorer_OutOfProc.cs
@@ -128,12 +128,8 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess
         public void ShowOutputWindow()
             => _inProc.ShowOutputWindow();
 
-        /// <summary>
-        /// Unloads the project. <paramref name="index"/> is 1 based.
-        /// </summary>
-        /// <param name="index"></param>
-        public void UnloadProject(int index)
-            => _inProc.UnloadProject(index);
+        public void UnloadProject(ProjectUtils.Project project)
+            => _inProc.UnloadProject(project.Name);
 
         public string[] GetProjectReferences(ProjectUtils.Project project)
             => _inProc.GetProjectReferences(project.Name);

--- a/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/WellKnownCommandNames.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.IntegrationTest.Utilities
         public const string InteractiveConsole_ClearScreen = "InteractiveConsole.ClearScreen";
         public const string InteractiveConsole_ExecuteInInteractive = "InteractiveConsole.ExecuteInInteractive";
 
-        public const string ProjectAndSolutionContextMenus_Solution_RestoreNuGetPackages = "ProjectAndSolutionContextMenus.Solution.RestoreNuGetPackages";
+        public const string ProjectAndSolutionContextMenus_Solution_RestoreNuGetPackages = "ProjectandSolutionContextMenus.Solution.RestoreNuGetPackages";
         public const string ProjectAndSolutionContextMenus_Project_ResetCSharpInteractiveFromProject 
             = "ProjectandSolutionContextMenus.Project.ResetC#InteractiveFromProject";
 


### PR DESCRIPTION
This is an integration utility fix.

1. Fix the APIs to unload and reload project from solution
2. Fix the WellKnown Command name for SolutionNugetRestore

@tannergooding @dotnet/project-system for review