### PR TITLE
Fix lambda analysis free

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -289,6 +289,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             CheckLocalsDefined(body);
 
+            analysis.Free();
+
             return body;
         }
 


### PR DESCRIPTION
Dependent on https://github.com/dotnet/roslyn/pull/20936 -- only the last commit is relevant.

This PR properly frees the LambdaRewriter Analysis type after allocation.