### PR TITLE
Launch settings for test projects

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -498,6 +498,11 @@
     <AdditionalFiles Include="@(PublicAPI)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Show launchSettings.json in the project if it exists. -->
+    <None Include="$(AppDesignerFolder)\launchSettings.json" Condition="Exists('$(AppDesignerFolder)\launchSettings.json')" />
+  </ItemGroup>
+
   <!-- CPS doesn't show these items by default, but we want to show them. -->
   <ItemGroup>
     <!-- XAML pages and resources -->

--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -226,6 +226,7 @@
     <xunitassertVersion>2.2.0-beta4-build3444</xunitassertVersion>
     <xunitconsolenetcoreVersion>1.0.2-prerelease-00104</xunitconsolenetcoreVersion>
     <xunitrunnerconsoleVersion>2.2.0-beta4-build3444</xunitrunnerconsoleVersion>
+    <xunitrunnerwpfVersion>1.0.41</xunitrunnerwpfVersion>
   </PropertyGroup>
 
 </Project>

--- a/build/Targets/Roslyn.Toolsets.Xunit.targets
+++ b/build/Targets/Roslyn.Toolsets.Xunit.targets
@@ -1,13 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <!-- xUnit.net Console Runner -->
     <XUnitPath>$(NuGetPackageRoot)\xunit.runner.console\$(xunitrunnerconsoleVersion)\tools\xunit.console.x86.exe</XUnitPath>
     <XUnitTestResultsDirectory>$(OutDir)\xUnitResults</XUnitTestResultsDirectory>
     <XUnitArguments>"$(OutDir)\$(AssemblyName).dll" -html "$(XUnitTestResultsDirectory)\$(AssemblyName).html" -noshadow</XUnitArguments>
     <PrepareForBuildDependsOn>$(PrepareForBuildDependsOn);AddDefaultTestAppConfig</PrepareForBuildDependsOn>
+
+    <!-- xUnit.net WPF Runner -->
+    <XUnitWpfPath>$(NuGetPackageRoot)\xunit.runner.wpf\$(xunitrunnerwpfVersion)\tools\xunit.runner.wpf.exe</XUnitWpfPath>
+    <XUnitWpfArguments>"$(OutDir)\$(AssemblyName).dll"</XUnitWpfArguments>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.runner.wpf" Version="$(xunitrunnerwpfVersion)" PrivateAssets="all" />
+  </ItemGroup>
 
   <Target Name="Test" DependsOnTargets="Build">
     <MakeDir Directories="$(XUnitTestResultsDirectory)" />

--- a/src/CodeStyle/CSharp/Tests/Properties/launchSettings.json
+++ b/src/CodeStyle/CSharp/Tests/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/CodeStyle/Core/Tests/Properties/launchSettings.json
+++ b/src/CodeStyle/Core/Tests/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/CodeStyle/VisualBasic/Tests/My Project/launchSettings.json
+++ b/src/CodeStyle/VisualBasic/Tests/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/CommandLine/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/Emit/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Emit/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Semantic/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Symbol/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/Syntax/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/CSharp/Test/WinRT/Properties/launchSettings.json
+++ b/src/Compilers/CSharp/Test/WinRT/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Properties/launchSettings.json
+++ b/src/Compilers/Core/CodeAnalysisTest/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/Properties/launchSettings.json
+++ b/src/Compilers/Core/MSBuildTaskTests/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/Properties/launchSettings.json
+++ b/src/Compilers/Server/VBCSCompilerTests/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/CommandLine/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/CommandLine/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/Emit/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/Emit/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/Semantic/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/Semantic/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/Symbol/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Compilers/VisualBasic/Test/Syntax/My Project/launchSettings.json
+++ b/src/Compilers/VisualBasic/Test/Syntax/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/EditorFeatures/CSharpTest/Properties/launchSettings.json
+++ b/src/EditorFeatures/CSharpTest/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/EditorFeatures/CSharpTest2/Properties/launchSettings.json
+++ b/src/EditorFeatures/CSharpTest2/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/EditorFeatures/Test/Properties/launchSettings.json
+++ b/src/EditorFeatures/Test/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/EditorFeatures/Test2/My Project/launchSettings.json
+++ b/src/EditorFeatures/Test2/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/EditorFeatures/VisualBasicTest/My Project/launchSettings.json
+++ b/src/EditorFeatures/VisualBasicTest/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/Properties/launchSettings.json
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Properties/launchSettings.json
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/ExpressionEvaluator/Core/Test/FunctionResolver/Properties/launchSettings.json
+++ b/src/ExpressionEvaluator/Core/Test/FunctionResolver/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/My Project/launchSettings.json
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/My Project/launchSettings.json
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ResultProvider/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Interactive/HostTest/Properties/launchSettings.json
+++ b/src/Interactive/HostTest/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Scripting/CSharpTest.Desktop/Properties/launchSettings.json
+++ b/src/Scripting/CSharpTest.Desktop/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Scripting/CSharpTest/Properties/launchSettings.json
+++ b/src/Scripting/CSharpTest/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Scripting/CoreTest.Desktop/Properties/launchSettings.json
+++ b/src/Scripting/CoreTest.Desktop/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Scripting/CoreTest/Properties/launchSettings.json
+++ b/src/Scripting/CoreTest/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Scripting/VisualBasicTest/My Project/launchSettings.json
+++ b/src/Scripting/VisualBasicTest/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/VisualStudio/CSharp/Test/Properties/launchSettings.json
+++ b/src/VisualStudio/CSharp/Test/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/VisualStudio/Core/Test.Next/Properties/launchSettings.json
+++ b/src/VisualStudio/Core/Test.Next/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/VisualStudio/Core/Test/My Project/launchSettings.json
+++ b/src/VisualStudio/Core/Test/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/VisualStudio/IntegrationTest/IntegrationTests/Properties/launchSettings.json
+++ b/src/VisualStudio/IntegrationTest/IntegrationTests/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Workspaces/CSharpTest/Properties/launchSettings.json
+++ b/src/Workspaces/CSharpTest/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Workspaces/CoreTest/Properties/launchSettings.json
+++ b/src/Workspaces/CoreTest/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }

--- a/src/Workspaces/VisualBasicTest/My Project/launchSettings.json
+++ b/src/Workspaces/VisualBasicTest/My Project/launchSettings.json
@@ -3,6 +3,10 @@
     "xUnit.net Console": {
       "executablePath": "$(XUnitPath)",
       "commandLineArgs": "$(XUnitArguments)"
+    },
+    "xUnit.net WPF Runner": {
+      "executablePath": "$(XUnitWpfPath)",
+      "commandLineArgs": "$(XUnitWpfArguments)"
     }
   }
 }


### PR DESCRIPTION
* Show **launchSettings.json** in Solution Explorer when it exists
* Add xunit.runner.wpf as a secondary launch target for test projects