### PR TITLE
Clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ DOTNET_VERSION := 1.0.1
 DOTNET_PATH := $(BINARIES_PATH)/dotnet-cli
 DOTNET := $(DOTNET_PATH)/dotnet
 export PATH := $(DOTNET_PATH):$(PATH)
-TARGET_FX := netcoreapp1.1
 
 # Workaround, see https://github.com/dotnet/roslyn/issues/10210
 ifeq ($(origin HOME), undefined)
@@ -38,8 +37,7 @@ endif
 MSBUILD_MAIN_ARGS := $(MSBUILD_ARGS)
 MSBUILD_BOOTSTRAP_ARGS := $(MSBUILD_ARGS)
 
-# arguments to dotnet build go in front, msbuild in back
-MSBUILD_BOOTSTRAP_ARGS := -r $(RUNTIME_ID) $(MSBUILD_BOOTSTRAP_ARGS)
+MSBUILD_BOOTSTRAP_ARGS += /p:RuntimeIdentifier=$(RUNTIME_ID)
 
 # This gets a bit complex. There are two cases here:
 # BOOTSTRAP=false:

--- a/Makefile
+++ b/Makefile
@@ -1,69 +1,70 @@
-SHELL = /usr/bin/env bash
-OS_NAME = $(shell uname -s)
-BUILD_CONFIGURATION = Debug
-BINARIES_PATH = $(shell pwd)/Binaries
-SRC_PATH = $(shell pwd)/src
-BOOTSTRAP_PATH = $(BINARIES_PATH)/Bootstrap
-BUILD_LOG_PATH =
-HOME_DIR = $(shell cd ~ && pwd)
-DOTNET_VERSION = 1.0.1
-DOTNET = $(BINARIES_PATH)/dotnet-cli/dotnet
-TARGET_FX = netcoreapp1.1
+SHELL := /usr/bin/env bash
+OS_NAME := $(shell uname -s)
+BUILD_CONFIGURATION := Debug
+THIS_MAKEFILE_PATH := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+BINARIES_PATH := $(THIS_MAKEFILE_PATH)/Binaries
+SRC_PATH := $(THIS_MAKEFILE_PATH)/src
+BOOTSTRAP_PATH := $(BINARIES_PATH)/Bootstrap
+BUILD_LOG_PATH :=
+DOTNET_VERSION := 1.0.1
+DOTNET_PATH := $(BINARIES_PATH)/dotnet-cli
+DOTNET := $(DOTNET_PATH)/dotnet
+export PATH := $(DOTNET_PATH):$(PATH)
+TARGET_FX := netcoreapp1.1
 
-MSBUILD_ADDITIONALARGS := /v:m /fl /fileloggerparameters:Verbosity=normal /p:Configuration=$(BUILD_CONFIGURATION)
-
-ifeq ($(OS_NAME),Linux)
-	RUNTIME_ID := $(shell . /etc/os-release && echo $$ID.$$VERSION_ID)-x64
-else ifeq ($(OS_NAME),Darwin)
-	RUNTIME_ID := osx.10.12-x64
+# Workaround, see https://github.com/dotnet/roslyn/issues/10210
+ifeq ($(origin HOME), undefined)
+    # Note that while ~ usually refers to $HOME, in the case where $HOME is unset,
+    # it looks up the current user's home dir, which is what we want.
+    # https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html
+    export HOME := $(shell cd ~ && pwd)
 endif
 
+ifeq ($(OS_NAME),Linux)
+    RUNTIME_ID := $(shell . /etc/os-release && echo $$ID.$$VERSION_ID)-x64
+else ifeq ($(OS_NAME),Darwin)
+    RUNTIME_ID := osx.10.12-x64
+else
+    $(error "Unknown OS_NAME: $(OS_NAME)")
+endif
+
+MSBUILD_ARGS := /v:m /fl /fileloggerparameters:Verbosity=normal /p:Configuration=$(BUILD_CONFIGURATION)
+
 ifneq ($(BUILD_LOG_PATH),)
-	MSBUILD_ADDITIONALARGS := $(MSBUILD_ADDITIONALARGS) /fileloggerparameters:LogFile=$(BUILD_LOG_PATH)
+    MSBUILD_ARGS := $(MSBUILD_ARGS) /fileloggerparameters:LogFile=$(BUILD_LOG_PATH)
 endif
 
 ifeq ($(BOOTSTRAP),true)
-	MSBUILD_ARGS = $(MSBUILD_ADDITIONALARGS) /p:CscToolPath=$(BOOTSTRAP_PATH)/csc /p:CscToolExe=csc /p:VbcToolPath=$(BOOTSTRAP_PATH)/vbc /p:VbcToolExe=vbc
-else
-	MSBUILD_ARGS = $(MSBUILD_ADDITIONALARGS)
+    MSBUILD_ARGS := $(MSBUILD_ARGS) /p:CscToolPath=$(BOOTSTRAP_PATH)/csc /p:CscToolExe=csc /p:VbcToolPath=$(BOOTSTRAP_PATH)/vbc /p:VbcToolExe=vbc
 endif
 
-BUILD_CMD = dotnet build $(MSBUILD_ARGS)
+BUILD_CMD := dotnet build $(MSBUILD_ARGS)
 
 .PHONY: all bootstrap test toolset
 
 all: restore
-	@export PATH="$(BINARIES_PATH)/dotnet-cli:$(PATH)" ; \
-	export HOME="$(HOME_DIR)" ; \
-	$(BUILD_CMD) CrossPlatform.sln
+	$(BUILD_CMD) $(THIS_MAKEFILE_PATH)/CrossPlatform.sln
 
 bootstrap: restore
-	export HOME="$(HOME_DIR)" ; \
-	export PATH="$(BINARIES_PATH)/dotnet-cli:$(PATH)" ; \
-	$(BUILD_CMD) src/Compilers/CSharp/CscCore && \
-	$(BUILD_CMD) src/Compilers/VisualBasic/VbcCore && \
-	mkdir -p $(BOOTSTRAP_PATH)/csc && mkdir -p $(BOOTSTRAP_PATH)/vbc && \
-	dotnet publish -c $(BUILD_CONFIGURATION) -r $(RUNTIME_ID) src/Compilers/CSharp/CscCore -o $(BOOTSTRAP_PATH)/csc && \
-	dotnet publish -c $(BUILD_CONFIGURATION) -r $(RUNTIME_ID) src/Compilers/VisualBasic/VbcCore -o $(BOOTSTRAP_PATH)/vbc
-	rm -rf Binaries/$(BUILD_CONFIGURATION)
+	$(BUILD_CMD) $(SRC_PATH)/Compilers/CSharp/CscCore
+	$(BUILD_CMD) $(SRC_PATH)/Compilers/VisualBasic/VbcCore
+	mkdir -p $(BOOTSTRAP_PATH)/csc
+	mkdir -p $(BOOTSTRAP_PATH)/vbc
+	dotnet publish -c $(BUILD_CONFIGURATION) -r $(RUNTIME_ID) $(SRC_PATH)/Compilers/CSharp/CscCore -o $(BOOTSTRAP_PATH)/csc
+	dotnet publish -c $(BUILD_CONFIGURATION) -r $(RUNTIME_ID) $(SRC_PATH)/Compilers/VisualBasic/VbcCore -o $(BOOTSTRAP_PATH)/vbc
+	rm -rf $(BINARIES_PATH)/$(BUILD_CONFIGURATION)
 
 test:
-	@export PATH="$(BINARIES_PATH)/dotnet-cli:$(PATH)" ; \
-	export HOME="$(HOME_DIR)" ; \
-	dotnet publish -r $(RUNTIME_ID) src/Test/DeployCoreClrTestRuntime -o $(BINARIES_PATH)/$(BUILD_CONFIGURATION)/CoreClrTest -p:RoslynRuntimeIdentifier=$(RUNTIME_ID) && \
-	build/scripts/tests.sh $(BUILD_CONFIGURATION)
+	dotnet publish -r $(RUNTIME_ID) $(SRC_PATH)/Test/DeployCoreClrTestRuntime -o $(BINARIES_PATH)/$(BUILD_CONFIGURATION)/CoreClrTest -p:RoslynRuntimeIdentifier=$(RUNTIME_ID)
+	./build/scripts/tests.sh $(BUILD_CONFIGURATION)
 
 restore: $(DOTNET)
-	export PATH="$(BINARIES_PATH)/dotnet-cli:$(PATH)" ; \
 	./build/scripts/restore.sh
 
 $(DOTNET):
-	mkdir -p $(BINARIES_PATH) ; \
-	pushd $(BINARIES_PATH) ; \
-	curl -O https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh && \
-	chmod +x dotnet-install.sh && \
-	./dotnet-install.sh --version "$(DOTNET_VERSION)" --install-dir "$(BINARIES_PATH)/dotnet-cli"
+	curl https://raw.githubusercontent.com/dotnet/cli/rel/$(DOTNET_VERSION)/scripts/obtain/dotnet-install.sh | \
+	$(SHELL) -s -- --version "$(DOTNET_VERSION)" --install-dir "$(DOTNET_PATH)"
 
 
 clean:
-	@rm -rf Binaries
+	rm -rf $(BINARIES_PATH)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ MSBUILD_BOOTSTRAP_ARGS := -r $(RUNTIME_ID) $(MSBUILD_BOOTSTRAP_ARGS)
 #   BootstrapBuildPath is specified, but *only* for the main build, *not* the
 #   bootstrap build.
 ifeq ($(BOOTSTRAP),true)
-    MSBUILD_MAIN_ARGS += /p:BootstrapBuildPath=$(BOOTSTRAP_PATH)
+    # MSBUILD_MAIN_ARGS += /p:BootstrapBuildPath=$(BOOTSTRAP_PATH)
+    MSBUILD_MAIN_ARGS += /p:CscToolPath=$(BOOTSTRAP_PATH)/csc /p:CscToolExe=csc /p:VbcToolPath=$(BOOTSTRAP_PATH)/vbc /p:VbcToolExe=vbc
     BOOTSTRAP_DEPENDENCY := bootstrap
 else
     BOOTSTRAP_DEPENDENCY :=
@@ -67,7 +68,6 @@ bootstrap: restore
 	@echo Building Bootstrap
 	dotnet publish $(SRC_PATH)/Compilers/CSharp/CscCore -o $(BOOTSTRAP_PATH)/csc $(MSBUILD_BOOTSTRAP_ARGS)
 	dotnet publish $(SRC_PATH)/Compilers/VisualBasic/VbcCore -o $(BOOTSTRAP_PATH)/vbc $(MSBUILD_BOOTSTRAP_ARGS)
-	dotnet publish $(SRC_PATH)/Compilers/Core/MSBuildTask -o $(BOOTSTRAP_PATH) $(MSBUILD_BOOTSTRAP_ARGS)
 	rm -rf $(BINARIES_PATH)/$(BUILD_CONFIGURATION)
 
 test:
@@ -75,7 +75,8 @@ test:
 	$(THIS_MAKEFILE_PATH)build/scripts/tests.sh $(BUILD_CONFIGURATION)
 
 restore: $(DOTNET)
-	$(THIS_MAKEFILE_PATH)build/scripts/restore.sh
+	dotnet restore -v Minimal --disable-parallel $(THIS_MAKEFILE_PATH)build/ToolsetPackages/BaseToolset.csproj
+	dotnet restore -v Minimal --disable-parallel $(THIS_MAKEFILE_PATH)CrossPlatform.sln
 
 $(DOTNET):
 	curl https://raw.githubusercontent.com/dotnet/cli/rel/$(DOTNET_VERSION)/scripts/obtain/dotnet-install.sh | \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ else
     $(error "Unknown OS_NAME: $(OS_NAME)")
 endif
 
-MSBUILD_ARGS := /p:TreatWarningsAsErrors=true /warnaserror /nologo '/consoleloggerparameters:Verbosity=minimal;summary' /p:Configuration=$(BUILD_CONFIGURATION)
+MSBUILD_ARGS := /nologo '/consoleloggerparameters:Verbosity=minimal;summary' /p:Configuration=$(BUILD_CONFIGURATION)
 
 ifneq ($(BUILD_LOG_PATH),)
 	MSBUILD_ARGS += /filelogger '/fileloggerparameters:Verbosity=normal;logFile=$(BUILD_LOG_PATH)'

--- a/build/scripts/restore.sh
+++ b/build/scripts/restore.sh
@@ -6,4 +6,4 @@ dotnet restore -v Minimal --disable-parallel $(pwd)/build/ToolsetPackages/BaseTo
 
 echo "Restore CrossPlatform.sln"
 
-dotnet restore $(pwd)/CrossPlatform.sln
+dotnet restore -v Minimal --disable-parallel $(pwd)/CrossPlatform.sln

--- a/build/scripts/restore.sh
+++ b/build/scripts/restore.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Restoring toolset packages"
-
-dotnet restore -v Minimal --disable-parallel $(pwd)/build/ToolsetPackages/BaseToolset.csproj
-
-echo "Restore CrossPlatform.sln"
-
-dotnet restore -v Minimal --disable-parallel $(pwd)/CrossPlatform.sln

--- a/build/scripts/restore.sh
+++ b/build/scripts/restore.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Workaround, see https://github.com/dotnet/roslyn/issues/10210
-export HOME=$(cd ~ && pwd)
-
 echo "Restoring toolset packages"
 
 dotnet restore -v Minimal --disable-parallel $(pwd)/build/ToolsetPackages/BaseToolset.csproj

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -2,9 +2,6 @@
 
 BUILD_CONFIGURATION=$1
 
-# This function will update the PATH variable to put the desired
-# version of Mono ahead of the system one. 
-
 cd Binaries/$BUILD_CONFIGURATION/CoreClrTest
 
 chmod +x ./corerun

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -10,7 +10,6 @@ usage()
     echo "  --debug               Build Debug (default)"
     echo "  --release             Build Release"
     echo "  --skiptest            Do not run tests"
-    echo "  --skipcrossgen        Do not crossgen the bootstrapped compiler"
     echo "  --skipcommitprinting  Do not print commit information"
     echo "  --nocache       Force download of toolsets"
 }
@@ -18,7 +17,6 @@ usage()
 BUILD_CONFIGURATION=Debug
 USE_CACHE=true
 SKIP_TESTS=false
-SKIP_CROSSGEN=false
 SKIP_COMMIT_PRINTING=false
 
 MAKE="make"
@@ -59,10 +57,6 @@ do
         SKIP_TESTS=true
         shift 1
         ;;
-        --skipcrossgen)
-        SKIP_CROSSGEN=true
-        shift 1
-        ;;
         --skipcommitprinting)
         SKIP_COMMIT_PRINTING=true
         shift 1
@@ -74,8 +68,6 @@ do
     esac
 done
 
-MAKE_ARGS="BUILD_CONFIGURATION=$BUILD_CONFIGURATION SKIP_CROSSGEN=$SKIP_CROSSGEN"
-
 if [ "$CLEAN_RUN" == "true" ]; then
     echo Clean out the enlistment
     git clean -dxf . 
@@ -86,13 +78,10 @@ if [ "$SKIP_COMMIT_PRINTING" == "false" ]; then
     git show --no-patch --pretty=raw HEAD
 fi
 
-echo Building Bootstrap
-$MAKE bootstrap $MAKE_ARGS 
-
-echo Building CrossPlatform.sln
-$MAKE all $MAKE_ARGS BOOTSTRAP=true BUILD_LOG_PATH=Binaries/Build.log
+MAKE_TARGET="all"
 
 if [ "$SKIP_TESTS" == "false" ]; then
-    $MAKE test $MAKE_ARGS
+    MAKE_TARGET="$MAKE_TARGET test"
 fi
 
+$MAKE $MAKE_TARGET BUILD_CONFIGURATION=$BUILD_CONFIGURATION BOOTSTRAP=true BUILD_LOG_PATH=Binaries/Build.log


### PR DESCRIPTION
Every time I opened up the Makefile, I got really sad. This cleans it up to be a tad more reasonable.

List of changes:

* Use immediate sets instead of recursive sets in many places
* Don't assume `$(shell pwd)` is the same thing as the location of the Makefile (use [MAKEFILE_LIST](https://ftp.gnu.org/old-gnu/Manuals/make/html_node/make_17.html) instead)
* Make the WTF of `HOME_DIR = $(shell cd ~ && pwd)` more clear with docs, and be more sane about setting it (and use Make's env-setting command, instead of copypasting `HOME=$(HOME_DIR)` everywhere)
* Clean up adding dotnet to `PATH` (again, use Make's export command, instead of copy-pasting `PATH=...`)
* Shuffle around whatever the heck `MSBUILD_ADDITIONALARGS` was (just use `MSBUILD_ARGS`)
* Tabs to spaces in areas that aren't rules
* Error if `OS_NAME` is unknown, instead of failing obscurely later
* Don't do bizarre things with `pushd` and single huge commands passed to the shell
* Root paths in commands with vars calculated earlier (e.g. why were we even calculating `SRC_PATH` and then never using it...)
* Pipe `dotnet-install.sh` into bash, instead of doing wacky writes to disk (where we have to worry about `chmod +x` and the current directory)
* Use the specified version of cli for dotnet-install, instead of hardcoding 1.0.0
* Remove `HOME` bizzare-ness from `restore.sh`, as we're setting that in the makefile
* Remove strange comment from `tests.sh`

I'm still really suspicious of strange things happening in the `bootstrap` rule, but that seems like a very invasive and potentially behavior-changing change, so I've left that for now.

Using `pr-for-personal-review-only` until I take a look at ci results to make sure nothing is terribly broken.