### PR TITLE
Compiler support for IgnoresAccessChecksToAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     // Report the main module as that is the only one checked. clr does not honor type forwarders in non-primary modules.
                     return CreateMultipleForwardingErrorTypeSymbol(ref emittedName, this.PrimaryModule, firstSymbol, secondSymbol);
                 }
-                
+
                 // Don't bother to check the forwarded-to assembly if we've already seen it.
                 if (visitedAssemblies != null && visitedAssemblies.Contains(firstSymbol))
                 {
@@ -211,8 +211,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         internal override bool AreInternalsVisibleToThisAssembly(AssemblySymbol potentialGiverOfAccess)
         {
-            IVTConclusion conclusion = MakeFinalIVTDetermination(potentialGiverOfAccess);
-            return conclusion == IVTConclusion.Match || conclusion == IVTConclusion.OneSignedOneNot;
+            FriendAccessConclusion conclusion = MakeFinalFriendAccessDetermination(potentialGiverOfAccess);
+            return conclusion == FriendAccessConclusion.Match || conclusion == FriendAccessConclusion.OneSignedOneNot;
         }
 
         internal override IEnumerable<ImmutableArray<byte>> GetInternalsVisibleToPublicKeys(string simpleName)

--- a/src/Compilers/CSharp/Test/Emit/Attributes/IgnoreAccessCheckToTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/IgnoreAccessCheckToTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class IgnoreAccessCheckToTests : CSharpTestBase
+    {
+        private const string IACTDeclaration = @"
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class IgnoresAccessChecksToAttribute : Attribute
+    {
+        public IgnoresAccessChecksToAttribute(string assemblyName)
+        {
+        }
+    }
+}";
+
+        [Fact]
+        public void IACTSuccessThroughIAssembly()
+        {
+            string s = @"internal class C {}";
+
+            var other = CreateStandardCompilation(s,
+                assemblyName: "Paul",
+                options: TestOptions.ReleaseDll);
+
+            other.VerifyDiagnostics();
+
+            var requestor = CreateStandardCompilation(
+    @"
+[assembly: System.Runtime.CompilerServices.IgnoresAccessChecksTo(""Paul"")]
+
+public class A
+{
+    public void M() => new C();
+}" + IACTDeclaration,
+                new MetadataReference[] { new CSharpCompilationReference(other) },
+                options: TestOptions.ReleaseDll,
+                assemblyName: "John");
+
+            Assert.True(((IAssemblySymbol)other.Assembly).GivesAccessTo(requestor.Assembly));
+            Assert.Empty(requestor.GetDiagnostics());
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -222,6 +222,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfAccessedThroughPropertyAttribute = { s_signature_HasThis_Void_String };
         private static readonly byte[][] s_signaturesOfIndexerNameAttribute = { s_signature_HasThis_Void_String };
         private static readonly byte[][] s_signaturesOfInternalsVisibleToAttribute = { s_signature_HasThis_Void_String };
+        private static readonly byte[][] s_signaturesOfIgnoresAccessChecksToAttribute = { s_signature_HasThis_Void_String };
         private static readonly byte[][] s_signaturesOfOptionalAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfDefaultParameterValueAttribute = { s_signature_HasThis_Void_Object };
         private static readonly byte[][] s_signaturesOfDateTimeConstantAttribute = { s_signature_HasThis_Void_Int64 };
@@ -407,6 +408,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription CaseSensitiveExtensionAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ExtensionAttribute", s_signaturesOfExtensionAttribute, matchIgnoringCase: false);
 
         internal static readonly AttributeDescription InternalsVisibleToAttribute = new AttributeDescription("System.Runtime.CompilerServices", "InternalsVisibleToAttribute", s_signaturesOfInternalsVisibleToAttribute);
+        internal static readonly AttributeDescription IgnoresAccessChecksToAttribute = new AttributeDescription("System.Runtime.CompilerServices", "IgnoresAccessChecksToAttribute", s_signaturesOfIgnoresAccessChecksToAttribute);
         internal static readonly AttributeDescription AssemblySignatureKeyAttribute = new AttributeDescription("System.Reflection", "AssemblySignatureKeyAttribute", s_signaturesOfAssemblySignatureKeyAttribute);
         internal static readonly AttributeDescription AssemblyKeyFileAttribute = new AttributeDescription("System.Reflection", "AssemblyKeyFileAttribute", s_signaturesOfAssemblyKeyFileAttribute);
         internal static readonly AttributeDescription AssemblyKeyNameAttribute = new AttributeDescription("System.Reflection", "AssemblyKeyNameAttribute", s_signaturesOfAssemblyKeyNameAttribute);


### PR DESCRIPTION
The `IgnoresAccessChecksToAttribute` is the reverse of the `InternalsVisibleToAttribute` - it allows an assembly to declare assemblies whose internals would be visible to it. The attribute class isn't declared in the BCL but is recognized by the CLR (Desktop >= 4.6 and Core), i.e. you can declare it in your code and it would work.

This PR adds compiler support for this attribute, just like IVT.

**Motivation:**

* It would help a lot of scenarios where we usually turn to Reflection (which is severely limited and slow) or, if we're lucky and the sources are available, copy the code.
* A lot of developers are willing to rely on unpublished APIs, taking the risk they might break without notice in future versions. Compiler support means that this would be much safer.
* There's so much useful code (even within Roslyn) that remains internal because publishing and supporting a stable API is a very hard and slow process. Entity Framework went so far as to publish their internal types as public, in a dedicated namespace, while providing no forward compatibility guarantee.

**Alternatives:**

* Create a build task to generate reference assemblies for the compiler which transforms the internal types and members to public (e.g. using Cecil), and then apply the attribute.

PS - I now realize I probably should've started with an issue. I wanted to get a POC working and it turned out to be pretty simple. Let me know if I should open one instead.