### PR TITLE
Add Shared attributes to code fix providers

### DIFF
--- a/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseIsNullCheck/CSharpUseIsNullCheckCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Composition;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -7,7 +8,7 @@ using Microsoft.CodeAnalysis.UseIsNullCheck;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     internal class CSharpUseIsNullCheckCodeFixProvider : AbstractUseIsNullCheckCodeFixProvider
     {
         protected override string GetIsNullTitle()

--- a/src/Features/VisualBasic/Portable/UseIsNullCheck/VisualBasicUseIsNullCheckCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/UseIsNullCheck/VisualBasicUseIsNullCheckCodeFixProvider.vb
@@ -1,11 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Composition
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.UseIsNullCheck
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UseIsNullCheck
-    <ExportCodeFixProvider(LanguageNames.VisualBasic)>
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
     Friend Class VisualBasicUseIsNullCheckCodeFixProvider
         Inherits AbstractUseIsNullCheckCodeFixProvider
 


### PR DESCRIPTION
Unbreaks the build introduced by a combination of https://github.com/dotnet/roslyn/pull/20930 and the re-enabling of RS0023 (Use [Shared] attribute)