### PR TITLE
Fixed IntelliSense suggestion on typing dot after method group

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -9106,5 +9106,48 @@ class C
             await VerifyItemExistsAsync(markup, "A");
             await VerifyItemExistsAsync(markup, "B");
         }
+
+        [WorkItem(8321, "https://github.com/dotnet/roslyn/issues/8321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task NotOnMethodGroup1()
+        {
+            var markup =
+@"namespace ConsoleApp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Main.$$
+        }
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [WorkItem(8321, "https://github.com/dotnet/roslyn/issues/8321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task NotOnMethodGroup2()
+        {
+            var markup =
+@"class C {
+    void M<T>() {M<C>.$$ }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
+
+        [WorkItem(8321, "https://github.com/dotnet/roslyn/issues/8321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task NotOnMethodGroup3()
+        {
+            var markup =
+@"class C {
+    void M() {M.$$}
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
@@ -457,8 +457,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
                     return ImmutableArray<ISymbol>.Empty;
                 }
 
-                // If the thing on the left is a method, we shouldn't show anything.
-                if (symbol.Kind == SymbolKind.Method)
+                // If the thing on the left is a lambda expression, we shouldn't show anything.
+                var originalExpressionKind = originalExpression.Kind();
+                if (symbol.Kind == SymbolKind.Method &&
+                    ((IMethodSymbol)symbol).MethodKind == MethodKind.AnonymousFunction)
+                {
+                    return ImmutableArray<ISymbol>.Empty;
+                }
+
+                if (symbol.Kind == SymbolKind.Method &&
+                    (originalExpressionKind == SyntaxKind.IdentifierName || originalExpressionKind == SyntaxKind.GenericName))
                 {
                     return ImmutableArray<ISymbol>.Empty;
                 }

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
@@ -458,13 +458,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
                 }
 
                 // If the thing on the left is a lambda expression, we shouldn't show anything.
-                var originalExpressionKind = originalExpression.Kind();
                 if (symbol.Kind == SymbolKind.Method &&
                     ((IMethodSymbol)symbol).MethodKind == MethodKind.AnonymousFunction)
                 {
                     return ImmutableArray<ISymbol>.Empty;
                 }
 
+                // If the thing on the left is a method name identifier, we shouldn't show anything.
+                var originalExpressionKind = originalExpression.Kind();
                 if (symbol.Kind == SymbolKind.Method &&
                     (originalExpressionKind == SyntaxKind.IdentifierName || originalExpressionKind == SyntaxKind.GenericName))
                 {

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
@@ -457,9 +457,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
                     return ImmutableArray<ISymbol>.Empty;
                 }
 
-                // If the thing on the left is a lambda expression, we shouldn't show anything.
-                if (symbol.Kind == SymbolKind.Method &&
-                    ((IMethodSymbol)symbol).MethodKind == MethodKind.AnonymousFunction)
+                // If the thing on the left is a method, we shouldn't show anything.
+                if (symbol.Kind == SymbolKind.Method)
                 {
                     return ImmutableArray<ISymbol>.Empty;
                 }


### PR DESCRIPTION
**Customer scenario**
Typing dot after method group incorrectly shows IntelliSense

**Bugs this fixes:**
Fixes #8321
Fixes #16069

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No

**How was the bug found?**
customer reported
