### PR TITLE
Fixed Make Method Asynchronous refactoring.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -684,31 +684,33 @@ index: 1);
         }
 
         [Theory]
-        [InlineData(0, "Task")]
-        [InlineData(1, "void")]
+        [InlineData(0, "void", "Task")]
+        [InlineData(1, "void", "void")]
+        [InlineData(0, "int", "Task<int>")]
+        [InlineData(0, "Task", "Task")]
         [Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         [WorkItem(18307, "https://github.com/dotnet/roslyn/issues/18307")]
-        public async Task AddAsyncInLocalFunctionKeepsTrivia(int codeFixIndex, string expectedReturn)
+        public async Task AddAsyncInLocalFunctionKeepsTrivia(int codeFixIndex, string initialReturn, string expectedReturn)
         {
             await TestInRegularAndScriptAsync(
-@"using System.Threading.Tasks;
+$@"using System.Threading.Tasks;
 
 class C
-{
+{{
     public void M1()
-    {
+    {{
         // Leading trivia
-        /*1*/ void /*2*/ M2/*3*/() /*4*/
-        {
+        /*1*/ {initialReturn} /*2*/ M2/*3*/() /*4*/
+        {{
             [|await M3Async();|]
-        }
-    }
+        }}
+    }}
 
     async Task<int> M3Async()
-    {
+    {{
         return 1;
-    }
-}",
+    }}
+}}",
 $@"using System.Threading.Tasks;
 
 class C
@@ -733,7 +735,7 @@ class C
 
         [Theory]
         [InlineData("", 0, "Task")]
-        [InlineData("", 1, "void", Skip = "https://github.com/dotnet/roslyn/issues/18396")]
+        [InlineData("", 1, "void")]
         [InlineData("public", 0, "Task")]
         [InlineData("public", 1, "void")]
         [Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -685,7 +685,7 @@ index: 1);
 
         [Theory]
         [InlineData(0, "Task")]
-        [InlineData(1, "void", Skip = "https://github.com/dotnet/roslyn/issues/18396")]
+        [InlineData(1, "void")]
         [Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodAsynchronous)]
         [WorkItem(18307, "https://github.com/dotnet/roslyn/issues/18307")]
         public async Task AddAsyncInLocalFunctionKeepsTrivia(int codeFixIndex, string expectedReturn)

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -73,17 +73,13 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
             bool keepVoid, IMethodSymbol methodSymbol, TypeSyntax returnType,
             INamedTypeSymbol taskType, INamedTypeSymbol taskOfTType, INamedTypeSymbol valueTaskOfTType)
         {
-            var newReturnType = returnType;
+            var newReturnType = returnType.WithAdditionalAnnotations(Formatter.Annotation);
 
             if (methodSymbol.ReturnsVoid)
             {
                 if (!keepVoid)
                 {
                     newReturnType = taskType.GenerateTypeSyntax();
-                }
-                else
-                {
-                    newReturnType = newReturnType.WithAdditionalAnnotations(Formatter.Annotation);
                 }
             }
             else
@@ -93,10 +89,6 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
                     // If it's not already Task-like, then wrap the existing return type
                     // in Task<>.
                     newReturnType = taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax();
-                }
-                else
-                {
-                    newReturnType = newReturnType.WithAdditionalAnnotations(Formatter.Annotation);
                 }
             }
 

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.MakeMethodAsynchronous;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
@@ -80,6 +80,10 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
                 if (!keepVoid)
                 {
                     newReturnType = taskType.GenerateTypeSyntax();
+                }
+                else
+                {
+                    newReturnType = newReturnType.WithAdditionalAnnotations(Formatter.Annotation);
                 }
             }
             else

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -94,6 +94,10 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
                     // in Task<>.
                     newReturnType = taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax();
                 }
+                else
+                {
+                    newReturnType = newReturnType.WithAdditionalAnnotations(Formatter.Annotation);
+                }
             }
 
             return newReturnType.WithTriviaFrom(returnType);


### PR DESCRIPTION
**Customer scenario**
Make Method Asynchronous does not preserve leading trivia properly

**Bugs this fixes:**
Fixes #18396

**Workarounds, if any**

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Missed Formatter annotation for kept void return type.

**How was the bug found?**
ad hoc testing
