### PR TITLE
fix const string

### DIFF
--- a/src/Compilers/Core/Portable/Symbols/Attributes/WellKnownAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/WellKnownAttributeData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis
         /// For some well-known attributes, the latter case will return string stored in <see cref="StringMissingValue"/>
         /// field.
         /// </summary>
-        public const string StringMissingValue = nameof(StringMissingValue);
+        public static readonly string StringMissingValue = nameof(StringMissingValue);
 
 #if DEBUG
         private bool _isSealed;


### PR DESCRIPTION
Bandaid fix for the signing issue that has taken down our RPS tests.

@dotnet/roslyn-infrastructure @jaredpar @jasonmalinowski 