### PR TITLE
Avoid AggregateException in TaskExtensions.WaitAndGetResult

### DIFF
--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -172,10 +172,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             {
                 return isRenamableIdentifierTask.WaitAndGetResult(cancellationToken) != TriggerIdentifierKind.NotRenamable;
             }
-            catch (AggregateException e) when (e.InnerException is OperationCanceledException)
+            catch (TaskCanceledException)
             {
                 // We passed in a different cancellationToken, so if there's a race and 
-                // isRenamableIdentifierTask was cancelled, we'll get an AggregateException
+                // isRenamableIdentifierTask was cancelled, we'll get a TaskCanceledException
                 return false;
             }
         }

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -172,10 +172,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             {
                 return isRenamableIdentifierTask.WaitAndGetResult(cancellationToken) != TriggerIdentifierKind.NotRenamable;
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException e) when (e.CancellationToken != cancellationToken || cancellationToken == CancellationToken.None)
             {
                 // We passed in a different cancellationToken, so if there's a race and 
-                // isRenamableIdentifierTask was cancelled, we'll get a TaskCanceledException
+                // isRenamableIdentifierTask was cancelled, we'll get a OperationCanceledException
                 return false;
             }
         }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -856,7 +856,7 @@ End Enum";
             source = new TaskCompletionSource<RenameTrackingTaggerProvider.TriggerIdentifierKind>();
             Assert.Throws<OperationCanceledException>(() => RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, new CancellationToken(canceled: true)));
             source.TrySetException(new Exception());
-            Assert.Throws<AggregateException>(() => RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, CancellationToken.None));
+            Assert.Throws<Exception>(() => RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, CancellationToken.None));
         }
 
         [WpfFact, WorkItem(1063943, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063943")]

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -854,6 +854,12 @@ End Enum";
             Assert.False(RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, CancellationToken.None));
 
             source = new TaskCompletionSource<RenameTrackingTaggerProvider.TriggerIdentifierKind>();
+            source.TrySetException(new OperationCanceledException());
+            Assert.False(RenameTrackingTaggerProvider.IsRenamableIdentifier(source.Task, waitForResult, CancellationToken.None));
+            Assert.False(RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, CancellationToken.None));
+            Assert.False(RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, new CancellationTokenSource().Token));
+
+            source = new TaskCompletionSource<RenameTrackingTaggerProvider.TriggerIdentifierKind>();
             Assert.Throws<OperationCanceledException>(() => RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, new CancellationToken(canceled: true)));
             source.TrySetException(new Exception());
             Assert.Throws<Exception>(() => RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, CancellationToken.None));

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -861,8 +861,10 @@ End Enum";
 
             source = new TaskCompletionSource<RenameTrackingTaggerProvider.TriggerIdentifierKind>();
             Assert.Throws<OperationCanceledException>(() => RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, new CancellationToken(canceled: true)));
-            source.TrySetException(new Exception());
-            Assert.Throws<Exception>(() => RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, CancellationToken.None));
+            var thrownException = new Exception();
+            source.TrySetException(thrownException);
+            var caughtException = Assert.Throws<Exception>(() => RenameTrackingTaggerProvider.WaitForIsRenamableIdentifier(source.Task, CancellationToken.None));
+            Assert.Same(thrownException, caughtException);
         }
 
         [WpfFact, WorkItem(1063943, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1063943")]

--- a/src/Workspaces/Core/Portable/Utilities/TaskExtensions.cs
+++ b/src/Workspaces/Core/Portable/Utilities/TaskExtensions.cs
@@ -60,8 +60,10 @@ namespace Roslyn.Utilities
         // thread.  In the future we are going ot be removing this and disallowing its use.
         public static T WaitAndGetResult_CanCallOnBackground<T>(this Task<T> task, CancellationToken cancellationToken)
         {
-            task.Wait(cancellationToken);
-            return task.Result;
+            // WaitAny waits for the task to complete with cancellation and without throwing;
+            // GetAwaiter().GetResult() is then used so that if the task failed, the exception is not wrapped in AggregateException
+            Task.WaitAny(new Task[] { task }, cancellationToken);
+            return task.GetAwaiter().GetResult();
         }
 
         // NOTE(cyrusn): Once we switch over to .Net 4.5 we can make our SafeContinueWith overloads

--- a/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Throws<TaskCanceledException>(() => Task.FromCanceled<int>(new CancellationToken(canceled: true)).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
             Assert.Throws<OperationCanceledException>(() => new TaskCompletionSource<int>().Task.WaitAndGetResult_CanCallOnBackground(new CancellationToken(canceled: true)));
             var ex = Assert.Throws<TestException>(() => Task.Run(() => ThrowTestException()).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
-            Assert.Contains("TaskExtensionsTests.ThrowTestException()", ex.StackTrace);
+            Assert.Contains($"{nameof(TaskExtensionsTests)}.{nameof(ThrowTestException)}()", ex.StackTrace);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Roslyn.Utilities;
@@ -14,10 +15,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void WaitAndGetResult()
         {
             Assert.Equal(42, Task.FromResult(42).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
-            Assert.Throws<TestException>(() => Task.FromException<int>(new TestException()).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
             Assert.Throws<TaskCanceledException>(() => Task.FromCanceled<int>(new CancellationToken(canceled: true)).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
             Assert.Throws<OperationCanceledException>(() => new TaskCompletionSource<int>().Task.WaitAndGetResult_CanCallOnBackground(new CancellationToken(canceled: true)));
+            var ex = Assert.Throws<TestException>(() => Task.Run(() => ThrowTestException()).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
+            Assert.Contains("TaskExtensionsTests.ThrowTestException()", ex.StackTrace);
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static int ThrowTestException() => throw new TestException();
 
         class TestException : Exception { }
     }

--- a/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/TaskExtensionsTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class TaskExtensionsTests
+    {
+        [Fact]
+        public void WaitAndGetResult()
+        {
+            Assert.Equal(42, Task.FromResult(42).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
+            Assert.Throws<TestException>(() => Task.FromException<int>(new TestException()).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
+            Assert.Throws<TaskCanceledException>(() => Task.FromCanceled<int>(new CancellationToken(canceled: true)).WaitAndGetResult_CanCallOnBackground(CancellationToken.None));
+            Assert.Throws<OperationCanceledException>(() => new TaskCompletionSource<int>().Task.WaitAndGetResult_CanCallOnBackground(new CancellationToken(canceled: true)));
+        }
+
+        class TestException : Exception { }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/20884.

This could theoretically ignore some exceptions, if the `Task` contains more than one. But `await` has the same issue, so I think doing this is okay.

<s>I didn't find any tests for `WaitAndGetResult` or any relevant tests for `Formatter.Format`, so I didn't add any tests for this. If I should, what kind of test should I add?</s>