### PR TITLE
Fixed smart variable naming

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -196,6 +196,7 @@ public class C
             await VerifyItemExistsAsync(markup, "cancellationToken", glyph: (int)Glyph.Parameter);
         }
 
+        [WorkItem(19260, "https://github.com/dotnet/roslyn/issues/19260")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void EscapeKeywords1()
         {
@@ -211,6 +212,7 @@ public class C
             await VerifyItemExistsAsync(markup, "builder", glyph: (int) Glyph.Parameter);
         }
 
+        [WorkItem(19260, "https://github.com/dotnet/roslyn/issues/19260")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void EscapeKeywords2()
         {
@@ -224,6 +226,7 @@ public class C
             await VerifyItemExistsAsync(markup, "@for", glyph: (int) Glyph.Parameter);
         }
 
+        [WorkItem(19260, "https://github.com/dotnet/roslyn/issues/19260")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void EscapeKeywords3()
         {
@@ -240,6 +243,7 @@ public class C
             await VerifyItemExistsAsync(markup, "@for");
         }
 
+        [WorkItem(19260, "https://github.com/dotnet/roslyn/issues/19260")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void EscapeKeywords4()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -197,6 +197,68 @@ public class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void EscapeKeywords1()
+        {
+            var markup = @"
+using System.Text;
+public class C
+{
+    void Foo(StringBuilder $$) {}
+}
+";
+            await VerifyItemExistsAsync(markup, "stringBuilder", glyph: (int) Glyph.Parameter);
+            await VerifyItemExistsAsync(markup, "@string", glyph: (int) Glyph.Parameter);
+            await VerifyItemExistsAsync(markup, "builder", glyph: (int) Glyph.Parameter);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void EscapeKeywords2()
+        {
+            var markup = @"
+class For { }
+public class C
+{
+    void Foo(For $$) {}
+}
+";
+            await VerifyItemExistsAsync(markup, "@for", glyph: (int) Glyph.Parameter);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void EscapeKeywords3()
+        {
+            var markup = @"
+class For { }
+public class C
+{
+    void foo()
+    {
+        For $$
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "@for");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async void EscapeKeywords4()
+        {
+            var markup = @"
+using System.Text;
+public class C
+{
+    void foo()
+    {
+        StringBuilder $$
+    }
+}
+";
+            await VerifyItemExistsAsync(markup, "stringBuilder");
+            await VerifyItemExistsAsync(markup, "@string");
+            await VerifyItemExistsAsync(markup, "builder");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async void NoSuggestionsForInt()
         {
             var markup = @"

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     {
                         foreach (var baseName in baseNames)
                         {
-                            var name = rule.NamingStyle.CreateName(baseName);
+                            var name = EscapeIdentifier(rule.NamingStyle.CreateName(baseName));
                             if (name.Length > 1 && !result.ContainsKey(name)) // Don't add multiple items for the same name
                             {
                                 result.Add(name, symbolKind);
@@ -188,6 +188,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
 
             return result.Select(kvp => (kvp.Key, kvp.Value)).ToImmutableArray();
+        }
+
+        private static string EscapeIdentifier(string identifier)
+        {
+            var kind = SyntaxFacts.GetKeywordKind(identifier);
+            return kind == SyntaxKind.None
+                ? identifier
+                : $"@{identifier}";
         }
 
         CompletionItem CreateCompletionItem(string name, Glyph glyph, string sortText)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -177,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     {
                         foreach (var baseName in baseNames)
                         {
-                            var name = EscapeIdentifier(rule.NamingStyle.CreateName(baseName));
+                            var name = rule.NamingStyle.CreateName(baseName).EscapeIdentifier(context.IsInQuery);
                             if (name.Length > 1 && !result.ContainsKey(name)) // Don't add multiple items for the same name
                             {
                                 result.Add(name, symbolKind);
@@ -188,14 +189,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
 
             return result.Select(kvp => (kvp.Key, kvp.Value)).ToImmutableArray();
-        }
-
-        private static string EscapeIdentifier(string identifier)
-        {
-            var kind = SyntaxFacts.GetKeywordKind(identifier);
-            return kind == SyntaxKind.None
-                ? identifier
-                : $"@{identifier}";
         }
 
         CompletionItem CreateCompletionItem(string name, Glyph glyph, string sortText)


### PR DESCRIPTION
**Customer scenario**

Keywords aren't escaped in Smart variable naming

**Bugs this fixes:**
Fixed #19260

**Workarounds, if any**

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Not implemented escaping for keywords

**How was the bug found?**
customer reported
