### PR TITLE
Remove CapturedVariablesByLambda

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.Tree.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// method being analyzed and has a null <see cref="Parent" />.
             /// </summary>
             [DebuggerDisplay("{ToString(), nq}")]
-            private sealed class Scope
+            public sealed class Scope
             {
                 public Scope Parent { get; }
 
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// variables into captured environments and for calculating
             /// the rewritten signature of the method.
             /// </summary>
-            private sealed class Closure
+            public sealed class Closure
             {
                 /// <summary>
                 /// The method symbol for the original lambda or local function.
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var capturesThis = new HashSet<MethodSymbol>();
                 var capturesVariable = new HashSet<MethodSymbol>();
                 var visitStack = new Stack<MethodSymbol>();
-                VisitClosures(_scopeTree, (scope, closure) =>
+                VisitClosures(ScopeTree, (scope, closure) =>
                 {
                     foreach (var capture in closure.CapturedVariables)
                     {
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                VisitClosures(_scopeTree, (scope, closure) =>
+                VisitClosures(ScopeTree, (scope, closure) =>
                 {
                     if (!capturesVariable.Contains(closure.OriginalMethodSymbol))
                     {
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <summary>
             /// Visit all closures in all nested scopes and run the <paramref name="action"/>.
             /// </summary>
-            private static void VisitClosures(Scope scope, Action<Scope, Closure> action)
+            public static void VisitClosures(Scope scope, Action<Scope, Closure> action)
             {
                 foreach (var closure in scope.Closures)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.cs
@@ -56,11 +56,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             public MultiDictionary<Symbol, SyntaxNode> CapturedVariables = new MultiDictionary<Symbol, SyntaxNode>();
 
             /// <summary>
-            /// For each lambda in the code, the set of variables that it captures.
-            /// </summary>
-            public OrderedMultiDictionary<MethodSymbol, Symbol> CapturedVariablesByLambda = new OrderedMultiDictionary<MethodSymbol, Symbol>();
-
-            /// <summary>
             /// If a local function is in the set, at some point in the code it is converted to a delegate and should then not be optimized to a struct closure.
             /// Also contains all lambdas (as they are converted to delegates implicitly).
             /// </summary>
@@ -105,7 +100,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// </summary>
             public Dictionary<MethodSymbol, BoundNode> LambdaScopes;
 
-            private Scope _scopeTree;
+            /// <summary>
+            /// The root of the scope tree for this method.
+            /// </summary>
+            public Scope ScopeTree { get; private set; }
 
             private Analysis(MethodSymbol method)
             {
@@ -123,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private void Analyze(BoundNode node)
             {
-                _scopeTree = ScopeTreeBuilder.Build(node, this);
+                ScopeTree = ScopeTreeBuilder.Build(node, this);
                 _currentScope = FindNodeToAnalyze(node);
 
                 Debug.Assert(!_inExpressionLambda);
@@ -181,84 +179,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             /// <summary>
-            /// The old version of <see cref="RemoveUnneededReferences"/> This is still necesary
-            /// because it modifies <see cref="CapturedVariablesByLambda"/>, which is still used
-            /// in other areas of the code. Once those uses are gone, this method should be removed.
-            /// </summary>
-            private void OldRemoveUnneededReferences()
-            {
-                // Note: methodGraph is the inverse of the dependency graph
-                var methodGraph = new MultiDictionary<MethodSymbol, MethodSymbol>();
-                var capturesThis = new HashSet<MethodSymbol>();
-                var capturesVariable = new HashSet<MethodSymbol>();
-                var visitStack = new Stack<MethodSymbol>();
-                foreach (var methodKvp in CapturedVariablesByLambda)
-                {
-                    foreach (var capture in methodKvp.Value)
-                    {
-                        var method = capture as MethodSymbol;
-                        if (method != null)
-                        {
-                            methodGraph.Add(method, methodKvp.Key);
-                        }
-                        else if (capture == _topLevelMethod.ThisParameter)
-                        {
-                            if (capturesThis.Add(methodKvp.Key))
-                            {
-                                visitStack.Push(methodKvp.Key);
-                            }
-                        }
-                        else if (capturesVariable.Add(methodKvp.Key) && !capturesThis.Contains(methodKvp.Key)) // if capturesThis contains methodKvp, it's already in the stack.
-                        {
-                            visitStack.Push(methodKvp.Key);
-                        }
-                    }
-                }
-
-                while (visitStack.Count > 0)
-                {
-                    var current = visitStack.Pop();
-                    var setToAddTo = capturesVariable.Contains(current) ? capturesVariable : capturesThis;
-                    foreach (var capturesCurrent in methodGraph[current])
-                    {
-                        if (setToAddTo.Add(capturesCurrent))
-                        {
-                            visitStack.Push(capturesCurrent);
-                        }
-                    }
-                }
-
-                var capturedVariablesByLambdaNew = new OrderedMultiDictionary<MethodSymbol, Symbol>();
-                foreach (var old in CapturedVariablesByLambda)
-                {
-                    if (capturesVariable.Contains(old.Key))
-                    {
-                        foreach (var oldValue in old.Value)
-                        {
-                            capturedVariablesByLambdaNew.Add(old.Key, oldValue);
-                        }
-                    }
-                    else if (capturesThis.Contains(old.Key))
-                    {
-                        capturedVariablesByLambdaNew.Add(old.Key, _topLevelMethod.ThisParameter);
-                    }
-                }
-                CapturedVariablesByLambda = capturedVariablesByLambdaNew;
-            }
-
-            /// <summary>
             /// Create the optimized plan for the location of lambda methods and whether scopes need access to parent scopes
             ///  </summary>
             internal void ComputeLambdaScopesAndFrameCaptures()
             {
-                // We need to keep this around
-                OldRemoveUnneededReferences();
                 RemoveUnneededReferences();
 
                 LambdaScopes = new Dictionary<MethodSymbol, BoundNode>(ReferenceEqualityComparer.Instance);
                 NeedsParentFrame = new HashSet<BoundNode>();
 
-                VisitClosures(_scopeTree, (scope, closure) =>
+                VisitClosures(ScopeTree, (scope, closure) =>
                 {
                     if (closure.CapturedVariables.Count > 0)
                     {
@@ -285,7 +215,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         if (captured is LocalFunctionSymbol localFunc)
                         {
-                            capturedVars.AddAll(FindClosureInScope(closureScope, localFunc).CapturedVariables);
+                            var (found, _) = FindClosureInScope(closureScope, localFunc);
+                            capturedVars.AddAll(found.CapturedVariables);
                         }
                     }
 
@@ -318,22 +249,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     capturedVars.Free();
 
                     return (innermost, outermost);
-                }
-
-                // Walk up the scope tree looking for a closure
-                Closure FindClosureInScope(Scope startingScope, MethodSymbol closureSymbol)
-                {
-                    var currentScope = startingScope;
-                    while (currentScope != null)
-                    {
-                        var found = currentScope.Closures.SingleOrDefault(c => c.OriginalMethodSymbol == closureSymbol);
-                        if (found != null)
-                        {
-                            return found;
-                        }
-                        currentScope = currentScope.Parent;
-                    }
-                    return null;
                 }
 
                 void RecordClosureScope(Scope innermost, Scope outermost, Closure closure)
@@ -370,6 +285,62 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
 
+                }
+            }
+
+            /// <summary>
+            /// Walk up the scope tree looking for a closure.
+            /// </summary>
+            /// <returns>
+            /// A tuple of the found <see cref="Closure"/> and the <see cref="Scope"/> it was found in.
+            /// </returns>
+            public static (Closure, Scope) FindClosureInScope(Scope startingScope, MethodSymbol closureSymbol)
+            {
+                var currentScope = startingScope;
+                while (currentScope != null)
+                {
+                    var found = currentScope.Closures.SingleOrDefault(c => c.OriginalMethodSymbol == closureSymbol);
+                    if (found != null)
+                    {
+                        return (found, currentScope);
+                    }
+                    currentScope = currentScope.Parent;
+                }
+                throw ExceptionUtilities.Unreachable;
+            }
+
+            /// <summary>
+            /// Finds a <see cref="Closure"/> with a matching original symbol somewhere in the given scope or nested scopes.
+            /// </summary>
+            public static Closure FindClosureInTree(Scope rootScope, MethodSymbol closureSymbol)
+            {
+                var result = Helper(rootScope);
+                if (result != null)
+                {
+                    return result;
+                }
+                throw ExceptionUtilities.Unreachable;
+
+                Closure Helper(Scope scope)
+                {
+                    foreach (var closure in scope.Closures)
+                    {
+                        if (closure.OriginalMethodSymbol == closureSymbol)
+                        {
+                            return closure;
+                        }
+                    }
+
+                    foreach (var nestedScope in scope.NestedScopes)
+                    {
+                        var found = Helper(nestedScope);
+                        if (found != null)
+                        {
+                            return found;
+                        }
+                    }
+
+                    return null;
                 }
             }
 
@@ -563,17 +534,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (_currentParent is MethodSymbol lambda && symbol != lambda && symbol.ContainingSymbol != lambda)
                 {
                     CapturedVariables.Add(symbol, syntax);
-
-                    // mark the variable as captured in each enclosing lambda up to the variable's point of declaration.
-                    while ((object)lambda != null &&
-                           symbol != lambda &&
-                           symbol.ContainingSymbol != lambda &&
-                           // Necessary because the EE can insert non-closure synthesized method symbols
-                           IsClosure(lambda))
-                    {
-                        CapturedVariablesByLambda.Add(lambda, symbol);
-                        lambda = lambda.ContainingSymbol as MethodSymbol;
-                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     localFuncsInProgress.Add(localFunc);
-                    var (found, foundScope) = Analysis.FindClosureInScope(scope, localFunc);
+                    var (found, foundScope) = Analysis.GetVisibleClosure(scope, localFunc);
                     bool transitivelyTrue = OnlyCapturesThis(found, foundScope, localFuncsInProgress);
 
                     if (freePool)
@@ -1332,7 +1332,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     closureOrdinal = containerAsFrame.ClosureOrdinal;
                 }
             }
-            else if (Analysis.FindClosureInTree(_analysis.ScopeTree, node.Symbol).CapturedVariables.Count == 0)
+            else if (Analysis.GetClosureInTree(_analysis.ScopeTree, node.Symbol).CapturedVariables.Count == 0)
             {
                 if (_analysis.MethodsConvertedToDelegates.Contains(node.Symbol))
                 {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenClosureLambdaTests.cs
@@ -1011,18 +1011,18 @@ class Program
     }
 }";
             var verifier = CompileAndVerify(source, expectedOutput: "pass_xy");
-            verifier.VerifyIL("Program.<>c__DisplayClass1_1<T>.<F>b__0", @"
+            verifier.VerifyIL("Program.<>c__DisplayClass1_0<T>.<F>b__0", @"
 {
   // Code size      131 (0x83)
   .maxstack  3
   .locals init (Program.<>c__DisplayClass1_2<T> V_0, //CS$<>8__locals0
-                Program.<>c__DisplayClass1_0<T> V_1, //CS$<>8__locals1
+                Program.<>c__DisplayClass1_1<T> V_1, //CS$<>8__locals1
                 T V_2)
   IL_0000:  newobj     ""Program.<>c__DisplayClass1_2<T>..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  ldarg.0
-  IL_0008:  stfld      ""Program.<>c__DisplayClass1_1<T> Program.<>c__DisplayClass1_2<T>.CS$<>8__locals1""
+  IL_0008:  stfld      ""Program.<>c__DisplayClass1_0<T> Program.<>c__DisplayClass1_2<T>.CS$<>8__locals1""
   IL_000d:  ldloc.0
   IL_000e:  ldstr      ""y""
   IL_0013:  stfld      ""string Program.<>c__DisplayClass1_2<T>.y""
@@ -1041,17 +1041,17 @@ class Program
     IL_002c:  ldc.i4.0
     IL_002d:  br.s       IL_005d
     IL_002f:  unbox.any  ""T""
-    IL_0034:  newobj     ""Program.<>c__DisplayClass1_0<T>..ctor()""
+    IL_0034:  newobj     ""Program.<>c__DisplayClass1_1<T>..ctor()""
     IL_0039:  stloc.1
     IL_003a:  ldloc.1
     IL_003b:  ldloc.0
-    IL_003c:  stfld      ""Program.<>c__DisplayClass1_2<T> Program.<>c__DisplayClass1_0<T>.CS$<>8__locals2""
+    IL_003c:  stfld      ""Program.<>c__DisplayClass1_2<T> Program.<>c__DisplayClass1_1<T>.CS$<>8__locals2""
     IL_0041:  stloc.2
     IL_0042:  ldloc.1
     IL_0043:  ldloc.2
-    IL_0044:  stfld      ""T Program.<>c__DisplayClass1_0<T>.e""
+    IL_0044:  stfld      ""T Program.<>c__DisplayClass1_1<T>.e""
     IL_0049:  ldloc.1
-    IL_004a:  ldftn      ""bool Program.<>c__DisplayClass1_0<T>.<F>b__1()""
+    IL_004a:  ldftn      ""bool Program.<>c__DisplayClass1_1<T>.<F>b__1()""
     IL_0050:  newobj     ""System.Func<bool>..ctor(object, System.IntPtr)""
     IL_0055:  callvirt   ""bool System.Func<bool>.Invoke()""
     IL_005a:  ldc.i4.0
@@ -1062,9 +1062,9 @@ class Program
     IL_005f:  pop
     IL_0060:  ldstr      ""pass_""
     IL_0065:  ldarg.0
-    IL_0066:  ldfld      ""string Program.<>c__DisplayClass1_1<T>.x""
+    IL_0066:  ldfld      ""string Program.<>c__DisplayClass1_0<T>.x""
     IL_006b:  ldloc.1
-    IL_006c:  ldfld      ""Program.<>c__DisplayClass1_2<T> Program.<>c__DisplayClass1_0<T>.CS$<>8__locals2""
+    IL_006c:  ldfld      ""Program.<>c__DisplayClass1_2<T> Program.<>c__DisplayClass1_1<T>.CS$<>8__locals2""
     IL_0071:  ldfld      ""string Program.<>c__DisplayClass1_2<T>.y""
     IL_0076:  call       ""string string.Concat(string, string, string)""
     IL_007b:  call       ""void System.Console.Write(string)""
@@ -3383,18 +3383,18 @@ class Program
     }
 }";
             CompileAndVerify(source, expectedOutput: "13").
-            VerifyIL("Program.c1.<>c__DisplayClass1_2.<Test>b__2",
+            VerifyIL("Program.c1.<>c__DisplayClass1_1.<Test>b__2",
 @"{
   // Code size       31 (0x1f)
   .maxstack  3
-  IL_0000:  newobj     ""Program.c1.<>c__DisplayClass1_1..ctor()""
+  IL_0000:  newobj     ""Program.c1.<>c__DisplayClass1_2..ctor()""
   IL_0005:  dup
   IL_0006:  ldarg.0
-  IL_0007:  stfld      ""Program.c1.<>c__DisplayClass1_2 Program.c1.<>c__DisplayClass1_1.CS$<>8__locals2""
+  IL_0007:  stfld      ""Program.c1.<>c__DisplayClass1_1 Program.c1.<>c__DisplayClass1_2.CS$<>8__locals2""
   IL_000c:  dup
   IL_000d:  ldarg.1
-  IL_000e:  stfld      ""int Program.c1.<>c__DisplayClass1_1.z""
-  IL_0013:  ldftn      ""int Program.c1.<>c__DisplayClass1_1.<Test>b__3(int)""
+  IL_000e:  stfld      ""int Program.c1.<>c__DisplayClass1_2.z""
+  IL_0013:  ldftn      ""int Program.c1.<>c__DisplayClass1_2.<Test>b__3(int)""
   IL_0019:  newobj     ""System.Func<int, int>..ctor(object, System.IntPtr)""
   IL_001e:  ret
 }");
@@ -3462,14 +3462,14 @@ using System;
   IL_0018:  ldloca.s   V_2
   IL_001a:  call       ""string int.ToString()""
   IL_001f:  brfalse.s  IL_0040
-  IL_0021:  newobj     ""Program.c1.<>c__DisplayClass1_2..ctor()""
+  IL_0021:  newobj     ""Program.c1.<>c__DisplayClass1_1..ctor()""
   IL_0026:  dup
   IL_0027:  ldloc.0
-  IL_0028:  stfld      ""Program.c1.<>c__DisplayClass1_0 Program.c1.<>c__DisplayClass1_2.CS$<>8__locals1""
+  IL_0028:  stfld      ""Program.c1.<>c__DisplayClass1_0 Program.c1.<>c__DisplayClass1_1.CS$<>8__locals1""
   IL_002d:  dup
   IL_002e:  ldc.i4.4
-  IL_002f:  stfld      ""int Program.c1.<>c__DisplayClass1_2.a""
-  IL_0034:  ldftn      ""System.Func<System.Func<int, System.Func<int>>> Program.c1.<>c__DisplayClass1_2.<Test>b__0()""
+  IL_002f:  stfld      ""int Program.c1.<>c__DisplayClass1_1.a""
+  IL_0034:  ldftn      ""System.Func<System.Func<int, System.Func<int>>> Program.c1.<>c__DisplayClass1_1.<Test>b__0()""
   IL_003a:  newobj     ""System.Func<System.Func<System.Func<int, System.Func<int>>>>..ctor(object, System.IntPtr)""
   IL_003f:  stloc.1
   IL_0040:  ldc.i4.2
@@ -3477,14 +3477,14 @@ using System;
   IL_0042:  ldloca.s   V_2
   IL_0044:  call       ""string int.ToString()""
   IL_0049:  brfalse.s  IL_006a
-  IL_004b:  newobj     ""Program.c1.<>c__DisplayClass1_4..ctor()""
+  IL_004b:  newobj     ""Program.c1.<>c__DisplayClass1_3..ctor()""
   IL_0050:  dup
   IL_0051:  ldloc.0
-  IL_0052:  stfld      ""Program.c1.<>c__DisplayClass1_0 Program.c1.<>c__DisplayClass1_4.CS$<>8__locals3""
+  IL_0052:  stfld      ""Program.c1.<>c__DisplayClass1_0 Program.c1.<>c__DisplayClass1_3.CS$<>8__locals3""
   IL_0057:  dup
   IL_0058:  ldc.i4.4
-  IL_0059:  stfld      ""int Program.c1.<>c__DisplayClass1_4.a""
-  IL_005e:  ldftn      ""System.Func<System.Func<int, System.Func<int>>> Program.c1.<>c__DisplayClass1_4.<Test>b__4()""
+  IL_0059:  stfld      ""int Program.c1.<>c__DisplayClass1_3.a""
+  IL_005e:  ldftn      ""System.Func<System.Func<int, System.Func<int>>> Program.c1.<>c__DisplayClass1_3.<Test>b__4()""
   IL_0064:  newobj     ""System.Func<System.Func<System.Func<int, System.Func<int>>>>..ctor(object, System.IntPtr)""
   IL_0069:  stloc.1
   IL_006a:  ldloc.1

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -77,49 +77,49 @@ class C
 @"0
 1");
             // L1
-            verifier.VerifyIL("C.<M>g__L12_0(ref C.<>c__DisplayClass2_1)", @"
+            verifier.VerifyIL("C.<M>g__L12_0(ref C.<>c__DisplayClass2_0)", @"
 {
   // Code size       13 (0xd)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C C.<>c__DisplayClass2_1.<>4__this""
+  IL_0001:  ldfld      ""C C.<>c__DisplayClass2_0.<>4__this""
   IL_0006:  ldarg.0
-  IL_0007:  call       ""void C.<M>g__L22_1(ref C.<>c__DisplayClass2_1)""
+  IL_0007:  call       ""void C.<M>g__L22_1(ref C.<>c__DisplayClass2_0)""
   IL_000c:  ret
 }");
             // L2
-            verifier.VerifyIL("C.<M>g__L22_1(ref C.<>c__DisplayClass2_1)", @"
+            verifier.VerifyIL("C.<M>g__L22_1(ref C.<>c__DisplayClass2_0)", @"
 {
   // Code size        8 (0x8)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.1
-  IL_0002:  call       ""void C.<M>g__L32_2(ref C.<>c__DisplayClass2_1)""
+  IL_0002:  call       ""void C.<M>g__L32_2(ref C.<>c__DisplayClass2_0)""
   IL_0007:  ret
 }");
             // Skip some... L5
-            verifier.VerifyIL("C.<M>g__L52_4(ref C.<>c__DisplayClass2_1, ref C.<>c__DisplayClass2_0)", @"
+            verifier.VerifyIL("C.<M>g__L52_4(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)", @"
 {
   // Code size        9 (0x9)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.1
-  IL_0002:  call       ""int C.<M>g__L62_5(ref C.<>c__DisplayClass2_1, ref C.<>c__DisplayClass2_0)""
+  IL_0002:  call       ""int C.<M>g__L62_5(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)""
   IL_0007:  pop
   IL_0008:  ret
 }");
             // L6
-            verifier.VerifyIL("C.<M>g__L62_5(ref C.<>c__DisplayClass2_1, ref C.<>c__DisplayClass2_0)", @"
+            verifier.VerifyIL("C.<M>g__L62_5(ref C.<>c__DisplayClass2_0, ref C.<>c__DisplayClass2_1)", @"
 {
   // Code size       35 (0x23)
   .maxstack  4
   .locals init (int V_0)
   IL_0000:  ldarg.1
-  IL_0001:  ldfld      ""int C.<>c__DisplayClass2_0.var2""
+  IL_0001:  ldfld      ""int C.<>c__DisplayClass2_1.var2""
   IL_0006:  ldarg.1
-  IL_0007:  ldfld      ""C C.<>c__DisplayClass2_0.<>4__this""
+  IL_0007:  ldfld      ""C C.<>c__DisplayClass2_1.<>4__this""
   IL_000c:  ldarg.1
-  IL_000d:  ldfld      ""C C.<>c__DisplayClass2_0.<>4__this""
+  IL_000d:  ldfld      ""C C.<>c__DisplayClass2_1.<>4__this""
   IL_0012:  ldfld      ""int C._x""
   IL_0017:  stloc.0
   IL_0018:  ldloc.0

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/LocalsTests.cs
@@ -1385,7 +1385,7 @@ class P
             var compilation0 = CreateStandardCompilation(source, options: TestOptions.DebugDll);
             WithRuntimeInstance(compilation0, runtime =>
             {
-                var context = CreateMethodContext(runtime, "C.<>c__DisplayClass1_1.<M>b__0");
+                var context = CreateMethodContext(runtime, "C.<>c__DisplayClass1_0.<M>b__0");
                 var testData = new CompilationTestData();
                 var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                 string typeName;
@@ -1395,17 +1395,17 @@ class P
 @"{
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (C.<>c__DisplayClass1_0 V_0, //CS$<>8__locals0
+  .locals init (C.<>c__DisplayClass1_1 V_0, //CS$<>8__locals0
                 object V_1)
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""C C.<>c__DisplayClass1_1.<>4__this""
+  IL_0001:  ldfld      ""C C.<>c__DisplayClass1_0.<>4__this""
   IL_0006:  ret
 }");
                 VerifyLocal(testData, typeName, locals[1], "<>m1", "_1", expectedILOpt:
 @"{
   // Code size        2 (0x2)
   .maxstack  1
-  .locals init (C.<>c__DisplayClass1_0 V_0, //CS$<>8__locals0
+  .locals init (C.<>c__DisplayClass1_1 V_0, //CS$<>8__locals0
                 object V_1)
   IL_0000:  ldarg.1
   IL_0001:  ret
@@ -1414,20 +1414,20 @@ class P
 @"{
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (C.<>c__DisplayClass1_0 V_0, //CS$<>8__locals0
+  .locals init (C.<>c__DisplayClass1_1 V_0, //CS$<>8__locals0
   object V_1)
   IL_0000:  ldloc.0
-  IL_0001:  ldfld      ""object C.<>c__DisplayClass1_0.y""
+  IL_0001:  ldfld      ""object C.<>c__DisplayClass1_1.y""
   IL_0006:  ret
 }");
                 VerifyLocal(testData, typeName, locals[3], "<>m3", "x", expectedILOpt:
 @"{
   // Code size        7 (0x7)
   .maxstack  1
-  .locals init (C.<>c__DisplayClass1_0 V_0, //CS$<>8__locals0
+  .locals init (C.<>c__DisplayClass1_1 V_0, //CS$<>8__locals0
   object V_1)
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""object C.<>c__DisplayClass1_1.x""
+  IL_0001:  ldfld      ""object C.<>c__DisplayClass1_0.x""
   IL_0006:  ret
 }");
                 Assert.Equal(locals.Count, 4);


### PR DESCRIPTION
Swaps out all uses of CapturedVariablesByLambda for functions on the
Scope tree.

Fixes https://github.com/dotnet/roslyn/projects/26#card-3753318