### PR TITLE
Fixed unexpected line break on InlineTemporary refactoring on anonymous type with comment

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4491,8 +4491,7 @@ class C
     void M()
     {
         var t = new {
-            /*comment*/
-            i = 1 + 2,
+            /*comment*/ i = 1 + 2,
             /*comment*/ j = 3
         };
     }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -332,6 +332,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     var inferredName = node.Expression.TryGetInferredMemberName();
                     if (inferredName != null)
                     {
+                        // Creating identifier without elastic trivia to avoid unexpected line break
                         var identifier = SyntaxFactory.Identifier(SyntaxTriviaList.Empty, inferredName, SyntaxTriviaList.Empty);
                         identifier = TryEscapeIdentifierToken(identifier, node, _semanticModel);
 

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -332,7 +332,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     var inferredName = node.Expression.TryGetInferredMemberName();
                     if (inferredName != null)
                     {
-                        var identifier = SyntaxFactory.Identifier(inferredName);
+                        var identifier = SyntaxFactory.Identifier(SyntaxTriviaList.Empty, inferredName, SyntaxTriviaList.Empty);
                         identifier = TryEscapeIdentifierToken(identifier, node, _semanticModel);
 
                         newDeclarator = newDeclarator


### PR DESCRIPTION
**Customer scenario**
InlineTemporary on anonymous type with comment introduces unexpected line break when formatting

**Bugs this fixes:**
Fixes #18882

**Risk**
Low

**Performance impact**
Low

**Is this a regression from a previous update?**
No
