### PR TITLE
Fixed Inline Temporary Variable refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4564,32 +4564,6 @@ class C
 ignoreTrivia: false);
         }
 
-        [WorkItem(16819, "https://github.com/dotnet/roslyn/issues/16819")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
-        public async Task InlineVariableDoesNotAddsDuplicateCast()
-        {
-            await TestInRegularAndScriptAsync(
-@"using System;
-
-class C
-{
-    void M()
-    {
-        var [||]o = (Exception)null;
-        Console.Write(o == new Exception());
-    }
-}",
-@"using System;
-
-class C
-{
-    void M()
-    {
-        Console.Write((Exception)null == new Exception());
-    }
-}");
-        }
-
         [WorkItem(11712, "https://github.com/dotnet/roslyn/issues/11712")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task InlineTemporary_OutParams()
@@ -4614,6 +4588,32 @@ class C
     }
 }",
 ignoreTrivia: false);
+        }
+
+        [WorkItem(16819, "https://github.com/dotnet/roslyn/issues/16819")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task InlineVariableDoesNotAddsDuplicateCast()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+        var [||]o = (Exception)null;
+        Console.Write(o == new Exception());
+    }
+}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        Console.Write((Exception)null == new Exception());
+    }
+}");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4564,6 +4564,32 @@ class C
 ignoreTrivia: false);
         }
 
+        [WorkItem(16819, "https://github.com/dotnet/roslyn/issues/16819")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineDeclaration)]
+        public async Task InlineVariableDoesNotAddsDuplicateCast()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    void M()
+    {
+        var [||]o = (Exception)null;
+        Console.Write(o == new Exception());
+    }
+}",
+@"using System;
+
+class C
+{
+    void M()
+    {
+        Console.Write((Exception)null == new Exception());
+    }
+}");
+        }
+
         [WorkItem(11712, "https://github.com/dotnet/roslyn/issues/11712")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
         public async Task InlineTemporary_OutParams()

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -373,6 +373,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             // the cast can be removed.
             if (expressionToCastType.IsIdentity)
             {
+                // Simple case: Is this an identity cast to another cast? If so, we're safe to remove it.
+                if (cast.Expression.WalkDownParentheses().IsKind(SyntaxKind.CastExpression))
+                {
+                    return true;
+                }
+
                 // Required explicit cast for reference comparison.
                 // Cast removal causes warning CS0252 (Possible unintended reference comparison).
                 //      object x = string.Intern("Hi!");

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             int position,
             SemanticModel semanticModel)
         {
-            if (targetType.ContainsAnonymousType() || expression.Kind() == SyntaxKind.CastExpression)
+            if (targetType.ContainsAnonymousType())
             {
                 return expression;
             }

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             int position,
             SemanticModel semanticModel)
         {
-            if (targetType.ContainsAnonymousType())
+            if (targetType.ContainsAnonymousType() || expression.Kind() == SyntaxKind.CastExpression)
             {
                 return expression;
             }


### PR DESCRIPTION
**Customer scenario**
Inline Temporary Variable adds duplicate cast

**Bugs this fixes:**
Fixes #16819

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**How was the bug found?**
customer reported
