### PR TITLE
Fix crash in nuget code when nuget.config file is broken.

### DIFF
--- a/src/VisualStudio/Core/Def/Packaging/IPackageServicesProxy.cs
+++ b/src/VisualStudio/Core/Def/Packaging/IPackageServicesProxy.cs
@@ -7,7 +7,9 @@ using NuGet.VisualStudio;
 
 namespace Microsoft.VisualStudio.LanguageServices.Packaging
 {
-    // Wrapper types to ensure we delay load the nuget libraries.
+    /// <summary>Wrapper type to ensure we delay load the nuget libraries.</summary> 
+    /// <remarks>All methods may throw exceptions due to <see cref="IVsPackageSourceProvider"/>
+    /// throwing in all sorts of bad nuget states (for example a bad nuget.config file)</remarks>
     internal interface IPackageServicesProxy
     {
         event EventHandler SourcesChanged;

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -145,9 +146,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
 
             this.AssertIsForeground();
 
-            PackageSources = _packageServices.GetSources(includeUnOfficial: true, includeDisabled: false)
-                .Select(r => new PackageSource(r.Key, r.Value))
-                .ToImmutableArrayOrEmpty();
+            try
+            {
+                PackageSources = _packageServices.GetSources(includeUnOfficial: true, includeDisabled: false)
+                    .Select(r => new PackageSource(r.Key, r.Value))
+                    .ToImmutableArrayOrEmpty();
+            }
+            catch (Exception ex) when (ex is InvalidDataException || ex is InvalidOperationException)
+            {
+                // These exceptions can happen when the nuget.config file is broken.
+                PackageSources = ImmutableArray<PackageSource>.Empty;
+            }
 
             PackageSourcesChanged?.Invoke(this, EventArgs.Empty);
         }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20IDE/_workitems?_a=edit&id=468626&triage=true