### PR TITLE
Fix crash with F# project references

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim;
@@ -74,6 +75,22 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             cpsProject.SetOptions(commandLineForOptions);
 
             return cpsProject;
+        }
+
+        public static CPSProject CreateNonCompilableProject(TestEnvironment environment, string projectName, string projectFilePath)
+        {
+            var hierarchy = environment.CreateHierarchy(projectName, projectFilePath, "");
+
+            return CPSProjectFactory.CreateCPSProject(
+                environment.ProjectTracker,
+                environment.ServiceProvider,
+                hierarchy,
+                projectName,
+                projectFilePath,
+                Guid.NewGuid(),
+                NoCompilationConstants.LanguageName,
+                commandLineParserService: null,
+                binOutputPath: null);
         }
 
         private static string GetOutputPathFromArguments(string[] commandLineArguments)

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/CSharpReferencesTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/CSharpReferencesTests.cs
@@ -135,5 +135,29 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
                 project1.Disconnect();
             }
         }
+
+
+        [WorkItem(461967, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/461967")]
+        [WpfFact()]
+        [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
+        public void AddingMetadataReferenceToProjectThatCannotCompileInTheIdeKeepsMetadataReference()
+        {
+            using (var environment = new TestEnvironment())
+            {
+                var project1 = CreateCSharpProject(environment, "project1");
+                environment.ProjectTracker.UpdateProjectBinPath(project1, null, @"c:\project1.dll");
+
+                var project2 = CreateNonCompilableProject(environment, "project2", @"C:\project2.fsproj");
+                environment.ProjectTracker.UpdateProjectBinPath(project2, null, @"c:\project2.dll");
+
+                project1.OnImportAdded(@"c:\project2.dll", "project2");
+
+                // We shoudl not have converted that to a project reference, because we would have no way to produce the compilation
+                Assert.Empty(project1.GetCurrentProjectReferences());
+
+                project2.Disconnect();
+                project1.Disconnect();
+            }
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -794,6 +794,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var project = this.ProjectTracker.GetProject(projectReference.ProjectId);
             if (project != null)
             {
+                // We won't allow project-to-project references if this one supports compilation and the other one doesn't.
+                // This causes problems because if we then try to create a compilation, we'll fail even though it would have worked with
+                // a metadata reference. If neither supports compilation, we'll let the reference go through on the assumption the
+                // language (TypeScript/F#, etc.) is doing that intentionally.
+                if (this.Language != project.Language && 
+                    this.ProjectTracker.WorkspaceServices.GetLanguageServices(this.Language).GetService<ICompilationFactoryService>() != null &&
+                    this.ProjectTracker.WorkspaceServices.GetLanguageServices(project.Language).GetService<ICompilationFactoryService>() == null)
+                {
+                    return false;
+                }
+
                 // cannot add a reference to a project that references us (it would make a cycle)
                 return !project.TransitivelyReferences(this.Id);
             }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -38,8 +38,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         #region Mutable fields accessed only from foreground thread - don't need locking for access (all accessing methods must have AssertIsForeground).
         private readonly List<WorkspaceHostState> _workspaceHosts;
 
-        private readonly HostWorkspaceServices _workspaceServices;
-
         /// <summary>
         /// Set to true while we're batching project loads. That is, between
         /// <see cref="IVsSolutionLoadEvents.OnBeforeLoadProjectBatch" /> and
@@ -113,6 +111,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
+        internal HostWorkspaceServices WorkspaceServices { get; }
+
         IReadOnlyList<IVisualStudioHostProject> IVisualStudioHostProjectContainer.GetProjects() => this.ImmutableProjects;
 
         void IVisualStudioHostProjectContainer.NotifyNonDocumentOpenedForProject(IVisualStudioHostProject project)
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             _serviceProvider = serviceProvider;
             _workspaceHosts = new List<WorkspaceHostState>(capacity: 1);
-            _workspaceServices = workspaceServices;
+            WorkspaceServices = workspaceServices;
 
             _vsSolution = (IVsSolution)serviceProvider.GetService(typeof(SVsSolution));
             _runningDocumentTable = (IVsRunningDocumentTable4)serviceProvider.GetService(typeof(SVsRunningDocumentTable));
@@ -653,7 +653,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (solutionConfig != null)
             {
                 // Capture the context so that we come back on the UI thread, and do the actual project creation there.
-                var deferredProjectWorkspaceService = _workspaceServices.GetService<IDeferredProjectWorkspaceService>();
+                var deferredProjectWorkspaceService = WorkspaceServices.GetService<IDeferredProjectWorkspaceService>();
                 projectInfos = await deferredProjectWorkspaceService.GetDeferredProjectInfoForConfigurationAsync(
                     $"{solutionConfig.Name}|{solutionConfig.PlatformName}",
                     cancellationToken).ConfigureAwait(true);
@@ -694,7 +694,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var targetPathsToProjectPaths = BuildTargetPathMap(projectInfos);
 
             var solution7 = (IVsSolution7)_vsSolution;
-            var analyzerAssemblyLoader = _workspaceServices.GetRequiredService<IAnalyzerService>().GetLoader();
+            var analyzerAssemblyLoader = WorkspaceServices.GetRequiredService<IAnalyzerService>().GetLoader();
             var componentModel = _serviceProvider.GetService(typeof(SComponentModel)) as IComponentModel;
             var workspaceProjectContextFactory = componentModel.GetService<IWorkspaceProjectContextFactory>();
             foreach (var (projectFilename, projectInfo) in projectInfos)
@@ -820,7 +820,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 return null;
             }
 
-            var commandLineParser = _workspaceServices.GetLanguageServices(languageName).GetService<ICommandLineParserService>();
+            var commandLineParser = WorkspaceServices.GetLanguageServices(languageName).GetService<ICommandLineParserService>();
             var projectDirectory = PathUtilities.GetDirectoryName(projectFilename);
             var commandLineArguments = commandLineParser.Parse(
                 projectInfo.CommandLineArguments,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -502,7 +502,7 @@ namespace Microsoft.CodeAnalysis
 
             private Compilation CreateEmptyCompilation()
             {
-                var compilationFactory = this.ProjectState.LanguageServices.GetService<ICompilationFactoryService>();
+                var compilationFactory = this.ProjectState.LanguageServices.GetRequiredService<ICompilationFactoryService>();
 
                 if (this.ProjectState.IsSubmission)
                 {


### PR DESCRIPTION
**Customer scenario:** Create a new F# project with dotnet cli, open the project with Visual Studio, add a C# project, and reference the F# project from the C# project.
**Bugs this fixes:** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/461967
**Workarounds, if any:** nothing good.
**Risk:** low.
**Performance impact:** none. Just an additional check in a relatively rare codepath.
**Is this a regression from a previous update?** yes, ish. Referencing F# from C# in older project types worked fine, but with newer project types it's broken due to us using more of CPS.
**Root cause analysis:** normally, adding a project reference from one project to another when they're different languages is done via telling one project about the output assembly of the other, adding it as a metadata reference. To create live IntelliSense cross-language for C#/VB, we try to convert this back to a project reference in our project model. We did this conversion for C#-to-F#, which wasn't going to work because F# doesn't fit other parts of the Roslyn model. This didn't crash previously because F# projects didn't always have output paths, so we couldn't do the matching to try to convert. A unit test has been added.
**How was the bug found?** Windows Error Reporting hits.