### PR TITLE
Add null check in ExplicitInterfaceTypeCompletionProvider for invalid code

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProviderTests.cs
@@ -37,6 +37,19 @@ class C : IList
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WorkItem(459044, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=459044")]
+        public async Task TestInMisplacedUsing()
+        {
+            var markup = @"
+class C
+{
+    using ($$)
+}
+";
+            await VerifyNoItemsExistAsync(markup); // no crash
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task TestAtStartOfStruct()
         {
             var markup = @"

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ExplicitInterfaceTypeCompletionProvider.cs
@@ -86,8 +86,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return SpecializedTasks.EmptyImmutableArray<ISymbol>();
             }
 
-            // Looks syntactically good.  See what interfaces our containing class/struct has
             var typeDeclaration = typeNode.GetAncestor<TypeDeclarationSyntax>();
+            if (typeDeclaration == null)
+            {
+                return SpecializedTasks.EmptyImmutableArray<ISymbol>();
+            }
+
+            // Looks syntactically good.  See what interfaces our containing class/struct has
             Debug.Assert(IsClassOrStruct(typeDeclaration));
 
             var semanticModel = context.SemanticModel;


### PR DESCRIPTION
**Customer scenario**

Type `class C { using (x) }`. As you type `x`, the IDE will crash.

**Bugs this fixes:**
Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=459044

**Risk**
**Performance impact**
Low. Just added a null check.

**How was the bug found?**
Watson

@CyrusNajmabadi @dotnet/roslyn-ide for review. Thanks
@jaredpar Should this go into 15.3? The VSO issue is marked as 15.4.