### PR TITLE
Remove old LambdaRewriter.Analysis visitors and replace with Scope tree

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8729,7 +8729,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Instance of type &apos;{0}&apos; cannot be used inside an anonymous function, query expression, iterator block or async method.
+        ///   Looks up a localized string similar to Instance of type &apos;{0}&apos; cannot be used inside a nested function, query expression, iterator block or async method.
         /// </summary>
         internal static string ERR_SpecialByRefInLambda {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -3906,7 +3906,7 @@ You should consider suppressing the warning only if you're sure that you don't w
     <value>Indexed property '{0}' must have all arguments optional</value>
   </data>
   <data name="ERR_SpecialByRefInLambda" xml:space="preserve">
-    <value>Instance of type '{0}' cannot be used inside an anonymous function, query expression, iterator block or async method</value>
+    <value>Instance of type '{0}' cannot be used inside a nested function, query expression, iterator block or async method</value>
   </data>
   <data name="ERR_SecurityAttributeMissingAction" xml:space="preserve">
     <value>First argument to a security attribute must be a valid SecurityAction</value>


### PR DESCRIPTION
Replaces all the functionality that the old LambdaRewriter.Analysis visitors had and uses the new Scope tree instead. The first commit replaces most of the functionality while asserting equivalence with the old visitors, and the second commit removes all the old visitors and deletes the assertions.