### PR TITLE
Enable analyzers on Roslyn.sln except for two very slow ones

### DIFF
--- a/build/Rulesets/Roslyn_BuildRules.ruleset
+++ b/build/Rulesets/Roslyn_BuildRules.ruleset
@@ -93,8 +93,8 @@
     <Rule Id="RS0026" Action="Error" />
     <Rule Id="RS0027" Action="Error" />
   </Rules>
-  <Rules AnalyzerId="System.Collections.Immutable.Analyzers" RuleNamespace="System.Collections.Immutable.Analyzers">
-    <Rule Id="RS0012" Action="Warning" />
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers.ImmutableCollections">
+    <Rule Id="RS0012" Action="None" /> <!-- Disabled for performance reasons: https://github.com/dotnet/roslyn/issues/21051 -->
   </Rules>
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
     <Rule Id="CA1305" Action="None" />
@@ -117,8 +117,8 @@
     <Rule Id="CA2101" Action="None" />
     <Rule Id="RS0015" Action="Warning" />
   </Rules>
-  <Rules AnalyzerId="System.Threading.Tasks.Analyzers" RuleNamespace="System.Threading.Tasks.Analyzers">
-    <Rule Id="RS0018" Action="Warning" />
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers.Tasks">
+    <Rule Id="RS0018" Action="None" /> <!-- Disabled for performance reasons: https://github.com/dotnet/roslyn/issues/21051 -->
   </Rules>
   <Rules AnalyzerId="XmlDocumentationComments.Analyzers" RuleNamespace="XmlDocumentationComments.Analyzers">
     <Rule Id="RS0010" Action="Warning" />

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -24,10 +24,7 @@
          Otherwise, it writes to the same file (GeneratedAssemblyInfoFile) as our GenerateAssemblyInfoFile target.
          Follow-up issue to reconcile the two: https://github.com/dotnet/roslyn/issues/19645 -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-
-    <!-- Disabling on developer builds until perf issue figured out 
-         https://github.com/dotnet/roslyn/issues/21041 -->
-    <UseRoslynAnalyzers Condition="'$(UseRoslynAnalyzers)' == '' AND '$(DeveloperBuild)' != 'true'">true</UseRoslynAnalyzers>
+    <UseRoslynAnalyzers Condition="'$(UseRoslynAnalyzers)' == ''">true</UseRoslynAnalyzers>
     <BaseOutputPath Condition="'$(BaseOutputPath)' == ''">$(RepoRoot)Binaries\</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RepoRoot)Binaries\Obj\</BaseIntermediateOutputPath>

--- a/src/Compilers/CSharp/CSharpCodeAnalysisRules.ruleset
+++ b/src/Compilers/CSharp/CSharpCodeAnalysisRules.ruleset
@@ -5,7 +5,4 @@
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.CSharp" RuleNamespace="Roslyn.Diagnostics.Analyzers.CSharp">
     <Rule Id="RS0013" Action="Warning" />
   </Rules>
-  <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.CSharp" RuleNamespace="Roslyn.Diagnostics.Analyzers.CSharp">
-    <Rule Id="RS0018" Action="Error" />
-  </Rules>
 </RuleSet>

--- a/src/Compilers/VisualBasic/BasicCodeAnalysisRules.ruleset
+++ b/src/Compilers/VisualBasic/BasicCodeAnalysisRules.ruleset
@@ -8,7 +8,4 @@
   <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.VisualBasic" RuleNamespace="Roslyn.Diagnostics.Analyzers.VisualBasic">
     <Rule Id="RS0013" Action="Warning" />
   </Rules>
-  <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers.VisualBasic" RuleNamespace="Roslyn.Diagnostics.Analyzers.VisualBasic">
-    <Rule Id="RS0018" Action="Error" />
-  </Rules>
 </RuleSet>


### PR DESCRIPTION
Closes #21041

| Approach | Build time (build.cmd on my machine) |
| --- | --- |
| UseRoslynAnalyzers=false (7d91bb391254f4aec786ed3d6cadf1b59741ba77) | 1:01 |
| UseRoslynAnalyzers=true (7d91bb391254f4aec786ed3d6cadf1b59741ba77 with #21042 reverted) | 3:27 |
| UseRoslynAnalyzers=true, RS0012 and RS0018 disabled | 1:21 |

⚠️ Due to limitations in the way rule set file inheritance works (and lack of a workaround in our build), this change results in these two diagnostics being disabled on developer machines *and* on the CI. However, it is my understanding that the underlying performance problem is understood, and we're just waiting for a new beta release of the packages to get published so we can consume them.

:link: See #21051 for the new issue to enable these two rules after the underlying performance problem is corrected.