### PR TITLE
Insert documentation comments in the face of trim_whitespace

### DIFF
--- a/src/EditorFeatures/CSharp/DocumentationComments/DocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/DocumentationComments/DocumentationCommentCommandHandler.cs
@@ -285,5 +285,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments
         {
             get { return true; }
         }
+
+        internal override bool HasSkippedTrailingTrivia(SyntaxToken token) => token.TrailingTrivia.Any(t => t.Kind() == SyntaxKind.SkippedTokensTrivia);
     }
 }

--- a/src/EditorFeatures/CSharp/DocumentationComments/DocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/DocumentationComments/DocumentationCommentCommandHandler.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments
             }
 
             return syntaxTree.GetRoot(cancellationToken).FindTokenOnLeftOfPosition(
-                position - 1, includeDirectives: true, includeDocumentationComments: true);
+                position - 1, includeDirectives: true, includeDocumentationComments: true, includeSkipped: true);
         }
 
         protected override bool IsDocCommentNewLine(SyntaxToken token)

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -1897,12 +1897,21 @@ class C { }";
 /// </summary>
 class C { }";
 
-            VerifyPressingEnter(code, expected, useTabs: true, setOptionsOpt:
+            try
+            {
+                VerifyPressingEnter(code, expected, useTabs: true, setOptionsOpt:
                 workspace =>
                 {
                     workspace.GetService<IEditorOptionsFactoryService>().GlobalOptions
                         .SetOptionValue(DefaultOptions.TrimTrailingWhiteSpaceOptionName, true);
                 });
+            }
+            finally
+            {
+                TestWorkspace.CreateCSharp("").GetService<IEditorOptionsFactoryService>().GlobalOptions
+                        .SetOptionValue(DefaultOptions.TrimTrailingWhiteSpaceOptionName, false);
+            }
+            
         }
 
         protected override char DocumentationCommentCharacter

--- a/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
+++ b/src/EditorFeatures/CSharpTest/DocumentationComments/DocumentationCommentTests.cs
@@ -5,6 +5,8 @@ using Microsoft.CodeAnalysis.Editor.CSharp.DocumentationComments;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Microsoft.VisualStudio.Text.Operations;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -1876,6 +1878,31 @@ $$
 }";
 
             VerifyOpenLineBelow(code, expected, useTabs: true);
+        }
+
+        [WorkItem(468638, @"https://devdiv.visualstudio.com/DevDiv/NET%20Developer%20Experience%20IDE/_workitems/edit/468638")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.DocumentationComments)]
+        public void VerifyEnterWithTrimNewLineEditorConfigOption()
+        {
+            const string code =
+@"/// <summary>
+/// $$
+/// </summary>
+class C { }";
+
+            const string expected =
+@"/// <summary>
+///
+/// $$
+/// </summary>
+class C { }";
+
+            VerifyPressingEnter(code, expected, useTabs: true, setOptionsOpt:
+                workspace =>
+                {
+                    workspace.GetService<IEditorOptionsFactoryService>().GlobalOptions
+                        .SetOptionValue(DefaultOptions.TrimTrailingWhiteSpaceOptionName, true);
+                });
         }
 
         protected override char DocumentationCommentCharacter

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
         {
             // Find the documentation comment before the new line that was just pressed
             var token = GetTokenToLeft(syntaxTree, position, cancellationToken);
-            if (!IsDocCommentNewLine(token) || token.Span.End != position)
+            if (!IsDocCommentNewLine(token))
             {
                 return false;
             }

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
         {
             // Find the documentation comment before the new line that was just pressed
             var token = GetTokenToLeft(syntaxTree, position, cancellationToken);
-            if (!IsDocCommentNewLine(token))
+            if (!IsDocCommentNewLine(token) && HasSkippedTrailingTrivia(token))
             {
                 // See PressingEnter_InsertSlashes11 for an example of
                 // a case where multiple skipped tokens trivia appear at the same position.
@@ -389,6 +389,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
 
             return true;
         }
+
+        internal abstract bool HasSkippedTrailingTrivia(SyntaxToken token);
 
         private bool InsertOnCommandInvoke(
             SyntaxTree syntaxTree,

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -334,8 +334,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             CancellationToken cancellationToken)
         {
             // Find the documentation comment before the new line that was just pressed
-            var token = GetTokenToRight(syntaxTree, originalPosition, cancellationToken);
-            if (!IsDocCommentNewLine(token) || token.SpanStart != originalPosition)
+            var token = GetTokenToLeft(syntaxTree, position, cancellationToken);
+            if (!IsDocCommentNewLine(token) || token.Span.End != position)
             {
                 return false;
             }

--- a/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/DocumentationComments/AbstractDocumentationCommentCommandHandler.cs
@@ -337,7 +337,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.DocumentationComments
             var token = GetTokenToLeft(syntaxTree, position, cancellationToken);
             if (!IsDocCommentNewLine(token))
             {
-                return false;
+                // See PressingEnter_InsertSlashes11 for an example of
+                // a case where multiple skipped tokens trivia appear at the same position.
+                // In that case, we need to ask for the token from the next position over.
+                token = GetTokenToLeft(syntaxTree, position + 1, cancellationToken);
+
+                if (!IsDocCommentNewLine(token))
+                {
+                    return false;
+                }
             }
 
             var currentLine = text.Lines.GetLineFromPosition(position);

--- a/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
+++ b/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
@@ -49,7 +49,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
 
                     var commandArgs = new ReturnKeyCommandArgs(view, view.TextBuffer);
                     var nextHandler = CreateInsertTextHandler(view, "\r\n");
-
                     commandHandler.ExecuteCommand(commandArgs, nextHandler);
                 });
         }

--- a/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
+++ b/src/EditorFeatures/TestUtilities/DocumentationComments/AbstractDocumentationCommentTests.cs
@@ -38,9 +38,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
                 });
         }
 
-        protected void VerifyPressingEnter(string initialMarkup, string expectedMarkup, bool useTabs = false, bool autoGenerateXmlDocComments = true)
+        protected void VerifyPressingEnter(string initialMarkup, string expectedMarkup, bool useTabs = false, bool autoGenerateXmlDocComments = true,
+            Action<TestWorkspace> setOptionsOpt = null)
         {
             Verify(initialMarkup, expectedMarkup, useTabs, autoGenerateXmlDocComments,
+                setOptionsOpt: setOptionsOpt,
                 execute: (view, undoHistoryRegistry, editorOperationsFactoryService, completionService) =>
                 {
                     var commandHandler = CreateCommandHandler(TestWaitIndicator.Default, undoHistoryRegistry, editorOperationsFactoryService) as ICommandHandler<ReturnKeyCommandArgs>;
@@ -113,7 +115,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
         }
 
         private void Verify(string initialMarkup, string expectedMarkup, bool useTabs, bool autoGenerateXmlDocComments,
-            Action<IWpfTextView, ITextUndoHistoryRegistry, IEditorOperationsFactoryService, IAsyncCompletionService> execute)
+            Action<IWpfTextView, ITextUndoHistoryRegistry, IEditorOperationsFactoryService, IAsyncCompletionService> execute,
+            Action<TestWorkspace> setOptionsOpt = null)
         {
             using (var workspace = CreateTestWorkspace(initialMarkup))
             {
@@ -143,6 +146,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.DocumentationComments
                 options = options.WithChangedOption(FeatureOnOffOptions.AutoXmlDocCommentGeneration, testDocument.Project.Language, autoGenerateXmlDocComments);
 
                 workspace.Options = options;
+
+                setOptionsOpt?.Invoke(workspace);
 
                 execute(
                     view,

--- a/src/EditorFeatures/VisualBasic/DocumentationComments/DocumentationCommentCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/DocumentationComments/DocumentationCommentCommandHandler.vb
@@ -265,5 +265,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.DocumentationComments
                 Return False
             End Get
         End Property
+
+        Friend Overrides Function HasSkippedTrailingTrivia(token As SyntaxToken) As Boolean
+            Return token.TrailingTrivia.Any(Function(t) t.Kind() = SyntaxKind.SkippedTokensTrivia)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
If the .editorconfig option "trim trailing whitespace" is enabled, the editor removes trailing whitespace from a line when the user presses enter. The automatic documentation comment feature used to do span math that assumed the whitespace was left in place in order to determine whether to insert ///. Now, the feature performs its initial checks on the SourceText prior to the handling of the enter command.

Fixes #18713