### PR TITLE
Fixed Inline Temporary Variable refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4537,5 +4537,57 @@ class C
 }",
 ignoreTrivia: false);
         }
+
+        [WorkItem(11712, "https://github.com/dotnet/roslyn/issues/11712")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task InlineTemporary_RefParams()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    bool M<T>(ref T x) 
+    {
+        var [||]b = M(ref x);
+        return b || b;
+    }
+}",
+
+@"
+class C
+{
+    bool M<T>(ref T x) 
+    {
+        return M(ref x) || M(ref x);
+    }
+}",
+ignoreTrivia: false);
+        }
+
+        [WorkItem(11712, "https://github.com/dotnet/roslyn/issues/11712")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task InlineTemporary_OutParams()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+class C
+{
+    bool M<T>(out T x) 
+    {
+        var [||]b = M(out x);
+        return b || b;
+    }
+}",
+
+@"
+class C
+{
+    bool M<T>(out T x) 
+    {
+        return M(out x) || M(out x);
+    }
+}",
+ignoreTrivia: false);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -278,7 +278,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 var argumentType = _semanticModel.GetTypeInfo(node.Expression).ConvertedType;
                 if (argumentType != null &&
                     !IsPassedToDelegateCreationExpression(node, argumentType) &&
-                    node.Expression.Kind() != SyntaxKind.DeclarationExpression)
+                    node.Expression.Kind() != SyntaxKind.DeclarationExpression &&
+                    node.RefOrOutKeyword.Kind() == SyntaxKind.None)
                 {
                     if (TryCastTo(argumentType, node.Expression, newArgument.Expression, out var newArgumentExpressionWithCast))
                     {


### PR DESCRIPTION
**Customer scenario**
Inline Temporary Variable creates unnecessary broken cast with generics & booleans

**Bugs this fixes:**
#11712

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**How was the bug found?**
customer reported
