### PR TITLE
Throw early if an invalid buffer is passed to ISuggestedActionsSource

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSource.cs
@@ -650,6 +650,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         return false;
                     }
 
+                    // Also make sure the range is from the same buffer that this source was created for
+                    Contract.ThrowIfFalse(
+                        range.Snapshot.TextBuffer.Equals(_subjectBuffer),
+                        $"Invalid text buffer passed to {nameof(HasSuggestedActionsAsync)}");
+
                     // Next, before we do any async work, acquire the user's selection, directly grabbing
                     // it from the UI thread if htat's what we're on. That way we don't have any reentrancy
                     // blocking concerns if VS wants to block on this call (for example, if the user 


### PR DESCRIPTION
This change serves as an early warning for the underlying bug reported in [this feedback item](https://developercommunity.visualstudio.com/content/problem/81009/indexaspx-mvc-application-javascript-section-visua.html). The exception information provided in Watson was from a different thread after an asynchronous invocation. By placing the validation prior to the asynchronous call, a recurrence of this situation will contain information necessary to track down the offending caller.