### PR TITLE
report more data on crash due to dispose

### DIFF
--- a/src/EditorFeatures/TestUtilities/Remote/WatsonReporter.cs
+++ b/src/EditorFeatures/TestUtilities/Remote/WatsonReporter.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+ 
+ using System;
+ 
+ namespace Microsoft.VisualStudio.LanguageServices.Implementation
+ {
+     /// <summary>
+     /// Mock to make test project build
+     /// </summary>
+     internal class WatsonReporter
+     {
+         public static void Report(string description, Exception exception, Func<IFaultUtility, int> callback)
+         {
+             // do nothing
+         }
+ 
+         public interface IFaultUtility
+         {
+             void AddProcessDump(int pid);
+             void AddFile(string fullpathname);
+         }
+     }
+ }

--- a/src/EditorFeatures/TestUtilities/ServicesTestUtilities.csproj
+++ b/src/EditorFeatures/TestUtilities/ServicesTestUtilities.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Preview\MockPreviewPaneService.cs" />
     <Compile Include="QuickInfo\AbstractQuickInfoSourceTests.cs" />
     <Compile Include="QuickInfo\AbstractSemanticQuickInfoSourceTests.cs" />
+    <Compile Include="Remote\WatsonReporter.cs" />
     <Compile Include="RenameTracking\MockPreviewDialogService.cs" />
     <Compile Include="RenameTracking\MockRefactorNotifyService.cs" />
     <Compile Include="Semantics\SpeculationAnalyzerTestsBase.cs" />


### PR DESCRIPTION
this is port of https://github.com/dotnet/roslyn/pull/20968 to dev15.3.x

**Customer scenario**

VS crashes at random point due to exception from out of proc process. (RoslynCodeAnalysis process)

**Bugs this fixes:**

N/A

this doesn't actually fix the bug, but collect more data for those bugs such as 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=453544&_a=edit

**Workarounds, if any**

there is no workaround except turning off OOP through hidden regkey

**Risk**

Changes are gathering more data on crash. it shouldn't cause, reduce or change crashing behavior.

**Performance impact**

it will spend more time when sending watson report.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

we are adding this to get better info on figuring out the root cause.

**How was the bug found?**

Dogfooding, Testing, Watson.
