### PR TITLE
Making async stack spiller aware of "readonly ref"

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -4364,8 +4364,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!arguments.IsDefault, "Field 'arguments' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
-            Debug.Assert(argumentRefKindsOpt.IsDefault || arguments.Length == argumentRefKindsOpt.Length);
-
             this.ReceiverOpt = receiverOpt;
             this.Method = method;
             this.Arguments = arguments;

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -4364,6 +4364,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(!arguments.IsDefault, "Field 'arguments' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
             Debug.Assert(type != null, "Field 'type' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
 
+            Debug.Assert(argumentRefKindsOpt.IsDefault || arguments.Length == argumentRefKindsOpt.Length);
+
             this.ReceiverOpt = receiverOpt;
             this.Method = method;
             this.Arguments = arguments;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -797,7 +797,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var receiverBuilder = new BoundSpillSequenceBuilder();
 
                 receiver = node.ReceiverOpt;
-                var refKind = ReceiverSpillRefKind(receiver);
+                var refKind = node.Method.ContainingType.IsReadOnly?
+                                                    RefKind.RefReadOnly:
+                                                    ReceiverSpillRefKind(receiver);
 
                 receiver = Spill(receiverBuilder, VisitExpression(ref receiverBuilder, receiver), refKind: refKind);
                 receiverBuilder.Include(builder);
@@ -809,8 +811,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static RefKind ReceiverSpillRefKind(BoundExpression receiver)
         {
-            return LocalRewriter.WouldBeAssignableIfUsedAsMethodReceiver(receiver) ? 
-                RefKind.Ref : 
+            return LocalRewriter.WouldBeAssignableIfUsedAsMethodReceiver(receiver) ?
+                RefKind.Ref :
                 RefKind.None;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AwaitExpressionSpiller.cs
@@ -372,11 +372,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case BoundKind.FieldAccess:
                         var field = (BoundFieldAccess)expression;
-                        var fiedlSymbol = field.FieldSymbol;
-                        if (fiedlSymbol.IsStatic)
+                        var fieldSymbol = field.FieldSymbol;
+                        if (fieldSymbol.IsStatic)
                         {
                             // no need to spill static fields if used as locations or if readonly
-                            if (refKind != RefKind.None || fiedlSymbol.IsReadOnly)
+                            if (refKind != RefKind.None || fieldSymbol.IsReadOnly)
                             {
                                 return field;
                             }
@@ -385,8 +385,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (refKind == RefKind.None) goto default;
 
-                        var receiver = Spill(builder, field.ReceiverOpt, field.FieldSymbol.ContainingType.IsValueType ? refKind : RefKind.None);
-                        return field.Update(receiver, field.FieldSymbol, field.ConstantValueOpt, field.ResultKind, field.Type);
+                        var receiver = Spill(builder, field.ReceiverOpt, fieldSymbol.ContainingType.IsValueType ? refKind : RefKind.None);
+                        return field.Update(receiver, fieldSymbol, field.ConstantValueOpt, field.ResultKind, field.Type);
 
                     case BoundKind.Call:
                         var call = (BoundCall)expression;
@@ -452,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool forceSpill = false,
             bool sideEffectsOnly = false)
         {
-            Debug.Assert(refKinds.IsDefaultOrEmpty || refKinds.Length == args.Length);
+            Debug.Assert(refKinds.IsDefault || refKinds.Length == args.Length);
 
             var newList = VisitList(args);
             Debug.Assert(newList.Length == args.Length);
@@ -488,7 +488,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = ArrayBuilder<BoundExpression>.GetInstance();
             for (int i = 0; i <= lastSpill; i++)
             {
-                var refKind = refKinds.IsDefaultOrEmpty ? RefKind.None : refKinds[i];
+                var refKind = refKinds.IsDefault ? RefKind.None : refKinds[i];
                 var replacement = Spill(builder, newList[i], refKind, sideEffectsOnly);
 
                 Debug.Assert(sideEffectsOnly || replacement != null);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -569,7 +569,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
 
                 case BoundKind.Call:
-                    return ((BoundCall)receiver).Method.RefKind != RefKind.None;
+                    return ((BoundCall)receiver).Method.RefKind == RefKind.Ref;
             }
 
             return false;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenReceiver: rewrittenReceiver,
                 method: method,
                 rewrittenArguments: rewrittenArguments,
-                argumentRefKinds: ImmutableArray<RefKind>.Empty,
+                argumentRefKinds: default(ImmutableArray<RefKind>),
                 invokedAsExtensionMethod: false,
                 resultKind: LookupResultKind.Viable,
                 type: type);
@@ -495,7 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// patch refKinds for "redonly ref" to have effective RefReadOnly kind.
+        /// patch refKinds for "readonly ref" to have effective RefReadOnly kind.
         /// </summary>
         private static ImmutableArray<RefKind> GetEffectiveArgumentRefKinds(ImmutableArray<RefKind> argumentRefKindsOpt, ImmutableArray<ParameterSymbol> parameters)
         {
@@ -528,6 +528,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argumentRefKindsOpt = refKindsBuilder.ToImmutableAndFree();
             }
 
+            Debug.Assert(argumentRefKindsOpt.IsDefault || argumentRefKindsOpt.Length == parameters.Length);
             return argumentRefKindsOpt;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -528,7 +528,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argumentRefKindsOpt = refKindsBuilder.ToImmutableAndFree();
             }
 
-            Debug.Assert(argumentRefKindsOpt.IsDefault || argumentRefKindsOpt.Length == parameters.Length);
+            // NOTE: we may have more arguments than parameters in a case of arglist. That is ok.
+            Debug.Assert(argumentRefKindsOpt.IsDefault || argumentRefKindsOpt.Length >= parameters.Length);
             return argumentRefKindsOpt;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _factory.TypeofDynamicOperationContextType()
             });
 
-            return MakeDynamicOperation(binderConstruction, null, RefKind.None, loweredArguments, ImmutableArray<RefKind>.Empty, null, resultType);
+            return MakeDynamicOperation(binderConstruction, null, RefKind.None, loweredArguments, default(ImmutableArray<RefKind>), null, resultType);
         }
 
         internal LoweredDynamicOperation MakeDynamicUnaryOperator(
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MakeCallSiteArgumentInfos(argumentInfoFactory, loweredArguments)
             }) : null;
 
-            return MakeDynamicOperation(binderConstruction, null, RefKind.None, loweredArguments, ImmutableArray<RefKind>.Empty, null, resultType);
+            return MakeDynamicOperation(binderConstruction, null, RefKind.None, loweredArguments, default(ImmutableArray<RefKind>), null, resultType);
         }
 
         internal LoweredDynamicOperation MakeDynamicBinaryOperator(
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MakeCallSiteArgumentInfos(argumentInfoFactory, loweredArguments)
             }) : null;
 
-            return MakeDynamicOperation(binderConstruction, null, RefKind.None, loweredArguments, ImmutableArray<RefKind>.Empty, null, resultType);
+            return MakeDynamicOperation(binderConstruction, null, RefKind.None, loweredArguments, default(ImmutableArray<RefKind>), null, resultType);
         }
 
         internal LoweredDynamicOperation MakeDynamicMemberInvocation(
@@ -282,7 +282,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MakeCallSiteArgumentInfos(argumentInfoFactory, loweredArguments, loweredReceiver: loweredReceiver, loweredRight: loweredHandler)
             }) : null;
 
-            return MakeDynamicOperation(binderConstruction, loweredReceiver, RefKind.None, loweredArguments, ImmutableArray<RefKind>.Empty, loweredHandler, resultType);
+            return MakeDynamicOperation(binderConstruction, loweredReceiver, RefKind.None, loweredArguments, default(ImmutableArray<RefKind>), loweredHandler, resultType);
         }
 
         internal LoweredDynamicOperation MakeDynamicInvocation(
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MakeCallSiteArgumentInfos(argumentInfoFactory, loweredArguments, loweredReceiver: loweredReceiver)
             }) : null;
 
-            return MakeDynamicOperation(binderConstruction, loweredReceiver, RefKind.None, loweredArguments, ImmutableArray<RefKind>.Empty, null, resultType);
+            return MakeDynamicOperation(binderConstruction, loweredReceiver, RefKind.None, loweredArguments, default(ImmutableArray<RefKind>), null, resultType);
         }
 
         internal LoweredDynamicOperation MakeDynamicSetMember(
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MakeCallSiteArgumentInfos(argumentInfoFactory, loweredArguments, loweredReceiver: loweredReceiver, loweredRight: loweredRight)
             }) : null;
 
-            return MakeDynamicOperation(binderConstruction, loweredReceiver, RefKind.None, loweredArguments, ImmutableArray<RefKind>.Empty, loweredRight, AssemblySymbol.DynamicType);
+            return MakeDynamicOperation(binderConstruction, loweredReceiver, RefKind.None, loweredArguments, default(ImmutableArray<RefKind>), loweredRight, AssemblySymbol.DynamicType);
         }
 
         internal LoweredDynamicOperation MakeDynamicGetIndex(
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 _factory.TypeofDynamicOperationContextType()
             });
 
-            return MakeDynamicOperation(binderConstruction, loweredReceiver, RefKind.None, ImmutableArray<BoundExpression>.Empty, ImmutableArray<RefKind>.Empty, null, resultType);
+            return MakeDynamicOperation(binderConstruction, loweredReceiver, RefKind.None, ImmutableArray<BoundExpression>.Empty, default(ImmutableArray<RefKind>), null, resultType);
         }
 
         private MethodSymbol GetArgumentInfoFactory()

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -640,7 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(method.ParameterCount == args.Length);
             return new BoundCall(
                 Syntax, receiver, method, args,
-                ImmutableArray<String>.Empty, ImmutableArray<RefKind>.Empty, false, false, false,
+                ImmutableArray<String>.Empty, default(ImmutableArray<RefKind>), false, false, false,
                 default(ImmutableArray<int>), LookupResultKind.Viable, null, method.ReturnType,
                 hasErrors:method.OriginalDefinition is ErrorMethodSymbol)
             { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -640,7 +640,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(method.ParameterCount == args.Length);
             return new BoundCall(
                 Syntax, receiver, method, args,
-                ImmutableArray<String>.Empty, default(ImmutableArray<RefKind>), false, false, false,
+                default(ImmutableArray<String>), default(ImmutableArray<RefKind>), false, false, false,
                 default(ImmutableArray<int>), LookupResultKind.Viable, null, method.ReturnType,
                 hasErrors:method.OriginalDefinition is ErrorMethodSymbol)
             { WasCompilerGenerated = true };
@@ -651,7 +651,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(method.ParameterCount == args.Length);
             return new BoundCall(
                 Syntax, receiver, method, args,
-                ImmutableArray<String>.Empty, refKinds, false, false, false,
+                default(ImmutableArray<String>), refKinds, false, false, false,
                 ImmutableArray<int>.Empty, LookupResultKind.Viable, null, method.ReturnType)
             { WasCompilerGenerated = true };
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.Property:
                     return ((PropertySymbol)member).ParameterRefKinds;
                 case SymbolKind.Event:
-                    return ImmutableArray<RefKind>.Empty;
+                    return default(ImmutableArray<RefKind>);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(member.Kind);
             }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncSpillTests.cs
@@ -3085,8 +3085,6 @@ class C
             CompileAndVerify(source, expected);
         }
 
-
-
         [Fact]
         [WorkItem(13734, "https://github.com/dotnet/roslyn/issues/13734")]
         public void MethodGroupConversionNoSpill()

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -793,7 +793,7 @@ class Program
 
         local = new S1();
 
-        // prints   1 42 3 3       note no aliasing for the first two arguments because of spilling of calls
+        // prints   1 42 3 3       note no aliasing for the first argument because of spilling of calls
         M1(GetLocal(ref local).f, await GetT(42), GetLocal(ref local).f, GetLocal(ref local).f);
     }
 
@@ -861,7 +861,7 @@ class Program
 
         local = new S1();
 
-        // prints   1 42 3 3       note no aliasing for the first two arguments because of spilling of calls
+        // prints   1 42 3 3       note no aliasing for the first argument because of spilling of calls
         M1(GetLocalWriteable(ref local).f, await GetT(42), GetLocalWriteable(ref local).f, GetLocalWriteable(ref local).f);
     }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenInParametersTests.cs
@@ -839,7 +839,7 @@ public struct S1
 
         [WorkItem(20764, "https://github.com/dotnet/roslyn/issues/20764")]
         [Fact]
-        public void ReadonlyParamAsyncSpillMethodsW()
+        public void ReadonlyParamAsyncSpillMethodsWriteable()
         {
             var text = @"
 using System.Threading.Tasks;


### PR DESCRIPTION
Making async stack spiller aware of "readonly ref"

- changing stack spiller to not treat everything that is not RefKind.None as RefKind.Ref
- making sure that "ref readonly" arguments and receivers of readonly structs are seen by the spiller as RefKind.RefReadOnly
- implementing spilling strategy where RefReadOnly stack operands are spilled "by-reference" when possible, and ! spilled "by-value" via a copy otherwise.  

(the latter is an error for ordinary ref operands, but it is ok for RefReadOnly since in the case of "ref readonly" the actual by-ref aliasing is an opportunistic feature and not a requirement)