### PR TITLE
Show modifier/method/type block declaration keywords after attribute …

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/ClassKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/ClassKeywordRecommenderTests.vb
@@ -264,5 +264,11 @@ End Namespace</File>, "Class")
         Public Async Function AfterAsyncTest() As Task
             Await VerifyRecommendationsMissingAsync(<ClassDeclaration>Async |</ClassDeclaration>, "Class")
         End Function
+
+        <WorkItem(20837, "https://github.com/dotnet/roslyn/issues/20837")>
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function AfterAttribute() As Task
+            Await VerifyRecommendationsContainAsync(<File>&lt;AttributeApplication&gt; |</File>, "Class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/FunctionKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/FunctionKeywordRecommenderTests.vb
@@ -250,5 +250,11 @@ End Module
 
 </File>, "Function")
         End Function
+
+        <WorkItem(20837, "https://github.com/dotnet/roslyn/issues/20837")>
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function AfterExtensionAttribute() As Task
+            Await VerifyRecommendationsContainAsync(<ClassDeclaration>&lt;Extension&gt; |</ClassDeclaration>, "Function")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/InterfaceKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/InterfaceKeywordRecommenderTests.vb
@@ -267,5 +267,11 @@ End Namespace</File>, "Interface")
         Public Async Function NotAfterAsyncTest() As Task
             Await VerifyRecommendationsMissingAsync(<ClassDeclaration>Async |</ClassDeclaration>, "Interface")
         End Function
+
+        <WorkItem(20837, "https://github.com/dotnet/roslyn/issues/20837")>
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function AfterAttribute() As Task
+            Await VerifyRecommendationsContainAsync(<File>&lt;AttributeApplication&gt; |</File>, "Interface")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/ModifierKeywordRecommenderTests.InsideClassDeclaration.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/ModifierKeywordRecommenderTests.InsideClassDeclaration.vb
@@ -116,6 +116,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.De
             Await VerifyRecommendationsContainAsync(<ClassDeclaration>Iterator |</ClassDeclaration>, "Public", "Protected", "Protected Friend", "Friend", "Private")
         End Function
 
+        <WorkItem(20837, "https://github.com/dotnet/roslyn/issues/20837")>
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function AfterExtensionAttribute() As Task
+            Await VerifyRecommendationsContainAsync(<ClassDeclaration>&lt;Extension&gt; |</ClassDeclaration>, "Public", "Protected", "Protected Friend", "Friend", "Private")
+        End Function
+
 #End Region
 
 #Region "Narrowing and Widening Keywords"

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/StructureKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/StructureKeywordRecommenderTests.vb
@@ -265,5 +265,11 @@ End Namespace</File>, "Structure")
         Public Async Function NotAfterAsyncTest() As Task
             Await VerifyRecommendationsMissingAsync(<ClassDeclaration>Async |</ClassDeclaration>, "Structure")
         End Function
+
+        <WorkItem(20837, "https://github.com/dotnet/roslyn/issues/20837")>
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function AfterAttribute() As Task
+            Await VerifyRecommendationsContainAsync(<File>&lt;AttributeApplication&gt; |</File>, "Structure")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/SubKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Declarations/SubKeywordRecommenderTests.vb
@@ -240,5 +240,11 @@ End Module
 
 </File>, "Sub")
         End Function
+
+        <WorkItem(20837, "https://github.com/dotnet/roslyn/issues/20837")>
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function AfterExtensionAttribute() As Task
+            Await VerifyRecommendationsContainAsync(<ClassDeclaration>&lt;Extension&gt; |</ClassDeclaration>, "Sub")
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.vb
@@ -146,14 +146,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 Return False
             End If
 
-            Dim afterDimOrModifiers = allowAfterModifiersOrDim AndAlso (targetToken.IsModifier OrElse
-                                                                        targetToken.Kind = SyntaxKind.DimKeyword OrElse
-                                                                        targetToken.HasMatchingText(SyntaxKind.AsyncKeyword) OrElse
-                                                                        targetToken.HasMatchingText(SyntaxKind.IteratorKeyword))
+            Dim afterDimOrModifiers = allowAfterModifiersOrDim AndAlso IsDimOrModifierOrAttributeList(targetToken)
 
             ' We either must be on a separate line, or else after Dim or modifiers
             If targetToken.FollowsEndOfStatement(position) OrElse afterDimOrModifiers Then
                 Return targetToken.GetInnermostDeclarationContext().IsKind(allowedParentBlocks)
+            End If
+
+            Return False
+        End Function
+
+        Private Function IsDimOrModifierOrAttributeList(token As SyntaxToken) As Boolean
+            If token.IsModifier Then
+                Return True
+            End If
+
+            If token.Kind = SyntaxKind.DimKeyword Then
+                Return True
+            End If
+
+            If token.HasMatchingText(SyntaxKind.AsyncKeyword) OrElse token.HasMatchingText(SyntaxKind.IteratorKeyword) Then
+                Return True
+            End If
+
+            ' eg. <Extension> |
+            If token.Kind = SyntaxKind.GreaterThanToken AndAlso token.Parent.Kind = SyntaxKind.AttributeList Then
+                Return True
             End If
 
             Return False


### PR DESCRIPTION
…lists

Fixes https://github.com/dotnet/roslyn/issues/20837

