### PR TITLE
Correctly deduplicate metadata references for lightweight projects

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -905,7 +905,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
-            var addedReferencePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var metadataReferencesToAdd = new Dictionary<string, MetadataReferenceProperties>(StringComparer.OrdinalIgnoreCase);
+
             foreach (var reference in metadataReferences)
             {
                 var path = GetReferencePath(reference);
@@ -916,10 +917,35 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     continue;
                 }
 
-                if (addedReferencePaths.Add(path))
+                if (metadataReferencesToAdd.TryGetValue(path, out var existingProperties))
                 {
-                    projectContext.AddMetadataReference(path, reference.Properties);
+                    // Merge existing aliases the properties that are already there
+                    var allAliases = existingProperties.Aliases.AddRange(reference.Properties.Aliases);
+
+                    // If one is empty and the other isn't, then we need to toss the global alias in too. The other cases
+                    // are they're both empty (and this was a direct duplicate) or they're both non-empty and the merge
+                    // is OK.
+                    if ((existingProperties.Aliases.IsDefaultOrEmpty && !reference.Properties.Aliases.IsDefaultOrEmpty) ||
+                        (!existingProperties.Aliases.IsDefaultOrEmpty && reference.Properties.Aliases.IsDefaultOrEmpty))
+                    {
+                        allAliases = allAliases.Add(MetadataReferenceProperties.GlobalAlias);
+                    }
+                    else
+                    {
+                        allAliases = allAliases.Distinct();
+                    }
+
+                    metadataReferencesToAdd[path] = existingProperties.WithAliases(allAliases);
                 }
+                else
+                {
+                    metadataReferencesToAdd.Add(path, reference.Properties);
+                }
+            }
+
+            foreach (var metadataReferenceToAdd in metadataReferencesToAdd)
+            {
+                projectContext.AddMetadataReference(metadataReferenceToAdd.Key, metadataReferenceToAdd.Value);
             }
 
             var addedAnalyzerPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
We were deduping metadata references by file path alone, which is not correct if we are referencing the same assembly with multiple aliases. This correctly merges those and adds a single reference.