### PR TITLE
Relax rules for matching tuple names in OHI (VB)

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
@@ -477,6 +477,7 @@ DoneWithErrorReporting:
             If implementedSym IsNot Nothing AndAlso implementingSym.ContainsTupleNames() AndAlso
                 Not MembersHaveMatchingTupleNames(implementingSym, implementedSym) Then
 
+                ' it is ok to implement with no tuple names, for compatibility with VB 14, but otherwise names should match
                 Binder.ReportDiagnostic(diagBag, implementedMemberSyntax, ERRID.ERR_ImplementingInterfaceWithDifferentTupleNames5,
                                         CustomSymbolDisplayFormatter.ShortErrorName(implementingSym),
                                         implementingSym.GetKindText(),

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplementsHelper.vb
@@ -474,7 +474,9 @@ DoneWithErrorReporting:
                 End If
             End If
 
-            If implementedSym IsNot Nothing AndAlso Not MembersHaveMatchingTupleNames(implementingSym, implementedSym) Then
+            If implementedSym IsNot Nothing AndAlso implementingSym.ContainsTupleNames() AndAlso
+                Not MembersHaveMatchingTupleNames(implementingSym, implementedSym) Then
+
                 Binder.ReportDiagnostic(diagBag, implementedMemberSyntax, ERRID.ERR_ImplementingInterfaceWithDifferentTupleNames5,
                                         CustomSymbolDisplayFormatter.ShortErrorName(implementingSym),
                                         implementingSym.GetKindText(),

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
@@ -901,7 +901,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     ReportBadOverriding(ERRID.ERR_OverrideWithConstraintMismatch2, member, overriddenMember, diagnostics)
                 ElseIf Not ConsistentAccessibility(member, overriddenMember, errorId) Then
                     ReportBadOverriding(errorId, member, overriddenMember, diagnostics)
-                ElseIf (comparisonResults And SymbolComparisonResults.TupleNamesMismatch) <> 0 Then
+                ElseIf member.ContainsTupleNames() AndAlso (comparisonResults And SymbolComparisonResults.TupleNamesMismatch) <> 0 Then
+                    ' it is ok to override with no tuple names, for compatibility with VB 14, but otherwise names should match
                     ReportBadOverriding(ERRID.WRN_InvalidOverrideDueToTupleNames2, member, overriddenMember, diagnostics)
                 Else
                     For Each inaccessibleMember In overriddenMembersResult.InaccessibleMembers

--- a/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
@@ -423,5 +423,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             Return member
         End Function
+
+        <Extension>
+        Friend Function ContainsTupleNames(member As Symbol) As Boolean
+            Select Case member.Kind
+                Case SymbolKind.Method
+                    Dim method = DirectCast(member, MethodSymbol)
+                    Return method.ReturnType.ContainsTupleNames() OrElse method.Parameters.Any(Function(p) p.Type.ContainsTupleNames())
+                Case SymbolKind.Property
+                    Return DirectCast(member, PropertySymbol).Type.ContainsTupleNames()
+                Case SymbolKind.Event
+                    ' We don't check the event Type directly because materializing it requires checking the tuple names in the type (to validate interface implementations)
+                    Return DirectCast(member, EventSymbol).DelegateParameters.Any(Function(dp) dp.Type.ContainsTupleNames())
+                Case Else
+                    '  We currently don't need to use this method for other kinds of symbols
+                    Throw ExceptionUtilities.UnexpectedValue(member.Kind)
+            End Select
+        End Function
     End Module
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
@@ -435,7 +435,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return [property].Type.ContainsTupleNames() OrElse ContainsTupleNames([property].Parameters)
                 Case SymbolKind.Event
                     ' We don't check the event Type directly because materializing it requires checking the tuple names in the type (to validate interface implementations)
-                    Return DirectCast(member, EventSymbol).DelegateParameters.Any(Function(dp) dp.Type.ContainsTupleNames())
+                    Return ContainsTupleNames(DirectCast(member, EventSymbol).DelegateParameters)
                 Case Else
                     '  We currently don't need to use this method for other kinds of symbols
                     Throw ExceptionUtilities.UnexpectedValue(member.Kind)

--- a/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
@@ -429,9 +429,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Select Case member.Kind
                 Case SymbolKind.Method
                     Dim method = DirectCast(member, MethodSymbol)
-                    Return method.ReturnType.ContainsTupleNames() OrElse method.Parameters.Any(Function(p) p.Type.ContainsTupleNames())
+                    Return method.ReturnType.ContainsTupleNames() OrElse ContainsTupleNames(method.Parameters)
                 Case SymbolKind.Property
-                    Return DirectCast(member, PropertySymbol).Type.ContainsTupleNames()
+                    Dim [property] = DirectCast(member, PropertySymbol)
+                    Return [property].Type.ContainsTupleNames() OrElse ContainsTupleNames([property].Parameters)
                 Case SymbolKind.Event
                     ' We don't check the event Type directly because materializing it requires checking the tuple names in the type (to validate interface implementations)
                     Return DirectCast(member, EventSymbol).DelegateParameters.Any(Function(dp) dp.Type.ContainsTupleNames())
@@ -439,6 +440,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     '  We currently don't need to use this method for other kinds of symbols
                     Throw ExceptionUtilities.UnexpectedValue(member.Kind)
             End Select
+        End Function
+
+        Private Function ContainsTupleNames(parameters As ImmutableArray(Of ParameterSymbol)) As Boolean
+            Return parameters.Any(Function(p) p.Type.ContainsTupleNames())
         End Function
     End Module
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -17933,6 +17933,105 @@ End Class
             CompilationUtils.AssertNoDiagnostics(compilation1)
         End Sub
 
+        <Fact()>
+        Public Sub ImplementingPropertyWithDifferentTupleNames()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Imports System
+Interface I1
+    Property P(x As (a As Integer, b As Integer)) As Boolean
+End Interface
+Class C1
+    Implements I1
+    Property P(x As (notA As Integer, notB As Integer)) As Boolean Implements I1.P
+        Get
+            Return True
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+        ]]></file>
+    </compilation>, references:=s_valueTupleRefs)
+
+            compilation.AssertTheseDiagnostics(<errors>
+BC30402: 'P' cannot implement property 'P' on interface 'I1' because the tuple element names in 'Public Property P(x As (notA As Integer, notB As Integer)) As Boolean' do not match those in 'Property P(x As (a As Integer, b As Integer)) As Boolean'.
+    Property P(x As (notA As Integer, notB As Integer)) As Boolean Implements I1.P
+                                                                              ~~~~
+                                               </errors>)
+        End Sub
+
+        <Fact()>
+        Public Sub ImplementingPropertyWithNoTupleNames()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Imports System
+Interface I1
+    Property P(x As (a As Integer, b As Integer)) As Boolean
+End Interface
+Class C1
+    Implements I1
+    Property P(x As (Integer, Integer)) As Boolean Implements I1.P
+        Get
+            Return True
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+        ]]></file>
+    </compilation>, references:=s_valueTupleRefs)
+
+            compilation.AssertTheseDiagnostics()
+        End Sub
+
+        <Fact()>
+        Public Sub ImplementingPropertyWithNoTupleNames2()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Imports System
+Interface I1
+    Property P As (a As Integer, b As Integer)
+End Interface
+Class C1
+    Implements I1
+    Property P As (Integer, Integer) Implements I1.P
+End Class
+        ]]></file>
+    </compilation>, references:=s_valueTupleRefs)
+
+            compilation.AssertTheseDiagnostics()
+        End Sub
+
+        <Fact()>
+        Public Sub ImplementingMethodWithNoTupleNames()
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Imports System
+Interface I1
+    Sub M(x As (a As Integer, b As Integer))
+    Function M2 As (a As Integer, b As Integer)
+End Interface
+Class C1
+    Implements I1
+
+    Sub M(x As (Integer, Integer)) Implements I1.M
+    End Sub
+
+    Function M2 As (Integer, Integer) Implements I1.M2
+        Return (1, 2)
+    End Function
+End Class
+        ]]></file>
+    </compilation>, references:=s_valueTupleRefs)
+
+            compilation.AssertTheseDiagnostics()
+        End Sub
+
         <Fact>
         Public Sub BC31407ERR_MultipleEventImplMismatch3_2()
             Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlib(

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -16029,6 +16029,58 @@ BC40001: 'Public Overrides Function M5() As (c As (notA As Integer, notB As Inte
         End Sub
 
         <Fact>
+        Public Sub OverriddenMethodWithNoTupleNamesInReturn()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class Base
+    Public Overridable Function M6() As (a As Integer, b As Integer)
+        Return (1, 2)
+    End Function
+End Class
+
+Public Class Derived
+    Inherits Base
+
+    Public Overrides Function M6() As (Integer, Integer)
+        Return (1, 2)
+    End Function
+    Sub M()
+        Dim result = Me.M6()
+        Dim result2 = MyBase.M6()
+        System.Console.Write(result.a)
+        System.Console.Write(result2.a)
+    End Sub
+End Class
+    </file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC30456: 'a' is not a member of '(Integer, Integer)'.
+        System.Console.Write(result.a)
+                             ~~~~~~~~
+</errors>)
+
+            Dim m6 = comp.GetMember(Of MethodSymbol)("Derived.M6").ReturnType
+            Assert.Equal("(System.Int32, System.Int32)", m6.ToTestDisplayString())
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+
+            Dim invocation = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(0)
+            Assert.Equal("Me.M6()", invocation.ToString())
+            Assert.Equal("Function Derived.M6() As (System.Int32, System.Int32)", model.GetSymbolInfo(invocation).Symbol.ToTestDisplayString())
+
+            Dim invocation2 = nodes.OfType(Of InvocationExpressionSyntax)().ElementAt(1)
+            Assert.Equal("MyBase.M6()", invocation2.ToString())
+            Assert.Equal("Function Base.M6() As (a As System.Int32, b As System.Int32)", model.GetSymbolInfo(invocation2).Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact>
         Public Sub OverriddenMethodWithDifferentTupleNamesInReturnUsingTypeArg()
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
@@ -17201,9 +17253,6 @@ additionalReferences:=s_valueTupleRefs)
 
             compDifferent2.AssertTheseDiagnostics(
 <errors>
-BC40001: 'Public Overrides Function M() As (Integer, Integer)' cannot override 'Public Overrides Function M() As (notA As Integer, notB As Integer)' because they differ by their tuple element names.
-    Public Overrides Function M() As (Integer, Integer)
-                              ~
 </errors>)
 
         End Sub
@@ -17283,6 +17332,125 @@ BC40001: 'Public Overrides Property P4 As (notA As Integer, notB As Integer)?' c
 BC40001: 'Public Overrides Property P5 As (c As (notA As Integer, notB As Integer), d As Integer)' cannot override 'Public Overridable Property P5 As (c As (a As Integer, b As Integer), d As Integer)' because they differ by their tuple element names.
     Public Overrides Property P5 As (c As (notA As Integer, notB As Integer), d As Integer)
                               ~~
+</errors>)
+
+        End Sub
+
+        <Fact>
+        Public Sub OverriddenPropertyWithNoTupleNames()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class Base
+    Public Overridable Property P6 As (a As Integer, b As Integer)
+End Class
+
+Public Class Derived
+    Inherits Base
+
+    Public Overrides Property P6 As (Integer, Integer)
+    Sub M()
+        Dim result = Me.P6
+        Dim result2 = MyBase.P6
+        System.Console.Write(result.a)
+        System.Console.Write(result2.a)
+    End Sub
+End Class
+    </file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+</errors>)
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+
+            Dim propertyAccess = nodes.OfType(Of MemberAccessExpressionSyntax)().ElementAt(0)
+            Assert.Equal("Me.P6", propertyAccess.ToString())
+            Assert.Equal("Property Derived.P6 As (System.Int32, System.Int32)", model.GetSymbolInfo(propertyAccess).Symbol.ToTestDisplayString())
+
+            Dim propertyAccess2 = nodes.OfType(Of MemberAccessExpressionSyntax)().ElementAt(1)
+            Assert.Equal("MyBase.P6", propertyAccess2.ToString())
+            Assert.Equal("Property Base.P6 As (a As System.Int32, b As System.Int32)", model.GetSymbolInfo(propertyAccess2).Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub OverriddenPropertyWithNoTupleNamesWithValueTuple()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class Base
+    Public Overridable Property P6 As (a As Integer, b As Integer)
+End Class
+
+Public Class Derived
+    Inherits Base
+
+    Public Overrides Property P6 As System.ValueTuple(Of Integer, Integer)
+    Sub M()
+        Dim result = Me.P6
+        Dim result2 = MyBase.P6
+        System.Console.Write(result.a)
+        System.Console.Write(result2.a)
+    End Sub
+End Class
+    </file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+</errors>)
+
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+
+            Dim propertyAccess = nodes.OfType(Of MemberAccessExpressionSyntax)().ElementAt(0)
+            Assert.Equal("Me.P6", propertyAccess.ToString())
+            Assert.Equal("Property Derived.P6 As (System.Int32, System.Int32)", model.GetSymbolInfo(propertyAccess).Symbol.ToTestDisplayString())
+
+            Dim propertyAccess2 = nodes.OfType(Of MemberAccessExpressionSyntax)().ElementAt(1)
+            Assert.Equal("MyBase.P6", propertyAccess2.ToString())
+            Assert.Equal("Property Base.P6 As (a As System.Int32, b As System.Int32)", model.GetSymbolInfo(propertyAccess2).Symbol.ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub OverriddenEventWithDifferentTupleNames()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Imports System
+Public Class Base
+    Public Overridable Event E1 As Action(Of (a As Integer, b As Integer))
+End Class
+
+Public Class Derived
+    Inherits Base
+
+    Public Overrides Event E1 As Action(Of (Integer, Integer))
+End Class
+    </file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC30243: 'Overridable' is not valid on an event declaration.
+    Public Overridable Event E1 As Action(Of (a As Integer, b As Integer))
+           ~~~~~~~~~~~
+BC30243: 'Overrides' is not valid on an event declaration.
+    Public Overrides Event E1 As Action(Of (Integer, Integer))
+           ~~~~~~~~~
+BC40004: event 'E1' conflicts with event 'E1' in the base class 'Base' and should be declared 'Shadows'.
+    Public Overrides Event E1 As Action(Of (Integer, Integer))
+                           ~~
 </errors>)
 
         End Sub
@@ -17743,6 +17911,26 @@ BC30402: 'evtTest3' cannot implement event 'evtTest2' on interface 'I1' because 
                                                                                              ~~~~~~~~~~~
                  ]]></errors>
             CompilationUtils.AssertTheseDeclarationDiagnostics(compilation1, expectedErrors1)
+        End Sub
+
+        <Fact()>
+        Public Sub ImplementingEventWithNoTupleNames()
+            Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlib(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Imports System
+Interface I1
+    Event evtTest1 As Action(Of (A As Integer, B As Integer))
+    Event evtTest2 As Action(Of (A As Integer, notB As Integer))
+End Interface
+Class C1
+    Implements I1
+    Event evtTest3 As Action(Of (Integer, Integer)) Implements I1.evtTest1, I1.evtTest2
+End Class
+        ]]></file>
+    </compilation>, references:=s_valueTupleRefs)
+
+            CompilationUtils.AssertNoDiagnostics(compilation1)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CustomModifiersTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CustomModifiersTests.vb
@@ -2407,12 +2407,7 @@ End Class
 </compilation>
 
             Dim comp2 = CreateCompilationWithCustomILSource(source2, il, appendDefaultHeader:=False, additionalReferences:={ValueTupleRef, SystemRuntimeFacadeRef})
-            comp2.AssertTheseDiagnostics(
-<errors>
-BC30402: 'P' cannot implement property 'P' on interface 'I' because the tuple element names in 'Public Property P As (Object, Object)' do not match those in 'Property P As (a As Object, b As Object)'.
-    Public Property P As (Object, Object) Implements I.P
-                                                     ~~~
-</errors>)
+            comp2.AssertTheseDiagnostics()
 
             Dim classProperty2 = comp2.GlobalNamespace.GetMember(Of PropertySymbol)("C.P")
 
@@ -2582,9 +2577,6 @@ End Class
 <errors>
 BC40001: 'Public Overrides Function M(x As (c As Object, d As Object)) As (Object, Object)' cannot override 'Public Overridable Overloads Function M(x As (c As Object, d As Object)) As (a As Object, b As Object)' because they differ by their tuple element names.
     Public Overrides Function M(x As (c As Object, d As Object)) As (Object, Object)
-                              ~
-BC40001: 'Public Overrides Property P As (Object, Object)' cannot override 'Public Overridable Overloads Property P As (a As Object, b As Object)' because they differ by their tuple element names.
-    Public Overrides Property P As (Object, Object)
                               ~
 </errors>)
 


### PR DESCRIPTION
Allows round-tripping across VB 14 and 15 with APIs involving tuples, despite VB 14 not supporting tuple element names.
For instance, you can override `Function M() As (int a, int b)` with `Function M() As ValueTuple<int, int>` or `Function M() As (int, int)`.

This is the VB change corresponding to https://github.com/dotnet/roslyn/pull/20838